### PR TITLE
gitignore: match the ./data symlink so auto-update can't split the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,12 @@ scripts/bench/results/quality/*.dat
 # crow-autoupdate-pull-only.
 /crow.db
 /crow.db-*
-/data/
+# Match both the real ./data/ dir and the symlink setup.js creates
+# (./data -> ~/.crow/data). A trailing slash matches only a directory, so the
+# symlink stayed untracked and the auto-updater's `git stash --include-untracked`
+# would sweep it away — init-db then recreated ./data as a real dir with a fresh
+# empty DB, splitting the database. No trailing slash matches the symlink too.
+/data
 servers/gateway/public/blog/
 bundles/.env.cuda
 bundles/*/.env


### PR DESCRIPTION
## Problem

On a self-hosted install, `setup.js` makes `./data` a **symlink** to `~/.crow/data` (the canonical data dir). The auto-updater can silently **split the database in two**, which surfaces to the user as the dashboard suddenly showing the **"set a new password"** setup screen even though a password (and all memories) already exist.

### Root cause

The anti-drift block in `.gitignore` (added 2026-05-29) ignores `/data/`. A **trailing slash matches only a directory**, so the `./data` *symlink* is treated as **untracked** (`?? data`). The failure chain during an auto-update:

1. `git stash --include-untracked` → sweeps the untracked `./data` symlink away.
2. `node scripts/init-db.js` → `mkdirSync('./data')` recreates `./data` as a **real directory** with a fresh, empty `crow.db`.
3. post-pull `git stash pop` conflicts (a real `./data` dir now occupies the path) → the fallback `git checkout -- .` leaves the real dir in place; the symlink is gone for good.

Result: the gateway (relative `CROW_DB_PATH=./data/crow.db`) now reads the **empty** `./data/crow.db` — no password, no memories — while the real data remains in `~/.crow/data/crow.db`. The MCP servers (absolute `CROW_DB_PATH`) keep using the real DB, so memory writes and the dashboard diverge.

## Fix

Drop the trailing slash: `/data/` → `/data`. Without a trailing slash the pattern matches **both** the real directory and the symlink, so `./data` is excluded from `git stash --include-untracked` and survives auto-updates. This is exactly the intent of the existing anti-drift block (which already protects `/crow.db` and `/crow.db-*` the same way).

## Verification

- `git check-ignore data` — before: no match (untracked); after: matches (ignored).
- `git status --porcelain` — `data` no longer appears.
- `git ls-files | grep '^data'` — no tracked files were accidentally ignored.

Ignored paths are excluded from `git stash --include-untracked` (they require `--all`), so the symlink is preserved and the database can no longer split.

## Note for operators already hit by this

If a deployment already split, the recovery is: stop the gateway, remove the stray real `./data` dir (after confirming it only holds an empty DB), recreate the symlink (`ln -s ~/.crow/data ./data`), and ideally pin the gateway to the absolute `CROW_DB_PATH=~/.crow/data/crow.db` so a future symlink loss can't repoint it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
