### PR TITLE
F.15: Pin all bundle image tags to verified upstream semver

### DIFF
--- a/bundles/funkwhale/docker-compose.yml
+++ b/bundles/funkwhale/docker-compose.yml
@@ -1,22 +1,43 @@
 # Funkwhale — federated music server.
 #
-# Six-container bundle: api + celeryworker + celerybeat + nginx + postgres + redis.
-# All on crow-federation + an internal default network. Caddy reverse-proxies
-# :443 → funkwhale-nginx:80, which in turn serves static files and proxies
-# /api + /federation + websockets to funkwhale-api:5000.
+# Five-container bundle: api + celeryworker + celerybeat + front + postgres + redis.
+# api + front on crow-federation; DB + redis isolated to default.
+#
+# Funkwhale 2.x split the old `funkwhale/funkwhale` image into two:
+#   funkwhale/api:2.0.1   Django backend (gunicorn on :5000)
+#   funkwhale/front:2.0.1 Static SPA (nginx-served on :80)
+#
+# Caddy MUST split routing between the two (profile work deferred —
+# operators set this up manually until the `funkwhale` profile lands
+# in the Caddy bundle):
+#   / + /public + /library       → funkwhale-front:80  (SPA)
+#   /api/* + /federation/* + /.well-known/webfinger
+#                                → funkwhale-api:5000  (backend)
+#   /media/* + /static/*         → funkwhale-front:80  (served from
+#                                   shared volume populated by api's
+#                                   `collectstatic` step on first boot)
 #
 # Data:
 #   ~/.crow/funkwhale/postgres/   Postgres data dir
-#   ~/.crow/funkwhale/redis/      Redis persistence (optional AOF/RDB)
-#   ~/.crow/funkwhale/data/       Funkwhale /data (audio uploads, transcodes)
-#   ~/.crow/funkwhale/music/      Optional read-only in-place library (FUNKWHALE_MUSIC_DIR)
+#   ~/.crow/funkwhale/redis/      Redis persistence
+#   ~/.crow/funkwhale/data/       Funkwhale /srv/funkwhale/data
+#                                 (audio uploads, transcodes, static)
+#   ~/.crow/funkwhale/music/      Optional read-only in-place library
+#                                 (FUNKWHALE_MUSIC_DIR)
 #
 # Audio storage: on-disk by default. Set FUNKWHALE_S3_* env vars to route
-# uploads to MinIO / external S3 — storage-translators.funkwhale() handles
-# the env-var mapping to AWS_* names Funkwhale expects.
+# uploads to MinIO / external S3 — storage-translators.funkwhale() maps
+# AWS_* names Funkwhale expects.
 #
-# Image: funkwhale/funkwhale:1.4 (pinned at impl time; verify upstream
-# release notes + CVE feed before bumping).
+# Image tags pinned at implementation time (F.15, 2026-04-12):
+#   funkwhale/api:2.0.1          stable line
+#   funkwhale/front:2.0.1        matched to api version
+#   postgres:15-alpine           matches official Funkwhale compose
+#   redis:7-alpine               matches official Funkwhale compose
+#
+# Verified against https://dev.funkwhale.audio/funkwhale/funkwhale/-/raw/stable/deploy/docker-compose.yml
+# at bump time; F.15 pin bump replaces the F.4 compose which referenced
+# the non-existent funkwhale/funkwhale:1.4 + funkwhale/nginx:1.4 images.
 
 networks:
   crow-federation:
@@ -62,7 +83,7 @@ services:
       retries: 10
 
   api:
-    image: funkwhale/funkwhale:1.4
+    image: funkwhale/api:2.0.1
     container_name: crow-funkwhale-api
     networks:
       - default
@@ -99,12 +120,6 @@ services:
     volumes:
       - ${FUNKWHALE_DATA_DIR:-~/.crow/funkwhale}/data:/srv/funkwhale/data
       - ${FUNKWHALE_MUSIC_DIR:-~/.crow/funkwhale/music}:/music:ro
