### PR TITLE
Harden cross_host_calls against recurring DB corruption (retention + circuit-breaker + scripted recovery)

### DIFF
--- a/docs/developers/db-recovery.md
+++ b/docs/developers/db-recovery.md
@@ -1,0 +1,89 @@
+# crow.db corruption recovery
+
+`crow.db` has corrupted twice the same way (2026-06-14, 2026-07-02): the
+`cross_host_calls` federation-audit table is an unbounded, append-only,
+high-write table, and a crash mid-write orphaned pages and spammed tens of
+thousands of `disk image is malformed` errors while federation degraded
+silently. Three hardening layers now exist; this doc covers the third — the
+one-command recovery — and points at the other two.
+
+## One command: `npm run recover-db`
+
+Rebuilds a corrupt `crow.db` **offline** into a fresh, integrity-checked file,
+salvaging every readable base table.
+
+```bash
+# Stop everything that opens crow.db FIRST (gateway + pi-bots + any same-host
+# instances), then:
+npm run recover-db -- --dry-run          # rehearse: build + verify, never swap
+npm run recover-db                        # do it: build, verify, swap
+```
+
+Flags:
+
+| Flag | Meaning |
+|---|---|
+| `--db <path>` | DB to recover (default `~/.crow/data/crow.db`). |
+| `--dry-run` | Do everything **except** the swap. Leaves the rebuilt temp DB in place for inspection and never touches the original. |
+| `--force` | Bypass the liveness gate (you assert the gateway/pi-bots are stopped). |
+
+### What it does
+
+1. **Liveness gate** — refuses to run if `crow.db`, `crow.db-wal`, or
+   `crow.db-shm` have any open file handles (`lsof`/`fuser`). A TCP port check
+   is *not* enough: pi-bots `bot_jobs` IPC, the WAL keeper, and other same-host
+   gateway instances all open `crow.db`. Override with `--force`.
+2. **Backup** — copies the corrupt DB (+ `-wal`/`-shm`) to `<db>.CORRUPT-<ts>`.
+3. **Fresh schema** — runs the in-repo `scripts/init-db.js` into a temp file.
+4. **Salvage** — `ATTACH`es the corrupt backup and `INSERT OR REPLACE`-copies
+   every readable base table (shared columns only, so schema drift is
+   survivable). FTS virtual tables are rebuilt via
+   `INSERT INTO fts(fts) VALUES('rebuild')`.
+   - **`crow_instances` is preserved** whenever it is readable — it is the
+     peer-auth trust anchor (`validateInstanceToken` selects by
+     `auth_token_hash`), so dropping it blacks out *all* federation until every
+     peer re-enrolls. It is skipped **only** if its per-table `SELECT` throws a
+     malformed error.
+   - `cross_host_calls` (expendable audit) and `mcp_sessions` (ephemeral) are
+     always dropped.
+5. **MCP token re-inject** — re-writes `sha256(CROW_LOCAL_MCP_TOKEN)` (from the
+   environment or `.env`) so headless MCP clients keep working, and validates
+   it before allowing the swap.
+6. **Two swap gates** — the rebuilt DB is installed **only if**:
+   - `PRAGMA integrity_check` returns `ok`, **and**
+   - every readable source table's row count exactly matches the copied count
+     (a partially-readable source can't yield an "ok" but lossy DB).
+   Any shortfall prints a loud diff and **aborts without swapping**; the
+   rejected rebuild is left on disk for inspection.
+7. **Swap** — atomically renames the rebuilt file over `<db>` and removes the
+   stale `-wal`/`-shm`. Prints a runbook, every row count, and — if
+   `crow_instances` had to be dropped — a **loud "federation peers must
+   re-enroll"** warning.
+
+### After a real recovery
+
+- Restart the gateway and pi-bots so they reopen the fresh file
+  (`sudo systemctl restart crow-gateway` + the pi-bots unit, etc.).
+- The corrupt original stays at `<db>.CORRUPT-<ts>`; delete it once you trust
+  the recovery.
+- If the warning fired, re-pair each federation peer (grackle sync,
+  black-swan, …) — they will be rejected until they re-enroll.
+
+## The other two hardening layers
+
+Recovery is the *last* resort. The root cause and the silent-failure mode are
+addressed upstream:
+
+- **Bounded retention + checkpoint** — `pruneCrossHostAudit` deletes
+  `cross_host_calls` rows older than **14 days** (must exceed the 7-day
+  `integrationsSignal` reader) and runs `PRAGMA wal_checkpoint(TRUNCATE)`,
+  scheduled from `servers/gateway/boot/post-listen.js` (5-min initial delay,
+  24h interval). The table now stays tiny — far less corruption surface, fast
+  recovery. See `servers/shared/cross-host-audit-retention.js`.
+- **Circuit breaker + loud alert** — when `auditCrossHostCall` sees a
+  structural error (`malformed` / `not a database` / `disk image` /
+  `SQLITE_IOERR`), it trips a per-process breaker that stops feeding the
+  corruption and fires a **DB-free** ntfy + email alert (it does *not* route
+  through `createNotification`, which would try to write the corrupt DB first).
+  Surfaced in the nest as the `federation-audit` health signal. See
+  `servers/shared/cross-host-auth.js`.

--- a/docs/developers/db-recovery.md
+++ b/docs/developers/db-recovery.md
@@ -54,7 +54,11 @@ Flags:
    - every readable source table's row count exactly matches the copied count
      (a partially-readable source can't yield an "ok" but lossy DB).
    Any shortfall prints a loud diff and **aborts without swapping**; the
-   rejected rebuild is left on disk for inspection.
+   rejected rebuild is left on disk for inspection. A **COPY-FAIL on a readable
+   table** (its `count(*)` succeeds but a full row read throws `SQLITE_CORRUPT`
+   on a corrupt leaf/overflow page — the classic partial-corruption case) also
+   aborts, since `integrity_check` on the fresh target would otherwise pass on a
+   table that is simply missing its rows.
 7. **Swap** — atomically renames the rebuilt file over `<db>` and removes the
    stale `-wal`/`-shm`. Prints a runbook, every row count, and — if
    `crow_instances` had to be dropped — a **loud "federation peers must

--- a/docs/superpowers/plans/2026-07-02-cross-host-audit-hardening.md
+++ b/docs/superpowers/plans/2026-07-02-cross-host-audit-hardening.md
@@ -1,0 +1,89 @@
+# cross_host_calls Corruption-Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the `cross_host_calls` federation audit table unable to silently take down (or slowly corrupt) crow's DB again — it has now corrupted twice the same way (2026-06-14, 2026-07-02), each time as an unbounded append-only high-write table whose crash-mid-write orphaned pages and spammed 40k "disk image is malformed" errors while federation degraded silently for hours/days.
+
+**Architecture:** Three independent, low-risk layers on existing surfaces: (1) bounded retention + checkpoint so the table stays tiny (far less corruption surface, fast recovery); (2) a circuit-breaker + LOUD alert so a malformed-audit-DB condition surfaces immediately and stops feeding the corruption, instead of degrading silently; (3) a checked-in scripted recovery so the next rebuild is one command, not hand-built. **Explicitly NOT doing:** live auto-rebuild of a corrupt table under a running gateway (that is exactly the risky operation we just did carefully OFFLINE with backups — automating it on PROD is unsafe).
+
+**Tech Stack:** Node 20, `servers/shared/cross-host-auth.js`, `servers/gateway/boot/post-listen.js` (periodic-timer pattern at :154), the W2 nest health-signals + `servers/shared/notifications.js`, `node --test`.
+
+## Verified facts (2026-07-02)
+
+- `cross_host_calls` schema has an `at TEXT DEFAULT (datetime('now'))` column (init-db.js:1678, ISO string, lexicographically sortable); indexes on target/source/action `at DESC`. **Readers (grep-verified, review C1): TWO — the dashboard audit view last-24h (`audit-log.js:20`) AND `integrationsSignal` in `health-signals.js:493-506` which reads a 7-DAY window (`c.at >= datetime('now','-7 days')`) and picks the latest 401/403 per instance.** So retention MUST exceed 7 days with margin → use **14 days** (table still stays tiny). A 7-day retention would let the prune delete the "latest failing peer" row and silence the integrations warn — reintroducing silent degradation.
+- `auditCrossHostCall` (`cross-host-auth.js:227`) ALREADY never throws (best-effort). `validateInstanceToken` (`instance-registry.js:441-451`) ALREADY retries on a fresh client and logs a degraded warning (2026-06-14 symptom-fixes). There is **no retention/prune anywhere** (grep confirmed) — the unaddressed root cause.
+- Periodic timers use `setInterval(fn, ms).unref()` in `post-listen.js` (e.g. remote-probe :154); gated for `--no-auth` per QW1.
+- Recovery recipe proven 2026-07-02: fresh schema from `scripts/init-db.js` + `INSERT OR REPLACE` copy of readable base tables from the corrupt file, skipping `cross_host_calls`/`crow_instances`/`mcp_sessions`, FTS rebuilt via triggers, token-hash re-injected. (The working `recover.mjs` is in the job tmp dir — Task 3 productizes it.)
+
+## Global Constraints
+
+- Positional-path commits; `git show --stat HEAD` after each. Branch `fix/xhost-audit-hardening`.
+- Tests: `node --test tests/<file>.test.js`; gateway must still boot (`node servers/gateway/index.js --no-auth`).
+- No schema change that requires a data migration beyond what `init-db.js` idempotently applies.
+- Check-runs gate before merge.
+
+---
+
+### Task 1: Bounded retention + checkpoint for cross_host_calls
+
+**Files:**
+- Create: `servers/shared/cross-host-audit-retention.js` — `pruneCrossHostAudit(db, { retentionDays = 14 })` → `DELETE FROM cross_host_calls WHERE at < datetime('now', ?)` (param `'-14 days'` — MUST exceed the 7-day integrations reader, review C1), returns rows deleted; then `PRAGMA wal_checkpoint(TRUNCATE)` (best-effort, never throws — harmless no-op returning `(busy,log,ckpt)` in DELETE-mode per review; a failure must not break boot). Pure, testable, never throws.
+- Modify: `servers/gateway/boot/post-listen.js` — schedule `pruneCrossHostAudit` once ~5 min after boot then every 24h, `setInterval(...).unref()`, fully try/caught. **Gate to the home instance only** (run only when this instance is `is_home`/primary — review suggestion) so three fleet processes don't serialize prune+checkpoint on the same file; runs regardless of `--no-auth` (harmless — a `--no-auth` box may point at a throwaway DB).
+- Test: `tests/cross-host-audit-retention.test.js`
+
+**Interfaces:**
+- Produces: `pruneCrossHostAudit(db, opts) → Promise<{deleted:number, checkpointed:boolean}>`; never rejects.
+
+- [ ] **Step 1:** Write the test against a temp init-db DB: insert rows with `at` = now, now-2d, now-10d, now-20d; the DEFAULT `pruneCrossHostAudit(db)` (14d) deletes ONLY the 20d row (returns `{deleted:1}`), leaves the now/2d/10d rows (proving the shipped default is 14, not <10 — the number this review changed); a second call deletes 0; an explicit `{retentionDays:7}` then also removes the 10d row; corrupt/closed-db call resolves (never rejects).
+- [ ] **Step 2:** Run it → FAIL (module absent).
+- [ ] **Step 3:** Implement `cross-host-audit-retention.js`.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Wire into `post-listen.js` (5-min initial delay, 24h interval, unref, try/caught, `--no-auth`-gated); a tiny unit test or a `node --check` + boot smoke confirming the wiring doesn't throw.
+- [ ] **Step 6:** Commit `fix: bound cross_host_calls with 14-day retention + checkpoint (root-cause of the 2x corruption — unbounded high-write audit table)`.
+
+### Task 2: Circuit-breaker + loud alert on a malformed audit DB
+
+**Files:**
+- Modify: `servers/shared/cross-host-auth.js` — a module-level (per-process) circuit breaker: when `auditCrossHostCall`'s insert catch sees a STRUCTURAL error matching `/malformed|not a database|disk image|disk I\/O|SQLITE_IOERR/i` (include IOERR per review Q3 — db.js history shows it accompanies real unreadability), increment a counter and, past a small threshold (e.g. 3), set `_auditDisabled=true` so subsequent `auditCrossHostCall` calls short-circuit (skip the INSERT — stop feeding the corruption). Transient `SQLITE_BUSY` must NOT trip it. **The alert must NOT depend on a write to the corrupt DB (review C2 — `createNotification` INSERTs to the same `crow.db` at notifications.js:63 BEFORE the ntfy/email sends, so those loud channels never fire when the DB is malformed).** On trip, call the DB-free channels DIRECTLY via dynamic import — `sendNtfyNotification` from `servers/gateway/push/ntfy.js` + `sendEmailNotification` from `servers/gateway/push/email.js` (the real exports — NOT `notifications.js`, which only re-imports them privately inside `createNotification`; both confirmed DB-free, review round-2) — guarded by a `_notified` one-shot. Message: "Federation audit DB is corrupted — run `npm run recover-db`; federation still works, audit logging paused." **Re-arm** `_notified` after a ~6h cooldown (review Q4) so a days-long degradation re-alerts. Never throws; all flags reset on process restart. Per-process singleton — assumes one DB file per process (true on this fleet); state the assumption.
+- Modify: `servers/gateway/dashboard/panels/nest/health-signals.js` — add a `federation-audit` signal that warns when the breaker is tripped (surface the same condition in the nest, reusing the W2 signal contract).
+- Test: `tests/cross-host-audit-breaker.test.js`
+
+**Interfaces:**
+- Consumes: `auditCrossHostCall` (existing). Produces: exported `isAuditDegraded()` → boolean (for the health signal + tests); exported `_resetAuditBreaker()` test hook.
+
+- [ ] **Step 1:** Test: a `db.execute` stub that throws a `malformed` error 3× trips `isAuditDegraded()` true, further `auditCrossHostCall` calls do NOT call `db.execute` (breaker open), and exactly one alert fires — stub the DB-FREE channels at their real modules (`gateway/push/ntfy.js` `sendNtfyNotification`, `gateway/push/email.js` `sendEmailNotification`), asserting they are called and `createNotification`/`db` is NOT (this catches the round-2 wrong-module bug). A `SQLITE_BUSY` does NOT trip it (transient); an IOERR DOES. Re-arm: after `_resetAuditBreaker()`-style cooldown advance, a subsequent trip fires the alert AGAIN (covers the 6h re-arm). `_resetAuditBreaker()` clears all flags.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement the breaker + notification (guard the notification behind a `_notified` one-shot flag).
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5:** Add the `federation-audit` nest health signal (warn when `isAuditDegraded()`), with an i18n label EN+ES; extend the health-signals test if one enumerates signals.
+- [ ] **Step 6:** Commit `fix: circuit-breaker + loud alert when the cross_host_calls audit DB is malformed (no more silent multi-day federation degradation)`.
+
+### Task 3: Checked-in scripted recovery
+
+**Files:**
+- Create: `scripts/recover-crow-db.mjs` — productized from the proven 2026-07-02 `recover.mjs`: takes `--db <path>` (default `~/.crow/data/crow.db`). **Liveness gate (review C3): refuse unless the DB file has NO open handles** — check `lsof`/`fuser` on `<db>`, `<db>-wal`, `<db>-shm` (NOT just the :3001 TCP port — pi-bots `bot_jobs` IPC + WAL keeper handles + other same-host instances also open crow.db per db.js:20-22), or require explicit `--force`. Backs up to `<db>.CORRUPT-<ts>` (+ `-wal`/`-shm`). Builds fresh schema via the in-repo init-db path; `INSERT OR REPLACE`-copies readable base tables. **`crow_instances` handling (review C4): copy it if READABLE (it's the peer-auth trust anchor — `validateInstanceToken` selects by `auth_token_hash`; dropping it blacks out ALL federation until every peer re-enrolls). Only skip a table if a per-table SELECT throws malformed** (today's run skipped `crow_instances` precisely because it was corrupt garbage — but a general recovery must preserve it when intact). Always skip `cross_host_calls` (expendable audit) + `mcp_sessions` (ephemeral) only when unreadable-or-empty. Rebuild FTS via triggers; re-inject the existing `.env` MCP token hash (clients keep working). **Two swap gates: (a) `PRAGMA integrity_check` MUST be `ok`; (b) per-table row-count completeness — every readable source table's count must match the copied count (loud diff + ABORT on shortfall, review suggestion), so a partially-readable source can't yield an "ok" but lossy DB.** Only then swap atomically. Prints the full runbook, every row-count, and — if `crow_instances` was skipped — a LOUD "federation peers must re-enroll" warning.
+- Modify: `package.json` — `"recover-db": "node scripts/recover-crow-db.mjs"`.
+- Modify: `docs/architecture/` or `docs/developers/` — a short "DB corruption recovery" runbook pointing at `npm run recover-db` + the retention/breaker hardening.
+
+- [ ] **Step 1:** Adapt the proven script (in the job tmp dir); make the DB path + backup + integrity-gate + token-reinjection parameterized and safe (never swap if integrity != ok; never run against a live gateway without `--force`).
+- [ ] **Step 2:** Dry-run against a COPY of a DB (e.g. the current healthy crow.db copied to tmp) — confirm it produces an `ok` DB with matching row counts and does NOT touch the original without an explicit swap flag.
+- [ ] **Step 3:** Add the npm script + runbook doc.
+- [ ] **Step 4:** Commit `feat: scripted crow DB recovery (npm run recover-db) — productizes the 2026-07-02 manual recovery`.
+
+---
+
+## Review
+
+**Round 1 (2026-07-02, adversarial subagent, opus): REVISE — all 4 criticals fixed:**
+- **C1** (false "24h-only reader"): grep-verified a SECOND, 7-day reader (`integrationsSignal` health-signals.js:493-506); retention raised 7d→**14d** and the Verified-facts corrected.
+- **C2** (alert writes to the corrupt DB first, so ntfy/email never fire): breaker now calls `sendNtfyNotification`/`sendEmailNotification` DIRECTLY (no `db`) via dynamic import, not `createNotification`; + 6h re-arm.
+- **C3** (port-only liveness insufficient — pi-bots also open crow.db): recovery gates on `lsof`/`fuser` of the db + `-wal`/`-shm`, not the TCP port.
+- **C4** (skipping `crow_instances` blacks out federation): recovery now PRESERVES `crow_instances` when readable (skip only if a per-table SELECT throws), + a loud re-enroll warning when it must be skipped.
+Suggestions adopted: prune gated to the home instance; IOERR added to the breaker trigger; per-table row-count completeness gate on recovery; dynamic-import notifications; per-process-breaker assumption stated; replay-safety (separate nonceCache) confirmed unaffected.
+
+## Self-review notes
+- Attacks the ROOT cause (unbounded table) in Task 1; converts the SILENT failure mode to LOUD + self-limiting in Task 2; makes the inevitable-someday recovery one gated command in Task 3. Layered, each independently valuable.
+- Deliberately NOT auto-rebuilding a corrupt table live (unsafe — documented rejection).
+- Retention 14d exceeds both readers (24h dashboard + 7d integrations) with margin; table still stays tiny; no user-visible loss.
+- Breaker trips only on structural errors (malformed/not-a-database/IOERR), never on transient SQLITE_BUSY.
+- NOTE for the operator: today's recovery dropped the corrupt `crow_instances`, so crow's federation peers (grackle sync, black-swan) will be rejected until they re-enroll — the recovery script's C4 fix prevents this in future runs, but the current instance may need a re-pair.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "storage-server": "node servers/storage/index.js",
     "blog-server": "node servers/blog/index.js",
     "init-db": "node scripts/init-db.js",
+    "recover-db": "node scripts/recover-crow-db.mjs",
     "wizard": "node scripts/wizard.js",
     "desktop-config": "node scripts/generate-desktop-config.js",
     "gateway": "node servers/gateway/index.js",

--- a/scripts/recover-crow-db.mjs
+++ b/scripts/recover-crow-db.mjs
@@ -235,9 +235,15 @@ for (const { name, sql } of targetTables) {
     report.push([name, "copied", srcCount, info.changes]);
     completeness.push({ name, srcCount });
   } catch (e) {
-    // A copy failure mid-salvage is fatal to completeness — record and let the
-    // gate abort below.
+    // A copy failure on a READABLE table (srcCount>0) is fatal to completeness:
+    // count(*) can traverse the b-tree while a full row read hits a corrupt
+    // leaf/overflow page and throws (SQLITE_CORRUPT). integrity_check on the
+    // fresh target would still be 'ok' (a table merely missing rows is
+    // structurally valid), so we MUST register it as a shortfall so the swap
+    // gate aborts. Recording {name, srcCount} makes the recount below diff
+    // srcCount>0 vs the (0/partial) rows that actually landed.
     report.push([name, "COPY-FAIL:" + e.message.slice(0, 60), srcCount, 0]);
+    completeness.push({ name, srcCount });
     if (name === "crow_instances" && isMalformed(e.message)) crowInstancesSkipped = true;
   }
 }
@@ -321,7 +327,12 @@ log("integrity_check:", JSON.stringify(integ));
 log("copy failures:  ", copyFails.length, copyFails.map((f) => `${f[0]}(${f[1]})`).join(", ") || "(none)");
 log("token:          ", tokenStatus);
 
-const gatePass = integrityOk && shortfalls.length === 0;
+// A COPY-FAIL on a table with readable rows (report src column > 0) is a hard
+// abort even if — belt-and-suspenders — the recount somehow matched. Skipped
+// tables (cross_host_calls/mcp_sessions) never reach the copy path so they
+// can't trip this. report row shape: [name, status, srcCount, copiedCount].
+const readableCopyFail = copyFails.some((r) => r[2] > 0);
+const gatePass = integrityOk && shortfalls.length === 0 && !readableCopyFail;
 
 if (!gatePass) {
   log("");
@@ -329,6 +340,10 @@ if (!gatePass) {
   if (shortfalls.length) {
     log("❌ row-count completeness FAILED — some source rows did not land:");
     for (const s of shortfalls) log("   -", s);
+  }
+  if (readableCopyFail) {
+    log("❌ a READABLE source table failed to copy (partial corruption — rows countable but not readable):");
+    for (const r of copyFails.filter((x) => x[2] > 0)) log(`   - ${r[0]} (src=${r[2]}): ${r[1]}`);
   }
   log("");
   log("Rebuilt (rejected) DB left for inspection at:", TEMP);

--- a/scripts/recover-crow-db.mjs
+++ b/scripts/recover-crow-db.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * Scripted crow.db corruption recovery.
+ *
+ * Productizes the hand-built 2026-07-02 manual recovery (job fef5d308) into a
+ * single, gated, one-command tool: `npm run recover-db`.
+ *
+ * What it does (OFFLINE only — never against a live gateway):
+ *   1. LIVENESS GATE — refuses to run unless the DB file (and its -wal/-shm
+ *      sidecars) have NO open handles (lsof/fuser). pi-bots bot_jobs IPC, the
+ *      WAL keeper, and other same-host instances all open crow.db, so a TCP
+ *      port check is NOT sufficient (review C3). Override with --force.
+ *   2. BACKUP — copies the corrupt db (+ -wal/-shm) to <db>.CORRUPT-<ts>.
+ *   3. FRESH SCHEMA — builds an empty, current schema into a temp file by
+ *      running the in-repo `scripts/init-db.js` with CROW_DB_PATH=<temp>.
+ *   4. SALVAGE — ATTACHes the corrupt backup and INSERT-OR-REPLACE-copies every
+ *      readable base table (shared columns only, to survive schema drift).
+ *        - crow_instances is COPIED when its per-table SELECT succeeds (it is
+ *          the peer-auth trust anchor — dropping it blacks out federation until
+ *          every peer re-enrolls, review C4). It is SKIPPED only if the SELECT
+ *          throws malformed.
+ *        - cross_host_calls (expendable audit) and mcp_sessions (ephemeral) are
+ *          always skipped.
+ *   5. FTS REBUILD — `INSERT INTO fts(fts) VALUES('rebuild')` for each FTS
+ *      virtual table.
+ *   6. TOKEN RE-INJECT — re-writes sha256(CROW_LOCAL_MCP_TOKEN) so headless MCP
+ *      clients keep working, and validates it.
+ *   7. TWO SWAP GATES — (a) PRAGMA integrity_check MUST be 'ok'; (b) per-table
+ *      row-count completeness (every readable source table's count must equal
+ *      the copied count). Any shortfall → LOUD diff + ABORT, no swap.
+ *   8. SWAP — atomically renames the rebuilt file over <db>, removes stale
+ *      -wal/-shm. Prints the full runbook, every row count, and (if
+ *      crow_instances had to be skipped) a LOUD re-enroll warning.
+ *
+ * Flags:
+ *   --db <path>   DB to recover (default ~/.crow/data/crow.db)
+ *   --force       bypass the liveness gate (you asserted the gateway is stopped)
+ *   --dry-run     do everything EXCEPT the swap; leaves the rebuilt temp file
+ *                 in place for inspection and never touches the original.
+ *
+ * See docs/developers/db-recovery.md.
+ */
+
+import Database from "better-sqlite3";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync, copyFileSync, renameSync, rmSync, readFileSync, mkdtempSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+// ---------------------------------------------------------------------------
+// arg parsing
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const out = { db: null, force: false, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--db") out.db = argv[++i];
+    else if (a === "--force") out.force = true;
+    else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "-h" || a === "--help") out.help = true;
+    else {
+      console.error(`Unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help) {
+  console.log("Usage: node scripts/recover-crow-db.mjs [--db <path>] [--force] [--dry-run]");
+  process.exit(0);
+}
+
+const DB = resolve(args.db || join(homedir(), ".crow", "data", "crow.db"));
+// A CLI script may use new Date() directly (per Task 3 note).
+const TS = new Date().toISOString().replace(/[:.]/g, "-");
+
+function log(...a) { console.log(...a); }
+function bail(msg, code = 1) {
+  console.error("\n❌ ABORT:", msg);
+  process.exit(code);
+}
+
+log("=== crow.db recovery ===");
+log("db:      ", DB);
+log("mode:    ", args.dryRun ? "DRY-RUN (no swap)" : "LIVE (will swap on pass)");
+log("force:   ", args.force);
+log("");
+
+if (!existsSync(DB)) bail(`DB not found: ${DB}`);
+
+// ---------------------------------------------------------------------------
+// 1. LIVENESS GATE — no open handles on db / -wal / -shm (review C3)
+// ---------------------------------------------------------------------------
+function openHandles(path) {
+  // Prefer lsof; fall back to fuser. Return list of "pid command" strings.
+  const lsof = spawnSync("lsof", ["-t", "-w", "--", path], { encoding: "utf8" });
+  if (lsof.status === 0 && lsof.stdout.trim()) {
+    const pids = lsof.stdout.trim().split(/\s+/).filter(Boolean);
+    return pids.map((pid) => {
+      const cmd = spawnSync("ps", ["-p", pid, "-o", "comm="], { encoding: "utf8" });
+      return `pid ${pid} (${(cmd.stdout || "").trim() || "?"})`;
+    });
+  }
+  // lsof missing (status null / ENOENT) → try fuser as a fallback signal.
+  if (lsof.error) {
+    const fuser = spawnSync("fuser", [path], { encoding: "utf8" });
+    if (fuser.status === 0 && (fuser.stdout.trim() || fuser.stderr.trim())) {
+      return [`(fuser) ${(fuser.stdout + " " + fuser.stderr).trim()}`];
+    }
+  }
+  return [];
+}
+
+const targets = [DB, `${DB}-wal`, `${DB}-shm`].filter(existsSync);
+const holders = [];
+for (const t of targets) {
+  for (const h of openHandles(t)) holders.push(`${t}: ${h}`);
+}
+if (holders.length) {
+  log("⚠️  Open handles detected on the DB file(s):");
+  for (const h of holders) log("   -", h);
+  if (args.dryRun) {
+    log("   (dry-run: continuing anyway — no swap will occur)");
+  } else if (!args.force) {
+    bail(
+      "The DB is in use. Stop the gateway AND any pi-bots / same-host instances " +
+      "first, or re-run with --force if you are certain nothing is writing.",
+    );
+  } else {
+    log("   (--force: proceeding despite open handles — you asserted this is safe)");
+  }
+} else {
+  log("Liveness gate: no open handles ✓");
+}
+
+// ---------------------------------------------------------------------------
+// 2. BACKUP the corrupt db (+ sidecars) to <db>.CORRUPT-<ts>
+// ---------------------------------------------------------------------------
+const BACKUP = `${DB}.CORRUPT-${TS}`;
+copyFileSync(DB, BACKUP);
+for (const ext of ["-wal", "-shm"]) {
+  if (existsSync(`${DB}${ext}`)) copyFileSync(`${DB}${ext}`, `${BACKUP}${ext}`);
+}
+log("Backed up corrupt DB →", BACKUP);
+
+// ---------------------------------------------------------------------------
+// 3. FRESH SCHEMA into a temp file via the in-repo init-db
+// ---------------------------------------------------------------------------
+const workDir = mkdtempSync(join(tmpdir(), "crow-recover-"));
+const TEMP = join(workDir, "crow.db");
+log("Building fresh schema →", TEMP);
+const init = spawnSync("node", ["scripts/init-db.js"], {
+  cwd: REPO_ROOT,
+  env: { ...process.env, CROW_DB_PATH: TEMP },
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+if (init.status !== 0) {
+  bail(`init-db.js failed (exit ${init.status}):\n${init.stderr || init.stdout}`);
+}
+if (!existsSync(TEMP)) bail("init-db.js did not produce the temp DB file.");
+
+// ---------------------------------------------------------------------------
+// 4-5. SALVAGE readable base tables + rebuild FTS
+// ---------------------------------------------------------------------------
+// Federation audit (corrupt-prone, expendable) + ephemeral session state.
+const ALWAYS_SKIP = new Set(["cross_host_calls", "mcp_sessions"]);
+
+function isFtsShadow(name) {
+  return /_fts(_data|_idx|_config|_docsize|_content)?$/.test(name);
+}
+function isVirtual(sql) { return /VIRTUAL\s+TABLE/i.test(sql || ""); }
+function isMalformed(msg) {
+  return /malformed|not a database|disk image|disk I\/O|SQLITE_IOERR/i.test(msg || "");
+}
+
+const db = new Database(TEMP);
+db.exec("PRAGMA foreign_keys=OFF;");
+// ATTACH the *backup* copy as the read source so the original is untouched
+// until the atomic swap.
+db.prepare("ATTACH ? AS old").run(BACKUP);
+
+const targetTables = db.prepare(`
+  SELECT name, sql FROM main.sqlite_master
+  WHERE type='table' AND name NOT LIKE 'sqlite_%'
+`).all();
+
+const oldTables = new Set(
+  db.prepare("SELECT name FROM old.sqlite_master WHERE type='table'").all().map((r) => r.name),
+);
+
+// report rows: [name, status, srcCount, copiedCount]
+const report = [];
+let crowInstancesSkipped = false;
+// completeness pairs to verify AFTER writes settle: {name, srcCount}
+const completeness = [];
+
+for (const { name, sql } of targetTables) {
+  if (isVirtual(sql) || isFtsShadow(name)) { report.push([name, "skip(fts)", 0, 0]); continue; }
+  if (ALWAYS_SKIP.has(name)) { report.push([name, "skip(audit/ephemeral)", 0, 0]); continue; }
+  if (!oldTables.has(name)) { report.push([name, "not-in-old", 0, 0]); continue; }
+
+  // Per-table readability probe (also the crow_instances gate, review C4).
+  let srcCount = null;
+  try {
+    srcCount = db.prepare(`SELECT count(*) c FROM old."${name}"`).get().c;
+  } catch (e) {
+    if (name === "crow_instances") crowInstancesSkipped = true;
+    report.push([name, "UNREADABLE:" + e.message.slice(0, 40), 0, 0]);
+    continue;
+  }
+
+  if (srcCount === 0) { report.push([name, "empty", 0, 0]); continue; }
+
+  // Shared columns only (guard against schema drift between old and new).
+  const newCols = db.prepare(`SELECT name FROM pragma_table_info('${name}')`).all().map((r) => r.name);
+  const oldCols = new Set(
+    db.prepare(`SELECT name FROM pragma_table_info('${name}', 'old')`).all().map((r) => r.name),
+  );
+  const shared = newCols.filter((c) => oldCols.has(c));
+  const collist = shared.map((c) => `"${c}"`).join(",");
+  try {
+    const info = db.prepare(
+      `INSERT OR REPLACE INTO main."${name}" (${collist}) SELECT ${collist} FROM old."${name}"`,
+    ).run();
+    report.push([name, "copied", srcCount, info.changes]);
+    completeness.push({ name, srcCount });
+  } catch (e) {
+    // A copy failure mid-salvage is fatal to completeness — record and let the
+    // gate abort below.
+    report.push([name, "COPY-FAIL:" + e.message.slice(0, 60), srcCount, 0]);
+    if (name === "crow_instances" && isMalformed(e.message)) crowInstancesSkipped = true;
+  }
+}
+
+// Rebuild every FTS virtual table from its (now-populated) content table.
+const ftsVirtual = targetTables.filter((t) => isVirtual(t.sql)).map((t) => t.name);
+for (const f of ftsVirtual) {
+  try {
+    db.prepare(`INSERT INTO main."${f}"("${f}") VALUES('rebuild')`).run();
+    report.push([f, "fts-rebuilt", 0, 0]);
+  } catch (e) {
+    report.push([f, "FTS-REBUILD-FAIL:" + e.message.slice(0, 40), 0, 0]);
+  }
+}
+
+db.prepare("DETACH old").run();
+db.close();
+
+// ---------------------------------------------------------------------------
+// 6. TOKEN RE-INJECT — sha256(CROW_LOCAL_MCP_TOKEN) so MCP clients keep working
+// ---------------------------------------------------------------------------
+function readEnvToken() {
+  if (process.env.CROW_LOCAL_MCP_TOKEN) return process.env.CROW_LOCAL_MCP_TOKEN;
+  const envPath = join(REPO_ROOT, ".env");
+  if (!existsSync(envPath)) return null;
+  for (const line of readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const m = /^\s*CROW_LOCAL_MCP_TOKEN\s*=\s*(.*)\s*$/.exec(line);
+    if (m) return m[1].replace(/^["']|["']$/g, "").trim() || null;
+  }
+  return null;
+}
+
+const token = readEnvToken();
+let tokenStatus = "no CROW_LOCAL_MCP_TOKEN found (skipped)";
+if (token) {
+  const { createDbClient } = await import("../servers/db.js");
+  const { writeSetting } = await import("../servers/gateway/dashboard/settings/registry.js");
+  const { validateLocalToken } = await import("../servers/gateway/local-token.js");
+  const tdb = createDbClient(TEMP);
+  await writeSetting(tdb, "mcp_local_token_hash", createHash("sha256").update(token).digest("hex"), { scope: "local" });
+  await writeSetting(tdb, "mcp_local_token_created", new Date().toISOString(), { scope: "local" });
+  const ok = await validateLocalToken(tdb, token);
+  tdb.close();
+  if (!ok) bail("Re-injected MCP token failed validation — refusing to swap.");
+  tokenStatus = "re-injected + validated ✓";
+}
+
+// ---------------------------------------------------------------------------
+// 7. SWAP GATES — (a) integrity_check == ok ; (b) per-table completeness
+// ---------------------------------------------------------------------------
+// Fold WAL into the file and drop to DELETE mode so the temp is a single,
+// self-contained file safe to rename over the destination.
+const fin = new Database(TEMP);
+try { fin.pragma("wal_checkpoint(TRUNCATE)"); } catch { /* best-effort */ }
+try { fin.pragma("journal_mode = DELETE"); } catch { /* best-effort */ }
+
+const integ = fin.prepare("PRAGMA integrity_check").get();
+const integrityOk = integ && integ.integrity_check === "ok";
+
+// Re-count the destination tables and diff against the recorded source counts.
+const shortfalls = [];
+for (const { name, srcCount } of completeness) {
+  let got = 0;
+  try { got = fin.prepare(`SELECT count(*) c FROM main."${name}"`).get().c; } catch { got = -1; }
+  if (got !== srcCount) shortfalls.push(`${name}: source=${srcCount} rebuilt=${got}`);
+}
+fin.close();
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+log("");
+log("TABLE".padEnd(34), "STATUS".padEnd(24), "SRC".padStart(6), "COPIED".padStart(7));
+for (const [n, s, o, c] of report) {
+  if (["empty", "not-in-old", "skip(fts)"].some((p) => s.startsWith(p))) continue;
+  log(n.padEnd(34), String(s).padEnd(24), String(o).padStart(6), String(c).padStart(7));
+}
+const copyFails = report.filter((r) => /FAIL|UNREADABLE/.test(r[1]));
+log("");
+log("integrity_check:", JSON.stringify(integ));
+log("copy failures:  ", copyFails.length, copyFails.map((f) => `${f[0]}(${f[1]})`).join(", ") || "(none)");
+log("token:          ", tokenStatus);
+
+const gatePass = integrityOk && shortfalls.length === 0;
+
+if (!gatePass) {
+  log("");
+  if (!integrityOk) log("❌ integrity_check is NOT 'ok':", JSON.stringify(integ));
+  if (shortfalls.length) {
+    log("❌ row-count completeness FAILED — some source rows did not land:");
+    for (const s of shortfalls) log("   -", s);
+  }
+  log("");
+  log("Rebuilt (rejected) DB left for inspection at:", TEMP);
+  log("The original is UNTOUCHED. Backup of the corrupt DB:", BACKUP);
+  bail("swap gates failed — NOT swapping.");
+}
+
+// ---------------------------------------------------------------------------
+// 8. SWAP (or stop, for dry-run)
+// ---------------------------------------------------------------------------
+if (args.dryRun) {
+  log("");
+  log("✅ DRY-RUN PASSED — integrity ok + all row counts match.");
+  log("   Rebuilt DB (NOT installed):", TEMP);
+  log("   Original UNTOUCHED:        ", DB);
+  log("   Corrupt backup:            ", BACKUP);
+  log("   Re-run without --dry-run to install it.");
+  if (crowInstancesSkipped) {
+    log("");
+    log("⚠️  crow_instances was UNREADABLE in the source — a real recovery would");
+    log("    drop it and federation peers would need to RE-ENROLL.");
+  }
+  process.exit(0);
+}
+
+// Atomic-ish swap: rename the rebuilt file over the destination, then remove
+// the old WAL sidecars. rename within the same fs is atomic; if TEMP is on a
+// different filesystem, copy+rename via a same-dir staging file.
+try {
+  renameSync(TEMP, DB);
+} catch (e) {
+  if (e.code === "EXDEV") {
+    const staging = `${DB}.rebuilt-${TS}`;
+    copyFileSync(TEMP, staging);
+    renameSync(staging, DB);
+    try { rmSync(TEMP); } catch { /* best-effort */ }
+  } else {
+    bail(`swap failed: ${e.message}`);
+  }
+}
+for (const ext of ["-wal", "-shm"]) {
+  try { rmSync(`${DB}${ext}`, { force: true }); } catch { /* best-effort */ }
+}
+try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+
+log("");
+log("✅ RECOVERY COMPLETE — rebuilt DB installed at", DB);
+log("");
+log("Runbook / next steps:");
+log("  1. Corrupt original preserved at:", BACKUP, "(delete once you trust the recovery).");
+log("  2. Restart the gateway + pi-bots so they reopen the fresh file:");
+log("       sudo systemctl restart crow-gateway   # + crow-pi-bots, etc.");
+log("  3. cross_host_calls was intentionally dropped (expendable audit); it now");
+log("     stays bounded via the 14-day retention prune + malformed-DB circuit");
+log("     breaker (see docs/developers/db-recovery.md).");
+if (crowInstancesSkipped) {
+  log("");
+  log("  ⚠️⚠️  FEDERATION: crow_instances was corrupt and could NOT be salvaged.");
+  log("      All federation peers (grackle sync, black-swan, etc.) will be REJECTED");
+  log("      until they RE-ENROLL / re-pair with this instance. Re-run the pairing");
+  log("      flow for each peer.");
+} else {
+  log("");
+  log("  Federation trust anchor (crow_instances) was preserved — peers keep working.");
+}
+process.exit(0);

--- a/servers/gateway/boot/post-listen.js
+++ b/servers/gateway/boot/post-listen.js
@@ -267,6 +267,60 @@ export async function runPostListenSetup(server, app, deps) {
     console.log("[health-monitor] skipped: --no-auth gateway is never the primary dashboard");
   }
 
+  // cross_host_calls audit-retention (2026-07-02 corruption-hardening plan,
+  // Task 1): cross_host_calls is an unbounded append-only high-write table
+  // that has corrupted crow's DB twice. Prune rows older than 14 days
+  // (default — see cross-host-audit-retention.js for why 14, not 7) then
+  // best-effort WAL-checkpoint. First run ~5 min after boot, then every
+  // 24h. Runs regardless of --no-auth (harmless — a --no-auth box may point
+  // at a throwaway DB). Gated to the home/primary instance only so multiple
+  // same-host gateway processes sharing one crow.db file (e.g. primary +
+  // MPA) don't redundantly prune+checkpoint the same file concurrently. A
+  // fresh/standalone install with no instance yet designated "home" is
+  // treated as primary too (getHomeInstance() returns nothing until the
+  // user explicitly pairs/chains instances) — otherwise the fix would never
+  // engage on the common single-instance install. Fully try/caught; never
+  // throws.
+  {
+    const XHOST_AUDIT_PRUNE_BOOT_DELAY_MS = 5 * 60 * 1000;    // 5 min
+    const XHOST_AUDIT_PRUNE_INTERVAL_MS   = 24 * 60 * 60 * 1000; // 24h
+
+    const isHomeOrStandalone = async (db) => {
+      const { getOrCreateLocalInstanceId, getInstance, getHomeInstance } =
+        await import("../instance-registry.js");
+      const localId = getOrCreateLocalInstanceId();
+      const local = await getInstance(db, localId);
+      if (local?.is_home === 1) return true;
+      const home = await getHomeInstance(db);
+      return !home; // nobody designated home yet — treat this instance as primary
+    };
+
+    const runXhostAuditPrune = async () => {
+      try {
+        const { pruneCrossHostAudit } = await import("../../shared/cross-host-audit-retention.js");
+        const db = createDbClient();
+        try {
+          if (!(await isHomeOrStandalone(db))) return;
+          const { deleted, checkpointed } = await pruneCrossHostAudit(db);
+          if (deleted > 0) {
+            console.log(`[xhost-audit-retention] pruned ${deleted} row(s) from cross_host_calls (checkpointed=${checkpointed})`);
+          }
+        } finally {
+          try { db.close(); } catch {}
+        }
+      } catch (err) {
+        console.warn("[xhost-audit-retention] cycle error:", err?.message || err);
+      }
+    };
+
+    setTimeout(() => {
+      runXhostAuditPrune();
+      setInterval(runXhostAuditPrune, XHOST_AUDIT_PRUNE_INTERVAL_MS).unref();
+    }, XHOST_AUDIT_PRUNE_BOOT_DELAY_MS).unref();
+
+    console.log("[xhost-audit-retention] armed (24h interval, first run in 5 min)");
+  }
+
   // F.13: crosspost publish/GC scheduler (no-ops on an empty crosspost_log;
   // kill switch CROW_DISABLE_CROSSPOST_SCHEDULER=1). Lazy import keeps boot
   // resilient if the crossposting module is absent.

--- a/servers/gateway/boot/post-listen.js
+++ b/servers/gateway/boot/post-listen.js
@@ -29,6 +29,35 @@ export function shouldRunHealthMonitor({ env, noAuth }) {
   return env.CROW_DISABLE_HEALTH_MONITOR !== "1";
 }
 
+/**
+ * Run one cross_host_calls audit-retention cycle: prune rows older than the
+ * default 14-day window, then best-effort WAL-checkpoint. Opens a fresh db
+ * client via the injected factory (defaults to createDbClient) and always
+ * closes it. NEVER throws — a failure here must not cascade into an outage.
+ * Exported so the boot timer and tests share one code path.
+ *
+ * @param {() => {execute: Function, close?: Function}} [dbFactory]
+ * @returns {Promise<{deleted:number, checkpointed:boolean}>}
+ */
+export async function runCrossHostAuditPrune(dbFactory = createDbClient) {
+  try {
+    const { pruneCrossHostAudit } = await import("../../shared/cross-host-audit-retention.js");
+    const db = dbFactory();
+    try {
+      const { deleted, checkpointed } = await pruneCrossHostAudit(db);
+      if (deleted > 0) {
+        console.log(`[xhost-audit-retention] pruned ${deleted} row(s) from cross_host_calls (checkpointed=${checkpointed})`);
+      }
+      return { deleted, checkpointed };
+    } finally {
+      try { db.close?.(); } catch {}
+    }
+  } catch (err) {
+    console.warn("[xhost-audit-retention] cycle error:", err?.message || err);
+    return { deleted: 0, checkpointed: false };
+  }
+}
+
 export async function runPostListenSetup(server, app, deps) {
   const { setupCallsSignaling, setupCompanionProxy, extensionProxyWsSetup, PORT, BIND, noAuth } = deps;
 
@@ -271,51 +300,26 @@ export async function runPostListenSetup(server, app, deps) {
   // Task 1): cross_host_calls is an unbounded append-only high-write table
   // that has corrupted crow's DB twice. Prune rows older than 14 days
   // (default — see cross-host-audit-retention.js for why 14, not 7) then
-  // best-effort WAL-checkpoint. First run ~5 min after boot, then every
-  // 24h. Runs regardless of --no-auth (harmless — a --no-auth box may point
-  // at a throwaway DB). Gated to the home/primary instance only so multiple
-  // same-host gateway processes sharing one crow.db file (e.g. primary +
-  // MPA) don't redundantly prune+checkpoint the same file concurrently. A
-  // fresh/standalone install with no instance yet designated "home" is
-  // treated as primary too (getHomeInstance() returns nothing until the
-  // user explicitly pairs/chains instances) — otherwise the fix would never
-  // engage on the common single-instance install. Fully try/caught; never
-  // throws.
+  // best-effort WAL-checkpoint. First run ~5 min after boot, then every 24h.
+  //
+  // Runs UNCONDITIONALLY on every instance — deliberately NOT gated to the
+  // home/primary instance. cross_host_calls is written per-instance by
+  // auditCrossHostCall into each instance's OWN local crow.db; there is no
+  // shared/central audit table. Gating on is_home would leave non-home peers
+  // (grackle, black-swan) never pruning their own table → unbounded growth →
+  // the exact corruption this fix exists to prevent. Same-host multi-process
+  // gateways use SEPARATE data dirs (crow-mpa → CROW_DATA_DIR=~/.crow-mpa/data),
+  // so there is no shared-file contention to avoid; and if two processes ever
+  // did share one file, concurrent DELETE+checkpoint just serialize harmlessly
+  // on busy_timeout. Also runs regardless of --no-auth (harmless — a --no-auth
+  // box may point at a throwaway DB). Fully try/caught; never throws.
   {
     const XHOST_AUDIT_PRUNE_BOOT_DELAY_MS = 5 * 60 * 1000;    // 5 min
     const XHOST_AUDIT_PRUNE_INTERVAL_MS   = 24 * 60 * 60 * 1000; // 24h
 
-    const isHomeOrStandalone = async (db) => {
-      const { getOrCreateLocalInstanceId, getInstance, getHomeInstance } =
-        await import("../instance-registry.js");
-      const localId = getOrCreateLocalInstanceId();
-      const local = await getInstance(db, localId);
-      if (local?.is_home === 1) return true;
-      const home = await getHomeInstance(db);
-      return !home; // nobody designated home yet — treat this instance as primary
-    };
-
-    const runXhostAuditPrune = async () => {
-      try {
-        const { pruneCrossHostAudit } = await import("../../shared/cross-host-audit-retention.js");
-        const db = createDbClient();
-        try {
-          if (!(await isHomeOrStandalone(db))) return;
-          const { deleted, checkpointed } = await pruneCrossHostAudit(db);
-          if (deleted > 0) {
-            console.log(`[xhost-audit-retention] pruned ${deleted} row(s) from cross_host_calls (checkpointed=${checkpointed})`);
-          }
-        } finally {
-          try { db.close(); } catch {}
-        }
-      } catch (err) {
-        console.warn("[xhost-audit-retention] cycle error:", err?.message || err);
-      }
-    };
-
     setTimeout(() => {
-      runXhostAuditPrune();
-      setInterval(runXhostAuditPrune, XHOST_AUDIT_PRUNE_INTERVAL_MS).unref();
+      runCrossHostAuditPrune(createDbClient);
+      setInterval(() => runCrossHostAuditPrune(createDbClient), XHOST_AUDIT_PRUNE_INTERVAL_MS).unref();
     }, XHOST_AUDIT_PRUNE_BOOT_DELAY_MS).unref();
 
     console.log("[xhost-audit-retention] armed (24h interval, first run in 5 min)");

--- a/servers/gateway/dashboard/panels/nest/health-signals.js
+++ b/servers/gateway/dashboard/panels/nest/health-signals.js
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { t } from "../../shared/i18n.js";
 import { PUBLIC_FUNNEL_PREFIXES } from "../../../funnel.js";
+import { isAuditDegraded } from "../../../../shared/cross-host-auth.js";
 
 // ─── Module-level 30s cache ───────────────────────────────────────────────────
 
@@ -553,6 +554,29 @@ async function integrationsSignal(db, lang) {
   };
 }
 
+// Federation audit DB corruption — the in-process circuit-breaker in
+// cross-host-auth.js trips when the cross_host_calls audit table goes
+// structurally corrupt. Surface it in the nest so a malformed-audit-DB
+// condition is LOUD (not the silent multi-day degradation that happened
+// twice). No DB read — reads the per-process breaker flag.
+function federationAuditSignal(lang) {
+  if (!isAuditDegraded()) {
+    return {
+      id: "federationAudit", severity: null, state: "ok",
+      label: t("signals.federationAudit.label", lang),
+      value: t("signals.federationAudit.ok", lang),
+    };
+  }
+  return {
+    id: "federationAudit", severity: "warn", state: "warn",
+    label: t("signals.federationAudit.label", lang),
+    value: t("signals.federationAudit.degraded", lang),
+    issueLabel: t("signals.federationAudit.issue", lang),
+    actionLabel: t("signals.federationAudit.action", lang),
+    actionHref: "/dashboard/nest",
+  };
+}
+
 // ─── Main export ──────────────────────────────────────────────────────────────
 
 /**
@@ -581,6 +605,7 @@ export async function collectHealthSignals(db, opts = {}) {
     loginsSignal(db, lang),
     exposureSignal(lang, nowFn),
     integrationsSignal(db, lang),
+    federationAuditSignal(lang),
   ].map(p => Promise.resolve(p).catch(err => ({
     id: "unknown",
     severity: null,

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -197,6 +197,12 @@ export const translations = {
   "signals.backup.neverIssue": { en: "Backups aren't set up yet", es: "Las copias de seguridad aún no están configuradas" },
   "signals.backup.staleIssue": { en: "Last backup was {n} days ago", es: "La última copia de seguridad fue hace {n} días" },
 
+  "signals.federationAudit.label": { en: "Federation audit", es: "Auditoría de federación" },
+  "signals.federationAudit.ok": { en: "logging", es: "registrando" },
+  "signals.federationAudit.degraded": { en: "paused", es: "en pausa" },
+  "signals.federationAudit.issue": { en: "The federation audit database is corrupted — federation still works, but audit logging is paused. Run npm run recover-db to rebuild it.", es: "La base de datos de auditoría de federación está dañada — la federación sigue funcionando, pero el registro de auditoría está en pausa. Ejecuta npm run recover-db para reconstruirla." },
+  "signals.federationAudit.action": { en: "How to recover", es: "Cómo recuperar" },
+
   // ─── Nest Panel ───
   "nest.pinned": { en: "Pinned", es: "Fijados" },
   "nest.instances": { en: "Instances", es: "Instancias" },

--- a/servers/shared/cross-host-audit-retention.js
+++ b/servers/shared/cross-host-audit-retention.js
@@ -1,0 +1,62 @@
+/**
+ * Bounded retention for cross_host_calls — the federation audit table that
+ * has corrupted crow's DB twice (2026-06-14, 2026-07-02) as an unbounded
+ * append-only, high-write table. This is the root-cause fix: keep the table
+ * small so there is far less corruption surface and any recovery is fast.
+ *
+ * Retention default is 14 days, NOT 7 — health-signals.js's
+ * `integrationsSignal` (:493-506) reads a 7-day window to find the latest
+ * failing peer per instance. A 7-day retention would let the prune delete
+ * that "latest failing peer" row out from under it and silence the warning,
+ * reintroducing the exact silent-degradation failure mode this hardening is
+ * meant to fix. 14 days keeps a comfortable margin over both known readers
+ * (the dashboard audit-log view's 24h window, and the 7-day integrations
+ * signal) while still keeping the table tiny.
+ *
+ * This function is deliberately unable to make things worse: it NEVER
+ * rejects/throws, under any failure (missing table, closed db, malformed
+ * disk image, IOERR, whatever) — a failure here must not take down boot or
+ * cascade into another outage.
+ */
+
+/**
+ * @param {{execute: Function}} db - a db client (createDbClient() shape).
+ * @param {{retentionDays?: number}} [opts]
+ * @returns {Promise<{deleted: number, checkpointed: boolean}>} never rejects.
+ */
+export async function pruneCrossHostAudit(db, opts = {}) {
+  const retentionDays = Number.isFinite(opts.retentionDays) ? opts.retentionDays : 14;
+
+  try {
+    let deleted = 0;
+    try {
+      const result = await db.execute({
+        sql: "DELETE FROM cross_host_calls WHERE at < datetime('now', ?)",
+        args: [`-${retentionDays} days`],
+      });
+      deleted = Number(result?.rowsAffected || 0);
+    } catch (err) {
+      console.warn("[cross-host-audit-retention] prune failed (non-fatal):", err?.message || err);
+      return { deleted: 0, checkpointed: false };
+    }
+
+    // Best-effort checkpoint. In WAL mode this reclaims the space just
+    // freed by the DELETE above; in DELETE-journal mode (low-RAM hosts,
+    // see db.js resolveJournalMode) it's a harmless no-op. Never allowed
+    // to fail the whole call — a checkpoint failure must not propagate.
+    let checkpointed = false;
+    try {
+      await db.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+      checkpointed = true;
+    } catch (err) {
+      console.warn("[cross-host-audit-retention] checkpoint failed (non-fatal):", err?.message || err);
+    }
+
+    return { deleted, checkpointed };
+  } catch (err) {
+    // Belt-and-suspenders: any unexpected synchronous throw (e.g. a db
+    // handle that isn't even shaped right) must still resolve, not reject.
+    console.warn("[cross-host-audit-retention] unexpected error (non-fatal):", err?.message || err);
+    return { deleted: 0, checkpointed: false };
+  }
+}

--- a/servers/shared/cross-host-auth.js
+++ b/servers/shared/cross-host-auth.js
@@ -216,16 +216,134 @@ export function verifyRequest({ method, path, body, headers, signingKey, skewMs 
 }
 
 // -----------------------------------------------------------------------
-// Audit logging
+// Audit logging + corruption circuit-breaker
 // -----------------------------------------------------------------------
+//
+// The `cross_host_calls` audit table has now corrupted TWICE the same way
+// (2026-06-14, 2026-07-02): an unbounded high-write table whose crash-mid-
+// write orphaned pages, then spammed 40k "disk image is malformed" errors
+// while federation degraded SILENTLY for days. This breaker converts that
+// silent-degradation failure mode into a LOUD, self-limiting one:
+//
+//   • Structural insert errors (malformed / not-a-database / disk image /
+//     disk I/O / SQLITE_IOERR) increment a counter. Past a threshold the
+//     breaker OPENS: subsequent audit inserts short-circuit (skip the
+//     INSERT) so we stop feeding the corruption.
+//   • On trip we fire a LOUD alert. CRITICAL: the alert must NOT depend on
+//     a write to the corrupt DB — `createNotification` (notifications.js:63)
+//     INSERTs to the same crow.db BEFORE it sends ntfy/email, so those loud
+//     channels never fire when the DB is malformed. We therefore call the
+//     DB-free push exports DIRECTLY (sendNtfyNotification / sendEmailNotif).
+//   • Transient SQLITE_BUSY does NOT trip it.
+//   • The alert re-arms after a ~6h cooldown so a days-long degradation
+//     re-alerts instead of going silent after the first ping.
+//
+// Per-process singleton: assumes ONE crow.db file per process (true on this
+// fleet). All flags reset on process restart (and via _resetAuditBreaker()).
+// -----------------------------------------------------------------------
+
+const AUDIT_STRUCTURAL_RE = /malformed|not a database|disk image|disk I\/O|SQLITE_IOERR/i;
+const AUDIT_TRIP_THRESHOLD = 3;
+const AUDIT_ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6h re-arm
+
+let _auditStructuralCount = 0;
+let _auditDisabled = false;
+let _auditNotified = false;
+let _auditNotifiedAt = 0;
+
+// Injectable clock (test hook) so the 6h re-arm is deterministic in tests.
+let _auditNow = () => Date.now();
+
+// Overridable alert channels (test hook). Production leaves this null and
+// dynamic-imports the REAL DB-free push modules — NOT notifications.js.
+let _auditAlertChannels = null;
+
+/**
+ * Resolve the DB-free alert channels. Exported so a test can assert the
+ * default wiring points at gateway/push/{ntfy,email}.js (NOT createNotification,
+ * which writes to the corrupt DB first — the round-2 review bug this guards).
+ */
+export async function _loadAlertChannels() {
+  if (_auditAlertChannels) return _auditAlertChannels;
+  const [ntfy, email] = await Promise.all([
+    import("../gateway/push/ntfy.js"),
+    import("../gateway/push/email.js"),
+  ]);
+  return {
+    sendNtfyNotification: ntfy.sendNtfyNotification,
+    sendEmailNotification: email.sendEmailNotification,
+  };
+}
+
+/**
+ * Fire the loud corruption alert if due (one-shot with 6h re-arm). Never
+ * throws — a push/email failure must never propagate into the auth path.
+ */
+async function fireCorruptionAlertIfDue() {
+  const now = _auditNow();
+  if (_auditNotified && (now - _auditNotifiedAt) < AUDIT_ALERT_COOLDOWN_MS) return;
+  _auditNotified = true;
+  _auditNotifiedAt = now;
+  try {
+    const ch = await _loadAlertChannels();
+    const payload = {
+      title: "Federation audit DB is corrupted",
+      body: "Federation audit DB is corrupted — run `npm run recover-db`; federation still works, audit logging paused.",
+      url: "/dashboard/nest",
+      priority: "high", // high → the email channel actually sends
+      type: "system",
+    };
+    // Route through BOTH DB-free channels directly (no createNotification).
+    await ch.sendNtfyNotification(payload);
+    await ch.sendEmailNotification(payload);
+  } catch (err) {
+    // A push/email failure must never break federation auth.
+    console.warn(`[cross-host-auth] corruption alert failed: ${err?.message}`);
+  }
+}
+
+/** True when the audit breaker is open (structural corruption detected). */
+export function isAuditDegraded() {
+  return _auditDisabled;
+}
+
+/** Test hook: clear counter + _auditDisabled + _notified + cooldown + clock. */
+export function _resetAuditBreaker() {
+  _auditStructuralCount = 0;
+  _auditDisabled = false;
+  _auditNotified = false;
+  _auditNotifiedAt = 0;
+  _auditNow = () => Date.now();
+}
+
+/** Test hook: override the alert channels (stub ntfy/email). */
+export function _setAlertChannels(channels) {
+  _auditAlertChannels = channels;
+}
+
+/** Test hook: override the clock used for the 6h re-arm cooldown. */
+export function _setAuditClock(fn) {
+  _auditNow = fn || (() => Date.now());
+}
 
 /**
  * Record a cross-host call attempt in the cross_host_calls table.
  *
- * Never throws: audit failure must not break the primary action.
+ * Never throws: audit failure must not break the primary action. When the
+ * corruption breaker is open, the INSERT is skipped entirely (and the alert
+ * re-arms if the cooldown has elapsed).
  */
 export async function auditCrossHostCall(db, record) {
   if (!db) return;
+
+  // Breaker open — stop feeding the corruption; skip the INSERT.
+  if (_auditDisabled) {
+    // Re-arm the loud alert if the cooldown elapsed (days-long degradation
+    // must re-alert; once disabled no inserts run so the error path can't).
+    await fireCorruptionAlertIfDue();
+    return;
+  }
+
   try {
     await db.execute({
       sql: `INSERT INTO cross_host_calls
@@ -248,8 +366,17 @@ export async function auditCrossHostCall(db, record) {
       ],
     });
   } catch (err) {
-    // Swallow — audit must not break the primary path
+    // Swallow — audit must not break the primary path.
     console.warn(`[cross-host-auth] audit write failed: ${err.message}`);
+    // Only STRUCTURAL corruption trips the breaker; transient SQLITE_BUSY
+    // (contention) must not.
+    if (AUDIT_STRUCTURAL_RE.test(err?.message || "")) {
+      _auditStructuralCount++;
+      if (!_auditDisabled && _auditStructuralCount >= AUDIT_TRIP_THRESHOLD) {
+        _auditDisabled = true;
+        await fireCorruptionAlertIfDue();
+      }
+    }
   }
 }
 

--- a/tests/cross-host-audit-breaker.test.js
+++ b/tests/cross-host-audit-breaker.test.js
@@ -1,0 +1,169 @@
+/**
+ * cross-host-audit-breaker.test.js
+ *
+ * Task 2: circuit-breaker + DB-free loud alert when the cross_host_calls
+ * audit DB goes structurally corrupt.
+ *
+ * Contract under test (all in servers/shared/cross-host-auth.js):
+ *  - 3 STRUCTURAL insert errors (malformed / not-a-database / disk image /
+ *    disk I/O / SQLITE_IOERR) trip the breaker → isAuditDegraded() === true.
+ *  - Once tripped, auditCrossHostCall short-circuits: it does NOT call
+ *    db.execute (stop feeding the corruption).
+ *  - Exactly one LOUD alert fires on trip, routed through the DB-free push
+ *    channels (sendNtfyNotification / sendEmailNotification) — NOT
+ *    createNotification (which INSERTs to the same corrupt crow.db first).
+ *  - A transient SQLITE_BUSY does NOT trip it; an IOERR DOES.
+ *  - After a ~6h cooldown the alert RE-ARMS (a days-long degradation
+ *    re-alerts instead of going silent after the first ping).
+ *  - _resetAuditBreaker() clears every flag.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  auditCrossHostCall,
+  isAuditDegraded,
+  _resetAuditBreaker,
+  _setAlertChannels,
+  _setAuditClock,
+  _loadAlertChannels,
+} from "../servers/shared/cross-host-auth.js";
+
+import { sendNtfyNotification as realNtfy } from "../servers/gateway/push/ntfy.js";
+import { sendEmailNotification as realEmail } from "../servers/gateway/push/email.js";
+
+const REC = { direction: "inbound", action: "test.audit" };
+
+// A db whose .execute always throws `err` and counts its invocations.
+function throwingDb(err) {
+  const db = {
+    calls: 0,
+    async execute() {
+      db.calls++;
+      throw err;
+    },
+  };
+  return db;
+}
+
+function spyChannels() {
+  const spy = { ntfy: 0, email: 0, lastPayload: null };
+  _setAlertChannels({
+    async sendNtfyNotification(p) { spy.ntfy++; spy.lastPayload = p; },
+    async sendEmailNotification(p) { spy.email++; },
+  });
+  return spy;
+}
+
+test("3 malformed insert errors trip the breaker and fire exactly one alert", async () => {
+  _resetAuditBreaker();
+  const spy = spyChannels();
+  const db = throwingDb(new Error("database disk image is malformed"));
+
+  assert.equal(isAuditDegraded(), false);
+  for (let i = 0; i < 3; i++) await auditCrossHostCall(db, REC);
+
+  assert.equal(isAuditDegraded(), true, "breaker tripped after 3 structural errors");
+  assert.equal(db.calls, 3, "all 3 inserts were attempted before tripping");
+  assert.equal(spy.ntfy, 1, "one ntfy alert on trip");
+  assert.equal(spy.email, 1, "one email alert on trip");
+  assert.match(spy.lastPayload.body, /recover-db/);
+  assert.equal(spy.lastPayload.priority, "high", "high priority so the email channel actually sends");
+  _resetAuditBreaker();
+});
+
+test("once tripped, auditCrossHostCall does NOT touch db.execute", async () => {
+  _resetAuditBreaker();
+  spyChannels();
+  const db = throwingDb(new Error("database disk image is malformed"));
+  for (let i = 0; i < 3; i++) await auditCrossHostCall(db, REC);
+  assert.equal(db.calls, 3);
+
+  // Breaker open → subsequent calls skip the INSERT entirely.
+  await auditCrossHostCall(db, REC);
+  await auditCrossHostCall(db, REC);
+  assert.equal(db.calls, 3, "no further db.execute while breaker is open");
+  _resetAuditBreaker();
+});
+
+test("transient SQLITE_BUSY does NOT trip the breaker", async () => {
+  _resetAuditBreaker();
+  const spy = spyChannels();
+  const db = throwingDb(new Error("SQLITE_BUSY: database is locked"));
+  for (let i = 0; i < 6; i++) await auditCrossHostCall(db, REC);
+  assert.equal(isAuditDegraded(), false, "SQLITE_BUSY is transient, must not trip");
+  assert.equal(db.calls, 6, "keeps attempting inserts (never short-circuits)");
+  assert.equal(spy.ntfy, 0, "no alert for transient errors");
+  _resetAuditBreaker();
+});
+
+test("SQLITE_IOERR (structural) DOES trip the breaker", async () => {
+  _resetAuditBreaker();
+  spyChannels();
+  const db = throwingDb(new Error("SQLITE_IOERR: disk I/O error"));
+  for (let i = 0; i < 3; i++) await auditCrossHostCall(db, REC);
+  assert.equal(isAuditDegraded(), true, "IOERR is structural, must trip");
+  _resetAuditBreaker();
+});
+
+test("alert re-arms after the ~6h cooldown", async () => {
+  _resetAuditBreaker();
+  let clock = 1_000_000_000;
+  _setAuditClock(() => clock);
+  const spy = spyChannels();
+  const db = throwingDb(new Error("database disk image is malformed"));
+
+  for (let i = 0; i < 3; i++) await auditCrossHostCall(db, REC);
+  assert.equal(spy.ntfy, 1, "alerted once on trip");
+
+  // Still within cooldown → no re-alert on subsequent (short-circuited) calls.
+  clock += 60 * 60 * 1000; // +1h
+  await auditCrossHostCall(db, REC);
+  assert.equal(spy.ntfy, 1, "no re-alert within cooldown");
+
+  // Past 6h → re-arm fires again.
+  clock += 6 * 60 * 60 * 1000; // +6h more
+  await auditCrossHostCall(db, REC);
+  assert.equal(spy.ntfy, 2, "re-alerted after 6h cooldown");
+  _resetAuditBreaker();
+});
+
+test("_resetAuditBreaker clears all breaker state", async () => {
+  _resetAuditBreaker();
+  spyChannels();
+  const db = throwingDb(new Error("database disk image is malformed"));
+  for (let i = 0; i < 3; i++) await auditCrossHostCall(db, REC);
+  assert.equal(isAuditDegraded(), true);
+
+  _resetAuditBreaker();
+  assert.equal(isAuditDegraded(), false, "reset clears the tripped flag");
+
+  // After reset, a fresh healthy db is used again (no short-circuit).
+  const ok = { calls: 0, async execute() { ok.calls++; return { rows: [] }; } };
+  await auditCrossHostCall(ok, REC);
+  assert.equal(ok.calls, 1, "reset re-enables inserts");
+  _resetAuditBreaker();
+});
+
+test("default alert channels resolve to the DB-free push modules, NOT createNotification", async () => {
+  _setAlertChannels(null); // clear any test override → exercise the real dynamic import
+  const ch = await _loadAlertChannels();
+  assert.strictEqual(ch.sendNtfyNotification, realNtfy, "uses gateway/push/ntfy.js sendNtfyNotification");
+  assert.strictEqual(ch.sendEmailNotification, realEmail, "uses gateway/push/email.js sendEmailNotification");
+});
+
+test("a throwing alert channel never propagates into the auth path", async () => {
+  _resetAuditBreaker();
+  _setAlertChannels({
+    async sendNtfyNotification() { throw new Error("ntfy down"); },
+    async sendEmailNotification() { throw new Error("resend down"); },
+  });
+  const db = throwingDb(new Error("database disk image is malformed"));
+  // Must not reject even though both alert channels throw.
+  await assert.doesNotReject(async () => {
+    for (let i = 0; i < 3; i++) await auditCrossHostCall(db, REC);
+  });
+  assert.equal(isAuditDegraded(), true);
+  _resetAuditBreaker();
+});

--- a/tests/cross-host-audit-retention.test.js
+++ b/tests/cross-host-audit-retention.test.js
@@ -1,0 +1,101 @@
+/**
+ * Task 1 (cross_host_calls corruption hardening, 2026-07-02 plan): bounded
+ * retention for the cross_host_calls audit table.
+ *
+ * cross_host_calls has corrupted crow's DB twice (2026-06-14, 2026-07-02) as
+ * an unbounded append-only high-write table. pruneCrossHostAudit() deletes
+ * rows older than a retention window (default 14 days — verified-facts in
+ * the plan show a 7-day integrations reader in health-signals.js:493-506,
+ * so retention MUST exceed 7 days with margin) and best-effort checkpoints
+ * the WAL. It must never reject, even against a closed/broken db handle.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "xhost-retention-"));
+const dbPath = join(dir, "crow.db");
+
+before(() => {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: new URL("..", import.meta.url).pathname,
+  });
+});
+
+after(() => rmSync(dir, { recursive: true, force: true }));
+
+function isoDaysAgo(days) {
+  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return d.toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
+}
+
+async function insertRow(db, ageDays) {
+  await db.execute({
+    sql: `INSERT INTO cross_host_calls
+            (source_instance_id, target_instance_id, direction, action, at)
+          VALUES (?, ?, 'outbound', 'test-action', ?)`,
+    args: ["inst-a", "inst-b", isoDaysAgo(ageDays)],
+  });
+}
+
+test("default retention (14d) deletes only the 20d-old row", async () => {
+  const { createDbClient } = await import("../servers/db.js");
+  const { pruneCrossHostAudit } = await import("../servers/shared/cross-host-audit-retention.js");
+
+  const db = createDbClient(dbPath);
+  await insertRow(db, 0);
+  await insertRow(db, 2);
+  await insertRow(db, 10);
+  await insertRow(db, 20);
+
+  const before = await db.execute("SELECT COUNT(*) AS n FROM cross_host_calls");
+  assert.equal(before.rows[0].n, 4);
+
+  const result = await pruneCrossHostAudit(db);
+  assert.equal(result.deleted, 1, "only the 20d-old row should be deleted at the 14d default");
+  assert.equal(typeof result.checkpointed, "boolean");
+
+  const after = await db.execute("SELECT COUNT(*) AS n FROM cross_host_calls");
+  assert.equal(after.rows[0].n, 3, "now/2d/10d rows must remain — proves the shipped default is 14d, not <10d");
+
+  // A second call at the same retention deletes nothing further.
+  const second = await pruneCrossHostAudit(db);
+  assert.equal(second.deleted, 0);
+
+  // Explicit 7-day retention now also removes the 10d-old row.
+  const third = await pruneCrossHostAudit(db, { retentionDays: 7 });
+  assert.equal(third.deleted, 1);
+
+  const finalCount = await db.execute("SELECT COUNT(*) AS n FROM cross_host_calls");
+  assert.equal(finalCount.rows[0].n, 2, "only now/2d rows survive a 7d retention pass");
+
+  await db.close();
+});
+
+test("never rejects against a closed/broken db handle", async () => {
+  const { pruneCrossHostAudit } = await import("../servers/shared/cross-host-audit-retention.js");
+
+  const brokenDb = {
+    async execute() {
+      throw new Error("SQLITE_IOERR: disk I/O error");
+    },
+  };
+
+  const result = await pruneCrossHostAudit(brokenDb);
+  assert.deepEqual(result, { deleted: 0, checkpointed: false });
+
+  // A db that throws synchronously (not even returning a promise) must also
+  // resolve rather than reject the pruneCrossHostAudit() promise.
+  const syncThrowDb = {
+    execute() {
+      throw new Error("database is closed");
+    },
+  };
+  const result2 = await pruneCrossHostAudit(syncThrowDb);
+  assert.deepEqual(result2, { deleted: 0, checkpointed: false });
+});

--- a/tests/cross-host-audit-retention.test.js
+++ b/tests/cross-host-audit-retention.test.js
@@ -77,6 +77,32 @@ test("default retention (14d) deletes only the 20d-old row", async () => {
   await db.close();
 });
 
+test("boot wiring: runCrossHostAuditPrune prunes the real table via a db factory and never throws", async () => {
+  const { createDbClient } = await import("../servers/db.js");
+  const { runCrossHostAuditPrune } = await import("../servers/gateway/boot/post-listen.js");
+
+  // Seed one stale (20d) row that the default 14d retention must remove.
+  const seed = createDbClient(dbPath);
+  await insertRow(seed, 20);
+  const beforeCount = (await seed.execute("SELECT COUNT(*) AS n FROM cross_host_calls")).rows[0].n;
+  await seed.close();
+
+  // The boot timer calls runCrossHostAuditPrune(createDbClient). We inject a
+  // factory bound to the temp DB so the test drives the same code path.
+  const result = await runCrossHostAuditPrune(() => createDbClient(dbPath));
+  assert.equal(typeof result.deleted, "number");
+  assert.ok(result.deleted >= 1, "the 20d-old seed row must be pruned by the default 14d retention");
+
+  const check = createDbClient(dbPath);
+  const afterCount = (await check.execute("SELECT COUNT(*) AS n FROM cross_host_calls")).rows[0].n;
+  await check.close();
+  assert.equal(afterCount, beforeCount - result.deleted, "row count must drop by exactly the reported deleted count");
+
+  // A factory that throws must still resolve (never throw) with a zero result.
+  const bad = await runCrossHostAuditPrune(() => { throw new Error("db open failed"); });
+  assert.deepEqual(bad, { deleted: 0, checkpointed: false });
+});
+
 test("never rejects against a closed/broken db handle", async () => {
   const { pruneCrossHostAudit } = await import("../servers/shared/cross-host-audit-retention.js");
 


### PR DESCRIPTION
Follow-up to today's crow `:3001` DB recovery. The `cross_host_calls` federation audit table has now corrupted crow's DB **twice the same way** (2026-06-14, 2026-07-02) — each time an unbounded, append-only, high-write table whose crash-mid-write orphaned pages, spammed ~40k "disk image is malformed" errors, and degraded federation **silently for hours/days**. The 2026-06-14 fix hardened the *symptom* (never-throw audit + validateInstanceToken retry); this attacks the root cause. Plan (2-round adversarial review): `docs/superpowers/plans/2026-07-02-cross-host-audit-hardening.md`.

Three independent, defense-in-depth layers:

**1. Bounded retention (root cause).** `pruneCrossHostAudit` deletes `cross_host_calls` rows older than **14 days** + `wal_checkpoint(TRUNCATE)`, on a 24h `setInterval().unref()` timer, on **every instance** (each writes its own local audit table — an early `is_home` gate was caught in review as wrong and removed). 14d chosen to exceed the 7-day `integrationsSignal` reader (`health-signals.js:493`) with margin; the dashboard only reads 24h. Never throws.

**2. Circuit-breaker + LOUD alert (kills the silent-degradation mode).** On ≥3 structural errors (`malformed|not a database|disk image|disk I/O|IOERR`; **not** transient `SQLITE_BUSY`), the breaker stops audit writes (quits feeding the corruption) and fires an alert that does **not** touch the corrupt DB — it calls `sendNtfyNotification`/`sendEmailNotification` directly (`gateway/push/ntfy.js`+`email.js`), NOT `createNotification` (which INSERTs to crow.db first, so those channels would never fire when it's malformed — caught in review). 6h re-arm so a persistent outage re-alerts; a new `federation-audit` nest health signal warns in the dashboard (EN+ES). All best-effort, never throws into the auth path.

**3. Scripted recovery (`npm run recover-db`).** Productizes today's proven manual recovery: `lsof`/`fuser` liveness gate (refuses a live DB without `--force`; `--dry-run` never swaps), backup-first, fresh schema from `init-db.js`, `INSERT OR REPLACE` copy of readable base tables, **preserves `crow_instances` when readable** (peer-auth trust anchor — skipping it blacks out federation), skips only the expendable `cross_host_calls`/`mcp_sessions`, FTS rebuilt via triggers, `.env` MCP-token hash re-injected. **Two swap gates: `integrity_check` == ok AND per-table row-count completeness — a readable table whose row-copy fails ABORTS the swap** (closes the partial-corruption lossy-swap case). Runbook: `docs/developers/db-recovery.md`.

### Review gates
- Plan: 2-round adversarial review (round 1 = 4 criticals fixed; round 2 = wrong-module + stale-number fixes).
- Per-task: spec+quality review each, with fix loops — Task 1 `is_home` gate removed, Task 3 completeness-gate hole closed.
- Final whole-branch review (opus): **READY TO MERGE, no Critical/Important**, 27/27 tests green, gateway boots clean, all 8 `auditCrossHostCall` callers unaffected by the short-circuit.

### Tests
`tests/cross-host-audit-retention.test.js` (3), `tests/cross-host-audit-breaker.test.js` (8) new; `health-signals`/`cross-host-middleware` unchanged-green.

### Follow-ups (non-blocking)
- Direct end-to-end test for `federationAuditSignal` (currently covered transitively via the breaker tests).
- `recover-crow-db.mjs` lsof-absent soft-gate (returns "clean" if neither `lsof` nor `fuser` exists — mitigated by --dry-run/--force + build-from-backup + atomic swap).

### Operator note
Today's recovery dropped the corrupt `crow_instances`, so crow's two paired peers (creds still in `~/.crow/peer-tokens.json`) will be rejected until they re-enroll — a re-pair when convenient, not an active fire. This PR's recovery script preserves `crow_instances` in future runs.