### PR TITLE
PR 0.5: Caddy reverse proxy bundle with automatic HTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,17 @@ CROW_FILES_PATH=/home
 
 # Cloudflare Tunnel token (for local network deployment only)
 # CLOUDFLARE_TUNNEL_TOKEN=
+
+# ── CADDY (reverse proxy bundle, PR 0.5) ─────────────────
+
+# Email address registered with Let's Encrypt for ACME cert issuance and
+# renewal notices. Required if caddy bundle is installed.
+# CADDY_EMAIL=you@example.com
+
+# Admin API URL — Crow's MCP server uses this to reload/inspect Caddy.
+# Defaults to http://127.0.0.1:2019 (matches docker-compose.yml in caddy bundle).
+# CADDY_ADMIN_URL=http://127.0.0.1:2019
+
+# Directory holding Caddyfile, data/ (ACME state, mode 0700), and config/.
+# Defaults to ~/.crow/caddy. Mounted into the caddy container.
+# CADDY_CONFIG_DIR=~/.crow/caddy

--- a/bundles/caddy/docker-compose.yml
+++ b/bundles/caddy/docker-compose.yml
@@ -1,0 +1,62 @@
+# Caddy reverse proxy with automatic HTTPS (ACME).
+#
+# Image tag note: caddy:2-alpine is one of the few tags we intentionally leave
+# floating on the major version. Caddy upstream explicitly recommends 2-alpine
+# for reverse-proxy use and guarantees v2.x semver compatibility. Every other
+# bundle in Crow pins a resolved semver — Caddy is the documented exception.
+#
+# Ports:
+#   80, 443 bind to 0.0.0.0 (required to answer public HTTPS traffic and
+#     complete Let's Encrypt HTTP-01 / TLS-ALPN-01 challenges).
+#   2019    binds to 127.0.0.1 (admin API used by the Crow MCP server for
+#     reload / status / site management — never expose this to the network).
+#
+# Layout of the single bind mount (~/.crow/caddy/):
+#   Caddyfile         — user-editable config (Crow's MCP tools also read/write)
+#   data/             — ACME private keys and cert cache (Caddy drops it here
+#                       via XDG_DATA_HOME). We chmod 0700 on first init.
+#   config/           — Caddy's auto-save state (XDG_CONFIG_HOME)
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: crow-caddy
+    ports:
+      - "0.0.0.0:80:80"
+      - "0.0.0.0:443:443"
+      - "0.0.0.0:443:443/udp"     # HTTP/3 (QUIC)
+      - "127.0.0.1:2019:2019"     # admin API, host-local only
+    volumes:
+      - ${CADDY_CONFIG_DIR:-~/.crow/caddy}:/srv/caddy
+    environment:
+      - CADDY_EMAIL=${CADDY_EMAIL}
+      - XDG_DATA_HOME=/srv/caddy
+      - XDG_CONFIG_HOME=/srv/caddy
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        if [ ! -f /srv/caddy/Caddyfile ]; then
+          cat > /srv/caddy/Caddyfile <<CADDYFILE_EOF
+        # Crow-managed Caddyfile. The global options block is required by
+        # Crow's MCP server/panel to reach the admin API from the host.
+        # Everything below is yours to edit. Run caddy_reload after edits.
+        {
+        	email {\$$CADDY_EMAIL}
+        	admin 0.0.0.0:2019
+        }
+        CADDYFILE_EOF
+        fi
+        mkdir -p /srv/caddy/caddy /srv/caddy/config
+        chmod 0700 /srv/caddy/caddy 2>/dev/null || true
+        exec caddy run --config /srv/caddy/Caddyfile --adapter caddyfile
+    init: true
+    mem_limit: 256m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:2019/config/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s

--- a/bundles/caddy/manifest.json
+++ b/bundles/caddy/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "caddy",
+  "name": "Caddy Reverse Proxy",
+  "version": "1.0.0",
+  "description": "Reverse proxy with automatic HTTPS via Let's Encrypt (ACME). Foundation for publicly exposed or federated bundles.",
+  "type": "bundle",
+  "author": "Crow",
+  "category": "infrastructure",
+  "tags": ["reverse-proxy", "https", "acme", "letsencrypt", "tls"],
+  "icon": "shield",
+  "docker": { "composefile": "docker-compose.yml" },
+  "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["CADDY_ADMIN_URL", "CADDY_CONFIG_DIR"] },
+  "panel": "panel/caddy.js",
+  "panelRoutes": "panel/routes.js",
+  "skills": ["skills/caddy.md"],
+  "consent_required": true,
+  "install_consent_messages": {
+    "en": "Caddy binds ports 80 and 443 on all interfaces (0.0.0.0) so it can answer HTTP/HTTPS requests from the public internet and complete Let's Encrypt ACME challenges. Make sure ports 80 and 443 are open on your firewall/router and that no other service on this host is already listening on them (e.g., another web server). Caddy will automatically request and renew TLS certificates for any domain you configure; the domain's A/AAAA record must point to this host first.",
+    "es": "Caddy se vincula a los puertos 80 y 443 en todas las interfaces (0.0.0.0) para responder a peticiones HTTP/HTTPS desde internet y completar los desafíos ACME de Let's Encrypt. Asegúrate de que los puertos 80 y 443 estén abiertos en tu firewall/router y que ningún otro servicio de este host los esté usando. Caddy solicitará y renovará certificados TLS automáticamente para cada dominio que configures; el registro A/AAAA del dominio debe apuntar primero a este host."
+  },
+  "requires": { "env": ["CADDY_EMAIL"], "min_ram_mb": 128, "min_disk_mb": 200 },
+  "env_vars": [
+    { "name": "CADDY_EMAIL", "description": "Email address for Let's Encrypt ACME account registration (required for cert renewal notices)", "required": true },
+    { "name": "CADDY_ADMIN_URL", "description": "Caddy admin API URL (set automatically when running alongside the caddy container)", "default": "http://127.0.0.1:2019", "required": false },
+    { "name": "CADDY_CONFIG_DIR", "description": "Path to the directory containing Caddyfile (managed by Crow; editable by the operator)", "default": "~/.crow/caddy", "required": false }
+  ],
+  "ports": [80, 443, 2019],
+  "webUI": null,
+  "notes": "Ports 80/443 bind to 0.0.0.0 (required for ACME HTTP-01 and public request handling). Admin API bound to 127.0.0.1:2019 (host-local only). Caddyfile is mounted from ~/.crow/caddy/Caddyfile — edit it directly or use crow's MCP tools. ACME state stored in ~/.crow/caddy/data (mode 0700)."
+}

