### PR TITLE
fix(nostr): self-heal kind:4 subscriptions across relay drops (re-subscribe hardening)

### DIFF
--- a/scripts/pi-bots/gateways/crow-messages.mjs
+++ b/scripts/pi-bots/gateways/crow-messages.mjs
@@ -6,7 +6,7 @@
 import { loadInstanceSeed, deriveBotIdentity } from "../../../servers/sharing/identity.js";
 import { chunkedSend, SerialQueue } from "./base.mjs";
 import * as cmStore from "./crow-messages-store.mjs";
-import { xOnly, buildDM, openDM, connectRelays, subscribe, publish, makeDedupeGate } from "./nostr-client.mjs";
+import { xOnly, buildDM, openDM, connectRelays, subscribeResilient, publish, makeDedupeGate } from "./nostr-client.mjs";
 
 export const type = "crow-messages";
 export const mode = "nostr";
@@ -119,7 +119,7 @@ export async function start({ bot_id, gw, log }) {
   const isNew = makeDedupeGate(); // collapse the same event arriving from N relays (in-process)
   const since = Math.floor(Date.now() / 1000) - 86400; // don't replay >24h of relay history
 
-  const subs = subscribe(relays, { kinds: [4], "#p": [botXOnly], since }, (event) => {
+  const subResilient = subscribeResilient(relays, { kinds: [4], "#p": [botXOnly] }, (event) => {
     if (!isNew(event.id)) return; // already handled from another relay (same process)
     // Cross-restart dedup: a relay replays up to 24h on resubscribe; persisting
     // processed ids stops re-answering chats the bot already handled pre-restart.
@@ -159,12 +159,16 @@ export async function start({ bot_id, gw, log }) {
         }, text, { log });
       },
     }).catch((e) => log("event handler error: " + (e && e.message))));
-  });
+  }, { initialSince: since });
 
   log("crow-messages bot=" + bot_id + " listening as " + botIdentity.crowId + " on " + relays.size + " relay(s)");
