### PR TITLE
Restart on non-systemd supervisors (launchd, Docker) so apply-on-change works

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,12 @@ CROW_DB_PATH=./data/crow.db
 # CROW_BACKUP_TOKEN=
 # Pull-based auto-update (set 0 to disable)
 # CROW_AUTO_UPDATE=1
+# "Apply on change" flows (auto-update, integration add/remove, bundle install)
+# restart the gateway by exiting the process for a supervisor to relaunch.
+# systemd is detected automatically (INVOCATION_ID). Under other supervisors
+# that restart on exit — macOS launchd (KeepAlive), Docker (restart: always),
+# pm2, etc. — set this so those restarts actually happen.
+# CROW_SUPERVISED=1
 
 # ── ACCESS CONTROL (advanced) ────────────────────────────
 

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -4,12 +4,13 @@
  * Enabled by default. Users can toggle via Settings panel or CROW_AUTO_UPDATE env var.
  * Stores state in dashboard_settings DB table.
  *
- * On update: git pull → npm install → init-db → restart (if systemd)
+ * On update: git pull → npm install → init-db → restart (if supervised)
  */
 
 import { execFile } from "node:child_process";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isSupervised } from "../shared/supervisor.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = dirname(dirname(__dirname));
@@ -172,11 +173,13 @@ export async function checkForUpdates() {
 
     log(`Updated: ${currentVersion} → ${newVersion}`);
 
-    // Restart if running as systemd service
-    if (process.env.INVOCATION_ID) {
-      log("Restarting gateway via systemd...");
+    // Restart to load the new code when supervised (systemd, launchd
+    // KeepAlive, Docker, etc.). Without a supervisor the pulled code only
+    // takes effect on the next manual restart.
+    if (isSupervised()) {
+      log("Restarting gateway to apply update...");
       // Close the HTTP server first to release the port, then exit
-      // so systemd restart doesn't hit EADDRINUSE
+      // so the supervisor's restart doesn't hit EADDRINUSE
       setTimeout(() => {
         process.emit("crow:shutdown");
         setTimeout(() => process.exit(1), 1000);

--- a/servers/gateway/dashboard/settings/sections/integrations.js
+++ b/servers/gateway/dashboard/settings/sections/integrations.js
@@ -5,6 +5,7 @@
 import { escapeHtml, badge } from "../../shared/components.js";
 import { t, tJs } from "../../shared/i18n.js";
 import { getProxyStatus } from "../../../proxy.js";
+import { isSupervised } from "../../../../shared/supervisor.js";
 
 export default {
   id: "integrations",
@@ -245,9 +246,9 @@ function pollHealth(attempts) {
         console.warn("[settings] Failed to regenerate .mcp.json:", e.message);
       }
 
-      const isSystemd = !!process.env.INVOCATION_ID;
-      res.json({ ok: true, restarting: isSystemd });
-      if (isSystemd) {
+      const supervised = isSupervised();
+      res.json({ ok: true, restarting: supervised });
+      if (supervised) {
         setTimeout(() => process.exit(0), 500);
       }
       return true;
@@ -281,9 +282,9 @@ function pollHealth(attempts) {
         console.warn("[settings] Failed to regenerate .mcp.json:", e.message);
       }
 
-      const isSystemd = !!process.env.INVOCATION_ID;
-      res.json({ ok: true, restarting: isSystemd });
-      if (isSystemd) {
+      const supervised = isSupervised();
+      res.json({ ok: true, restarting: supervised });
+      if (supervised) {
         setTimeout(() => process.exit(0), 500);
       }
       return true;

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -19,6 +19,7 @@
 import { Router } from "express";
 import { createNotification } from "../../shared/notifications.js";
 import bus from "../../shared/event-bus.js";
+import { isSupervised } from "../../shared/supervisor.js";
 import { createDbClient } from "../../db.js";
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync, copyFileSync, unlinkSync, symlinkSync } from "node:fs";
@@ -747,14 +748,14 @@ function revertEnvInGateway(envKeys) {
 
 /**
  * Schedule a graceful gateway restart so new env vars take effect.
- * Uses the same pattern as auto-update: exit with code 1 so systemd restarts.
+ * Uses the same pattern as auto-update: exit with code 1 so the supervisor restarts.
  * Emits 'crow:shutdown' on process so the HTTP server can close its listening
- * socket before the exit — prevents EADDRINUSE when systemd starts the new instance.
- * For non-systemd, just sets process.env so the storage server can reinitialize.
+ * socket before the exit — prevents EADDRINUSE when the supervisor starts the new instance.
+ * When unsupervised, just sets process.env so the storage server can reinitialize.
  */
 function scheduleGatewayRestart(delayMs = 2000) {
-  if (process.env.INVOCATION_ID) {
-    // Running as systemd service — close server, then exit to trigger restart
+  if (isSupervised()) {
+    // Supervised — close server, then exit to trigger restart
     console.log("[bundles] Restarting gateway to apply new configuration...");
     setTimeout(() => {
       process.emit("crow:shutdown");
@@ -762,7 +763,7 @@ function scheduleGatewayRestart(delayMs = 2000) {
       setTimeout(() => process.exit(1), 1000);
     }, delayMs);
   } else {
-    // Not systemd — reload env vars into current process
+    // Unsupervised — reload env vars into current process
     try {
       const envContent = readFileSync(APP_ENV_PATH, "utf8");
       for (const line of envContent.split("\n")) {

--- a/servers/shared/supervisor.js
+++ b/servers/shared/supervisor.js
@@ -1,0 +1,20 @@
+/**
+ * Process-supervision detection.
+ *
+ * Several "apply on change" flows (auto-update, integration add/remove, bundle
+ * installs) restart the gateway by simply exiting the process and letting a
+ * supervisor start it again. That is only safe when something is actually
+ * watching the process.
+ *
+ * Historically this was gated on `INVOCATION_ID`, which only systemd sets — so
+ * on other supervisors (macOS launchd with KeepAlive, Docker restart policies,
+ * pm2, etc.) the process never restarted and the change silently failed to
+ * apply. Such supervisors can opt in by setting `CROW_SUPERVISED=1`.
+ *
+ * @returns {boolean} true if exiting the process will trigger a restart.
+ */
+export function isSupervised() {
+  if (process.env.INVOCATION_ID) return true; // systemd
+  const v = process.env.CROW_SUPERVISED;
+  return v === "1" || v === "true";
+}

--- a/tests/supervisor.test.js
+++ b/tests/supervisor.test.js
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSupervised } from "../servers/shared/supervisor.js";
+
+// Run fn with a temporary process.env, restoring it afterwards.
+function withEnv(vars, fn) {
+  const saved = {};
+  for (const k of Object.keys(vars)) {
+    saved[k] = process.env[k];
+    if (vars[k] === undefined) delete process.env[k];
+    else process.env[k] = vars[k];
+  }
+  try {
+    return fn();
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test("unsupervised by default (no INVOCATION_ID / CROW_SUPERVISED)", () => {
+  withEnv({ INVOCATION_ID: undefined, CROW_SUPERVISED: undefined }, () => {
+    assert.equal(isSupervised(), false);
+  });
+});
+
+test("systemd INVOCATION_ID is treated as supervised", () => {
+  withEnv({ INVOCATION_ID: "deadbeef", CROW_SUPERVISED: undefined }, () => {
+    assert.equal(isSupervised(), true);
+  });
+});
+
+test("CROW_SUPERVISED=1 opts in (launchd / Docker / pm2)", () => {
+  withEnv({ INVOCATION_ID: undefined, CROW_SUPERVISED: "1" }, () => {
+    assert.equal(isSupervised(), true);
+  });
+});
+
+test("CROW_SUPERVISED=true opts in", () => {
+  withEnv({ INVOCATION_ID: undefined, CROW_SUPERVISED: "true" }, () => {
+    assert.equal(isSupervised(), true);
+  });
+});
+
+test("CROW_SUPERVISED=0 does not opt in", () => {
+  withEnv({ INVOCATION_ID: undefined, CROW_SUPERVISED: "0" }, () => {
+    assert.equal(isSupervised(), false);
+  });
+});


### PR DESCRIPTION
## Problem

The gateway's *apply-on-change* flows — **auto-update**, **integration add/remove**, and **bundle install** — apply changes by exiting the process and letting a process supervisor relaunch it. That restart was gated on `process.env.INVOCATION_ID`, which **only systemd sets**.

On any other supervisor that restarts a process when it exits — **macOS launchd** (`KeepAlive`), **Docker** (`restart: always`), **pm2**, etc. — the new code/config was pulled to disk but **never applied**: the old process kept running until a manual restart. So e.g. on a Mac running the gateway under launchd, auto-update would fetch every 6h and report success, yet the running gateway stayed on the old commit indefinitely.

## Fix

Add `servers/shared/supervisor.js` exporting `isSupervised()`:

```js
export function isSupervised() {
  if (process.env.INVOCATION_ID) return true;        // systemd (auto-detected)
  const v = process.env.CROW_SUPERVISED;
  return v === "1" || v === "true";                  // opt-in: launchd/Docker/pm2/...
}
```

Replace the three `process.env.INVOCATION_ID` restart gates with `isSupervised()`:
- `servers/gateway/auto-update.js`
- `servers/gateway/routes/bundles.js` (`scheduleGatewayRestart`)
- `servers/gateway/dashboard/settings/sections/integrations.js` (add + remove integration)

Document `CROW_SUPERVISED` in `.env.example`, and add `tests/supervisor.test.js`.

## Compatibility

Fully backward-compatible: **systemd deployments need no change** (still auto-detected via `INVOCATION_ID`). Non-systemd supervisors opt in with `CROW_SUPERVISED=1`. Unsupervised runs are unchanged (no surprise exits).

## Testing

- `node --test tests/supervisor.test.js` — 5/5 pass (default unsupervised; `INVOCATION_ID`; `CROW_SUPERVISED=1`/`true`/`0`).
- Verified the three modified modules still import cleanly.
- Verified end-to-end on macOS/launchd: with `CROW_SUPERVISED=1`, the gateway exits on update and launchd's `KeepAlive` respawns it on the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)