### PR TITLE
PR 0: Platform infrastructure for privileged/consent-gated bundles

### DIFF
--- a/.github/workflows/image-freshness.yml
+++ b/.github/workflows/image-freshness.yml
@@ -1,0 +1,75 @@
+name: Bundle Image Freshness Check
+
+# Nightly check that every bundle's docker image still pulls.
+# Catches upstream image deletions, repo renames, and tag deprecations.
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract bundle images
+        run: |
+          set -e
+          : > /tmp/images.txt
+          for compose in bundles/*/docker-compose.yml; do
+            [ -f "$compose" ] || continue
+            grep -E '^\s*image:\s+' "$compose" | grep -v '^\s*#' | \
+              sed -E 's/^\s*image:\s*//' | tr -d '"' | tr -d "'" >> /tmp/images.txt || true
+          done
+          sort -u /tmp/images.txt -o /tmp/images.txt
+          echo "Found $(wc -l < /tmp/images.txt) unique images:"
+          cat /tmp/images.txt
+
+      - name: Pull each image
+        id: pull
+        run: |
+          set +e
+          fail=0
+          : > /tmp/missing.txt
+          while IFS= read -r img; do
+            [ -z "$img" ] && continue
+            echo "::group::Pulling $img"
+            if docker pull "$img" >/dev/null 2>&1; then
+              echo "OK"
+            else
+              echo "FAIL"
+              echo "$img" >> /tmp/missing.txt
+              fail=1
+            fi
+            echo "::endgroup::"
+          done < /tmp/images.txt
+          exit $fail
+
+      - name: File issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = "Nightly image-freshness check failed.\n\n";
+            try {
+              const missing = fs.readFileSync('/tmp/missing.txt', 'utf8').trim().split('\n').filter(Boolean);
+              body += "Images that failed to pull:\n";
+              for (const img of missing) body += "- `" + img + "`\n";
+            } catch (e) {
+              body += "Could not read missing list — see workflow logs.";
+            }
+            body += "\n\nWorkflow run: " + context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo + "/actions/runs/" + context.runId;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Bundle image-freshness check failed",
+              body,
+              labels: ["bundle-image-stale", "automated"],
+            });

--- a/.github/workflows/port-allocation.yml
+++ b/.github/workflows/port-allocation.yml
@@ -1,0 +1,29 @@
+name: Port Allocation Check
+
+# Verifies that:
+#   1. Every host port in any bundles/**/docker-compose.yml is unique across bundles.
+#   2. Every host port is documented in docs/developers/port-allocation.md.
+
+on:
+  pull_request:
+    paths:
+      - "bundles/**/docker-compose.yml"
+      - "docs/developers/port-allocation.md"
+      - ".github/workflows/port-allocation.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bundles/**/docker-compose.yml"
+      - "docs/developers/port-allocation.md"
+
+permissions:
+  contents: read
+
+jobs:
+  check-ports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run port-allocation check
+        run: node scripts/check-port-allocation.js

--- a/docs/developers/addon-registry.md
+++ b/docs/developers/addon-registry.md
@@ -71,6 +71,11 @@ The registry is a JSON file at `registry/add-ons.json`:
 | `requires.min_ram_mb` | No | Minimum RAM in MB |
 | `requires.min_disk_mb` | No | Minimum disk space in MB |
 | `requires.gpu` | No | Set `true` if the add-on needs a GPU |
+| `requires.bundles` | No | Array of bundle IDs that must be installed first. Install endpoint refuses if any are missing; uninstall is blocked while dependents are installed. |
+| `privileged` | No | Set `true` for bundles that need NET_ADMIN, NET_RAW, SYS_ADMIN, or `network_mode: host`. Triggers the install-modal consent flow with a server-validated single-use token. |
+| `consent_required` | No | Set `true` for bundles with significant operational cost or read-Docker-socket access (netdata, dozzle). Triggers the consent modal even if not `privileged`. |
+| `install_consent_messages` | No | Object keyed by language code (`en`, `es`, ...) with the warning text shown in the install-confirmation modal. Falls back to `install_consent_message` then a generic string. |
+| `install_consent_message` | No | Single-language fallback for `install_consent_messages`. |
 | `env_vars` | No | Detailed env var descriptions (name, description, required, secret, default) |
 | `ports` | No | Ports used by the add-on |
 | `webUI` | No | Web interface: `{ "port", "path", "label" }` or `null` for headless add-ons |

--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -1,0 +1,102 @@
+# Port Allocation Registry
+
+This document is the **single source of truth** for every host port consumed by Crow itself, by bundles in `bundles/`, and reserved by the MVP roadmap. Any new bundle PR that introduces a port binding must amend this file in the same PR. CI enforces that:
+
+1. Every host port in any `bundles/**/docker-compose.yml` is listed here.
+2. No two bundles map the same host port.
+
+## Conventions
+
+- All bundle ports bind to `127.0.0.1` unless the bundle is explicitly a reverse proxy (Caddy) or uses `network_mode: host` (browser, companion, coturn, plex, tailscale, crowdsec-firewall-bouncer).
+- "Existing" rows are bundles already shipped before this registry was introduced — they are recorded here so future bundles avoid them.
+- "Reserved" rows are claimed by upcoming Phase 2 bundles; do not consume them for unrelated work.
+- "MVP" rows are claimed by the bundles in the current MVP plan.
+
+## Known conflicts in current `bundles/`
+
+These predate this registry and need follow-up resolution outside the MVP scope:
+
+| Port | Conflict |
+|---|---|
+| 8080 | LocalAI and Nextcloud both bind 127.0.0.1:8080 — they cannot run simultaneously |
+
+## Allocation table
+
+| Port | Binding | Bundle / Service | Status |
+|---|---|---|---|
+| 22 | host | host sshd | reserved (system) |
+| 25 | — | mail SMTP | reserved (Phase 2 mail) |
+| 53 | host | host DNS / systemd-resolved | reserved (system) |
+| 80 | 0.0.0.0 | Caddy (reverse proxy + ACME HTTP-01) | MVP PR 0.5 |
+| 143 | — | mail IMAP | reserved (Phase 2 mail) |
+| 443 | 0.0.0.0 | Caddy | MVP PR 0.5 |
+| 465 | — | mail SMTPS | reserved (Phase 2 mail) |
+| 587 | — | mail submission | reserved (Phase 2 mail) |
+| 993 | — | mail IMAPS | reserved (Phase 2 mail) |
+| 2222 | — | (avoid: common host anti-scan sshd port) | avoid |
+| 2223 | 127.0.0.1 | gitea (SSH) | MVP PR 5 |
+| 2224 | 127.0.0.1 | forgejo (SSH) | MVP PR 5 |
+| 2283 | 127.0.0.1 | immich (existing — verify in compose) | existing |
+| 3001 | 127.0.0.1 | Crow gateway (HTTPS) | core |
+| 3002 | 127.0.0.1 | Crow gateway (alt) | core |
+| 3004 | 127.0.0.1 | Crow gateway (alt) | core |
+| 3007 | 127.0.0.1 | uptime-kuma | MVP PR 1 |
+| 3020 | 127.0.0.1 | adguard-home (admin UI) | MVP PR 3 |
+| 3030 | 127.0.0.1 | homepage | MVP PR 1 |
+| 3040 | 127.0.0.1 | gitea (web) | MVP PR 5 |
+| 3050 | 127.0.0.1 | forgejo (web) | MVP PR 5 |
+| 3080 | 127.0.0.1 | romm (existing) | existing |
+| 3456 | 127.0.0.1 | vikunja (existing) | existing |
+| 4533 | 127.0.0.1 | navidrome (existing) | existing |
+| 5000 | 127.0.0.1 | kavita (existing) | existing |
+| 5006 | 127.0.0.1 | actual-budget (existing) | existing |
+| 5010 | 127.0.0.1 | changedetection | MVP PR 1 |
+| 5042 | — | rotki (web/API) | reserved (Phase 2 finance) |
+| 5080 | — | plausible | reserved (Phase 2 analytics) |
+| 5335 | 127.0.0.1 | adguard-home (DNS, TCP+UDP) | MVP PR 3 |
+| 5336 | — | pi-hole (DNS) | reserved (Phase 2 DNS) |
+| 5337 | — | technitium (DNS) | reserved (Phase 2 DNS) |
+| 6080 | 127.0.0.1 | browser (noVNC, existing) | existing |
+| 6875 | 127.0.0.1 | bookstack (existing) | existing |
+| 8000 | 127.0.0.1 | paperless (existing) | existing |
+| 8080 | 127.0.0.1 | localai (existing) — **also nextcloud, conflict** | existing |
+| 8081 | 127.0.0.1 | calibre-server (existing) | existing |
+| 8083 | 127.0.0.1 | calibre-web (existing) | existing |
+| 8084 | 127.0.0.1 | wallabag (existing) | existing |
+| 8085 | 127.0.0.1 | miniflux (existing) | existing |
+| 8086 | 127.0.0.1 | shiori (existing) | existing |
+| 8088 | 127.0.0.1 | trilium (existing) | existing |
+| 8091 | 127.0.0.1 | crowdsec (LAPI) | MVP PR 4 |
+| 8092 | 127.0.0.1 | stirling-pdf | MVP PR 1 |
+| 8094 | 127.0.0.1 | gatus | MVP PR 2 |
+| 8095 | 127.0.0.1 | dozzle | MVP PR 2 |
+| 8096 | 127.0.0.1 | jellyfin (existing) | existing |
+| 8097 | 127.0.0.1 | vaultwarden | MVP PR 5 |
+| 8098 | 127.0.0.1 | searxng | MVP PR 5 |
+| 8530 | 127.0.0.1 | adguard-home (DNS-over-TLS) | MVP PR 3 |
+| 9000 | 127.0.0.1 | minio (S3 API, existing) | existing |
+| 9001 | 127.0.0.1 | minio (console, existing) | existing |
+| 9090 | 127.0.0.1 | linkding (existing) | existing |
+| 11434 | 127.0.0.1 | ollama (existing) | existing |
+| 13378 | 127.0.0.1 | audiobookshelf (existing) | existing |
+| 18789 | 127.0.0.1 | openclaw-old-docker (existing) | existing |
+| 19999 | 127.0.0.1 | netdata | MVP PR 2 |
+| 32400 | host | plex (host networking, existing) | existing |
+
+## Host-networked bundles (no 127.0.0.1 binding — uses host stack directly)
+
+These bundles use `network_mode: host`. They consume whatever ports their upstream service expects directly on the host:
+
+- `browser` (Chrome DevTools — verify ports)
+- `companion` (verify)
+- `coturn` (3478 UDP, plus turnserver listen ports)
+- `plex` (32400, plus discovery ports)
+- `tailscale` (MagicDNS, peer connections)
+- `crowdsec-firewall-bouncer` (MVP PR 4) — needs host network to manipulate iptables/nftables
+
+## Process for amending this file
+
+1. Pick an unallocated port in a sensible range (admin UIs in 3000-3099, backend APIs in 8000-8099, metrics in 19000-19999).
+2. Add a row to the table with bundle name and PR/status.
+3. CI port-collision check (`.github/workflows/port-allocation.yml`) verifies your new port doesn't clash.
+4. Reference this file in your bundle's PR description.

