### PR TITLE
v1 Refoundation — Foundation Phase (F1 + F2): provider/profiles cleanup, roles fix, settings framework + search

### DIFF
--- a/scripts/smoke/compat-check.js
+++ b/scripts/smoke/compat-check.js
@@ -17,8 +17,11 @@ function check(desc, actual, expected) {
 function containsCode(arr, code) { return Array.isArray(arr) && arr.some((e) => e.code === code); }
 
 // --- role-shape sanity ---
+// The preset roster grows as presets are added (incl. the mpa-* family), so
+// assert a sane lower bound rather than a brittle exact count.
 const roles = listAllRoles();
-check("12 preset-agent rows", roles.length, 12);
+if (roles.length >= 12) { console.log(`  ok: ${roles.length} preset-agent rows (>= 12)`); }
+else { failed++; console.error(`FAIL: preset-agent rows — expected >= 12, got ${roles.length}`); }
 
 const viewer = roleShape("vision_team", "viewer");
 check("vision_team.viewer.needs_vision", viewer.needs_vision, true);

--- a/servers/gateway/dashboard/panels/settings.js
+++ b/servers/gateway/dashboard/panels/settings.js
@@ -7,6 +7,7 @@
  */
 
 import { t } from "../shared/i18n.js";
+import { escapeHtml } from "../shared/components.js";
 import {
   registerSettingsSection,
   getSettingsSections,
@@ -112,8 +113,22 @@ export default {
       const section = getSettingsSection(resolvedId);
       if (!section) return res.redirect("/dashboard/settings");
       const html = await section.render({ req, res, db, lang });
-      const back = `<a href="/dashboard/settings" class="settings-back">&larr; ${t("settings.backToSettings", lang)}</a>`;
-      return layout({ title: t(section.labelKey, lang), content: back + html });
+      const sectionLabel = t(section.labelKey, lang);
+      // Breadcrumb: "← Settings / <Section>" so the active location is obvious
+      // on every sub-page (self-contained styles; no dependency on the menu CSS).
+      const crumb = `<style>
+        .settings-breadcrumb { display:flex; align-items:center; gap:0.4rem; font-size:0.9rem; margin-bottom:1rem; }
+        .settings-breadcrumb a { color:var(--crow-accent); text-decoration:none; display:inline-flex; align-items:center; gap:0.3rem; }
+        .settings-breadcrumb a:hover { text-decoration:underline; }
+        .settings-breadcrumb-sep { color:var(--crow-text-muted); }
+        .settings-breadcrumb-current { color:var(--crow-text-muted); }
+      </style>
+      <nav class="settings-breadcrumb" aria-label="Breadcrumb">
+        <a href="/dashboard/settings">&larr; ${escapeHtml(t("settings.backToSettings", lang))}</a>
+        <span class="settings-breadcrumb-sep">/</span>
+        <span class="settings-breadcrumb-current">${escapeHtml(sectionLabel)}</span>
+      </nav>`;
+      return layout({ title: sectionLabel, content: crumb + html });
     }
 
     // Main menu: grouped menu rows

--- a/servers/gateway/dashboard/panels/settings.js
+++ b/servers/gateway/dashboard/panels/settings.js
@@ -14,6 +14,7 @@ import {
   dispatchAction,
   loadAddonSettings,
 } from "../settings/registry.js";
+import { checkSyncKeyDrift } from "../settings/sync-allowlist.js";
 import { renderSettingsMenu } from "../settings/menu-renderer.js";
 
 // Import all built-in sections
@@ -70,8 +71,16 @@ registerSettingsSection(identitySection);
 registerSettingsSection(passwordSection);
 registerSettingsSection(twoFactorSection);
 
-// Load add-on settings (async, non-blocking)
-loadAddonSettings().catch(err => console.warn("[settings] Add-on settings load error:", err.message));
+// Load add-on settings (async, non-blocking), then run the advisory
+// sync-allowlist drift check once every section (built-in + add-on) is
+// registered. Advisory only — never blocks startup.
+loadAddonSettings()
+  .catch(err => console.warn("[settings] Add-on settings load error:", err.message))
+  .finally(() => {
+    try { checkSyncKeyDrift(getSettingsSections()); } catch (err) {
+      console.warn("[settings] sync-allowlist drift check failed:", err.message);
+    }
+  });
 
 export default {
   id: "settings",

--- a/servers/gateway/dashboard/settings/menu-renderer.js
+++ b/servers/gateway/dashboard/settings/menu-renderer.js
@@ -4,6 +4,7 @@
 
 import { GROUPS, readSettings } from "./registry.js";
 import { t } from "../shared/i18n.js";
+import { escapeHtml } from "../shared/components.js";
 
 /**
  * Render the grouped settings menu.
@@ -35,6 +36,16 @@ export async function renderSettingsMenu(sections, db, lang) {
   );
 
   let html = `<style>${menuCss()}</style>`;
+  // Client-side filter box — the "where do I change X?" entry point. Filters
+  // the already-rendered rows by label/group text; no server round-trip, so
+  // no new route and the network-exposure invariant is untouched.
+  const searchPlaceholder = escapeHtml(t("settings.searchPlaceholder", lang) || "Search settings");
+  html += `<div class="settings-search">
+    <svg class="settings-search-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+    <input type="search" id="settings-search-input" class="settings-search-input"
+      placeholder="${searchPlaceholder}" autocomplete="off" spellcheck="false"
+      oninput="window.crowSettingsFilter && window.crowSettingsFilter(this.value)">
+  </div>`;
   html += `<div class="settings-menu">`;
 
   for (const groupKey of sortedGroups) {
@@ -42,7 +53,9 @@ export async function renderSettingsMenu(sections, db, lang) {
     if (!items || items.length === 0) continue;
 
     const groupDef = GROUPS[groupKey];
-    html += `<div class="settings-group-label">${t(groupDef.labelKey, lang)}</div>`;
+    const groupLabel = t(groupDef.labelKey, lang);
+    html += `<div class="settings-group">`;
+    html += `<div class="settings-group-label">${groupLabel}</div>`;
     html += `<div class="settings-group-card">`;
 
     for (let i = 0; i < items.length; i++) {
@@ -56,24 +69,97 @@ export async function renderSettingsMenu(sections, db, lang) {
 
       const isLast = i === items.length - 1;
       const borderClass = isLast ? "" : " settings-row-bordered";
+      const label = t(section.labelKey, lang);
+      // Haystack for the filter: section label + group label + id, lowercased.
+      const hay = escapeHtml(`${label} ${groupLabel} ${section.id}`.toLowerCase());
 
-      html += `<a href="/dashboard/settings?section=${section.id}" class="settings-row${borderClass}">
+      html += `<a href="/dashboard/settings?section=${section.id}" class="settings-row${borderClass}" data-search="${hay}">
         <span class="settings-row-icon">${section.icon || ""}</span>
-        <span class="settings-row-label">${t(section.labelKey, lang)}</span>
+        <span class="settings-row-label">${label}</span>
         <span class="settings-row-preview">${preview}</span>
         <span class="settings-row-chevron">&rsaquo;</span>
       </a>`;
     }
 
-    html += `</div>`;
+    html += `</div></div>`;
   }
 
   html += `</div>`;
+  const noResults = escapeHtml(t("settings.searchNoResults", lang) || "No settings match your search.");
+  html += `<div id="settings-no-results" class="settings-no-results" style="display:none">${noResults}</div>`;
+  html += menuFilterScript();
   return html;
+}
+
+/**
+ * Client-side filter: hides non-matching rows and any group with no visible
+ * rows; toggles the empty-state message. Bound via the input's `oninput`
+ * attribute so it survives Turbo Drive body swaps (no script-timing reliance).
+ */
+function menuFilterScript() {
+  return `<script>
+  window.crowSettingsFilter = function (q) {
+    q = (q || "").trim().toLowerCase();
+    var menu = document.querySelector(".settings-menu");
+    if (!menu) return;
+    var anyVisible = false;
+    menu.querySelectorAll(".settings-group").forEach(function (g) {
+      var groupVisible = false;
+      g.querySelectorAll(".settings-row").forEach(function (r) {
+        var hay = r.getAttribute("data-search") || "";
+        var match = !q || hay.indexOf(q) !== -1;
+        r.style.display = match ? "" : "none";
+        if (match) groupVisible = true;
+      });
+      g.style.display = groupVisible ? "" : "none";
+      if (groupVisible) anyVisible = true;
+    });
+    var empty = document.getElementById("settings-no-results");
+    if (empty) empty.style.display = anyVisible ? "none" : "";
+  };
+  </script>`;
 }
 
 function menuCss() {
   return `
+  .settings-search {
+    max-width: 640px;
+    position: relative;
+    margin-bottom: 0.75rem;
+  }
+  .settings-search-icon {
+    position: absolute;
+    left: 0.7rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    color: var(--crow-text-muted);
+    pointer-events: none;
+  }
+  .settings-search-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.6rem 0.8rem 0.6rem 2.1rem;
+    font-size: 0.9rem;
+    color: var(--crow-text-primary);
+    background: var(--crow-bg-surface);
+    border: 1px solid var(--crow-border);
+    border-radius: var(--crow-radius-card, 12px);
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  .settings-search-input:focus {
+    border-color: var(--crow-accent);
+  }
+  .settings-search-input::placeholder { color: var(--crow-text-muted); }
+  .settings-no-results {
+    max-width: 640px;
+    padding: 1rem;
+    color: var(--crow-text-muted);
+    font-size: 0.9rem;
+    text-align: center;
+  }
   .settings-menu { max-width: 640px; }
   .settings-group-label {
     font-size: 0.75rem;

--- a/servers/gateway/dashboard/settings/registry.js
+++ b/servers/gateway/dashboard/settings/registry.js
@@ -23,6 +23,26 @@ export const GROUPS = {
 
 /**
  * Register a settings section.
+ *
+ * Section manifest contract (a section module's default export):
+ *   Required:
+ *     - id:        string — unique section id (used in ?section=<id>)
+ *     - group:     string — one of GROUPS (serves as the section's category)
+ *     - labelKey:  string — i18n key for the menu label
+ *     - render({ req, res, db, lang }): Promise<string>
+ *   Optional:
+ *     - navOrder:  number — order within the group
+ *     - icon:      string — inline SVG markup
+ *     - getPreview({ db, lang }): Promise<string> — menu subtitle
+ *     - handleAction({ req, res, db, action }): Promise<boolean>
+ *     - scope:     "global" | "local" | "mixed" — declares whether the
+ *                  section's settings are operator-global (synced), strictly
+ *                  per-instance, or a mix. Advisory metadata for the UI /
+ *                  future tooling; enforcement still lives in writeSetting.
+ *     - syncKeys:  string[] — the dashboard_settings keys this section writes
+ *                  that are MEANT to replicate. Validated against
+ *                  SYNC_ALLOWLIST at boot by checkSyncKeyDrift() (advisory).
+ *
  * @param {object} manifest - Section module default export
  */
 export function registerSettingsSection(manifest) {

--- a/servers/gateway/dashboard/settings/sections/llm.js
+++ b/servers/gateway/dashboard/settings/sections/llm.js
@@ -34,6 +34,10 @@ export default {
   id: "llm",
   group: "ai",
   navOrder: 5, // above ai-provider (10) during the dual-ship window
+  // F2.2 metadata: providers are local/per-instance config; the profile
+  // blobs (ai/tts/stt/vision) replicate to paired instances.
+  scope: "mixed",
+  syncKeys: ["ai_profiles", "tts_profiles", "stt_profiles", "vision_profiles"],
   icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>`,
   labelKey: "settings.section.llm",
 

--- a/servers/gateway/dashboard/settings/sections/llm/ai-profiles.js
+++ b/servers/gateway/dashboard/settings/sections/llm/ai-profiles.js
@@ -2,11 +2,11 @@
  * Settings Section: AI Profiles
  */
 
-import { escapeHtml } from "../../shared/components.js";
-import { t, tJs } from "../../shared/i18n.js";
-import { upsertSetting } from "../registry.js";
-import { renderScopeToggle, scopeToggleScript } from "../../shared/scope-toggle.js";
-import { listProvidersAll } from "../../../../orchestrator/providers-db.js";
+import { escapeHtml } from "../../../shared/components.js";
+import { t, tJs } from "../../../shared/i18n.js";
+import { upsertSetting } from "../../registry.js";
+import { renderScopeToggle, scopeToggleScript } from "../../../shared/scope-toggle.js";
+import { listProvidersAll } from "../../../../../orchestrator/providers-db.js";
 
 // Canonical route ids the Smart Chat router dispatches to. Keep in sync
 // with DEFAULT_ROUTES in servers/gateway/ai/smart-router.js.
@@ -496,7 +496,7 @@ export default {
       if (!profile) { res.json({ ok: false, error: "Profile not found" }); return true; }
 
       try {
-        const { testProfileConnection } = await import("../../../ai/provider.js");
+        const { testProfileConnection } = await import("../../../../ai/provider.js");
         const result = await testProfileConnection(profile, db);
         res.json(result);
       } catch (err) {

--- a/servers/gateway/dashboard/settings/sections/llm/profiles-tab.js
+++ b/servers/gateway/dashboard/settings/sections/llm/profiles-tab.js
@@ -18,10 +18,10 @@
 
 import { escapeHtml } from "../../../shared/components.js";
 import { readSetting, upsertSetting } from "../../registry.js";
-import aiProfilesSection from "../ai-profiles.js";
-import ttsProfilesSection from "../tts-profiles.js";
-import sttProfilesSection from "../stt-profiles.js";
-import visionProfilesSection from "../vision-profiles.js";
+import aiProfilesSection from "./ai-profiles.js";
+import ttsProfilesSection from "./tts-profiles.js";
+import sttProfilesSection from "./stt-profiles.js";
+import visionProfilesSection from "./vision-profiles.js";
 
 const SUBTABS = [
   { id: "chat",   label: "Chat",   section: aiProfilesSection },

--- a/servers/gateway/dashboard/settings/sections/llm/roles-tab.js
+++ b/servers/gateway/dashboard/settings/sections/llm/roles-tab.js
@@ -17,8 +17,38 @@ import { listAllRoles, roleShape } from "../../../../../orchestrator/role-shape.
 import { listProvidersAll, listRoleOverrides, setRoleOverride, clearRoleOverride } from "../../../../../orchestrator/providers-db.js";
 import { compat } from "../../../../../orchestrator/compat.js";
 import { presets } from "../../../../../orchestrator/presets.js";
+import { readSetting } from "../../registry.js";
 
 const BACK = "?section=llm&tab=roles";
+
+// Maestro-Press (MPA) presets are workflow-specific to the MPA host and read
+// as "stale" on a general install. We hide them from the Roles tab unless
+// this is the MPA host or the operator explicitly opts in. This is a UI-only
+// filter — runtime preset resolution (presets[name]) is untouched, so the
+// live MPA pipelines keep resolving these presets regardless of this flag.
+function isMpaPreset(presetName) {
+  return presetName.startsWith("mpa-") || presetName.startsWith("bot-mpa-");
+}
+
+// Auto-detect the MPA host from its data-dir convention (the MPA gateway runs
+// with CROW_HOME / CROW_DATA_DIR under ~/.crow-mpa). General installs use
+// ~/.crow and won't match.
+function isMpaHost() {
+  const probe = `${process.env.CROW_HOME || ""}|${process.env.CROW_DATA_DIR || ""}`;
+  return /\.crow-mpa(\/|\b|$)/.test(probe);
+}
+
+// feature_flags is a local-only (non-synced) settings blob. An explicit
+// boolean mpa_presets wins; otherwise default to the auto-detected host.
+async function showMpaPresets(db) {
+  let flags = {};
+  try {
+    const raw = await readSetting(db, "feature_flags");
+    if (raw) flags = JSON.parse(raw) || {};
+  } catch { /* ignore malformed flags */ }
+  if (typeof flags.mpa_presets === "boolean") return flags.mpa_presets;
+  return isMpaHost();
+}
 
 function presetAgentDefault(presetName, agentName) {
   const p = presets[presetName];
@@ -46,7 +76,8 @@ function optionLabel(role, provider, otherAssignments) {
 
 export default {
   async render({ db }) {
-    const roles = listAllRoles();
+    const showMpa = await showMpaPresets(db);
+    const roles = listAllRoles().filter((r) => showMpa || !isMpaPreset(r.preset_name));
     const providers = await listProvidersAll(db);
     const overrides = await listRoleOverrides(db);
     const ovByAgent = new Map(

--- a/servers/gateway/dashboard/settings/sections/llm/stt-profiles.js
+++ b/servers/gateway/dashboard/settings/sections/llm/stt-profiles.js
@@ -9,10 +9,10 @@
  * bundle). PR 3 flips the flag to make it visible.
  */
 
-import { escapeHtml } from "../../shared/components.js";
-import { upsertSetting } from "../registry.js";
-import { PROVIDER_INFO } from "../../../ai/stt/index.js";
-import { renderScopeToggle, scopeToggleScript } from "../../shared/scope-toggle.js";
+import { escapeHtml } from "../../../shared/components.js";
+import { upsertSetting } from "../../registry.js";
+import { PROVIDER_INFO } from "../../../../ai/stt/index.js";
+import { renderScopeToggle, scopeToggleScript } from "../../../shared/scope-toggle.js";
 
 export default {
   id: "stt-profiles",
@@ -320,7 +320,7 @@ export default {
       const profile = profiles.find(p => p.id === profile_id);
       if (!profile) { res.json({ ok: false, error: "Profile not found" }); return true; }
       try {
-        const { testSttProfile } = await import("../../../ai/stt/index.js");
+        const { testSttProfile } = await import("../../../../ai/stt/index.js");
         const result = await testSttProfile(profile);
         res.json(result);
       } catch (err) {

--- a/servers/gateway/dashboard/settings/sections/llm/tts-profiles.js
+++ b/servers/gateway/dashboard/settings/sections/llm/tts-profiles.js
@@ -13,10 +13,10 @@
  * the third-pass review decision in the plan).
  */
 
-import { escapeHtml } from "../../shared/components.js";
-import { upsertSetting } from "../registry.js";
-import { PROVIDER_INFO } from "../../../ai/tts/index.js";
-import { renderScopeToggle, scopeToggleScript } from "../../shared/scope-toggle.js";
+import { escapeHtml } from "../../../shared/components.js";
+import { upsertSetting } from "../../registry.js";
+import { PROVIDER_INFO } from "../../../../ai/tts/index.js";
+import { renderScopeToggle, scopeToggleScript } from "../../../shared/scope-toggle.js";
 
 /** Write a profile's voice into the compat mirror. */
 async function mirrorVoice(db, voice) {
@@ -345,7 +345,7 @@ export default {
       const profile = profiles.find(p => p.id === profile_id);
       if (!profile) { res.json({ ok: false, error: "Profile not found" }); return true; }
       try {
-        const { testTtsProfile } = await import("../../../ai/tts/index.js");
+        const { testTtsProfile } = await import("../../../../ai/tts/index.js");
         const result = await testTtsProfile(profile);
         res.json(result);
       } catch (err) {

--- a/servers/gateway/dashboard/settings/sections/llm/vision-profiles.js
+++ b/servers/gateway/dashboard/settings/sections/llm/vision-profiles.js
@@ -11,11 +11,11 @@
  * profiles track orchestrator/models.json changes automatically.
  */
 
-import { escapeHtml } from "../../shared/components.js";
-import { readSetting, writeSetting, getSettingScope } from "../registry.js";
-import { renderScopeToggle, scopeToggleScript } from "../../shared/scope-toggle.js";
-import { listProviders, resolveProvider } from "../../../ai/resolve-provider.js";
-import { analyzeImage } from "../../../ai/vision.js";
+import { escapeHtml } from "../../../shared/components.js";
+import { readSetting, writeSetting, getSettingScope } from "../../registry.js";
+import { renderScopeToggle, scopeToggleScript } from "../../../shared/scope-toggle.js";
+import { listProviders, resolveProvider } from "../../../../ai/resolve-provider.js";
+import { analyzeImage } from "../../../../ai/vision.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve as resolvePath } from "node:path";
@@ -413,7 +413,7 @@ export default {
         let bytes;
         const fixturePath = resolvePath(
           dirname(fileURLToPath(import.meta.url)),
-          "../../../../..",
+          "../../../../../..",
           "bundles/meta-glasses/assets/test-fixture.jpg",
         );
         try { bytes = readFileSync(fixturePath); }

--- a/servers/gateway/dashboard/settings/sections/ports.js
+++ b/servers/gateway/dashboard/settings/sections/ports.js
@@ -25,6 +25,8 @@ function statusCell(r) {
 export default {
   id: "ports",
   group: "system",
+  // F2.2 metadata: read-only host registry; nothing here replicates.
+  scope: "local",
   icon: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M6 7V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v3"/></svg>`,
   labelKey: "settings.section.ports",
   navOrder: 55,

--- a/servers/gateway/dashboard/settings/sync-allowlist.js
+++ b/servers/gateway/dashboard/settings/sync-allowlist.js
@@ -52,3 +52,34 @@ export function isSyncable(key) {
 export function listSyncableKeys() {
   return Object.entries(SYNC_ALLOWLIST).map(([pattern, description]) => ({ pattern, description }));
 }
+
+/**
+ * Advisory drift check. Verifies that every settings section's declared
+ * `syncKeys` is actually covered by SYNC_ALLOWLIST. The allowlist stays the
+ * single ENFORCEMENT source of truth — `writeSetting` consults `isSyncable`,
+ * not this function. This only catches the "a section declares a synced key
+ * but nobody added it to the allowlist" class of bug, logging it once at
+ * boot so the operator notices a key that silently won't replicate. Never
+ * throws; returns the drift list for tests.
+ *
+ * @param {Array<{id?:string, syncKeys?:string[]}>} sections
+ * @returns {Array<{section:string, key:string}>}
+ */
+export function checkSyncKeyDrift(sections) {
+  const drift = [];
+  for (const s of sections || []) {
+    const keys = Array.isArray(s?.syncKeys) ? s.syncKeys : [];
+    for (const key of keys) {
+      if (!isSyncable(key)) drift.push({ section: s?.id || "(unknown)", key });
+    }
+  }
+  if (drift.length) {
+    const lines = drift.map((d) => `  - ${d.section}: "${d.key}"`).join("\n");
+    console.warn(
+      "[settings] sync-allowlist drift — section(s) declare syncKeys absent from " +
+        "SYNC_ALLOWLIST; these keys will NOT replicate to paired instances:\n" +
+        lines,
+    );
+  }
+  return drift;
+}

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -461,6 +461,8 @@ const translations = {
 
   // ─── Settings Panel ───
   "settings.pageTitle": { en: "Settings", es: "Ajustes" },
+  "settings.searchPlaceholder": { en: "Search settings", es: "Buscar ajustes" },
+  "settings.searchNoResults": { en: "No settings match your search.", es: "Ningún ajuste coincide con tu búsqueda." },
   "settings.passwordUpdated": { en: "Password updated.", es: "Contraseña actualizada." },
   "settings.passwordTooShort": { en: "Password must be at least 12 characters.", es: "La contraseña debe tener al menos 12 caracteres." },
   "settings.passwordMismatch": { en: "Passwords don't match.", es: "Las contraseñas no coinciden." },


### PR DESCRIPTION
## Summary

First phase of the v1 refoundation (keep the proven substrate, consolidate the fragmented layers on top). Scoped to making the existing settings/AI surface rock-solid and easier to navigate — depth over breadth. Plan was adversarially reviewed before execution; several first-draft assumptions were corrected against the code (chat already pointer-resolves; the DBs are not shared; the preset split is a UI-only filter).

## What's in this PR

**F2.2 — Declarative section metadata + allowlist drift check**
- Optional `scope` / `syncKeys` on the settings section manifest (`group` already serves as category).
- Advisory boot-time `checkSyncKeyDrift()` warns when a section declares a synced key absent from `SYNC_ALLOWLIST`. The allowlist stays the single enforcement source of truth; the check never throws or blocks startup.
- `llm` (mixed; ai/tts/stt/vision profile keys) and `ports` (local) annotated as reference shapes.

**F1.3 — Hide MPA presets from the Roles tab** *(the visible "stale roles" fix)*
- The Roles tab no longer surfaces the Maestro-Press `mpa-*`/`bot-mpa-` presets on a general install. Gated on auto-detected MPA host (`CROW_HOME`/`CROW_DATA_DIR` under `~/.crow-mpa`) with a local, non-synced `feature_flags.mpa_presets` override.
- **UI-only filter** — runtime `presets[name]` resolution is untouched, so live MPA pipelines are unaffected (verified). Also de-brittles `compat-check`'s hardcoded role count.

**F1.2 — Relocate the 4 legacy profile modules into `sections/llm/`**
- `ai-profiles`/`tts-profiles`/`stt-profiles`/`vision-profiles` were unregistered sub-modules of the `llm` section but sat in `sections/` looking like standalone menu sections. Moved under `sections/llm/` (their sole importer). Clean git renames; no behavior change. (Inlining ~1,650 lines into one file was rejected as a megafile.)

**F1.1 — Direct-mode reader audit (no code change)**
- Audited every reader of legacy direct-mode profile fields. They are live tolerant fallbacks (the profile editor still creates direct-mode profiles), so nothing is dead to remove. Confirmed the migration's v3 legacy-field strip is safe — every `createAdapterFromProfile` caller passes `db`. Verified empirically against the live DB.

**F2.3 — Searchable settings landing + sub-page breadcrumb**
- Client-side search box on the settings menu (filters rows by label/group/id, hides empty groups, empty-state). Pure client-side (`oninput`, Turbo-safe) — **no new route, network-exposure invariant intact**.
- "← Settings / &lt;Section&gt;" breadcrumb on every sub-page. en/es i18n added.

## Verification

- `node scripts/smoke/compat-check.js` ✅
- `node scripts/smoke/pointer-profile-adapter.js` ✅ (live DB, pointer profiles resolve with legacy fields stripped)
- `node tests/auth-network.test.js` — 13/13 ✅ (dashboard-privacy invariant)
- Full render check: real settings pages rendered through the panel handler against a copy of the live DB — search box live, 23 sections / 7 groups, zero `mpa-*` rows on a general install, breadcrumb present.

## Deferred (own spec → plan cycle)

F3 Bot Builder → core · F4 capability/MCP harness + `bundle = service+tools+skills` (+ extensions audit) · F5 symmetric multi-instance viewer · F6 onboarding + design system · F7 docs/GitHub-page realignment. A reusable versioned settings-migration runner was intentionally deferred to F3 (F1 ships no data migration). A shared toggle component + bulk component adoption deferred to avoid churn on working sections.