### PR TITLE
fix(notion): correct backfill command + non-zero exit on partial sync failure

### DIFF
--- a/docs/integrations/notion.md
+++ b/docs/integrations/notion.md
@@ -92,7 +92,7 @@ npm run sync-notion -- --once --force                # re-embed everything
 
 Flags: `--dry-run` (show insert/update/skip, no writes), `--limit N` (cap pages),
 `--force` (ignore `last_edited_time`). If the embedding provider is offline the pages
-are still stored (keyword-searchable); run `npm run backfill -- --only memories` later
+are still stored (keyword-searchable); run `node scripts/backfill-embeddings.js --only memories` later
 to fill embeddings.
 
 > One memory per page (v1). Very long, multi-topic pages are averaged into a single

--- a/scripts/sync-notion.js
+++ b/scripts/sync-notion.js
@@ -262,7 +262,7 @@ export async function runSync(opts = {}) {
   if (info.ok) {
     log(`embed provider=${info.provider} model=${info.model}`);
   } else {
-    log(`embed provider offline (${info.error}) — storing FTS-only; run 'npm run backfill -- --only memories' once it's back`);
+    log(`embed provider offline (${info.error}) — storing FTS-only; run 'node scripts/backfill-embeddings.js --only memories' once it's back`);
   }
 
   const ownsDb = !opts.db;
@@ -335,6 +335,7 @@ export async function runSync(opts = {}) {
         await sleep(THROTTLE_MS);
       } catch (err) {
         stats.failed++;
+        stats.ok = false; // surface partial failures in the CLI exit code (cron/monitoring)
         log.error(`  FAILED "${title}" (${page?.id}): ${err.message}`);
       }
     }


### PR DESCRIPTION
## What

Follow-up to #109 (already merged), fixing two issues found in post-merge review.

## Changes

1. **Wrong backfill command.** The offline-embed log message (`scripts/sync-notion.js`) and the docs (`docs/integrations/notion.md`) both told users to run `npm run backfill -- --only memories` — but there is **no `backfill` npm script**, so that command fails with `npm ERR! Missing script: backfill`. Corrected both to the real entry point: `node scripts/backfill-embeddings.js --only memories`.

2. **Silent exit 0 on partial failures.** `stats.ok` was initialized `true` and never cleared, so the CLI exited `0` even when individual pages failed to sync (`stats.failed > 0`). A cron job or monitor saw success while the failed pages stayed unsynced. Now `stats.ok` is set `false` when a page fails, so the exit code (and any caller inspecting `stats.ok`) reflects partial failure.

## Test

`node --test tests/notion-sync.test.js` → 11/11 pass.

(Not fixed here, flagged for discussion: `--limit` with no numeric arg parses to `NaN` and silently disables the cap — but this mirrors the existing `scripts/backfill-embeddings.js` arg-parsing pattern, so left as-is.)