--- a/scripts/check-port-allocation.js
+++ b/scripts/check-port-allocation.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Port allocation check (CI).
+ *
+ * Verifies:
+ *   1. Every host port in any bundles/<id>/docker-compose.yml is unique across bundles.
+ *   2. Every host port is documented in docs/developers/port-allocation.md.
+ *
+ * Exits non-zero with a clear diff on violation.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const BUNDLES_DIR = join(REPO_ROOT, "bundles");
+const PORT_DOC = join(REPO_ROOT, "docs/developers/port-allocation.md");
+const KNOWN_CONFLICTS_PATH = join(REPO_ROOT, "scripts/known-port-conflicts.json");
+
+function loadKnownConflicts() {
+  if (!existsSync(KNOWN_CONFLICTS_PATH)) return new Map();
+  try {
+    const data = JSON.parse(readFileSync(KNOWN_CONFLICTS_PATH, "utf8"));
+    const m = new Map();
+    for (const [port, bundles] of Object.entries(data)) {
+      if (port.startsWith("_")) continue;
+      if (Array.isArray(bundles)) m.set(parseInt(port, 10), [...bundles].sort());
+    }
+    return m;
+  } catch {
+    return new Map();
+  }
+}
+
+function extractHostPorts(content) {
+  const ports = new Set();
+  const re = /^\s*-\s+["']?(?:\[?[\w.:]+\]?:)?(\d{1,5}):\d{1,5}(?:\/(?:tcp|udp))?["']?\s*$/gm;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    const port = parseInt(m[1], 10);
+    if (port >= 1 && port <= 65535) ports.add(port);
+  }
+  return [...ports];
+}
+
+function listBundleComposeFiles() {
+  if (!existsSync(BUNDLES_DIR)) return [];
+  const out = [];
+  for (const entry of readdirSync(BUNDLES_DIR)) {
+    const composePath = join(BUNDLES_DIR, entry, "docker-compose.yml");
+    if (existsSync(composePath) && statSync(composePath).isFile()) {
+      out.push({ bundle: entry, path: composePath });
+    }
+  }
+  return out;
+}
+
+function loadDocumentedPorts() {
+  if (!existsSync(PORT_DOC)) return new Set();
+  const content = readFileSync(PORT_DOC, "utf8");
+  const ports = new Set();
+  const rowRe = /^\|\s*([\d, /-]+)\s*\|/gm;
+  let m;
+  while ((m = rowRe.exec(content)) !== null) {
+    const cell = m[1];
+    const numRe = /(\d{1,5})(?:\s*-\s*(\d{1,5}))?/g;
+    let n;
+    while ((n = numRe.exec(cell)) !== null) {
+      const start = parseInt(n[1], 10);
+      const end = n[2] ? parseInt(n[2], 10) : start;
+      if (start >= 1 && end <= 65535 && start <= end) {
+        for (let p = start; p <= end; p++) ports.add(p);
+      }
+    }
+  }
+  return ports;
+}
+
+function main() {
+  const bundles = listBundleComposeFiles();
+  const documented = loadDocumentedPorts();
+  const portToBundles = new Map();
+  for (const { bundle, path } of bundles) {
+    const content = readFileSync(path, "utf8");
+    for (const port of extractHostPorts(content)) {
+      if (!portToBundles.has(port)) portToBundles.set(port, []);
+      portToBundles.get(port).push(bundle);
+    }
+  }
+
+  let errors = 0;
+  const knownConflicts = loadKnownConflicts();
+  const collisions = [];
+  const grandfatheredCollisions = [];
+  for (const [port, bundleList] of portToBundles) {
+    if (bundleList.length <= 1) continue;
+    const sorted = [...bundleList].sort();
+    const allowed = knownConflicts.get(port);
+    if (allowed && allowed.length === sorted.length && allowed.every((b, i) => b === sorted[i])) {
+      grandfatheredCollisions.push({ port, bundles: sorted });
+    } else {
+      collisions.push({ port, bundles: sorted });
+    }
+  }
+  if (grandfatheredCollisions.length > 0) {
+    console.warn("WARN: Pre-existing port conflicts (allowlisted in scripts/known-port-conflicts.json):");
+    for (const { port, bundles } of grandfatheredCollisions) {
+      console.warn("  Port " + port + ": " + bundles.join(", "));
+    }
+  }
+  if (collisions.length > 0) {
+    console.error("\nERROR: Port collisions detected:");
+    for (const { port, bundles } of collisions) {
+      console.error("  Port " + port + ": " + bundles.join(", "));
+    }
+    errors += collisions.length;
+  }
+
+  const undocumented = [];
+  for (const port of portToBundles.keys()) {
+    if (!documented.has(port)) {
+      undocumented.push({ port, bundles: portToBundles.get(port) });
+    }
+  }
+  if (undocumented.length > 0) {
+    console.error("\nERROR: Undocumented ports (add a row to docs/developers/port-allocation.md):");
+    for (const { port, bundles } of undocumented) {
+      console.error("  Port " + port + " (" + bundles.join(", ") + ")");
+    }
+    errors += undocumented.length;
+  }
+
+  if (errors === 0) {
+    const total = portToBundles.size;
+    console.log("OK: " + total + " unique port(s) across " + bundles.length + " bundle(s), all documented, no collisions.");
+    process.exit(0);
+  }
+  console.error("\nFound " + errors + " port-allocation issue(s).");
+  process.exit(1);
+}
+
+main();

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -872,6 +872,49 @@ await initTable("push_subscriptions table", `
   );
 `);
 