+  const healthMs = Number(process.env.PIBOT_NOSTR_HEALTH_MS) || 45000;
+  const healthTimer = setInterval(() => { subResilient.ensureAllHealthy().catch(() => {}); }, healthMs);
+  if (healthTimer.unref) healthTimer.unref();
   return {
     stop() {
-      for (const s of subs) { try { s.close(); } catch {} }
+      try { clearInterval(healthTimer); } catch {}
+      try { subResilient.stop(); } catch {}
       for (const [, relay] of relays) { try { relay.close(); } catch {} }
       try { db.close(); } catch {}
     },

--- a/scripts/pi-bots/gateways/nostr-client.mjs
+++ b/scripts/pi-bots/gateways/nostr-client.mjs
@@ -24,6 +24,7 @@ import { finalizeEvent } from "nostr-tools/pure";
 import * as nip44 from "nostr-tools/nip44";
 import { Relay, useWebSocketImplementation } from "nostr-tools/relay";
 import { safeRelayPublish } from "../../../servers/sharing/safe-relay-publish.js";
+import { makeResilientSub } from "../../../servers/sharing/resilient-subscribe.js";
 // Pin the implementation explicitly (survives a future nostr-tools that drops
 // the constructor-time `|| WebSocket` fallback).
 if (globalThis.WebSocket) { try { useWebSocketImplementation(globalThis.WebSocket); } catch { /* older nostr-tools: runtime fallback covers it */ } }
@@ -75,7 +76,7 @@ export async function connectRelays(urls, timeoutMs = 10000) {
   const relays = new Map();
   const results = await Promise.allSettled(urls.map(async (url) => {
     const relay = await Promise.race([
-      Relay.connect(url),
+      Relay.connect(url, { enablePing: true }),
       new Promise((_, rej) => setTimeout(() => rej(new Error("connection timeout")), timeoutMs)),
     ]);
     return { url, relay };
@@ -91,6 +92,21 @@ export function subscribe(relays, filter, onevent) {
     try { subs.push(relay.subscribe([filter], { onevent })); } catch { /* per-relay */ }
   }
   return subs;
+}
+
+/**
+ * Resilient variant of subscribe(): one self-healing handle per relay. The
+ * caller drives recovery by calling ensureAllHealthy() on an interval and tears
+ * down with stop(). Pair with Relay.connect(url, { enablePing: true }).
+ */
+export function subscribeResilient(relays, filter, onevent, opts = {}) {
+  const handles = [];
+  for (const [, relay] of relays) handles.push(makeResilientSub(relay, filter, onevent, opts));
+  return {
+    handles,
+    async ensureAllHealthy() { for (const h of handles) await h.ensureHealthy(); },
+    stop() { for (const h of handles) { try { h.close(); } catch {} } },
+  };
 }
 
 /** Publish an event to all relays (best-effort). */

--- a/scripts/pi-bots/gateways/nostr-client.mjs
+++ b/scripts/pi-bots/gateways/nostr-client.mjs
@@ -23,6 +23,7 @@ if (typeof globalThis.WebSocket === "undefined") {
 import { finalizeEvent } from "nostr-tools/pure";
 import * as nip44 from "nostr-tools/nip44";
 import { Relay, useWebSocketImplementation } from "nostr-tools/relay";
+import { safeRelayPublish } from "../../../servers/sharing/safe-relay-publish.js";
 // Pin the implementation explicitly (survives a future nostr-tools that drops
 // the constructor-time `|| WebSocket` fallback).
 if (globalThis.WebSocket) { try { useWebSocketImplementation(globalThis.WebSocket); } catch { /* older nostr-tools: runtime fallback covers it */ } }
@@ -94,5 +95,7 @@ export function subscribe(relays, filter, onevent) {
 
 /** Publish an event to all relays (best-effort). */
 export async function publish(relays, event) {
-  for (const [, relay] of relays) { try { await relay.publish(event); } catch { /* per-relay */ } }
+  // safeRelayPublish reconnects-or-skips a dropped relay so a closed-connection
+  // send() can't leak an unhandled rejection and crash the pi-bots host.
+  for (const [, relay] of relays) { try { await safeRelayPublish(relay, event); } catch { /* per-relay */ } }
 }

--- a/scripts/pi-bots/gateways/nostr-client.mjs
+++ b/scripts/pi-bots/gateways/nostr-client.mjs
@@ -76,6 +76,10 @@ export async function connectRelays(urls, timeoutMs = 10000) {
   const relays = new Map();
   const results = await Promise.allSettled(urls.map(async (url) => {
     const relay = await Promise.race([
+      // enablePing is load-bearing for the health loop: a ping timeout closes a
+      // silently-dead half-open socket (ws.close → relay.connected = false), which
+      // is the ONLY signal ensureHealthy() has to trigger a reconnect/resubscribe.
+      // Without it, relay.connected stays true forever and the sub never re-establishes.
       Relay.connect(url, { enablePing: true }),
       new Promise((_, rej) => setTimeout(() => rej(new Error("connection timeout")), timeoutMs)),
     ]);
@@ -104,7 +108,10 @@ export function subscribeResilient(relays, filter, onevent, opts = {}) {
   for (const [, relay] of relays) handles.push(makeResilientSub(relay, filter, onevent, opts));
   return {
     handles,
-    async ensureAllHealthy() { for (const h of handles) await h.ensureHealthy(); },
+    // Heal all relays concurrently (parity with the gateway side): one slow/hung
+    // relay reconnect must not serialize the others. ensureHealthy self-guards
+    // (busy/stopped, bounded connect) so concurrent calls are safe.
+    async ensureAllHealthy() { await Promise.allSettled(handles.map((h) => h.ensureHealthy())); },
     stop() { for (const h of handles) { try { h.close(); } catch {} } },
   };
 }

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -29,6 +29,7 @@ import * as nip44 from "nostr-tools/nip44";
 import * as nip19 from "nostr-tools/nip19";
 import { Relay } from "nostr-tools/relay";
 import { safeRelayPublish } from "./safe-relay-publish.js";
+import { makeResilientSub } from "./resilient-subscribe.js";
 
 const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
@@ -42,6 +43,7 @@ export class NostrManager {
     this.relays = new Map(); // url -> Relay
     this.subscriptions = new Map(); // contactCrowId -> sub
     this.onMessage = null; // callback(contactId, message)
+    this._healthTimer = null; // single health loop for all resilient subs
   }
 
   /**
@@ -75,7 +77,7 @@ export class NostrManager {
     const results = await Promise.allSettled(
       relayUrls.map(async (url) => {
         const relay = await Promise.race([
-          Relay.connect(url),
+          Relay.connect(url, { enablePing: true }),
           new Promise((_, reject) =>
             setTimeout(() => reject(new Error("connection timeout")), 10000)
           ),
@@ -184,6 +186,27 @@ export class NostrManager {
   }
 
   /**
+   * Start the single periodic health loop that re-establishes any resilient
+   * subscription whose relay has dropped. Idempotent (created once). unref'd so
+   * it never keeps the process alive on its own.
+   */
+  _startHealthLoop() {
+    if (this._healthTimer) return;
+    const ms = Number(process.env.CROW_NOSTR_HEALTH_MS) || 45000;
+    this._healthTimer = setInterval(() => {
+      for (const h of this.subscriptions.values()) {
+        // ensureHealthy is async — a sync try/catch would NOT catch a rejected
+        // promise. Wrap so a stray rejection can never become an unhandledRejection
+        // (the whole point of this arc is a gateway that never silently dies).
+        if (h && typeof h.ensureHealthy === "function") {
+          Promise.resolve(h.ensureHealthy()).catch(() => {});
+        }
+      }
+    }, ms);
+    if (this._healthTimer.unref) this._healthTimer.unref();
+  }
+
+  /**
    * Subscribe to messages from a specific contact.
    */
   async subscribeToContact(contact) {
@@ -201,92 +224,79 @@ export class NostrManager {
 
     for (const [url, relay] of this.relays) {
       try {
-        const sub = relay.subscribe(
-          [
-            {
-              kinds: [4],
-              authors: [contactPubkey],
-              "#p": [ownPubkey],
-            },
-          ],
-          {
-            onevent: async (event) => {
+        const onevent = async (event) => {
+          try {
+            const conversationKey = nip44.v2.utils.getConversationKey(
+              this.identity.secp256k1Priv,
+              contactPubkey
+            );
+            const decrypted = nip44.v2.decrypt(event.content, conversationKey);
+
+            if (decrypted.startsWith("{")) {
               try {
-                // Decrypt NIP-44
-                const conversationKey = nip44.v2.utils.getConversationKey(
-                  this.identity.secp256k1Priv,
-                  contactPubkey
-                );
-                const decrypted = nip44.v2.decrypt(event.content, conversationKey);
-
-                // Skip system messages — don't store as regular messages
-                // These are handled by subscribeToIncoming's social callback
-                if (decrypted.startsWith("{")) {
-                  try {
-                    const parsed = JSON.parse(decrypted);
-                    if (parsed.type === "invite_accepted" || parsed.type === "crow_social") {
-                      return;
-                    }
-                  } catch {
-                    // Not valid JSON, treat as regular message
-                  }
+                const parsed = JSON.parse(decrypted);
+                if (parsed.type === "invite_accepted" || parsed.type === "crow_social") {
+                  return;
                 }
-
-                // Cache locally
-                if (contactId && this.db) {
-                  try {
-                    const result = await this.db.execute({
-                      sql: `INSERT OR IGNORE INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
-                            VALUES (?, ?, ?, 'received', 0, datetime(?, 'unixepoch'))`,
-                      args: [contactId, event.id, decrypted, event.created_at],
-                    });
-                    // Only notify for genuinely new messages, not replays
-                    if (result.rowsAffected > 0) {
-                      try {
-                        await createNotification(this.db, {
-                          title: `Message from ${contact.display_name || crowId}`,
-                          type: "peer",
-                          source: "sharing:message",
-                          action_url: "/dashboard/messages",
-                        });
-                      } catch {}
-                      // Broadcast the new per-peer unread count to any
-                      // live Turbo Stream subscribers. Swallowed
-                      // errors must not break the inbound message path.
-                      try {
-                        const { rows } = await this.db.execute({
-                          sql: `SELECT COUNT(*) AS unread FROM messages
-                                WHERE contact_id = ? AND is_read = 0 AND direction = 'received'`,
-                          args: [contactId],
-                        });
-                        const unread = Number(rows?.[0]?.unread ?? 0);
-                        bus.emit("messages:changed", { contactId, unread });
-                      } catch {}
-                    }
-                  } catch {
-                    // Duplicate event, ignore
-                  }
-                }
-
-                if (this.onMessage) {
-                  this.onMessage(crowId, {
-                    eventId: event.id,
-                    content: decrypted,
-                    timestamp: event.created_at,
-                  });
-                }
-              } catch (err) {
-                // Decryption failed — not for us or corrupted
+              } catch {
+                // Not valid JSON, treat as regular message
               }
-            },
-          }
-        );
+            }
 
-        this.subscriptions.set(`${crowId}:${url}`, sub);
+            if (contactId && this.db) {
+              try {
+                const result = await this.db.execute({
+                  sql: `INSERT OR IGNORE INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
+                        VALUES (?, ?, ?, 'received', 0, datetime(?, 'unixepoch'))`,
+                  args: [contactId, event.id, decrypted, event.created_at],
+                });
+                if (result.rowsAffected > 0) {
+                  try {
+                    await createNotification(this.db, {
+                      title: `Message from ${contact.display_name || crowId}`,
+                      type: "peer",
+                      source: "sharing:message",
+                      action_url: "/dashboard/messages",
+                    });
+                  } catch {}
+                  try {
+                    const { rows } = await this.db.execute({
+                      sql: `SELECT COUNT(*) AS unread FROM messages
+                            WHERE contact_id = ? AND is_read = 0 AND direction = 'received'`,
+                      args: [contactId],
+                    });
+                    const unread = Number(rows?.[0]?.unread ?? 0);
+                    bus.emit("messages:changed", { contactId, unread });
+                  } catch {}
+                }
+              } catch {
+                // Duplicate event, ignore
+              }
+            }
+
+            if (this.onMessage) {
+              this.onMessage(crowId, { eventId: event.id, content: decrypted, timestamp: event.created_at });
+            }
+          } catch (err) {
+            // Decryption failed — not for us or corrupted
+          }
+        };
+        const handle = makeResilientSub(
+          relay,
+          { kinds: [4], authors: [contactPubkey], "#p": [ownPubkey] },
+          onevent,
+          {} // no initialSince → contact subs keep their full-history-then-rolling behavior
+        );
+        // Close any prior resilient handle for this key before replacing it, so a
+        // re-subscribe can't orphan a live sub (no longer health-driven, leaked by destroy()).
+        const prev = this.subscriptions.get(`${crowId}:${url}`);
+        if (prev && typeof prev.close === "function") { try { prev.close(); } catch {} }
+        this.subscriptions.set(`${crowId}:${url}`, handle);
       } catch (err) {
         // Subscription failed for this relay
       }
     }
+    this._startHealthLoop();
   }
 
   /**
@@ -349,56 +359,50 @@ export class NostrManager {
     const ownPubkey = this.pubkey?.length === 66 ? this.pubkey.slice(2) : this.pubkey;
     const seenEventIds = new Set();
 
+    const incomingSince = Math.floor(Date.now() / 1000) - 86400; // Last 24h only
     for (const [url, relay] of this.relays) {
       try {
-        const sub = relay.subscribe(
-          [
-            {
-              kinds: [4],
-              "#p": [ownPubkey],
-              since: Math.floor(Date.now() / 1000) - 86400, // Last 24h only
-            },
-          ],
-          {
-            onevent: async (event) => {
-              // Deduplicate events across relays
-              if (seenEventIds.has(event.id)) return;
-              seenEventIds.add(event.id);
-
+        const onevent = async (event) => {
+          if (seenEventIds.has(event.id)) return;
+          seenEventIds.add(event.id);
+          try {
+            let senderPubkey = event.pubkey;
+            const conversationKey = nip44.v2.utils.getConversationKey(
+              this.identity.secp256k1Priv,
+              senderPubkey
+            );
+            const decrypted = nip44.v2.decrypt(event.content, conversationKey);
+            if (decrypted.startsWith("{")) {
               try {
-                // Derive sender pubkey from event
-                let senderPubkey = event.pubkey;
-
-                const conversationKey = nip44.v2.utils.getConversationKey(
-                  this.identity.secp256k1Priv,
-                  senderPubkey
-                );
-                const decrypted = nip44.v2.decrypt(event.content, conversationKey);
-
-                // Check if it's a structured JSON message
-                if (decrypted.startsWith("{")) {
-                  try {
-                    const payload = JSON.parse(decrypted);
-                    if (payload.type === "invite_accepted" && onInviteAccepted) {
-                      await onInviteAccepted(payload);
-                    } else if (payload.type === "crow_social" && payload.subtype && onSocialMessage) {
-                      await onSocialMessage(payload.subtype, payload.payload || {}, senderPubkey);
-                    }
-                  } catch {
-                    // Not valid JSON or not our message type
-                  }
+                const payload = JSON.parse(decrypted);
+                if (payload.type === "invite_accepted" && onInviteAccepted) {
+                  await onInviteAccepted(payload);
+                } else if (payload.type === "crow_social" && payload.subtype && onSocialMessage) {
+                  await onSocialMessage(payload.subtype, payload.payload || {}, senderPubkey);
                 }
-              } catch (decryptErr) {
-                // Decryption failed — event not for us or from unknown sender
+              } catch {
+                // Not valid JSON or not our message type
               }
-            },
+            }
+          } catch (decryptErr) {
+            // Decryption failed — event not for us or from unknown sender
           }
+        };
+        const handle = makeResilientSub(
+          relay,
+          { kinds: [4], "#p": [ownPubkey] },
+          onevent,
+          { initialSince: incomingSince }
         );
-        this.subscriptions.set(`incoming:${url}`, sub);
+        // Close any prior resilient handle for this key before replacing it (see subscribeToContact).
+        const prevIncoming = this.subscriptions.get(`incoming:${url}`);
+        if (prevIncoming && typeof prevIncoming.close === "function") { try { prevIncoming.close(); } catch {} }
+        this.subscriptions.set(`incoming:${url}`, handle);
       } catch {
         // Subscription failed for this relay
       }
     }
+    this._startHealthLoop();
   }
 
   /**
@@ -421,6 +425,10 @@ export class NostrManager {
    * Disconnect from all relays.
    */
   async destroy() {
+    if (this._healthTimer) {
+      clearInterval(this._healthTimer);
+      this._healthTimer = null;
+    }
     for (const sub of this.subscriptions.values()) {
       try {
         sub.close();

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -77,6 +77,10 @@ export class NostrManager {
     const results = await Promise.allSettled(
       relayUrls.map(async (url) => {
         const relay = await Promise.race([
+          // enablePing is load-bearing for the health loop: a ping timeout closes a
+          // silently-dead half-open socket (ws.close → relay.connected = false), which
+          // is the ONLY signal ensureHealthy() has to trigger a reconnect/resubscribe.
+          // Without it, relay.connected stays true forever and the sub never re-establishes.
           Relay.connect(url, { enablePing: true }),
           new Promise((_, reject) =>
             setTimeout(() => reject(new Error("connection timeout")), 10000)

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -28,6 +28,7 @@ import bus from "../shared/event-bus.js";
 import * as nip44 from "nostr-tools/nip44";
 import * as nip19 from "nostr-tools/nip19";
 import { Relay } from "nostr-tools/relay";
+import { safeRelayPublish } from "./safe-relay-publish.js";
 
 const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
@@ -136,12 +137,13 @@ export class NostrManager {
       content: encrypted,
     }, this.identity.secp256k1Priv);
 
-    // Publish to all connected relays
+    // Publish to all connected relays. safeRelayPublish reconnects-or-skips a
+    // dropped relay so a closed-connection send() can't leak an unhandled
+    // rejection and crash the process (see safe-relay-publish.js).
     const published = [];
     for (const [url, relay] of this.relays) {
       try {
-        await relay.publish(event);
-        published.push(url);
+        if (await safeRelayPublish(relay, event)) published.push(url);
       } catch (err) {
         // Publishing failed to this relay
       }
@@ -176,7 +178,7 @@ export class NostrManager {
     const event = finalizeEvent({ kind: 4, created_at: Math.floor(Date.now() / 1000), tags: [["p", recipientPubkey]], content: encrypted }, this.identity.secp256k1Priv);
     const published = [];
     for (const [url, relay] of this.relays) {
-      try { await relay.publish(event); published.push(url); } catch { /* relay best-effort */ }
+      try { if (await safeRelayPublish(relay, event)) published.push(url); } catch { /* relay best-effort */ }
     }
     return { eventId: event.id, relays: published };
   }

--- a/servers/sharing/resilient-subscribe.js
+++ b/servers/sharing/resilient-subscribe.js
@@ -1,0 +1,88 @@
+/**
+ * Keep a single Nostr subscription alive across relay socket drops.
+ *
+ * nostr-tools' `relay.subscribe(...)` is established once and is NOT re-created
+ * when the socket drops, goes idle, or the relay closes the long-lived REQ — the
+ * relay keeps holding events but they never reach the handler until the process
+ * restarts and re-subscribes. This wraps ONE subscribe against ONE relay and
+ * re-establishes it whenever the relay reports disconnected.
+ *
+ * Design: the caller owns the relay lifecycle and runs a periodic health loop
+ * that calls `ensureHealthy()` on each handle. Pair this with
+ * `Relay.connect(url, { enablePing: true })` so a silently-dead half-open socket
+ * flips `relay.connected` to false (ping timeout → ws.close) and the loop then
+ * reconnects it. `enableReconnect` is intentionally left OFF — this is the single
+ * app-level reconnect engine. Mirrors the reconnect-or-skip philosophy of
+ * safe-relay-publish.js, on the subscribe side.
+ *
+ * Never touches sqlite and never constructs/closes the relay — that keeps the
+ * same code usable from the pi-bots adapter (better-sqlite3) and NostrManager
+ * (libsql) unchanged.
+ *
+ * @param {object} relay  connected nostr-tools Relay (or a stub)
+ * @param {object} filter Nostr filter WITHOUT `since` (this injects `since`)
+ * @param {function} onevent  called with each event (the caller dedups/decodes)
+ * @param {{initialSince?:number, skewSec?:number, connectTimeoutMs?:number}} opts
+ * @returns {{ensureHealthy:()=>Promise<void>, close:()=>void}}
+ */
+export function makeResilientSub(relay, filter, onevent, opts = {}) {
+  const skewSec = opts.skewSec ?? 120;
+  const connectTimeoutMs = opts.connectTimeoutMs ?? 10000;
+  const initialSince = opts.initialSince ?? null;
+  let lastSeen = null; // max event.created_at delivered
+  let sub = null;      // current sub handle, or null if none / dropped
+  let stopped = false;
+  let busy = false;
+
+  const wrapped = (event) => {
+    if (event && typeof event.created_at === "number" && (lastSeen === null || event.created_at > lastSeen)) {
+      lastSeen = event.created_at;
+    }
+    onevent(event);
+  };
+
+  function doSubscribe() {
+    const since = lastSeen !== null ? lastSeen - skewSec : initialSince;
+    const f = since !== null ? { ...filter, since } : { ...filter };
+    try {
+      sub = relay.subscribe([f], { onevent: wrapped, onclose: () => { sub = null; } });
+    } catch {
+      sub = null; // relay not ready; ensureHealthy retries next tick
+    }
+  }
+
+  // Subscribe immediately (relay is connected at construction) so listening
+  // starts right away, exactly like the pre-hardening one-shot subscribe.
+  doSubscribe();
+
+  async function ensureHealthy() {
+    if (stopped || busy) return;
+    busy = true;
+    try {
+      if (!relay.connected) {
+        let to;
+        try {
+          await Promise.race([
+            relay.connect(),
+            new Promise((_, rej) => { to = setTimeout(() => rej(new Error("connect timeout")), connectTimeoutMs); }),
+          ]);
+        } catch {
+          return; // still down → retry next tick
+        } finally {
+          clearTimeout(to); // don't leave the race timer dangling when connect wins
+        }
+      }
+      if (!relay.connected) return;
+      if (!sub) doSubscribe();
+    } finally {
+      busy = false;
+    }
+  }
+
+  function close() {
+    stopped = true;
+    if (sub) { try { sub.close(); } catch {} sub = null; }
+  }
+
+  return { ensureHealthy, close };
+}

--- a/servers/sharing/resilient-subscribe.js
+++ b/servers/sharing/resilient-subscribe.js
@@ -35,8 +35,14 @@ export function makeResilientSub(relay, filter, onevent, opts = {}) {
   let busy = false;
 
   const wrapped = (event) => {
-    if (event && typeof event.created_at === "number" && (lastSeen === null || event.created_at > lastSeen)) {
-      lastSeen = event.created_at;
+    if (event && typeof event.created_at === "number") {
+      // Clamp the watermark to no more than now + skew. A future-dated created_at
+      // (malicious or clock-skewed) must never push `since` (= lastSeen - skew)
+      // into the future, or the resubscribe filter would match nothing and cause a
+      // permanent receive blackout that a restart can't clear.
+      const ceiling = Math.floor(Date.now() / 1000) + skewSec;
+      const clamped = Math.min(event.created_at, ceiling);
+      if (lastSeen === null || clamped > lastSeen) lastSeen = clamped;
     }
     onevent(event);
   };
@@ -72,6 +78,10 @@ export function makeResilientSub(relay, filter, onevent, opts = {}) {
           clearTimeout(to); // don't leave the race timer dangling when connect wins
         }
       }
+      // Re-check `stopped` after the connect await: close() may have raced the
+      // in-flight reconnect (teardown-during-reconnect). Without this, we'd
+      // resurrect a subscription on a relay that's being torn down.
+      if (stopped) return;
       if (!relay.connected) return;
       if (!sub) doSubscribe();
     } finally {

--- a/servers/sharing/safe-relay-publish.js
+++ b/servers/sharing/safe-relay-publish.js
@@ -1,0 +1,31 @@
+/**
+ * Publish a Nostr event to a single relay WITHOUT risking an unhandled-rejection
+ * process crash.
+ *
+ * Why this exists: nostr-tools' `Relay.publish()` calls `Relay.send()` WITHOUT
+ * awaiting it. When the relay's WebSocket has dropped, `send()` rejects with
+ * `SendingOnClosedConnection` (connectionPromise === null). That rejection is on
+ * the orphaned `send()` promise — NOT the promise `publish()` returns — so it
+ * escapes any `try { await relay.publish() } catch {}` around the call site. Under
+ * Node's default `--unhandled-rejections=throw` an unhandled rejection terminates
+ * the whole process. This is exactly what took down the crow-mpa gateway mid
+ * room fan-out when relay.damus.io had dropped its connection.
+ *
+ * Guard: never invoke `publish()` on a relay that is not connected. Reconnect a
+ * dropped relay first (best-effort, bounded by nostr-tools' own connect timeout);
+ * if it is still down, skip it. The `connected` check sits immediately before the
+ * synchronous `publish()` call with no `await` between them, so a close event
+ * cannot interleave (single-threaded, no yield point) — the deterministic
+ * closed-relay trigger is removed.
+ *
+ * @returns {Promise<boolean>} true if we published, false if the relay was skipped.
+ */
+export async function safeRelayPublish(relay, event) {
+  if (!relay) return false;
+  if (!relay.connected) {
+    try { await relay.connect(); } catch { /* reconnect best-effort; skip below if still down */ }
+  }
+  if (!relay.connected) return false; // still closed → skip; do NOT trigger the leak
+  await relay.publish(event);
+  return true;
+}

--- a/tests/crow-messages-adapter.test.js
+++ b/tests/crow-messages-adapter.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { deriveBotIdentity } from "../servers/sharing/identity.js";
-import { xOnly, buildDM, openDM, makeDedupeGate } from "../scripts/pi-bots/gateways/nostr-client.mjs";
+import { xOnly, buildDM, openDM, makeDedupeGate, subscribeResilient } from "../scripts/pi-bots/gateways/nostr-client.mjs";
 import Database from "better-sqlite3";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -102,4 +102,47 @@ test("crow-messages is registered as a host-managed adapter", () => {
   assert.equal(isHostManaged("crow-messages"), true);
   const a = getAdapter("crow-messages");
   assert.ok(a && a.type === "crow-messages" && typeof a.start === "function");
+});
+
+// subscribe() throws synchronously when down — a test-only model (real
+// nostr-tools leaks an un-awaited rejection instead); production never subscribes
+// while disconnected. See tests/resilient-subscribe.test.js for the full note.
+function stubRelay({ connected = true } = {}) {
+  const r = {
+    connected, connectCalls: 0, subscribeCalls: [], _subs: [], closed: false,
+    subscribe(filters, { onevent, onclose }) {
+      if (!r.connected) throw new Error("closed");
+      r.subscribeCalls.push({ filters, onevent, onclose });
+      const s = { onevent, onclose, closed: false, close() { this.closed = true; } };
+      r._subs.push(s); return s;
+    },
+    async connect() { r.connectCalls++; r.connected = true; },
+    close() { r.closed = true; },
+    drop() { r.connected = false; const s = r._subs[r._subs.length - 1]; if (s && s.onclose) s.onclose(); },
+  };
+  return r;
+}
+
+test("subscribeResilient builds one handle per relay and reconnects all on ensureAllHealthy", async () => {
+  const a = stubRelay(); const b = stubRelay();
+  const relays = new Map([["wss://a", a], ["wss://b", b]]);
+  const sub = subscribeResilient(relays, { kinds: [4], "#p": ["bot"] }, () => {}, { initialSince: 10 });
+  assert.equal(a.subscribeCalls.length, 1);
+  assert.equal(b.subscribeCalls.length, 1);
+  a.drop(); b.drop();
+  await sub.ensureAllHealthy();
+  assert.equal(a.subscribeCalls.length, 2);
+  assert.equal(b.subscribeCalls.length, 2);
+  sub.stop();
+});
+
+test("subscribeResilient.stop() closes every handle (later ensureAllHealthy is a no-op)", async () => {
+  const a = stubRelay();
+  const relays = new Map([["wss://a", a]]);
+  const sub = subscribeResilient(relays, { kinds: [4] }, () => {}, {});
+  sub.stop();
+  a.drop();
+  await sub.ensureAllHealthy();
+  assert.equal(a.connectCalls, 0);
+  assert.equal(a.subscribeCalls.length, 1);
 });

--- a/tests/nostr-resubscribe.test.js
+++ b/tests/nostr-resubscribe.test.js
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { NostrManager } from "../servers/sharing/nostr.js";
+
+// subscribe() throws synchronously when down — a test-only model (real
+// nostr-tools leaks an un-awaited rejection instead); production never subscribes
+// while disconnected. See tests/resilient-subscribe.test.js for the full note.
+function stubRelay({ connected = true } = {}) {
+  const r = {
+    connected, connectCalls: 0, subscribeCalls: [], _subs: [], closed: false,
+    subscribe(filters, { onevent, onclose }) {
+      if (!r.connected) throw new Error("closed");
+      r.subscribeCalls.push({ filters, onevent, onclose });
+      const s = { onevent, onclose, closed: false, close() { this.closed = true; } };
+      r._subs.push(s); return s;
+    },
+    async connect() { r.connectCalls++; r.connected = true; },
+    close() { r.closed = true; },
+    drop() { r.connected = false; const s = r._subs[r._subs.length - 1]; if (s && s.onclose) s.onclose(); },
+  };
+  return r;
+}
+
+const identity = { secp256k1Pubkey: "a".repeat(64), secp256k1Priv: new Uint8Array(32) };
+
+test("subscribeToIncoming registers a resilient handle that resubscribes after a drop", async () => {
+  const mgr = new NostrManager(identity, null);
+  const relay = stubRelay();
+  mgr.relays.set("wss://stub", relay); // pre-populate so connectRelays() is a no-op
+  await mgr.subscribeToIncoming(async () => {}, async () => {});
+  assert.equal(relay.subscribeCalls.length, 1);
+  const handle = mgr.subscriptions.get("incoming:wss://stub");
+  assert.ok(handle && typeof handle.ensureHealthy === "function");
+
+  relay.drop();
+  await handle.ensureHealthy();
+  assert.equal(relay.connectCalls, 1);
+  assert.equal(relay.subscribeCalls.length, 2);
+
+  await mgr.destroy();
+  assert.equal(mgr._healthTimer, null);
+  assert.equal(relay.closed, true);
+});
+
+test("subscribeToContact registers a resilient handle (no `since` on first subscribe)", async () => {
+  const mgr = new NostrManager(identity, null);
+  const relay = stubRelay();
+  mgr.relays.set("wss://stub", relay);
+  await mgr.subscribeToContact({ id: 1, crow_id: "crow:c", secp256k1_pubkey: "b".repeat(64), display_name: "C" });
+  assert.equal(relay.subscribeCalls.length, 1);
+  assert.equal("since" in relay.subscribeCalls[0].filters[0], false);
+  const handle = mgr.subscriptions.get("crow:c:wss://stub");
+  assert.ok(handle && typeof handle.ensureHealthy === "function");
+  await mgr.destroy();
+});

--- a/tests/resilient-subscribe.test.js
+++ b/tests/resilient-subscribe.test.js
@@ -88,6 +88,20 @@ test("replay of the same event id collapses at the caller's dedupe gate", async 
   assert.deepEqual(business, ["dup"]); // business callback fired once
 });
 
+test("future-dated created_at cannot poison the resubscribe `since` (clamped to now + skew)", async () => {
+  const relay = makeStubRelay();
+  const now = Math.floor(Date.now() / 1000);
+  const skewSec = 120;
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, { initialSince: 1000, skewSec });
+  // A malicious / clock-skewed event 10 days in the future.
+  relay.deliver({ id: "evil", created_at: now + 10 * 86400 });
+  relay.drop();
+  await h.ensureHealthy();
+  const since = relay.subscribeCalls[1].filters[0].since;
+  // since must NOT be in the future, or the relay returns nothing → receive blackout.
+  assert.ok(since <= now + skewSec, `since ${since} must be <= now+skew ${now + skewSec}`);
+});
+
 test("close() makes a later ensureHealthy a no-op (no reconnect, no resubscribe)", async () => {
   const relay = makeStubRelay();
   const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {});
@@ -96,6 +110,19 @@ test("close() makes a later ensureHealthy a no-op (no reconnect, no resubscribe)
   await h.ensureHealthy();
   assert.equal(relay.connectCalls, 0);
   assert.equal(relay.subscribeCalls.length, 1); // only the initial subscribe
+});
+
+test("close() during an in-flight reconnect prevents a post-close resubscribe", async () => {
+  const relay = makeStubRelay({ connected: false });
+  let release;
+  relay.connect = async () => { relay.connectCalls++; await new Promise((r) => { release = r; }); relay.connected = true; };
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {}); // initial subscribe throws (disconnected) → sub=null
+  assert.equal(relay.subscribeCalls.length, 0);
+  const p = h.ensureHealthy(); // enters connect branch, awaits
+  h.close();                   // teardown races the in-flight reconnect
+  release();                   // connect resolves → relay.connected = true
+  await p;
+  assert.equal(relay.subscribeCalls.length, 0); // no resubscribe after close
 });
 
 test("overlapping ensureHealthy ticks do not double-subscribe (busy guard)", async () => {

--- a/tests/resilient-subscribe.test.js
+++ b/tests/resilient-subscribe.test.js
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeResilientSub } from "../servers/sharing/resilient-subscribe.js";
+import { makeDedupeGate } from "../scripts/pi-bots/gateways/nostr-client.mjs";
+
+// Stub nostr-tools Relay. NOTE on fidelity: the real relay.subscribe() does NOT
+// throw on a closed connection — it returns a sub handle and leaks an un-awaited
+// rejected send(). We model "subscribe while down" as a SYNCHRONOUS throw purely
+// for testability (it drives sub=null in the busy-guard test). This is safe
+// because production never calls doSubscribe() while disconnected: at
+// construction the relay is connected, and in ensureHealthy() the synchronous
+// subscribe is gated by `if (!relay.connected) return` with no await between the
+// check and the call. drop() simulates a socket loss: connected=false + fire the
+// live sub's onclose. deliver() pushes an event to the latest live sub.
+function makeStubRelay({ connected = true } = {}) {
+  const relay = {
+    connected,
+    connectCalls: 0,
+    subscribeCalls: [], // { filters, onevent, onclose }
+    closed: false,
+    _subs: [],
+    subscribe(filters, { onevent, onclose }) {
+      if (!relay.connected) throw new Error("subscribe on closed relay");
+      relay.subscribeCalls.push({ filters, onevent, onclose });
+      const sub = { onevent, onclose, closed: false, close() { this.closed = true; } };
+      relay._subs.push(sub);
+      return sub;
+    },
+    async connect() { relay.connectCalls++; relay.connected = true; },
+    close() { relay.closed = true; },
+    deliver(event) { const s = relay._subs[relay._subs.length - 1]; if (s && !s.closed) s.onevent(event); },
+    drop() { relay.connected = false; const s = relay._subs[relay._subs.length - 1]; if (s && s.onclose) s.onclose(); },
+  };
+  return relay;
+}
+
+test("initial subscribe happens at construction; events reach the handler", () => {
+  const relay = makeStubRelay();
+  const got = [];
+  makeResilientSub(relay, { kinds: [4], "#p": ["bob"] }, (e) => got.push(e.id), { initialSince: 1000 });
+  assert.equal(relay.subscribeCalls.length, 1);
+  assert.equal(relay.subscribeCalls[0].filters[0].since, 1000);
+  relay.deliver({ id: "e1", created_at: 2000 });
+  assert.deepEqual(got, ["e1"]);
+});
+
+test("drop → ensureHealthy reconnects + resubscribes + delivers a post-reconnect event", async () => {
+  const relay = makeStubRelay();
+  const got = [];
+  const h = makeResilientSub(relay, { kinds: [4] }, (e) => got.push(e.id), { initialSince: 1000 });
+  relay.deliver({ id: "e1", created_at: 2000 });
+  relay.drop();
+  await h.ensureHealthy();
+  assert.equal(relay.connectCalls, 1);
+  assert.equal(relay.subscribeCalls.length, 2);
+  relay.deliver({ id: "e2", created_at: 3000 });
+  assert.deepEqual(got, ["e1", "e2"]);
+});
+
+test("resubscribe since = lastSeen - 120; fresh handle with no event uses initialSince", async () => {
+  const relay = makeStubRelay();
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, { initialSince: 1000 });
+  relay.deliver({ id: "e1", created_at: 5000 });
+  relay.drop();
+  await h.ensureHealthy();
+  assert.equal(relay.subscribeCalls[1].filters[0].since, 4880); // 5000 - 120
+
+  const r2 = makeStubRelay();
+  makeResilientSub(r2, { kinds: [4] }, () => {}, { initialSince: 555 });
+  assert.equal(r2.subscribeCalls[0].filters[0].since, 555);
+});
+
+test("no initialSince and no event → no `since` key on the filter", () => {
+  const relay = makeStubRelay();
+  makeResilientSub(relay, { kinds: [4], authors: ["a"] }, () => {}, {});
+  assert.equal("since" in relay.subscribeCalls[0].filters[0], false);
+});
+
+test("replay of the same event id collapses at the caller's dedupe gate", async () => {
+  const relay = makeStubRelay();
+  const gate = makeDedupeGate();
+  const business = [];
+  const h = makeResilientSub(relay, { kinds: [4] }, (e) => { if (gate(e.id)) business.push(e.id); }, { initialSince: 0 });
+  relay.deliver({ id: "dup", created_at: 100 });
+  relay.drop();
+  await h.ensureHealthy();
+  relay.deliver({ id: "dup", created_at: 100 }); // replay post-resubscribe
+  assert.deepEqual(business, ["dup"]); // business callback fired once
+});
+
+test("close() makes a later ensureHealthy a no-op (no reconnect, no resubscribe)", async () => {
+  const relay = makeStubRelay();
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {});
+  h.close();
+  relay.connected = false;
+  await h.ensureHealthy();
+  assert.equal(relay.connectCalls, 0);
+  assert.equal(relay.subscribeCalls.length, 1); // only the initial subscribe
+});
+
+test("overlapping ensureHealthy ticks do not double-subscribe (busy guard)", async () => {
+  const relay = makeStubRelay({ connected: false });
+  let release;
+  relay.connect = async () => { relay.connectCalls++; await new Promise((r) => { release = r; }); relay.connected = true; };
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {}); // initial subscribe throws (disconnected) → sub=null
+  const p1 = h.ensureHealthy(); // enters, awaits connect → busy
+  const p2 = h.ensureHealthy(); // busy → returns immediately
+  release();
+  await Promise.all([p1, p2]);
+  assert.equal(relay.connectCalls, 1);          // second tick did not re-enter connect
+  assert.equal(relay.subscribeCalls.length, 1); // exactly one subscribe
+});

--- a/tests/safe-relay-publish.test.js
+++ b/tests/safe-relay-publish.test.js
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { safeRelayPublish } from "../servers/sharing/safe-relay-publish.js";
+
+/**
+ * Models the failure mode that crashed the crow-mpa gateway: nostr-tools'
+ * Relay.publish() fires Relay.send() WITHOUT awaiting it. When the relay's
+ * WebSocket has dropped (connected === false / connectionPromise === null),
+ * send() rejects with SendingOnClosedConnection — a rejection that escapes the
+ * caller's try/catch (it is not the promise publish() returns) and, under
+ * Node's default --unhandled-rejections=throw, terminates the process.
+ *
+ * safeRelayPublish must NEVER call publish() on a relay that is not connected.
+ */
+function fakeRelay({ connected = true, reconnectsTo = null } = {}) {
+  return {
+    connected,
+    publishCalls: 0,
+    connectCalls: 0,
+    async connect() {
+      this.connectCalls++;
+      if (reconnectsTo !== null) this.connected = reconnectsTo;
+    },
+    async publish() {
+      this.publishCalls++;
+      // Mirror nostr-tools: a closed relay would leak an unhandled rejection
+      // from the un-awaited send(). If safeRelayPublish ever calls us while
+      // disconnected, fail loudly so the test catches the regression.
+      if (!this.connected) throw new Error("publish() called on a closed relay");
+      return { id: "ev" };
+    },
+  };
+}
+
+test("safeRelayPublish publishes when the relay is connected", async () => {
+  const relay = fakeRelay({ connected: true });
+  const ok = await safeRelayPublish(relay, { id: "e" });
+  assert.equal(ok, true);
+  assert.equal(relay.publishCalls, 1);
+  assert.equal(relay.connectCalls, 0); // already connected → no reconnect
+});
+
+test("safeRelayPublish SKIPS a closed relay that fails to reconnect — never calls publish()", async () => {
+  const relay = fakeRelay({ connected: false, reconnectsTo: false });
+  const ok = await safeRelayPublish(relay, { id: "e" });
+  assert.equal(ok, false);
+  assert.equal(relay.connectCalls, 1); // attempted reconnect
+  assert.equal(relay.publishCalls, 0); // but never published on the closed relay (the crash trigger)
+});
+
+test("safeRelayPublish reconnects a dropped relay, then publishes", async () => {
+  const relay = fakeRelay({ connected: false, reconnectsTo: true });
+  const ok = await safeRelayPublish(relay, { id: "e" });
+  assert.equal(ok, true);
+  assert.equal(relay.connectCalls, 1);
+  assert.equal(relay.publishCalls, 1);
+});
+
+test("safeRelayPublish swallows a reconnect() that throws and skips publish", async () => {
+  const relay = {
+    connected: false,
+    publishCalls: 0,
+    async connect() { throw new Error("connection timed out"); },
+    async publish() { this.publishCalls++; },
+  };
+  const ok = await safeRelayPublish(relay, { id: "e" });
+  assert.equal(ok, false);
+  assert.equal(relay.publishCalls, 0);
+});


### PR DESCRIPTION
## Problem

A long-lived `relay.subscribe(...)` is established **once** and never re-established when the relay WebSocket drops, goes idle, or the relay closes the long-running REQ. The relay keeps holding events (verified retrievable by a fresh REQ) but they never reach the handler until a process restart. This silently breaks **receiving** in two places:

1. **pi-bots crow-messages adapter** — a bot stops receiving room messages AND 1:1 DMs until `pibot-gateways@<inst>` is restarted (caught live during the 2026-06-25 rooms test).
2. **Gateway's own messaging** (`servers/sharing/nostr.js`) — `subscribeToIncoming` (peer invites/accepts, room inbound) and `subscribeToContact` (1:1) had the same latent bug.

## Approach

`nostr-tools@2.23.3` already ships reconnect machinery but it is opt-in and was off. We enable only **`enablePing: true`** at every `Relay.connect` (so a silently-dead half-open socket flips `relay.connected` to false via ping timeout) and keep **`enableReconnect` OFF** — relying on it would NOT self-heal a hard `ws.onerror`/RST or connection-timeout (those set `skipReconnection=true`), and it isn't unit-testable. Instead we own a single app-level reconnect engine:

- **`servers/sharing/resilient-subscribe.js`** (`makeResilientSub`) — relay/db-agnostic primitive that wraps one `relay.subscribe`, records `lastSeen`, and re-subscribes (rolling `since = lastSeen − skew`) whenever the relay dropped. The caller runs ONE periodic health loop calling `ensureHealthy()`.
- Applied to the **pi-bots adapter** (`subscribeResilient` + health timer in `crow-messages.mjs` `start()`/`stop()`) and **`NostrManager`** (`subscribeToIncoming` + `subscribeToContact` + a single manager health loop, cleaned up in `destroy()`).
- Carries forward the previously-uncommitted **`safe-relay-publish.js`** publish-path crash fix (reconnect-or-skip on the publish side) as the foundation.

Replay on resubscribe is harmless — collapsed by existing dedup (`makeDedupeGate`/`markEventSeen` in the adapter, `seenEventIds` / `INSERT OR IGNORE` in the gateway).

## Hardening (from final review)

- **CRITICAL** — clamp the `lastSeen` watermark to `min(created_at, now+skew)` so a future-dated `created_at` (malicious/clock-skewed) can't poison `since` and cause a permanent receive blackout. TDD regression test added.
- **IMPORTANT** — re-check `stopped` after the connect await so a `close()` racing an in-flight reconnect can't resurrect a torn-down subscription. Regression test added.

## Tests

- New `tests/resilient-subscribe.test.js` (9, incl. the 2 regression tests above); `tests/nostr-resubscribe.test.js` (2); `tests/safe-relay-publish.test.js` (4).
- Full nostr/sharing/crow-messages/room blast radius green (25 files, ~150 tests). Whole `tests/` dir: 831 pass / 1 fail, where the single failure (`health-signals`) and one slow-test timeout (`crow-accept-bot-invite`) reproduce identically on `main` without these changes (env-dependent, pre-existing).
- Gateway boot smoke clean. `/security-review`: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uGq1DjDtTxK4GLDnowN4S