### PR TITLE
QW3 (Theme 10): iPhone access via PWA — install docs EN+ES, platforms cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Unlike hosted, auto-authoring bot platforms, Crow keeps the engine on your hardw
 
 Crow is the first AI platform with built-in encrypted peer-to-peer sharing. No cloud middleman, no accounts to create, just your Crow ID.
 
-Crow spans your devices, pulling multiple instances into one private interface — access and control all of your connected instances from the open-source Android app, or from the dashboard in any browser.
+Crow spans your devices, pulling multiple instances into one private interface — access and control all of your connected instances from the open-source Android app, an installable iPhone web app (no App Store needed), or from the dashboard in any browser.
 
 - **Share memories and projects**: Send a memory or an entire project space to a friend's Crow, encrypted end-to-end.
 - **Collaborate on project spaces**: Project spaces have members, roles (owner / editor / viewer / guest), and per-member capability overrides. Clone-share delivers a one-shot snapshot today; live one-way subscription is a planned follow-on.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
               { text: 'Cline', link: '/es/platforms/cline' },
               { text: 'Qwen Code', link: '/es/platforms/qwen-coder' },
               { text: 'Aplicación Android', link: '/es/platforms/android' },
+              { text: 'iPhone (PWA)', link: '/es/platforms/ios' },
             ],
           },
           {
@@ -247,6 +248,7 @@ export default defineConfig({
           { text: 'Qwen Code', link: '/platforms/qwen-coder' },
 
           { text: 'Android App', link: '/platforms/android' },
+          { text: 'iPhone (PWA)', link: '/platforms/ios' },
         ],
       },
       {

--- a/docs/es/platforms/index.md
+++ b/docs/es/platforms/index.md
@@ -17,6 +17,15 @@ Crow usa el estándar abierto [Model Context Protocol (MCP)](https://modelcontex
 | [Cline](./cline) | stdio / HTTP | Varía | Fácil | Compatible |
 | [Qwen Code](./qwen-coder) | stdio / HTTP | OAuth 2.1 | Fácil | Compatible |
 
+## Apps móviles
+
+La tabla anterior cubre los clientes MCP (asistentes de IA que se conectan a las herramientas de Crow). Crow también tiene acceso móvil dedicado al propio panel del Crow's Nest:
+
+| Plataforma | Método de instalación | Estado |
+|---|---|---|
+| [Aplicación Android](./android) | APK nativo, o PWA vía Chrome | Totalmente probado |
+| [iPhone (PWA)](./ios) | App web instalable vía Safari (sin App Store) | Totalmente probado |
+
 ## Endpoints MCP
 
 Cada ruta es relativa a la URL de tu gateway (por ejemplo, `http://crow:3001`). Cada servidor está disponible vía Streamable HTTP en `<prefix>/mcp` y vía SSE legado en `<prefix>/sse` + `<prefix>/messages`:

--- a/docs/es/platforms/ios.md
+++ b/docs/es/platforms/ios.md
@@ -27,7 +27,7 @@ Si tu iPhone y tu servidor Crow están en la misma red doméstica, puedes saltar
 ## Paso 2: Abre la URL de tu Crow's Nest en Safari
 
 1. Abre **Safari** (tiene que ser Safari — otros navegadores en iOS no pueden instalar apps web en la pantalla de inicio)
-2. Escribe la dirección que te dio quien configuró tu Crow — se parece a una dirección web, por ejemplo `http://100.121.254.89:3001` o `https://tu-servidor.ts.net`
+2. Escribe la dirección que te dio quien configuró tu Crow — se parece a una dirección web, por ejemplo `http://100.121.254.89:3001` o `https://tu-servidor.tu-tailnet.ts.net:8444/dashboard` (el número después de los `:` varía según la configuración — consulta la [guía de Configuración de Tailscale](/es/getting-started/tailscale-setup) o ejecuta `tailscale serve status` en el servidor para encontrar el tuyo)
 3. Inicia sesión con tu contraseña del Crow's Nest
 
 ## Paso 3: Agrega Crow a tu Pantalla de Inicio

--- a/docs/es/platforms/ios.md
+++ b/docs/es/platforms/ios.md
@@ -1,0 +1,75 @@
+---
+title: iPhone (PWA)
+---
+
+# iPhone (PWA)
+
+Accede a Crow desde tu iPhone instalando el Crow's Nest como una app web — sin cuenta de App Store, sin APK, nada que aprobar. Esto se llama Progressive Web App (PWA) y se ve y se comporta como cualquier otro ícono de app en tu pantalla de inicio.
+
+::: tip Requiere iOS 16.4 o posterior
+Apple agregó soporte de notificaciones push para apps web instaladas en iOS 16.4. Si no ves la opción de notificaciones, revisa **Ajustes** > **General** > **Información** > **Versión de software** y actualiza si hace falta.
+:::
+
+## Paso 1: Únete a la red Tailscale de tu Crow
+
+Si tu gateway de Crow se ejecuta en un servidor casero (algo que no es accesible desde internet directamente), instala Tailscale primero para que tu iPhone pueda alcanzarlo de forma segura desde cualquier lugar:
+
+1. Instala la [app de Tailscale desde App Store](https://apps.apple.com/app/tailscale/id1470499037)
+2. Abre Tailscale e inicia sesión con la misma cuenta que usas en tu servidor Crow
+3. Activa Tailscale
+
+Consulta la [guía de Configuración de Tailscale](/es/getting-started/tailscale-setup) completa si es la primera vez que la configuras, o si necesitas la dirección Tailscale de tu servidor.
+
+::: tip ¿Ya estás en la misma Wi-Fi?
+Si tu iPhone y tu servidor Crow están en la misma red doméstica, puedes saltarte Tailscale y usar directamente la dirección local del servidor.
+:::
+
+## Paso 2: Abre la URL de tu Crow's Nest en Safari
+
+1. Abre **Safari** (tiene que ser Safari — otros navegadores en iOS no pueden instalar apps web en la pantalla de inicio)
+2. Escribe la dirección que te dio quien configuró tu Crow — se parece a una dirección web, por ejemplo `http://100.121.254.89:3001` o `https://tu-servidor.ts.net`
+3. Inicia sesión con tu contraseña del Crow's Nest
+
+## Paso 3: Agrega Crow a tu Pantalla de Inicio
+
+1. Toca el botón **Compartir** (el cuadrado con una flecha hacia arriba, en la barra inferior)
+2. Desplázate por la lista de opciones y toca **Agregar a pantalla de inicio**
+3. Confirma el nombre (o déjalo como "Crow") y toca **Agregar**
+
+Ahora aparece un ícono de Crow en tu pantalla de inicio, igual que cualquier otra app.
+
+## Paso 4: Abre Crow desde la Pantalla de Inicio y activa las notificaciones
+
+::: warning Abre el ícono, no la pestaña de Safari
+El permiso de notificaciones solo se puede conceder **desde dentro de la app instalada** — al tocar el ícono de la pantalla de inicio. Safari por sí solo no ofrecerá activar las notificaciones del sitio, aunque sea la misma página.
+:::
+
+1. Cierra Safari y toca el **ícono de Crow** en tu pantalla de inicio
+2. Ve a **Ajustes** > **Notificaciones** dentro del Crow's Nest
+3. Toca **Activar Push**
+4. Cuando iOS pregunte si permite las notificaciones, toca **Permitir**
+
+Listo — Crow ahora se ejecuta a pantalla completa, sin la barra de direcciones de Safari, y puede enviarte notificaciones push para llamadas, mensajes y recordatorios.
+
+## Solución de problemas
+
+### No veo la opción para activar notificaciones
+
+Asegúrate de haber abierto Crow desde el **ícono de la pantalla de inicio**, no desde una pestaña o marcador de Safari. Si no estás seguro, cierra Safari por completo y vuelve a tocar el ícono de Crow.
+
+### Ya lo agregué a la Pantalla de Inicio, pero las notificaciones siguen sin funcionar
+
+- Quita el ícono de la pantalla de inicio (mantén presionado > **Eliminar app** > **Eliminar de la pantalla de inicio**) y repite los Pasos 2 al 4. Esto obliga a iOS a volver a registrar la app.
+- Confirma que tienes iOS 16.4 o posterior (**Ajustes** > **General** > **Información**).
+- Revisa que las notificaciones no estén silenciadas por un modo Enfoque: **Ajustes** > **Enfoque**, y asegúrate de que el Enfoque activo (No Molestar, Dormir, Trabajo, etc.) permita notificaciones de Crow, o desactiva el Enfoque.
+- Revisa **Ajustes** > **Notificaciones** > **Crow** en el propio iPhone y confirma que "Permitir Notificaciones" esté activado.
+
+### La página se ve como un sitio web normal, no como una app
+
+Si sigue mostrando la barra de direcciones y las pestañas de Safari, estás viendo la pestaña de Safari, no la app instalada. Vuelve al Paso 3 y agrégala a la pantalla de inicio, y ábrela siempre desde ese ícono de ahí en adelante.
+
+### No puedo acceder a la página
+
+- Si estás fuera de casa, confirma que Tailscale esté conectado (abre la app de Tailscale y revisa que diga "Conectado")
+- Verifica bien la dirección — distingue mayúsculas/minúsculas y necesita la parte `http://` o `https://`
+- Pide a quien administra tu servidor Crow que confirme que el gateway está funcionando

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -17,6 +17,15 @@ Crow uses the open [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | [Cline](./cline) | stdio / HTTP | Varies | Easy | Compatible |
 | [Qwen Code](./qwen-coder) | stdio / HTTP | OAuth 2.1 | Easy | Compatible |
 
+## Mobile Apps
+
+The table above covers MCP clients (AI assistants that connect to Crow's tools). Crow also has dedicated mobile access to the Crow's Nest dashboard itself:
+
+| Platform | Install method | Status |
+|---|---|---|
+| [Android App](./android) | Native APK, or PWA via Chrome | Fully tested |
+| [iPhone (PWA)](./ios) | Installable web app via Safari (no App Store) | Fully tested |
+
 ## MCP Endpoints
 
 Every path is relative to your gateway URL (e.g. `http://crow:3001`). Each server is available over Streamable HTTP at `<prefix>/mcp` and over legacy SSE at `<prefix>/sse` + `<prefix>/messages`:

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -1,0 +1,71 @@
+# iPhone (PWA)
+
+Access Crow from your iPhone by installing the Crow's Nest as a web app — no App Store account, no APK, nothing to approve. This is called a Progressive Web App (PWA), and it looks and behaves like any other app icon on your Home Screen.
+
+::: tip Requires iOS 16.4 or later
+Apple added push notification support for installed web apps in iOS 16.4. If notifications don't show up as an option, check **Settings** > **General** > **About** > **Software Version** and update if needed.
+:::
+
+## Step 1: Join your Crow's Tailscale network
+
+If your Crow gateway runs on a home server (not something already reachable from the open internet), install Tailscale first so your iPhone can reach it securely from anywhere:
+
+1. Install the [Tailscale app from the App Store](https://apps.apple.com/app/tailscale/id1470499037)
+2. Open Tailscale and sign in with the same account used on your Crow server
+3. Toggle Tailscale **on**
+
+See the full [Tailscale Setup guide](../getting-started/tailscale-setup) if this is your first time setting it up, or if you need the server's Tailscale address.
+
+::: tip Already on the same Wi-Fi?
+If your iPhone and your Crow server are on the same home network, you can skip Tailscale and use the server's local address directly.
+:::
+
+## Step 2: Open your Crow's Nest URL in Safari
+
+1. Open **Safari** (this must be Safari — other browsers on iOS can't install web apps to the Home Screen)
+2. Type in the address whoever set up your Crow gave you — it looks like a website address, for example `http://100.121.254.89:3001` or `https://your-server.ts.net`
+3. Log in with your Crow's Nest password
+
+## Step 3: Add Crow to your Home Screen
+
+1. Tap the **Share** button (the square with an arrow pointing up, in the bottom toolbar)
+2. Scroll down the list of options and tap **Add to Home Screen**
+3. Confirm the name (or leave it as "Crow") and tap **Add**
+
+A Crow icon now appears on your Home Screen, just like any other app.
+
+## Step 4: Open Crow from the Home Screen and turn on notifications
+
+::: warning Open the icon, not the Safari tab
+Notification permission can only be granted from **inside the installed app** — tapping the Home Screen icon. Safari itself will not offer to turn on notifications for the site, even though it's the same page.
+:::
+
+1. Close Safari and tap the **Crow icon** on your Home Screen
+2. Go to **Settings** > **Notifications** inside Crow's Nest
+3. Tap **Enable Push**
+4. When iOS asks to allow notifications, tap **Allow**
+
+That's it — Crow now runs full-screen, without Safari's address bar, and can send you push notifications for calls, messages, and reminders.
+
+## Troubleshooting
+
+### I don't see an option to enable notifications
+
+Make sure you opened Crow from the **Home Screen icon**, not from a Safari tab or bookmark. If you're not sure, close Safari completely, then tap the Crow icon again.
+
+### I already added it to the Home Screen, but notifications still don't work
+
+- Remove the icon from your Home Screen (long-press it > **Remove App** > **Remove from Home Screen**) and repeat Steps 2-4. This forces iOS to re-register the app.
+- Confirm you're on iOS 16.4 or later (**Settings** > **General** > **About**).
+- Check that notifications aren't being silenced by a Focus mode: **Settings** > **Focus**, and make sure the active Focus (Do Not Disturb, Sleep, Work, etc.) allows notifications from Crow, or turn the Focus off.
+- Check **Settings** > **Notifications** > **Crow** on the iPhone itself and confirm "Allow Notifications" is on.
+
+### The page looks like a normal website, not an app
+
+If it still shows Safari's address bar and tabs, you're looking at the Safari tab, not the installed app. Go back to Step 3 and add it to the Home Screen, then always open it from that icon going forward.
+
+### I can't reach the page at all
+
+- If you're away from home, confirm Tailscale is connected (open the Tailscale app and check it says "Connected")
+- Double-check the address — it's case-sensitive and needs the `http://` or `https://` part
+- Ask whoever manages your Crow server to confirm the gateway is running

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -23,7 +23,7 @@ If your iPhone and your Crow server are on the same home network, you can skip T
 ## Step 2: Open your Crow's Nest URL in Safari
 
 1. Open **Safari** (this must be Safari — other browsers on iOS can't install web apps to the Home Screen)
-2. Type in the address whoever set up your Crow gave you — it looks like a website address, for example `http://100.121.254.89:3001` or `https://your-server.ts.net`
+2. Type in the address whoever set up your Crow gave you — it looks like a website address, for example `http://100.121.254.89:3001` or `https://your-server.your-tailnet.ts.net:8444/dashboard` (the number after the `:` varies per setup — see the [Tailscale Setup guide](../getting-started/tailscale-setup) or run `tailscale serve status` on the server to find yours)
 3. Log in with your Crow's Nest password
 
 ## Step 3: Add Crow to your Home Screen


### PR DESCRIPTION
Phase 0 quick win #3 of the Crow Messages usability arc — closes the old improvement arc's Theme 10 (documentation-first scope locked 2026-06-12; the PWA already works on iPhone).

- New `docs/platforms/ios.md` + `docs/es/platforms/ios.md`, written for a non-technical user: Tailscale iOS app → Safari → dashboard URL (real Serve-port pattern, `https://…ts.net:8444/dashboard`, with a pointer to find your own port) → Add to Home Screen → enable notifications from the installed icon (iOS 16.4+; permission must be granted inside the installed app). Troubleshooting section included.
- Cross-linked: platforms index EN+ES (new Mobile Apps section — also fixes Android never having been listed there), VitePress sidebar EN+ES, README platform line.
- `docs && npm run build` clean (dead-link check on).

**Follow-up (not in this PR):** the layout emits `<link rel="apple-touch-icon">` pointing at the SVG icon, but iOS requires PNG for home-screen icons and no PNG exists in `servers/gateway/public/` — the home-screen icon currently falls back to a page screenshot. Needs a PNG render of the crow icon + manifest entry.