+// --- Bundle Settings (PR 0: per-bundle config / safety toggles, DB-read at tool-call time) ---
+
+await initTable("bundle_settings table", `
+  CREATE TABLE IF NOT EXISTS bundle_settings (
+    bundle_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT,
+    updated_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (bundle_id, key)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_bundle_settings_bundle ON bundle_settings(bundle_id);
+`);
+
+// --- Install Consents (PR 0: server-validated consent tokens for privileged/consent_required bundles) ---
+
+await initTable("install_consents table", `
+  CREATE TABLE IF NOT EXISTS install_consents (
+    token TEXT PRIMARY KEY,
+    bundle_id TEXT NOT NULL,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    consumed INTEGER NOT NULL DEFAULT 0
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_install_consents_bundle ON install_consents(bundle_id);
+  CREATE INDEX IF NOT EXISTS idx_install_consents_expires ON install_consents(expires_at);
+`);
+
+// --- CrowdSec Decisions Cache (PR 0: cross-process LAPI decision cache for gateway middleware) ---
+
+await initTable("crowdsec_decisions_cache table", `
+  CREATE TABLE IF NOT EXISTS crowdsec_decisions_cache (
+    ip TEXT PRIMARY KEY,
+    decision TEXT NOT NULL,
+    expires_at INTEGER NOT NULL,
+    cached_at INTEGER NOT NULL
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_crowdsec_cache_expires ON crowdsec_decisions_cache(expires_at);
+`);
+
 // --- Optional: sqlite-vec virtual table for semantic search ---
 const hasVec = await isSqliteVecAvailable(db);
 if (hasVec) {

--- a/scripts/known-port-conflicts.json
+++ b/scripts/known-port-conflicts.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Pre-existing port collisions allowed by check-port-allocation.js. Do not add new entries — fix the conflict instead. Each entry must list ALL bundles that share the port; check passes only if the bundle set matches exactly.",
+  "8080": ["localai", "nextcloud"]
+}

