### PR TITLE
feat(embeddings): make the embedding provider configurable

### DIFF
--- a/docs/guide/ai-providers.md
+++ b/docs/guide/ai-providers.md
@@ -247,7 +247,17 @@ Crow uses `grackle-embed` by default, but the provider is configurable so you ca
    ```
 3. **`grackle-embed`** fallback (preserves prior behavior).
 
-The value is the provider `id` as registered (e.g. by an embedding bundle). After changing it, allow up to ~30s for the in-process cache to refresh.
+The value is the provider `id` as registered (e.g. by an embedding bundle). After changing it, allow up to ~30s for the in-process cache to refresh (running processes re-probe the new provider automatically — no restart needed).
+
+::: warning Re-embed after switching to a different model
+Embeddings are only comparable within the same model's vector space, and semantic search filters stored vectors by model. If the new provider serves a **different** model than the one your existing memories were embedded with (e.g. switching `grackle-embed`'s Qwen3-Embedding to `nomic-embed-text`), those older memories drop out of semantic results until you re-embed them. Re-embed once after switching:
+
+```
+node scripts/backfill-embeddings.js --only memories
+```
+
+Switching between providers that serve the **same** model (e.g. the GPU and CPU Qwen3-Embedding bundles) needs no re-embed — the vectors are interchangeable.
+:::
 
 ### How it works
 

--- a/docs/guide/ai-providers.md
+++ b/docs/guide/ai-providers.md
@@ -232,8 +232,22 @@ When an embedding provider is configured, Crow enhances memory search with **sem
 
 ### Requirements
 
-- An embedding provider entry in `models.json` — any OpenAI-compatible embeddings endpoint works (a local vLLM/llama.cpp embedding model, Ollama with `nomic-embed-text`, or a cloud provider). Crow looks for a provider named `grackle-embed` by default.
+- An embedding provider entry in `models.json` or the providers DB — any OpenAI-compatible embeddings endpoint works (a local vLLM/llama.cpp embedding model, Ollama with `nomic-embed-text`, or a cloud provider).
 - That's it — embeddings are stored as plain BLOBs in the `memory_embeddings` table and compared in-process, which is plenty fast at personal-knowledge-base scale.
+
+### Choosing the embedding provider
+
+Crow uses `grackle-embed` by default, but the provider is configurable so you can point semantic search at whatever embedder you run. Resolution order (first match wins):
+
+1. **`CROW_EMBED_PROVIDER`** environment variable — best for headless/scripted runs and the gateway (loaded from `.env`).
+2. **`embed_provider`** key in `dashboard_settings` — stored in the shared `crow.db`, so it reaches **every** process (the gateway, the MCP servers Claude Code spawns, the sync/backfill scripts) with no re-registration. Set it once:
+   ```sql
+   INSERT INTO dashboard_settings (key, value) VALUES ('embed_provider', '<provider-id>')
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+   ```
+3. **`grackle-embed`** fallback (preserves prior behavior).
+
+The value is the provider `id` as registered (e.g. by an embedding bundle). After changing it, allow up to ~30s for the in-process cache to refresh.
 
 ### How it works
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "test:sso-ticket": "node --test tests/sso-ticket.test.js",
     "test:gpu-vram": "node --test tests/gpu-arch-vram.test.js",
     "test:port-inventory": "node --test tests/port-inventory.test.js",
-    "test:notion-sync": "node --test tests/notion-sync.test.js"
+    "test:notion-sync": "node --test tests/notion-sync.test.js",
+    "test:embed-provider": "node --test tests/embed-provider.test.js"
   },
   "dependencies": {
     "@libsql/client": "^0.17.2",

--- a/servers/memory/embeddings.js
+++ b/servers/memory/embeddings.js
@@ -12,16 +12,55 @@
  */
 
 import { loadProviders } from "../shared/providers.js";
+import { createDbClient } from "../db.js";
 
-const DEFAULT_PROVIDER = "grackle-embed";
+// Fallback when no provider is configured via env or the dashboard setting.
+const FALLBACK_PROVIDER = "grackle-embed";
 const EMBED_TIMEOUT_MS = 10_000;
 const FETCH_RETRIES = 1;
+
+// Default embedding-provider resolution, in priority order:
+//   1. CROW_EMBED_PROVIDER env var (headless/scripts/gateway via .env)
+//   2. dashboard_settings 'embed_provider' (shared crow.db — reaches every
+//      process, including the MCP servers Claude Code spawns, with no
+//      re-registration; settable from the dashboard)
+//   3. FALLBACK_PROVIDER ("grackle-embed") — preserves prior behavior
+// Cached for 30s so the hot embed path stays cheap.
+let _defaultProviderCache = null;
+let _defaultProviderAt = 0;
+const DEFAULT_PROVIDER_TTL_MS = 30_000;
+
+export async function resolveDefaultProvider() {
+  if (process.env.CROW_EMBED_PROVIDER) return process.env.CROW_EMBED_PROVIDER;
+  if (_defaultProviderCache && Date.now() - _defaultProviderAt < DEFAULT_PROVIDER_TTL_MS) {
+    return _defaultProviderCache;
+  }
+  let resolved = FALLBACK_PROVIDER;
+  try {
+    const db = createDbClient();
+    try {
+      const { rows } = await db.execute({
+        sql: "SELECT value FROM dashboard_settings WHERE key = 'embed_provider'",
+        args: [],
+      });
+      const v = rows?.[0]?.value;
+      if (v && String(v).trim()) resolved = String(v).trim();
+    } finally {
+      db.close?.();
+    }
+  } catch {
+    // DB unavailable — keep the fallback.
+  }
+  _defaultProviderCache = resolved;
+  _defaultProviderAt = Date.now();
+  return resolved;
+}
 
 // -----------------------------------------------------------------------
 // Provider resolution
 // -----------------------------------------------------------------------
 
-function resolveEmbedConfig(providerName = DEFAULT_PROVIDER) {
+function resolveEmbedConfig(providerName = FALLBACK_PROVIDER) {
   const cfg = loadProviders();
   const p = cfg.providers?.[providerName];
   if (!p || !p.baseUrl) {
@@ -40,8 +79,8 @@ function resolveEmbedConfig(providerName = DEFAULT_PROVIDER) {
  * Embed a single text (or array of texts).
  * Returns Float32Array (for single) or Float32Array[] (for array).
  */
-export async function embedText(text, { providerName = DEFAULT_PROVIDER } = {}) {
-  const cfg = resolveEmbedConfig(providerName);
+export async function embedText(text, { providerName } = {}) {
+  const cfg = resolveEmbedConfig(providerName || (await resolveDefaultProvider()));
   const isArray = Array.isArray(text);
   const input = isArray ? text : [text];
 
@@ -78,9 +117,9 @@ export async function embedText(text, { providerName = DEFAULT_PROVIDER } = {}) 
  * Query the health/config of an embedding provider.
  * Returns { ok, model, dim, baseUrl } or { ok: false, error }.
  */
-export async function embedProviderInfo(providerName = DEFAULT_PROVIDER) {
+export async function embedProviderInfo(providerName) {
   try {
-    const cfg = resolveEmbedConfig(providerName);
+    const cfg = resolveEmbedConfig(providerName || (await resolveDefaultProvider()));
     const res = await fetch(cfg.baseUrl.replace(/\/+$/, "") + "/models", {
       signal: AbortSignal.timeout(3000),
     });

--- a/servers/memory/server.js
+++ b/servers/memory/server.js
@@ -14,6 +14,7 @@ import { createNotification, cleanupNotifications } from "../shared/notification
 import {
   embedText as phase4EmbedText,
   embedProviderInfo,
+  resolveDefaultProvider,
   upsertMemoryEmbedding,
   loadMemoryEmbeddings,
   rankByCosine,
@@ -28,25 +29,33 @@ export function createMemoryServer(dbPath, options = {}) {
   // When set, mutations emit change entries to connected instances.
   const syncManager = options.syncManager || null;
 
-  // --- Phase 4: BLOB-based semantic memory via grackle-embed ---
-  // Cache provider-health check so we don't probe on every write.
+  // --- Phase 4: BLOB-based semantic memory ---
+  // Cache provider-health check so we don't probe on every write. Keyed on the
+  // resolved default provider so a runtime change to the embed provider (env or
+  // the dashboard_settings 'embed_provider' key) re-probes within one
+  // resolveDefaultProvider TTL instead of serving the old provider's model/dim
+  // forever. info.provider is then pinned onto every embedText call below so the
+  // vector's source endpoint and its stored `model` tag can never diverge.
   let _phase4ProviderInfo = null;
+  let _phase4ProviderName = null;
   async function phase4ProviderHealthy() {
-    if (_phase4ProviderInfo === null) {
-      _phase4ProviderInfo = await embedProviderInfo().catch(() => ({ ok: false }));
+    const providerName = await resolveDefaultProvider();
+    if (_phase4ProviderInfo === null || providerName !== _phase4ProviderName) {
+      _phase4ProviderName = providerName;
+      _phase4ProviderInfo = await embedProviderInfo(providerName).catch(() => ({ ok: false }));
     }
     return _phase4ProviderInfo;
   }
 
   // Store embedding for a memory (fire-and-forget, errors don't block).
-  // Phase 4 BLOB + grackle-embed path (the only path since the never-wired
-  // sqlite-vec legacy branch was removed in W5.5).
+  // Phase 4 BLOB path (the only path since the never-wired sqlite-vec legacy
+  // branch was removed in W5.5).
   async function storeEmbedding(memoryId, content) {
     // Non-blocking, degrades to no-op on provider failure
     const info = await phase4ProviderHealthy();
     if (!info.ok) return;
     try {
-      const vec = await phase4EmbedText(content);
+      const vec = await phase4EmbedText(content, { providerName: info.provider });
       if (!vec || vec.length === 0) return;
       await upsertMemoryEmbedding(db, memoryId, vec, {
         model: info.model,
@@ -130,7 +139,7 @@ export function createMemoryServer(dbPath, options = {}) {
         try {
           const info = await phase4ProviderHealthy();
           if (info.ok) {
-            const queryVec = await phase4EmbedText(query);
+            const queryVec = await phase4EmbedText(query, { providerName: info.provider });
             const allEmbs = await loadMemoryEmbeddings(db, { model: info.model });
             if (queryVec && allEmbs.length > 0) {
               const topK = Math.min(Math.max(limit * 3, 30), 200);
@@ -625,7 +634,7 @@ export function createMemoryServer(dbPath, options = {}) {
       let succeeded = 0, failed = 0;
       for (const m of rows) {
         try {
-          const vec = await phase4EmbedText(m.content);
+          const vec = await phase4EmbedText(m.content, { providerName: info.provider });
           if (vec && vec.length > 0) {
             await upsertMemoryEmbedding(db, m.id, vec, { model: info.model, dim: vec.length });
             succeeded++;

--- a/tests/embed-provider.test.js
+++ b/tests/embed-provider.test.js
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveDefaultProvider } from "../servers/memory/embeddings.js";
+
+test("CROW_EMBED_PROVIDER env var takes precedence", async () => {
+  const prev = process.env.CROW_EMBED_PROVIDER;
+  process.env.CROW_EMBED_PROVIDER = "test-embed-provider";
+  try {
+    assert.equal(await resolveDefaultProvider(), "test-embed-provider");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_EMBED_PROVIDER;
+    else process.env.CROW_EMBED_PROVIDER = prev;
+  }
+});
+
+test("falls back to grackle-embed when no env override and DB unreachable", async () => {
+  const prevProvider = process.env.CROW_EMBED_PROVIDER;
+  const prevDb = process.env.CROW_DB_PATH;
+  delete process.env.CROW_EMBED_PROVIDER;
+  // Point at a path whose parent dir does not exist so the lookup fails and we
+  // exercise the fallback branch deterministically.
+  process.env.CROW_DB_PATH = "/nonexistent-dir-xyz-123/none.db";
+  try {
+    assert.equal(await resolveDefaultProvider(), "grackle-embed");
+  } finally {
+    if (prevProvider !== undefined) process.env.CROW_EMBED_PROVIDER = prevProvider;
+    if (prevDb === undefined) delete process.env.CROW_DB_PATH;
+    else process.env.CROW_DB_PATH = prevDb;
+  }
+});


### PR DESCRIPTION
## What

Makes the embedding provider **configurable** instead of hardcoded. `servers/memory/embeddings.js` resolved `DEFAULT_PROVIDER = "grackle-embed"` as a constant, so hosts that can't reach grackle (e.g. a Mac on a different tailnet) had no way to point semantic search at a local embedder.

## How

`resolveDefaultProvider()` picks the provider in priority order (first match wins):

1. **`CROW_EMBED_PROVIDER`** env var — headless/scripts and the gateway (loaded from `.env`).
2. **`dashboard_settings.embed_provider`** — stored in the shared `crow.db`, so it reaches **every** process (gateway, the MCP servers Claude Code spawns that embed search *queries*, sync/backfill) with **no re-registration**. An env var alone can't reach those MCP servers.
3. **`grackle-embed`** fallback — preserves prior behavior.

Result is cached 30s to keep the hot embed path cheap. `embedText()` / `embedProviderInfo()` now resolve through this; fully backward compatible (no env + no setting ⇒ identical to before).

## Changes

- `servers/memory/embeddings.js` — `resolveDefaultProvider()` + route the public fns through it.
- `tests/embed-provider.test.js` (new) — env precedence + fallback.
- `package.json` — `test:embed-provider`.
- `docs/guide/ai-providers.md` — "Choosing the embedding provider".

## Test

`node --test tests/embed-provider.test.js` → 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
