### PR TITLE
fix(embeddings,notion): cold-start provider fallback, configurable embed timeout, skip Notion database rows

### DIFF
--- a/scripts/sync-notion.js
+++ b/scripts/sync-notion.js
@@ -179,22 +179,33 @@ async function notionFetch(token, path, { method = "GET", body } = {}) {
   throw lastErr || new Error("Notion request failed");
 }
 
-/** Enumerate all pages shared with the integration. */
-async function searchPages(token, { limit } = {}) {
+/**
+ * A page whose parent is a database is a database row (e.g. a calendar cell or
+ * tracker entry) — usually low-signal noise for semantic search. Exported for tests.
+ */
+export function isDatabaseRow(page) {
+  return page?.parent?.type === "database_id";
+}
+
+/** Enumerate pages shared with the integration. Skips database-row pages unless includeDbRows. */
+async function searchPages(token, { limit, includeDbRows = false } = {}) {
   const pages = [];
+  let dbRowsSkipped = 0;
   let cursor;
   do {
     const body = { filter: { value: "page", property: "object" }, page_size: 100 };
     if (cursor) body.start_cursor = cursor;
     const data = await notionFetch(token, "/search", { method: "POST", body });
     for (const r of data.results || []) {
-      if (r.object === "page") pages.push(r);
-      if (limit && pages.length >= limit) return pages.slice(0, limit);
+      if (r.object !== "page") continue;
+      if (!includeDbRows && isDatabaseRow(r)) { dbRowsSkipped++; continue; }
+      pages.push(r);
+      if (limit && pages.length >= limit) return { pages: pages.slice(0, limit), dbRowsSkipped };
     }
     cursor = data.has_more ? data.next_cursor : null;
     if (cursor) await sleep(THROTTLE_MS);
   } while (cursor);
-  return pages;
+  return { pages, dbRowsSkipped };
 }
 
 /** Fetch a block's children recursively, attaching `children` arrays. */
@@ -242,7 +253,7 @@ async function fetchPageMarkdown(token, pageId) {
  */
 export async function runSync(opts = {}) {
   const token = opts.token ?? process.env.NOTION_TOKEN;
-  const { limit = null, dryRun = false, force = false } = opts;
+  const { limit = null, dryRun = false, force = false, includeDbRows = false } = opts;
   const logger = opts.log ?? console.log;
   const log = (msg) => logger(msg);
   log.error = (msg) => (opts.logError ?? console.error)(msg);
@@ -268,8 +279,8 @@ export async function runSync(opts = {}) {
   const ownsDb = !opts.db;
   const db = opts.db ?? createDbClient();
   try {
-    const pages = await searchPages(token, { limit });
-    log(`found ${pages.length} shared page(s)`);
+    const { pages, dbRowsSkipped } = await searchPages(token, { limit, includeDbRows });
+    log(`found ${pages.length} content page(s)` + (dbRowsSkipped ? `, skipped ${dbRowsSkipped} database-row page(s)` : ""));
 
     for (const page of pages) {
       const title = extractTitle(page);
@@ -365,6 +376,7 @@ function parseArgs(argv) {
     else if (a === "--dry-run") out.dryRun = true;
     else if (a === "--force") out.force = true;
     else if (a === "--once") out.once = true; // single pass is the only mode; accepted for clarity
+    else if (a === "--include-db-rows") out.includeDbRows = true;
     else if (a === "--help" || a === "-h") out.help = true;
   }
   return out;
@@ -378,6 +390,7 @@ async function main() {
     console.log("  --dry-run       show insert/update/skip decisions without writing");
     console.log("  --limit N       cap the number of pages (for testing)");
     console.log("  --force         re-embed every page regardless of last_edited_time");
+    console.log("  --include-db-rows  also sync database-row pages (default: skip them)");
     console.log("\nRequires NOTION_TOKEN in the environment.");
     process.exit(0);
   }
@@ -385,6 +398,7 @@ async function main() {
     limit: args.limit,
     dryRun: args.dryRun,
     force: args.force,
+    includeDbRows: args.includeDbRows,
   });
   if (!result.ok) process.exit(1);
 }

--- a/servers/memory/embeddings.js
+++ b/servers/memory/embeddings.js
@@ -16,7 +16,9 @@ import { createDbClient } from "../db.js";
 
 // Fallback when no provider is configured via env or the dashboard setting.
 const FALLBACK_PROVIDER = "grackle-embed";
-const EMBED_TIMEOUT_MS = 10_000;
+// Per-request embed timeout. Default suits fast GPU endpoints; CPU/local
+// embedders (e.g. llamafile) need more for long documents — raise via env.
+const EMBED_TIMEOUT_MS = Number(process.env.CROW_EMBED_TIMEOUT_MS) || 10_000;
 const FETCH_RETRIES = 1;
 
 // Default embedding-provider resolution, in priority order:
@@ -60,15 +62,41 @@ export async function resolveDefaultProvider() {
 // Provider resolution
 // -----------------------------------------------------------------------
 
-function resolveEmbedConfig(providerName = FALLBACK_PROVIDER) {
-  const cfg = loadProviders();
-  const p = cfg.providers?.[providerName];
+async function resolveEmbedConfig(providerName = FALLBACK_PROVIDER) {
+  let p = loadProviders().providers?.[providerName];
+  // Cold-cache / DB-only provider: loadProviders() returns models.json on a
+  // process's first call (it warms from the DB asynchronously). Fall back to a
+  // direct providers-table read so one-shot scripts and first-in-process calls
+  // still resolve providers that exist only in the DB (e.g. installed bundles).
   if (!p || !p.baseUrl) {
-    throw new Error(`embedding provider "${providerName}" not configured in models.json`);
+    p = await loadProviderFromDb(providerName);
+  }
+  if (!p || !p.baseUrl) {
+    throw new Error(`embedding provider "${providerName}" not configured`);
   }
   const model = p.models?.[0]?.id || "default";
   const dim = p.models?.[0]?.dim || null;
   return { baseUrl: p.baseUrl, apiKey: p.apiKey, model, dim, name: providerName };
+}
+
+async function loadProviderFromDb(id) {
+  try {
+    const db = createDbClient();
+    try {
+      const { rows } = await db.execute({
+        sql: "SELECT base_url, api_key, models FROM providers WHERE id = ? AND (disabled IS NULL OR disabled = 0) LIMIT 1",
+        args: [id],
+      });
+      if (!rows.length) return null;
+      let models = [];
+      try { models = JSON.parse(rows[0].models || "[]"); } catch {}
+      return { baseUrl: rows[0].base_url, apiKey: rows[0].api_key, models };
+    } finally {
+      db.close?.();
+    }
+  } catch {
+    return null;
+  }
 }
 
 // -----------------------------------------------------------------------
@@ -80,7 +108,7 @@ function resolveEmbedConfig(providerName = FALLBACK_PROVIDER) {
  * Returns Float32Array (for single) or Float32Array[] (for array).
  */
 export async function embedText(text, { providerName } = {}) {
-  const cfg = resolveEmbedConfig(providerName || (await resolveDefaultProvider()));
+  const cfg = await resolveEmbedConfig(providerName || (await resolveDefaultProvider()));
   const isArray = Array.isArray(text);
   const input = isArray ? text : [text];
 
@@ -119,7 +147,7 @@ export async function embedText(text, { providerName } = {}) {
  */
 export async function embedProviderInfo(providerName) {
   try {
-    const cfg = resolveEmbedConfig(providerName || (await resolveDefaultProvider()));
+    const cfg = await resolveEmbedConfig(providerName || (await resolveDefaultProvider()));
     const res = await fetch(cfg.baseUrl.replace(/\/+$/, "") + "/models", {
       signal: AbortSignal.timeout(3000),
     });

--- a/tests/notion-sync.test.js
+++ b/tests/notion-sync.test.js
@@ -8,6 +8,7 @@ import {
   decideAction,
   buildContent,
   buildContext,
+  isDatabaseRow,
 } from "../scripts/sync-notion.js";
 
 test("richTextToPlain joins plain_text segments and tolerates empties", () => {
@@ -90,6 +91,14 @@ test("buildContent caps length and prefixes the title", () => {
   const content = buildContent("Title", "body");
   assert.equal(content, "# Title\n\nbody");
   assert.ok(buildContent("T", "x".repeat(60000)).length <= 50000);
+});
+
+test("isDatabaseRow flags pages whose parent is a database (the noisy calendar cells)", () => {
+  assert.equal(isDatabaseRow({ parent: { type: "database_id", database_id: "x" } }), true);
+  assert.equal(isDatabaseRow({ parent: { type: "page_id", page_id: "y" } }), false);
+  assert.equal(isDatabaseRow({ parent: { type: "workspace", workspace: true } }), false);
+  assert.equal(isDatabaseRow({}), false);
+  assert.equal(isDatabaseRow(undefined), false);
 });
 
 test("buildContext records provenance for dedup/change detection", () => {


### PR DESCRIPTION
## What

Three hardening fixes that surfaced while activating local embeddings on a CPU/macOS host (no GPU, can't reach `grackle-embed`).

### 1. Cold-start provider resolution (`embeddings.js`)
`loadProviders()` returns `models.json` on a process's *first* call and warms from the DB asynchronously. So a **DB-only provider** (e.g. one registered by an installed bundle) was invisible to one-shot scripts (`sync-notion`, `backfill`) and to the first call in a long-running process. `resolveEmbedConfig` now falls back to a **direct `providers`-table read** when `loadProviders()` misses — the same DB the rest of the system already uses. Eliminates the race; no warm-up needed.

### 2. Configurable embed timeout (`embeddings.js`)
`EMBED_TIMEOUT_MS` is now `CROW_EMBED_TIMEOUT_MS || 10_000`. The 10s default is fine for fast GPU endpoints but too tight for **CPU** embedders (e.g. llamafile) on long documents, which were timing out and storing FTS-only.

### 3. Skip Notion database rows (`sync-notion.js`)
A shared Notion **database** otherwise imports every row as its own page — a habit-tracker flooded memory with 1000+ calendar-cell pages ("1".."31", dates). `searchPages` now skips pages whose `parent.type === "database_id"` by default; `--include-db-rows` keeps them. (In testing: 7 real content pages kept, 1023 database rows skipped.)

## Tests

- New `isDatabaseRow` tests in `tests/notion-sync.test.js`.
- `tests/embed-provider.test.js` + `tests/notion-sync.test.js` green.
- Verified end-to-end: filtered sync → local CPU embeddings → semantic recall (e.g. "cómo crear bases de datos en notion" → the Notion-databases page, 0.86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