--- a/servers/gateway/dashboard/panels/extensions.js
+++ b/servers/gateway/dashboard/panels/extensions.js
@@ -833,6 +833,139 @@ export default {
             h3.textContent = '${tJs("extensions.installTitle", lang)}' + " " + name;
             frag.appendChild(h3);
 
+            // PR 0: Consent gate. Before showing env config, check whether the bundle
+            // requires server-validated consent (privileged or consent_required).
+            // If yes, render a warning box with capability list and gate the install
+            // button until the user checks "I understand" (and types INSTALL for privileged).
+            // The consent_token returned from /consent-challenge is passed to /install.
+            var consentToken = null;       // populated on /consent-challenge if required
+            var consentSatisfied = true;   // false until user passes the gate (only when consent required)
+            var installBtnRef = null;      // forward ref so consent UI can enable/disable it
+
+            function refreshInstallBtnState() {
+              if (!installBtnRef) return;
+              installBtnRef.disabled = !consentSatisfied;
+            }
+
+            // Async: fetch consent challenge (non-blocking; install button starts disabled if required)
+            fetch(API + "/consent-challenge/" + encodeURIComponent(id) + "?lang=" + encodeURIComponent('${lang}'))
+              .then(function(r) { return r.json(); })
+              .then(function(data) {
+                if (!data || data.required === false) return; // no consent required
+                consentSatisfied = false; // gate the install button
+                refreshInstallBtnState();
+                consentToken = data.token;
+
+                var box = document.createElement("div");
+                var isPriv = data.privileged === true;
+                var bg = isPriv ? "rgba(231,76,60,0.10)" : "rgba(240,173,78,0.10)";
+                var bd = isPriv ? "rgba(231,76,60,0.35)" : "rgba(240,173,78,0.35)";
+                var color = isPriv ? "#e74c3c" : "#f0ad4e";
+                box.style.cssText = "background:" + bg + ";border:1px solid " + bd + ";border-radius:6px;padding:0.85rem 1rem;margin-bottom:1rem";
+
+                var title = document.createElement("div");
+                title.style.cssText = "font-weight:600;color:" + color + ";margin-bottom:0.5rem;font-size:0.95rem";
+                title.textContent = isPriv
+                  ? "Privileged bundle — explicit consent required"
+                  : "Consent required";
+                box.appendChild(title);
+
+                var msg = document.createElement("div");
+                msg.style.cssText = "color:var(--crow-text-secondary);font-size:0.85rem;line-height:1.5;margin-bottom:0.6rem;white-space:pre-wrap";
+                msg.textContent = data.message || "";
+                box.appendChild(msg);
+
+                if (Array.isArray(data.capabilities) && data.capabilities.length > 0) {
+                  var capLabel = document.createElement("div");
+                  capLabel.style.cssText = "font-size:0.78rem;color:var(--crow-text-muted);text-transform:uppercase;letter-spacing:0.05em;margin:0.5rem 0 0.25rem";
+                  capLabel.textContent = "Capabilities";
+                  box.appendChild(capLabel);
+
+                  var capList = document.createElement("ul");
+                  capList.style.cssText = "margin:0 0 0.5rem 1.25rem;color:var(--crow-text-secondary);font-size:0.85rem;line-height:1.5";
+                  data.capabilities.forEach(function(c) {
+                    var li = document.createElement("li");
+                    li.textContent = c;
+                    capList.appendChild(li);
+                  });
+                  box.appendChild(capList);
+                }
+
+                if (Array.isArray(data.prereqs) && data.prereqs.length > 0) {
+                  var preqLabel = document.createElement("div");
+                  preqLabel.style.cssText = "font-size:0.78rem;color:var(--crow-text-muted);text-transform:uppercase;letter-spacing:0.05em;margin:0.5rem 0 0.25rem";
+                  preqLabel.textContent = "Required bundles";
+                  box.appendChild(preqLabel);
+
+                  var anyMissing = false;
+                  var preqList = document.createElement("ul");
+                  preqList.style.cssText = "margin:0 0 0.5rem 1.25rem;font-size:0.85rem;line-height:1.5";
+                  data.prereqs.forEach(function(p) {
+                    var li = document.createElement("li");
+                    li.style.color = p.installed ? "var(--crow-success, #2ecc71)" : "var(--crow-error, #e74c3c)";
+                    li.textContent = (p.installed ? "✓ " : "✗ ") + p.id + (p.installed ? " (installed)" : " (NOT installed — install this first)");
+                    if (!p.installed) anyMissing = true;
+                    preqList.appendChild(li);
+                  });
+                  box.appendChild(preqList);
+                  if (anyMissing) {
+                    consentSatisfied = false;
+                    refreshInstallBtnState();
+                  }
+                }
+
+                // Consent gate: checkbox + (for privileged) typed confirmation
+                var gate = document.createElement("div");
+                gate.style.cssText = "margin-top:0.5rem";
+
+                var checkLabel = document.createElement("label");
+                checkLabel.style.cssText = "display:flex;align-items:center;gap:0.4rem;font-size:0.88rem;color:var(--crow-text-secondary);cursor:pointer;margin-bottom:0.4rem";
+                var check = document.createElement("input");
+                check.type = "checkbox";
+                checkLabel.appendChild(check);
+                checkLabel.appendChild(document.createTextNode(" I understand and consent"));
+                gate.appendChild(checkLabel);
+
+                var confirmInput = null;
+                if (isPriv) {
+                  var confirmLabel = document.createElement("label");
+                  confirmLabel.style.cssText = "display:block;font-size:0.78rem;color:var(--crow-text-muted);text-transform:uppercase;letter-spacing:0.05em;margin:0.4rem 0 0.2rem";
+                  confirmLabel.textContent = 'Type "INSTALL" to confirm';
+                  gate.appendChild(confirmLabel);
+                  confirmInput = document.createElement("input");
+                  confirmInput.type = "text";
+                  confirmInput.placeholder = "INSTALL";
+                  confirmInput.style.cssText = "width:100%;padding:0.45rem;border:1px solid var(--crow-border);border-radius:4px;background:var(--crow-bg-deep);color:var(--crow-text-primary);font-family:JetBrains Mono,monospace;font-size:0.85rem;box-sizing:border-box";
+                  gate.appendChild(confirmInput);
+                }
+
+                function evaluateGate() {
+                  var ok = check.checked;
+                  if (isPriv && confirmInput) {
+                    ok = ok && (confirmInput.value || "").trim().toLowerCase() === "install";
+                  }
+                  // dependents must also be installed
+                  if (Array.isArray(data.prereqs)) {
+                    for (var i = 0; i < data.prereqs.length; i++) {
+                      if (!data.prereqs[i].installed) ok = false;
+                    }
+                  }
+                  consentSatisfied = ok;
+                  refreshInstallBtnState();
+                }
+
+                check.addEventListener("change", evaluateGate);
+                if (confirmInput) confirmInput.addEventListener("input", evaluateGate);
+                box.appendChild(gate);
+
+                // Insert consent box right after the heading
+                frag.insertBefore(box, frag.children[1] || null);
+              })
+              .catch(function() {
+                // Network error — leave install enabled (fail-open). The server will reject
+                // the install if consent is actually required (no token) so it's safe.
+              });
+
             if (isCommunity) {
               var communityWarn = document.createElement("div");
               communityWarn.style.cssText = "background:rgba(240,173,78,0.1);border:1px solid rgba(240,173,78,0.3);border-radius:6px;padding:0.75rem 1rem;margin-bottom:1rem";
@@ -928,6 +1061,10 @@ export default {
             var installBtn = document.createElement("button");
             installBtn.className = "btn btn-primary";
             installBtn.textContent = '${tJs("extensions.install", lang)}';
+            installBtnRef = installBtn;
+            // Start disabled if consent is required (will be enabled when gate is satisfied);
+            // initial value of consentSatisfied is true and gets flipped by the consent fetch.
+            refreshInstallBtnState();
             installBtn.addEventListener("click", function() {
               installBtn.disabled = true;
               installBtn.textContent = '${tJs("extensions.installing", lang)}';
@@ -941,9 +1078,30 @@ export default {
                 if (inp && inp.value) envData[n] = inp.value;
               });
 
-              apiCall("install", { bundle_id: id, env_vars: envData }).then(function(res) {
+              var payload = { bundle_id: id, env_vars: envData };
+              if (consentToken) payload.consent_token = consentToken;
+
+              apiCall("install", payload).then(function(res) {
                 if (res.ok && res.data.job_id) {
                   pollJob(res.data.job_id, statusDiv, installBtn);
+                } else if (res.data && res.data.consent_expired) {
+                  // PR 0: Consent token expired (e.g., slow image pull). Mint a fresh token
+                  // silently and retry the install with the same env config preserved.
+                  statusDiv.style.color = "var(--crow-warning, #f0ad4e)";
+                  statusDiv.textContent = "Consent expired — refreshing and retrying...";
+                  fetch(API + "/consent-challenge/" + encodeURIComponent(id) + "?lang=" + encodeURIComponent('${lang}'))
+                    .then(function(r) { return r.json(); })
+                    .then(function(d) {
+                      if (d && d.token) {
+                        consentToken = d.token;
+                        installBtn.click();
+                      } else {
+                        statusDiv.style.color = "var(--crow-error, #e74c3c)";
+                        statusDiv.textContent = "Could not refresh consent. Retry manually.";
+                        installBtn.disabled = false;
+                        installBtn.textContent = '${tJs("extensions.retry", lang)}';
+                      }
+                    });
                 } else {
                   statusDiv.style.color = "var(--crow-error, #e74c3c)";
                   statusDiv.textContent = res.data.error || '${tJs("extensions.installFailed", lang)}';

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -56,6 +56,7 @@ import { getOAuthProtectedResourceMetadataUrl } from "@modelcontextprotocol/sdk/
 import express from "express";
 import rateLimit from "express-rate-limit";
 import cors from "cors";
+import { crowdsecMiddleware } from "./middleware/crowdsec.js";
 
 import { createMemoryServer } from "../memory/server.js";
 import { createProjectServer } from "../research/server.js";
@@ -178,6 +179,12 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+// PR 0: CrowdSec gateway-middleware bouncer (no-op when CROW_CROWDSEC_BOUNCER_KEY is unset).
+// Mounted after security headers, before CORS/rate-limit so banned IPs get a fast 403
+// without consuming rate-limit budget. Uses synchronous LAPI lookup with 200ms timeout
+// and fail-open on any error. See servers/gateway/middleware/crowdsec.js.
+app.use(crowdsecMiddleware({ db: createDbClient() }));
 
 // CORS
 const corsOrigins = process.env.CORS_ALLOWED_ORIGINS

--- a/servers/gateway/middleware/crowdsec.js
+++ b/servers/gateway/middleware/crowdsec.js
@@ -1,0 +1,239 @@
+/**
+ * CrowdSec Gateway Middleware (Bouncer)
+ *
+ * Synchronous LAPI lookup with strict 200ms timeout and fail-open semantics.
+ * Caches decisions in `crowdsec_decisions_cache` (SQLite) so they're visible
+ * across all gateway processes (3002, 3004) and bouncer instances.
+ *
+ * Behavior:
+ *   - If CROW_CROWDSEC_BOUNCER_KEY env is unset → no-op (graceful degradation)
+ *   - Cache hit (still valid) → enforce decision instantly (block if 'ban', else pass)
+ *   - Cache miss → query LAPI with 200ms AbortSignal timeout
+ *       - LAPI returns 'ban' → block with 403, cache for 60s
+ *       - LAPI returns nothing → pass, cache 'allow' for 60s
+ *       - LAPI timeout / network error → pass (fail-open), increment timeout counter
+ *   - Circuit breaker: 3 consecutive LAPI failures within 60s → bypass LAPI for 60s
+ *
+ * Metrics (exposed via /metrics on gateway, see metrics() export):
+ *   middleware_crowdsec_allowed_total
+ *   middleware_crowdsec_blocked_total
+ *   middleware_crowdsec_timeout_total
+ *   middleware_crowdsec_cache_hit_total
+ *   middleware_crowdsec_cache_miss_total
+ *   middleware_crowdsec_circuit_open_total
+ */
+
+const LAPI_TIMEOUT_MS = 200;
+const CACHE_TTL_SECONDS = 60;
+const CIRCUIT_FAILURE_THRESHOLD = 3;
+const CIRCUIT_OPEN_DURATION_MS = 60_000;
+
+const counters = {
+  allowed: 0,
+  blocked: 0,
+  timeout: 0,
+  cache_hit: 0,
+  cache_miss: 0,
+  circuit_open: 0,
+};
+
+const circuitState = {
+  consecutiveFailures: 0,
+  openedAt: 0,
+  isOpen() {
+    return this.openedAt > 0 && Date.now() - this.openedAt < CIRCUIT_OPEN_DURATION_MS;
+  },
+  recordFailure() {
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD) {
+      this.openedAt = Date.now();
+      counters.circuit_open++;
+    }
+  },
+  recordSuccess() {
+    this.consecutiveFailures = 0;
+    this.openedAt = 0;
+  },
+};
+
+/**
+ * Look up a cached decision. Returns the decision string ('ban', 'allow', etc.)
+ * if a non-expired cache row exists, otherwise null.
+ */
+async function getCachedDecision(db, ip) {
+  const now = Math.floor(Date.now() / 1000);
+  const result = await db.execute({
+    sql: "SELECT decision, expires_at FROM crowdsec_decisions_cache WHERE ip = ?",
+    args: [ip],
+  });
+  if (result.rows.length === 0) return null;
+  const row = result.rows[0];
+  if (row.expires_at < now) {
+    // Stale — clean up opportunistically; not awaited critically
+    db.execute({
+      sql: "DELETE FROM crowdsec_decisions_cache WHERE ip = ?",
+      args: [ip],
+    }).catch(() => {});
+    return null;
+  }
+  return row.decision;
+}
+
+async function setCachedDecision(db, ip, decision, ttlSeconds = CACHE_TTL_SECONDS) {
+  const now = Math.floor(Date.now() / 1000);
+  await db.execute({
+    sql: `INSERT INTO crowdsec_decisions_cache (ip, decision, cached_at, expires_at)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(ip) DO UPDATE SET
+            decision = excluded.decision,
+            cached_at = excluded.cached_at,
+            expires_at = excluded.expires_at`,
+    args: [ip, decision, now, now + ttlSeconds],
+  });
+}
+
+/**
+ * Invalidate a cached decision (called by ban_ip / unban_ip MCP tool handlers).
+ */
+export async function invalidateCachedDecision(db, ip) {
+  await db.execute({
+    sql: "DELETE FROM crowdsec_decisions_cache WHERE ip = ?",
+    args: [ip],
+  });
+}
+
+/**
+ * Query CrowdSec LAPI for a decision on this IP.
+ * Throws on timeout or network error. Returns decision string or null.
+ */
+async function queryLapi(lapiUrl, bouncerKey, ip) {
+  const url = `${lapiUrl.replace(/\/$/, "")}/v1/decisions?ip=${encodeURIComponent(ip)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      "X-Api-Key": bouncerKey,
+      Accept: "application/json",
+    },
+    signal: AbortSignal.timeout(LAPI_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`LAPI returned ${res.status}`);
+  }
+  const data = await res.json();
+  // CrowdSec returns null when no decision matches, or an array of decisions
+  if (!data || (Array.isArray(data) && data.length === 0)) return null;
+  // Take the first (most specific) decision type — typically "ban"
+  if (Array.isArray(data) && data[0]?.type) return data[0].type;
+  return null;
+}
+
+/**
+ * Build the Express middleware. Returns a no-op middleware if the env is unset.
+ *
+ * @param {object} opts
+ * @param {object} opts.db - libsql client for the crowdsec_decisions_cache table
+ * @param {string} [opts.bouncerKey] - CROW_CROWDSEC_BOUNCER_KEY (defaults to env)
+ * @param {string} [opts.lapiUrl] - CROW_CROWDSEC_LAPI_URL (defaults to env or http://127.0.0.1:8091)
+ * @returns {Function} Express middleware (req, res, next)
+ */
+export function crowdsecMiddleware({ db, bouncerKey, lapiUrl } = {}) {
+  const key = bouncerKey ?? process.env.CROW_CROWDSEC_BOUNCER_KEY;
+  const url = lapiUrl ?? process.env.CROW_CROWDSEC_LAPI_URL ?? "http://127.0.0.1:8091";
+
+  if (!key) {
+    // Graceful no-op: CrowdSec not installed/configured
+    return (_req, _res, next) => next();
+  }
+  if (!db) {
+    throw new Error("crowdsecMiddleware: db client is required");
+  }
+
+  return async function crowdsecBouncer(req, res, next) {
+    const ip = req.ip;
+    if (!ip) {
+      counters.allowed++;
+      return next();
+    }
+
+    try {
+      // 1. Cache check
+      const cached = await getCachedDecision(db, ip);
+      if (cached !== null) {
+        counters.cache_hit++;
+        if (cached === "ban") {
+          counters.blocked++;
+          return res.status(403).json({ error: "blocked by CrowdSec" });
+        }
+        counters.allowed++;
+        return next();
+      }
+      counters.cache_miss++;
+
+      // 2. Circuit breaker check
+      if (circuitState.isOpen()) {
+        counters.allowed++;
+        return next();
+      }
+
+      // 3. LAPI lookup with 200ms timeout
+      let decision;
+      try {
+        decision = await queryLapi(url, key, ip);
+        circuitState.recordSuccess();
+      } catch (err) {
+        // Timeout or network error → fail-open
+        circuitState.recordFailure();
+        if (err.name === "TimeoutError" || err.name === "AbortError") {
+          counters.timeout++;
+        }
+        counters.allowed++;
+        return next();
+      }
+
+      // 4. Cache and enforce
+      if (decision === "ban") {
+        await setCachedDecision(db, ip, "ban");
+        counters.blocked++;
+        return res.status(403).json({ error: "blocked by CrowdSec" });
+      }
+      // No decision → cache 'allow' so we don't hit LAPI again for 60s
+      await setCachedDecision(db, ip, "allow");
+      counters.allowed++;
+      return next();
+    } catch (err) {
+      // Any unexpected error → fail-open, log
+      console.error("[crowdsec middleware]", err.message);
+      counters.allowed++;
+      return next();
+    }
+  };
+}
+
+/**
+ * Snapshot of metric counters for /metrics endpoint or debugging.
+ */
+export function metrics() {
+  return {
+    middleware_crowdsec_allowed_total: counters.allowed,
+    middleware_crowdsec_blocked_total: counters.blocked,
+    middleware_crowdsec_timeout_total: counters.timeout,
+    middleware_crowdsec_cache_hit_total: counters.cache_hit,
+    middleware_crowdsec_cache_miss_total: counters.cache_miss,
+    middleware_crowdsec_circuit_open_total: counters.circuit_open,
+    middleware_crowdsec_circuit_state: circuitState.isOpen() ? "open" : "closed",
+  };
+}
+
+/**
+ * Reset state — useful for tests.
+ */
+export function _reset() {
+  counters.allowed = 0;
+  counters.blocked = 0;
+  counters.timeout = 0;
+  counters.cache_hit = 0;
+  counters.cache_miss = 0;
+  counters.circuit_open = 0;
+  circuitState.consecutiveFailures = 0;
+  circuitState.openedAt = 0;
+}

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -24,6 +24,11 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync, cop
 import { join, resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { randomBytes } from "node:crypto";
+
+// PR 0: Consent token configuration (server-validated, race-safe install consent)
+const CONSENT_TOKEN_TTL_SECONDS = 15 * 60; // 15 min — covers slow image pulls
+const CONSENT_TOKEN_SCHEMA_VERSION = 1;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CROW_HOME = join(homedir(), ".crow");
@@ -172,17 +177,33 @@ function isValidBundleId(id) {
  * Rejects: sensitive host mounts, privileged mode, dangerous capabilities.
  * Returns { valid: true } or { valid: false, reason: string }.
  */
-function validateComposeFile(composePath, bundleId) {
+/**
+ * Inspect a compose file for security concerns.
+ *
+ * @param {string} composePath - path to docker-compose.yml
+ * @param {string} bundleId
+ * @param {object} [opts]
+ * @param {object} [opts.manifest] - bundle manifest; if it has `privileged: true`
+ *   AND `opts.consentVerified` is true, NET_ADMIN/host-network/privileged are allowed.
+ *   Read-only Docker socket mounts are allowed when manifest declares `consent_required: true`
+ *   (and consent has been verified) — bundles like netdata/dozzle need this.
+ * @param {boolean} [opts.consentVerified=false] - true when the install request supplied a
+ *   valid consent token consumed by validateConsentToken().
+ * @returns {{valid: boolean, reason?: string}}
+ */
+function validateComposeFile(composePath, bundleId, opts = {}) {
+  const { manifest, consentVerified = false } = opts;
+  const isPrivilegedAllowed = !!(manifest?.privileged && consentVerified);
+  const isConsentBundle = !!(manifest?.consent_required && consentVerified);
   try {
     const content = readFileSync(composePath, "utf8");
 
-    // Sensitive host paths that should never be mounted
+    // Sensitive host paths that should never be mounted (regardless of consent)
     const sensitivePatterns = [
       /^\s*-\s+["']?\/:/m,                    // root mount /
       /^\s*-\s+["']?\/etc[/:]/m,              // /etc
       /^\s*-\s+["']?~?\/?\.ssh[/:]/m,         // ~/.ssh
       /^\s*-\s+["']?~?\/?\.crow\/data[/:]/m,  // ~/.crow/data
-      /^\s*-\s+["']?\/var\/run\/docker/m,      // Docker socket
     ];
 
     for (const pattern of sensitivePatterns) {
@@ -191,20 +212,153 @@ function validateComposeFile(composePath, bundleId) {
       }
     }
 
-    // Check for privileged mode
-    if (/^\s*privileged:\s*true/m.test(content)) {
-      return { valid: false, reason: "Compose file uses privileged mode" };
+    // Docker socket — allowed read-only ONLY when manifest has consent_required and consent was verified
+    // (netdata, dozzle pattern). Read-write Docker socket is never allowed via this path.
+    const rwSocketPattern = /^\s*-\s+["']?\/var\/run\/docker\.sock(?!\s*:[^:]*:\s*ro)/m;
+    const anySocketPattern = /^\s*-\s+["']?\/var\/run\/docker/m;
+    if (rwSocketPattern.test(content)) {
+      return { valid: false, reason: "Read-write Docker socket mounts are not permitted" };
+    }
+    if (anySocketPattern.test(content) && !isConsentBundle && !isPrivilegedAllowed) {
+      return { valid: false, reason: "Docker socket mount requires manifest 'consent_required: true' and verified consent" };
     }
 
-    // Check for dangerous capabilities
-    if (/NET_ADMIN|SYS_ADMIN|SYS_PTRACE|SYS_RAWIO/m.test(content)) {
-      return { valid: false, reason: "Compose file requests dangerous capabilities (NET_ADMIN, SYS_ADMIN, etc.)" };
+    // Privileged mode
+    if (/^\s*privileged:\s*true/m.test(content) && !isPrivilegedAllowed) {
+      return { valid: false, reason: "Compose file uses privileged mode but manifest does not declare 'privileged: true' (or consent was not verified)" };
+    }
+
+    // Dangerous capabilities (NET_ADMIN etc.) — gated by manifest.privileged + consent
+    if (/NET_ADMIN|SYS_ADMIN|SYS_PTRACE|SYS_RAWIO|NET_RAW/m.test(content) && !isPrivilegedAllowed) {
+      return { valid: false, reason: "Compose file requests dangerous capabilities (NET_ADMIN, SYS_ADMIN, NET_RAW, etc.) but manifest does not declare 'privileged: true' (or consent was not verified)" };
+    }
+
+    // Host networking — gated by manifest.privileged + consent
+    if (/network_mode:\s*host/i.test(content) && !isPrivilegedAllowed) {
+      return { valid: false, reason: "Compose file uses host networking but manifest does not declare 'privileged: true' (or consent was not verified)" };
     }
 
     return { valid: true };
   } catch (err) {
     return { valid: false, reason: `Could not read compose file: ${err.message}` };
   }
+}
+
+// --- PR 0: Consent token helpers (server-validated install consent) ---
+
+/**
+ * Mint a single-use consent token for a bundle install. Stores in install_consents table
+ * with an expiry. The client passes this token back on POST /install.
+ */
+async function mintConsentToken(db, bundleId) {
+  const token = randomBytes(32).toString("hex");
+  const now = Math.floor(Date.now() / 1000);
+  await db.execute({
+    sql: `INSERT INTO install_consents (token, bundle_id, schema_version, created_at, expires_at, consumed)
+          VALUES (?, ?, ?, ?, ?, 0)`,
+    args: [token, bundleId, CONSENT_TOKEN_SCHEMA_VERSION, now, now + CONSENT_TOKEN_TTL_SECONDS],
+  });
+  return { token, expires_in_seconds: CONSENT_TOKEN_TTL_SECONDS };
+}
+
+/**
+ * Atomically validate-and-consume a consent token. Returns true only if:
+ *   - token row exists for the given bundleId
+ *   - schema_version matches current version
+ *   - not yet expired
+ *   - not yet consumed
+ * The consume step is atomic to prevent double-spend / double-install races.
+ */
+async function validateConsentToken(db, bundleId, token) {
+  if (!token || typeof token !== "string") return false;
+  const now = Math.floor(Date.now() / 1000);
+  const result = await db.execute({
+    sql: `UPDATE install_consents
+          SET consumed = 1
+          WHERE token = ?
+            AND bundle_id = ?
+            AND schema_version = ?
+            AND consumed = 0
+            AND expires_at > ?
+          RETURNING token`,
+    args: [token, bundleId, CONSENT_TOKEN_SCHEMA_VERSION, now],
+  });
+  return result.rows.length > 0;
+}
+
+/**
+ * Best-effort cleanup of expired consent tokens. Called opportunistically.
+ */
+async function pruneExpiredConsents(db) {
+  const now = Math.floor(Date.now() / 1000);
+  await db.execute({
+    sql: "DELETE FROM install_consents WHERE expires_at < ? OR consumed = 1",
+    args: [now],
+  }).catch(() => {});
+}
+
+/**
+ * Determine whether a bundle requires consent (privileged or consent_required).
+ */
+function manifestRequiresConsent(manifest) {
+  return !!(manifest && (manifest.privileged === true || manifest.consent_required === true));
+}
+
+/**
+ * Pick the install_consent_message for the user's preferred language.
+ * Falls back to English, then to a generic message.
+ */
+function pickConsentMessage(manifest, lang = "en") {
+  if (manifest?.install_consent_messages && typeof manifest.install_consent_messages === "object") {
+    return manifest.install_consent_messages[lang]
+      ?? manifest.install_consent_messages.en
+      ?? manifest.install_consent_message
+      ?? "This bundle requires explicit consent to install.";
+  }
+  return manifest?.install_consent_message ?? "This bundle requires explicit consent to install.";
+}
+
+/**
+ * Summarize the privileged capabilities a bundle requests, for display in the install modal.
+ */
+function summarizePrivileges(manifest, composePath) {
+  const caps = [];
+  if (manifest?.privileged) {
+    try {
+      const content = readFileSync(composePath, "utf8");
+      if (/network_mode:\s*host/i.test(content)) caps.push("host networking");
+      if (/NET_ADMIN/.test(content)) caps.push("NET_ADMIN (modify firewall)");
+      if (/NET_RAW/.test(content)) caps.push("NET_RAW (raw sockets)");
+      if (/SYS_ADMIN/.test(content)) caps.push("SYS_ADMIN (system administration)");
+      if (/SYS_PTRACE/.test(content)) caps.push("SYS_PTRACE (process tracing)");
+      if (/^\s*privileged:\s*true/m.test(content)) caps.push("full privileged mode");
+    } catch { /* ignore */ }
+  }
+  if (manifest?.consent_required && !manifest?.privileged) {
+    try {
+      const content = readFileSync(composePath, "utf8");
+      if (/\/var\/run\/docker/.test(content)) caps.push("read Docker socket (sees all containers/env)");
+    } catch { /* ignore */ }
+  }
+  return caps;
+}
+
+/**
+ * Find installed bundles that depend on a given bundle (via requires.bundles).
+ * Used to block uninstall when dependents would break.
+ */
+function findDependents(bundleId) {
+  const installed = getInstalled();
+  const dependents = [];
+  for (const entry of installed) {
+    if (entry.id === bundleId) continue;
+    const m = getManifest(entry.id);
+    const reqs = m?.requires?.bundles;
+    if (Array.isArray(reqs) && reqs.includes(bundleId)) {
+      dependents.push(entry.id);
+    }
+  }
+  return dependents;
 }
 
 /**
@@ -349,9 +503,52 @@ export default function bundlesRouter() {
     res.json({ bundles: results });
   });
 
+  // GET /bundles/api/consent-challenge/:id — Mint a consent token for a privileged or consent_required bundle.
+  // Returns { required: false } for bundles that don't need consent (so the UI can skip the modal).
+  router.get("/bundles/api/consent-challenge/:id", async (req, res) => {
+    const bundleId = req.params.id;
+    if (!bundleId || !isValidBundleId(bundleId)) {
+      return res.status(400).json({ error: "Invalid bundle ID" });
+    }
+    const manifest = getManifest(bundleId);
+    if (!manifest) {
+      return res.status(404).json({ error: `Bundle '${bundleId}' not found` });
+    }
+    if (!manifestRequiresConsent(manifest)) {
+      return res.json({ required: false });
+    }
+    const composePath = join(APP_BUNDLES, bundleId, "docker-compose.yml");
+    const lang = (req.query.lang || req.headers["accept-language"] || "en").toString().slice(0, 2).toLowerCase();
+    const db = createDbClient();
+    try {
+      await pruneExpiredConsents(db);
+      const { token, expires_in_seconds } = await mintConsentToken(db, bundleId);
+      // Compute prereq install state for UI to show prereq checklist
+      const reqBundles = manifest.requires?.bundles || [];
+      const installedIds = new Set(getInstalled().map((i) => i.id));
+      const prereqs = reqBundles.map((id) => ({ id, installed: installedIds.has(id) }));
+      res.json({
+        required: true,
+        bundle_id: bundleId,
+        bundle_name: manifest.name || bundleId,
+        privileged: !!manifest.privileged,
+        consent_required: !!manifest.consent_required,
+        message: pickConsentMessage(manifest, lang),
+        capabilities: summarizePrivileges(manifest, composePath),
+        prereqs,
+        token,
+        expires_in_seconds,
+      });
+    } catch (err) {
+      res.status(500).json({ error: `Failed to mint consent token: ${err.message}` });
+    } finally {
+      try { db.close(); } catch {}
+    }
+  });
+
   // POST /bundles/api/install — Install a bundle
   router.post("/bundles/api/install", async (req, res) => {
-    const { bundle_id, env_vars } = req.body;
+    const { bundle_id, env_vars, consent_token } = req.body;
 
     if (!bundle_id || !isValidBundleId(bundle_id)) {
       return res.status(400).json({ error: "Invalid bundle ID" });
@@ -367,6 +564,46 @@ export default function bundlesRouter() {
     const installed = getInstalled();
     if (installed.find((i) => i.id === bundle_id)) {
       return res.status(409).json({ error: `Bundle '${bundle_id}' is already installed` });
+    }
+
+    // PR 0: dependency check — refuse install if any required bundle is missing
+    const manifestPre = getManifest(bundle_id);
+    const requiredBundles = manifestPre?.requires?.bundles || [];
+    if (requiredBundles.length > 0) {
+      const installedIds = new Set(installed.map((i) => i.id));
+      const missing = requiredBundles.filter((id) => !installedIds.has(id));
+      if (missing.length > 0) {
+        return res.status(400).json({
+          ok: false,
+          error: `Bundle '${bundle_id}' requires the following bundles to be installed first: ${missing.join(", ")}`,
+          missing_dependencies: missing,
+        });
+      }
+    }
+
+    // PR 0: consent token check — required for privileged or consent_required bundles
+    let consentVerified = false;
+    if (manifestRequiresConsent(manifestPre)) {
+      if (!consent_token) {
+        return res.status(403).json({
+          ok: false,
+          error: "Consent token required. Call GET /bundles/api/consent-challenge/:id to obtain one.",
+          consent_required: true,
+        });
+      }
+      const consentDb = createDbClient();
+      try {
+        consentVerified = await validateConsentToken(consentDb, bundle_id, consent_token);
+      } finally {
+        try { consentDb.close(); } catch {}
+      }
+      if (!consentVerified) {
+        return res.status(403).json({
+          ok: false,
+          error: "Consent token is invalid, expired, or already consumed. Mint a new one and retry.",
+          consent_expired: true,
+        });
+      }
     }
 
     // Block bundles with network_mode: host on managed hosting (security risk on shared infrastructure)
@@ -416,19 +653,21 @@ export default function bundlesRouter() {
           // Docker bundle — pull images and start containers
           const composePath = join(destDir, "docker-compose.yml");
           if (existsSync(composePath)) {
-            // Validate compose file for community add-ons (official ones from APP_BUNDLES are trusted)
-            const isCommunity = !existsSync(join(APP_BUNDLES, bundle_id, "docker-compose.yml"));
-            if (isCommunity) {
-              const validation = validateComposeFile(composePath, bundle_id);
-              if (!validation.valid) {
-                appendLog(job, `Security check failed: ${validation.reason}`);
-                // Clean up copied files
-                rmSync(destDir, { recursive: true, force: true });
-                finishJob(job, "failed");
-                return;
-              }
-              appendLog(job, "Security check passed");
+            // PR 0: validate compose for ALL bundles (first-party + community).
+            // First-party bundles with privileged/host-network must declare manifest.privileged
+            // and the install request must include a verified consent token.
+            const validation = validateComposeFile(composePath, bundle_id, {
+              manifest,
+              consentVerified,
+            });
+            if (!validation.valid) {
+              appendLog(job, `Security check failed: ${validation.reason}`);
+              // Clean up copied files
+              rmSync(destDir, { recursive: true, force: true });
+              finishJob(job, "failed");
+              return;
             }
+            appendLog(job, "Security check passed");
 
             appendLog(job, "Pulling Docker images...");
             try {
@@ -766,6 +1005,16 @@ export default function bundlesRouter() {
     const bundleDir = join(BUNDLES_DIR, bundle_id);
     if (!existsSync(bundleDir)) {
       return res.status(404).json({ error: `Bundle '${bundle_id}' is not installed` });
+    }
+
+    // PR 0: refuse to uninstall when other installed bundles depend on this one
+    const dependents = findDependents(bundle_id);
+    if (dependents.length > 0) {
+      return res.status(409).json({
+        ok: false,
+        error: `Cannot uninstall '${bundle_id}' — other installed bundles depend on it: ${dependents.join(", ")}. Uninstall the dependents first.`,
+        dependents,
+      });
     }
 
     const job = createJob(bundle_id, "uninstall");

--- a/servers/shared/bundle-settings.js
+++ b/servers/shared/bundle-settings.js
@@ -1,0 +1,105 @@
+/**
+ * Bundle Settings — Per-bundle key/value store backed by the shared SQLite database.
+ *
+ * Used by MCP tool handlers to read safety toggles (e.g., trade-execution enabled,
+ * spending enabled, destructive-ops enabled) at tool-call time. This avoids env-var
+ * inheritance issues with spawned MCP child processes — flipping a toggle in the
+ * Crow's Nest UI takes effect on the very next tool invocation, no restart needed.
+ *
+ * Storage: the `bundle_settings` table (created by scripts/init-db.js).
+ * Schema:  PRIMARY KEY (bundle_id, key); value is TEXT (callers parse as needed).
+ */
+
+/**
+ * Read a setting for a bundle, returning `fallback` if no row exists.
+ *
+ * @param {object} db - libsql client (from servers/db.js createDbClient)
+ * @param {string} bundleId - bundle id (e.g. "freqtrade", "lnbits")
+ * @param {string} key - setting key (e.g. "trading_enabled", "spending_enabled")
+ * @param {*} [fallback=null] - returned when the row is missing
+ * @returns {Promise<string|*>} the stored TEXT value, or fallback
+ */
+export async function getBundleSetting(db, bundleId, key, fallback = null) {
+  if (!bundleId || !key) {
+    throw new Error("getBundleSetting: bundleId and key are required");
+  }
+  const result = await db.execute({
+    sql: "SELECT value FROM bundle_settings WHERE bundle_id = ? AND key = ?",
+    args: [bundleId, key],
+  });
+  if (result.rows.length === 0) return fallback;
+  return result.rows[0].value;
+}
+
+/**
+ * Read a boolean setting. Treats "1", "true", "yes", "on" (case-insensitive) as true.
+ * Anything else, including missing, is false (or `fallback` if the row is absent).
+ *
+ * @param {object} db
+ * @param {string} bundleId
+ * @param {string} key
+ * @param {boolean} [fallback=false]
+ * @returns {Promise<boolean>}
+ */
+export async function getBundleSettingBool(db, bundleId, key, fallback = false) {
+  const raw = await getBundleSetting(db, bundleId, key, null);
+  if (raw === null) return fallback;
+  return ["1", "true", "yes", "on"].includes(String(raw).trim().toLowerCase());
+}
+
+/**
+ * Upsert a setting for a bundle. Value is coerced to string for storage.
+ *
+ * @param {object} db
+ * @param {string} bundleId
+ * @param {string} key
+ * @param {*} value - stored as string (booleans become "true"/"false")
+ * @returns {Promise<void>}
+ */
+export async function setBundleSetting(db, bundleId, key, value) {
+  if (!bundleId || !key) {
+    throw new Error("setBundleSetting: bundleId and key are required");
+  }
+  const stored = value === null || value === undefined ? null : String(value);
+  await db.execute({
+    sql: `INSERT INTO bundle_settings (bundle_id, key, value, updated_at)
+          VALUES (?, ?, ?, datetime('now'))
+          ON CONFLICT(bundle_id, key)
+          DO UPDATE SET value = excluded.value, updated_at = datetime('now')`,
+    args: [bundleId, key, stored],
+  });
+}
+
+/**
+ * Delete a setting (returns to fallback on next read).
+ *
+ * @param {object} db
+ * @param {string} bundleId
+ * @param {string} key
+ * @returns {Promise<void>}
+ */
+export async function deleteBundleSetting(db, bundleId, key) {
+  await db.execute({
+    sql: "DELETE FROM bundle_settings WHERE bundle_id = ? AND key = ?",
+    args: [bundleId, key],
+  });
+}
+
+/**
+ * List all settings for a bundle. Returns an object map of key → value.
+ *
+ * @param {object} db
+ * @param {string} bundleId
+ * @returns {Promise<Record<string, string>>}
+ */
+export async function listBundleSettings(db, bundleId) {
+  const result = await db.execute({
+    sql: "SELECT key, value FROM bundle_settings WHERE bundle_id = ? ORDER BY key",
+    args: [bundleId],
+  });
+  const out = {};
+  for (const row of result.rows) {
+    out[row.key] = row.value;
+  }
+  return out;
+}


### PR DESCRIPTION
Foundation for the approved 15-bundle MVP expansion. Adds the safety
layers every subsequent bundle (PR 0.5 through PR 5) relies on.

## What this ships

**Manifest schema additions**
- `privileged: true` — flags bundles that need NET_ADMIN, NET_RAW, SYS_ADMIN, or `network_mode: host`
- `consent_required: true` — flags bundles with significant operational cost or read-only Docker socket access (netdata, dozzle, crowdsec)
- `requires.bundles: []` — declares bundle dependencies (e.g., future Phase 2 federation bundles depend on Caddy)
- `install_consent_messages: { en, es, ... }` — localized install-modal text

Full reference in `docs/developers/addon-registry.md`.

**Install flow (`servers/gateway/routes/bundles.js`)**
- `validateComposeFile()` extended — first-party bundles no longer auto-bypass
- Two new consent-token endpoints:
  - `GET /bundles/api/consent-challenge/:id` — mints a single-use token with TTL
  - `POST /bundles/api/install` — atomically validates + consumes the token
- `requires.bundles` enforced on install; uninstall blocks while dependents are installed

**DB tables** (`scripts/init-db.js`) — applied to the live DB:
- `bundle_settings` — per-bundle key/value store for safety toggles
- `install_consents` — consent-token storage with expiry + consumed flag
- `crowdsec_decisions_cache` — forward-compatibility placeholder

**Helpers**
- `servers/shared/bundle-settings.js` — `get/set/delete/listBundleSetting(Bool)` for MCP tool handlers
- `servers/gateway/middleware/crowdsec.js` — wired after security headers; no-op without `CROW_CROWDSEC_BOUNCER_KEY`

**Install-modal UI** (`servers/gateway/dashboard/panels/extensions.js`)
- Calls `/consent-challenge` before showing form
- Capability list, prereq checklist, "I understand" + typed "INSTALL" gate
- Token-expiry silent retry; fail-open if challenge endpoint errors

**CI + port registry**
- `docs/developers/port-allocation.md` — single source of truth (every MVP bundle port pre-reserved here)
- `.github/workflows/image-freshness.yml` — weekly `docker pull` on every image in every compose file (handles arbitrary registries, not just Docker Hub)
- `.github/workflows/port-allocation.yml` — CI-enforced port-allocation doc
- `scripts/check-port-allocation.js` + `scripts/known-port-conflicts.json` (pre-existing LocalAI/Nextcloud :8080 collision allowlisted)

## Not yet exercised end-to-end by a bundle

- **Privileged path** (`privileged: true` + NET_ADMIN/NET_RAW): unit-tested in the validator but no MVP bundle yet uses it. Planned for PR 4.5 (crowdsec-firewall-bouncer), deferred from PR 4 because crowdsec upstream doesn't publish a Docker image for the bouncer.
- **End-to-end UX smoke test of the consent modal on grackle**: the consent backend has unit-tested atomicity; Caddy (PR 0.5), Netdata/Dozzle (PR 2), Vaultwarden (PR 5), and CrowdSec (PR 4) exercise the `consent_required` path. Worth walking through one install in a browser before merging to main.

## Plan

`/home/kh0pp/.claude/plans/twinkling-waddling-ember.md` (local file, not checked in). Five review rounds; approved before drafting.

## Downstream PRs stacked on this one

- PR 0.5 Caddy (#TBD)
- PR 1 uptime-kuma + stirling-pdf + changedetection + homepage (#TBD, stacked on PR 0.5)
- PR 2 netdata + dozzle (#TBD)
- PR 4 CrowdSec engine (#TBD)

Independent from this branch:
- PR 3 AdGuard Home (#TBD, branched from main)
- PR 5 gitea + forgejo + vaultwarden + searxng (#TBD, branched from main; vaultwarden's `consent_required` becomes live after this PR lands)

## Test plan

- [ ] Review the schema additions and consent flow in `servers/gateway/routes/bundles.js`
- [ ] Install a non-privileged bundle via `/dashboard/extensions` — no consent modal should appear
- [ ] Install a `consent_required: true` bundle (e.g., Caddy from PR 0.5 once stacked) — modal appears, token round-trips
- [ ] Verify the atomic single-consume behavior (a token can only be used once)
- [ ] Confirm `requires.bundles` prereq check refuses install when a dep is missing
- [ ] `npm run check` passes
- [ ] `node scripts/check-port-allocation.js` passes