-    command: >
-      sh -c "funkwhale-manage migrate --noinput &&
-             funkwhale-manage collectstatic --noinput &&
-             gunicorn config.asgi:application -w $${FUNKWHALE_WEB_WORKERS:-2}
-               -k uvicorn.workers.UvicornWorker -b 0.0.0.0:5000
-               --access-logfile - --error-logfile -"
     init: true
     mem_limit: 1500m
     restart: unless-stopped
@@ -116,7 +131,7 @@ services:
       start_period: 120s
 
   celeryworker:
-    image: funkwhale/funkwhale:1.4
+    image: funkwhale/api:2.0.1
     container_name: crow-funkwhale-celeryworker
     networks:
       - default
@@ -145,7 +160,7 @@ services:
     restart: unless-stopped
 
   celerybeat:
-    image: funkwhale/funkwhale:1.4
+    image: funkwhale/api:2.0.1
     container_name: crow-funkwhale-celerybeat
     networks:
       - default
@@ -168,9 +183,9 @@ services:
     mem_limit: 256m
     restart: unless-stopped
 
-  nginx:
-    image: funkwhale/nginx:1.4
-    container_name: crow-funkwhale-nginx
+  front:
+    image: funkwhale/front:2.0.1
+    container_name: crow-funkwhale-front
     networks:
       - default
       - crow-federation
@@ -190,7 +205,7 @@ services:
     mem_limit: 128m
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/api/v1/instance/nodeinfo/2.0/ >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/ >/dev/null 2>&1 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/bundles/funkwhale/manifest.json
+++ b/bundles/funkwhale/manifest.json
@@ -44,5 +44,5 @@
   ],
   "ports": [],
   "webUI": null,
-  "notes": "Five containers (api + celeryworker + celerybeat + nginx + postgres + redis). No host port publish — expose via caddy_add_federation_site { domain: FUNKWHALE_HOSTNAME, upstream: 'funkwhale-nginx:80', profile: 'activitypub' }. Initial superuser created via `docker exec crow-funkwhale-api funkwhale-manage createsuperuser`. Audio storage defaults to on-disk; set FUNKWHALE_S3_* to wire MinIO/external S3 via the storage-translators funkwhale() mapping."
+  "notes": "Five containers (api + celeryworker + celerybeat + front + postgres + redis). Funkwhale 2.x images: funkwhale/api:2.0.1 (backend) + funkwhale/front:2.0.1 (SPA). Caddy must SPLIT-ROUTE: /api, /federation, /.well-known/webfinger → funkwhale-api:5000; everything else → funkwhale-front:80. The shared activitypub profile needs per-path matchers — follow-up PR adds a dedicated funkwhale profile to the Caddy bundle. Initial superuser via `docker exec crow-funkwhale-api funkwhale-manage createsuperuser`. Audio storage: on-disk default; set FUNKWHALE_S3_* to wire S3 via storage-translators.funkwhale()."
 }

--- a/bundles/gotosocial/docker-compose.yml
+++ b/bundles/gotosocial/docker-compose.yml
@@ -14,7 +14,7 @@ networks:
 
 services:
   gotosocial:
-    image: superseriousbusiness/gotosocial:0.18.0
+    image: superseriousbusiness/gotosocial:0.21.2
     container_name: crow-gotosocial
     networks:
       - default

--- a/bundles/lemmy/docker-compose.yml
+++ b/bundles/lemmy/docker-compose.yml
@@ -13,7 +13,7 @@
 #   ~/.crow/lemmy/lemmy.hjson  Generated once at install time; not volume-mounted
 #                              because lemmy reads env-var overrides too.
 #
-# Images: dessalines/lemmy:0.19 and dessalines/lemmy-ui:0.19 (floats
+# Images: dessalines/lemmy:0.19.17 and dessalines/lemmy-ui:0.19.17 (floats
 # within 0.19.x — verify latest + CVE feed at implementation time per the
 # plan's image-tag policy).
 
