### PR TITLE
docs(ports): document port 8007 for llamacpp-cpu-qwen3-embed (fixes CI)

### DIFF
--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -61,6 +61,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 6875 | 127.0.0.1 | bookstack (existing) | existing |
 | 8000 | 127.0.0.1 | paperless (existing) | existing |
 | 8004 | 127.0.0.1 | faster-whisper-server (local STT) | existing |
+| 8007 | 127.0.0.1 | llamacpp-cpu-qwen3-embed (CPU embeddings) | PR #111 |
 | 8080 | 127.0.0.1 | localai (existing) — **also nextcloud, conflict** | existing |
 | 8081 | 127.0.0.1 | calibre-server (existing) | existing |
 | 8083 | 127.0.0.1 | calibre-web (existing) | existing |


### PR DESCRIPTION
## Problem

The **Port Allocation Check** CI (`scripts/check-port-allocation.js`) is failing on `main` and was failing on PR #111. The CPU embedding bundle (#111) binds host port `8007` (`127.0.0.1:8007:8000`), but the corresponding row was never added to `docs/developers/port-allocation.md`. The check requires every bundle host port to be documented, so it exits non-zero:

```
ERROR: Undocumented ports (add a row to docs/developers/port-allocation.md):
  Port 8007 (llamacpp-cpu-qwen3-embed)
```

(This check is a GitHub Actions *check run*, which is why it didn't appear in the legacy commit-status API when #111 was merged.)

## Fix

Add the `8007` row in numeric order. The check now passes:

```
OK: 43 unique port(s) across 73 bundle(s), all documented, no collisions.
```

## Note

The `deploy-docs` VitePress build was verified separately and passes (exit 0) — the only failing workflow was the port check.