### PR TITLE
security: block Tailscale Funnel access to Crow's Nest dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,17 @@ scripts/crow-update.sh         → Safe update with rollback
 scripts/migrate-data-dir.js    → Data directory migration (./data/ → ~/.crow/data/)
 ```
 
+### Network exposure invariant
+
+**The Crow's Nest dashboard and all private routes (MCP, AI chat, storage, push, instance sync) MUST NEVER be reachable via Tailscale Funnel.** Only `/blog`, `/robots.txt`, `/sitemap.xml`, `/.well-known/`, `/favicon.ico`, and `/manifest.json` are safe to expose publicly.
+
+Enforcement:
+1. **Server-side middleware** — `servers/gateway/index.js` rejects any request carrying the `Tailscale-Funnel-Request` header unless the path matches `PUBLIC_FUNNEL_PREFIXES` or `CROW_DASHBOARD_PUBLIC=true`.
+2. **`isAllowedNetwork()`** in `servers/gateway/dashboard/auth.js` — uses the Tailscale-injected `Tailscale-User-Login` / `Tailscale-Funnel-Request` headers (verified unforgeable against `tailscale/ipn/ipnlocal/serve.go:1046-1072`) to distinguish tailnet Serve from public Funnel. Bare loopback is rejected — callers on the same host must use `CROW_ALLOWED_IPS` or `CROW_DASHBOARD_PUBLIC=true`.
+3. **Funnel config** — never map `/` or any non-public prefix. Use `tailscale funnel --set-path=/blog` and friends. The docs at `docs/getting-started/tailscale-setup.md` show the correct pattern.
+
+If you touch any of these three layers, run the `servers/gateway/__tests__/auth.test.js` integration tests.
+
 ### Data Directory
 
 Data lives in `~/.crow/data/` (preferred) or `./data/` (fallback). Resolution order: `CROW_DATA_DIR` env → `~/.crow/data/` (if exists) → `./data/`. The `resolveDataDir()` function in `servers/db.js` handles this. Migration script (`scripts/migrate-data-dir.js`) moves data from `./data/` to `~/.crow/data/` and creates a symlink for backward compatibility.

--- a/docs/getting-started/tailscale-setup.md
+++ b/docs/getting-started/tailscale-setup.md
@@ -102,13 +102,35 @@ Your blog is public at your gateway URL, but the Crow's Nest stays private. To m
 
 ### Option A: Tailscale Funnel (Personal/Hobby Use)
 
-The simplest approach — expose port 3001 publicly:
+::: danger Never funnel the root path
+`sudo tailscale funnel 3001` (or any command that maps `/` to the gateway) exposes the Crow's Nest dashboard login to the public internet. The gateway blocks funneled dashboard requests server-side, but the correct configuration is to funnel only the public blog paths. Always use `--set-path` as shown below.
+:::
+
+Expose only the public blog paths (blog, feeds, OAuth discovery):
 
 ```bash
-sudo tailscale funnel 3001
+sudo tailscale funnel --bg --set-path=/blog http://localhost:3001/blog
+sudo tailscale funnel --bg --set-path=/robots.txt http://localhost:3001/robots.txt
+sudo tailscale funnel --bg --set-path=/sitemap.xml http://localhost:3001/sitemap.xml
+sudo tailscale funnel --bg --set-path=/.well-known/ http://localhost:3001/.well-known/
 ```
 
-The gateway's built-in network restrictions ensure `/dashboard/*` routes are only accessible from local/Tailscale IPs, so the Crow's Nest remains protected even with Funnel enabled. Only the blog, health check, and MCP endpoints (which require OAuth) are accessible publicly.
+Verify the Crow's Nest is **not** publicly reachable:
+
+```bash
+curl -I https://<your-tailnet>.ts.net/dashboard   # expect 404 (no handler)
+curl -I https://<your-tailnet>.ts.net/blog        # expect 200
+```
+
+The gateway also rejects any funneled request to a private path server-side (it sets `Tailscale-Funnel-Request` on Funnel traffic, which `isAllowedNetwork()` uses to fail closed). This is defense in depth — you still must not funnel `/`.
+
+For tailnet-only access to the full gateway (dashboard, MCP, AI chat), use `tailscale serve` on a separate port:
+
+```bash
+sudo tailscale serve --bg --https=8444 http://localhost:3001
+```
+
+Then reach the Nest at `https://<your-tailnet>.ts.net:8444/dashboard` from any device on your tailnet.
 
 ::: warning Tailscale Funnel Limitations
 Tailscale Funnel is designed for **personal and hobby use**. It has bandwidth limits and is not intended as a production hosting solution. If you plan to monetize your blog or podcast (ads, subscriptions, paid content), use a proper reverse proxy with a custom domain instead (Option B below) or consider [managed hosting](./managed-hosting).

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "backup": "bash scripts/backup.sh",
     "restore": "bash scripts/restore.sh",
     "reset-password": "node scripts/reset-password.js",
-    "test:claude-ai": "node scripts/test-claude-ai.js"
+    "test:claude-ai": "node scripts/test-claude-ai.js",
+    "test:auth": "node --test tests/auth-network.test.js"
   },
   "dependencies": {
     "@libsql/client": "^0.14.0",

--- a/servers/gateway/dashboard/auth.js
+++ b/servers/gateway/dashboard/auth.js
@@ -288,33 +288,22 @@ export async function destroySession(token) {
 }
 
 /**
- * Check if request IP is on the local/Tailscale allowlist.
+ * True if ip is RFC1918 private, Tailscale CGNAT (100.64.0.0/10), or in
+ * CROW_ALLOWED_IPS. Does NOT include bare loopback — callers decide whether
+ * to trust localhost based on the request's Tailscale header context.
  */
