### PR TITLE
PR 5: Identity, search, git — gitea, forgejo, vaultwarden, searxng

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,3 +170,13 @@ CROW_FILES_PATH=/home
 # Same setup flow: wizard -> admin user -> personal access token.
 # FORGEJO_URL=http://localhost:3050
 # FORGEJO_TOKEN=
+
+# ── VAULTWARDEN (password manager) ───────────────────────
+
+# Bitwarden-compatible server on port 8097. Use the official Bitwarden
+# browser extension / mobile app as the client.
+# Generate ADMIN_TOKEN with: openssl rand -base64 48
+# VAULTWARDEN_URL=http://localhost:8097
+# VAULTWARDEN_ADMIN_TOKEN=
+# VAULTWARDEN_DOMAIN=http://localhost:8097
+# VAULTWARDEN_SIGNUPS_ALLOWED=true

--- a/.env.example
+++ b/.env.example
@@ -163,3 +163,10 @@ CROW_FILES_PATH=/home
 # generate a personal access token under Settings > Applications.
 # GITEA_URL=http://localhost:3040
 # GITEA_TOKEN=
+
+# ── FORGEJO (community-driven git) ───────────────────────
+
+# Web UI on port 3050, SSH on port 2224. API-compatible with Gitea.
+# Same setup flow: wizard -> admin user -> personal access token.
+# FORGEJO_URL=http://localhost:3050
+# FORGEJO_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -180,3 +180,10 @@ CROW_FILES_PATH=/home
 # VAULTWARDEN_ADMIN_TOKEN=
 # VAULTWARDEN_DOMAIN=http://localhost:8097
 # VAULTWARDEN_SIGNUPS_ALLOWED=true
+
+# ── SEARXNG (metasearch) ─────────────────────────────────
+
+# Privacy-respecting metasearch on port 8098. Config in ~/.crow/searxng/.
+# Leave SECRET_KEY empty to let the entrypoint generate one on first boot.
+# SEARXNG_BASE_URL=http://localhost:8098/
+# SEARXNG_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,11 @@ CROW_FILES_PATH=/home
 
 # Cloudflare Tunnel token (for local network deployment only)
 # CLOUDFLARE_TUNNEL_TOKEN=
+
+# ── GITEA (self-hosted git) ──────────────────────────────
+
+# Web UI on port 3040, SSH on port 2223 (built-in Go SSH server).
+# Complete the first-run setup wizard at http://localhost:3040, then
+# generate a personal access token under Settings > Applications.
+# GITEA_URL=http://localhost:3040
+# GITEA_TOKEN=

--- a/bundles/forgejo/docker-compose.yml
+++ b/bundles/forgejo/docker-compose.yml
@@ -1,0 +1,46 @@
+# Forgejo — community-driven soft-fork of Gitea.
+#
+# Image registry note:
+#   codeberg.org/forgejo/forgejo is hosted on Codeberg's own OCI registry,
+#   not Docker Hub. `docker pull` handles this transparently. CI's
+#   image-freshness workflow calls `docker pull` directly, so it covers
+#   non-Docker-Hub registries without any special handling.
+#
+# Storage:
+#   ~/.crow/forgejo/data — bind mount for repos, attachments, SQLite DB.
+#
+# Ports:
+#   3050 (host) -> 3000 (container) — HTTP web UI + API on 127.0.0.1
+#   2224 (host) -> 22   (container) — built-in Go SSH server on 127.0.0.1.
+#                                     Clone with ssh://git@host:2224/user/repo
+
+services:
+  forgejo:
+    image: codeberg.org/forgejo/forgejo:9.0.3
+    container_name: crow-forgejo
+    ports:
+      - "127.0.0.1:3050:3000"
+      - "127.0.0.1:2224:22"
+    volumes:
+      - ${FORGEJO_DATA_DIR:-~/.crow/forgejo/data}:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - FORGEJO__database__DB_TYPE=sqlite3
+      - FORGEJO__database__PATH=/data/gitea/forgejo.db
+      - FORGEJO__server__DOMAIN=localhost
+      - FORGEJO__server__ROOT_URL=${FORGEJO_URL:-http://localhost:3050}/
+      - FORGEJO__server__SSH_PORT=2224
+      - FORGEJO__server__SSH_LISTEN_PORT=22
+      - FORGEJO__server__START_SSH_SERVER=true
+    init: true
+    mem_limit: 512m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3000/api/healthz || wget -q --spider http://localhost:3000/api/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s

--- a/bundles/forgejo/manifest.json
+++ b/bundles/forgejo/manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "forgejo",
+  "name": "Forgejo",
+  "version": "1.0.0",
+  "description": "Community-driven soft-fork of Gitea — self-hosted git with an independent governance model and ActivityPub federation roadmap",
+  "type": "bundle",
+  "author": "Crow",
+  "category": "infrastructure",
+  "tags": ["git", "scm", "source-control", "code-hosting", "self-hosted", "federated"],
+  "icon": "git",
+  "docker": { "composefile": "docker-compose.yml" },
+  "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["FORGEJO_URL", "FORGEJO_TOKEN"] },
+  "panel": "panel/forgejo.js",
+  "panelRoutes": "panel/routes.js",
+  "skills": ["skills/forgejo.md"],
+  "requires": { "env": ["FORGEJO_TOKEN"], "min_ram_mb": 512, "min_disk_mb": 500 },
+  "env_vars": [
+    { "name": "FORGEJO_URL", "description": "Forgejo server URL", "default": "http://localhost:3050", "required": true },
+    { "name": "FORGEJO_TOKEN", "description": "Personal access token (Settings > Applications > Generate New Token)", "required": true, "secret": true }
+  ],
+  "ports": [3050, 2224],
+  "webUI": { "port": 3050, "path": "/", "label": "Forgejo" },
+  "notes": "Forgejo is API-compatible with Gitea (v1 REST endpoints). First-run: open http://localhost:3050 to complete the setup wizard, then generate a personal access token under Settings > Applications. Git over SSH uses port 2224: clone with ssh://git@host:2224/user/repo.git. Install this bundle if you prefer Forgejo's community-governed, AGPL-licensed fork; install gitea for the upstream project. Running both on the same host is fine — ports do not collide."
+}

