### PR TITLE
feat(notion): sync Notion pages into memory for local semantic search

### DIFF
--- a/docs/integrations/notion.md
+++ b/docs/integrations/notion.md
@@ -67,3 +67,70 @@ Notion search only returns pages that have been explicitly connected to the inte
 ### Token starts with "secret_" instead of "ntn_"
 
 Older Notion integrations used the `secret_` prefix. Both formats work — just paste the full token as-is.
+
+## Sync Notion into Crow memory (local semantic search)
+
+Notion's API (and its MCP server) only does **keyword** search. Crow's **semantic**
+search runs over the `memories` table, not over Notion live. `scripts/sync-notion.js`
+bridges the two: it pulls every page shared with your integration, converts it to
+Markdown, and stores each as a memory (`category=learning`, `tags=notion,sync`). The
+normal embedding pipeline then makes that content semantically searchable through
+`crow_search_memories` / `crow_deep_recall` from any connected client.
+
+It's **idempotent** — pages are deduped on `source = notion:<pageId>` and only re-embedded
+when their Notion `last_edited_time` changes — and **inert** when `NOTION_TOKEN` is unset,
+so instances that don't use Notion are unaffected.
+
+### Run it
+
+```bash
+# Token must be in the environment (e.g. via --env-file=.env, Node >= 20):
+npm run sync-notion -- --once --dry-run --limit 5   # preview decisions, no writes
+npm run sync-notion -- --once                        # full sync
+npm run sync-notion -- --once --force                # re-embed everything
+```
+
+Flags: `--dry-run` (show insert/update/skip, no writes), `--limit N` (cap pages),
+`--force` (ignore `last_edited_time`). If the embedding provider is offline the pages
+are still stored (keyword-searchable); run `npm run backfill -- --only memories` later
+to fill embeddings.
+
+> One memory per page (v1). Very long, multi-topic pages are averaged into a single
+> embedding and content past ~8000 chars is excluded from the *embedding* (still stored
+> and keyword-searchable). The `source` key already supports a future per-section
+> (`notion:<pageId>#<n>`) chunking upgrade with no schema change.
+
+### Schedule it
+
+Run the sync on a timer. A macOS launchd template is provided at
+[`examples/notion-sync/com.crow.notion-sync.plist.example`](https://github.com/kh0pper/crow/blob/main/examples/notion-sync/com.crow.notion-sync.plist.example)
+(fill in the placeholder paths, copy to `~/Library/LaunchAgents/`, `launchctl load`).
+
+::: tip Why not crow_create_schedule?
+The built-in scheduler only advances DB rows and emits notifications — it does not spawn
+external scripts. Use an OS timer (launchd / systemd / cron) instead.
+:::
+
+**Linux (systemd user timer)** — `~/.config/systemd/user/crow-notion-sync.{service,timer}`:
+
+```ini
+# crow-notion-sync.service
+[Service]
+Type=oneshot
+WorkingDirectory=%h/Developer/crow
+ExecStart=/usr/bin/node --env-file=%h/Developer/crow/.env scripts/sync-notion.js --once
+
+# crow-notion-sync.timer
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=6h
+[Install]
+WantedBy=timers.target
+```
+Enable with `systemctl --user enable --now crow-notion-sync.timer`.
+
+**cron** (every 6 hours):
+
+```cron
+0 */6 * * * cd $HOME/Developer/crow && /usr/bin/node --env-file=.env scripts/sync-notion.js --once >> $HOME/.crow/logs/notion-sync.log 2>&1
+```

--- a/examples/notion-sync/com.crow.notion-sync.plist.example
+++ b/examples/notion-sync/com.crow.notion-sync.plist.example
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  macOS launchd template for scheduling the Notion -> Crow memory sync.
+
+  Setup:
+    1. Replace every /ABSOLUTE/PATH/TO and YOU placeholder below.
+       - node:  run `which node` (use the absolute path; nvm users must pin the
+         versioned path, e.g. ~/.nvm/versions/node/vXX.Y.Z/bin/node).
+       - crow:  the repo checkout, e.g. /Users/you/Developer/crow
+    2. Put your token in <repo>/.env as NOTION_TOKEN=ntn_... (loaded via --env-file;
+       requires Node >= 20. On Node 18, instead add NOTION_TOKEN to
+       <EnvironmentVariables> below and drop the --env-file argument).
+    3. Copy to ~/Library/LaunchAgents/com.crow.notion-sync.plist, then:
+         chmod 600 ~/Library/LaunchAgents/com.crow.notion-sync.plist
+         launchctl load ~/Library/LaunchAgents/com.crow.notion-sync.plist
+       Trigger a run immediately:
+         launchctl kickstart -k gui/$(id -u)/com.crow.notion-sync
+
+  Notes:
+    - StartInterval runs every 6h (21600s). launchd will NOT start an overlapping
+      run if a previous one is still going, and the sync is idempotent regardless.
+    - Do NOT add <KeepAlive> — this is a periodic job, not a long-running daemon.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.crow.notion-sync</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/ABSOLUTE/PATH/TO/node</string>
+    <string>--env-file=/ABSOLUTE/PATH/TO/crow/.env</string>
+    <string>/ABSOLUTE/PATH/TO/crow/scripts/sync-notion.js</string>
+    <string>--once</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/YOU</string>
+    <key>CROW_DB_PATH</key>
+    <string>/Users/YOU/.crow/data/crow.db</string>
+    <!-- On Node 18 (no --env-file): uncomment and set the token here instead.
+    <key>NOTION_TOKEN</key>
+    <string>ntn_REPLACE_ME</string>
+    -->
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>/ABSOLUTE/PATH/TO/crow</string>
+
+  <key>StartInterval</key>
+  <integer>21600</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/YOU/.crow/logs/notion-sync.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOU/.crow/logs/notion-sync.err.log</string>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "identity:import": "node -e \"import('./servers/sharing/identity.js').then(m => m.importIdentity())\"",
     "create-integration": "node scripts/create-integration.js",
     "mcp-config": "node scripts/generate-mcp-config.js",
+    "sync-notion": "node scripts/sync-notion.js",
     "migrate-data": "node scripts/migrate-data-dir.js",
     "check": "node scripts/check.js",
     "sync-skills": "node scripts/sync-skills.js",
@@ -40,7 +41,8 @@
     "test:pir-routes": "node --test tests/pir-routes.test.js",
     "test:sso-ticket": "node --test tests/sso-ticket.test.js",
     "test:gpu-vram": "node --test tests/gpu-arch-vram.test.js",
-    "test:port-inventory": "node --test tests/port-inventory.test.js"
+    "test:port-inventory": "node --test tests/port-inventory.test.js",
+    "test:notion-sync": "node --test tests/notion-sync.test.js"
   },
   "dependencies": {
     "@libsql/client": "^0.17.2",

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -43,6 +43,7 @@ await initTable("memories table", `
   CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
   CREATE INDEX IF NOT EXISTS idx_memories_importance ON memories(importance DESC);
   CREATE INDEX IF NOT EXISTS idx_memories_tags ON memories(tags);
+  CREATE INDEX IF NOT EXISTS idx_memories_source ON memories(source);
 `);
 
 await initTable("memories FTS index", `

--- a/scripts/sync-notion.js
+++ b/scripts/sync-notion.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * Sync Notion pages into Crow's memory store for local semantic search.
+ *
+ * Notion's own MCP only does keyword search, and Crow's semantic search runs
+ * over the `memories` table — not over Notion live. This script bridges the two:
+ * it fetches every page shared with your Notion integration, converts it to
+ * Markdown, and stores it as a memory (category=learning, tags=notion,sync).
+ * The existing embedding pipeline (grackle-embed by default) then makes the
+ * content semantically searchable via crow_search_memories / crow_deep_recall.
+ *
+ * Idempotent: dedups on `source = "notion:<pageId>"` and only re-embeds a page
+ * when its Notion `last_edited_time` changed. Inert when NOTION_TOKEN is unset,
+ * so instances that pull this script but don't use Notion are unaffected.
+ *
+ * Usage:
+ *   node scripts/sync-notion.js --once               # one full sync pass
+ *   node scripts/sync-notion.js --once --dry-run     # show insert/update/skip, no writes
+ *   node scripts/sync-notion.js --once --limit 5     # cap pages (for testing)
+ *   node scripts/sync-notion.js --once --force       # re-embed every page regardless of last_edited_time
+ *
+ * Requires NOTION_TOKEN in the environment (e.g. node --env-file=.env ...).
+ */
+
+import { createDbClient } from "../servers/db.js";
+import {
+  embedText,
+  embedProviderInfo,
+  upsertMemoryEmbedding,
+} from "../servers/memory/embeddings.js";
+
+const NOTION_API = "https://api.notion.com/v1";
+const NOTION_VERSION = "2022-06-28";
+const THROTTLE_MS = 350; // Notion allows ~3 req/s
+const MAX_RETRIES = 3;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_CONTENT_CHARS = 50_000; // memories.content storage cap
+const MAX_EMBED_CHARS = 8_000; // matches backfill-embeddings.js
+
+const MEMORY_CATEGORY = "learning";
+const MEMORY_TAGS = "notion,sync";
+const MEMORY_IMPORTANCE = 4; // just below default 5 so bulk imports don't outrank hand-curated memories
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ----------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ----------------------------------------------------------------------
+
+/** Concatenate a Notion rich_text array into plain text. */
+export function richTextToPlain(rich) {
+  if (!Array.isArray(rich)) return "";
+  return rich.map((r) => r?.plain_text ?? r?.text?.content ?? "").join("");
+}
+
+/** Render a single Notion block (and its children, indented) to Markdown. */
+export function blockToMarkdown(block, depth = 0) {
+  const indent = "  ".repeat(depth);
+  const type = block?.type;
+  const data = (type && block[type]) || {};
+  const text = richTextToPlain(data.rich_text);
+
+  let line = "";
+  switch (type) {
+    case "paragraph": line = text; break;
+    case "heading_1": line = `# ${text}`; break;
+    case "heading_2": line = `## ${text}`; break;
+    case "heading_3": line = `### ${text}`; break;
+    case "bulleted_list_item": line = `- ${text}`; break;
+    case "numbered_list_item": line = `1. ${text}`; break;
+    case "to_do": line = `- [${data.checked ? "x" : " "}] ${text}`; break;
+    case "quote": line = `> ${text}`; break;
+    case "callout": line = `> ${text}`; break;
+    case "toggle": line = `- ${text}`; break;
+    case "code": line = "```" + (data.language || "") + "\n" + text + "\n```"; break;
+    case "divider": line = "---"; break;
+    default: line = text; break; // unknown types: best-effort plain text
+  }
+
+  const lines = [];
+  if (line !== "") lines.push(indent + line);
+  if (Array.isArray(block.children)) {
+    for (const child of block.children) {
+      const sub = blockToMarkdown(child, depth + 1);
+      if (sub !== "") lines.push(sub);
+    }
+  }
+  return lines.join("\n");
+}
+
+/** Render a list of top-level blocks to Markdown. */
+export function blocksToMarkdown(blocks, depth = 0) {
+  if (!Array.isArray(blocks)) return "";
+  return blocks
+    .map((b) => blockToMarkdown(b, depth))
+    .filter((s) => s !== "")
+    .join("\n\n");
+}
+
+/** Extract a page's title from its properties (the `title`-type property). */
+export function extractTitle(page) {
+  const props = page?.properties || {};
+  for (const key of Object.keys(props)) {
+    const p = props[key];
+    if (p && p.type === "title") {
+      return richTextToPlain(p.title) || "Untitled";
+    }
+  }
+  return "Untitled";
+}
+
+/**
+ * Decide what to do with a page given the existing memory row (if any).
+ * Returns "insert" | "update" | "skip". Pure + testable.
+ */
+export function decideAction(existingRow, page, { force = false } = {}) {
+  if (!existingRow) return "insert";
+  if (force) return "update";
+  let stored = null;
+  try {
+    stored = JSON.parse(existingRow.context || "{}").last_edited_time;
+  } catch {
+    stored = null;
+  }
+  return stored === page?.last_edited_time ? "skip" : "update";
+}
+
+/** Build the memory content blob for a page. */
+export function buildContent(title, markdown) {
+  return `# ${title}\n\n${markdown}`.slice(0, MAX_CONTENT_CHARS);
+}
+
+/** Build the provenance/context JSON stored alongside the memory. */
+export function buildContext(page, title) {
+  return JSON.stringify({
+    notion_page_id: page.id,
+    notion_url: page.url,
+    last_edited_time: page.last_edited_time,
+    title,
+    chunk: 0,
+  });
+}
+
+// ----------------------------------------------------------------------
+// Notion REST client (network)
+// ----------------------------------------------------------------------
+
+async function notionFetch(token, path, { method = "GET", body } = {}) {
+  const url = path.startsWith("http") ? path : `${NOTION_API}${path}`;
+  let lastErr;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Notion-Version": NOTION_VERSION,
+          "Content-Type": "application/json",
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (res.status === 429 || res.status >= 500) {
+        const retryAfter = Number(res.headers.get("retry-after")) || attempt + 1;
+        lastErr = new Error(`Notion HTTP ${res.status}`);
+        await sleep(retryAfter * 1000);
+        continue;
+      }
+      if (!res.ok) {
+        const txt = await res.text().catch(() => "");
+        throw new Error(`Notion HTTP ${res.status}: ${txt.slice(0, 200)}`);
+      }
+      return res.json();
+    } catch (err) {
+      lastErr = err;
+      await sleep((attempt + 1) * 500);
+    }
+  }
+  throw lastErr || new Error("Notion request failed");
+}
+
+/** Enumerate all pages shared with the integration. */
+async function searchPages(token, { limit } = {}) {
+  const pages = [];
+  let cursor;
+  do {
+    const body = { filter: { value: "page", property: "object" }, page_size: 100 };
+    if (cursor) body.start_cursor = cursor;
+    const data = await notionFetch(token, "/search", { method: "POST", body });
+    for (const r of data.results || []) {
+      if (r.object === "page") pages.push(r);
+      if (limit && pages.length >= limit) return pages.slice(0, limit);
+    }
+    cursor = data.has_more ? data.next_cursor : null;
+    if (cursor) await sleep(THROTTLE_MS);
+  } while (cursor);
+  return pages;
+}
+
+/** Fetch a block's children recursively, attaching `children` arrays. */
+async function fetchBlockChildren(token, blockId) {
+  const blocks = [];
+  let cursor;
+  do {
+    const qs = cursor
+      ? `?start_cursor=${cursor}&page_size=100`
+      : "?page_size=100";
+    const data = await notionFetch(token, `/blocks/${blockId}/children${qs}`);
+    for (const block of data.results || []) {
+      if (block.has_children) {
+        await sleep(THROTTLE_MS);
+        block.children = await fetchBlockChildren(token, block.id);
+      }
+      blocks.push(block);
+    }
+    cursor = data.has_more ? data.next_cursor : null;
+    if (cursor) await sleep(THROTTLE_MS);
+  } while (cursor);
+  return blocks;
+}
+
+async function fetchPageMarkdown(token, pageId) {
+  const blocks = await fetchBlockChildren(token, pageId);
+  return blocksToMarkdown(blocks);
+}
+
+// ----------------------------------------------------------------------
+// Sync driver
+// ----------------------------------------------------------------------
+
+/**
+ * Run one full sync pass.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.token]   — Notion token (defaults to process.env.NOTION_TOKEN)
+ * @param {object} [opts.db]      — caller-provided db client; created/closed locally if omitted
+ * @param {number|null} [opts.limit]
+ * @param {boolean} [opts.dryRun]
+ * @param {boolean} [opts.force]
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {Promise<{ok, skipped, inserted, updated, unchanged, embedded, ftsOnly, failed}>}
+ */
+export async function runSync(opts = {}) {
+  const token = opts.token ?? process.env.NOTION_TOKEN;
+  const { limit = null, dryRun = false, force = false } = opts;
+  const logger = opts.log ?? console.log;
+  const log = (msg) => logger(msg);
+  log.error = (msg) => (opts.logError ?? console.error)(msg);
+
+  const stats = {
+    ok: true, skipped: false,
+    inserted: 0, updated: 0, unchanged: 0, embedded: 0, ftsOnly: 0, failed: 0,
+  };
+
+  if (!token) {
+    log("NOTION_TOKEN not set — nothing to sync, skipping.");
+    stats.skipped = true;
+    return stats;
+  }
+
+  const info = await embedProviderInfo();
+  if (info.ok) {
+    log(`embed provider=${info.provider} model=${info.model}`);
+  } else {
+    log(`embed provider offline (${info.error}) — storing FTS-only; run 'npm run backfill -- --only memories' once it's back`);
+  }
+
+  const ownsDb = !opts.db;
+  const db = opts.db ?? createDbClient();
+  try {
+    const pages = await searchPages(token, { limit });
+    log(`found ${pages.length} shared page(s)`);
+
+    for (const page of pages) {
+      const title = extractTitle(page);
+      try {
+        const key = `notion:${page.id}`;
+        const { rows } = await db.execute({
+          sql: "SELECT id, context FROM memories WHERE source = ? LIMIT 1",
+          args: [key],
+        });
+        const existing = rows[0];
+        const action = decideAction(existing, page, { force });
+
+        if (action === "skip") {
+          stats.unchanged++;
+          continue;
+        }
+        if (dryRun) {
+          log(`  [dry-run] ${action}: ${title}`);
+          if (action === "insert") stats.inserted++;
+          else stats.updated++;
+          continue;
+        }
+
+        const markdown = await fetchPageMarkdown(token, page.id);
+        const content = buildContent(title, markdown);
+        const context = buildContext(page, title);
+
+        let id;
+        if (action === "insert") {
+          const r = await db.execute({
+            sql: "INSERT INTO memories (content, category, context, tags, source, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            args: [content, MEMORY_CATEGORY, context, MEMORY_TAGS, key, MEMORY_IMPORTANCE],
+          });
+          id = Number(r.lastInsertRowid);
+          stats.inserted++;
+        } else {
+          await db.execute({
+            sql: "UPDATE memories SET content = ?, context = ?, updated_at = datetime('now') WHERE id = ?",
+            args: [content, context, existing.id],
+          });
+          id = existing.id;
+          stats.updated++;
+        }
+
+        if (info.ok) {
+          try {
+            const vec = await embedText(content.slice(0, MAX_EMBED_CHARS));
+            if (vec?.length) {
+              await upsertMemoryEmbedding(db, id, vec, { model: info.model, dim: vec.length });
+              stats.embedded++;
+            } else {
+              stats.ftsOnly++;
+            }
+          } catch (err) {
+            log.error(`  embed failed "${title}": ${err.message}`);
+            stats.ftsOnly++;
+          }
+        } else {
+          stats.ftsOnly++;
+        }
+
+        log(`  ${action}: ${title}`);
+        await sleep(THROTTLE_MS);
+      } catch (err) {
+        stats.failed++;
+        log.error(`  FAILED "${title}" (${page?.id}): ${err.message}`);
+      }
+    }
+  } finally {
+    if (ownsDb) {
+      try { db.close?.(); } catch {}
+    }
+  }
+
+  log(
+    `done — inserted=${stats.inserted} updated=${stats.updated} ` +
+    `unchanged=${stats.unchanged} embedded=${stats.embedded} ` +
+    `fts-only=${stats.ftsOnly} failed=${stats.failed}`
+  );
+  return stats;
+}
+
+// ----------------------------------------------------------------------
+// CLI
+// ----------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const out = { limit: null, dryRun: false, force: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--limit") out.limit = parseInt(argv[++i], 10);
+    else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--force") out.force = true;
+    else if (a === "--once") out.once = true; // single pass is the only mode; accepted for clarity
+    else if (a === "--help" || a === "-h") out.help = true;
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log("sync-notion — mirror Notion pages into Crow memory for semantic search");
+    console.log("  --once          run a single sync pass (default behavior)");
+    console.log("  --dry-run       show insert/update/skip decisions without writing");
+    console.log("  --limit N       cap the number of pages (for testing)");
+    console.log("  --force         re-embed every page regardless of last_edited_time");
+    console.log("\nRequires NOTION_TOKEN in the environment.");
+    process.exit(0);
+  }
+  const result = await runSync({
+    limit: args.limit,
+    dryRun: args.dryRun,
+    force: args.force,
+  });
+  if (!result.ok) process.exit(1);
+}
+
+const invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(`FAIL: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/tests/notion-sync.test.js
+++ b/tests/notion-sync.test.js
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  richTextToPlain,
+  blockToMarkdown,
+  blocksToMarkdown,
+  extractTitle,
+  decideAction,
+  buildContent,
+  buildContext,
+} from "../scripts/sync-notion.js";
+
+test("richTextToPlain joins plain_text segments and tolerates empties", () => {
+  assert.equal(richTextToPlain([{ plain_text: "Hello " }, { plain_text: "world" }]), "Hello world");
+  assert.equal(richTextToPlain([{ text: { content: "fallback" } }]), "fallback");
+  assert.equal(richTextToPlain([]), "");
+  assert.equal(richTextToPlain(undefined), "");
+});
+
+test("blocksToMarkdown renders the common block types", () => {
+  const blocks = [
+    { type: "heading_1", heading_1: { rich_text: [{ plain_text: "Title" }] } },
+    { type: "paragraph", paragraph: { rich_text: [{ plain_text: "A paragraph." }] } },
+    { type: "bulleted_list_item", bulleted_list_item: { rich_text: [{ plain_text: "item" }] } },
+    { type: "numbered_list_item", numbered_list_item: { rich_text: [{ plain_text: "first" }] } },
+    { type: "to_do", to_do: { rich_text: [{ plain_text: "task" }], checked: true } },
+    { type: "quote", quote: { rich_text: [{ plain_text: "wisdom" }] } },
+    { type: "code", code: { rich_text: [{ plain_text: "x = 1" }], language: "python" } },
+    { type: "divider", divider: {} },
+  ];
+  const md = blocksToMarkdown(blocks);
+  assert.match(md, /^# Title/m);
+  assert.match(md, /A paragraph\./);
+  assert.match(md, /^- item$/m);
+  assert.match(md, /^1\. first$/m);
+  assert.match(md, /^- \[x\] task$/m);
+  assert.match(md, /^> wisdom$/m);
+  assert.match(md, /```python\nx = 1\n```/);
+  assert.match(md, /^---$/m);
+});
+
+test("blockToMarkdown indents nested children", () => {
+  const blocks = [
+    {
+      type: "bulleted_list_item",
+      bulleted_list_item: { rich_text: [{ plain_text: "parent" }] },
+      children: [
+        { type: "bulleted_list_item", bulleted_list_item: { rich_text: [{ plain_text: "child" }] } },
+      ],
+    },
+  ];
+  const md = blocksToMarkdown(blocks);
+  assert.match(md, /^- parent$/m);
+  assert.match(md, /^ {2}- child$/m);
+});
+
+test("blockToMarkdown skips empty/unknown blocks gracefully", () => {
+  assert.equal(blockToMarkdown({ type: "paragraph", paragraph: { rich_text: [] } }), "");
+  assert.equal(blockToMarkdown({ type: "unsupported_widget", unsupported_widget: {} }), "");
+});
+
+test("extractTitle reads the title-type property", () => {
+  const page = { properties: { Name: { type: "title", title: [{ plain_text: "My Page" }] } } };
+  assert.equal(extractTitle(page), "My Page");
+  assert.equal(extractTitle({ properties: {} }), "Untitled");
+  assert.equal(extractTitle({}), "Untitled");
+});
+
+test("decideAction: insert when there is no existing row", () => {
+  assert.equal(decideAction(null, { last_edited_time: "t1" }), "insert");
+});
+
+test("decideAction: skip when last_edited_time is unchanged", () => {
+  const existing = { id: 1, context: JSON.stringify({ last_edited_time: "t1" }) };
+  assert.equal(decideAction(existing, { last_edited_time: "t1" }), "skip");
+});
+
+test("decideAction: update when last_edited_time changed", () => {
+  const existing = { id: 1, context: JSON.stringify({ last_edited_time: "t1" }) };
+  assert.equal(decideAction(existing, { last_edited_time: "t2" }), "update");
+});
+
+test("decideAction: force always updates; bad context updates", () => {
+  const existing = { id: 1, context: JSON.stringify({ last_edited_time: "t1" }) };
+  assert.equal(decideAction(existing, { last_edited_time: "t1" }, { force: true }), "update");
+  assert.equal(decideAction({ id: 2, context: "not-json" }, { last_edited_time: "t1" }), "update");
+});
+
+test("buildContent caps length and prefixes the title", () => {
+  const content = buildContent("Title", "body");
+  assert.equal(content, "# Title\n\nbody");
+  assert.ok(buildContent("T", "x".repeat(60000)).length <= 50000);
+});
+
+test("buildContext records provenance for dedup/change detection", () => {
+  const ctx = JSON.parse(buildContext({ id: "abc", url: "https://n/abc", last_edited_time: "t1" }, "Title"));
+  assert.equal(ctx.notion_page_id, "abc");
+  assert.equal(ctx.last_edited_time, "t1");
+  assert.equal(ctx.title, "Title");
+  assert.equal(ctx.chunk, 0);
+});


### PR DESCRIPTION
## What

Adds `scripts/sync-notion.js` — mirrors pages shared with your Notion integration into Crow's `memories` table so they become **semantically searchable** locally (via `crow_search_memories` / `crow_deep_recall`).

Notion's API/MCP only do keyword search, and Crow's semantic search runs over the memory store, not over Notion live — this bridges the gap.

## Highlights

- **Idempotent**: dedups on `source = notion:<pageId>`; re-embeds only when Notion's `last_edited_time` changes.
- **Inert when unconfigured**: no-ops (exit 0) if `NOTION_TOKEN` is unset, so instances that pull this but don't use Notion are unaffected.
- **Graceful when embeddings offline**: stores rows FTS-only and tells you to `npm run backfill -- --only memories` later.
- **No new dependencies**: direct Notion REST via `fetch`, with 429/5xx backoff and ~3 req/s throttle.
- Reuses existing `createDbClient` / `embedText` / `embedProviderInfo` / `upsertMemoryEmbedding`; mirrors `scripts/backfill-embeddings.js`.

## Changes

- `scripts/sync-notion.js` (new) — fetch → block→Markdown → store/embed.
- `scripts/init-db.js` — add `idx_memories_source` (speeds the dedup lookup).
- `package.json` — `sync-notion` + `test:notion-sync` scripts.
- `tests/notion-sync.test.js` (new) — 11 unit tests for the pure helpers (Markdown conversion, title extraction, dedup decision).
- `docs/integrations/notion.md` — usage + launchd/systemd/cron scheduling.
- `examples/notion-sync/com.crow.notion-sync.plist.example` (new) — macOS launchd template.

## Usage

```
npm run sync-notion -- --once --dry-run --limit 5   # preview
npm run sync-notion -- --once                        # full sync
```

## Test

`node --test tests/notion-sync.test.js` → 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
