### PR TITLE
F5: full-mesh visibility for the multi-instance viewer (gossip roster)

### DIFF
--- a/servers/gateway/dashboard/overview-cache.js
+++ b/servers/gateway/dashboard/overview-cache.js
@@ -94,6 +94,38 @@ function validateTile(tile) {
   };
 }
 
+const HEX_ID_REGEX = /^[a-f0-9]{8,64}$/i;
+const PEER_STATUS_ENUM = new Set(["active", "offline", "paused"]);
+const MAX_PEERS = 50;
+
+/**
+ * Validate one gossip-roster peer entry (F5). Returns the sanitized peer or
+ * `null` to drop it. A peer with no safe gateway_url is dropped — it can't be
+ * opened, so it has no display value. URL must be absolute http(s); this is a
+ * link the renderer puts in an href, so reject anything that could smuggle a
+ * javascript:/data: scheme.
+ */
+function validatePeerEntry(p) {
+  if (!p || typeof p !== "object") return null;
+  if (typeof p.id !== "string" || !HEX_ID_REGEX.test(p.id)) return null;
+  let gateway_url = null;
+  if (typeof p.gateway_url === "string" && p.gateway_url) {
+    try {
+      const u = new URL(p.gateway_url);
+      if (u.protocol === "https:" || u.protocol === "http:") gateway_url = u.href;
+    } catch { /* invalid URL → drop */ }
+  }
+  if (!gateway_url) return null;
+  return {
+    id: p.id,
+    name: typeof p.name === "string" ? p.name.slice(0, 256) : null,
+    gateway_url,
+    hostname: typeof p.hostname === "string" ? p.hostname.slice(0, 256) : null,
+    is_home: p.is_home === true,
+    status: PEER_STATUS_ENUM.has(p.status) ? p.status : "active",
+  };
+}
+
 /**
  * Validate the outer overview envelope. Returns the sanitized envelope or
  * `null` when the response is structurally invalid.
@@ -113,6 +145,9 @@ function validateEnvelope(body) {
     if (t) tiles.push(t);
     // silently drop invalid entries; entire-envelope invalid case is caught above
   }
+  const peers = Array.isArray(body.peers)
+    ? body.peers.map(validatePeerEntry).filter(Boolean).slice(0, MAX_PEERS)
+    : [];
   return {
     instance: {
       id: body.instance.id,
@@ -121,6 +156,7 @@ function validateEnvelope(body) {
       is_home: body.instance.is_home === true,
     },
     tiles,
+    peers,
     health: body.health && typeof body.health === "object" ? {
       status: body.health.status === "ok" ? "ok" : "degraded",
       checkedAt: typeof body.health.checkedAt === "string" ? body.health.checkedAt : null,
@@ -182,6 +218,7 @@ async function doFetch(db, instanceId) {
       status: "ok",
       instance: sanitized.instance,
       tiles: sanitized.tiles,
+      peers: sanitized.peers,
       health: sanitized.health,
       fetchedAt: new Date().toISOString(),
     },

--- a/servers/gateway/dashboard/panels/nest/data-queries.js
+++ b/servers/gateway/dashboard/panels/nest/data-queries.js
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { getPeerCreds } from "../../../../shared/peer-credentials.js";
+import { getOrCreateLocalInstanceId } from "../../../instance-registry.js";
 import { readSetting } from "../../settings/registry.js";
 
 // Docker status cache
@@ -181,6 +182,17 @@ export async function getNestData(db, lang, opts = {}) {
   const trustedInstances = Array.isArray(opts.trustedInstances) ? opts.trustedInstances : [];
   const peerOverviews = Array.isArray(opts.peerOverviews) ? opts.peerOverviews : [];
 
+  // Full-mesh visibility (F5): fold gossip-discovered instances (from each
+  // trusted peer's roster) into the carousel set as link-only sections. Kept
+  // index-aligned: append to both arrays in the same order.
+  let localInstanceId = "";
+  try { localInstanceId = getOrCreateLocalInstanceId(); } catch {}
+  const { discoveredInstances, discoveredOverviews } = mergeDiscoveredPeers(
+    trustedInstances, peerOverviews, localInstanceId
+  );
+  const allTrustedInstances = [...trustedInstances, ...discoveredInstances];
+  const allPeerOverviews = [...peerOverviews, ...discoveredOverviews];
+
   // Cross-instance SSO eligibility. Decorate every instance row (both the
   // legacy `instances` list and the unified `trustedInstances` list — they are
   // distinct arrays) with `paired` = a shared signing key exists for it. The
@@ -193,8 +205,8 @@ export async function getNestData(db, lang, opts = {}) {
   return {
     pinnedItems, bundles, dockerInfo, dbStats, recentChats, recentSessions,
     instances: withPaired(instances),
-    trustedInstances: withPaired(trustedInstances),
-    peerOverviews,
+    trustedInstances: withPaired(allTrustedInstances),
+    peerOverviews: allPeerOverviews,
     ssoEnabled,
   };
 }
@@ -216,4 +228,47 @@ export async function getTrustedInstances(db) {
   } catch {
     return [];
   }
+}
+
+/**
+ * Full-mesh visibility (F5). Each trusted peer's overview carries a gossip
+ * `peers` roster (the instances IT knows about). Merge any roster entry this
+ * node doesn't already render — not self, not an already-trusted peer, not a
+ * duplicate — into the carousel as a link-only "discovered" instance. We
+ * never have credentials for these, so they get no tile fetch and no SSO:
+ * just an "open" link to their gateway_url. This is what makes every node
+ * converge to the full mesh regardless of who paired with whom.
+ *
+ * Pure function (no I/O) so it's unit-testable. Returns parallel arrays that
+ * the caller appends to trustedInstances / peerOverviews (kept index-aligned).
+ *
+ * @param {Array<{id:string}>} trustedInstances
+ * @param {Array<{status:string, peers?:Array}>} peerOverviews
+ * @param {string} localId
+ * @returns {{ discoveredInstances: Array, discoveredOverviews: Array }}
+ */
+export function mergeDiscoveredPeers(trustedInstances, peerOverviews, localId) {
+  const known = new Set([localId, ...(trustedInstances || []).map((i) => i?.id).filter(Boolean)]);
+  const seen = new Set();
+  const discoveredInstances = [];
+  const discoveredOverviews = [];
+  for (const ov of peerOverviews || []) {
+    if (!ov || ov.status !== "ok" || !Array.isArray(ov.peers)) continue;
+    for (const pr of ov.peers) {
+      if (!pr || !pr.id || !pr.gateway_url) continue;
+      if (known.has(pr.id) || seen.has(pr.id)) continue;
+      seen.add(pr.id);
+      discoveredInstances.push({
+        id: pr.id,
+        name: pr.name || null,
+        gateway_url: pr.gateway_url,
+        hostname: pr.hostname || null,
+        is_home: pr.is_home ? 1 : 0,
+        status: "active",
+        discovered: true,
+      });
+      discoveredOverviews.push({ instanceId: pr.id, status: "discovered", tiles: [], reason: "gossip" });
+    }
+  }
+  return { discoveredInstances, discoveredOverviews };
 }