--- a/bundles/forgejo/package-lock.json
+++ b/bundles/forgejo/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "crow-forgejo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-forgejo",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/forgejo/package.json
+++ b/bundles/forgejo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crow-forgejo",
+  "version": "1.0.0",
+  "description": "Forgejo MCP server — self-hosted git via REST API (API-compatible with Gitea v1)",
+  "type": "module",
+  "main": "server/index.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/bundles/forgejo/panel/forgejo.js
+++ b/bundles/forgejo/panel/forgejo.js
@@ -1,0 +1,217 @@
+/**
+ * Crow's Nest Panel — Forgejo: repo overview and web UI embed.
+ *
+ * Mirrors the Gitea panel — Forgejo's REST API is compatible. Client-side
+ * JS uses textContent + createElement only (XSS-safe).
+ */
+
+export default {
+  id: "forgejo",
+  name: "Forgejo",
+  icon: "git",
+  route: "/dashboard/forgejo",
+  navOrder: 43,
+  category: "infrastructure",
+
+  async handler(req, res, { layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+
+    const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
+    const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
+
+    const tab = req.query.tab || "overview";
+    const tabs = [
+      { id: "overview", label: "Overview" },
+      { id: "webui", label: "Web UI" },
+    ];
+
+    const tabBar = `<div class="fj-tabs">${tabs.map((t) =>
+      `<a href="?tab=${escapeHtml(t.id)}" class="fj-tab${tab === t.id ? " active" : ""}">${escapeHtml(t.label)}</a>`
+    ).join("")}</div>`;
+
+    let body = "";
+    if (tab === "webui") {
+      const url = process.env.FORGEJO_URL || "http://localhost:3050";
+      body = `<div class="fj-webui"><iframe src="${escapeHtml(url)}" class="fj-iframe" allow="fullscreen"></iframe></div>`;
+    } else {
+      body = renderOverview();
+    }
+
+    const content = `
+      <style>${forgejoStyles()}</style>
+      <div class="fj-panel">
+        <h1>Forgejo</h1>
+        ${tabBar}
+        <div class="fj-body">${body}</div>
+      </div>
+      <script>${forgejoScript()}</script>
+    `;
+
+    res.send(layout({ title: "Forgejo", content }));
+  },
+};
+
+function renderOverview() {
+  return `
+    <div class="fj-overview">
+      <div class="fj-section">
+        <h3>Status</h3>
+        <div id="fj-status" class="fj-status"><div class="np-loading">Checking...</div></div>
+      </div>
+      <div class="fj-section">
+        <h3>Recently Updated Repos</h3>
+        <div id="fj-repos" class="fj-repo-list"><div class="np-loading">Loading...</div></div>
+      </div>
+    </div>
+  `;
+}
+
+function forgejoScript() {
+  return `
+    async function loadStatus() {
+      const el = document.getElementById('fj-status');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/forgejo/stats');
+        const data = await res.json();
+        el.textContent = '';
+        if (!data.reachable) {
+          const err = document.createElement('div');
+          err.className = 'np-error';
+          err.textContent = data.error || 'Cannot reach Forgejo.';
+          el.appendChild(err);
+          return;
+        }
+        const card = document.createElement('div');
+        card.className = 'stat-card';
+        const val = document.createElement('div');
+        val.className = 'stat-value';
+        val.textContent = 'OK';
+        card.appendChild(val);
+        const label = document.createElement('div');
+        label.className = 'stat-label';
+        label.textContent = data.has_token ? 'Connected with token' : 'No token configured';
+        card.appendChild(label);
+        el.appendChild(card);
+
+        const urlCard = document.createElement('div');
+        urlCard.className = 'stat-card';
+        const uv = document.createElement('div');
+        uv.className = 'stat-url';
+        uv.textContent = data.url;
+        urlCard.appendChild(uv);
+        const ul = document.createElement('div');
+        ul.className = 'stat-label';
+        ul.textContent = 'Server URL';
+        urlCard.appendChild(ul);
+        el.appendChild(urlCard);
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to reach status endpoint.';
+        el.appendChild(err);
+      }
+    }
+
+    async function loadRepos() {
+      const el = document.getElementById('fj-repos');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/forgejo/repos');
+        const data = await res.json();
+        el.textContent = '';
+        if (data.error) {
+          const err = document.createElement('div');
+          err.className = 'np-error';
+          err.textContent = data.error;
+          el.appendChild(err);
+          return;
+        }
+        const repos = data.repos || [];
+        if (repos.length === 0) {
+          const idle = document.createElement('div');
+          idle.className = 'np-idle';
+          idle.textContent = 'No repositories yet — create one on the Web UI tab.';
+          el.appendChild(idle);
+          return;
+        }
+        repos.forEach(function(r) {
+          const card = document.createElement('div');
+          card.className = 'lib-card';
+
+          const title = document.createElement('div');
+          title.className = 'lib-title';
+          title.textContent = r.full_name + (r.private ? ' (private)' : '');
+          card.appendChild(title);
+
+          if (r.description) {
+            const d = document.createElement('div');
+            d.className = 'lib-desc';
+            d.textContent = r.description;
+            card.appendChild(d);
+          }
+
+          const meta = document.createElement('div');
+          meta.className = 'lib-meta';
+          const parts = [];
+          if (typeof r.stars === 'number') parts.push('\\u2605 ' + r.stars);
+          if (typeof r.open_issues === 'number') parts.push('issues: ' + r.open_issues);
+          if (r.updated_at) parts.push('updated ' + new Date(r.updated_at).toLocaleDateString());
+          meta.textContent = parts.join(' \\u00b7 ');
+          card.appendChild(meta);
+
+          el.appendChild(card);
+        });
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to load repositories.';
+        el.appendChild(err);
+      }
+    }
+
+    loadStatus();
+    loadRepos();
+  `;
+}
+
+function forgejoStyles() {
+  return `
+    .fj-panel h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .fj-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--crow-border); margin-bottom: 1.5rem; }
+    .fj-tab { padding: 0.6rem 1.2rem; color: var(--crow-text-secondary); text-decoration: none;
+              border-bottom: 2px solid transparent; transition: all 0.2s; }
+    .fj-tab:hover { color: var(--crow-text-primary); }
+    .fj-tab.active { color: var(--crow-accent); border-bottom-color: var(--crow-accent); }
+
+    .fj-overview { display: flex; flex-direction: column; gap: 1.5rem; }
+    .fj-section h3 { font-size: 0.85rem; color: var(--crow-text-muted); text-transform: uppercase;
+                     letter-spacing: 0.05em; margin: 0 0 0.8rem; }
+
+    .fj-status { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .stat-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 1rem 1.2rem;
+                 border: 1px solid var(--crow-border); min-width: 150px; }
+    .stat-value { font-size: 1.2rem; font-weight: 700; color: var(--crow-accent); }
+    .stat-url { font-size: 0.9rem; font-family: monospace; color: var(--crow-text-primary); word-break: break-all; }
+    .stat-label { font-size: 0.8rem; color: var(--crow-text-muted); margin-top: 0.25rem; }
+
+    .fj-repo-list { display: flex; flex-direction: column; gap: 0.6rem; }
+    .lib-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 1rem;
+                border: 1px solid var(--crow-border); transition: border-color 0.2s; }
+    .lib-card:hover { border-color: var(--crow-accent); }
+    .lib-title { font-weight: 600; color: var(--crow-text-primary); font-size: 0.95rem; }
+    .lib-desc { font-size: 0.85rem; color: var(--crow-text-secondary); margin-top: 0.3rem; }
+    .lib-meta { font-size: 0.8rem; color: var(--crow-text-muted); margin-top: 0.3rem; }
+
+    .np-idle, .np-loading { color: var(--crow-text-muted); font-size: 0.9rem; padding: 1rem;
+                            background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+    .np-error { color: var(--crow-error); font-size: 0.9rem; padding: 1rem;
+                background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+
+    .fj-webui { width: 100%; height: calc(100vh - 200px); min-height: 500px; }
+    .fj-iframe { width: 100%; height: 100%; border: none; border-radius: 12px; background: var(--crow-bg-elevated); }
+  `;
+}

--- a/bundles/forgejo/panel/routes.js
+++ b/bundles/forgejo/panel/routes.js
@@ -1,0 +1,72 @@
+/**
+ * Forgejo panel routes — mirrors the Gitea bundle structure since the v1
+ * REST API is compatible.
+ */
+
+import { Router } from "express";
+
+const FORGEJO_URL = () => (process.env.FORGEJO_URL || "http://localhost:3050").replace(/\/+$/, "");
+const FORGEJO_TOKEN = () => process.env.FORGEJO_TOKEN || "";
+
+async function fjFetch(path) {
+  const url = `${FORGEJO_URL()}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const token = FORGEJO_TOKEN();
+    const headers = {};
+    if (token) headers["Authorization"] = `token ${token}`;
+    const res = await fetch(url, { signal: controller.signal, headers });
+    if (!res.ok) throw new Error(`Forgejo ${res.status}: ${res.statusText}`);
+    const text = await res.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error("Forgejo request timed out");
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error("Cannot reach Forgejo — is the server running?");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export default function forgejoRouter(authMiddleware) {
+  const router = Router();
+
+  router.get("/api/forgejo/stats", authMiddleware, async (req, res) => {
+    try {
+      const data = await fjFetch(`/api/v1/repos/search?limit=1&uid=0`);
+      const total = Array.isArray(data?.data) ? data.data.length : 0;
+      res.json({
+        url: FORGEJO_URL(),
+        reachable: true,
+        has_token: !!FORGEJO_TOKEN(),
+        visible_repo_count_hint: total,
+      });
+    } catch (err) {
+      res.json({ url: FORGEJO_URL(), reachable: false, error: err.message });
+    }
+  });
+
+  router.get("/api/forgejo/repos", authMiddleware, async (req, res) => {
+    try {
+      const data = await fjFetch(`/api/v1/repos/search?limit=20&uid=0&sort=updated&order=desc`);
+      const repos = (Array.isArray(data?.data) ? data.data : []).map((r) => ({
+        full_name: r.full_name,
+        private: !!r.private,
+        fork: !!r.fork,
+        description: r.description ? r.description.slice(0, 200) : null,
+        stars: r.stars_count || 0,
+        open_issues: r.open_issues_count || 0,
+        updated_at: r.updated_at || null,
+        html_url: r.html_url || null,
+      }));
+      res.json({ repos });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/bundles/forgejo/server/index.js
+++ b/bundles/forgejo/server/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/**
+ * Forgejo MCP Server — stdio transport entry point
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createForgejoServer } from "./server.js";
+
+const server = createForgejoServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/bundles/forgejo/server/server.js
+++ b/bundles/forgejo/server/server.js
@@ -1,0 +1,229 @@
+/**
+ * Forgejo MCP Server
+ *
+ * Forgejo's v1 REST API is compatible with Gitea's, so this server is
+ * structurally identical to the Gitea bundle — only env var names and
+ * default URL differ. Tools:
+ *   - forgejo_list_repos
+ *   - forgejo_repo_info
+ *   - forgejo_create_repo
+ *   - forgejo_list_issues
+ *   - forgejo_create_issue
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const FORGEJO_URL = () => (process.env.FORGEJO_URL || "http://localhost:3050").replace(/\/+$/, "");
+const FORGEJO_TOKEN = () => process.env.FORGEJO_TOKEN || "";
+
+async function fjFetch(path, options = {}) {
+  const url = `${FORGEJO_URL()}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const token = FORGEJO_TOKEN();
+    const headers = { "Content-Type": "application/json", ...options.headers };
+    if (token) headers["Authorization"] = `token ${token}`;
+
+    const res = await fetch(url, { ...options, signal: controller.signal, headers });
+
+    if (!res.ok) {
+      if (res.status === 401) throw new Error("Authentication failed — check FORGEJO_TOKEN");
+      if (res.status === 403) throw new Error("Permission denied — token lacks required scope");
+      if (res.status === 404) throw new Error(`Not found: ${path}`);
+      const body = await res.text().catch(() => "");
+      throw new Error(`Forgejo API error: ${res.status} ${res.statusText}${body ? ` — ${body.slice(0, 200)}` : ""}`);
+    }
+
+    const text = await res.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error(`Forgejo request timed out after 10s: ${path}`);
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error(`Cannot reach Forgejo at ${FORGEJO_URL()} — is the server running?`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function repoSummary(r) {
+  return {
+    id: r.id,
+    full_name: r.full_name,
+    name: r.name,
+    owner: r.owner?.login || null,
+    private: !!r.private,
+    fork: !!r.fork,
+    description: r.description ? r.description.slice(0, 300) : null,
+    default_branch: r.default_branch || null,
+    stars: r.stars_count || 0,
+    forks: r.forks_count || 0,
+    open_issues: r.open_issues_count || 0,
+    html_url: r.html_url || null,
+    ssh_url: r.ssh_url || null,
+    clone_url: r.clone_url || null,
+    updated_at: r.updated_at || null,
+  };
+}
+
+function issueSummary(i) {
+  return {
+    number: i.number,
+    title: i.title,
+    state: i.state,
+    user: i.user?.login || null,
+    labels: (i.labels || []).map((l) => l.name),
+    assignees: (i.assignees || []).map((a) => a.login),
+    comments: i.comments || 0,
+    created_at: i.created_at,
+    updated_at: i.updated_at,
+    html_url: i.html_url || null,
+  };
+}
+
+export function createForgejoServer(options = {}) {
+  const server = new McpServer(
+    { name: "crow-forgejo", version: "1.0.0" },
+    { instructions: options.instructions },
+  );
+
+  server.tool(
+    "forgejo_list_repos",
+    "List repositories the current token owner can access (paginated)",
+    {
+      page: z.number().min(1).optional().default(1).describe("Page number (default 1)"),
+      per_page: z.number().min(1).max(50).optional().default(20).describe("Results per page (max 50)"),
+      query: z.string().max(200).optional().describe("Optional search query"),
+    },
+    async ({ page, per_page, query }) => {
+      try {
+        const params = new URLSearchParams({ page: String(page), limit: String(per_page) });
+        const path = query
+          ? `/api/v1/repos/search?${params}&q=${encodeURIComponent(query)}`
+          : `/api/v1/repos/search?${params}&uid=0`;
+        const data = await fjFetch(path);
+        const repos = (Array.isArray(data?.data) ? data.data : []).map(repoSummary);
+        return {
+          content: [{
+            type: "text",
+            text: repos.length
+              ? `${repos.length} repo(s):\n${JSON.stringify(repos, null, 2)}`
+              : "No repositories found.",
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "forgejo_repo_info",
+    "Get detailed info for one repository",
+    {
+      owner: z.string().max(100).describe("Repo owner"),
+      repo: z.string().max(100).describe("Repo name"),
+    },
+    async ({ owner, repo }) => {
+      try {
+        const data = await fjFetch(`/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`);
+        return { content: [{ type: "text", text: JSON.stringify(repoSummary(data), null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "forgejo_create_repo",
+    "Create a new repository owned by the token user",
+    {
+      name: z.string().max(100).describe("Repo name"),
+      description: z.string().max(1000).optional().describe("Repo description"),
+      private: z.boolean().optional().default(false).describe("Create as private"),
+      auto_init: z.boolean().optional().default(true).describe("Initialize with README"),
+      default_branch: z.string().max(100).optional().default("main").describe("Default branch"),
+    },
+    async ({ name, description, private: isPrivate, auto_init, default_branch }) => {
+      try {
+        const body = { name, description, private: isPrivate, auto_init, default_branch };
+        const data = await fjFetch(`/api/v1/user/repos`, {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `Repository created:\n${JSON.stringify(repoSummary(data), null, 2)}`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "forgejo_list_issues",
+    "List issues in a repository",
+    {
+      owner: z.string().max(100).describe("Repo owner"),
+      repo: z.string().max(100).describe("Repo name"),
+      state: z.enum(["open", "closed", "all"]).optional().default("open"),
+      page: z.number().min(1).optional().default(1),
+      per_page: z.number().min(1).max(50).optional().default(20),
+    },
+    async ({ owner, repo, state, page, per_page }) => {
+      try {
+        const params = new URLSearchParams({ state, page: String(page), limit: String(per_page), type: "issues" });
+        const data = await fjFetch(`/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues?${params}`);
+        const issues = (Array.isArray(data) ? data : []).map(issueSummary);
+        return {
+          content: [{
+            type: "text",
+            text: issues.length
+              ? `${issues.length} issue(s):\n${JSON.stringify(issues, null, 2)}`
+              : "No issues found.",
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "forgejo_create_issue",
+    "Open a new issue in a repository",
+    {
+      owner: z.string().max(100).describe("Repo owner"),
+      repo: z.string().max(100).describe("Repo name"),
+      title: z.string().max(500).describe("Issue title"),
+      body: z.string().max(50000).optional().describe("Issue body (markdown)"),
+    },
+    async ({ owner, repo, title, body }) => {
+      try {
+        const payload = { title };
+        if (body) payload.body = body;
+        const data = await fjFetch(`/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `Issue opened:\n${JSON.stringify(issueSummary(data), null, 2)}`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  return server;
+}

--- a/bundles/forgejo/skills/forgejo.md
+++ b/bundles/forgejo/skills/forgejo.md
@@ -1,0 +1,78 @@
+---
+name: forgejo
+description: Forgejo — community-driven soft-fork of Gitea for self-hosted git
+triggers:
+  - "forgejo"
+  - "federated git"
+  - "codeberg"
+  - "community git"
+  - "servidor git comunitario"
+tools:
+  - forgejo_list_repos
+  - forgejo_repo_info
+  - forgejo_create_repo
+  - forgejo_list_issues
+  - forgejo_create_issue
+---
+
+# Forgejo — community-driven git
+
+Forgejo is a community-governed, AGPL-licensed soft-fork of Gitea. It runs
+on Codeberg.org and is API-compatible with Gitea's v1 REST endpoints.
+
+## Why both Gitea and Forgejo?
+
+Both bundles ship because the choice is principled, not technical:
+
+- **Gitea** is the upstream project with the broader ecosystem and a
+  Business Source License for newer code.
+- **Forgejo** is a fork started in 2022 after governance changes at Gitea.
+  It stays fully AGPL-licensed, is governed by the Codeberg e.V.
+  non-profit, and actively works on ActivityPub federation so forges can
+  follow each other like Mastodon instances.
+
+Install whichever matches your values. Running both on the same host is
+fine — the default ports do not collide (Gitea 3040/2223, Forgejo
+3050/2224).
+
+## First-run setup
+
+1. Start the bundle from the Extensions panel.
+2. Open **http://localhost:3050** in a browser.
+3. Complete the initial setup wizard. The database is preconfigured to
+   SQLite.
+4. Set a strong admin username + password and click Install.
+5. Log in as admin, then go to **Settings > Applications > Generate New
+   Token**. Give it the `repo`, `issue`, and `user` scopes.
+6. Copy the token into your `.env` as `FORGEJO_TOKEN`, then reload Crow.
+
+## Git over SSH
+
+Forgejo's built-in SSH server listens on host port **2224**:
+
+```
+ssh://git@localhost:2224/username/repo.git
+```
+
+The short `git@host:user/repo` scp-style syntax hits port 22 and will
+NOT reach Forgejo. Use the full URL or an `~/.ssh/config` alias:
+
+```
+Host myforgejo
+  HostName localhost
+  Port 2224
+  User git
+```
+
+## ActivityPub federation (optional, future)
+
+Forgejo's federation features are maturing. If you want other forges to
+follow your repos, you'll eventually need a public HTTPS domain served
+through the Caddy bundle (`requires.bundles: ["caddy"]`) and a valid TLS
+cert. Until then, Forgejo still works perfectly as a standalone self-
+hosted git service — federation is opt-in.
+
+## Backups
+
+Everything lives in `~/.crow/forgejo/data`. Back up that directory to
+preserve repos, issues, attachments, and the SQLite database.

--- a/bundles/gitea/docker-compose.yml
+++ b/bundles/gitea/docker-compose.yml
@@ -1,0 +1,47 @@
+# Gitea — self-hosted git service.
+#
+# Storage:
+#   ~/.crow/gitea/data is a bind mount so repos, attachments, and the SQLite
+#   database live in a user-inspectable location. Back this directory up to
+#   preserve all git history.
+#
+# Ports:
+#   3040 (host) -> 3000 (container) — HTTP web UI + API, bound to 127.0.0.1
+#   2223 (host) -> 22   (container) — Gitea's built-in Go SSH server for git
+#                                     clone/push over SSH. Bound to 127.0.0.1;
+#                                     expose at the reverse proxy / firewall
+#                                     level if you want remote access.
+#
+# Gitea does NOT run sshd — the built-in Go implementation serves on 22 inside
+# the container. Clone with: ssh://git@localhost:2223/user/repo.git
+
+services:
+  gitea:
+    image: gitea/gitea:1.23.8
+    container_name: crow-gitea
+    ports:
+      - "127.0.0.1:3040:3000"
+      - "127.0.0.1:2223:22"
+    volumes:
+      - ${GITEA_DATA_DIR:-~/.crow/gitea/data}:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - GITEA__database__DB_TYPE=sqlite3
+      - GITEA__database__PATH=/data/gitea/gitea.db
+      - GITEA__server__DOMAIN=localhost
+      - GITEA__server__ROOT_URL=${GITEA_URL:-http://localhost:3040}/
+      - GITEA__server__SSH_PORT=2223
+      - GITEA__server__SSH_LISTEN_PORT=22
+      - GITEA__server__START_SSH_SERVER=true
+    init: true
+    mem_limit: 512m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3000/api/healthz || wget -q --spider http://localhost:3000/api/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s

--- a/bundles/gitea/manifest.json
+++ b/bundles/gitea/manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "gitea",
+  "name": "Gitea",
+  "version": "1.0.0",
+  "description": "Self-hosted git service — repos, issues, pull requests, and built-in SSH server for git over SSH",
+  "type": "bundle",
+  "author": "Crow",
+  "category": "infrastructure",
+  "tags": ["git", "scm", "source-control", "code-hosting", "self-hosted"],
+  "icon": "git",
+  "docker": { "composefile": "docker-compose.yml" },
+  "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["GITEA_URL", "GITEA_TOKEN"] },
+  "panel": "panel/gitea.js",
+  "panelRoutes": "panel/routes.js",
+  "skills": ["skills/gitea.md"],
+  "requires": { "env": ["GITEA_TOKEN"], "min_ram_mb": 512, "min_disk_mb": 500 },
+  "env_vars": [
+    { "name": "GITEA_URL", "description": "Gitea server URL", "default": "http://localhost:3040", "required": true },
+    { "name": "GITEA_TOKEN", "description": "Personal access token (Settings > Applications > Generate New Token)", "required": true, "secret": true }
+  ],
+  "ports": [3040, 2223],
+  "webUI": { "port": 3040, "path": "/", "label": "Gitea" },
+  "notes": "First-run: open http://localhost:3040 to complete the setup wizard (database is preconfigured to SQLite). Then create the first admin user, log in, and generate a personal access token under Settings > Applications. Git over SSH uses port 2223: clone with ssh://git@host:2223/user/repo.git (the scp-style git@host:user/repo silently hits port 22 and will not reach this bundle)."
+}

--- a/bundles/gitea/package-lock.json
+++ b/bundles/gitea/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "crow-gitea",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-gitea",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/gitea/package.json
+++ b/bundles/gitea/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crow-gitea",
+  "version": "1.0.0",
+  "description": "Gitea MCP server — self-hosted git via REST API",
+  "type": "module",
+  "main": "server/index.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/bundles/gitea/panel/gitea.js
+++ b/bundles/gitea/panel/gitea.js
@@ -1,0 +1,216 @@
+/**
+ * Crow's Nest Panel — Gitea: repo overview and web UI embed.
+ *
+ * Client-side JS uses textContent + createElement only (XSS-safe).
+ */
+
+export default {
+  id: "gitea",
+  name: "Gitea",
+  icon: "git",
+  route: "/dashboard/gitea",
+  navOrder: 42,
+  category: "infrastructure",
+
+  async handler(req, res, { layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+
+    const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
+    const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
+
+    const tab = req.query.tab || "overview";
+    const tabs = [
+      { id: "overview", label: "Overview" },
+      { id: "webui", label: "Web UI" },
+    ];
+
+    const tabBar = `<div class="gt-tabs">${tabs.map((t) =>
+      `<a href="?tab=${escapeHtml(t.id)}" class="gt-tab${tab === t.id ? " active" : ""}">${escapeHtml(t.label)}</a>`
+    ).join("")}</div>`;
+
+    let body = "";
+    if (tab === "webui") {
+      const url = process.env.GITEA_URL || "http://localhost:3040";
+      body = `<div class="gt-webui"><iframe src="${escapeHtml(url)}" class="gt-iframe" allow="fullscreen"></iframe></div>`;
+    } else {
+      body = renderOverview();
+    }
+
+    const content = `
+      <style>${giteaStyles()}</style>
+      <div class="gt-panel">
+        <h1>Gitea</h1>
+        ${tabBar}
+        <div class="gt-body">${body}</div>
+      </div>
+      <script>${giteaScript()}</script>
+    `;
+
+    res.send(layout({ title: "Gitea", content }));
+  },
+};
+
+function renderOverview() {
+  return `
+    <div class="gt-overview">
+      <div class="gt-section">
+        <h3>Status</h3>
+        <div id="gt-status" class="gt-status"><div class="np-loading">Checking...</div></div>
+      </div>
+      <div class="gt-section">
+        <h3>Recently Updated Repos</h3>
+        <div id="gt-repos" class="gt-repo-list"><div class="np-loading">Loading...</div></div>
+      </div>
+    </div>
+  `;
+}
+
+function giteaScript() {
+  return `
+    async function loadStatus() {
+      const el = document.getElementById('gt-status');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/gitea/stats');
+        const data = await res.json();
+        el.textContent = '';
+        if (!data.reachable) {
+          const err = document.createElement('div');
+          err.className = 'np-error';
+          err.textContent = data.error || 'Cannot reach Gitea.';
+          el.appendChild(err);
+          return;
+        }
+        const card = document.createElement('div');
+        card.className = 'stat-card';
+        const val = document.createElement('div');
+        val.className = 'stat-value';
+        val.textContent = 'OK';
+        card.appendChild(val);
+        const label = document.createElement('div');
+        label.className = 'stat-label';
+        label.textContent = data.has_token ? 'Connected with token' : 'No token configured';
+        card.appendChild(label);
+        el.appendChild(card);
+
+        const urlCard = document.createElement('div');
+        urlCard.className = 'stat-card';
+        const uv = document.createElement('div');
+        uv.className = 'stat-url';
+        uv.textContent = data.url;
+        urlCard.appendChild(uv);
+        const ul = document.createElement('div');
+        ul.className = 'stat-label';
+        ul.textContent = 'Server URL';
+        urlCard.appendChild(ul);
+        el.appendChild(urlCard);
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to reach status endpoint.';
+        el.appendChild(err);
+      }
+    }
+
+    async function loadRepos() {
+      const el = document.getElementById('gt-repos');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/gitea/repos');
+        const data = await res.json();
+        el.textContent = '';
+        if (data.error) {
+          const err = document.createElement('div');
+          err.className = 'np-error';
+          err.textContent = data.error;
+          el.appendChild(err);
+          return;
+        }
+        const repos = data.repos || [];
+        if (repos.length === 0) {
+          const idle = document.createElement('div');
+          idle.className = 'np-idle';
+          idle.textContent = 'No repositories yet — create one on the Web UI tab.';
+          el.appendChild(idle);
+          return;
+        }
+        repos.forEach(function(r) {
+          const card = document.createElement('div');
+          card.className = 'lib-card';
+
+          const title = document.createElement('div');
+          title.className = 'lib-title';
+          title.textContent = r.full_name + (r.private ? ' (private)' : '');
+          card.appendChild(title);
+
+          if (r.description) {
+            const d = document.createElement('div');
+            d.className = 'lib-desc';
+            d.textContent = r.description;
+            card.appendChild(d);
+          }
+
+          const meta = document.createElement('div');
+          meta.className = 'lib-meta';
+          const parts = [];
+          if (typeof r.stars === 'number') parts.push('\\u2605 ' + r.stars);
+          if (typeof r.open_issues === 'number') parts.push('issues: ' + r.open_issues);
+          if (r.updated_at) parts.push('updated ' + new Date(r.updated_at).toLocaleDateString());
+          meta.textContent = parts.join(' \\u00b7 ');
+          card.appendChild(meta);
+
+          el.appendChild(card);
+        });
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to load repositories.';
+        el.appendChild(err);
+      }
+    }
+
+    loadStatus();
+    loadRepos();
+  `;
+}
+
+function giteaStyles() {
+  return `
+    .gt-panel h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .gt-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--crow-border); margin-bottom: 1.5rem; }
+    .gt-tab { padding: 0.6rem 1.2rem; color: var(--crow-text-secondary); text-decoration: none;
+              border-bottom: 2px solid transparent; transition: all 0.2s; }
+    .gt-tab:hover { color: var(--crow-text-primary); }
+    .gt-tab.active { color: var(--crow-accent); border-bottom-color: var(--crow-accent); }
+
+    .gt-overview { display: flex; flex-direction: column; gap: 1.5rem; }
+    .gt-section h3 { font-size: 0.85rem; color: var(--crow-text-muted); text-transform: uppercase;
+                     letter-spacing: 0.05em; margin: 0 0 0.8rem; }
+
+    .gt-status { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .stat-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 1rem 1.2rem;
+                 border: 1px solid var(--crow-border); min-width: 150px; }
+    .stat-value { font-size: 1.2rem; font-weight: 700; color: var(--crow-accent); }
+    .stat-url { font-size: 0.9rem; font-family: monospace; color: var(--crow-text-primary); word-break: break-all; }
+    .stat-label { font-size: 0.8rem; color: var(--crow-text-muted); margin-top: 0.25rem; }
+
+    .gt-repo-list { display: flex; flex-direction: column; gap: 0.6rem; }
+    .lib-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 1rem;
+                border: 1px solid var(--crow-border); transition: border-color 0.2s; }
+    .lib-card:hover { border-color: var(--crow-accent); }
+    .lib-title { font-weight: 600; color: var(--crow-text-primary); font-size: 0.95rem; }
+    .lib-desc { font-size: 0.85rem; color: var(--crow-text-secondary); margin-top: 0.3rem; }
+    .lib-meta { font-size: 0.8rem; color: var(--crow-text-muted); margin-top: 0.3rem; }
+
+    .np-idle, .np-loading { color: var(--crow-text-muted); font-size: 0.9rem; padding: 1rem;
+                            background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+    .np-error { color: var(--crow-error); font-size: 0.9rem; padding: 1rem;
+                background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+
+    .gt-webui { width: 100%; height: calc(100vh - 200px); min-height: 500px; }
+    .gt-iframe { width: 100%; height: 100%; border: none; border-radius: 12px; background: var(--crow-bg-elevated); }
+  `;
+}

--- a/bundles/gitea/panel/routes.js
+++ b/bundles/gitea/panel/routes.js
@@ -1,0 +1,74 @@
+/**
+ * Gitea panel routes — backs the dashboard panel via authenticated GETs.
+ */
+
+import { Router } from "express";
+
+const GITEA_URL = () => (process.env.GITEA_URL || "http://localhost:3040").replace(/\/+$/, "");
+const GITEA_TOKEN = () => process.env.GITEA_TOKEN || "";
+
+async function gtFetch(path) {
+  const url = `${GITEA_URL()}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const token = GITEA_TOKEN();
+    const headers = {};
+    if (token) headers["Authorization"] = `token ${token}`;
+    const res = await fetch(url, { signal: controller.signal, headers });
+    if (!res.ok) throw new Error(`Gitea ${res.status}: ${res.statusText}`);
+    const text = await res.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error("Gitea request timed out");
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error("Cannot reach Gitea — is the server running?");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export default function giteaRouter(authMiddleware) {
+  const router = Router();
+
+  router.get("/api/gitea/stats", authMiddleware, async (req, res) => {
+    try {
+      const data = await gtFetch(`/api/v1/repos/search?limit=1&uid=0`);
+      const total = data && typeof data.data !== "undefined"
+        ? (Array.isArray(data.data) ? (data.data.length) : 0)
+        : 0;
+      // Gitea puts the total count in an X-Total-Count header; fall back to best-effort
+      res.json({
+        url: GITEA_URL(),
+        reachable: true,
+        has_token: !!GITEA_TOKEN(),
+        visible_repo_count_hint: total,
+      });
+    } catch (err) {
+      res.json({ url: GITEA_URL(), reachable: false, error: err.message });
+    }
+  });
+
+  router.get("/api/gitea/repos", authMiddleware, async (req, res) => {
+    try {
+      const data = await gtFetch(`/api/v1/repos/search?limit=20&uid=0&sort=updated&order=desc`);
+      const repos = (Array.isArray(data?.data) ? data.data : []).map((r) => ({
+        full_name: r.full_name,
+        private: !!r.private,
+        fork: !!r.fork,
+        description: r.description ? r.description.slice(0, 200) : null,
+        stars: r.stars_count || 0,
+        open_issues: r.open_issues_count || 0,
+        updated_at: r.updated_at || null,
+        html_url: r.html_url || null,
+      }));
+      res.json({ repos });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/bundles/gitea/server/index.js
+++ b/bundles/gitea/server/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/**
+ * Gitea MCP Server — stdio transport entry point
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createGiteaServer } from "./server.js";
+
+const server = createGiteaServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/bundles/gitea/server/server.js
+++ b/bundles/gitea/server/server.js
@@ -1,0 +1,230 @@
+/**
+ * Gitea MCP Server
+ *
+ * Tools to manage a self-hosted Gitea instance via the v1 REST API:
+ *   - gitea_list_repos        List repos the token owner has access to
+ *   - gitea_repo_info         Details for a single repo
+ *   - gitea_create_repo       Create a new repo under the token owner
+ *   - gitea_list_issues       List issues in a repo
+ *   - gitea_create_issue      Open a new issue
+ *
+ * Auth: personal access token (Settings > Applications). Token requires
+ * the "repo" and "issue" scopes for write operations.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const GITEA_URL = () => (process.env.GITEA_URL || "http://localhost:3040").replace(/\/+$/, "");
+const GITEA_TOKEN = () => process.env.GITEA_TOKEN || "";
+
+async function giteaFetch(path, options = {}) {
+  const url = `${GITEA_URL()}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    const token = GITEA_TOKEN();
+    const headers = { "Content-Type": "application/json", ...options.headers };
+    if (token) headers["Authorization"] = `token ${token}`;
+
+    const res = await fetch(url, { ...options, signal: controller.signal, headers });
+
+    if (!res.ok) {
+      if (res.status === 401) throw new Error("Authentication failed — check GITEA_TOKEN");
+      if (res.status === 403) throw new Error("Permission denied — token lacks required scope");
+      if (res.status === 404) throw new Error(`Not found: ${path}`);
+      const body = await res.text().catch(() => "");
+      throw new Error(`Gitea API error: ${res.status} ${res.statusText}${body ? ` — ${body.slice(0, 200)}` : ""}`);
+    }
+
+    const text = await res.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error(`Gitea request timed out after 10s: ${path}`);
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error(`Cannot reach Gitea at ${GITEA_URL()} — is the server running?`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function repoSummary(r) {
+  return {
+    id: r.id,
+    full_name: r.full_name,
+    name: r.name,
+    owner: r.owner?.login || null,
+    private: !!r.private,
+    fork: !!r.fork,
+    description: r.description ? r.description.slice(0, 300) : null,
+    default_branch: r.default_branch || null,
+    stars: r.stars_count || 0,
+    forks: r.forks_count || 0,
+    open_issues: r.open_issues_count || 0,
+    html_url: r.html_url || null,
+    ssh_url: r.ssh_url || null,
+    clone_url: r.clone_url || null,
+    updated_at: r.updated_at || null,
+  };
+}
+
+function issueSummary(i) {
+  return {
+    number: i.number,
+    title: i.title,
+    state: i.state,
+    user: i.user?.login || null,
+    labels: (i.labels || []).map((l) => l.name),
+    assignees: (i.assignees || []).map((a) => a.login),
+    comments: i.comments || 0,
+    created_at: i.created_at,
+    updated_at: i.updated_at,
+    html_url: i.html_url || null,
+  };
+}
+
+export function createGiteaServer(options = {}) {
+  const server = new McpServer(
+    { name: "crow-gitea", version: "1.0.0" },
+    { instructions: options.instructions },
+  );
+
+  server.tool(
+    "gitea_list_repos",
+    "List repositories the current token owner can access (paginated)",
+    {
+      page: z.number().min(1).optional().default(1).describe("Page number (default 1)"),
+      per_page: z.number().min(1).max(50).optional().default(20).describe("Results per page (max 50)"),
+      query: z.string().max(200).optional().describe("Optional search query to filter by name"),
+    },
+    async ({ page, per_page, query }) => {
+      try {
+        const params = new URLSearchParams({ page: String(page), limit: String(per_page) });
+        const path = query
+          ? `/api/v1/repos/search?${params}&q=${encodeURIComponent(query)}`
+          : `/api/v1/repos/search?${params}&uid=0`;
+        const data = await giteaFetch(path);
+        const repos = (Array.isArray(data?.data) ? data.data : []).map(repoSummary);
+        return {
+          content: [{
+            type: "text",
+            text: repos.length
+              ? `${repos.length} repo(s):\n${JSON.stringify(repos, null, 2)}`
+              : "No repositories found.",
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "gitea_repo_info",
+    "Get detailed info for one repository",
+    {
+      owner: z.string().max(100).describe("Repo owner (user or org)"),
+      repo: z.string().max(100).describe("Repo name"),
+    },
+    async ({ owner, repo }) => {
+      try {
+        const data = await giteaFetch(`/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`);
+        return { content: [{ type: "text", text: JSON.stringify(repoSummary(data), null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "gitea_create_repo",
+    "Create a new repository owned by the token user",
+    {
+      name: z.string().max(100).describe("Repo name"),
+      description: z.string().max(1000).optional().describe("Repo description"),
+      private: z.boolean().optional().default(false).describe("Create as private (default false)"),
+      auto_init: z.boolean().optional().default(true).describe("Initialize with README (default true)"),
+      default_branch: z.string().max(100).optional().default("main").describe("Default branch (default 'main')"),
+    },
+    async ({ name, description, private: isPrivate, auto_init, default_branch }) => {
+      try {
+        const body = { name, description, private: isPrivate, auto_init, default_branch };
+        const data = await giteaFetch(`/api/v1/user/repos`, {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `Repository created:\n${JSON.stringify(repoSummary(data), null, 2)}`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "gitea_list_issues",
+    "List issues in a repository",
+    {
+      owner: z.string().max(100).describe("Repo owner"),
+      repo: z.string().max(100).describe("Repo name"),
+      state: z.enum(["open", "closed", "all"]).optional().default("open"),
+      page: z.number().min(1).optional().default(1),
+      per_page: z.number().min(1).max(50).optional().default(20),
+    },
+    async ({ owner, repo, state, page, per_page }) => {
+      try {
+        const params = new URLSearchParams({ state, page: String(page), limit: String(per_page), type: "issues" });
+        const data = await giteaFetch(`/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues?${params}`);
+        const issues = (Array.isArray(data) ? data : []).map(issueSummary);
+        return {
+          content: [{
+            type: "text",
+            text: issues.length
+              ? `${issues.length} issue(s):\n${JSON.stringify(issues, null, 2)}`
+              : "No issues found.",
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "gitea_create_issue",
+    "Open a new issue in a repository",
+    {
+      owner: z.string().max(100).describe("Repo owner"),
+      repo: z.string().max(100).describe("Repo name"),
+      title: z.string().max(500).describe("Issue title"),
+      body: z.string().max(50000).optional().describe("Issue body (markdown)"),
+    },
+    async ({ owner, repo, title, body }) => {
+      try {
+        const payload = { title };
+        if (body) payload.body = body;
+        const data = await giteaFetch(`/api/v1/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`, {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `Issue opened:\n${JSON.stringify(issueSummary(data), null, 2)}`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  return server;
+}

--- a/bundles/gitea/skills/gitea.md
+++ b/bundles/gitea/skills/gitea.md
@@ -1,0 +1,72 @@
+---
+name: gitea
+description: Gitea — self-hosted git service with issues, PRs, and built-in SSH
+triggers:
+  - "gitea"
+  - "self-host git"
+  - "git server"
+  - "host my own repo"
+  - "crear repo en gitea"
+  - "servidor git"
+tools:
+  - gitea_list_repos
+  - gitea_repo_info
+  - gitea_create_repo
+  - gitea_list_issues
+  - gitea_create_issue
+---
+
+# Gitea — self-hosted git
+
+Gitea is a lightweight, self-hosted git service. It handles code hosting,
+issues, pull requests, and git over SSH with a built-in Go SSH server (no
+host `sshd` required).
+
+## First-run setup
+
+1. Start the bundle from the Extensions panel.
+2. Open **http://localhost:3040** in a browser.
+3. Complete the initial setup wizard. The database is preconfigured to
+   SQLite — leave those fields alone and scroll down.
+4. Set a strong admin username + password under "Administrator Account
+   Settings" and click Install.
+5. Log in as the admin, then go to **Settings > Applications >
+   Generate New Token**. Give it the `repo`, `issue`, and `user` scopes.
+6. Copy the token into your `.env` as `GITEA_TOKEN`, then reload Crow.
+
+## Git over SSH
+
+Gitea's built-in SSH server listens on container port 22, mapped to host
+port **2223**. Clone with an explicit port:
+
+```
+ssh://git@localhost:2223/username/repo.git
+```
+
+The short `git@host:user/repo` scp-style syntax silently hits port 22 and
+will NOT reach Gitea. Always use the full `ssh://...:2223/...` form. If you
+need the short form, add this to `~/.ssh/config`:
+
+```
+Host mygitea
+  HostName localhost
+  Port 2223
+  User git
+```
+
+Then `git clone mygitea:username/repo.git` works.
+
+## What the MCP tools can do
+
+- `gitea_list_repos` — list the repos the token owner can see
+- `gitea_repo_info` — details for a specific repo
+- `gitea_create_repo` — create a new repo under the token owner
+- `gitea_list_issues` — list open/closed/all issues in a repo
+- `gitea_create_issue` — open a new issue
+
+## Backups
+
+Everything — repos, issues, attachments, the SQLite database — lives in
+`~/.crow/gitea/data`. Back this directory up on a schedule; a plain tar
+while the container is running is safe for SQLite because Gitea uses WAL
+mode, though a briefly stopped container is the gold standard.

--- a/bundles/searxng/docker-compose.yml
+++ b/bundles/searxng/docker-compose.yml
@@ -1,0 +1,75 @@
+# SearXNG — privacy-respecting metasearch engine.
+#
+# Config:
+#   ~/.crow/searxng/settings.yml — user-editable config (mounted)
+#   The entrypoint seeds a minimal working settings.yml on first boot if
+#   the file does not exist. It also rewrites the secret_key line if the
+#   user leaves SEARXNG_SECRET_KEY empty — a fresh random secret is
+#   generated per install.
+#
+# JSON API:
+#   SearXNG's JSON output format is enabled in the seeded settings.yml so
+#   the Crow MCP server can issue /search?format=json queries.
+
+services:
+  searxng:
+    image: searxng/searxng:2026.4.11-9e08a6771
+    container_name: crow-searxng
+    ports:
+      - "127.0.0.1:8098:8080"
+    volumes:
+      - ${SEARXNG_CONFIG_DIR:-~/.crow/searxng}:/etc/searxng
+    environment:
+      - SEARXNG_BASE_URL=${SEARXNG_BASE_URL:-http://localhost:8098/}
+      - SEARXNG_SECRET_KEY=${SEARXNG_SECRET_KEY:-}
+      - UWSGI_WORKERS=2
+      - UWSGI_THREADS=4
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        CONFIG=/etc/searxng/settings.yml
+        if [ ! -f "$$CONFIG" ]; then
+          # Seed a minimal working config on first boot.
+          SECRET="$$SEARXNG_SECRET_KEY"
+          if [ -z "$$SECRET" ]; then
+            SECRET=$$(head -c 32 /dev/urandom | base64 | tr -d '\n/+' | head -c 48)
+          fi
+          cat > "$$CONFIG" <<CFG_EOF
+        # Seeded by Crow on first boot. Edit freely and restart the bundle.
+        use_default_settings: true
+        general:
+          instance_name: "Crow SearXNG"
+          contact_url: false
+        server:
+          secret_key: "$$SECRET"
+          limiter: false
+          image_proxy: true
+          bind_address: "0.0.0.0"
+          port: 8080
+        search:
+          formats:
+            - html
+            - json
+          safe_search: 0
+          autocomplete: "duckduckgo"
+        ui:
+          static_use_hash: true
+        CFG_EOF
+        else
+          # Rotate secret_key on subsequent boots only if user passes one via env.
+          if [ -n "$$SEARXNG_SECRET_KEY" ]; then
+            sed -i "s|^  secret_key:.*|  secret_key: \"$$SEARXNG_SECRET_KEY\"|" "$$CONFIG" || true
+          fi
+        fi
+        exec /usr/local/searxng/dockerfiles/docker-entrypoint.sh
+    init: true
+    mem_limit: 512m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s

--- a/bundles/searxng/manifest.json
+++ b/bundles/searxng/manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "searxng",
+  "name": "SearXNG",
+  "version": "1.0.0",
+  "description": "Privacy-respecting metasearch engine — aggregates results from 70+ sources (Google, Bing, DuckDuckGo, Wikipedia, GitHub, arXiv, more) without tracking",
+  "type": "bundle",
+  "author": "Crow",
+  "category": "productivity",
+  "tags": ["search", "metasearch", "privacy", "self-hosted"],
+  "icon": "search",
+  "docker": { "composefile": "docker-compose.yml" },
+  "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["SEARXNG_BASE_URL"] },
+  "panel": "panel/searxng.js",
+  "panelRoutes": "panel/routes.js",
+  "skills": ["skills/searxng.md"],
+  "requires": { "min_ram_mb": 256, "min_disk_mb": 150 },
+  "env_vars": [
+    { "name": "SEARXNG_BASE_URL", "description": "Public URL SearXNG advertises in generated links", "default": "http://localhost:8098/", "required": false },
+    { "name": "SEARXNG_SECRET_KEY", "description": "Secret key used to sign SearXNG tokens. If left empty, the entrypoint generates one on first boot (stored inside the container config volume).", "required": false, "secret": true }
+  ],
+  "ports": [8098],
+  "webUI": { "port": 8098, "path": "/", "label": "SearXNG" },
+  "notes": "Config lives in ~/.crow/searxng/ (settings.yml, uwsgi.ini). On first boot the container seeds a default settings.yml and generates a random SECRET_KEY if the env var is empty. JSON API is enabled for MCP use — the crow skill documents how to extend it with more engines."
+}

--- a/bundles/searxng/package-lock.json
+++ b/bundles/searxng/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "crow-searxng",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-searxng",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/searxng/package.json
+++ b/bundles/searxng/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crow-searxng",
+  "version": "1.0.0",
+  "description": "SearXNG MCP server — privacy-respecting metasearch via JSON API",
+  "type": "module",
+  "main": "server/index.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/bundles/searxng/panel/routes.js
+++ b/bundles/searxng/panel/routes.js
@@ -1,0 +1,68 @@
+/**
+ * SearXNG panel routes — proxies search + config to the local SearXNG.
+ */
+
+import { Router } from "express";
+
+const SEARXNG_URL = () => (process.env.SEARXNG_BASE_URL || "http://localhost:8098/").replace(/\/+$/, "");
+
+async function sxFetch(path, timeoutMs = 15000) {
+  const url = `${SEARXNG_URL()}${path}`;
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { "Accept": "application/json" },
+    });
+    if (!res.ok) throw new Error(`SearXNG ${res.status}: ${res.statusText}`);
+    const text = await res.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error("SearXNG request timed out");
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error("Cannot reach SearXNG — is the server running?");
+    }
+    throw err;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export default function searxngRouter(authMiddleware) {
+  const router = Router();
+
+  router.get("/api/searxng/status", authMiddleware, async (req, res) => {
+    try {
+      const url = SEARXNG_URL();
+      const controller = new AbortController();
+      const t = setTimeout(() => controller.abort(), 8000);
+      const r = await fetch(`${url}/healthz`, { signal: controller.signal });
+      clearTimeout(t);
+      res.json({ url, reachable: r.ok });
+    } catch (err) {
+      res.json({ url: SEARXNG_URL(), reachable: false, error: err.message });
+    }
+  });
+
+  router.get("/api/searxng/search", authMiddleware, async (req, res) => {
+    const q = (req.query.q || "").toString().trim();
+    if (!q) return res.json({ results: [] });
+    if (q.length > 500) return res.json({ error: "Query too long" });
+    try {
+      const params = new URLSearchParams({ q, format: "json", language: "en", pageno: "1" });
+      const data = await sxFetch(`/search?${params}`);
+      const results = (Array.isArray(data?.results) ? data.results : []).slice(0, 10).map((r) => ({
+        title: r.title || "",
+        url: r.url || "",
+        content: r.content ? r.content.slice(0, 300) : "",
+        engine: r.engine || "",
+      }));
+      res.json({ query: q, results });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/bundles/searxng/panel/searxng.js
+++ b/bundles/searxng/panel/searxng.js
@@ -1,0 +1,225 @@
+/**
+ * Crow's Nest Panel — SearXNG: simple search box + results + web UI embed.
+ *
+ * Client-side JS uses textContent + createElement only (XSS-safe).
+ */
+
+export default {
+  id: "searxng",
+  name: "SearXNG",
+  icon: "search",
+  route: "/dashboard/searxng",
+  navOrder: 45,
+  category: "productivity",
+
+  async handler(req, res, { layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+
+    const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
+    const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
+
+    const tab = req.query.tab || "search";
+    const tabs = [
+      { id: "search", label: "Search" },
+      { id: "webui", label: "Web UI" },
+    ];
+
+    const tabBar = `<div class="sx-tabs">${tabs.map((t) =>
+      `<a href="?tab=${escapeHtml(t.id)}" class="sx-tab${tab === t.id ? " active" : ""}">${escapeHtml(t.label)}</a>`
+    ).join("")}</div>`;
+
+    let body = "";
+    if (tab === "webui") {
+      const url = process.env.SEARXNG_BASE_URL || "http://localhost:8098/";
+      body = `<div class="sx-webui"><iframe src="${escapeHtml(url)}" class="sx-iframe" allow="fullscreen"></iframe></div>`;
+    } else {
+      body = renderSearch();
+    }
+
+    const content = `
+      <style>${searxngStyles()}</style>
+      <div class="sx-panel">
+        <h1>SearXNG</h1>
+        ${tabBar}
+        <div class="sx-body">${body}</div>
+      </div>
+      <script>${searxngScript()}</script>
+    `;
+
+    res.send(layout({ title: "SearXNG", content }));
+  },
+};
+
+function renderSearch() {
+  return `
+    <div class="sx-search-wrap">
+      <div id="sx-status" class="sx-status"><div class="np-loading">Checking...</div></div>
+
+      <form id="sx-form" class="sx-form" onsubmit="return false;">
+        <input id="sx-q" type="search" placeholder="Search the web privately..." autocomplete="off" maxlength="500" />
+        <button id="sx-btn" type="submit">Search</button>
+      </form>
+
+      <div id="sx-results" class="sx-results"></div>
+    </div>
+  `;
+}
+
+function searxngScript() {
+  return `
+    async function loadStatus() {
+      const el = document.getElementById('sx-status');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/searxng/status');
+        const data = await res.json();
+        el.textContent = '';
+        const card = document.createElement('div');
+        card.className = 'stat-card';
+        const val = document.createElement('div');
+        val.className = 'stat-value';
+        val.textContent = data.reachable ? 'Online' : 'Offline';
+        if (!data.reachable) card.classList.add('stat-warn');
+        card.appendChild(val);
+        const label = document.createElement('div');
+        label.className = 'stat-label';
+        label.textContent = data.url;
+        card.appendChild(label);
+        el.appendChild(card);
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to check status.';
+        el.appendChild(err);
+      }
+    }
+
+    async function doSearch() {
+      const q = document.getElementById('sx-q').value.trim();
+      const out = document.getElementById('sx-results');
+      out.textContent = '';
+      if (!q) return;
+
+      const loading = document.createElement('div');
+      loading.className = 'np-loading';
+      loading.textContent = 'Searching...';
+      out.appendChild(loading);
+
+      try {
+        const res = await fetch('/api/searxng/search?q=' + encodeURIComponent(q));
+        const data = await res.json();
+        out.textContent = '';
+        if (data.error) {
+          const err = document.createElement('div');
+          err.className = 'np-error';
+          err.textContent = data.error;
+          out.appendChild(err);
+          return;
+        }
+        const results = data.results || [];
+        if (results.length === 0) {
+          const idle = document.createElement('div');
+          idle.className = 'np-idle';
+          idle.textContent = 'No results.';
+          out.appendChild(idle);
+          return;
+        }
+        results.forEach(function(r) {
+          const card = document.createElement('div');
+          card.className = 'res-card';
+
+          const a = document.createElement('a');
+          a.className = 'res-title';
+          a.href = r.url;
+          a.target = '_blank';
+          a.rel = 'noopener';
+          a.textContent = r.title || r.url;
+          card.appendChild(a);
+
+          const u = document.createElement('div');
+          u.className = 'res-url';
+          u.textContent = r.url;
+          card.appendChild(u);
+
+          if (r.content) {
+            const c = document.createElement('div');
+            c.className = 'res-snippet';
+            c.textContent = r.content;
+            card.appendChild(c);
+          }
+
+          if (r.engine) {
+            const e = document.createElement('div');
+            e.className = 'res-meta';
+            e.textContent = 'via ' + r.engine;
+            card.appendChild(e);
+          }
+
+          out.appendChild(card);
+        });
+      } catch (e) {
+        out.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Search failed.';
+        out.appendChild(err);
+      }
+    }
+
+    loadStatus();
+    const form = document.getElementById('sx-form');
+    if (form) {
+      form.addEventListener('submit', function(ev) { ev.preventDefault(); doSearch(); });
+    }
+    const btn = document.getElementById('sx-btn');
+    if (btn) btn.addEventListener('click', doSearch);
+  `;
+}
+
+function searxngStyles() {
+  return `
+    .sx-panel h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .sx-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--crow-border); margin-bottom: 1.5rem; }
+    .sx-tab { padding: 0.6rem 1.2rem; color: var(--crow-text-secondary); text-decoration: none;
+              border-bottom: 2px solid transparent; transition: all 0.2s; }
+    .sx-tab:hover { color: var(--crow-text-primary); }
+    .sx-tab.active { color: var(--crow-accent); border-bottom-color: var(--crow-accent); }
+
+    .sx-status { display: flex; gap: 1rem; margin-bottom: 1rem; }
+    .stat-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 0.6rem 1rem;
+                 border: 1px solid var(--crow-border); min-width: 160px; }
+    .stat-card.stat-warn { border-color: var(--crow-error); }
+    .stat-card.stat-warn .stat-value { color: var(--crow-error); }
+    .stat-value { font-size: 1rem; font-weight: 700; color: var(--crow-accent); }
+    .stat-label { font-size: 0.75rem; color: var(--crow-text-muted); margin-top: 0.2rem; font-family: monospace; word-break: break-all; }
+
+    .sx-form { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; }
+    .sx-form input { flex: 1; padding: 0.6rem 0.8rem; background: var(--crow-bg-elevated);
+                     border: 1px solid var(--crow-border); border-radius: 8px; color: var(--crow-text-primary);
+                     font-size: 0.95rem; }
+    .sx-form input:focus { outline: none; border-color: var(--crow-accent); }
+    .sx-form button { padding: 0.6rem 1.2rem; background: var(--crow-accent); color: #fff;
+                      border: none; border-radius: 8px; font-weight: 600; cursor: pointer; }
+    .sx-form button:hover { filter: brightness(1.1); }
+
+    .sx-results { display: flex; flex-direction: column; gap: 0.8rem; }
+    .res-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 0.9rem 1rem;
+                border: 1px solid var(--crow-border); transition: border-color 0.2s; }
+    .res-card:hover { border-color: var(--crow-accent); }
+    .res-title { font-weight: 600; color: var(--crow-accent); text-decoration: none; font-size: 0.98rem; }
+    .res-title:hover { text-decoration: underline; }
+    .res-url { font-size: 0.78rem; color: var(--crow-text-muted); font-family: monospace; word-break: break-all; margin-top: 0.15rem; }
+    .res-snippet { font-size: 0.88rem; color: var(--crow-text-secondary); margin-top: 0.4rem; line-height: 1.4; }
+    .res-meta { font-size: 0.75rem; color: var(--crow-text-muted); margin-top: 0.3rem; }
+
+    .np-idle, .np-loading { color: var(--crow-text-muted); font-size: 0.9rem; padding: 1rem;
+                            background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+    .np-error { color: var(--crow-error); font-size: 0.9rem; padding: 0.8rem;
+                background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+
+    .sx-webui { width: 100%; height: calc(100vh - 200px); min-height: 500px; }
+    .sx-iframe { width: 100%; height: 100%; border: none; border-radius: 12px; background: var(--crow-bg-elevated); }
+  `;
+}

--- a/bundles/searxng/server/index.js
+++ b/bundles/searxng/server/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/**
+ * SearXNG MCP Server — stdio transport entry point
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createSearxngServer } from "./server.js";
+
+const server = createSearxngServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/bundles/searxng/server/server.js
+++ b/bundles/searxng/server/server.js
@@ -1,0 +1,156 @@
+/**
+ * SearXNG MCP Server
+ *
+ * Tools:
+ *   - searxng_search        Run a metasearch query; return top 10 results
+ *   - searxng_list_engines  List engines configured in this instance
+ *   - searxng_status        Check reachability + healthz
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const SEARXNG_URL = () => (process.env.SEARXNG_BASE_URL || "http://localhost:8098/").replace(/\/+$/, "");
+
+async function sxFetch(path, { timeoutMs = 15000 } = {}) {
+  const url = `${SEARXNG_URL()}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { "Accept": "application/json" },
+    });
+    if (!res.ok) throw new Error(`SearXNG ${res.status}: ${res.statusText}`);
+    const text = await res.text();
+    return text ? JSON.parse(text) : {};
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error(`SearXNG request timed out: ${path}`);
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error(`Cannot reach SearXNG at ${SEARXNG_URL()} — is the server running?`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function createSearxngServer(options = {}) {
+  const server = new McpServer(
+    { name: "crow-searxng", version: "1.0.0" },
+    { instructions: options.instructions },
+  );
+
+  server.tool(
+    "searxng_search",
+    "Run a metasearch query via SearXNG and return the top results. SearXNG aggregates answers from multiple engines (Google, DuckDuckGo, Wikipedia, etc.) without tracking.",
+    {
+      query: z.string().min(1).max(1000).describe("Search query"),
+      categories: z.string().max(200).optional().describe("Comma-separated categories (e.g. 'general', 'it', 'science', 'news')"),
+      engines: z.string().max(200).optional().describe("Comma-separated engine names to restrict the search to (e.g. 'duckduckgo,wikipedia')"),
+      language: z.string().max(10).optional().default("en").describe("Language code (e.g. 'en', 'es', 'de')"),
+      pageno: z.number().min(1).max(10).optional().default(1).describe("Page number"),
+      limit: z.number().min(1).max(30).optional().default(10).describe("Max results to return"),
+    },
+    async ({ query, categories, engines, language, pageno, limit }) => {
+      try {
+        const params = new URLSearchParams({
+          q: query,
+          format: "json",
+          language,
+          pageno: String(pageno),
+        });
+        if (categories) params.set("categories", categories);
+        if (engines) params.set("engines", engines);
+
+        const data = await sxFetch(`/search?${params}`);
+        const results = (Array.isArray(data?.results) ? data.results : []).slice(0, limit).map((r) => ({
+          title: r.title || null,
+          url: r.url || null,
+          content: r.content ? r.content.slice(0, 500) : null,
+          engine: r.engine || null,
+          category: r.category || null,
+          score: typeof r.score === "number" ? Number(r.score.toFixed(3)) : null,
+          publishedDate: r.publishedDate || null,
+        }));
+        const infoboxes = (Array.isArray(data?.infoboxes) ? data.infoboxes : []).slice(0, 2).map((i) => ({
+          title: i.infobox || i.title || null,
+          content: i.content ? i.content.slice(0, 500) : null,
+          engine: i.engine || null,
+        }));
+
+        return {
+          content: [{
+            type: "text",
+            text: results.length
+              ? JSON.stringify({
+                  query,
+                  number_of_results: data?.number_of_results || results.length,
+                  results,
+                  infoboxes: infoboxes.length ? infoboxes : undefined,
+                }, null, 2)
+              : `No results for "${query}"`,
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "searxng_list_engines",
+    "List the search engines configured in this SearXNG instance",
+    {
+      enabled_only: z.boolean().optional().default(true).describe("Return only engines that are currently enabled (default true)"),
+    },
+    async ({ enabled_only }) => {
+      try {
+        const data = await sxFetch("/config");
+        const engines = Array.isArray(data?.engines) ? data.engines : [];
+        const filtered = enabled_only ? engines.filter((e) => !e.disabled) : engines;
+        const summary = filtered.map((e) => ({
+          name: e.name,
+          categories: e.categories || [],
+          shortcut: e.shortcut || null,
+          disabled: !!e.disabled,
+        }));
+        return {
+          content: [{
+            type: "text",
+            text: summary.length
+              ? `${summary.length} engine(s):\n${JSON.stringify(summary, null, 2)}`
+              : "No engines returned by /config.",
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "searxng_status",
+    "Check whether SearXNG is reachable and responding to healthz",
+    {},
+    async () => {
+      try {
+        const url = SEARXNG_URL();
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 8000);
+        const res = await fetch(`${url}/healthz`, { signal: controller.signal });
+        clearTimeout(t);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ url, reachable: res.ok, http_status: res.status }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  return server;
+}

--- a/bundles/searxng/skills/searxng.md
+++ b/bundles/searxng/skills/searxng.md
@@ -1,0 +1,76 @@
+---
+name: searxng
+description: SearXNG — privacy-respecting metasearch engine aggregating 70+ sources
+triggers:
+  - "searxng"
+  - "private search"
+  - "search the web"
+  - "buscar privado"
+  - "búsqueda privada"
+  - "metasearch"
+tools:
+  - searxng_search
+  - searxng_list_engines
+  - searxng_status
+---
+
+# SearXNG — privacy-respecting metasearch
+
+SearXNG aggregates results from dozens of search engines (Google, Bing,
+DuckDuckGo, Wikipedia, GitHub, arXiv, Stack Exchange, and many more)
+without tracking or profiling you. It runs entirely on your host.
+
+## First-run
+
+1. Start the bundle from the Extensions panel.
+2. The entrypoint seeds `~/.crow/searxng/settings.yml` on first boot and
+   generates a random `secret_key` inline. You can edit this file later
+   to enable/disable engines, tweak categories, or adjust rate limits —
+   changes apply after a bundle restart.
+3. Open **http://localhost:8098** to use the web UI, or call the MCP
+   tools to query from an AI session.
+
+## Using the MCP tools
+
+- `searxng_search` — run a query, return the top 10 results
+  ```
+  searxng_search(query: "pgvector vs pgai", engines: "duckduckgo,wikipedia")
+  ```
+- `searxng_list_engines` — see which engines are active
+- `searxng_status` — healthcheck
+
+The search tool returns structured JSON (title, URL, content snippet,
+engine, score) so downstream tools can chain on it.
+
+## Enabling more engines
+
+The default `settings.yml` uses SearXNG's bundled engine defaults. To
+activate an engine that's disabled by default, open `~/.crow/searxng/
+settings.yml` and add:
+
+```yaml
+engines:
+  - name: github
+    disabled: false
+  - name: arxiv
+    disabled: false
+```
+
+See [SearXNG's docs](https://docs.searxng.org/admin/settings/settings_engine.html)
+for the full list.
+
+## Trade-off: simplicity over stock-conforming config
+
+The seeded `settings.yml` is intentionally minimal: `use_default_settings:
+true` inherits SearXNG's upstream defaults, so we only need to override a
+handful of fields (secret_key, instance_name, JSON format support,
+bind_address). This works on day one and is easy to diff if upstream
+changes. If you want tight control, replace the file wholesale — the
+bundle's entrypoint only seeds it when it's missing.
+
+## Bot detection and rate limits
+
+SearXNG's built-in limiter is **off by default** in the seeded config so
+MCP tool calls don't fight a bot-detection heuristic. If you expose
+SearXNG publicly via Caddy, flip `limiter: true` in settings.yml and
+restart. For local-only use, leaving it off is the right call.

--- a/bundles/vaultwarden/docker-compose.yml
+++ b/bundles/vaultwarden/docker-compose.yml
@@ -1,0 +1,33 @@
+# Vaultwarden — unofficial Bitwarden-compatible server.
+#
+# Security notes:
+#   - Bind to 127.0.0.1 only. To reach the vault remotely, front this with
+#     the Caddy bundle (public HTTPS) — NEVER expose 8097 directly.
+#   - ADMIN_TOKEN gates the /admin panel. Keep it strong and secret.
+#   - Data lives in ~/.crow/vaultwarden/data as a bind mount so backups are
+#     straightforward. This dir contains the SQLite DB, attachments, and
+#     RSA keys — treat it like the crown jewels it is.
+
+services:
+  vaultwarden:
+    image: vaultwarden/server:1.32.7
+    container_name: crow-vaultwarden
+    ports:
+      - "127.0.0.1:8097:80"
+    volumes:
+      - ${VAULTWARDEN_DATA_DIR:-~/.crow/vaultwarden/data}:/data
+    environment:
+      - ADMIN_TOKEN=${VAULTWARDEN_ADMIN_TOKEN}
+      - DOMAIN=${VAULTWARDEN_DOMAIN:-http://localhost:8097}
+      - SIGNUPS_ALLOWED=${VAULTWARDEN_SIGNUPS_ALLOWED:-true}
+      - ROCKET_PORT=80
+      - WEB_VAULT_ENABLED=true
+    init: true
+    mem_limit: 256m
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:80/alive"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 15s

--- a/bundles/vaultwarden/manifest.json
+++ b/bundles/vaultwarden/manifest.json
@@ -1,0 +1,31 @@
+{
+  "id": "vaultwarden",
+  "name": "Vaultwarden",
+  "version": "1.0.0",
+  "description": "Bitwarden-compatible password manager — self-hosted vault for passwords, notes, and 2FA, used with the Bitwarden browser and mobile apps",
+  "type": "bundle",
+  "author": "Crow",
+  "category": "infrastructure",
+  "tags": ["passwords", "vault", "bitwarden", "secrets", "security", "self-hosted"],
+  "icon": "lock",
+  "docker": { "composefile": "docker-compose.yml" },
+  "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["VAULTWARDEN_URL", "VAULTWARDEN_ADMIN_TOKEN"] },
+  "panel": "panel/vaultwarden.js",
+  "panelRoutes": "panel/routes.js",
+  "skills": ["skills/vaultwarden.md"],
+  "consent_required": true,
+  "install_consent_messages": {
+    "en": "Vaultwarden stores the passwords and secrets for your entire digital life. Before you install: (1) this bundle will hold every credential you import, so back up ~/.crow/vaultwarden/data on a recurring schedule — losing it means losing everything; (2) the admin token sits in your .env file in plaintext — anyone with shell access on this host can administer the vault; (3) signups default to OPEN — without the admin token, anyone who can reach http://localhost:8097 can create the first account and lock you out. Create your account immediately after first start, then set VAULTWARDEN_SIGNUPS_ALLOWED=false and restart the bundle. The Crow MCP tools intentionally do NOT expose vault contents — use the official Bitwarden browser extension or mobile app as your working client.",
+    "es": "Vaultwarden guardará las contraseñas y secretos de toda tu vida digital. Antes de instalar: (1) este bundle contendrá todas tus credenciales, haz copias de seguridad periódicas de ~/.crow/vaultwarden/data — perderlo significa perderlo todo; (2) el token de administrador queda en el archivo .env en texto plano — cualquiera con acceso al shell puede administrar el vault; (3) por defecto se permiten registros — sin proteger el token, cualquiera que pueda alcanzar http://localhost:8097 puede crear la primera cuenta y dejarte fuera. Crea tu cuenta inmediatamente tras el primer arranque, luego pon VAULTWARDEN_SIGNUPS_ALLOWED=false y reinicia. Las herramientas MCP de Crow intencionalmente NO exponen el contenido del vault — usa la extensión oficial de Bitwarden o la app móvil como cliente."
+  },
+  "requires": { "env": ["VAULTWARDEN_ADMIN_TOKEN"], "min_ram_mb": 256, "min_disk_mb": 200 },
+  "env_vars": [
+    { "name": "VAULTWARDEN_URL", "description": "Vaultwarden server URL", "default": "http://localhost:8097", "required": true },
+    { "name": "VAULTWARDEN_ADMIN_TOKEN", "description": "Argon2id or Bcrypt hash protecting /admin. Generate with: openssl rand -base64 48 (store the output, then run `vaultwarden hash` inside the container to get the hash to paste here). For a simpler MVP you may paste the plain random string — Vaultwarden accepts both.", "required": true, "secret": true },
+    { "name": "VAULTWARDEN_DOMAIN", "description": "Public URL Vaultwarden advertises to clients (set to https://... when put behind Caddy)", "default": "http://localhost:8097", "required": false },
+    { "name": "VAULTWARDEN_SIGNUPS_ALLOWED", "description": "Whether new users can sign up via the web UI. Start true, create your admin account, then flip to false and restart.", "default": "true", "required": false }
+  ],
+  "ports": [8097],
+  "webUI": { "port": 8097, "path": "/", "label": "Vaultwarden" },
+  "notes": "Password managers need careful handling. See the skill for the recommended setup order (create account → disable signups → back up data dir). The MCP tools are deliberately minimal: status, user_count, backup_info. They do NOT read vault contents — use the Bitwarden browser extension or mobile app for day-to-day password access."
+}

--- a/bundles/vaultwarden/package-lock.json
+++ b/bundles/vaultwarden/package-lock.json
@@ -1,0 +1,1139 @@
+{
+  "name": "crow-vaultwarden",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-vaultwarden",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/vaultwarden/package.json
+++ b/bundles/vaultwarden/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "crow-vaultwarden",
+  "version": "1.0.0",
+  "description": "Vaultwarden MCP server — minimal status and backup info (deliberately no vault access)",
+  "type": "module",
+  "main": "server/index.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  }
+}

--- a/bundles/vaultwarden/panel/routes.js
+++ b/bundles/vaultwarden/panel/routes.js
@@ -1,0 +1,73 @@
+/**
+ * Vaultwarden panel routes — status and backup info only. No secret access.
+ */
+
+import { Router } from "express";
+import { statSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const VAULTWARDEN_URL = () => (process.env.VAULTWARDEN_URL || "http://localhost:8097").replace(/\/+$/, "");
+
+function resolveDataDir() {
+  const env = process.env.VAULTWARDEN_DATA_DIR;
+  if (env) return env.replace(/^~/, homedir());
+  return join(homedir(), ".crow/vaultwarden/data");
+}
+
+function dirSize(dir) {
+  if (!existsSync(dir)) return { size: null, newest: null };
+  let total = 0;
+  let newest = 0;
+  function walk(d) {
+    let entries;
+    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const p = join(d, e.name);
+      try {
+        const s = statSync(p);
+        if (e.isDirectory()) walk(p);
+        else { total += s.size; if (s.mtimeMs > newest) newest = s.mtimeMs; }
+      } catch { /* skip */ }
+    }
+  }
+  walk(dir);
+  return { size: total, newest };
+}
+
+export default function vaultwardenRouter(authMiddleware) {
+  const router = Router();
+
+  router.get("/api/vaultwarden/status", authMiddleware, async (req, res) => {
+    const url = VAULTWARDEN_URL();
+    try {
+      const controller = new AbortController();
+      const t = setTimeout(() => controller.abort(), 8000);
+      const resp = await fetch(`${url}/alive`, { signal: controller.signal });
+      clearTimeout(t);
+      res.json({ url, reachable: resp.ok });
+    } catch (err) {
+      res.json({ url, reachable: false, error: err.message });
+    }
+  });
+
+  router.get("/api/vaultwarden/backup", authMiddleware, async (req, res) => {
+    try {
+      const dir = resolveDataDir();
+      const { size, newest } = dirSize(dir);
+      if (size === null) {
+        return res.json({ data_dir: dir, exists: false });
+      }
+      res.json({
+        data_dir: dir,
+        exists: true,
+        total_bytes: size,
+        last_modified: newest ? new Date(newest).toISOString() : null,
+      });
+    } catch (err) {
+      res.json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/bundles/vaultwarden/panel/vaultwarden.js
+++ b/bundles/vaultwarden/panel/vaultwarden.js
@@ -1,0 +1,197 @@
+/**
+ * Crow's Nest Panel — Vaultwarden
+ *
+ * Status card + backup freshness + link to the web UI. Password managers
+ * should open in a full browser window (not an iframe) so browser
+ * extensions and autofill work correctly. Client-side JS uses
+ * textContent + createElement only (XSS-safe).
+ */
+
+export default {
+  id: "vaultwarden",
+  name: "Vaultwarden",
+  icon: "lock",
+  route: "/dashboard/vaultwarden",
+  navOrder: 44,
+  category: "infrastructure",
+
+  async handler(req, res, { layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+
+    const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
+    const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
+
+    const url = process.env.VAULTWARDEN_URL || "http://localhost:8097";
+
+    const content = `
+      <style>${vaultwardenStyles()}</style>
+      <div class="vw-panel">
+        <h1>Vaultwarden</h1>
+
+        <div class="vw-hero">
+          <p>Your self-hosted Bitwarden-compatible vault. Use the official Bitwarden browser extension or mobile app to read, create, and autofill credentials.</p>
+          <a href="${escapeHtml(url)}" target="_blank" rel="noopener" class="vw-btn">Open Web Vault</a>
+        </div>
+
+        <div class="vw-section">
+          <h3>Status</h3>
+          <div id="vw-status" class="vw-status"><div class="np-loading">Checking...</div></div>
+        </div>
+
+        <div class="vw-section">
+          <h3>Backup Freshness</h3>
+          <div id="vw-backup" class="vw-backup"><div class="np-loading">Loading...</div></div>
+          <div class="vw-hint">The data directory is the single source of truth. Losing it means losing every stored credential. Schedule recurring backups.</div>
+        </div>
+      </div>
+      <script>${vaultwardenScript()}</script>
+    `;
+
+    res.send(layout({ title: "Vaultwarden", content }));
+  },
+};
+
+function vaultwardenScript() {
+  return `
+    async function loadStatus() {
+      const el = document.getElementById('vw-status');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/vaultwarden/status');
+        const data = await res.json();
+        el.textContent = '';
+        const card = document.createElement('div');
+        card.className = 'stat-card';
+        const val = document.createElement('div');
+        val.className = 'stat-value';
+        val.textContent = data.reachable ? 'Online' : 'Offline';
+        if (!data.reachable) card.classList.add('stat-warn');
+        card.appendChild(val);
+        const label = document.createElement('div');
+        label.className = 'stat-label';
+        label.textContent = data.url;
+        card.appendChild(label);
+        el.appendChild(card);
+        if (data.error) {
+          const err = document.createElement('div');
+          err.className = 'np-error';
+          err.textContent = data.error;
+          el.appendChild(err);
+        }
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to reach status endpoint.';
+        el.appendChild(err);
+      }
+    }
+
+    function formatBytes(n) {
+      if (!n) return '0 B';
+      if (n < 1024) return n + ' B';
+      if (n < 1048576) return (n / 1024).toFixed(1) + ' KB';
+      if (n < 1073741824) return (n / 1048576).toFixed(1) + ' MB';
+      return (n / 1073741824).toFixed(2) + ' GB';
+    }
+
+    async function loadBackup() {
+      const el = document.getElementById('vw-backup');
+      if (!el) return;
+      try {
+        const res = await fetch('/api/vaultwarden/backup');
+        const data = await res.json();
+        el.textContent = '';
+        if (!data.exists) {
+          const idle = document.createElement('div');
+          idle.className = 'np-idle';
+          idle.textContent = 'Data directory not found yet — Vaultwarden may not have been started.';
+          el.appendChild(idle);
+          return;
+        }
+        const sizeCard = document.createElement('div');
+        sizeCard.className = 'stat-card';
+        const sv = document.createElement('div');
+        sv.className = 'stat-value';
+        sv.textContent = formatBytes(data.total_bytes);
+        sizeCard.appendChild(sv);
+        const sl = document.createElement('div');
+        sl.className = 'stat-label';
+        sl.textContent = 'Data size';
+        sizeCard.appendChild(sl);
+        el.appendChild(sizeCard);
+
+        if (data.last_modified) {
+          const ageCard = document.createElement('div');
+          ageCard.className = 'stat-card';
+          const av = document.createElement('div');
+          av.className = 'stat-value';
+          av.textContent = new Date(data.last_modified).toLocaleString();
+          ageCard.appendChild(av);
+          const al = document.createElement('div');
+          al.className = 'stat-label';
+          al.textContent = 'Last write';
+          ageCard.appendChild(al);
+          el.appendChild(ageCard);
+        }
+
+        const pathCard = document.createElement('div');
+        pathCard.className = 'stat-card stat-path';
+        const pv = document.createElement('div');
+        pv.className = 'stat-url';
+        pv.textContent = data.data_dir;
+        pathCard.appendChild(pv);
+        const pl = document.createElement('div');
+        pl.className = 'stat-label';
+        pl.textContent = 'Data directory';
+        pathCard.appendChild(pl);
+        el.appendChild(pathCard);
+      } catch (e) {
+        el.textContent = '';
+        const err = document.createElement('div');
+        err.className = 'np-error';
+        err.textContent = 'Failed to load backup info.';
+        el.appendChild(err);
+      }
+    }
+
+    loadStatus();
+    loadBackup();
+  `;
+}
+
+function vaultwardenStyles() {
+  return `
+    .vw-panel h1 { margin: 0 0 1rem; font-size: 1.5rem; }
+    .vw-hero { background: var(--crow-bg-elevated); border: 1px solid var(--crow-border);
+               border-radius: 12px; padding: 1.2rem; margin-bottom: 1.5rem; }
+    .vw-hero p { margin: 0 0 0.8rem; color: var(--crow-text-secondary); }
+    .vw-btn { display: inline-block; padding: 0.5rem 1rem; background: var(--crow-accent);
+              color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600; }
+    .vw-btn:hover { filter: brightness(1.1); }
+
+    .vw-section { margin-bottom: 1.5rem; }
+    .vw-section h3 { font-size: 0.85rem; color: var(--crow-text-muted); text-transform: uppercase;
+                     letter-spacing: 0.05em; margin: 0 0 0.8rem; }
+
+    .vw-status, .vw-backup { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .stat-card { background: var(--crow-bg-elevated); border-radius: 10px; padding: 1rem 1.2rem;
+                 border: 1px solid var(--crow-border); min-width: 160px; }
+    .stat-card.stat-warn { border-color: var(--crow-error); }
+    .stat-card.stat-warn .stat-value { color: var(--crow-error); }
+    .stat-card.stat-path { flex: 1; min-width: 300px; }
+    .stat-value { font-size: 1.1rem; font-weight: 700; color: var(--crow-accent); }
+    .stat-url { font-size: 0.85rem; font-family: monospace; color: var(--crow-text-primary); word-break: break-all; }
+    .stat-label { font-size: 0.8rem; color: var(--crow-text-muted); margin-top: 0.25rem; }
+
+    .vw-hint { font-size: 0.8rem; color: var(--crow-text-muted); margin-top: 0.8rem;
+               padding: 0.6rem; border-left: 2px solid var(--crow-accent);
+               background: var(--crow-bg-elevated); border-radius: 4px; }
+
+    .np-idle, .np-loading { color: var(--crow-text-muted); font-size: 0.9rem; padding: 1rem;
+                            background: var(--crow-bg-elevated); border-radius: 12px; text-align: center; }
+    .np-error { color: var(--crow-error); font-size: 0.9rem; padding: 0.8rem;
+                background: var(--crow-bg-elevated); border-radius: 12px; margin-top: 0.5rem; }
+  `;
+}

--- a/bundles/vaultwarden/server/index.js
+++ b/bundles/vaultwarden/server/index.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+/**
+ * Vaultwarden MCP Server — stdio transport entry point
+ */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createVaultwardenServer } from "./server.js";
+
+const server = createVaultwardenServer();
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/bundles/vaultwarden/server/server.js
+++ b/bundles/vaultwarden/server/server.js
@@ -1,0 +1,200 @@
+/**
+ * Vaultwarden MCP Server
+ *
+ * Deliberately minimal. Vaultwarden does not expose a "read passwords" API
+ * by design — that's what the Bitwarden browser extension and mobile app
+ * are for. The tools here only surface operational health:
+ *
+ *   - vaultwarden_status       Is the server reachable? Build version?
+ *   - vaultwarden_user_count   How many accounts exist? (via /admin)
+ *   - vaultwarden_backup_info  Size and age of ~/.crow/vaultwarden/data
+ *
+ * Any tool that could expose secrets is intentionally not provided.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { statSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const VAULTWARDEN_URL = () => (process.env.VAULTWARDEN_URL || "http://localhost:8097").replace(/\/+$/, "");
+const ADMIN_TOKEN = () => process.env.VAULTWARDEN_ADMIN_TOKEN || "";
+
+function resolveDataDir() {
+  const env = process.env.VAULTWARDEN_DATA_DIR;
+  if (env) return env.replace(/^~/, homedir());
+  return join(homedir(), ".crow/vaultwarden/data");
+}
+
+async function vwFetch(path, options = {}) {
+  const url = `${VAULTWARDEN_URL()}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json", ...options.headers },
+    });
+    return res;
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error(`Vaultwarden request timed out: ${path}`);
+    if (err.message.includes("fetch failed") || err.message.includes("ECONNREFUSED")) {
+      throw new Error(`Cannot reach Vaultwarden at ${VAULTWARDEN_URL()} — is the server running?`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function formatBytes(n) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function dirStats(dir) {
+  if (!existsSync(dir)) return null;
+  let total = 0;
+  let newest = 0;
+  let oldest = Infinity;
+  function walk(d) {
+    let entries;
+    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const p = join(d, e.name);
+      try {
+        const s = statSync(p);
+        if (e.isDirectory()) walk(p);
+        else {
+          total += s.size;
+          if (s.mtimeMs > newest) newest = s.mtimeMs;
+          if (s.mtimeMs < oldest) oldest = s.mtimeMs;
+        }
+      } catch { /* skip */ }
+    }
+  }
+  walk(dir);
+  return { total_bytes: total, newest_mtime: newest, oldest_mtime: oldest === Infinity ? 0 : oldest };
+}
+
+export function createVaultwardenServer(options = {}) {
+  const server = new McpServer(
+    { name: "crow-vaultwarden", version: "1.0.0" },
+    { instructions: options.instructions },
+  );
+
+  server.tool(
+    "vaultwarden_status",
+    "Check whether Vaultwarden is reachable and return its build info",
+    {},
+    async () => {
+      try {
+        const aliveRes = await vwFetch("/alive");
+        if (!aliveRes.ok) {
+          return { content: [{ type: "text", text: `Vaultwarden unhealthy: HTTP ${aliveRes.status}` }] };
+        }
+        let version = null;
+        try {
+          const r = await vwFetch("/api/config");
+          if (r.ok) {
+            const data = await r.json();
+            version = data?.version || null;
+          }
+        } catch { /* /api/config may require auth in some versions */ }
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              reachable: true,
+              url: VAULTWARDEN_URL(),
+              version,
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "vaultwarden_user_count",
+    "Return the number of registered Vaultwarden users. Requires a valid VAULTWARDEN_ADMIN_TOKEN — the admin API does not expose passwords, only account metadata.",
+    {},
+    async () => {
+      try {
+        const token = ADMIN_TOKEN();
+        if (!token) {
+          return { content: [{ type: "text", text: "Error: VAULTWARDEN_ADMIN_TOKEN is not set" }] };
+        }
+        const res = await vwFetch("/admin/users", {
+          headers: { "Authorization": `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          if (res.status === 401 || res.status === 403) {
+            return { content: [{ type: "text", text: "Error: admin token rejected — check VAULTWARDEN_ADMIN_TOKEN" }] };
+          }
+          return { content: [{ type: "text", text: `Error: admin API returned ${res.status}` }] };
+        }
+        const users = await res.json();
+        const list = Array.isArray(users) ? users : [];
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              user_count: list.length,
+              accounts: list.map((u) => ({
+                email: u.Email || u.email || null,
+                disabled: !!(u.Disabled ?? u.disabled),
+                two_factor: !!(u.TwoFactorEnabled ?? u.two_factor_enabled),
+                last_active: u.LastActive || u.last_active || null,
+              })),
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  server.tool(
+    "vaultwarden_backup_info",
+    "Report the size and modification time of the Vaultwarden data directory (for backup freshness checks). Does NOT read vault contents.",
+    {},
+    async () => {
+      try {
+        const dir = resolveDataDir();
+        const stats = dirStats(dir);
+        if (!stats) {
+          return { content: [{ type: "text", text: `Vaultwarden data directory not found at ${dir}` }] };
+        }
+        const now = Date.now();
+        const ageMs = stats.newest_mtime ? now - stats.newest_mtime : 0;
+        const ageHours = Math.round(ageMs / 3600000);
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              data_dir: dir,
+              total_size: formatBytes(stats.total_bytes),
+              total_bytes: stats.total_bytes,
+              last_modified: stats.newest_mtime ? new Date(stats.newest_mtime).toISOString() : null,
+              hours_since_last_write: ageHours,
+              hint: "Back up this directory regularly. Losing it means losing every stored credential.",
+            }, null, 2),
+          }],
+        };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message}` }] };
+      }
+    },
+  );
+
+  return server;
+}

--- a/bundles/vaultwarden/skills/vaultwarden.md
+++ b/bundles/vaultwarden/skills/vaultwarden.md
@@ -1,0 +1,83 @@
+---
+name: vaultwarden
+description: Vaultwarden — self-hosted Bitwarden-compatible password manager
+triggers:
+  - "vaultwarden"
+  - "bitwarden"
+  - "password manager"
+  - "self-host passwords"
+  - "gestor de contraseñas"
+  - "bóveda de contraseñas"
+tools:
+  - vaultwarden_status
+  - vaultwarden_user_count
+  - vaultwarden_backup_info
+---
+
+# Vaultwarden — self-hosted password vault
+
+Vaultwarden is an unofficial Bitwarden-compatible server written in Rust.
+Your passwords, notes, TOTP codes, and attachments live in a SQLite vault
+on this host; the official Bitwarden browser extension and mobile apps
+connect to it over HTTP(S).
+
+## One-time setup (do this in order)
+
+1. **Generate an admin token:**
+   ```
+   openssl rand -base64 48
+   ```
+   Store the output in `.env` as `VAULTWARDEN_ADMIN_TOKEN`. Vaultwarden
+   accepts the raw token (simplest) or a hashed form — for MVP, use the
+   raw token and keep `.env` readable only by your user.
+
+2. **Start the bundle** from the Extensions panel.
+
+3. **Create your account** at `http://localhost:8097` — this becomes your
+   personal vault. Use a long, memorable master password you will
+   remember forever. It cannot be reset from the admin panel.
+
+4. **Disable open signups.** Edit `.env`:
+   ```
+   VAULTWARDEN_SIGNUPS_ALLOWED=false
+   ```
+   Restart the bundle. New users can now only be invited from the
+   admin panel.
+
+5. **Set up a backup.** The one thing standing between you and
+   catastrophic loss is `~/.crow/vaultwarden/data`. A reasonable
+   approach:
+   ```
+   0 3 * * * tar czf ~/backups/vaultwarden-$(date +\%Y\%m\%d).tgz -C ~/.crow vaultwarden/data
+   ```
+   Copy those tarballs off-host. Test a restore at least once.
+
+## Day-to-day use
+
+The MCP tools here are intentionally minimal:
+- `vaultwarden_status` — is the server up?
+- `vaultwarden_user_count` — how many accounts, via the admin API
+- `vaultwarden_backup_info` — size and age of the data directory
+
+**Vaultwarden does not have a "read my passwords" API and Crow does not
+build one.** Use the Bitwarden browser extension, desktop app, or mobile
+app for every interactive password operation. Point them at
+`http://localhost:8097` (or your Caddy-fronted HTTPS URL).
+
+## Remote access
+
+Vaultwarden binds to `127.0.0.1:8097`. To reach it from other devices:
+
+- **Best:** install the Caddy bundle and add a site mapping, e.g.
+  `vault.yourdomain.com -> http://127.0.0.1:8097`. Caddy handles TLS.
+- **Tailscale:** connect your phone to the same Tailscale network and
+  use the host's Tailscale IP + `:8097`.
+- **Do not** bind Vaultwarden directly to `0.0.0.0` on the public
+  internet without TLS — vault sync is fine over HTTP, but logins are
+  not.
+
+## Recovery from a forgotten master password
+
+You can't. That's the point. Your master password encrypts the vault
+and is never sent to the server in usable form. If you forget it, the
+vault is gone. Store a printed one-time recovery code somewhere safe.

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1476,6 +1476,30 @@
       "notes": "3 MCP tools (status, user_count, backup_info). Deliberately does NOT expose vault contents — use the Bitwarden browser extension or mobile app for credential access. Back up ~/.crow/vaultwarden/data regularly."
     },
     {
+      "id": "searxng",
+      "name": "SearXNG",
+      "description": "Privacy-respecting metasearch engine aggregating 70+ sources without tracking",
+      "type": "bundle",
+      "version": "1.0.0",
+      "author": "Crow",
+      "category": "productivity",
+      "tags": ["search", "metasearch", "privacy", "self-hosted"],
+      "icon": "search",
+      "docker": { "composefile": "docker-compose.yml" },
+      "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["SEARXNG_BASE_URL"] },
+      "panel": "panel/searxng.js",
+      "panelRoutes": "panel/routes.js",
+      "skills": ["skills/searxng.md"],
+      "requires": { "min_ram_mb": 256, "min_disk_mb": 150 },
+      "env_vars": [
+        { "name": "SEARXNG_BASE_URL", "description": "Public URL SearXNG advertises in links", "default": "http://localhost:8098/", "required": false },
+        { "name": "SEARXNG_SECRET_KEY", "description": "Secret key for SearXNG. Auto-generated on first boot if left empty.", "required": false, "secret": true }
+      ],
+      "ports": [8098],
+      "webUI": { "port": 8098, "path": "/", "label": "SearXNG" },
+      "notes": "Config in ~/.crow/searxng/settings.yml. JSON API enabled. First-boot entrypoint seeds a default config and random secret if not provided. 3 MCP tools: search, list_engines, status."
+    },
+    {
       "id": "vikunja",
       "name": "Vikunja",
       "description": "Self-hosted task management — projects, kanban boards, due dates, labels, and team collaboration",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1445,6 +1445,37 @@
       "notes": "Uses built-in SQLite. First-run setup wizard at http://localhost:3040. SSH on port 2223 via Gitea's built-in Go SSH server (no host sshd needed). Clone with ssh://git@host:2223/user/repo (scp-style git@host:user/repo silently hits port 22 and will not reach this bundle)."
     },
     {
+      "id": "vaultwarden",
+      "name": "Vaultwarden",
+      "description": "Bitwarden-compatible password manager — self-hosted vault used with the official Bitwarden browser and mobile apps",
+      "type": "bundle",
+      "version": "1.0.0",
+      "author": "Crow",
+      "category": "infrastructure",
+      "tags": ["passwords", "vault", "bitwarden", "secrets", "security", "self-hosted"],
+      "icon": "lock",
+      "docker": { "composefile": "docker-compose.yml" },
+      "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["VAULTWARDEN_URL", "VAULTWARDEN_ADMIN_TOKEN"] },
+      "panel": "panel/vaultwarden.js",
+      "panelRoutes": "panel/routes.js",
+      "skills": ["skills/vaultwarden.md"],
+      "consent_required": true,
+      "install_consent_messages": {
+        "en": "Vaultwarden stores the passwords and secrets for your entire digital life. Before you install: (1) back up ~/.crow/vaultwarden/data on a recurring schedule — losing it means losing everything; (2) the admin token sits in .env in plaintext; (3) open signups are ON by default — create your account immediately after first start and flip VAULTWARDEN_SIGNUPS_ALLOWED=false. The Crow MCP tools intentionally do NOT expose vault contents — use the official Bitwarden browser extension or mobile app.",
+        "es": "Vaultwarden guardará las contraseñas de toda tu vida digital. Antes de instalar: (1) haz copias de seguridad periódicas de ~/.crow/vaultwarden/data — perderlo significa perderlo todo; (2) el token de administrador queda en .env en texto plano; (3) los registros abiertos están activados por defecto — crea tu cuenta inmediatamente y pon VAULTWARDEN_SIGNUPS_ALLOWED=false. Las herramientas MCP de Crow NO exponen el contenido del vault — usa la extensión oficial de Bitwarden."
+      },
+      "requires": { "env": ["VAULTWARDEN_ADMIN_TOKEN"], "min_ram_mb": 256, "min_disk_mb": 200 },
+      "env_vars": [
+        { "name": "VAULTWARDEN_URL", "description": "Vaultwarden server URL", "default": "http://localhost:8097", "required": true },
+        { "name": "VAULTWARDEN_ADMIN_TOKEN", "description": "Secret that unlocks /admin. Generate with: openssl rand -base64 48", "required": true, "secret": true },
+        { "name": "VAULTWARDEN_DOMAIN", "description": "Public URL (set to https://... behind Caddy)", "default": "http://localhost:8097", "required": false },
+        { "name": "VAULTWARDEN_SIGNUPS_ALLOWED", "description": "Allow open signups. Start true, create your account, then flip to false.", "default": "true", "required": false }
+      ],
+      "ports": [8097],
+      "webUI": { "port": 8097, "path": "/", "label": "Vaultwarden" },
+      "notes": "3 MCP tools (status, user_count, backup_info). Deliberately does NOT expose vault contents — use the Bitwarden browser extension or mobile app for credential access. Back up ~/.crow/vaultwarden/data regularly."
+    },
+    {
       "id": "vikunja",
       "name": "Vikunja",
       "description": "Self-hosted task management — projects, kanban boards, due dates, labels, and team collaboration",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1397,6 +1397,30 @@
       "notes": "Docker stack includes MariaDB. Port remapped from 80 to 6875. Composite token auth (ID:SECRET). 8 MCP tools."
     },
     {
+      "id": "forgejo",
+      "name": "Forgejo",
+      "description": "Community-driven soft-fork of Gitea — self-hosted git with an AGPL license and ActivityPub federation roadmap",
+      "type": "bundle",
+      "version": "1.0.0",
+      "author": "Crow",
+      "category": "infrastructure",
+      "tags": ["git", "scm", "source-control", "code-hosting", "self-hosted", "federated"],
+      "icon": "git",
+      "docker": { "composefile": "docker-compose.yml" },
+      "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["FORGEJO_URL", "FORGEJO_TOKEN"] },
+      "panel": "panel/forgejo.js",
+      "panelRoutes": "panel/routes.js",
+      "skills": ["skills/forgejo.md"],
+      "requires": { "env": ["FORGEJO_TOKEN"], "min_ram_mb": 512, "min_disk_mb": 500 },
+      "env_vars": [
+        { "name": "FORGEJO_URL", "description": "Forgejo server URL", "default": "http://localhost:3050", "required": true },
+        { "name": "FORGEJO_TOKEN", "description": "Personal access token (Settings > Applications)", "required": true, "secret": true }
+      ],
+      "ports": [3050, 2224],
+      "webUI": { "port": 3050, "path": "/", "label": "Forgejo" },
+      "notes": "API-compatible with Gitea's v1 REST endpoints. SSH on port 2224 via Forgejo's built-in Go SSH server. Use ssh://git@host:2224/user/repo (not scp-style git@host:user/repo which hits port 22). Install alongside Gitea — ports do not collide."
+    },
+    {
       "id": "gitea",
       "name": "Gitea",
       "description": "Self-hosted git service — repos, issues, pull requests, and built-in SSH server for git over SSH",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1397,6 +1397,30 @@
       "notes": "Docker stack includes MariaDB. Port remapped from 80 to 6875. Composite token auth (ID:SECRET). 8 MCP tools."
     },
     {
+      "id": "gitea",
+      "name": "Gitea",
+      "description": "Self-hosted git service — repos, issues, pull requests, and built-in SSH server for git over SSH",
+      "type": "bundle",
+      "version": "1.0.0",
+      "author": "Crow",
+      "category": "infrastructure",
+      "tags": ["git", "scm", "source-control", "code-hosting", "self-hosted"],
+      "icon": "git",
+      "docker": { "composefile": "docker-compose.yml" },
+      "server": { "command": "node", "args": ["server/index.js"], "envKeys": ["GITEA_URL", "GITEA_TOKEN"] },
+      "panel": "panel/gitea.js",
+      "panelRoutes": "panel/routes.js",
+      "skills": ["skills/gitea.md"],
+      "requires": { "env": ["GITEA_TOKEN"], "min_ram_mb": 512, "min_disk_mb": 500 },
+      "env_vars": [
+        { "name": "GITEA_URL", "description": "Gitea server URL", "default": "http://localhost:3040", "required": true },
+        { "name": "GITEA_TOKEN", "description": "Personal access token (Settings > Applications)", "required": true, "secret": true }
+      ],
+      "ports": [3040, 2223],
+      "webUI": { "port": 3040, "path": "/", "label": "Gitea" },
+      "notes": "Uses built-in SQLite. First-run setup wizard at http://localhost:3040. SSH on port 2223 via Gitea's built-in Go SSH server (no host sshd needed). Clone with ssh://git@host:2223/user/repo (scp-style git@host:user/repo silently hits port 22 and will not reach this bundle)."
+    },
+    {
       "id": "vikunja",
       "name": "Vikunja",
       "description": "Self-hosted task management — projects, kanban boards, due dates, labels, and team collaboration",

--- a/servers/gateway/dashboard/panels/extensions.js
+++ b/servers/gateway/dashboard/panels/extensions.js
@@ -45,6 +45,7 @@ const ICON_MAP = {
   dollar: "\u{1F4B0}",
   document: "\u{1F4D1}",
   git: "\u{1F33F}",
+  lock: "\u{1F512}",
 };
 
 const CATEGORY_COLORS = {

--- a/servers/gateway/dashboard/panels/extensions.js
+++ b/servers/gateway/dashboard/panels/extensions.js
@@ -44,6 +44,7 @@ const ICON_MAP = {
   "check-square": "\u2705",
   dollar: "\u{1F4B0}",
   document: "\u{1F4D1}",
+  git: "\u{1F33F}",
 };
 
 const CATEGORY_COLORS = {

--- a/servers/gateway/dashboard/panels/extensions.js
+++ b/servers/gateway/dashboard/panels/extensions.js
@@ -46,6 +46,7 @@ const ICON_MAP = {
   document: "\u{1F4D1}",
   git: "\u{1F33F}",
   lock: "\u{1F512}",
+  search: "\u{1F50D}",
 };
 
 const CATEGORY_COLORS = {


### PR DESCRIPTION
Four bundles covering identity (password manager), self-hosted git (two options), and metasearch.

**Independent of other MVP PRs — branched from main.** Vaultwarden's `consent_required: true` is a no-op on this branch (PR 0's infrastructure is needed for it to take effect); it will activate as soon as #1 lands, regardless of merge order.

## Bundles

### gitea (v1.23.8)

- Self-hosted git at `127.0.0.1:3040` + SSH on `127.0.0.1:2223`
- Uses built-in SQLite — single container, no separate postgres
- Bind-mount at `~/.crow/gitea/data/` so repos are user-backupable
- Healthcheck: `/api/healthz` (returns 200 pre-wizard, unlike `/api/v1/version` which 404s until setup completes)
- MCP tools (5): `list_repos`, `repo_info`, `create_repo`, `list_issues`, `create_issue`
- First-boot: open `localhost:3040`, walk the setup wizard, generate a personal access token in Settings → Applications, copy to `.env`

### forgejo (v9.0.3)

- API-compatible fork of Gitea, from `codeberg.org/forgejo/forgejo` (not Docker Hub)
- Web on `127.0.0.1:3050`, SSH on `127.0.0.1:2224`
- Thin wrapper MCP server over the Gitea-compatible API (deliberate code duplication for MVP clarity)
- Skill explains "why both?" — Forgejo is the open-source community fork; users pick one

**CI note**: PR 0's `.github/workflows/image-freshness.yml` uses `docker pull` directly on every `image:` line, which handles arbitrary registries transparently. `codeberg.org/forgejo/forgejo` works with no special handling (verified).

### vaultwarden (v1.32.7)

- Bitwarden-compatible password manager at `127.0.0.1:8097`
- **`consent_required: true`** with EN/ES messages covering: "this holds all your passwords; back up `~/.crow/vaultwarden/data/` regularly; the admin token is in `.env`; without it anyone on `localhost:8097` can create the first account"
- Bind-mount at `~/.crow/vaultwarden/data/`
- MCP tools kept minimal — Vaultwarden intentionally doesn't expose a "read passwords" API. Tools: `vaultwarden_status`, `vaultwarden_user_count`, `vaultwarden_backup_info` (size, age of data dir). Skill points to the Bitwarden browser extension / mobile app for actual password use
- Healthcheck: `/alive` via curl (image has curl, no wget)

### searxng (2026.4.11-9e08a6771)

- Privacy-respecting metasearch at `127.0.0.1:8098`
- Bind-mount `~/.crow/searxng/` (settings.yml + SECRET_KEY). Entrypoint seeds default settings + a random SECRET_KEY on first boot
- MCP tools (3): `searxng_search`, `searxng_list_engines`, `searxng_status`
- Healthcheck: `/healthz`
- Panel: simple search box + results list (XSS-safe) + iframe to full web UI

## Platform updates

- `registry/add-ons.json` entries (ordered: forgejo, gitea, vaultwarden, searxng — commit order, not strictly alphabetical)
- Icon map additions
- `.env.example` sections per bundle
- Ports 3040, 3050, 2223, 2224, 8097, 8098 — these are reserved in PR 0's port-allocation.md. When PR 0 merges, the allocation entries cover them; this branch doesn't modify the doc

## Verified per bundle

- `docker pull <image>:<tag>` succeeded for all four (exact digests in commits)
- All four containers boot healthy on alternate ports (grackle has some of these in use)
- Healthcheck endpoints return OK: Vaultwarden `/alive`, SearXNG `/healthz`, Gitea/Forgejo `/api/healthz`
- `node server/index.js < /dev/null` exits 0 for all four
- `registry/add-ons.json` parses as valid JSON
- No `innerHTML` usage anywhere in the new panel files

## Test plan

- [ ] Install each bundle (Vaultwarden triggers consent modal after PR 0 is live; others don't)
- [ ] Gitea: complete setup wizard, generate PAT, test `gitea_list_repos`
- [ ] Forgejo: same pattern; verify API compatibility with the MCP tools
- [ ] Vaultwarden: set `VAULTWARDEN_ADMIN_TOKEN` (generate with `openssl rand -base64 48`), verify Bitwarden browser extension syncs; flip `SIGNUPS_ALLOWED=false` after creating your first account
- [ ] SearXNG: run a search via `searxng_search`, verify results