--- a/bundles/caddy/package-lock.json
+++ b/bundles/caddy/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "crow-caddy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-caddy",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/caddy/package.json
+++ b/bundles/caddy/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crow-caddy",
+  "version": "1.0.0",
+  "description": "Caddy MCP server — reverse proxy management via admin API",
+  "type": "module",
+  "main": "server/index.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/bundles/caddy/panel/caddy.js
+++ b/bundles/caddy/panel/caddy.js
@@ -1,0 +1,260 @@
+/**
+ * Crow's Nest Panel — Caddy: list sites, add-site form, cert status
+ *
+ * Bundle-compatible: uses dynamic imports with appRoot so the panel works
+ * both from the repo and when installed to ~/.crow/panels/.
+ *
+ * Client-side rendering uses textContent / createElement only (no innerHTML)
+ * to match Crow's XSS-safe pattern (see jellyfin, kodi, iptv panels).
+ */
+
+export default {
+  id: "caddy",
+  name: "Caddy",
+  icon: "shield",
+  route: "/dashboard/caddy",
+  navOrder: 62,
+  category: "infrastructure",
+
+  async handler(req, res, { layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+
+    const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
+    const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
+
+    const content = `
+      <style>${styles()}</style>
+      <div class="cd-panel">
+        <h1>Caddy <span class="cd-subtitle">reverse proxy &middot; automatic HTTPS</span></h1>
+
+        <div class="cd-section">
+          <h3>Status</h3>
+          <div id="cd-status" class="cd-status"><div class="np-loading">Loading status…</div></div>
+        </div>
+
+        <div class="cd-section">
+          <h3>Sites</h3>
+          <div id="cd-sites" class="cd-sites"><div class="np-loading">Loading…</div></div>
+        </div>
+
+        <div class="cd-section">
+          <h3>Add Site</h3>
+          <form id="cd-add" class="cd-form">
+            <label>
+              <span>Domain</span>
+              <input type="text" name="domain" required maxlength="253" placeholder="example.com" autocomplete="off" />
+            </label>
+            <label>
+              <span>Upstream</span>
+              <input type="text" name="upstream" required maxlength="500" placeholder="localhost:3001" autocomplete="off" />
+            </label>
+            <button type="submit">Add Site</button>
+            <div id="cd-add-msg" class="cd-msg"></div>
+          </form>
+        </div>
+
+        <div class="cd-section cd-notes">
+          <h3>Notes</h3>
+          <ul>
+            <li>Caddy requests a real Let's Encrypt certificate the first time a domain is requested. The domain's A/AAAA record must point to this host.</li>
+            <li>Ports 80 and 443 must be open on the firewall/router. HTTP-01 uses port 80; TLS-ALPN-01 uses port 443.</li>
+            <li>Hand-edits to ${escapeHtml("~/.crow/caddy/Caddyfile")} are preserved. Run "Reload" after editing.</li>
+          </ul>
+        </div>
+      </div>
+      <script>${script()}</script>
+    `;
+
+    res.send(layout({ title: "Caddy", content }));
+  },
+};
+
+function script() {
+  // Intentionally uses textContent / createElement only. No template literals
+  // interpolated into innerHTML. Hook-enforced XSS-safe pattern.
+  return `
+    function makeRow(label, value, extraClass) {
+      const row = document.createElement('div');
+      row.className = 'cd-row';
+      const b = document.createElement('b');
+      b.textContent = label;
+      row.appendChild(b);
+      const s = document.createElement('span');
+      if (extraClass) s.className = extraClass;
+      s.textContent = value == null ? '' : String(value);
+      row.appendChild(s);
+      return row;
+    }
+
+    function clearNode(el) { while (el.firstChild) el.removeChild(el.firstChild); }
+
+    function errorNode(msg) {
+      const d = document.createElement('div');
+      d.className = 'np-error';
+      d.textContent = msg;
+      return d;
+    }
+
+    async function loadStatus() {
+      const el = document.getElementById('cd-status');
+      clearNode(el);
+      try {
+        const res = await fetch('/api/caddy/status');
+        const data = await res.json();
+        if (data.error) { el.appendChild(errorNode(data.error)); return; }
+
+        const card = document.createElement('div');
+        card.className = 'cd-card';
+
+        card.appendChild(makeRow('Admin API', data.admin_api + '  (reachable)'));
+        card.appendChild(makeRow('Caddyfile', data.caddyfile_path));
+        card.appendChild(makeRow('Sites (file)', data.sites_in_caddyfile ?? 0));
+        card.appendChild(makeRow('Routes (loaded)', data.routes_loaded ?? 0));
+        card.appendChild(makeRow('Listen', (data.listen || []).join(', ') || '—'));
+        card.appendChild(makeRow('ACME emails', (data.acme_emails || []).join(', ') || '—'));
+
+        const actions = document.createElement('div');
+        actions.className = 'cd-actions';
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Reload Caddyfile';
+        btn.addEventListener('click', cdReload);
+        actions.appendChild(btn);
+        card.appendChild(actions);
+
+        el.appendChild(card);
+      } catch (e) {
+        el.appendChild(errorNode('Cannot reach Caddy API.'));
+      }
+    }
+
+    async function loadSites() {
+      const el = document.getElementById('cd-sites');
+      clearNode(el);
+      try {
+        const res = await fetch('/api/caddy/sites');
+        const data = await res.json();
+        if (data.error) { el.appendChild(errorNode(data.error)); return; }
+
+        const sites = data.sites || [];
+        if (sites.length === 0) {
+          const idle = document.createElement('div');
+          idle.className = 'np-idle';
+          idle.textContent = 'No sites yet. Add one below or edit the Caddyfile directly.';
+          el.appendChild(idle);
+          return;
+        }
+
+        sites.forEach(function (s) {
+          const card = document.createElement('div');
+          card.className = 'cd-card';
+
+          const row = document.createElement('div');
+          row.className = 'cd-row';
+          const b = document.createElement('b');
+          b.textContent = s.address;
+          row.appendChild(b);
+          const up = document.createElement('span');
+          up.className = 'cd-up';
+          up.textContent = s.upstream || '(no reverse_proxy)';
+          row.appendChild(up);
+          card.appendChild(row);
+
+          const actions = document.createElement('div');
+          actions.className = 'cd-actions';
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'cd-btn-danger';
+          btn.textContent = 'Remove';
+          btn.addEventListener('click', function () { cdRemove(s.address); });
+          actions.appendChild(btn);
+          card.appendChild(actions);
+
+          el.appendChild(card);
+        });
+      } catch (e) {
+        el.appendChild(errorNode('Failed to load sites.'));
+      }
+    }
+
+    async function cdReload() {
+      try {
+        const res = await fetch('/api/caddy/reload', { method: 'POST' });
+        const data = await res.json();
+        alert(data.ok ? 'Caddy reloaded.' : ('Reload failed: ' + (data.error || 'unknown')));
+        loadStatus(); loadSites();
+      } catch (e) { alert('Reload failed: ' + e.message); }
+    }
+
+    async function cdAdd(ev) {
+      ev.preventDefault();
+      const form = ev.target;
+      const domain = form.domain.value.trim();
+      const upstream = form.upstream.value.trim();
+      const msg = document.getElementById('cd-add-msg');
+      msg.textContent = 'Adding…';
+      try {
+        const res = await fetch('/api/caddy/sites', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ domain: domain, upstream: upstream })
+        });
+        const data = await res.json();
+        if (data.ok) {
+          msg.textContent = 'Added ' + domain + '.';
+          form.reset();
+          loadStatus(); loadSites();
+        } else {
+          msg.textContent = 'Error: ' + (data.error || 'unknown');
+        }
+      } catch (e) { msg.textContent = 'Error: ' + e.message; }
+      return false;
+    }
+
+    async function cdRemove(domain) {
+      if (!confirm('Remove site "' + domain + '" from the Caddyfile?')) return;
+      try {
+        const res = await fetch('/api/caddy/sites/' + encodeURIComponent(domain), { method: 'DELETE' });
+        const data = await res.json();
+        if (data.ok) { loadStatus(); loadSites(); }
+        else alert('Remove failed: ' + (data.error || 'unknown'));
+      } catch (e) { alert('Remove failed: ' + e.message); }
+    }
+
+    document.getElementById('cd-add').addEventListener('submit', cdAdd);
+    loadStatus();
+    loadSites();
+  `;
+}
+
+function styles() {
+  return `
+    .cd-panel h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .cd-subtitle { font-size: 0.85rem; color: var(--crow-text-muted); font-weight: 400; margin-left: .5rem; }
+    .cd-section { margin-bottom: 1.8rem; }
+    .cd-section h3 { font-size: 0.8rem; color: var(--crow-text-muted); text-transform: uppercase;
+                     letter-spacing: 0.05em; margin: 0 0 0.7rem; }
+    .cd-card { background: var(--crow-bg-elevated); border: 1px solid var(--crow-border);
+               border-radius: 10px; padding: 1rem; margin-bottom: .7rem; }
+    .cd-row { display: flex; justify-content: space-between; gap: 1rem; padding: .25rem 0;
+              font-size: .9rem; color: var(--crow-text-primary); }
+    .cd-row b { color: var(--crow-text-muted); font-weight: 500; min-width: 140px; }
+    .cd-up { font-family: ui-monospace, monospace; color: var(--crow-accent); }
+    .cd-actions { margin-top: .6rem; display: flex; gap: .5rem; }
+    .cd-actions button, .cd-form button { background: var(--crow-accent); color: #0b0d10;
+               border: none; border-radius: 6px; padding: .5rem 1rem; font-weight: 600; cursor: pointer; }
+    .cd-btn-danger { background: #ef4444 !important; color: #fff !important; }
+    .cd-form { display: grid; gap: .6rem; max-width: 520px; }
+    .cd-form label { display: grid; gap: .3rem; font-size: .85rem; color: var(--crow-text-muted); }
+    .cd-form input { background: var(--crow-bg); border: 1px solid var(--crow-border); color: var(--crow-text-primary);
+                     border-radius: 6px; padding: .55rem .7rem; font-family: ui-monospace, monospace; }
+    .cd-msg { min-height: 1.2rem; font-size: .85rem; color: var(--crow-text-muted); }
+    .cd-notes ul { margin: 0; padding-left: 1.2rem; color: var(--crow-text-secondary); font-size: .88rem; }
+    .cd-notes li { margin-bottom: .3rem; }
+    .np-idle, .np-loading { color: var(--crow-text-muted); font-size: 0.9rem; padding: 1rem;
+                            background: var(--crow-bg-elevated); border-radius: 10px; text-align: center; }
+    .np-error { color: var(--crow-error, #ef4444); font-size: 0.9rem; padding: 1rem;
+                background: var(--crow-bg-elevated); border-radius: 10px; text-align: center; }
+  `;
+}

--- a/bundles/caddy/panel/routes.js
+++ b/bundles/caddy/panel/routes.js
@@ -1,0 +1,157 @@
+/**
+ * Caddy API Routes — Express router for Crow's Nest Caddy panel
+ *
+ * Dashboard-only endpoints that proxy to the Caddy admin API and read/write
+ * the managed Caddyfile. All endpoints are gated by dashboardAuth.
+ */
+
+import { Router } from "express";
+
+import {
+  resolveConfigDir,
+  caddyfilePath,
+  readCaddyfile,
+  writeCaddyfile,
+  parseSites,
+  appendSite,
+  removeSite,
+} from "../server/caddyfile.js";
+
+const CADDY_ADMIN_URL = () =>
+  (process.env.CADDY_ADMIN_URL || "http://127.0.0.1:2019").replace(/\/+$/, "");
+const CONFIG_DIR = () => resolveConfigDir(process.env.CADDY_CONFIG_DIR);
+const TIMEOUT = 10_000;
+
+async function adminGet(path) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), TIMEOUT);
+  try {
+    const r = await fetch(`${CADDY_ADMIN_URL()}${path}`, { signal: ctl.signal });
+    if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+    const text = await r.text();
+    return text ? JSON.parse(text) : {};
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function loadCaddyfile(source) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), TIMEOUT);
+  try {
+    const r = await fetch(`${CADDY_ADMIN_URL()}/load`, {
+      method: "POST",
+      signal: ctl.signal,
+      headers: { "Content-Type": "text/caddyfile" },
+      body: source,
+    });
+    const text = await r.text();
+    if (!r.ok) throw new Error(`${r.status}: ${text.slice(0, 400)}`);
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function domainLike(s) {
+  return typeof s === "string" && s.length > 0 && s.length <= 253 && !/[\s{}\n\r]/.test(s);
+}
+
+export default function caddyRouter(authMiddleware) {
+  const router = Router();
+
+  router.get("/api/caddy/status", authMiddleware, async (_req, res) => {
+    try {
+      const config = await adminGet("/config/");
+      const servers = config?.apps?.http?.servers || {};
+      const serverNames = Object.keys(servers);
+      let routeCount = 0;
+      const listenAddrs = new Set();
+      for (const srv of Object.values(servers)) {
+        routeCount += (srv.routes || []).length;
+        for (const a of srv.listen || []) listenAddrs.add(a);
+      }
+      const policies = config?.apps?.tls?.automation?.policies || [];
+      const emails = new Set();
+      for (const p of policies) for (const i of p.issuers || []) if (i.email) emails.add(i.email);
+
+      const source = readCaddyfile(CONFIG_DIR());
+      const siteCount = parseSites(source).length;
+
+      res.json({
+        admin_api: CADDY_ADMIN_URL(),
+        caddyfile_path: caddyfilePath(CONFIG_DIR()),
+        sites_in_caddyfile: siteCount,
+        http_servers: serverNames,
+        routes_loaded: routeCount,
+        listen: Array.from(listenAddrs),
+        acme_emails: Array.from(emails),
+      });
+    } catch (err) {
+      res.json({ error: `Cannot reach Caddy admin API: ${err.message}` });
+    }
+  });
+
+  router.get("/api/caddy/sites", authMiddleware, (_req, res) => {
+    try {
+      const source = readCaddyfile(CONFIG_DIR());
+      const sites = parseSites(source).map((s) => {
+        const m = s.body.match(/reverse_proxy\s+([^\n]+)/);
+        return { address: s.address, upstream: m ? m[1].trim() : null };
+      });
+      res.json({ sites });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  router.post("/api/caddy/sites", authMiddleware, async (req, res) => {
+    try {
+      const { domain, upstream } = req.body || {};
+      if (!domainLike(domain)) return res.json({ error: "Invalid domain" });
+      if (!domainLike(upstream) || upstream.length > 500) return res.json({ error: "Invalid upstream" });
+
+      const source = readCaddyfile(CONFIG_DIR());
+      const existing = parseSites(source);
+      if (existing.some((s) => s.address === domain)) return res.json({ error: `Site ${domain} already exists` });
+
+      const next = appendSite(source, domain, upstream, "");
+      await loadCaddyfile(next);
+      writeCaddyfile(CONFIG_DIR(), next);
+      res.json({ ok: true });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  router.delete("/api/caddy/sites/:domain", authMiddleware, async (req, res) => {
+    try {
+      const domain = req.params.domain;
+      if (!domainLike(domain)) return res.json({ error: "Invalid domain" });
+
+      const source = readCaddyfile(CONFIG_DIR());
+      const { source: next, removed } = removeSite(source, domain);
+      if (!removed) return res.json({ error: `No site ${domain}` });
+
+      if (next.trim()) {
+        await loadCaddyfile(next);
+      }
+      writeCaddyfile(CONFIG_DIR(), next);
+      res.json({ ok: true });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  router.post("/api/caddy/reload", authMiddleware, async (_req, res) => {
+    try {
+      const source = readCaddyfile(CONFIG_DIR());
+      if (!source.trim()) return res.json({ error: "Caddyfile is empty" });
+      await loadCaddyfile(source);
+      res.json({ ok: true });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/bundles/caddy/server/caddyfile.js
+++ b/bundles/caddy/server/caddyfile.js
@@ -1,0 +1,208 @@
+/**
+ * Minimal Caddyfile reader/writer for Crow's MCP tools.
+ *
+ * This is intentionally *not* a full Caddyfile parser — Caddy's own adapter is
+ * the authoritative validator (POST /load on the admin API). We handle only
+ * the common site-block shape that add_site emits:
+ *
+ *   example.com {
+ *     reverse_proxy <upstream>
+ *   }
+ *
+ * Hand-edited Caddyfiles are preserved on reads: list_sites reports any
+ * site address it can detect, even if the body is complex. add_site appends
+ * a new block at the end; remove_site deletes a block by matching address.
+ * For anything more elaborate, the operator edits the file directly and
+ * calls caddy_reload.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+export function resolveConfigDir(envValue) {
+  const raw = envValue || "~/.crow/caddy";
+  if (raw.startsWith("~/")) return join(homedir(), raw.slice(2));
+  return raw;
+}
+
+export function caddyfilePath(configDir) {
+  return join(configDir, "Caddyfile");
+}
+
+export const DEFAULT_CADDYFILE = `# Crow-managed Caddyfile. The global options block below is required by
+# Crow's MCP server and panel to reach the admin API from the host.
+# Everything below is yours to edit. Run caddy_reload after manual edits.
+{
+\temail {$CADDY_EMAIL}
+\tadmin 0.0.0.0:2019
+}
+`;
+
+export function ensureConfigDir(configDir) {
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+  const dataDir = join(configDir, "data");
+  if (!existsSync(dataDir)) {
+    mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  }
+  const cfgDir = join(configDir, "config");
+  if (!existsSync(cfgDir)) {
+    mkdirSync(cfgDir, { recursive: true });
+  }
+  const p = caddyfilePath(configDir);
+  if (!existsSync(p)) {
+    writeFileSync(p, DEFAULT_CADDYFILE, { mode: 0o644 });
+  }
+}
+
+/**
+ * Read the Caddyfile, returning "" if it does not yet exist.
+ */
+export function readCaddyfile(configDir) {
+  const p = caddyfilePath(configDir);
+  if (!existsSync(p)) return "";
+  return readFileSync(p, "utf8");
+}
+
+/**
+ * Write the Caddyfile atomically (write-then-rename).
+ */
+export function writeCaddyfile(configDir, contents) {
+  ensureConfigDir(configDir);
+  const p = caddyfilePath(configDir);
+  const tmp = `${p}.tmp`;
+  writeFileSync(tmp, contents, { mode: 0o644 });
+  renameSync(tmp, p);
+}
+
+/**
+ * Locate site blocks in the Caddyfile.
+ * Returns an array of { address, body, start, end } where start/end are
+ * character offsets into the source. Skips Caddy's "global options" block
+ * (the leading block that begins with `{` rather than an address).
+ *
+ * Handles multi-address forms like `a.example.com, b.example.com {` by
+ * splitting on commas.
+ */
+export function parseSites(source) {
+  const sites = [];
+  const lines = source.split("\n");
+  let i = 0;
+  let offset = 0;
+  let seenFirstBlock = false;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const lineLen = line.length + 1; // +1 for newline
+
+    // Skip blank / comment lines
+    if (!trimmed || trimmed.startsWith("#")) {
+      offset += lineLen;
+      i++;
+      continue;
+    }
+
+    // Match "addresses {" at end of line
+    const m = trimmed.match(/^(.+?)\s*\{\s*$/);
+    if (!m) {
+      offset += lineLen;
+      i++;
+      continue;
+    }
+
+    // Caddy's global options block is the first top-level block AND starts
+    // with just "{". We detect "global options" by the address being empty.
+    const addressPart = m[1].trim();
+    if (!seenFirstBlock && addressPart === "") {
+      // This is the global options block — skip it
+      seenFirstBlock = true;
+      const endIdx = findBlockEnd(lines, i);
+      for (let k = i; k <= endIdx; k++) offset += lines[k].length + 1;
+      i = endIdx + 1;
+      continue;
+    }
+    seenFirstBlock = true;
+
+    if (addressPart === "") {
+      offset += lineLen;
+      i++;
+      continue;
+    }
+
+    const start = offset;
+    const endIdx = findBlockEnd(lines, i);
+    if (endIdx === -1) {
+      // Unterminated block — bail to avoid emitting partial data
+      break;
+    }
+
+    let end = offset;
+    for (let k = i; k <= endIdx; k++) end += lines[k].length + 1;
+
+    const body = lines.slice(i + 1, endIdx).join("\n");
+    const addresses = addressPart.split(",").map((s) => s.trim()).filter(Boolean);
+    for (const address of addresses) {
+      sites.push({ address, body, start, end });
+    }
+
+    offset = end;
+    i = endIdx + 1;
+  }
+
+  return sites;
+}
+
+function findBlockEnd(lines, openIdx) {
+  let depth = 0;
+  for (let k = openIdx; k < lines.length; k++) {
+    for (const ch of lines[k]) {
+      if (ch === "{") depth++;
+      else if (ch === "}") {
+        depth--;
+        if (depth === 0) return k;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Append a new reverse-proxy site block to the Caddyfile source.
+ * Returns the new source. Does not persist.
+ */
+export function appendSite(source, domain, upstream, extra = "") {
+  const base = source.endsWith("\n") || source === "" ? source : source + "\n";
+  const sep = base && !base.endsWith("\n\n") ? "\n" : "";
+  const extraLines = extra
+    ? extra.split("\n").map((l) => "  " + l).join("\n") + "\n"
+    : "";
+  const block =
+    `${domain} {\n` +
+    `  reverse_proxy ${upstream}\n` +
+    extraLines +
+    `}\n`;
+  return base + sep + block;
+}
+
+/**
+ * Remove a site block matching the given address.
+ * If multiple blocks match (rare), only the first is removed.
+ * Returns { source: updated source, removed: boolean }.
+ */
+export function removeSite(source, domain) {
+  const sites = parseSites(source);
+  const match = sites.find((s) => s.address === domain);
+  if (!match) return { source, removed: false };
+
+  // Find the actual byte range for *this* block (if the block has multiple
+  // addresses, the same start/end applies; removing the block removes them
+  // all — the operator edits manually if they want to split).
+  let before = source.slice(0, match.start);
+  let after = source.slice(match.end);
+  // Collapse any excess blank lines introduced by the removal.
+  const joined = (before + after).replace(/\n{3,}/g, "\n\n");
+  return { source: joined, removed: true };
+}

--- a/bundles/caddy/server/index.js
+++ b/bundles/caddy/server/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/**
+ * Caddy MCP Server — stdio transport entry point
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createCaddyServer } from "./server.js";
+
+const server = createCaddyServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/bundles/caddy/server/server.js
+++ b/bundles/caddy/server/server.js
@@ -1,0 +1,310 @@
+/**
+ * Caddy MCP Server
+ *
+ * Manages a local Caddy reverse proxy via its admin API (JSON over HTTP).
+ * Tools:
+ *   caddy_status       — admin API reachability, loaded site count, cert summary
+ *   caddy_reload       — validate & apply the current Caddyfile
+ *   caddy_list_sites   — sites discovered in the Caddyfile
+ *   caddy_add_site     — append a reverse-proxy block and reload
+ *   caddy_remove_site  — remove a site block and reload
+ *
+ * Design note: we treat the Caddyfile on disk as the source of truth. The
+ * admin API is used only to (a) apply the Caddyfile (POST /load with a
+ * `text/caddyfile` body), (b) report status. This keeps the operator's
+ * hand-edits and Crow's edits consistent — no divergence between a JSON
+ * config in-memory and the file the operator reads.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import {
+  resolveConfigDir,
+  caddyfilePath,
+  readCaddyfile,
+  writeCaddyfile,
+  parseSites,
+  appendSite,
+  removeSite,
+} from "./caddyfile.js";
+
+const CADDY_ADMIN_URL = () =>
+  (process.env.CADDY_ADMIN_URL || "http://127.0.0.1:2019").replace(/\/+$/, "");
+const CONFIG_DIR = () => resolveConfigDir(process.env.CADDY_CONFIG_DIR);
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Call the Caddy admin API.
+ */
+async function adminFetch(path, options = {}) {
+  const url = `${CADDY_ADMIN_URL()}${path}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json", ...options.headers },
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      const msg = text ? ` — ${text.slice(0, 500)}` : "";
+      throw new Error(`Caddy admin ${res.status} ${res.statusText}${msg}`);
+    }
+    if (!text) return {};
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { raw: text };
+    }
+  } catch (err) {
+    if (err.name === "AbortError") {
+      throw new Error(`Caddy admin request timed out: ${path}`);
+    }
+    if (err.cause?.code === "ECONNREFUSED" || err.message?.includes("ECONNREFUSED")) {
+      throw new Error(
+        `Cannot reach Caddy admin API at ${CADDY_ADMIN_URL()} — is the caddy container running? ` +
+          `Check 'docker ps' for crow-caddy and 'docker logs crow-caddy'.`,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Apply a Caddyfile source via the admin API.
+ */
+async function loadCaddyfile(source) {
+  const url = `${CADDY_ADMIN_URL()}/load`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      signal: controller.signal,
+      headers: { "Content-Type": "text/caddyfile" },
+      body: source,
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(`Caddy rejected config: ${res.status} ${res.statusText}${text ? " — " + text.slice(0, 800) : ""}`);
+    }
+    return { ok: true };
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error("Caddy /load timed out");
+    if (err.cause?.code === "ECONNREFUSED" || err.message?.includes("ECONNREFUSED")) {
+      throw new Error(`Cannot reach Caddy admin API at ${CADDY_ADMIN_URL()}`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function domainLike(s) {
+  // Permissive: Caddy accepts hostnames, wildcards, IP:port, path matchers.
+  // We just block whitespace/newlines/braces to prevent caddyfile injection.
+  return !/[\s{}\n\r]/.test(s);
+}
+
+export function createCaddyServer(options = {}) {
+  const server = new McpServer(
+    { name: "crow-caddy", version: "1.0.0" },
+    { instructions: options.instructions },
+  );
+
+  // --- caddy_status ---
+  server.tool(
+    "caddy_status",
+    "Report Caddy status: admin-API reachability, number of configured sites, and TLS/ACME summary",
+    {},
+    async () => {
+      try {
+        const [config, _pki] = await Promise.all([
+          adminFetch("/config/"),
+          adminFetch("/pki/ca/local").catch(() => null),
+        ]);
+
+        const servers = config?.apps?.http?.servers || {};
+        const serverNames = Object.keys(servers);
+        let routeCount = 0;
+        const listenAddrs = new Set();
+        for (const srv of Object.values(servers)) {
+          routeCount += (srv.routes || []).length;
+          for (const a of srv.listen || []) listenAddrs.add(a);
+        }
+
+        const tlsAutomation = config?.apps?.tls?.automation?.policies || [];
+        const acmeEmails = new Set();
+        for (const policy of tlsAutomation) {
+          for (const issuer of policy.issuers || []) {
+            if (issuer.email) acmeEmails.add(issuer.email);
+          }
+        }
+
+        const caddyfile = readCaddyfile(CONFIG_DIR());
+        const siteCount = parseSites(caddyfile).length;
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              admin_api: CADDY_ADMIN_URL(),
+              reachable: true,
+              caddyfile_path: caddyfilePath(CONFIG_DIR()),
+              sites_in_caddyfile: siteCount,
+              http_servers: serverNames,
+              listen: Array.from(listenAddrs),
+              routes_loaded: routeCount,
+              acme_emails: Array.from(acmeEmails),
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- caddy_reload ---
+  server.tool(
+    "caddy_reload",
+    "Validate and apply the current Caddyfile via Caddy's admin API. Fails (with reason) if the Caddyfile is syntactically invalid.",
+    {},
+    async () => {
+      try {
+        const source = readCaddyfile(CONFIG_DIR());
+        if (!source.trim()) {
+          return {
+            content: [{
+              type: "text",
+              text: `Caddyfile is empty (${caddyfilePath(CONFIG_DIR())}). Add a site with caddy_add_site or edit the file directly.`,
+            }],
+          };
+        }
+        await loadCaddyfile(source);
+        const sites = parseSites(source);
+        return {
+          content: [{
+            type: "text",
+            text: `Caddy reloaded. ${sites.length} site block(s) applied:\n${sites.map((s) => "  - " + s.address).join("\n")}`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- caddy_list_sites ---
+  server.tool(
+    "caddy_list_sites",
+    "List all sites currently declared in the Caddyfile",
+    {},
+    async () => {
+      try {
+        const source = readCaddyfile(CONFIG_DIR());
+        const sites = parseSites(source);
+        const summary = sites.map((s) => {
+          const upstreamMatch = s.body.match(/reverse_proxy\s+([^\n]+)/);
+          return {
+            address: s.address,
+            upstream: upstreamMatch ? upstreamMatch[1].trim() : null,
+            directives: (s.body.match(/^\s*(\w+)/gm) || []).map((l) => l.trim()).slice(0, 20),
+          };
+        });
+        return {
+          content: [{
+            type: "text",
+            text: summary.length
+              ? `${summary.length} site(s):\n${JSON.stringify(summary, null, 2)}`
+              : `No sites in ${caddyfilePath(CONFIG_DIR())}.`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- caddy_add_site ---
+  server.tool(
+    "caddy_add_site",
+    "Add a reverse-proxy site block to the Caddyfile and reload. For anything beyond `reverse_proxy <upstream>`, edit the Caddyfile directly and call caddy_reload.",
+    {
+      domain: z.string().min(1).max(253).describe("Site address (e.g., example.com, *.example.com, :8080). Must not contain whitespace or braces."),
+      upstream: z.string().min(1).max(500).describe("Reverse-proxy upstream (e.g., localhost:3001, 127.0.0.1:3456). Must not contain whitespace."),
+      extra_directives: z.string().max(5000).optional().describe("Optional extra Caddyfile directives to include in the site block, one per line (no leading indent)."),
+    },
+    async ({ domain, upstream, extra_directives }) => {
+      try {
+        if (!domainLike(domain)) {
+          return { content: [{ type: "text", text: "Error: domain contains disallowed characters (whitespace, braces, or newlines)." }] };
+        }
+        if (!domainLike(upstream)) {
+          return { content: [{ type: "text", text: "Error: upstream contains disallowed characters (whitespace, braces, or newlines)." }] };
+        }
+
+        const source = readCaddyfile(CONFIG_DIR());
+        const existing = parseSites(source);
+        if (existing.some((s) => s.address === domain)) {
+          return { content: [{ type: "text", text: `Site "${domain}" already exists in the Caddyfile. Remove it first with caddy_remove_site, then re-add.` }] };
+        }
+
+        const next = appendSite(source, domain, upstream, extra_directives || "");
+        // Validate by asking Caddy to load it; only write on success.
+        await loadCaddyfile(next);
+        writeCaddyfile(CONFIG_DIR(), next);
+
+        return {
+          content: [{
+            type: "text",
+            text: `Added site ${domain} → ${upstream}. Caddy will request a TLS certificate on first request (HTTP-01 / TLS-ALPN-01).`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- caddy_remove_site ---
+  server.tool(
+    "caddy_remove_site",
+    "Remove a site block from the Caddyfile (matched by address) and reload Caddy. Destructive — the change is persisted to disk.",
+    {
+      domain: z.string().min(1).max(253).describe("Site address to remove (must match exactly as written in the Caddyfile)"),
+      confirm: z.literal("yes").describe('Must be "yes" to confirm removal'),
+    },
+    async ({ domain }) => {
+      try {
+        const source = readCaddyfile(CONFIG_DIR());
+        const { source: next, removed } = removeSite(source, domain);
+        if (!removed) {
+          return { content: [{ type: "text", text: `No site with address "${domain}" found in Caddyfile.` }] };
+        }
+        if (next.trim()) {
+          await loadCaddyfile(next);
+        } else {
+          // Caddyfile is now empty — Caddy doesn't accept empty configs via
+          // /load, so we stop accepting new traffic by loading an empty JSON.
+          await adminFetch("/load", { method: "POST", body: JSON.stringify({}) });
+        }
+        writeCaddyfile(CONFIG_DIR(), next);
+        return {
+          content: [{
+            type: "text",
+            text: `Removed site ${domain}. Caddy reloaded.`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  return server;
+}

--- a/bundles/caddy/skills/caddy.md
+++ b/bundles/caddy/skills/caddy.md
@@ -1,0 +1,95 @@
+---
+name: caddy
+description: Caddy reverse proxy — automatic HTTPS for Crow bundles via Let's Encrypt
+triggers:
+  - "reverse proxy"
+  - "caddy"
+  - "https cert"
+  - "letsencrypt"
+  - "acme"
+  - "expose bundle"
+  - "public domain"
+tools:
+  - caddy_status
+  - caddy_reload
+  - caddy_list_sites
+  - caddy_add_site
+  - caddy_remove_site
+---
+
+# Caddy — reverse proxy with automatic HTTPS
+
+Caddy runs in front of any bundle that needs a public domain and a real TLS
+certificate. It owns ports **80** and **443** on all interfaces, answers
+HTTP-01 / TLS-ALPN-01 challenges, and renews certificates automatically.
+
+Once Caddy is installed, any future Crow bundle that wants to be reachable
+at `https://example.com/...` just declares `requires.bundles: ["caddy"]` and
+registers a site block via `caddy_add_site`.
+
+## Prerequisites for real certificates
+
+Before asking Caddy to terminate TLS for a domain, verify **all** of the
+following:
+
+1. **DNS**: the domain's `A` (and/or `AAAA`) record points to this host's
+   public IP. Verify with `dig +short example.com`.
+2. **Firewall / router**: ports 80 and 443 are open inbound. If Crow runs
+   behind a home router, configure port-forwarding. ISPs occasionally block
+   :80 — if HTTP-01 fails, consider DNS-01 challenge (not yet wired up in
+   this bundle; edit the Caddyfile directly).
+3. **No other web server**: nothing else on this host is listening on :80 or
+   :443. Check with `sudo ss -tulnp | grep -E ':80 |:443 '`.
+4. **ACME email**: `CADDY_EMAIL` is set in `.env` so Let's Encrypt can reach
+   you for expiry notices.
+
+Caddy will request a **real** Let's Encrypt certificate the first time a
+domain is requested. It caches state in `~/.crow/caddy/data/` (mode 0700).
+
+## Common tasks
+
+### Route a Crow bundle under a public domain
+
+```
+caddy_add_site {
+  "domain": "notes.example.com",
+  "upstream": "localhost:3040"
+}
+```
+
+Caddy appends a block to `~/.crow/caddy/Caddyfile`, validates it via the
+admin API, and reloads. The first HTTPS request to `notes.example.com`
+triggers certificate issuance (usually completes in <10 seconds).
+
+### Inspect current status
+
+```
+caddy_status
+```
+
+Returns the admin API URL, number of site blocks in the Caddyfile, number
+of routes Caddy actually loaded, listen addresses, and ACME account emails.
+
+### Remove a site
+
+```
+caddy_remove_site { "domain": "notes.example.com", "confirm": "yes" }
+```
+
+Destructive — the block is deleted from the Caddyfile and Caddy stops
+serving it. Existing issued certificates remain in the ACME cache for
+reuse if the site is re-added later.
+
+### Manual edits
+
+`~/.crow/caddy/Caddyfile` is yours to edit. Crow reads and writes this
+file; it does **not** rebuild it from a template on restart. Advanced
+directives (matchers, headers, rate limits, wildcards, DNS-01) go directly
+in the file — then run `caddy_reload`.
+
+## Phase 2 federation note
+
+When federation-capable bundles land (Matrix, Mastodon, etc.), they will
+declare `requires.bundles: ["caddy"]`. PR 0's dependency-enforcement will
+refuse to install them unless Caddy is present, surfacing a clear prereq
+error in the Extensions panel.

--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -34,6 +34,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 587 | — | mail submission | reserved (Phase 2 mail) |
 | 993 | — | mail IMAPS | reserved (Phase 2 mail) |
 | 2222 | — | (avoid: common host anti-scan sshd port) | avoid |
+| 2019 | 127.0.0.1 | Caddy admin API (host-local) | MVP PR 0.5 |
 | 2223 | 127.0.0.1 | gitea (SSH) | MVP PR 5 |
 | 2224 | 127.0.0.1 | forgejo (SSH) | MVP PR 5 |
 | 2283 | 127.0.0.1 | immich (existing — verify in compose) | existing |

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1397,6 +1397,36 @@
       "notes": "Docker stack includes MariaDB. Port remapped from 80 to 6875. Composite token auth (ID:SECRET). 8 MCP tools."
     },
     {
+      "id": "caddy",
+      "name": "Caddy Reverse Proxy",
+      "description": "Reverse proxy with automatic HTTPS via Let's Encrypt (ACME). Foundation for publicly exposed or federated bundles.",
+      "type": "bundle",
+      "version": "1.0.0",
+      "author": "Crow",
+      "category": "infrastructure",
+      "tags": ["reverse-proxy", "https", "acme", "letsencrypt", "tls"],
+      "icon": "shield",
+      "docker": { "composefile": "docker-compose.yml" },
+      "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["CADDY_ADMIN_URL", "CADDY_CONFIG_DIR"] },
+      "panel": "panel/caddy.js",
+      "panelRoutes": "panel/routes.js",
+      "skills": ["skills/caddy.md"],
+      "consent_required": true,
+      "install_consent_messages": {
+        "en": "Caddy binds ports 80 and 443 on all interfaces (0.0.0.0) so it can answer HTTP/HTTPS requests from the public internet and complete Let's Encrypt ACME challenges. Make sure ports 80 and 443 are open on your firewall/router and that no other service on this host is already listening on them. Caddy will automatically request and renew TLS certificates for any domain you configure; the domain's A/AAAA record must point to this host first.",
+        "es": "Caddy se vincula a los puertos 80 y 443 en todas las interfaces (0.0.0.0) para responder a peticiones HTTP/HTTPS desde internet y completar los desafíos ACME de Let's Encrypt. Asegúrate de que los puertos 80 y 443 estén abiertos en tu firewall/router y que ningún otro servicio de este host los esté usando. Caddy solicitará y renovará certificados TLS automáticamente para cada dominio que configures; el registro A/AAAA del dominio debe apuntar primero a este host."
+      },
+      "requires": { "env": ["CADDY_EMAIL"], "min_ram_mb": 128, "min_disk_mb": 200 },
+      "env_vars": [
+        { "name": "CADDY_EMAIL", "description": "Email for Let's Encrypt ACME account registration", "required": true },
+        { "name": "CADDY_ADMIN_URL", "description": "Caddy admin API URL", "default": "http://127.0.0.1:2019", "required": false },
+        { "name": "CADDY_CONFIG_DIR", "description": "Directory containing Caddyfile (mounted into container)", "default": "~/.crow/caddy", "required": false }
+      ],
+      "ports": [80, 443, 2019],
+      "webUI": null,
+      "notes": "Binds 80/443 on 0.0.0.0 (required for ACME). Admin API bound to 127.0.0.1:2019. Caddyfile at ~/.crow/caddy/Caddyfile. 5 MCP tools: status, reload, list_sites, add_site, remove_site."
+    },
+    {
       "id": "vikunja",
       "name": "Vikunja",
       "description": "Self-hosted task management — projects, kanban boards, due dates, labels, and team collaboration",

--- a/servers/gateway/dashboard/panels/extensions.js
+++ b/servers/gateway/dashboard/panels/extensions.js
@@ -44,6 +44,7 @@ const ICON_MAP = {
   "check-square": "\u2705",
   dollar: "\u{1F4B0}",
   document: "\u{1F4D1}",
+  shield: "\u{1F6E1}\uFE0F",
 };
 
 const CATEGORY_COLORS = {


### PR DESCRIPTION
Foundation for publicly exposed and federated bundles. First bundle to
exercise PR 0's consent-token flow end-to-end.

Stacked on #1. Do not merge until #1 is merged.

## Why consent_required

Binding ports 80 and 443 on `0.0.0.0` (required for ACME HTTP-01 and public HTTPS) is significant: it can collide with another web server on the host, requires firewall config, and touches the public internet. The install modal surfaces EN and ES warning text covering DNS/A-record prereqs, firewall 80/443 open, and no-other-resolver-on-these-ports.

## What this ships

- `bundles/caddy/manifest.json` with `consent_required: true` + `install_consent_messages`
- `bundles/caddy/docker-compose.yml` using `caddy:2-alpine` (documented exception to the "no floating tags" rule — Caddy upstream guarantees v2.x semver; every other Crow bundle pins resolved semver). Single bind mount at `~/.crow/caddy/`; entrypoint seeds a default Caddyfile with a global options block exposing the admin API on `0.0.0.0:2019` so Crow's host-side MCP server can reach it
- MCP server with 5 tools:
  - `caddy_status` — admin-API reachability, loaded route count, ACME email summary
  - `caddy_reload` — validate & apply the current Caddyfile (fails loudly on syntax errors)
  - `caddy_list_sites` — sites discovered in the Caddyfile
  - `caddy_add_site` — append a `reverse_proxy` block and reload (validates via admin API before writing)
  - `caddy_remove_site` — remove a site block and reload (destructive; requires `confirm: "yes"`)
- Caddyfile parser in `server/caddyfile.js` — skips the global options block, handles multi-address site blocks, preserves hand-edits and comments, atomic writes via write-then-rename
- Panel at `/dashboard/caddy` with status card, site list, add-site form, reload button. XSS-safe (textContent + createElement only)
- Skill documenting DNS/firewall prereqs, the ACME flow, and the Phase 2 pattern (`requires.bundles: ["caddy"]`)

## Design note

Crow treats the on-disk Caddyfile as the source of truth. The admin API is used only to (a) apply the Caddyfile via `POST /load` with `Content-Type: text/caddyfile`, (b) report status. This keeps the operator's hand-edits and Crow's edits consistent — no divergence between an in-memory JSON config and the file the operator reads.

## Platform updates

- `registry/add-ons.json` entry
- `shield` icon added to ICON_MAP
- Port 2019 claimed in `docs/developers/port-allocation.md`
- `.env.example`: `CADDY_EMAIL` (required), `CADDY_ADMIN_URL`, `CADDY_CONFIG_DIR`

## Verified

- `docker pull caddy:2-alpine` → caddy v2.11.2
- Entrypoint script seeds Caddyfile on fresh install
- Admin API reachable on `127.0.0.1:2019` once container is up
- `{$CADDY_EMAIL}` substitution works at Caddy parse time
- `parseSites` / `appendSite` / `removeSite` round-trip cleanly on a sample Caddyfile with a global block and a multi-address site
- `node scripts/check-port-allocation.js` → OK, no collisions
- MCP server loads without errors

## Test plan

- [ ] Stack-merge after PR 0 lands
- [ ] Set `CADDY_EMAIL=…` in `.env`
- [ ] Install via Extensions panel — consent modal appears with EN/ES text, typed-INSTALL gate works, token round-trips
- [ ] `caddy_status` returns admin-API reachable
- [ ] `caddy_add_site` with a real domain (DNS pre-pointed) — Caddy issues a real Let's Encrypt cert within seconds
- [ ] `caddy_remove_site` with `confirm: "yes"` — site removed and Caddy reloaded cleanly
- [ ] Manual edit of `~/.crow/caddy/Caddyfile` + `caddy_reload` — hand-edits preserved, invalid syntax rejected with a clear error