@@ -45,7 +45,7 @@ services:
       start_period: 20s
 
   pictrs:
-    image: asonix/pictrs:0.5
+    image: asonix/pictrs:0.5.23
     container_name: crow-lemmy-pictrs
     user: "991:991"
     networks:
@@ -66,7 +66,7 @@ services:
     restart: unless-stopped
 
   lemmy:
-    image: dessalines/lemmy:0.19
+    image: dessalines/lemmy:0.19.17
     container_name: crow-lemmy
     hostname: lemmy
     networks:
@@ -129,7 +129,7 @@ services:
       start_period: 60s
 
   lemmy-ui:
-    image: dessalines/lemmy-ui:0.19
+    image: dessalines/lemmy-ui:0.19.17
     container_name: crow-lemmy-ui
     networks:
       - default

--- a/bundles/matrix-bridges/docker-compose.yml
+++ b/bundles/matrix-bridges/docker-compose.yml
@@ -20,7 +20,7 @@ networks:
 
 services:
   mautrix-signal:
-    image: dock.mau.dev/mautrix/signal:latest
+    image: dock.mau.dev/mautrix/signal:v0.8.0
     container_name: crow-mautrix-signal
     profiles: ["signal"]
     networks:
@@ -44,7 +44,7 @@ services:
       start_period: 30s
 
   mautrix-telegram:
-    image: dock.mau.dev/mautrix/telegram:latest
+    image: dock.mau.dev/mautrix/telegram:v0.15.3
     container_name: crow-mautrix-telegram
     profiles: ["telegram"]
     networks:
@@ -68,7 +68,7 @@ services:
       start_period: 30s
 
   mautrix-whatsapp:
-    image: dock.mau.dev/mautrix/whatsapp:latest
+    image: dock.mau.dev/mautrix/whatsapp:v0.11.2
     container_name: crow-mautrix-whatsapp
     profiles: ["whatsapp"]
     networks:

--- a/bundles/matrix-dendrite/docker-compose.yml
+++ b/bundles/matrix-dendrite/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       start_period: 20s
 
   dendrite:
-    image: matrixdotorg/dendrite-monolith:v0.13.8
+    image: matrixdotorg/dendrite-monolith:v0.15.2
     container_name: crow-dendrite
     networks:
       - default

--- a/bundles/peertube/docker-compose.yml
+++ b/bundles/peertube/docker-compose.yml
@@ -16,7 +16,7 @@
 # envelope to .env. Without S3 + aggressive pruning, a single active
 # channel can fill a 500 GB disk within months.
 #
-# Image: chocobozzz/peertube:production-bookworm (stable line; pin tag to
+# Image: chocobozzz/peertube:v8.1.5-bookworm (stable line; pin tag to
 # a specific release for production — we use the floating tag for the
 # roll-out, will pin before merge).
 
@@ -64,7 +64,7 @@ services:
       retries: 10
 
   peertube:
-    image: chocobozzz/peertube:production-bookworm
+    image: chocobozzz/peertube:v8.1.5-bookworm
     container_name: crow-peertube
     networks:
       - default

--- a/bundles/pixelfed/docker-compose.yml
+++ b/bundles/pixelfed/docker-compose.yml
@@ -16,7 +16,7 @@
 # FILESYSTEM_CLOUD=s3 envelope Pixelfed expects. configure-storage.mjs in
 # scripts/ does the translation at install time.
 #
-# Image: zknt/pixelfed:0.12 (floats within 0.12.x — verify the current
+# Image: zknt/pixelfed:2026-03-24 (floats within 0.12.x — verify the current
 # tag + CVE feed at implementation time per the plan's image-tag policy).
 
 networks:
@@ -63,7 +63,7 @@ services:
       retries: 10
 
   pixelfed:
-    image: zknt/pixelfed:0.12
+    image: zknt/pixelfed:2026-03-24
     container_name: crow-pixelfed
     networks:
       - default
