### PR TITLE
chore(deps): move open-multi-agent to optionalDependencies + repo guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Working with this repo
+
+- **Always commit with a positional path arg**: `git commit <path> -m "..."`, not `git add <path> && git commit -m "..."`. The repo's index frequently carries unrelated WIP across branch checkouts because parallel Claude sessions modify files in the working tree concurrently. `git add` extends the index rather than replacing it, so a subsequent `git commit` without a path will sweep in those WIP files. Verify with `git show --stat HEAD` after every commit. (See `~/.claude/CLAUDE.md` Learnings 2026-04-14 for the incident this came from.)
+- **Always `git pull --rebase` before pushing a branch** — parallel sessions commonly push to `main` between your fetch and your push. `--rebase` cleanly drops upstream-equivalent commits.
+
 ## Build & Run Commands
 
 ```bash
@@ -303,6 +308,8 @@ Node.js >= 18 required. ESM modules (`"type": "module"` in package.json).
 ### Multi-Agent Orchestrator
 
 The `servers/orchestrator/` server provides multi-agent orchestration powered by the `open-multi-agent` engine. Multiple AI agents collaborate on complex goals, with access to Crow's MCP tools.
+
+**`open-multi-agent` is an `optionalDependency`** (`file:../open-multi-agent` sibling repo). Hosted relays and minimal deployments don't need it. The gateway lazy-imports the orchestrator at three call sites and gracefully omits orchestrator tools when the package is missing — you'll see `[router] orchestrator unavailable` / `[pipeline-runner] Orchestrator unavailable` warnings in the logs but the rest of the gateway runs normally. If you change orchestrator imports, update **all three** call sites: `servers/gateway/router.js`, `servers/gateway/ai/tool-executor.js`, and `servers/gateway/index.js` (pipeline runner).
 
 **Tools:**
 - `crow_orchestrate` — Start a multi-agent team on a goal (async, returns job ID)

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "minio": "^8.0.7",
         "multer": "^2.1.1",
         "nostr-tools": "^2.10.0",
-        "open-multi-agent": "file:../open-multi-agent",
         "otpauth": "^9.5.0",
         "qrcode": "^1.5.4",
         "sanitize-html": "^2.17.1",
@@ -38,11 +37,15 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "open-multi-agent": "file:../open-multi-agent"
       }
     },
     "../open-multi-agent": {
       "version": "0.1.0",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
         "openai": "^4.73.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "minio": "^8.0.7",
     "multer": "^2.1.1",
     "nostr-tools": "^2.10.0",
-    "open-multi-agent": "file:../open-multi-agent",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4",
     "sanitize-html": "^2.17.1",
@@ -56,6 +55,9 @@
     "ws": "^8.19.0",
     "youtube-sr": "^4.3.12",
     "zod": "^3.24.0"
+  },
+  "optionalDependencies": {
+    "open-multi-agent": "file:../open-multi-agent"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary

Moves `open-multi-agent` (sibling-repo path dep) from `dependencies` to `optionalDependencies` in package.json. Completes the contract: the gateway already lazy-imports it at three call sites (PRs #26, #27); now `npm install` won't fail on hosts without the sibling.

Also adds two short repo-working-with notes to CLAUDE.md captured during the security hotfix rollout this session — about positional-path commits and `git pull --rebase` discipline.

## Test plan

- [x] `npm install` on grackle (sibling exists) → `node_modules/open-multi-agent/dist/index.js` present.
- [ ] On a host without sibling, `npm install` exits 0 with a single optional-dep warning; gateway boots with `[router] orchestrator unavailable` warning.