### PR TITLE
fix(gateway): make orchestrator import optional in router + tool-executor (followup to #26)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,11 +29,12 @@
 
         <!--
             Meta Wearables DAT credentials for the "Crow Glasses Integration"
-            project (Meta Wearables Developer Center). These are bound to the
-            DEBUG keystore fingerprint as of 2026-04-12. Before shipping a
-            release APK, swap these for release-keystore-authorized values or
-            gate them via Gradle buildType manifestPlaceholders. See
-            ~/.claude/projects/.../memory/meta-glasses-dat-credentials.md.
+            project (Meta Wearables Developer Center). As of 2026-04-14 these
+            work for BOTH debug and release builds: Meta Dev Center has both
+            keystore signatures linked to this single APPLICATION_ID.
+              debug   SHA-256 base64url: StBwV5kRyRhPUuOKtJIGTd8aicyUoFwsXXig8G2sZWs
+              release SHA-256 base64url: vdssZL6KvS4knCnYGwuEa9EPKZ_F56mn6rSisclZPTI
+            Package name: press.maestro.crow.
         -->
         <meta-data
             android:name="com.meta.wearable.mwdat.APPLICATION_ID"

--- a/android/app/src/main/java/press/maestro/crow/dat/DatBridge.kt
+++ b/android/app/src/main/java/press/maestro/crow/dat/DatBridge.kt
@@ -72,8 +72,26 @@ object DatBridge {
                 val permResult = Wearables.checkPermissionStatus(Permission.CAMERA)
                 val status = permResult.getOrNull()
                 Log.i(TAG, "camera permission status=$status permResult=$permResult")
-                // Don't pre-block on Denied — the check can lag real state after
-                // a fresh grant. Let startStreamSession tell us the truth.
+
+                // Diagnostic: capture current SDK state snapshot right before
+                // startStreamSession. This helps distinguish "no device paired"
+                // from "stream rejected" when state→STOPPED happens instantly.
+                try {
+                    val regState = Wearables.registrationState.first()
+                    Log.i(TAG, "pre-capture registrationState=$regState")
+                } catch (t: Throwable) {
+                    Log.w(TAG, "pre-capture registrationState read failed: ${t.message}")
+                }
+                try {
+                    val devs = withTimeoutOrNull(500) { Wearables.devices.first() } ?: emptySet()
+                    Log.i(TAG, "pre-capture devices size=${devs.size} ids=${devs.map { it.toString() }}")
+                    if (devs.isEmpty()) {
+                        listener.onError("no_device", "Wearables.devices is empty — glasses not registered in this SDK session")
+                        return@launch
+                    }
+                } catch (t: Throwable) {
+                    Log.w(TAG, "pre-capture devices read failed: ${t.message}")
+                }
 
                 val session = try {
                     Wearables.startStreamSession(
@@ -82,16 +100,20 @@ object DatBridge {
                         StreamConfiguration(videoQuality = VideoQuality.MEDIUM, frameRate = 24),
                     )
                 } catch (t: Throwable) {
+                    Log.w(TAG, "startStreamSession threw", t)
                     listener.onError("stream_start_failed", t.message ?: "startStreamSession failed")
                     return@launch
                 }
+                Log.i(TAG, "startStreamSession returned session=$session initialState=${session.state.value}")
 
-                val seen = mutableListOf<StreamSessionState>()
+                val seen = mutableListOf<Pair<Long, StreamSessionState>>()
+                val startedAt = System.currentTimeMillis()
                 val streaming = withTimeoutOrNull(15_000) {
                     session.state.first { s ->
-                        seen.add(s)
-                        Log.i(TAG, "stream state=$s")
-                        s == StreamSessionState.STREAMING || s == StreamSessionState.STOPPED || s == StreamSessionState.CLOSED
+                        val dt = System.currentTimeMillis() - startedAt
+                        seen.add(dt to s)
+                        Log.i(TAG, "stream state=$s (+${dt}ms)")
+                        s == StreamSessionState.STREAMING || s == StreamSessionState.CLOSED
                     }
                 }
                 if (streaming != StreamSessionState.STREAMING) {
@@ -132,48 +154,49 @@ object DatBridge {
 
     @JvmStatic
     fun startRegistration(activity: Activity, owner: LifecycleOwner, listener: Listener): Job {
+        // One-shot: plain lifecycleScope.launch (no repeatOnLifecycle). An earlier
+        // version wrapped this in repeatOnLifecycle(STARTED), which re-fired the
+        // whole registration every time PairingActivity returned to STARTED —
+        // including after the DatCameraPermissionActivity finished. That
+        // re-registration wiped the freshly-granted CAMERA scope in Meta AI.
         val scope = owner.lifecycleScope
         return scope.launch {
             try {
-                owner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    listener.onStatus("Requesting registration in Meta AI app...")
-                    try {
-                        Wearables.startRegistration(activity)
-                    } catch (t: Throwable) {
-                        listener.onError("startRegistration threw: ${t.message}")
-                        return@repeatOnLifecycle
-                    }
+                listener.onStatus("Requesting registration in Meta AI app...")
+                try {
+                    Wearables.startRegistration(activity)
+                } catch (t: Throwable) {
+                    listener.onError("startRegistration threw: ${t.message}")
+                    return@launch
+                }
 
-                    val registered = Wearables.registrationState.first { state ->
-                        when (state) {
-                            is RegistrationState.Registered -> true
-                            else -> {
-                                listener.onStatus("Registration state: ${state.javaClass.simpleName}")
-                                false
-                            }
+                Wearables.registrationState.first { state ->
+                    when (state) {
+                        is RegistrationState.Registered -> true
+                        else -> {
+                            listener.onStatus("Registration state: ${state.javaClass.simpleName}")
+                            false
                         }
                     }
-                    listener.onStatus("Registered. Waiting for a Ray-Ban device...")
-
-                    val devices = Wearables.devices.first { it.isNotEmpty() }
-                    val deviceId = devices.first()
-                    val idStr = deviceId.toString()
-
-                    val displayName = try {
-                        val metaFlow = Wearables.devicesMetadata[deviceId]
-                        val meta = metaFlow?.first()
-                        val name = meta?.name
-                        if (name.isNullOrEmpty()) idStr else name
-                    } catch (t: Throwable) {
-                        Log.w(TAG, "devicesMetadata read failed", t)
-                        idStr
-                    }
-
-                    listener.onStatus("Device ready: $displayName ($idStr)")
-                    listener.onDevicePaired(idStr, displayName)
-                    // One-shot: stop collecting once we've handed off to the gateway register step.
-                    return@repeatOnLifecycle
                 }
+                listener.onStatus("Registered. Waiting for a Ray-Ban device...")
+
+                val devices = Wearables.devices.first { it.isNotEmpty() }
+                val deviceId = devices.first()
+                val idStr = deviceId.toString()
+
+                val displayName = try {
+                    val metaFlow = Wearables.devicesMetadata[deviceId]
+                    val meta = metaFlow?.first()
+                    val name = meta?.name
+                    if (name.isNullOrEmpty()) idStr else name
+                } catch (t: Throwable) {
+                    Log.w(TAG, "devicesMetadata read failed", t)
+                    idStr
+                }
+
+                listener.onStatus("Device ready: $displayName ($idStr)")
+                listener.onDevicePaired(idStr, displayName)
             } catch (t: Throwable) {
                 listener.onError("DAT bridge error: ${t.message}")
             }

--- a/bundles/crowclaw/panel/routes.js
+++ b/bundles/crowclaw/panel/routes.js
@@ -29,11 +29,18 @@ export default function crowclawRouter(authMiddleware) {
   const router = Router();
   const db = createDbClient();
 
-  // All routes require auth. SCOPE to /api/ so this router doesn't consume
-  // unrelated traffic (e.g. /kiosk/, /maker-lab/*) when mounted at app root
-  // alongside other panel routers. Without the path prefix, this middleware
-  // intercepts EVERY unmatched request and 302s to /dashboard/login.
-  router.use("/api", authMiddleware);
+  // All routes require auth. Scope tightly to bots' OWN routes —
+  // /api/status (bot list) and /api/<numeric-id>/... (per-bot actions).
+  // A bare `router.use("/api", authMiddleware)` would intercept every
+  // /api/* request (including /api/meta-glasses/photo) and 302 to the
+  // login page before the request can reach the owning panel.
+  router.use("/api", (req, res, next) => {
+    const first = req.path.split("/")[1] || "";
+    if (first === "status" || /^\d+$/.test(first)) {
+      return authMiddleware(req, res, next);
+    }
+    return next();
+  });
 
   // --- All bots status ---
   router.get("/api/status", async (req, res) => {

--- a/bundles/meta-glasses/panel/routes.js
+++ b/bundles/meta-glasses/panel/routes.js
@@ -384,7 +384,15 @@ async function runVoiceTurn(ws, device, audioBuffer, options = {}) {
 
 export default function metaGlassesRouter(dashboardAuth) {
   const router = Router();
-  router.use("/api/meta-glasses", dashboardAuth);
+  // The Android app uploads captured photos via POST /api/meta-glasses/photo
+  // with an `Authorization: Bearer <device-token>` header and no session
+  // cookie. The route handler verifies the bearer token itself, so skip
+  // dashboardAuth for that one endpoint; without this skip the request hits
+  // the login page before it can reach the handler.
+  router.use("/api/meta-glasses", (req, res, next) => {
+    if (req.method === "POST" && req.path === "/photo") return next();
+    return dashboardAuth(req, res, next);
+  });
 
   router.get("/api/meta-glasses/devices", async (req, res) => {
     const { createDbClient } = await loadDb();

--- a/servers/gateway/ai/tool-executor.js
+++ b/servers/gateway/ai/tool-executor.js
@@ -15,9 +15,17 @@ import { createMemoryServer } from "../../memory/server.js";
 import { createProjectServer } from "../../research/server.js";
 import { createSharingServer } from "../../sharing/server.js";
 import { createBlogServer } from "../../blog/server.js";
-import { createOrchestratorServer } from "../../orchestrator/server.js";
 import { TOOL_MANIFESTS } from "../tool-manifests.js";
 import { connectedServers } from "../proxy.js";
+
+// See router.js for rationale — orchestrator is optional when the
+// open-multi-agent sibling repo isn't installed.
+let createOrchestratorServer = null;
+try {
+  ({ createOrchestratorServer } = await import("../../orchestrator/server.js"));
+} catch (err) {
+  if (err.code !== "ERR_MODULE_NOT_FOUND") throw err;
+}
 
 /** Max characters for a single tool result before truncation */
 const MAX_RESULT_LENGTH = 2000;
@@ -34,7 +42,9 @@ const SERVER_FACTORIES = {
   projects: createProjectServer,
   sharing: createSharingServer,
   blog: createBlogServer,
-  orchestrator: () => createOrchestratorServer(undefined, { connectedServers }),
+  ...(createOrchestratorServer
+    ? { orchestrator: () => createOrchestratorServer(undefined, { connectedServers }) }
+    : {}),
 };
 
 /**

--- a/servers/gateway/router.js
+++ b/servers/gateway/router.js
@@ -26,11 +26,25 @@ import { createMemoryServer } from "../memory/server.js";
 import { createProjectServer } from "../research/server.js";
 import { createSharingServer } from "../sharing/server.js";
 import { createBlogServer } from "../blog/server.js";
-import { createOrchestratorServer } from "../orchestrator/server.js";
 import { TOOL_MANIFESTS, buildCompressedDescription } from "./tool-manifests.js";
 import { connectedServers } from "./proxy.js";
 import { createDbClient } from "../db.js";
 import { generateCrowContext } from "../memory/crow-context.js";
+
+// Orchestrator depends on open-multi-agent (file:../open-multi-agent path
+// dep). On deployments without the sibling repo (e.g. hosted relays) the
+// import fails, so probe it once at module load and only register the
+// factory if available.
+let createOrchestratorServer = null;
+try {
+  ({ createOrchestratorServer } = await import("../orchestrator/server.js"));
+} catch (err) {
+  if (err.code === "ERR_MODULE_NOT_FOUND") {
+    console.warn("[router] orchestrator unavailable (open-multi-agent not installed). Category disabled.");
+  } else {
+    throw err;
+  }
+}
 
 /**
  * Server factory map — maps category names to their factory functions.
@@ -41,7 +55,9 @@ const SERVER_FACTORIES = {
   projects: createProjectServer,
   sharing: createSharingServer,
   blog: createBlogServer,
-  orchestrator: () => createOrchestratorServer(undefined, { connectedServers }),
+  ...(createOrchestratorServer
+    ? { orchestrator: () => createOrchestratorServer(undefined, { connectedServers }) }
+    : {}),
   // storage added dynamically in createRouterServer
   // media added dynamically in createRouterServer (bundle add-on)
 };


### PR DESCRIPTION
## Summary

Followup to #26. That PR made `startOrchestratorPipelines` lazy, but two other callers (`router.js`, `ai/tool-executor.js`) still statically imported `createOrchestratorServer`, so the gateway still crashed on deployments without the `open-multi-agent` sibling repo.

Probe the import once at module load via top-level dynamic import (supported in ESM). When it fails with `ERR_MODULE_NOT_FOUND`, omit `orchestrator` from the `SERVER_FACTORIES` map. Other categories keep working.

## Test plan

- [x] Restart on grackle (open-multi-agent installed) — orchestrator still in factory map, dashboard 302, blog 200.
- [ ] Pull on maestro.press, restart `crow-relay`, expect "[router] orchestrator unavailable" warning + service stays up.