### PR TITLE
PR 3: AdGuard Home bundle (DNS ad blocker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,3 +169,15 @@ CROW_FILES_PATH=/home
 # Directory holding Caddyfile, data/ (ACME state, mode 0700), and config/.
 # Defaults to ~/.crow/caddy. Mounted into the caddy container.
 # CADDY_CONFIG_DIR=~/.crow/caddy
+
+# ── ADGUARD HOME (PR 3 — DNS ad blocker) ─────────────────
+
+# Admin URL. Defaults to http://localhost:3020.
+# ADGUARD_URL=http://localhost:3020
+
+# Credentials set during the first-run wizard at localhost:3020.
+# ADGUARD_USERNAME=
+# ADGUARD_PASSWORD=
+
+# Optional: override the bind-mount base path (default ~/.crow/adguard-home).
+# ADGUARD_CONFIG_DIR=~/.crow/adguard-home

--- a/bundles/adguard-home/docker-compose.yml
+++ b/bundles/adguard-home/docker-compose.yml
@@ -1,0 +1,37 @@
+# AdGuard Home — network-wide DNS-based ad/tracker blocking.
+#
+# Pinned to v0.107.73 (current stable at time of authoring).
+#
+# Ports (all 127.0.0.1-bound by default):
+#   3020 → 3000 admin UI (also the initial-setup wizard endpoint)
+#   5335 → 53   DNS (UDP + TCP). Non-standard host port so we don't collide
+#               with systemd-resolved / libnss on port 53. Clients that need
+#               AdGuard's DNS explicitly target 127.0.0.1:5335, or you edit
+#               this file to bind :53:53 on 0.0.0.0 after confirming no
+#               other resolver is listening.
+#   8530 → 853  DNS-over-TLS (for future when the admin configures certs).
+#
+# Volumes bind-mount ~/.crow/adguard-home/ so config and filter lists are
+# user-inspectable and back-upable.
+
+services:
+  adguard:
+    image: adguard/adguardhome:v0.107.73
+    container_name: crow-adguard
+    ports:
+      - "127.0.0.1:3020:3000"
+      - "127.0.0.1:5335:53/tcp"
+      - "127.0.0.1:5335:53/udp"
+      - "127.0.0.1:8530:853/tcp"
+    volumes:
+      - ${ADGUARD_CONFIG_DIR:-~/.crow/adguard-home}/work:/opt/adguardhome/work
+      - ${ADGUARD_CONFIG_DIR:-~/.crow/adguard-home}/conf:/opt/adguardhome/conf
+    init: true
+    mem_limit: 384m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 15s

--- a/bundles/adguard-home/manifest.json
+++ b/bundles/adguard-home/manifest.json
@@ -1,0 +1,25 @@
+{
+  "id": "adguard-home",
+  "name": "AdGuard Home",
+  "version": "1.0.0",
+  "description": "Network-wide ads and tracker blocking DNS server. Filters queries with user-configurable blocklists and serves the admin UI in the browser.",
+  "type": "bundle",
+  "author": "Crow",
+  "category": "networking",
+  "tags": ["dns", "adblock", "privacy", "network", "security"],
+  "icon": "shield",
+  "docker": { "composefile": "docker-compose.yml" },
+  "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["ADGUARD_URL", "ADGUARD_USERNAME", "ADGUARD_PASSWORD"] },
+  "panel": "panel/adguard-home.js",
+  "panelRoutes": "panel/routes.js",
+  "skills": ["skills/adguard-home.md"],
+  "requires": { "env": ["ADGUARD_USERNAME", "ADGUARD_PASSWORD"], "min_ram_mb": 256, "min_disk_mb": 200 },
+  "env_vars": [
+    { "name": "ADGUARD_URL", "description": "AdGuard Home admin URL", "default": "http://localhost:3020", "required": false },
+    { "name": "ADGUARD_USERNAME", "description": "Admin username (set during initial setup wizard)", "required": true },
+    { "name": "ADGUARD_PASSWORD", "description": "Admin password (set during initial setup wizard)", "required": true, "secret": true }
+  ],
+  "ports": [3020, 5335, 8530],
+  "webUI": { "port": 3020, "path": "/", "label": "AdGuard Home" },
+  "notes": "First-boot: open http://localhost:3020 and complete the setup wizard. Bind admin to port 3000 (container), DNS to port 53, and set admin credentials — then copy them into .env. DNS port exposed on 127.0.0.1:5335 to avoid conflicting with systemd-resolved on host. To serve DNS to your LAN, edit the compose to bind 0.0.0.0:53 (significant — plan the host firewall and upstream DNS redirect first)."
+}

--- a/bundles/adguard-home/package-lock.json
+++ b/bundles/adguard-home/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "crow-adguard-home",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-adguard-home",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/adguard-home/package.json
+++ b/bundles/adguard-home/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crow-adguard-home",
+  "version": "1.0.0",
+  "description": "AdGuard Home MCP server — DNS filtering stats, query log, and rule management",
+  "type": "module",
+  "main": "server/index.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/bundles/adguard-home/panel/adguard-home.js
+++ b/bundles/adguard-home/panel/adguard-home.js
@@ -1,0 +1,161 @@
+/**
+ * Crow's Nest Panel — AdGuard Home: stats overview + web UI.
+ * XSS-safe: textContent + createElement only.
+ */
+
+export default {
+  id: "adguard-home",
+  name: "AdGuard Home",
+  icon: "shield",
+  route: "/dashboard/adguard-home",
+  navOrder: 66,
+  category: "networking",
+
+  async handler(req, res, { layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+    const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
+    const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
+
+    const tab = req.query.tab || "overview";
+    const tabs = [
+      { id: "overview", label: "Overview" },
+      { id: "webui", label: "Web UI" },
+    ];
+    const tabBar = `<div class="ag-tabs">${tabs.map((t) =>
+      `<a href="?tab=${escapeHtml(t.id)}" class="ag-tab${tab === t.id ? " active" : ""}">${escapeHtml(t.label)}</a>`
+    ).join("")}</div>`;
+
+    let body = "";
+    if (tab === "webui") {
+      const url = (process.env.ADGUARD_URL || "http://localhost:3020").replace(/\/+$/, "");
+      body = `<div class="ag-webui"><iframe src="${escapeHtml(url)}" class="ag-iframe" allow="fullscreen"></iframe></div>`;
+    } else {
+      body = `
+        <div class="ag-section">
+          <h3>Status</h3>
+          <div id="ag-status"><div class="np-loading">Loading…</div></div>
+        </div>
+        <div class="ag-section">
+          <h3>Top Blocked Domains (24h)</h3>
+          <div id="ag-blocked"><div class="np-loading">Loading…</div></div>
+        </div>
+      `;
+    }
+
+    const content = `
+      <style>${styles()}</style>
+      <div class="ag-panel">
+        <h1>AdGuard Home <span class="ag-subtitle">DNS filtering</span></h1>
+        ${tabBar}
+        <div class="ag-body">${body}</div>
+      </div>
+      <script>${script()}</script>
+    `;
+    res.send(layout({ title: "AdGuard Home", content }));
+  },
+};
+
+function script() {
+  return `
+    function clearNode(el) { while (el.firstChild) el.removeChild(el.firstChild); }
+    function errorNode(msg) { const d = document.createElement('div'); d.className = 'np-error'; d.textContent = msg; return d; }
+    function idleNode(msg) { const d = document.createElement('div'); d.className = 'np-idle'; d.textContent = msg; return d; }
+
+    function statCard(label, value, warnClass) {
+      const c = document.createElement('div');
+      c.className = 'ag-card' + (warnClass ? ' ' + warnClass : '');
+      const v = document.createElement('div');
+      v.className = 'ag-val';
+      v.textContent = value == null ? '—' : String(value);
+      c.appendChild(v);
+      const l = document.createElement('div');
+      l.className = 'ag-label';
+      l.textContent = label;
+      c.appendChild(l);
+      return c;
+    }
+
+    async function loadStatus() {
+      const el = document.getElementById('ag-status');
+      if (!el) return;
+      clearNode(el);
+      try {
+        const res = await fetch('/api/adguard/status');
+        const d = await res.json();
+        if (d.error) { el.appendChild(errorNode(d.error)); return; }
+        const grid = document.createElement('div');
+        grid.className = 'ag-grid';
+        grid.appendChild(statCard('Version', d.version || '—'));
+        grid.appendChild(statCard('Protection', d.protection_enabled ? 'On' : 'Off', d.protection_enabled ? '' : 'ag-warn'));
+        grid.appendChild(statCard('Queries (24h)', d.num_dns_queries_today != null ? d.num_dns_queries_today.toLocaleString() : '—'));
+        grid.appendChild(statCard('Blocked (24h)', d.num_blocked_filtering_today != null ? d.num_blocked_filtering_today.toLocaleString() : '—'));
+        grid.appendChild(statCard('Filter Lists', (d.filter_lists_enabled ?? 0) + '/' + (d.filter_lists_total ?? 0)));
+        grid.appendChild(statCard('Rules', d.filter_rules_total != null ? d.filter_rules_total.toLocaleString() : '—'));
+        el.appendChild(grid);
+      } catch (e) {
+        el.appendChild(errorNode('Cannot reach AdGuard Home.'));
+      }
+    }
+
+    async function loadBlocked() {
+      const el = document.getElementById('ag-blocked');
+      if (!el) return;
+      clearNode(el);
+      try {
+        const res = await fetch('/api/adguard/top-blocked');
+        const d = await res.json();
+        if (d.error) { el.appendChild(errorNode(d.error)); return; }
+        const items = d.top_blocked || [];
+        if (items.length === 0) { el.appendChild(idleNode('No blocked queries yet (needs real DNS traffic).')); return; }
+        items.forEach(function (item) {
+          const row = document.createElement('div');
+          row.className = 'ag-row';
+          const name = document.createElement('span');
+          name.textContent = item.name;
+          const count = document.createElement('span');
+          count.className = 'ag-count';
+          count.textContent = item.count.toLocaleString();
+          row.appendChild(name);
+          row.appendChild(count);
+          el.appendChild(row);
+        });
+      } catch (e) {
+        el.appendChild(errorNode('Failed to load blocked domains.'));
+      }
+    }
+
+    if (document.getElementById('ag-status')) loadStatus();
+    if (document.getElementById('ag-blocked')) loadBlocked();
+  `;
+}
+
+function styles() {
+  return `
+    .ag-panel h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .ag-subtitle { font-size: .85rem; color: var(--crow-text-muted); font-weight: 400; margin-left: .5rem; }
+    .ag-tabs { display: flex; border-bottom: 1px solid var(--crow-border); margin-bottom: 1.5rem; }
+    .ag-tab { padding: .6rem 1.2rem; color: var(--crow-text-secondary); text-decoration: none;
+              border-bottom: 2px solid transparent; }
+    .ag-tab.active { color: var(--crow-accent); border-bottom-color: var(--crow-accent); }
+    .ag-section { margin-bottom: 1.6rem; }
+    .ag-section h3 { font-size: .8rem; color: var(--crow-text-muted); text-transform: uppercase;
+                     letter-spacing: .05em; margin: 0 0 .6rem; }
+    .ag-grid { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .ag-card { background: var(--crow-bg-elevated); border: 1px solid var(--crow-border);
+               border-radius: 10px; padding: 1rem 1.2rem; min-width: 120px; text-align: center; }
+    .ag-card.ag-warn { border-color: #f59e0b; }
+    .ag-card.ag-warn .ag-val { color: #f59e0b; }
+    .ag-val { font-size: 1.4rem; font-weight: 700; color: var(--crow-accent); }
+    .ag-label { font-size: .8rem; color: var(--crow-text-muted); margin-top: .2rem; }
+    .ag-row { display: flex; justify-content: space-between; padding: .4rem .7rem; border-radius: 6px;
+              background: var(--crow-bg-elevated); margin-bottom: .3rem; font-size: .9rem; }
+    .ag-count { color: var(--crow-accent); font-family: ui-monospace, monospace; }
+    .ag-webui { width: 100%; height: calc(100vh - 220px); min-height: 500px; }
+    .ag-iframe { width: 100%; height: 100%; border: none; border-radius: 10px; background: var(--crow-bg-elevated); }
+    .np-idle, .np-loading { color: var(--crow-text-muted); padding: 1rem;
+                            background: var(--crow-bg-elevated); border-radius: 10px; text-align: center; }
+    .np-error { color: #ef4444; padding: 1rem;
+                background: var(--crow-bg-elevated); border-radius: 10px; text-align: center; }
+  `;
+}

--- a/bundles/adguard-home/panel/routes.js
+++ b/bundles/adguard-home/panel/routes.js
@@ -1,0 +1,70 @@
+import { Router } from "express";
+
+const ADGUARD_URL = () =>
+  (process.env.ADGUARD_URL || "http://localhost:3020").replace(/\/+$/, "");
+
+function authHeader() {
+  const u = process.env.ADGUARD_USERNAME || "";
+  const p = process.env.ADGUARD_PASSWORD || "";
+  if (!u || !p) return null;
+  return "Basic " + Buffer.from(`${u}:${p}`).toString("base64");
+}
+
+async function agGet(path) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), 10_000);
+  const auth = authHeader();
+  try {
+    const r = await fetch(`${ADGUARD_URL()}${path}`, {
+      signal: ctl.signal,
+      headers: auth ? { Authorization: auth } : {},
+    });
+    if (r.status === 401 || r.status === 403) throw new Error("Auth failed — check ADGUARD_USERNAME and ADGUARD_PASSWORD");
+    if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+    const text = await r.text();
+    return text ? JSON.parse(text) : {};
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export default function adguardRouter(authMiddleware) {
+  const router = Router();
+
+  router.get("/api/adguard/status", authMiddleware, async (_req, res) => {
+    try {
+      const [status, stats, filters] = await Promise.all([
+        agGet("/control/status"),
+        agGet("/control/stats").catch(() => ({})),
+        agGet("/control/filtering/status").catch(() => ({})),
+      ]);
+      res.json({
+        version: status.version,
+        protection_enabled: status.protection_enabled,
+        running: status.running,
+        num_dns_queries_today: stats.num_dns_queries ?? null,
+        num_blocked_filtering_today: stats.num_blocked_filtering ?? null,
+        filter_lists_enabled: (filters.filters || []).filter((f) => f.enabled).length,
+        filter_lists_total: (filters.filters || []).length,
+        filter_rules_total: filters.filters?.reduce((sum, f) => sum + (f.rules_count || 0), 0) ?? null,
+      });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  router.get("/api/adguard/top-blocked", authMiddleware, async (_req, res) => {
+    try {
+      const stats = await agGet("/control/stats");
+      const top = (stats.top_blocked_domains || []).slice(0, 10).map((d) => {
+        const [name, count] = Object.entries(d)[0];
+        return { name, count };
+      });
+      res.json({ top_blocked: top });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/bundles/adguard-home/server/index.js
+++ b/bundles/adguard-home/server/index.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createAdguardServer } from "./server.js";
+
+const server = createAdguardServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/bundles/adguard-home/server/server.js
+++ b/bundles/adguard-home/server/server.js
@@ -1,0 +1,195 @@
+/**
+ * AdGuard Home MCP Server
+ *
+ * Wraps the /control/* HTTP API (well documented at
+ * https://github.com/AdguardTeam/AdGuardHome/wiki/API). Tools intentionally
+ * avoid anything destructive by default — toggle_protection requires a
+ * confirm literal.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const ADGUARD_URL = () =>
+  (process.env.ADGUARD_URL || "http://localhost:3020").replace(/\/+$/, "");
+const ADGUARD_USERNAME = () => process.env.ADGUARD_USERNAME || "";
+const ADGUARD_PASSWORD = () => process.env.ADGUARD_PASSWORD || "";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function authHeader() {
+  const u = ADGUARD_USERNAME();
+  const p = ADGUARD_PASSWORD();
+  if (!u || !p) return null;
+  return "Basic " + Buffer.from(`${u}:${p}`).toString("base64");
+}
+
+async function agFetch(path, options = {}) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), REQUEST_TIMEOUT_MS);
+  const auth = authHeader();
+  try {
+    const res = await fetch(`${ADGUARD_URL()}${path}`, {
+      ...options,
+      signal: ctl.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(auth ? { Authorization: auth } : {}),
+        ...options.headers,
+      },
+    });
+    const text = await res.text();
+    if (res.status === 401 || res.status === 403) {
+      throw new Error("Authentication failed — check ADGUARD_USERNAME and ADGUARD_PASSWORD");
+    }
+    if (!res.ok) throw new Error(`AdGuard API ${res.status}: ${text.slice(0, 300)}`);
+    if (!text) return {};
+    try { return JSON.parse(text); } catch { return { raw: text }; }
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error(`Request timed out: ${path}`);
+    if (err.cause?.code === "ECONNREFUSED" || err.message?.includes("ECONNREFUSED")) {
+      throw new Error(`Cannot reach AdGuard at ${ADGUARD_URL()} — is the container running?`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function createAdguardServer(options = {}) {
+  const server = new McpServer(
+    { name: "crow-adguard-home", version: "1.0.0" },
+    { instructions: options.instructions },
+  );
+
+  // --- adguard_status ---
+  server.tool(
+    "adguard_status",
+    "AdGuard Home status: version, protection state, upstream DNS servers, filter count, stats summary",
+    {},
+    async () => {
+      try {
+        const [status, stats, filters] = await Promise.all([
+          agFetch("/control/status"),
+          agFetch("/control/stats").catch(() => ({})),
+          agFetch("/control/filtering/status").catch(() => ({})),
+        ]);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              url: ADGUARD_URL(),
+              version: status.version,
+              protection_enabled: status.protection_enabled,
+              dns_port: status.dns_port,
+              running: status.running,
+              upstream_dns: status.dns_addresses,
+              num_dns_queries_today: stats.num_dns_queries ?? null,
+              num_blocked_filtering_today: stats.num_blocked_filtering ?? null,
+              avg_processing_time_ms: stats.avg_processing_time != null ? Math.round(stats.avg_processing_time * 1000) : null,
+              filter_lists_enabled: (filters.filters || []).filter((f) => f.enabled).length,
+              filter_lists_total: (filters.filters || []).length,
+              filter_rules_total: filters.filters?.reduce((sum, f) => sum + (f.rules_count || 0), 0) ?? null,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- adguard_stats ---
+  server.tool(
+    "adguard_stats",
+    "Query stats: queries, blocked counts, top clients, top domains, top blocked domains (defaults to last 24h window)",
+    {},
+    async () => {
+      try {
+        const stats = await agFetch("/control/stats");
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              time_units: stats.time_units,
+              num_dns_queries: stats.num_dns_queries,
+              num_blocked_filtering: stats.num_blocked_filtering,
+              num_replaced_safebrowsing: stats.num_replaced_safebrowsing,
+              num_replaced_safesearch: stats.num_replaced_safesearch,
+              num_replaced_parental: stats.num_replaced_parental,
+              avg_processing_time_sec: stats.avg_processing_time,
+              top_queried_domains: (stats.top_queried_domains || []).slice(0, 10),
+              top_blocked_domains: (stats.top_blocked_domains || []).slice(0, 10),
+              top_clients: (stats.top_clients || []).slice(0, 10),
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- adguard_query_log ---
+  server.tool(
+    "adguard_query_log",
+    "Recent DNS queries. Returns the last N entries with timestamp, client, question, response, and whether it was blocked.",
+    {
+      limit: z.number().int().min(1).max(500).optional().default(50).describe("Number of recent queries to return (default 50)"),
+      search: z.string().max(200).optional().describe("Substring search over domain names"),
+    },
+    async ({ limit, search }) => {
+      try {
+        const params = new URLSearchParams({ limit: String(limit) });
+        if (search) params.set("search", search);
+        const data = await agFetch(`/control/querylog?${params}`);
+        const rows = (data.data || []).map((q) => ({
+          time: q.time,
+          client: q.client,
+          question: q.question?.name,
+          type: q.question?.type,
+          answer: (q.answer || []).slice(0, 3).map((a) => a.value),
+          blocked: q.reason && q.reason.startsWith("Filtered") ? q.reason : null,
+          elapsed_ms: q.elapsedMs,
+        }));
+        return {
+          content: [{
+            type: "text",
+            text: rows.length
+              ? `${rows.length} recent queries:\n${JSON.stringify(rows, null, 2)}`
+              : "No queries in log.",
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  // --- adguard_toggle_protection ---
+  server.tool(
+    "adguard_toggle_protection",
+    "Enable or disable AdGuard Home protection. Disabling stops ALL DNS filtering until re-enabled — clients will resolve via upstream with no blocking.",
+    {
+      enabled: z.boolean().describe("true to enable protection, false to disable"),
+      confirm: z.literal("yes").describe('Must be "yes" to confirm the state change'),
+    },
+    async ({ enabled }) => {
+      try {
+        await agFetch("/control/dns_config", {
+          method: "POST",
+          body: JSON.stringify({ protection_enabled: enabled }),
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `Protection ${enabled ? "enabled" : "disabled"}. ${enabled ? "" : "ALL DNS queries now resolve through upstream with no filtering."}`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    }
+  );
+
+  return server;
+}

--- a/bundles/adguard-home/skills/adguard-home.md
+++ b/bundles/adguard-home/skills/adguard-home.md
@@ -1,0 +1,94 @@
+---
+name: adguard-home
+description: Network-wide DNS-based ad/tracker blocking with AdGuard Home
+triggers:
+  - "dns"
+  - "adblock"
+  - "block ads"
+  - "tracker"
+  - "adguard"
+  - "privacy filter"
+tools:
+  - adguard_status
+  - adguard_stats
+  - adguard_query_log
+  - adguard_toggle_protection
+---
+
+# AdGuard Home — DNS-based ad and tracker blocking
+
+AdGuard Home is a DNS server that filters queries against curated blocklists.
+It's not a per-app content blocker — it decides what your network can resolve.
+Point a device's DNS at AdGuard Home and ads/trackers disappear before any
+browser plugin gets involved.
+
+## First-run setup (required)
+
+The image ships without credentials. Before any MCP tool will work:
+
+1. `docker compose up -d` inside the bundle directory
+2. Open `http://localhost:3020` in a browser
+3. Walk through the setup wizard:
+   - **Admin web interface port**: leave as 3000 (container-side; host-mapped
+     to 3020)
+   - **DNS server port**: leave as 53 (container-side; host-mapped to 5335)
+   - **Admin credentials**: pick a username + strong password
+4. Copy the credentials into your Crow `.env`:
+   ```
+   ADGUARD_USERNAME=<your-username>
+   ADGUARD_PASSWORD=<your-password>
+   ```
+5. Restart Crow gateway so it picks up the new env.
+
+## Using Crow DNS on the host
+
+On the host:
+```bash
+nslookup example.com 127.0.0.1 -port=5335
+# or set a single client's DNS to 127.0.0.1:5335
+```
+
+To serve the LAN, edit `docker-compose.yml` and change `127.0.0.1:5335:53` to
+`0.0.0.0:53:53`. First verify no other resolver (systemd-resolved,
+dnsmasq, BIND) is listening on :53 — `sudo ss -tulnp | grep ':53 '`.
+
+## MCP tools
+
+```
+adguard_status
+```
+Version, protection state, upstream DNS, filter list count, queries today.
+Start here.
+
+```
+adguard_stats
+```
+Top queried / blocked domains, top clients, total query counts.
+
+```
+adguard_query_log { "limit": 50 }
+adguard_query_log { "limit": 20, "search": "youtube" }
+```
+Recent per-query records with timestamp, client, question, response, block
+reason.
+
+```
+adguard_toggle_protection { "enabled": false, "confirm": "yes" }
+```
+**Destructive.** Disabling protection stops ALL filtering until re-enabled;
+every query resolves through upstream DNS with zero blocking. Useful for
+troubleshooting a legitimate site AdGuard is mis-blocking — remember to turn
+it back on.
+
+## Common gotchas
+
+- **Port 53 conflict**: every major Linux distro has `systemd-resolved` or
+  similar listening on 53. The bundle sidesteps this by exposing DNS on
+  :5335 by default. Don't change to :53 without disabling the conflicting
+  resolver first, or `docker compose up` will fail with "address already in
+  use."
+- **Stats empty on first boot**: nothing to show until a client actually
+  sends queries. Point one device at `127.0.0.1:5335` to generate traffic.
+- **Losing the admin password**: edit `~/.crow/adguard-home/conf/AdGuardHome.yaml`
+  to reset the `users:` block (password is bcrypt-hashed; generate with
+  `htpasswd -B -n -b <user> <pass>` and paste the hash in).

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1427,6 +1427,31 @@
       "notes": "Binds 80/443 on 0.0.0.0 (required for ACME). Admin API bound to 127.0.0.1:2019. Caddyfile at ~/.crow/caddy/Caddyfile. 5 MCP tools: status, reload, list_sites, add_site, remove_site."
     },
     {
+      "id": "adguard-home",
+      "name": "AdGuard Home",
+      "description": "Network-wide ads and tracker blocking DNS server. Filters queries with user-configurable blocklists and serves the admin UI in the browser.",
+      "type": "bundle",
+      "version": "1.0.0",
+      "author": "Crow",
+      "category": "networking",
+      "tags": ["dns", "adblock", "privacy", "network", "security"],
+      "icon": "shield",
+      "docker": { "composefile": "docker-compose.yml" },
+      "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["ADGUARD_URL", "ADGUARD_USERNAME", "ADGUARD_PASSWORD"] },
+      "panel": "panel/adguard-home.js",
+      "panelRoutes": "panel/routes.js",
+      "skills": ["skills/adguard-home.md"],
+      "requires": { "env": ["ADGUARD_USERNAME", "ADGUARD_PASSWORD"], "min_ram_mb": 256, "min_disk_mb": 200 },
+      "env_vars": [
+        { "name": "ADGUARD_URL", "description": "AdGuard Home admin URL", "default": "http://localhost:3020", "required": false },
+        { "name": "ADGUARD_USERNAME", "description": "Admin username (set during setup wizard)", "required": true },
+        { "name": "ADGUARD_PASSWORD", "description": "Admin password (set during setup wizard)", "required": true, "secret": true }
+      ],
+      "ports": [3020, 5335, 8530],
+      "webUI": { "port": 3020, "path": "/", "label": "AdGuard Home" },
+      "notes": "First-boot: run setup wizard at localhost:3020, create admin credentials, copy to .env. DNS bound to 127.0.0.1:5335 to avoid systemd-resolved collision. 4 MCP tools: status, stats, query_log, toggle_protection."
+    },
+    {
       "id": "vikunja",
       "name": "Vikunja",
       "description": "Self-hosted task management — projects, kanban boards, due dates, labels, and team collaboration",


### PR DESCRIPTION
Network-wide DNS filtering via AdGuard Home. Non-privileged, no consent_required — ports bound to `127.0.0.1` and no host socket access.

**Independent of other MVP PRs — branched from main.** AdGuard doesn't need PR 0's consent infrastructure. Ports 3020/5335/8530 are reserved in PR 0's port-allocation.md; if PR 0 lands first, no additional action needed, and if this one lands first, PR 0's port-allocation doc already accounts for AdGuard.

## What this ships

Pinned to `adguard/adguardhome:v0.107.73`.

**Ports** (all 127.0.0.1):
- `3020 → 3000` admin UI + setup wizard
- `5335 → 53` DNS (UDP+TCP). Non-standard host port to avoid colliding with systemd-resolved on most Linux hosts. Skill documents how to re-bind to `0.0.0.0:53` for LAN-wide DNS after disabling the conflicting host resolver.
- `8530 → 853` DoT, ready for when the admin enables it

**First-boot flow** (documented in the skill):
1. `docker compose up -d`
2. Open `localhost:3020`, walk through the setup wizard, pick admin credentials
3. Copy credentials into `.env` as `ADGUARD_USERNAME` / `ADGUARD_PASSWORD`
4. Restart gateway

Without those env vars, the MCP tools error with a clear "Auth failed — check ADGUARD_USERNAME and ADGUARD_PASSWORD" message.

**MCP tools** (4):
- `adguard_status` — version, protection state, upstream DNS, query counts, filter-list and rule summary
- `adguard_stats` — top queried/blocked domains, top clients, hit rate
- `adguard_query_log` — last N queries with blocked/allowed reasons
- `adguard_toggle_protection` — destructive; requires `confirm: "yes"` and includes the "ALL filtering stops" warning

**Panel**
- Overview tab: 6-card grid (version, protection on/off, queries/blocked today, filter-list count, rule count) + Top Blocked Domains
- Web UI tab: iframe to admin console
- XSS-safe (textContent + createElement)

**Config**
- Bind-mount at `~/.crow/adguard-home/` so `AdGuardHome.yaml` and the filter cache are user-inspectable and backup-able

## Platform updates

- `registry/add-ons.json` entry
- `shield` icon added to ICON_MAP (🛡️)
- `.env.example`: `ADGUARD_URL`, `ADGUARD_USERNAME`, `ADGUARD_PASSWORD`, `ADGUARD_CONFIG_DIR`

## Verified

- `docker pull adguard/adguardhome:v0.107.73`
- Container boots to "healthy" within ~5s
- Admin UI responds 302 → `/install.html` (expected pre-setup)
- `node bundles/adguard-home/server/index.js` exits cleanly

## Test plan

- [ ] Install via Extensions panel (no consent modal — non-privileged)
- [ ] Complete setup wizard, copy credentials to `.env`, restart gateway
- [ ] `adguard_status` returns real version + protection state
- [ ] Point a device at `127.0.0.1:5335` for DNS; verify `adguard_query_log` shows traffic within a minute
- [ ] `adguard_toggle_protection` with `confirm: "yes"` flips state and logs explain filtering is stopped