-export function isAllowedNetwork(req) {
-  if (process.env.CROW_DASHBOARD_PUBLIC === "true") return true;
-
-  const ip = req.ip || req.connection?.remoteAddress || "";
-  // Normalize IPv6-mapped IPv4
-  const addr = ip.replace(/^::ffff:/, "");
-
-  // Localhost
-  if (addr === "127.0.0.1" || addr === "::1" || addr === "localhost") return true;
-
-  // RFC 1918 private ranges
+function isPrivateOrAllowlistedIp(addr) {
   if (/^10\./.test(addr)) return true;
   if (/^172\.(1[6-9]|2\d|3[01])\./.test(addr)) return true;
   if (/^192\.168\./.test(addr)) return true;
 
-  // Tailscale CGNAT range (100.64.0.0/10)
   const parts = addr.split(".").map(Number);
   if (parts.length === 4 && parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true;
 
-  // Custom IP allowlist (comma-separated IPs or CIDR ranges)
   const custom = process.env.CROW_ALLOWED_IPS;
   if (custom) {
     for (const entry of custom.split(",").map((s) => s.trim()).filter(Boolean)) {
       if (entry.includes("/")) {
-        // CIDR check
         const [net, bits] = entry.split("/");
         const netParts = net.split(".").map(Number);
         const mask = ~((1 << (32 - Number(bits))) - 1) >>> 0;
@@ -328,6 +317,41 @@ export function isAllowedNetwork(req) {
   }
 
   return false;
+}
+
+/**
+ * Decide whether a request is allowed to reach private routes (/dashboard,
+ * MCP endpoints, etc.).
+ *
+ * INVARIANT: private routes MUST NEVER be reachable via Tailscale Funnel.
+ * req.ip is 127.0.0.1 for BOTH Funnel and Serve (tailscaled proxies via
+ * localhost either way), so we distinguish via headers that tailscaled
+ * strips-then-re-sets based on authenticated origin. Verified against
+ * tailscale/ipn/ipnlocal/serve.go:1046-1072 — Header.Del is called
+ * unconditionally on Tailscale-User-Login, Tailscale-Funnel-Request, etc.
+ * before re-setting, so public clients cannot forge either header.
+ */
+export function isAllowedNetwork(req) {
+  if (process.env.CROW_DASHBOARD_PUBLIC === "true") return true;
+
+  // Hard reject: tailscaled marks public Funnel traffic with this. Client
+  // forgeries are Del'd upstream before the Set at serve.go:1059.
+  if (req.headers["tailscale-funnel-request"]) return false;
+
+  // Serve (tailnet) traffic carries authenticated identity headers. Clients
+  // cannot forge them (same Del-then-Set upstream).
+  if (req.headers["tailscale-user-login"]) return true;
+
+  const addr = (req.ip || req.connection?.remoteAddress || "").replace(/^::ffff:/, "");
+
+  // No Tailscale headers: direct peer connection. Reject bare loopback —
+  // any local process (including a misconfigured reverse proxy) would land
+  // here, and we can't distinguish malicious from trusted. Operators who
+  // front Crow with Caddy/nginx on the same host must use CROW_ALLOWED_IPS
+  // or CROW_DASHBOARD_PUBLIC=true (with their own ACLs at the proxy).
+  if (addr === "127.0.0.1" || addr === "::1" || addr === "localhost") return false;
+
+  return isPrivateOrAllowlistedIp(addr);
 }
 
 /**

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -99,6 +99,11 @@ if (noAuth) {
   console.warn("⚠️  WARNING: Running without authentication. Do NOT use in production.");
 }
 
+if (process.env.CROW_DASHBOARD_PUBLIC === "true") {
+  console.warn("⚠️  WARNING: CROW_DASHBOARD_PUBLIC=true — Crow's Nest dashboard is exposed to the public internet.");
+  console.warn("   Ensure you have a strong admin password and 2FA enabled. Prefer `tailscale serve` for private remote access.");
+}
+
 // Initialize OAuth tables
 await initOAuthTables();
 
@@ -194,6 +199,29 @@ app.use((req, res, next) => {
   next();
 });
 
+// Reject Tailscale Funnel traffic for all non-public paths. Public paths
+// are blog, feeds, sitemap, robots, setup, .well-known (OAuth metadata),
+// health, push subscription endpoints are also blocked here by default —
+// if an operator needs a path public, either add it to PUBLIC_FUNNEL_PREFIXES
+// or set CROW_DASHBOARD_PUBLIC=true.
+// This is defense in depth: a misconfigured `tailscale funnel /` used to
+// expose the entire gateway (including the Nest dashboard) to the internet;
+// this middleware ensures even that misconfig fails closed.
+const PUBLIC_FUNNEL_PREFIXES = [
+  "/blog",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/.well-known/",
+  "/favicon.ico",
+  "/manifest.json",
+];
+app.use((req, res, next) => {
+  if (!req.headers["tailscale-funnel-request"]) return next();
+  if (process.env.CROW_DASHBOARD_PUBLIC === "true") return next();
+  if (PUBLIC_FUNNEL_PREFIXES.some((p) => req.path === p || req.path.startsWith(p))) return next();
+  res.status(403).type("text/plain").send("Forbidden: private path not reachable via Tailscale Funnel.");
+});
+
 // PR 0: CrowdSec gateway-middleware bouncer (no-op when CROW_CROWDSEC_BOUNCER_KEY is unset).
 // Mounted after security headers, before CORS/rate-limit so banned IPs get a fast 403
 // without consuming rate-limit budget. Uses synchronous LAPI lookup with 200ms timeout
@@ -233,6 +261,20 @@ const authLimiter = rateLimit({
 app.use("/authorize", authLimiter);
 app.use("/token", authLimiter);
 app.use("/register", authLimiter);
+
+// Dashboard login rate limit. Key on req.ip + Tailscale-User-Login because
+// Funnel traffic all appears as 127.0.0.1 and would otherwise share one
+// bucket with the legit operator. rejectFunneled blocks Funnel before this
+// fires, but this is defense in depth if that middleware is ever bypassed.
+const dashboardLoginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => `${req.ip}:${req.headers["tailscale-user-login"] || ""}`,
+  message: { error: "Too many login attempts, please try again later" },
+});
+app.use("/dashboard/login", dashboardLoginLimiter);
 
 // Body parsing with size limit
 app.use(express.json({ limit: "1mb" }));

--- a/tests/auth-network.test.js
+++ b/tests/auth-network.test.js
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import http from "node:http";
+import { isAllowedNetwork } from "../servers/gateway/dashboard/auth.js";
+
+function mkReq({ ip = "127.0.0.1", headers = {} } = {}) {
+  return { ip, headers, connection: { remoteAddress: ip } };
+}
+
+test("isAllowedNetwork: Funnel header rejects even with tailnet IP", () => {
+  assert.equal(
+    isAllowedNetwork(mkReq({ ip: "100.64.0.5", headers: { "tailscale-funnel-request": "?1" } })),
+    false,
+  );
+});
+
+test("isAllowedNetwork: Funnel header rejects even with forged identity header", () => {
+  assert.equal(
+    isAllowedNetwork(mkReq({
+      headers: {
+        "tailscale-funnel-request": "?1",
+        "tailscale-user-login": "alice@example.com",
+      },
+    })),
+    false,
+  );
+});
+
+test("isAllowedNetwork: Tailscale-User-Login alone is sufficient", () => {
+  assert.equal(
+    isAllowedNetwork(mkReq({ headers: { "tailscale-user-login": "alice@example.com" } })),
+    true,
+  );
+});
+
+test("isAllowedNetwork: bare localhost with no Tailscale headers is rejected", () => {
+  assert.equal(isAllowedNetwork(mkReq({ ip: "127.0.0.1" })), false);
+  assert.equal(isAllowedNetwork(mkReq({ ip: "::1" })), false);
+});
+
+test("isAllowedNetwork: RFC1918 and CGNAT IPs pass", () => {
+  assert.equal(isAllowedNetwork(mkReq({ ip: "10.0.0.5" })), true);
+  assert.equal(isAllowedNetwork(mkReq({ ip: "192.168.1.10" })), true);
+  assert.equal(isAllowedNetwork(mkReq({ ip: "172.16.0.1" })), true);
+  assert.equal(isAllowedNetwork(mkReq({ ip: "100.64.0.1" })), true);
+  assert.equal(isAllowedNetwork(mkReq({ ip: "100.127.0.1" })), true);
+});
+
+test("isAllowedNetwork: public IP rejected", () => {
+  assert.equal(isAllowedNetwork(mkReq({ ip: "8.8.8.8" })), false);
+  assert.equal(isAllowedNetwork(mkReq({ ip: "1.2.3.4" })), false);
+});
+
+test("isAllowedNetwork: CROW_DASHBOARD_PUBLIC=true short-circuits allow", () => {
+  process.env.CROW_DASHBOARD_PUBLIC = "true";
+  try {
+    assert.equal(isAllowedNetwork(mkReq({ ip: "8.8.8.8" })), true);
+    assert.equal(
+      isAllowedNetwork(mkReq({ ip: "8.8.8.8", headers: { "tailscale-funnel-request": "?1" } })),
+      true,
+    );
+  } finally {
+    delete process.env.CROW_DASHBOARD_PUBLIC;
+  }
+});
+
+test("isAllowedNetwork: CROW_ALLOWED_IPS CIDR match", () => {
+  process.env.CROW_ALLOWED_IPS = "203.0.113.0/24";
+  try {
+    assert.equal(isAllowedNetwork(mkReq({ ip: "203.0.113.42" })), true);
+    assert.equal(isAllowedNetwork(mkReq({ ip: "203.0.114.1" })), false);
+  } finally {
+    delete process.env.CROW_ALLOWED_IPS;
+  }
+});
+
+// Integration test for the rejectFunneled middleware. We rebuild the
+// middleware inline so the test doesn't need to boot the full gateway
+// (which initializes DB, MCP servers, etc.).
+function makeFunnelMiddleware() {
+  const PUBLIC_FUNNEL_PREFIXES = [
+    "/blog",
+    "/robots.txt",
+    "/sitemap.xml",
+    "/.well-known/",
+    "/favicon.ico",
+    "/manifest.json",
+  ];
+  return (req, res, next) => {
+    if (!req.headers["tailscale-funnel-request"]) return next();
+    if (process.env.CROW_DASHBOARD_PUBLIC === "true") return next();
+    if (PUBLIC_FUNNEL_PREFIXES.some((p) => req.path === p || req.path.startsWith(p))) return next();
+    res.status(403).type("text/plain").send("Forbidden: private path not reachable via Tailscale Funnel.");
+  };
+}
+
+function startTestApp() {
+  const app = express();
+  app.use(makeFunnelMiddleware());
+  app.get(/.*/, (req, res) => res.status(200).send("ok"));
+  return new Promise((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function request(port, path, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, path, method: "GET", headers }, (res) => {
+      let body = "";
+      res.on("data", (c) => (body += c));
+      res.on("end", () => resolve({ status: res.statusCode, body }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+test("rejectFunneled middleware: private paths blocked with Funnel header", async () => {
+  const server = await startTestApp();
+  try {
+    const port = server.address().port;
+    for (const path of ["/dashboard/nest", "/router/mcp", "/api/chat/conversations", "/storage/upload", "/"]) {
+      const r = await request(port, path, { "tailscale-funnel-request": "?1" });
+      assert.equal(r.status, 403, `expected 403 on ${path}, got ${r.status}`);
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test("rejectFunneled middleware: public paths pass with Funnel header", async () => {
+  const server = await startTestApp();
+  try {
+    const port = server.address().port;
+    for (const path of ["/blog", "/blog/post-1", "/robots.txt", "/sitemap.xml", "/.well-known/oauth-authorization-server", "/favicon.ico", "/manifest.json"]) {
+      const r = await request(port, path, { "tailscale-funnel-request": "?1" });
+      assert.equal(r.status, 200, `expected 200 on ${path}, got ${r.status}`);
+    }
+  } finally {
+    server.close();
+  }
+});
+
+test("rejectFunneled middleware: no Funnel header, all paths pass", async () => {
+  const server = await startTestApp();
+  try {
+    const port = server.address().port;
+    const r = await request(port, "/dashboard/nest");
+    assert.equal(r.status, 200);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary

Fixes a deployment-wide security issue: on every Crow instance that followed the Tailscale Funnel setup docs, the Crow's Nest dashboard login was reachable from the public internet. Only the admin password protected the Nest.

**Root cause.** Tailscale Funnel proxies to `localhost:3002`, so `req.ip` is always `127.0.0.1` regardless of whether traffic came from the public internet or the tailnet. `isAllowedNetwork()` had a localhost branch that allowed `127.0.0.1` unconditionally — so every funneled request passed the allowlist. The docs claimed this check protected the dashboard; it did not.

**Fix.** Rewrite the network check to use headers that `tailscaled` strips then re-sets based on authenticated origin. Verified against Tailscale source (`tailscale/ipn/ipnlocal/serve.go:1046-1072`) — `Header.Del` is called unconditionally before re-setting, so public clients cannot forge `Tailscale-User-Login` or `Tailscale-Funnel-Request`.

## Changes

- `servers/gateway/dashboard/auth.js` — `isAllowedNetwork()` now fails closed: hard-rejects `Tailscale-Funnel-Request`, positive-allows `Tailscale-User-Login`, rejects bare loopback without Tailscale headers.
- `servers/gateway/index.js` — global `rejectFunneled` middleware blocks funneled access to non-public paths. Public prefixes: `/blog`, `/robots.txt`, `/sitemap.xml`, `/.well-known/`, `/favicon.ico`, `/manifest.json`.
- `servers/gateway/index.js` — `/dashboard/login` rate limit keyed on `req.ip + Tailscale-User-Login` so Funnel attackers can't share one bucket with legitimate users.
- `servers/gateway/index.js` — boot-time WARN when `CROW_DASHBOARD_PUBLIC=true`.
- `docs/getting-started/tailscale-setup.md` — rewrite Option A to use `--set-path=/blog` etc. Add danger callout never to funnel `/`.
- `CLAUDE.md` — document the network exposure invariant.
- `tests/auth-network.test.js` — 11 integration tests using only Node builtins, no new deps. Runs via `npm run test:auth`.

## Behavior changes operators should know about

- Local reverse proxies (Caddy/nginx on same host) now hit the 127.0.0.1 reject. Mitigation: `CROW_ALLOWED_IPS` with the proxy's source CIDR, or `CROW_DASHBOARD_PUBLIC=true` with ACLs at the proxy layer.
- SSH port-forward (`ssh -L 3001:localhost:3001`) hits the same reject. Use `tailscale serve` instead.
- Caddy-in-front-of-tailscale case remains correct: `Tailscale-Funnel-Request` is preserved through the proxy chain.
- **Rollback** if legitimate tailnet users get 403: set `CROW_ALLOWED_IPS=100.64.0.0/10` (allow all CGNAT) as interim. Do NOT use `CROW_DASHBOARD_PUBLIC=true` — that reopens the dashboard.

## Test plan

- [x] `npm run test:auth` — 11 tests pass (pure `isAllowedNetwork()` + `rejectFunneled` middleware via in-process HTTP)
- [x] Local gateway restart + smoke test:
  - `curl http://localhost:3002/dashboard` → 403 (bare loopback rejected)
  - `curl -H "Tailscale-Funnel-Request: ?1" http://localhost:3002/dashboard` → 403
  - `curl -H "Tailscale-User-Login: alice@example.com" http://localhost:3002/dashboard` → 302 (redirect to login, positive allow)
  - `curl -H "Tailscale-Funnel-Request: ?1" http://localhost:3002/blog` → 200 (public prefix exempted)
- [x] External verification via Tailscale Funnel (path-scoped on grackle):
  - `curl https://<tailnet>.ts.net/dashboard` → 404 (no funnel handler)
  - `curl https://<tailnet>.ts.net/blog` → 200