@@ -143,7 +143,7 @@ services:
       start_period: 120s
 
   horizon:
-    image: zknt/pixelfed:0.12
+    image: zknt/pixelfed:2026-03-24
     container_name: crow-pixelfed-horizon
     networks:
       - default

--- a/bundles/writefreely/docker-compose.yml
+++ b/bundles/writefreely/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   writefreely:
-    image: writeas/writefreely:0.15
+    image: writeas/writefreely:0.12.0
     container_name: crow-writefreely
     networks:
       - default


### PR DESCRIPTION
## Summary

Follow-up #3 after Phase 2. Pre-merge image-tag hygiene pass. Every floating / unverified tag in the federated-bundle compose files now points at a specific semver version verified on Docker Hub as of 2026-04-12.

**Also fixes a material image-name bug from F.4 Funkwhale** — the original compose referenced `funkwhale/funkwhale:1.4` and `funkwhale/nginx:1.4`, neither of which exist on Docker Hub. Funkwhale 2.x split the old monolithic image into `funkwhale/api` + `funkwhale/front`; this PR swaps in the real images pinned to 2.0.1.

## Pin table

| Bundle | Before | After |
|--------|--------|-------|
| peertube | `chocobozzz/peertube:production-bookworm` | `:v8.1.5-bookworm` |
| pixelfed | `zknt/pixelfed:0.12` | `:2026-03-24` (zknt switched to date tags) |
| lemmy | `dessalines/lemmy:0.19` | `:0.19.17` |
| lemmy-ui | `dessalines/lemmy-ui:0.19` | `:0.19.17` |
| pict-rs | `asonix/pictrs:0.5` | `:0.5.23` |
| dendrite | `:v0.13.8` | `:v0.15.2` |
| gotosocial | `:0.18.0` | `:0.21.2` |
| writefreely | `:0.15` (didn't exist) | `:0.12.0` |
| mautrix/signal | `:latest` | `:v0.8.0` |
| mautrix/telegram | `:latest` | `:v0.15.3` |
| mautrix/whatsapp | `:latest` | `:v0.11.2` |

`postgres:15-alpine`, `postgres:16-alpine`, `redis:7-alpine` keep their alpine-major floats per policy (security patches within a major without breaking changes).

## Funkwhale — material bug fix

`funkwhale/funkwhale:1.4` doesn't exist — that repo stops at 1.2.10. Funkwhale 2.x split into:
- `funkwhale/api:2.0.1` — Django backend (gunicorn on :5000)
- `funkwhale/front:2.0.1` — Static SPA (nginx-served on :80)

`funkwhale/nginx` never existed as a standalone image. The official Funkwhale compose has no nginx sidecar; it assumes operator-layer reverse-proxy handles the split.

This PR:
- Swaps api/celeryworker/celerybeat to `funkwhale/api:2.0.1`
- Replaces the phantom nginx service with a real `funkwhale/front:2.0.1` service
- Updates the manifest note and compose header to document the new Caddy split-routing requirement: `/api/*`, `/federation/*`, `/.well-known/webfinger` → api:5000; everything else → front:80
- A dedicated Caddy `funkwhale` profile that codifies path-based split is deferred to a follow-up (the existing `activitypub` profile is single-upstream)

## Verified

- `docker compose config --quiet` clean on all 9 bundles with required env vars
- Tag existence for non-mautrix images verified via hub.docker.com API
- mautrix tags cross-referenced against the project's documented release lines
- `npm run check` passes

## What this PR does NOT do

- **Not @sha256: pinned.** Semver is sufficient for policy + reviewable diffs; full digest pinning is a separate hardening pass.
- **Not live-tested.** Dendrite v0.13 → v0.15, mastodon v4.3, funkwhale 2.x migration each need care on real hosts.
- **Not resource-profile-updated.** Manifest `min_ram_mb` / `recommended_ram_mb` values are unchanged; newer versions may have shifted footprints.

## Rollout position

Stacked on F.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)