--- a/servers/gateway/dashboard/panels/nest/html.js
+++ b/servers/gateway/dashboard/panels/nest/html.js
@@ -296,6 +296,27 @@ export function buildNestHTML(data, lang) {
       const sectionId = escapeHtml(ti.id || `peer-${i}`);
       const displayName = escapeHtml(peer.displayName || ti.name || "peer");
 
+      // Full-mesh visibility (F5): an instance we learned about via a trusted
+      // peer's gossip roster, but for which we hold no credentials. We can't
+      // fetch its tiles or SSO into it — render a single link-out to its
+      // public gateway so the operator can still reach it from any node.
+      if (peer.status === "discovered") {
+        const openUrl = ti.gateway_url || "";
+        const openLabel = escapeHtml(t("nest.openInstance", lang) || "Open");
+        sections.push(
+          `<section class="nest-instance-section nest-instance-section--discovered" data-instance="${sectionId}" role="tabpanel" aria-labelledby="crow-instance-tab-${sectionId}">
+            <div class="nest-section-label" style="padding:0.5rem 1rem 0;font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;color:var(--crow-text-muted);font-weight:600">${displayName}</div>
+            <div class="nest-grid">
+              ${openUrl ? `<a href="${escapeHtml(openUrl)}" target="_blank" rel="noopener noreferrer" class="nest-app nest-app--instance">
+                <div class="nest-app-icon">${resolvePeerIcon("instance")}</div>
+                <div class="nest-app-label">${openLabel} ${displayName}</div>
+              </a>` : ""}
+            </div>
+          </section>`
+        );
+        continue;
+      }
+
       if (peer.status !== "ok") {
         const lastSeen = ti.last_seen_at
           ? new Date(ti.last_seen_at).toLocaleString(lang === "es" ? "es-ES" : "en-US")

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -159,6 +159,7 @@ const translations = {
   // ─── Nest Panel ───
   "nest.pinned": { en: "Pinned", es: "Fijados" },
   "nest.instances": { en: "Instances", es: "Instancias" },
+  "nest.openInstance": { en: "Open", es: "Abrir" },
 
   // ─── Messages Panel ───
   "messages.pageTitle": { en: "Messages", es: "Mensajes" },

--- a/servers/gateway/routes/federation.js
+++ b/servers/gateway/routes/federation.js
@@ -24,6 +24,14 @@
  *       port:     number|null,
  *       category: "local-panel"|"bundle"|"instance"
  *     }>,
+ *     peers: Array<{          // gossip roster: instances THIS node knows about,
+ *       id:          string,  // so a fetcher converges to the full mesh (F5).
+ *       name:        string|null,
+ *       gateway_url: string|null,  // public https URL; the only way to "open" it
+ *       hostname:    string|null,
+ *       is_home:     boolean,
+ *       status:      "active"|"offline"|"paused"
+ *     }>,                      // metadata only — NO credentials. Capped at 50.
  *     health: { status: "ok"|"degraded", checkedAt: string }
  *   }
  *
@@ -200,6 +208,35 @@ function buildTiles() {
 }
 
 /**
+ * Build the gossip roster: every instance THIS node knows about (active /
+ * offline / paused, not revoked, not the local-MCP pseudo-instance, not
+ * self). A fetching peer merges these into its own carousel so visibility
+ * converges to the full mesh regardless of who paired with whom. Metadata
+ * only — never any credential. Capped so a misbehaving peer can't bloat
+ * the response.
+ */
+async function buildPeerRoster(db, localId) {
+  try {
+    const { rows } = await db.execute({
+      sql: "SELECT id, name, gateway_url, hostname, is_home, status FROM crow_instances "
+        + "WHERE status != 'revoked' AND (crow_id IS NULL OR crow_id != '__local_mcp__') "
+        + "AND id != ? ORDER BY is_home DESC, name ASC LIMIT 50",
+      args: [localId],
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name || null,
+      gateway_url: r.gateway_url || null,
+      hostname: r.hostname || null,
+      is_home: r.is_home === 1,
+      status: r.status || "active",
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Factory: returns an Express router with GET /dashboard/overview mounted.
  *
  * @param {object} args
@@ -224,6 +261,7 @@ export default function federationRouter({ createDbClient }) {
           is_home: inst?.is_home === 1,
         },
         tiles: buildTiles(),
+        peers: await buildPeerRoster(db, localId),
         health: {
           status: "ok",
           checkedAt: new Date().toISOString(),

--- a/tests/nest-mesh.test.js
+++ b/tests/nest-mesh.test.js
@@ -1,0 +1,134 @@
+/**
+ * F5 — full-mesh visibility tests.
+ *
+ * Covers the three layers of the gossip path:
+ *   1. overview-cache sanitizes the `peers` roster a peer advertises
+ *   2. mergeDiscoveredPeers folds roster entries into the carousel set
+ *   3. buildNestHTML renders a discovered instance as a link-only section
+ */
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// peer-credentials is pulled in transitively; point it at an empty file.
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+const tmp = mkdtempSync(join(tmpdir(), "crow-nest-mesh-test-"));
+writeFileSync(join(tmp, "peer-tokens.json"), "{}", { mode: 0o600 });
+process.env.CROW_PEER_TOKENS_PATH = join(tmp, "peer-tokens.json");
+
+const { getPeerOverview, _resetCache, _setFetchImpl } = await import(
+  "../servers/gateway/dashboard/overview-cache.js"
+);
+const { mergeDiscoveredPeers } = await import(
+  "../servers/gateway/dashboard/panels/nest/data-queries.js"
+);
+const { buildNestHTML } = await import(
+  "../servers/gateway/dashboard/panels/nest/html.js"
+);
+
+const fakeDb = { execute: async () => ({ rows: [] }), close: () => {} };
+
+beforeEach(() => { _resetCache(); _setFetchImpl(null); });
+
+test("overview-cache sanitizes the gossip peers roster", async () => {
+  _setFetchImpl(async () => ({
+    ok: true,
+    body: {
+      instance: { id: "49cf71ca", name: "Grackle", is_home: true },
+      tiles: [],
+      peers: [
+        { id: "77ac9c01", name: "black-swan", gateway_url: "https://bs.ts.net:8444", status: "active", is_home: false },
+        { id: "BADID!!", name: "x", gateway_url: "https://x.ts.net" },        // bad id
+        { id: "abcdef12", name: "noUrl" },                                     // no url
+        { id: "abcdef34", name: "evil", gateway_url: "javascript:alert(1)" },  // bad scheme
+        { id: "abcdef56", name: "ok2", gateway_url: "https://ok2.ts.net" },
+      ],
+      health: { status: "ok", checkedAt: "2026-06-07T00:00:00Z" },
+    },
+  }));
+  const ov = await getPeerOverview(fakeDb, "49cf71ca");
+  assert.equal(ov.status, "ok");
+  assert.equal(ov.peers.length, 2, "drops bad-id / no-url / bad-scheme entries");
+  assert.ok(ov.peers.every((p) => p.gateway_url.startsWith("https://")));
+  assert.ok(!ov.peers.some((p) => p.gateway_url.includes("javascript")));
+});
+
+test("overview-cache caps the roster at 50", async () => {
+  const peers = Array.from({ length: 80 }, (_, i) => ({
+    id: "ab" + String(i).padStart(6, "0"),
+    name: "p" + i,
+    gateway_url: "https://p" + i + ".ts.net",
+  }));
+  _setFetchImpl(async () => ({
+    ok: true,
+    body: { instance: { id: "aaa111" }, tiles: [], peers, health: { status: "ok" } },
+  }));
+  const ov = await getPeerOverview(fakeDb, "aaa111");
+  assert.equal(ov.peers.length, 50);
+});
+
+test("mergeDiscoveredPeers excludes self, known, dups, and no-url entries", () => {
+  const trusted = [{ id: "49cf71ca", name: "Grackle" }];
+  const overviews = [{
+    instanceId: "49cf71ca", status: "ok", peers: [
+      { id: "77ac9c01", name: "black-swan", gateway_url: "https://bs", is_home: false, status: "active" },
+      { id: "0867ac28", name: "me", gateway_url: "https://me" },     // == localId
+      { id: "49cf71ca", name: "already", gateway_url: "https://g" }, // already trusted
+      { id: "77ac9c01", name: "dup", gateway_url: "https://bs2" },   // duplicate
+    ],
+  }];
+  const { discoveredInstances, discoveredOverviews } = mergeDiscoveredPeers(trusted, overviews, "0867ac28");
+  assert.equal(discoveredInstances.length, 1);
+  assert.equal(discoveredInstances[0].id, "77ac9c01");
+  assert.equal(discoveredInstances[0].discovered, true);
+  assert.equal(discoveredOverviews.length, 1);
+  assert.equal(discoveredOverviews[0].status, "discovered");
+});
+
+test("mergeDiscoveredPeers ignores non-ok overviews", () => {
+  const { discoveredInstances } = mergeDiscoveredPeers(
+    [], [{ status: "unavailable", peers: [{ id: "z", gateway_url: "https://z" }] }], "me"
+  );
+  assert.equal(discoveredInstances.length, 0);
+});
+
+test("buildNestHTML renders a discovered instance as a link-only section", () => {
+  const data = {
+    pinnedItems: [], bundles: [], dockerInfo: { available: false }, dbStats: {},
+    recentChats: [], recentSessions: [], instances: [],
+    trustedInstances: [
+      { id: "49cf71ca", name: "Grackle", paired: true, gateway_url: "https://g" },
+      { id: "77ac9c01", name: "black-swan", discovered: true, paired: false, gateway_url: "https://bs.ts.net:8444" },
+    ],
+    peerOverviews: [
+      { instanceId: "49cf71ca", status: "ok", tiles: [] },
+      { instanceId: "77ac9c01", status: "discovered", tiles: [] },
+    ],
+    ssoEnabled: false,
+  };
+  const html = buildNestHTML(data, "en");
+  assert.ok(html.includes("nest-instance-section--discovered"), "renders discovered section");
+  assert.ok(html.includes("https://bs.ts.net:8444"), "open link points at gateway_url");
+  assert.ok(html.includes("black-swan"), "shows the discovered instance name");
+});
+
+test("buildNestHTML escapes a malicious discovered gateway label", () => {
+  // gateway_url is sanitized upstream, but the renderer must still escape it.
+  const data = {
+    pinnedItems: [], bundles: [], dockerInfo: { available: false }, dbStats: {},
+    recentChats: [], recentSessions: [], instances: [],
+    trustedInstances: [
+      { id: "49cf71ca", name: "Grackle", paired: true, gateway_url: "https://g" },
+      { id: "ab000001", name: '<img src=x onerror=alert(1)>', discovered: true, paired: false, gateway_url: "https://ok.ts.net" },
+    ],
+    peerOverviews: [
+      { instanceId: "49cf71ca", status: "ok", tiles: [] },
+      { instanceId: "ab000001", status: "discovered", tiles: [] },
+    ],
+    ssoEnabled: false,
+  };
+  const html = buildNestHTML(data, "en");
+  assert.ok(!html.includes("<img src=x onerror=alert(1)>"), "name is HTML-escaped");
+});


### PR DESCRIPTION
## Problem

The Crow's Nest multi-instance carousel only rendered an instance's **directly-paired** peers. In a hub-and-spoke deployment, only the hub (the node that paired with everyone) showed the complete mesh; spoke nodes saw a partial view. Concretely: `crow` only knew about `grackle`, so its dashboard showed Crow + grackle — never black-swan or MPA — while grackle (which paired with all of them) showed the full set. Diagnosis confirmed the viewer is **not** gated on `is_home`; each node simply only knows its own trusted peers, and `crow_instances` sync forwards go-forward changes only (no backfill), so pre-existing peer rows never propagated to later-paired nodes.

## Fix — gossip the roster through peer overviews

Every instance already fetches each trusted peer's `/dashboard/overview`. That payload now carries a **`peers` roster** — the instances *that* node knows about:

- **Serve** (`federation.js`): add `peers[]` (id, name, gateway_url, hostname, is_home, status) — **public metadata only, no credentials**, capped at 50, excluding self and the local-MCP pseudo-instance.
- **Sanitize** (`overview-cache.js`): validate each roster entry on fetch — hex id, **http(s)-only** `gateway_url` (rejects `javascript:`/`data:`), status enum, cap 50. Threaded into the cached overview.
- **Merge** (`data-queries.js`): new pure `mergeDiscoveredPeers()` folds roster entries this node doesn't already render (not self, not already-trusted, deduped, must have a gateway_url) into the carousel as link-only **"discovered"** instances.
- **Render** (`nest/html.js`): discovered instances get a section with a single **"Open"** link to their gateway — **no tile fetch, no SSO** (we hold no credentials for them). Name is HTML-escaped.

Net: every node converges to the full mesh regardless of who paired with whom, without sharing any credential and without touching the trust/pairing layer.

## Security

- Rosters travel only over the existing HMAC-gated `/dashboard/overview` (trusted peers only).
- Only public metadata is shared; discovered peers are display-and-link-only.
- `gateway_url` is validated to absolute http(s) before it ever reaches an `href`; names are escaped (covered by `nest-xss` + a new escape test).

## Tests

- New `tests/nest-mesh.test.js` (6): roster sanitization, 50-cap, merge exclusions (self/known/dup/no-url), non-ok overviews contribute nothing, discovered render, XSS-escape.
- Existing suites green: `overview-cache` (15), `federation-overview` (9), `nest-xss` (7), `federation-companion` (4), `federation-resolve` (7).

## Deploy note

Requires the new code on **both** sides — peers must *serve* the roster and the viewer must *render* it. After merge: `git pull` + restart `crow-gateway` on each host.

## Follow-up (not in this PR)

Duplicate instance-id `520a8629` shared by crow's and grackle's `~/.crow-mpa` (grackle's is a dormant stale copy) — being retired separately.