### PR TITLE
fix(messages): L6 — unknown-sender DMs become Message Requests instead of vanishing

### DIFF
--- a/docs/superpowers/plans/2026-07-02-messages-p1b-l6-message-requests.md
+++ b/docs/superpowers/plans/2026-07-02-messages-p1b-l6-message-requests.md
@@ -1,0 +1,144 @@
+# Messages Phase 1b — L6 fix: Message Requests (no more silently-dropped DMs) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fix **L6** — the confirmed root cause of the operator's "message never received" bug. Today a decrypted plaintext DM from a sender who isn't a contact is **silently dropped** (`servers/sharing/nostr.js:379-393`: `subscribeToIncoming`'s `onevent` only acts on JSON `invite_accepted`/`crow_social`; plaintext falls through). After this: such a DM becomes a **message request** — stored, surfaced in the Messages UI with Accept/Decline, and (first-message-only) notified — so nothing vanishes and a half-completed contact handshake is recoverable in one click.
+
+**Architecture:** No new table. A minimal `contacts` row tagged with a new `request_status` column (three states: **NULL** = full contact; **'pending'** = unaccepted request; **'accepted'** = accepted-but-partial, secp-only) holds the unknown sender; the DM is stored as a normal `messages` row. A cold DM carries ONLY the 32-byte secp pubkey — no ed25519 key, no crow_id — so an accepted request is a **partial** contact that can receive/send DMs (`subscribeToContact` works off the secp key) but CANNOT do peer/DHT sync or be room-trusted until R4 supplies its real identity. Accept therefore moves 'pending'→**'accepted'** (NOT NULL — flipping to NULL would make the malformed-identity row masquerade as a full contact in the boot peer-join loop, sync, and room trust). The `request_status` gate is applied at the **complete** set of surfaces a partial row must be excluded from (see Task 3 — 7 surfaces, security-relevant).
+
+**Tech Stack:** Node 20, `servers/sharing/{nostr.js,boot.js}`, `servers/gateway/dashboard/panels/messages/{data-queries.js,html.js,api-handlers.js,client.js}`, `scripts/init-db.js`, `servers/shared/notifications.js`, `node --test`.
+
+## Verified facts (explored 2026-07-02)
+
+- **Drop site:** `nostr.js:369-393` `onevent` — decrypt succeeds, then `if (decrypted.startsWith("{"))` routes JSON only; plaintext (a real human DM) is discarded. `senderPubkey = event.pubkey` is 32-byte x-only (64 hex); stored `contacts.secp256k1_pubkey` is 33-byte compressed (66 hex, `02`/`03` prefix). **Any pubkey match must normalize to trailing-64 lowercase** (the existing pattern at `data-queries.js:171`).
+- **`messages`** (`init-db.js:531-547`): `contact_id INTEGER NOT NULL` FK → a message REQUIRES a contacts row (hence the minimal request contact). Received insert shape at `nostr.js:252-256` (`INSERT OR IGNORE`, `nostr_event_id UNIQUE` dedup).
+- **`contacts`** (`init-db.js:454-464` + migrations): `crow_id NOT NULL UNIQUE`, `ed25519_pubkey NOT NULL`, `secp256k1_pubkey NOT NULL`. A cold sender gives only the secp key → synthesize `crow_id='req:<pubkey16>'`, `ed25519_pubkey=''` placeholder. `origin` column already models discovery-source ('advertised'); a dedicated `request_status` column is cleaner than overloading it (chosen).
+- **Gating points (COMPLETE set — review found the plan's original "3 gates" incomplete, incl. a security bypass):**
+  1. `getUnifiedConversationList` (`data-queries.js:51`) — exclude 'pending' (show NULL + 'accepted').
+  2. `getBotDirectory` pubkey map (`data-queries.js:168`) — exclude non-NULL.
+  3. Boot subscribe loop (`boot.js:180`, `WHERE is_blocked=0`) — SPLIT: NULL → `initContact`+`joinContact`+`subscribeToContact`; 'accepted' → `subscribeToContact` ONLY (no ed25519 → joinContact('')  is a no-op error every boot); 'pending' → skip (broad `subscribeToIncoming` covers it).
+  4. **`room-inbound.js:27` (SECURITY, C1)** — `room_join` trust reads `SELECT secp256k1_pubkey FROM contacts WHERE is_blocked=0`; a bare request row would PASS → a stranger who DMs (creates a request) then sends `room_join` gains room-host trust. Gate on `request_status IS NULL`. Same for the member/host matches at `:52`/`:55`.
+  5. Contacts panel `getContacts` (`servers/gateway/dashboard/panels/contacts/data-queries.js:41`) — exclude non-NULL (else `req:` rows show as bare contacts).
+  6. `crow_list_contacts` MCP tool (`servers/sharing/tools/contacts.js:245`) — exclude non-NULL.
+  7. **Sync:** `contacts` is in `SYNCED_TABLES` (`instance-sync.js:52`) BUT there is **no `emitChange("contacts")` anywhere** (grep-confirmed) → contacts do NOT push-sync today, so request rows won't propagate. Defensive: if an outbound/`shouldSyncRow` filter exists, exclude non-NULL `request_status`; the new column is nullable so a not-yet-upgraded peer's apply self-heals (`instance-sync.js:595-597`).
+- **Wiring:** `subscribeToIncoming(onInviteAccepted, onSocialMessage)` (`nostr.js:357`) is wired once at `boot.js:211`; add a 3rd `onMessageRequest` callback.
+- **UI:** Messages panel `messages.js` → `buildMessagesHTML` (`html.js`); a "Requests (N)" block slots at `html.js:126` next to `botInviteCard`; the `msg-bot-invite-card` form (`html.js:39-47`) is the Accept-button template. POST actions handled in `api-handlers.js` (`send_peer`/`block`/`accept_invite` pattern), each `res.redirectAfterPost("/dashboard/messages")`.
+- **Notifications:** `createNotification` (`notifications.js:28`) has NO per-sender cap — the request path must cap itself (first message only).
+
+## Global Constraints
+
+- Branch `fix/messages-l6-requests`. Positional-path commits; `git show --stat HEAD` after each.
+- Tests: `node --test tests/<file>.test.js`. Gateway must boot: `node servers/gateway/index.js --no-auth`.
+- The receive path is live-messaging-critical: every new branch is defensively try/caught and must NEVER throw out of `onevent` (a throw kills the subscription). Preserve the existing "never break delivery" contract.
+- FTS/schema: `contacts` has no FTS shadow; `request_status` is a plain nullable column via `addColumnIfMissing` (idempotent, matches `init-db.js:1818` style).
+- Deploy note: after merge, crow's gateway restart picks it up; fleet via pull-only auto-update.
+
+---
+
+### Task 1: Schema + shared pubkey/lookup helpers
+
+**Files:**
+- Modify: `scripts/init-db.js` — `addColumnIfMissing("contacts", "request_status", "TEXT")` (nullable; NULL = normal contact, 'pending' = unaccepted request), near the other contacts `addColumnIfMissing` calls (~:1818-1822).
+- Create: `servers/sharing/pubkey-util.js` — `normalizePubkey(pk)` → trailing-64 lowercase (`String(pk).slice(-64).toLowerCase()`); `findContactByPubkey(db, pk)` → `SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ?` bound to `normalizePubkey(pk)`, returns row or null.
+- Test: `tests/pubkey-util.test.js`
+
+**Interfaces:**
+- Produces: `normalizePubkey(pk:string):string`, `findContactByPubkey(db, pk):Promise<row|null>`.
+
+- [ ] **Step 1:** Test `normalizePubkey`: 66-hex-with-02prefix and the same 64-hex-x-only normalize equal; case-insensitive. Test `findContactByPubkey` against a temp init-db DB: insert a contact with a 66-hex secp key, look it up by the 64-hex x-only form → found; unknown key → null.
+- [ ] **Step 2:** Run → FAIL (module/column absent).
+- [ ] **Step 3:** Add the migration + implement `pubkey-util.js`.
+- [ ] **Step 4:** Run → PASS. Verify migration idempotent: run `CROW_DB_PATH=<tmp> node scripts/init-db.js` twice, no error, column present once.
+- [ ] **Step 5:** Commit `feat(messages): request_status column + pubkey normalize/lookup helpers (L6 groundwork)`.
+
+### Task 2: Receive-path — plaintext-from-unknown becomes a request (the core fix)
+
+**Files:**
+- Modify: `servers/sharing/nostr.js` — `subscribeToIncoming` gains a 3rd param `onMessageRequest`. **The onevent restructure (M1): thread a `handled` flag that tracks "a handler was ACTUALLY INVOKED" (not merely "type string matched")** through the `if (decrypted.startsWith("{"))` block — set `handled=true` ONLY on the exact conditions the current code invokes a handler: `payload.type==='invite_accepted' && onInviteAccepted` → invoke, handled=true; `payload.type==='crow_social' && payload.subtype && onSocialMessage` → invoke, handled=true. A `crow_social` WITHOUT a subtype, an unknown type, and a `JSON.parse` throw (starts with `{` but malformed) all leave `handled=false`. After the block, `if (!handled) await onMessageRequest(senderPubkey, decrypted, event)` — so plaintext, malformed JSON, AND a subtype-less crow_social all route to the request path (never silently dropped) without double-firing on a real handled envelope. This covers plaintext (never entered the block) AND unknown/malformed JSON, and MUST NOT double-fire for a matched type. Guard the call in its own try/catch; never throw out of onevent.
+- Modify: `servers/sharing/boot.js` — at the `subscribeToIncoming(...)` wiring (:211), pass `onMessageRequest`. Prefer an exported testable `handleIncomingRequest(db, managers, {senderPubkey, content, eventId})`: (a) `findContactByPubkey`; if a contact with `request_status IS NULL` exists → do nothing (the per-contact sub already stores it — avoids double-store); if a `request_status IN ('pending','accepted')` contact exists → reuse its id; else INSERT a minimal request contact — **`crow_id='req:'+normalizePubkey(pk)` (FULL 64-hex, not truncated — a 16-hex prefix can collide → UNIQUE violation → the colliding sender's DM re-dropped, reintroducing L6)**, `secp256k1_pubkey=pk`, `ed25519_pubkey=''`, `display_name=NULL`, `request_status='pending'`, `contact_type='crow'`. Capture whether the row was NEWLY created. (b) `INSERT OR IGNORE INTO messages (...)` direction='received', is_read=0, keyed by `event.id`. (c) **Notify only when the request contact row was NEWLY created this call** (deterministic first-contact signal — NOT a post-insert `count==1`, which races at the async INSERT/COUNT boundary), `source:"sharing:message_request"`, `action_url:"/dashboard/messages"`. All best-effort/try-caught.
+- Test: `tests/message-request-receive.test.js`
+
+**Interfaces:**
+- Consumes: `findContactByPubkey`, `normalizePubkey` (Task 1). Produces: an `onMessageRequest(senderPubkey, plaintext, event)` handler (exported from a small module or defined inline in boot with a testable helper `handleMessageRequest(deps)` — prefer a pure-ish exported `handleIncomingRequest(db, managers, {senderPubkey, content, eventId})` so it's unit-testable without live relays).
+
+- [ ] **Step 1:** Write `tests/message-request-receive.test.js` against a temp init-db DB with injected deps: calling `handleIncomingRequest` with an unknown pubkey creates ONE `request_status='pending'` contact + ONE received message + fires ONE notification (stub); a second message from the same pubkey adds a message but does NOT create a second contact and does NOT re-notify; a pubkey that matches an EXISTING accepted contact creates NO request row (returns early). Assert the event-id dedup (same event.id twice → one message).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `handleIncomingRequest` + wire `onMessageRequest` in boot.js + the 3rd branch in nostr.js. Verify `onevent` still can't throw (wrap the new call).
+- [ ] **Step 4:** Run → PASS. Boot smoke: `node servers/gateway/index.js --no-auth` starts clean (subscribeToIncoming wires with 3 args).
+- [ ] **Step 5:** Commit `fix(messages): unknown-sender DMs become message requests instead of being silently dropped (L6)`.
+
+### Task 3: Gate request rows out of ALL normal surfaces (7 gates incl. the security bypass)
+
+**Files (the COMPLETE gate set — a missed gate leaks a bare/partial row into normal flows; gate #4 is a security fix):**
+- Modify: `servers/gateway/dashboard/panels/messages/data-queries.js` — `getUnifiedConversationList` (:51): `AND (c.request_status IS NULL OR c.request_status='accepted')` (show full + accepted; hide 'pending'). `getBotDirectory` (:168): exclude `request_status IS NOT NULL`.
+- Modify: `servers/sharing/boot.js` — startup loop (:180): SELECT `request_status` too, then SPLIT per row: `request_status IS NULL` → `initContact`+`joinContact`+`subscribeToContact`; `'accepted'` → `subscribeToContact` ONLY; `'pending'` → skip.
+- Modify: `servers/sharing/room-inbound.js` — **SECURITY (C1, expanded round-2). Trust surfaces = NULL ONLY:** (a) :27 `room_join` host-trust `SELECT` → `AND request_status IS NULL`; (b) **:36 member-add** `SELECT id FROM contacts WHERE crow_id=?` → `AND request_status IS NULL` (else a `room_join` payload naming a partial `req:<pubkey>` crow_id injects it into `contact_group_members`); (c) :55 host match → `AND request_status IS NULL`.
+- Modify: `servers/gateway/dashboard/panels/messages/rooms-store.js` `listRoomMembers` (:54-57) — add `AND c.request_status IS NULL` so a partial row that somehow became a member can NOT pass the `room_message` signer-auth `.find()` at `room-inbound.js:52` (the round-2 escalation path).
+- Modify: `servers/sharing/tools/messaging.js` `crow_send_message` (:28) — the target lookup `WHERE (crow_id=? OR display_name=?) AND is_blocked=0` → add `AND (request_status IS NULL OR request_status='accepted')` so a **'pending'** (not-yet-accepted) request can't be messaged by guessing its `req:<pubkey>` id, while an **accepted** one CAN (you replied to it). (Messaging surface = NULL + accepted.)
+- Modify: `servers/gateway/dashboard/panels/contacts/data-queries.js` (:41 `getContacts`) — add `request_status IS NULL` to its WHERE so `req:` rows don't show as bare contacts.
+- Modify: `servers/sharing/tools/contacts.js` (:245 `crow_list_contacts`) — exclude `request_status IS NOT NULL`.
+- Modify (defensive): the `contacts` outbound-sync filter IF one exists (`instance-sync.js` `shouldSyncRow`/emit path) — exclude non-NULL `request_status`. (Contacts don't push-sync today — no `emitChange("contacts")` — so this is belt-and-braces; confirm during impl and note.)
+- Test: extend `tests/message-request-receive.test.js` + a room-inbound security test.
+
+- [ ] **Step 1:** Failing assertions: (a) a 'pending' contact absent from `getUnifiedConversationList`, an 'accepted' one present; (b) **security:** a `room_join` from a pubkey that only has a 'pending'/'accepted' request row is REJECTED (no room created) AND its member-list injection (:36) does NOT add a partial contact to `contact_group_members` AND `listRoomMembers` excludes partial rows AND a NULL contact IS accepted; (c) 'pending'/'accepted' absent from `getContacts` + `crow_list_contacts`; (d) `crow_send_message` refuses a 'pending' target but allows an 'accepted' one.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Apply all gates.
+- [ ] **Step 4:** Run → PASS; grep for ANY OTHER `FROM contacts` reads that assume full contacts (report the full list; gate any that would act on a partial row).
+- [ ] **Step 5:** Commit `fix(messages): gate request rows out of conversation list, sync loop, bot directory, Contacts panel, crow_list_contacts, and room-join trust (security)`.
+
+### Task 4: Messages UI — "Requests (N)" block + Accept/Decline actions
+
+**Files:**
+- Modify: `servers/gateway/dashboard/panels/messages/data-queries.js` — new `getMessageRequests(db)` → pending-request rows with a preview (latest message content + count + created_at), ordered newest-first.
+- Modify: `servers/gateway/dashboard/panels/messages/messages.js` — fetch requests, pass to `buildMessagesHTML`.
+- Modify: `servers/gateway/dashboard/panels/messages/html.js` — render a "Requests (N)" collapsible block at ~:126 (template: `msg-bot-invite-card` :39-47), each with the sender (`req:<id>` / short pubkey), the message preview, an **Accept** and a **Decline** button (both `<form method="POST">` with CSRF via `csrfInput(req)`, hidden `action=accept_request`/`decline_request`, hidden `request_id`). i18n keys EN+ES for the labels.
+- Modify: `servers/gateway/dashboard/panels/messages/api-handlers.js` — `accept_request`: set `request_status='accepted'` (NOT NULL — keeps the partial-identity row gated from peer-join/sync/room-trust until R4 upgrades it), mark its messages read, call `nostrManager.subscribeToContact({id, crow_id, secp256k1_pubkey})` (best-effort). `decline_request`: delete the request contact (CASCADE drops its messages). Decline-delete is safe because request rows don't sync (no re-sync race). Both `res.redirectAfterPost("/dashboard/messages")`, guarded.
+- Test: `tests/message-request-actions.test.js` (handlePostAction with a stubbed managers/db — accept flips status + subscribes; decline removes the row).
+
+- [ ] **Step 1:** Test the two actions via `handlePostAction` (reuse the injectable `sharingClientFactory`/managers pattern from the QW2 work): `accept_request` sets `request_status='accepted'` + calls `subscribeToContact`; `decline_request` removes the contact. Assert unknown/blocked request_id is a safe no-op redirect.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement `getMessageRequests`, the HTML block (+ i18n EN/ES), and the two handlers.
+- [ ] **Step 4:** Run → PASS. Live-render check: `node servers/gateway/index.js --no-auth`, open Messages with a seeded pending request, confirm the block + buttons render (or assert via the render path).
+- [ ] **Step 5:** Commit `feat(messages): Requests (N) inbox with Accept/Decline (EN+ES)`.
+
+### Task 5: End-to-end proof via the harness (L6 no longer drops)
+
+**Files:**
+- Modify (on this branch, cherry-pick or note): the messages-e2e harness `half-handshake-drop` scenario asserts what CHANGED — after the fix, a DM from a non-contact must produce a `request_status='pending'` row + a stored message on the recipient (NOT zero delivery). (The harness lives on `feat/messages-p1a-harness`/Gitea; here just add a focused integration-style test, `tests/message-request-e2e.test.js`, that drives `handleIncomingRequest` + `accept_request` end-to-end against a temp DB and asserts the message is retained + surfaces after accept.)
+
+- [ ] **Step 1:** Integration test: simulate the L6 sequence (unknown pubkey DM → request created + message stored → accept → message now in the normal thread via `getPeerMessages`, contact `request_status='accepted'`). Assert the message was NEVER lost.
+- [ ] **Step 2:** **Negative security assertion (so C1 can't ship green):** the SAME unknown pubkey, while only a 'pending' request (and again while 'accepted'), sends a `room_join` `crow_social` envelope → `handleInboundRoomEnvelope` must REJECT it (no room row created). Only a NULL contact passes.
+- [ ] **Step 3:** Run → PASS (green proves L6 closed AND the trust boundary held).
+- [ ] **Step 4:** Full suite `node --test tests/` stays green (no regression). Commit `test(messages): end-to-end request retention + room-join trust-boundary proof (L6 closed, no bypass)`.
+
+---
+
+## Follow-on Phase 1b (outline — separate plans/PRs after L6 ships)
+
+- **R2 — honest sender feedback**: add `delivery_status` to `messages` (`pending`/`relayed(n)`/`failed`); `crow_send_message` returns `isError` on 0 relays; dashboard surfaces failures instead of `console.error`+redirect (`api-handlers.js:51-54`); bubble state in `client.js`.
+- **Relay-SPOF fix** (found in P1a run: crow publishes to only 1 of 2 default relays — damus.io silently skipped): root-cause `connectRelays`/`safeRelayPublish` (why one default relay never connects on crow), + wire `getConfiguredRelays` (dead code, L4) so relay set is configurable/observable.
+- **R4 handshake de-fragilize**: idempotent persisted `invite_accepted` processing (kill the 24h `initialSince` cliff, L3) + "add by crow_id + ed25519 + secp" repair primitive (promotes a request to a full peer-synced contact once identity is known).
+- **R6/R8**: `ss -K` L2 reconnect-window test; decouple Nostr subscription wiring from Hyperswarm start (L11).
+
+## Review
+
+**Round 2 (2026-07-02, adversarial subagent): REVISE — more room-trust surfaces + a send gap + an M1 edge, all fixed:**
+- room-inbound.js:36 member-add and `rooms-store.js listRoomMembers` (the `room_message` signer-auth source at :52) were ungated → a partial contact could be injected as a room member and pass signer auth. Both now gated `request_status IS NULL`.
+- `crow_send_message` (messaging.js:28) could message a still-'pending' request by guessing `req:<pubkey>` → gated to NULL + 'accepted' (crisp model: **trust/peer surfaces = NULL only; messaging surfaces = NULL + accepted**).
+- M1 `handled` clarified to mean "handler actually invoked" (a `crow_social` with no subtype now routes to the request path instead of being dropped — would've been a narrow L6 recurrence).
+- Task 5 security assertions expanded to cover member-injection + listRoomMembers + send-to-pending. Round 2 positively confirmed the three-state predicates are internally consistent across all gates and the CASCADE deletes are safe.
+
+**Round 1 (2026-07-02, adversarial subagent, opus): REVISE — all criticals fixed:**
+- **C1 (security bypass):** an unknown sender who DMs (auto-creating a request row) then sends `room_join` would satisfy `room-inbound.js:27`'s `is_blocked=0` trust check → room-host trust. Added gate #4 (`request_status IS NULL` on the room-join trust query) + a negative security test (Task 5 Step 2).
+- **C2 (contacts is SYNCED_TABLE):** verified NO `emitChange("contacts")` exists → contacts don't push-sync, so request rows won't propagate; nullable column self-heals on peers. Added a defensive outbound-sync exclusion (gate #7).
+- **C3/S3 (incomplete gating):** Contacts panel `getContacts` + `crow_list_contacts` also read the raw table → added as gates #5/#6. Total gate set now 7 (was 3).
+- **M1:** onevent restructure now threads a `handled` flag through all 3 JSON sub-paths (matched / unmatched-type / parse-throws) so plaintext AND malformed JSON route to the request path without double-firing on matched types.
+- **M2:** accept → `'accepted'` (a distinct GATED state), NOT NULL — prevents the partial-identity row from masquerading as a full contact in the boot peer-join loop, sync, and room trust.
+- **M3:** `crow_id='req:'+FULL 64-hex` (not 16) — no UNIQUE-collision that would re-drop a colliding sender's DM.
+- **S1:** notify on request-row-newly-created (deterministic), not a racy post-insert `count==1`.
+Scope (Q7): closing L6 with a *partial* accept (messaging restored, full peer-sync deferred to R4) is a legitimate honest cut — it stops losing the DMs and lets the operator reply, without the C1/M2 fallout of a fake-full contact.
+
+## Self-review notes
+- Closes L6 (the confirmed operator bug) end-to-end AND holds the room-join trust boundary: no silent drop, visible request, one-click accept, first-contact notification, message retained through accept, and a partial row can never gain peer/sync/room trust.
+- Three-state `request_status` (NULL/pending/accepted) with a COMPLETE 7-surface gate set; accept produces a deliberately-partial contact (documented) pending R4 identity upgrade.
+- Receive path stays throw-proof (guarded new branch; the whole point is to not break delivery).

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1820,6 +1820,8 @@ await addColumnIfMissing("contacts", "notes", "TEXT");
 await addColumnIfMissing("contacts", "contact_type", "TEXT DEFAULT 'crow'");
 await addColumnIfMissing("contacts", "email", "TEXT");
 await addColumnIfMissing("contacts", "phone", "TEXT");
+// NULL = normal contact; 'pending' = unaccepted message request; 'accepted' = accepted partial contact (L6).
+await addColumnIfMissing("contacts", "request_status", "TEXT");
 
 // --- Contact Groups ---
 await initTable("contact_groups table", `

--- a/servers/gateway/dashboard/panels/contacts/data-queries.js
+++ b/servers/gateway/dashboard/panels/contacts/data-queries.js
@@ -14,7 +14,9 @@ import { escapeLikePattern } from "../../../../db.js";
 export async function getContacts(db, opts = {}) {
   const { search, groupId, type, limit = 100, offset = 0 } = opts;
   const args = [];
-  const conditions = [];
+  // Request rows (request_status 'pending'/'accepted') are partial secp-only
+  // contacts — never surface them as normal contacts.
+  const conditions = ["c.request_status IS NULL"];
 
   if (search) {
     conditions.push("(c.display_name LIKE ? OR c.email LIKE ? OR c.crow_id LIKE ?)");

--- a/servers/gateway/dashboard/panels/messages.js
+++ b/servers/gateway/dashboard/panels/messages.js
@@ -14,7 +14,7 @@ import { messagesCSS } from "./messages/css.js";
 import { buildMessagesHTML } from "./messages/html.js";
 import { messagesClientJS } from "./messages/client.js";
 import { handlePostAction } from "./messages/api-handlers.js";
-import { getUnifiedConversationList, getBotDirectory } from "./messages/data-queries.js";
+import { getUnifiedConversationList, getBotDirectory, getMessageRequests } from "./messages/data-queries.js";
 import { csrfInput } from "../shared/csrf.js";
 
 export default {
@@ -60,6 +60,10 @@ export default {
     let botDirectory = { groups: [], total: 0, notAddedCount: 0 };
     try { botDirectory = await getBotDirectory(db); } catch {}
 
+    // Pending message requests (L6 "Requests (N)" inbox; never throws).
+    let requests = [];
+    try { requests = await getMessageRequests(db); } catch {}
+
     // --- Bot-invite landing: a shared link opened on THIS instance (?bot_invite=<code>).
     // Parse here (we have `req`) so the still-sync HTML builder just renders strings.
     let botInvite = null;
@@ -86,6 +90,7 @@ export default {
       lang,
       botInvite,
       botDirectory,
+      requests,
       csrf: csrfInput(req),
     });
     const js = messagesClientJS({ aiConfigured, storageAvailable, lang });

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -207,5 +207,51 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
     return res.redirectAfterPost("/dashboard/messages?openRoom=" + groupId);
   }
 
+  // L6: accept a pending message request. Flips 'pending'→'accepted' (a distinct
+  // GATED state — NOT NULL, so the partial secp-only row can't masquerade as a
+  // full contact in peer-join/sync/room-trust until R4 supplies its identity),
+  // marks its messages read, and (best-effort) opens a per-contact Nostr sub so
+  // replies flow. Unknown / already-handled id = safe no-op redirect.
+  if (action === "accept_request" && req.body.request_id) {
+    const id = parseInt(req.body.request_id, 10);
+    if (Number.isInteger(id)) {
+      const { rows } = await db.execute({
+        sql: "SELECT id, crow_id, secp256k1_pubkey FROM contacts WHERE id = ? AND request_status = 'pending'",
+        args: [id],
+      });
+      if (rows.length > 0) {
+        const c = rows[0];
+        await db.execute({ sql: "UPDATE contacts SET request_status = 'accepted' WHERE id = ?", args: [id] });
+        await db.execute({ sql: "UPDATE messages SET is_read = 1 WHERE contact_id = ?", args: [id] });
+        if (managers?.nostrManager) {
+          try {
+            await managers.nostrManager.subscribeToContact({
+              id: c.id,
+              crow_id: c.crow_id,
+              secp256k1_pubkey: c.secp256k1_pubkey,
+            });
+          } catch (err) {
+            console.error("[messages] accept_request subscribe failed:", err.message);
+          }
+        }
+      }
+    }
+    return res.redirectAfterPost("/dashboard/messages");
+  }
+
+  // L6: decline a pending message request → delete the request contact. CASCADE
+  // drops its messages (and any group memberships). Safe: request rows don't
+  // push-sync, so there's no re-sync race. Unknown id = safe no-op redirect.
+  if (action === "decline_request" && req.body.request_id) {
+    const id = parseInt(req.body.request_id, 10);
+    if (Number.isInteger(id)) {
+      await db.execute({
+        sql: "DELETE FROM contacts WHERE id = ? AND request_status = 'pending'",
+        args: [id],
+      });
+    }
+    return res.redirectAfterPost("/dashboard/messages");
+  }
+
   return false; // Action not handled
 }

--- a/servers/gateway/dashboard/panels/messages/css.js
+++ b/servers/gateway/dashboard/panels/messages/css.js
@@ -672,6 +672,38 @@ export function messagesCSS() {
     white-space: nowrap;
   }
   .msg-btn-primary:hover { filter: brightness(1.08); }
+  .msg-btn-secondary {
+    padding: 6px 12px;
+    font-size: 0.8rem;
+    border: 1px solid var(--crow-border);
+    border-radius: 6px;
+    background: transparent;
+    color: var(--crow-text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .msg-btn-secondary:hover { background: var(--crow-bg-elevated); }
+
+  /* === L6 Message Requests inbox === */
+  .msg-requests-block { border-bottom: 1px solid var(--crow-border); padding: 4px 0; }
+  .msg-requests-block > summary {
+    cursor: pointer; padding: 8px 12px; font-size: 0.85rem; font-weight: 600;
+    color: var(--crow-text); list-style-position: inside;
+  }
+  .msg-requests-help { padding: 0 12px 6px; font-size: 0.72rem; color: var(--crow-text-muted); }
+  .msg-request-row { padding: 8px 12px; border-top: 1px solid var(--crow-border); }
+  .msg-request-meta { font-size: 0.8rem; color: var(--crow-text); }
+  .msg-request-count {
+    display: inline-block; min-width: 16px; padding: 0 5px; margin-left: 4px;
+    border-radius: 8px; background: var(--crow-accent); color: #fff;
+    font-size: 0.65rem; line-height: 16px; text-align: center;
+  }
+  .msg-request-preview {
+    font-size: 0.75rem; color: var(--crow-text-muted); margin: 4px 0 8px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .msg-request-actions { display: flex; gap: 8px; }
+  .msg-request-actions form { margin: 0; }
 
   /* === Bot Directory Browse Entry + Modal === */
   .msg-browse-bots { padding:8px 12px; cursor:pointer; font-size:0.8rem; color:var(--crow-text-muted); border-bottom:1px solid var(--crow-border); }

--- a/servers/gateway/dashboard/panels/messages/data-queries.js
+++ b/servers/gateway/dashboard/panels/messages/data-queries.js
@@ -112,6 +112,52 @@ export async function getUnifiedConversationList(db) {
 }
 
 /**
+ * Get pending message requests (unknown-sender DMs, L6). Each is a minimal
+ * `contacts` row tagged `request_status='pending'` with its stored messages.
+ * Returns the newest-first list the "Requests (N)" inbox renders, each with a
+ * short display, the latest message as a preview, the message count, and the
+ * contact/created timestamps. 'accepted' and full (NULL) contacts are excluded.
+ * Never throws.
+ */
+export async function getMessageRequests(db) {
+  try {
+    const { rows } = await db.execute(`
+      SELECT c.id, c.crow_id, c.display_name, c.created_at,
+             COUNT(m.id) AS msg_count,
+             MAX(m.created_at) AS last_msg_at,
+             (SELECT content FROM messages WHERE contact_id = c.id ORDER BY id DESC LIMIT 1) AS preview
+      FROM contacts c
+      LEFT JOIN messages m ON m.contact_id = c.id
+      WHERE c.request_status = 'pending'
+      GROUP BY c.id
+      ORDER BY last_msg_at DESC NULLS LAST, c.created_at DESC
+    `);
+    return rows.map((r) => {
+      const crowId = String(r.crow_id || "");
+      // `req:<64-hex pubkey>` → a compact `req:<first 10>…`; other ids → prefix.
+      let shortId;
+      if (crowId.startsWith("req:")) {
+        shortId = "req:" + crowId.slice(4, 14) + "…";
+      } else {
+        shortId = crowId.length > 16 ? crowId.substring(0, 16) + "…" : crowId;
+      }
+      return {
+        id: Number(r.id),
+        crowId,
+        displayName: r.display_name || shortId,
+        shortId,
+        preview: r.preview || "",
+        msgCount: Number(r.msg_count) || 0,
+        createdAt: r.created_at,
+        lastMsgAt: r.last_msg_at,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Get peer messages for a specific contact.
  */
 export async function getPeerMessages(db, contactId, { limit = 50, offset = 0 } = {}) {

--- a/servers/gateway/dashboard/panels/messages/data-queries.js
+++ b/servers/gateway/dashboard/panels/messages/data-queries.js
@@ -49,6 +49,7 @@ export async function getUnifiedConversationList(db) {
       FROM contacts c
       LEFT JOIN messages m ON m.contact_id = c.id
       WHERE c.is_blocked = 0 AND (c.origin IS NULL OR c.origin != 'local-bot')
+        AND (c.request_status IS NULL OR c.request_status = 'accepted')
       GROUP BY c.id
       ORDER BY last_msg_at DESC NULLS LAST, c.created_at DESC
     `);
@@ -165,7 +166,7 @@ export async function getMessageStatus(db) {
 export async function getBotDirectory(db) {
   const known = new Map(); // trailing-64 lowercased x-only pubkey -> contact id
   try {
-    const { rows } = await db.execute("SELECT id, secp256k1_pubkey FROM contacts WHERE secp256k1_pubkey IS NOT NULL");
+    const { rows } = await db.execute("SELECT id, secp256k1_pubkey FROM contacts WHERE secp256k1_pubkey IS NOT NULL AND request_status IS NULL");
     for (const r of rows) {
       const h = String(r.secp256k1_pubkey || "");
       if (h.length >= 64) known.set(h.slice(-64).toLowerCase(), Number(r.id));

--- a/servers/gateway/dashboard/panels/messages/html.js
+++ b/servers/gateway/dashboard/panels/messages/html.js
@@ -63,6 +63,46 @@ export function buildMessagesHTML(data) {
       `</div></div>`;
   }
 
+  // L6 "Requests (N)" inbox: unknown-sender DMs surfaced with Accept/Decline.
+  // Collapsible block, templated on the msg-bot-invite-card Accept form; each
+  // row is two classic <form method="POST"> submits (CSRF via the pre-rendered
+  // `csrf` input, same as the New Group / bot-invite forms in this file).
+  const requests = data.requests || [];
+  let requestsBlock = "";
+  if (requests.length > 0) {
+    const rows = requests.map((r) => {
+      const preview = r.preview ? escapeHtml(String(r.preview).substring(0, 140)) : "";
+      const idAttr = escapeHtml(String(r.id));
+      const countBadge = r.msgCount > 1 ? ` <span class="msg-request-count">${escapeHtml(String(r.msgCount))}</span>` : "";
+      return (
+        `<div class="msg-request-row">` +
+        `<div class="msg-request-meta"><strong>${escapeHtml(r.shortId || r.crowId)}</strong>${countBadge}</div>` +
+        (preview ? `<div class="msg-request-preview">${preview}</div>` : "") +
+        `<div class="msg-request-actions">` +
+        `<form method="POST" action="/dashboard/messages">` +
+        `<input type="hidden" name="action" value="accept_request">` +
+        `<input type="hidden" name="request_id" value="${idAttr}">` +
+        `${csrf || ""}` +
+        `<button type="submit" class="msg-btn-primary">${escapeHtml(t("messages.acceptRequest", lang))}</button>` +
+        `</form>` +
+        `<form method="POST" action="/dashboard/messages">` +
+        `<input type="hidden" name="action" value="decline_request">` +
+        `<input type="hidden" name="request_id" value="${idAttr}">` +
+        `${csrf || ""}` +
+        `<button type="submit" class="msg-btn-secondary">${escapeHtml(t("messages.declineRequest", lang))}</button>` +
+        `</form>` +
+        `</div>` +
+        `</div>`
+      );
+    }).join("");
+    requestsBlock =
+      `<details class="msg-requests-block" open>` +
+      `<summary>${escapeHtml(t("messages.requests", lang).replace("{n}", String(requests.length)))}</summary>` +
+      `<div class="msg-requests-help">${escapeHtml(t("messages.requestsHelp", lang))}</div>` +
+      rows +
+      `</details>`;
+  }
+
   // Build avatar strip items
   const avatarItems = items.map((item) => {
     if (item.type === "ai") {
@@ -115,7 +155,7 @@ export function buildMessagesHTML(data) {
 
   const noChatsLabel = escapeHtml(t("messages.noChats", lang));
 
-  return botInviteCard + browseEntry + `
+  return botInviteCard + requestsBlock + browseEntry + `
     <div class="msg-hub" style="position:relative">
       ${inviteBanner}
       ${botDirModal}

--- a/servers/gateway/dashboard/panels/messages/rooms-store.js
+++ b/servers/gateway/dashboard/panels/messages/rooms-store.js
@@ -55,7 +55,7 @@ export async function listRoomMembers(db, groupId) {
   const { rows } = await db.execute({
     sql: `SELECT c.id, c.crow_id, c.display_name, c.is_bot, c.secp256k1_pubkey, c.is_blocked
           FROM contact_group_members gm JOIN contacts c ON c.id = gm.contact_id
-          WHERE gm.group_id = ? AND c.is_blocked = 0`,
+          WHERE gm.group_id = ? AND c.is_blocked = 0 AND c.request_status IS NULL`,
     args: [groupId],
   });
   return rows;

--- a/servers/gateway/dashboard/panels/projects.js
+++ b/servers/gateway/dashboard/panels/projects.js
@@ -331,7 +331,7 @@ async function renderDetailView(db, projectId, layout, lang) {
              ORDER BY pm.granted_at ASC`,
       args: [projectId],
     }),
-    db.execute({ sql: "SELECT id, display_name, crow_id FROM contacts WHERE is_blocked = 0 ORDER BY display_name, id LIMIT 200" }),
+    db.execute({ sql: "SELECT id, display_name, crow_id FROM contacts WHERE is_blocked = 0 AND request_status IS NULL ORDER BY display_name, id LIMIT 200" }),
     db.execute({
       sql: `SELECT created_at, actor_type, actor_id, action, target, payload
               FROM project_audit_log WHERE project_id = ?

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -315,6 +315,10 @@ export const translations = {
   "messages.roomAddMember": { en: "Add member", es: "Agregar miembro" },
   "messages.roomAddBotPrompt": { en: "Local bot id to add:", es: "ID del bot local a agregar:" },
   "messages.roomLeaveHint": { en: "Bots reply only to people, never to each other.", es: "Los bots responden solo a personas, nunca entre ellos." },
+  "messages.requests": { en: "Requests ({n})", es: "Solicitudes ({n})" },
+  "messages.requestsHelp": { en: "People who messaged you but aren't contacts yet.", es: "Personas que te escribieron pero aún no son contactos." },
+  "messages.acceptRequest": { en: "Accept", es: "Aceptar" },
+  "messages.declineRequest": { en: "Decline", es: "Rechazar" },
 
   // ─── Blog Panel ───
   "blog.pageTitle": { en: "Blog", es: "Blog" },

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -278,11 +278,26 @@ export async function initSharingRuntime(managers, helpers) {
   peerManager.start().then(async () => {
     try {
       const contacts = await db.execute({
-        sql: "SELECT id, crow_id, display_name, ed25519_pubkey, secp256k1_pubkey FROM contacts WHERE is_blocked = 0",
+        sql: "SELECT id, crow_id, display_name, ed25519_pubkey, secp256k1_pubkey, request_status FROM contacts WHERE is_blocked = 0",
         args: [],
       });
       for (const c of contacts.rows) {
         try {
+          // SPLIT by request_status:
+          //   NULL      → full contact: peer-join + sync + Nostr subscribe (unchanged).
+          //   'accepted'→ partial (secp-only, no ed25519): Nostr subscribe ONLY —
+          //               initContact/joinContact would fail on the empty ed25519 key.
+          //   'pending' → skip entirely; the broad subscribeToIncoming still receives it.
+          if (c.request_status === "pending") continue;
+          if (c.request_status === "accepted") {
+            await nostrManager.subscribeToContact({
+              id: c.id,
+              crow_id: c.crow_id,
+              secp256k1_pubkey: c.secp256k1_pubkey,
+              display_name: c.display_name,
+            });
+            continue;
+          }
           await syncManager.initContact(c.id, null);
           await peerManager.joinContact({
             crowId: c.crow_id,

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -14,11 +14,112 @@
 
 import { createNotification } from "../shared/notifications.js";
 import { ensureColumn } from "../db.js";
+import { normalizePubkey, findContactByPubkey } from "./pubkey-util.js";
 import {
   resolveLocalInstanceName,
   resolvePendingRelay,
   handleIncomingBotRelay,
 } from "./bot-relay.js";
+
+/**
+ * L6 receive-path fix — turn a decrypted DM from an unknown sender into a
+ * visible **message request** instead of silently dropping it.
+ *
+ * Called by the `onMessageRequest` branch of `subscribeToIncoming` for every
+ * event NOT consumed by a real handler (plaintext, malformed JSON, or a
+ * subtype-less crow_social). It:
+ *   1. Resolves the sender by secp256k1 pubkey (trailing-64 normalized).
+ *      - Existing FULL contact (request_status IS NULL) → return early; the
+ *        per-contact `subscribeToContact` already stores that DM (no double-store).
+ *      - Existing request contact ('pending'/'accepted') → reuse its id.
+ *      - Otherwise → INSERT a minimal request contact
+ *        (`crow_id='req:'+<FULL 64-hex>`, empty ed25519, 'pending').
+ *   2. Stores the DM as a `received` message (INSERT OR IGNORE, dedup on
+ *      nostr_event_id).
+ *   3. Notifies ONLY when the request contact row was NEWLY created this call
+ *      (deterministic first-contact signal — not a racy post-insert count).
+ *
+ * Exported for unit testing without live relays. NEVER throws — the receive
+ * path must not break delivery. `managers.createNotification` may be injected
+ * (tests); otherwise the shared helper is used.
+ *
+ * @param {object} db
+ * @param {object} managers - may carry an optional `createNotification` override
+ * @param {{senderPubkey:string, content:string, eventId:string}} evt
+ */
+export async function handleIncomingRequest(db, managers, { senderPubkey, content, eventId } = {}) {
+  const notify = (managers && managers.createNotification) || createNotification;
+  try {
+    if (!db || !senderPubkey) return;
+
+    let contactId;
+    let newlyCreated = false;
+
+    const existing = await findContactByPubkey(db, senderPubkey);
+    if (existing) {
+      // A full contact (request_status NULL) is already handled by the
+      // per-contact subscription — do nothing here to avoid a double-store.
+      if (existing.request_status === null || existing.request_status === undefined) {
+        return;
+      }
+      // 'pending' or 'accepted' request contact — reuse it.
+      contactId = existing.id;
+    } else {
+      // Minimal request contact. crow_id uses the FULL 64-hex normalized
+      // pubkey (NOT a 16-hex prefix) so two senders can never collide on the
+      // UNIQUE crow_id and re-drop a DM (reintroducing L6).
+      const crowId = "req:" + normalizePubkey(senderPubkey);
+      try {
+        const result = await db.execute({
+          sql: `INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, display_name, request_status, contact_type)
+                VALUES (?, ?, '', NULL, 'pending', 'crow')`,
+          args: [crowId, senderPubkey],
+        });
+        contactId = Number(result.lastInsertRowid);
+        newlyCreated = true;
+      } catch (insErr) {
+        // Concurrent insert of the same crow_id (UNIQUE) — re-resolve and
+        // reuse rather than dropping the DM.
+        const again = await findContactByPubkey(db, senderPubkey);
+        if (!again) throw insErr;
+        contactId = again.id;
+      }
+    }
+
+    // Store the DM (dedup on the UNIQUE nostr_event_id).
+    try {
+      await db.execute({
+        sql: `INSERT OR IGNORE INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
+              VALUES (?, ?, ?, 'received', 0, datetime('now'))`,
+        args: [contactId, eventId ?? null, content ?? ""],
+      });
+    } catch (msgErr) {
+      try { console.warn("[sharing] message-request store failed:", msgErr.message); } catch {}
+    }
+
+    // First-contact notification only (deterministic: the request row was
+    // just created this call).
+    if (newlyCreated) {
+      try {
+        const preview = typeof content === "string" && content.length > 200
+          ? content.slice(0, 200) + "..."
+          : (content || "Someone wants to message you");
+        await notify(db, {
+          title: "New message request",
+          body: preview,
+          type: "peer",
+          source: "sharing:message_request",
+          action_url: "/dashboard/messages",
+        });
+      } catch (notifyErr) {
+        try { console.warn("[sharing] message-request notify failed:", notifyErr.message); } catch {}
+      }
+    }
+  } catch (err) {
+    // Never throw out of the receive path — a throw would kill the subscription.
+    try { console.warn("[sharing] handleIncomingRequest failed:", err.message); } catch {}
+  }
+}
 
 /**
  * Deliver all pending shared_items rows for a connected peer.
@@ -340,6 +441,20 @@ export async function initSharingRuntime(managers, helpers) {
         } else if (subtype === "room_message" || subtype === "room_join") {
           const { handleInboundRoomEnvelope } = await import("./room-inbound.js");
           await handleInboundRoomEnvelope({ db, nostrManager, identity, subtype, payload, senderPubkey, log: (m) => console.log("[rooms]", m) });
+        }
+      }, async (senderPubkey, content, event) => {
+        // L6: any decrypted DM NOT consumed by a real handler (plaintext,
+        // malformed JSON, or a subtype-less crow_social) becomes a visible
+        // message request instead of being silently dropped. handleIncomingRequest
+        // never throws, but double-guard so onevent stays throw-proof.
+        try {
+          await handleIncomingRequest(db, managers, {
+            senderPubkey,
+            content,
+            eventId: event?.id,
+          });
+        } catch (err) {
+          try { console.warn("[sharing] onMessageRequest wiring failed:", err.message); } catch {}
         }
       });
       console.log("[sharing] Subscribed to incoming Nostr messages");

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -352,9 +352,17 @@ export class NostrManager {
    * Subscribe to all incoming DMs directed at us.
    * Routes message types:
    *   - invite_accepted → onInviteAccepted(payload)
-   *   - crow_social → onSocialMessage(subtype, payload, senderPubkey)
+   *   - crow_social (with subtype) → onSocialMessage(subtype, payload, senderPubkey)
+   *   - ANYTHING ELSE (plaintext, malformed JSON, subtype-less crow_social,
+   *     unknown type) → onMessageRequest(senderPubkey, decrypted, event)
+   *
+   * L6 fix: previously a decrypted DM that was not a recognized JSON envelope
+   * fell through and was silently dropped. Now `handled` tracks whether a real
+   * handler was ACTUALLY INVOKED; if not, the DM routes to onMessageRequest so
+   * nothing vanishes. Every branch is guarded — onevent must NEVER throw (a
+   * throw kills the subscription and breaks all delivery).
    */
-  async subscribeToIncoming(onInviteAccepted, onSocialMessage) {
+  async subscribeToIncoming(onInviteAccepted, onSocialMessage, onMessageRequest) {
     await this.connectRelays();
 
     if (this.relays.size > 0) {
@@ -376,16 +384,41 @@ export class NostrManager {
               senderPubkey
             );
             const decrypted = nip44.v2.decrypt(event.content, conversationKey);
+
+            // `handled` = a real handler was ACTUALLY INVOKED (not merely
+            // "the type string matched"). We set it true at the point we
+            // decide to invoke — BEFORE the await — so that a handler which
+            // itself throws does NOT fall through and get double-processed as
+            // a message request. It stays false for genuine JSON.parse
+            // failures and unrecognized/subtype-less payloads, which then
+            // correctly route to the request path below.
+            let handled = false;
             if (decrypted.startsWith("{")) {
               try {
                 const payload = JSON.parse(decrypted);
                 if (payload.type === "invite_accepted" && onInviteAccepted) {
+                  handled = true;
                   await onInviteAccepted(payload);
                 } else if (payload.type === "crow_social" && payload.subtype && onSocialMessage) {
+                  handled = true;
                   await onSocialMessage(payload.subtype, payload.payload || {}, senderPubkey);
                 }
               } catch {
-                // Not valid JSON or not our message type
+                // Malformed JSON (starts with "{" but JSON.parse threw) OR a
+                // handler threw. If a handler was invoked, `handled` is
+                // already true → we won't double-fire below.
+              }
+            }
+
+            // L6: route everything a real handler did NOT consume —
+            // plaintext, malformed JSON, a subtype-less crow_social — to the
+            // message-request path so no DM is silently dropped. Wrapped in
+            // its own try/catch: onevent must NEVER throw.
+            if (!handled && onMessageRequest) {
+              try {
+                await onMessageRequest(senderPubkey, decrypted, event);
+              } catch {
+                // Request path must never break the subscription.
               }
             }
           } catch (decryptErr) {

--- a/servers/sharing/pubkey-util.js
+++ b/servers/sharing/pubkey-util.js
@@ -1,0 +1,46 @@
+/**
+ * Shared secp256k1 pubkey normalization + contact lookup helpers (L6
+ * message-requests groundwork).
+ *
+ * Nostr events carry a 32-byte x-only pubkey (64 hex chars) as
+ * `event.pubkey`; `contacts.secp256k1_pubkey` stores the 33-byte
+ * compressed form collected at contact-add time (66 hex chars, `02`/`03`
+ * prefix). Any pubkey match across these two representations MUST
+ * normalize to the trailing 64 hex chars, lowercased — mirrors the
+ * existing ad-hoc pattern at
+ * servers/gateway/dashboard/panels/messages/data-queries.js:171.
+ */
+
+/**
+ * Normalize a secp256k1 pubkey (64-hex x-only, or 66-hex 02/03-prefixed
+ * compressed) to its trailing-64-hex lowercase form. Never throws —
+ * null/undefined/short input just produces a short/garbage string that
+ * won't match any stored key.
+ */
+export function normalizePubkey(pk) {
+  try {
+    return String(pk).slice(-64).toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Look up a contacts row by secp256k1 pubkey, matching on the trailing
+ * 64 hex chars so a 66-hex compressed key and its 64-hex x-only tail
+ * resolve to the same contact. Returns the row or null. Never throws
+ * (bad/missing db, null/short pk, or a query error all resolve to null).
+ */
+export async function findContactByPubkey(db, pk) {
+  try {
+    const normalized = normalizePubkey(pk);
+    if (!normalized) return null;
+    const { rows } = await db.execute({
+      sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ?",
+      args: [normalized],
+    });
+    return rows && rows.length > 0 ? rows[0] : null;
+  } catch {
+    return null;
+  }
+}

--- a/servers/sharing/room-inbound.js
+++ b/servers/sharing/room-inbound.js
@@ -24,7 +24,7 @@ export async function handleInboundRoomEnvelope({ db, nostrManager, identity, su
   if (subtype === "room_join") {
     // Trust: only a KNOWN contact (the host) may pull us into a room. Fail-closed —
     // prevents an unknown sender from auto-creating room rows in our list.
-    const { rows: known } = await db.execute("SELECT secp256k1_pubkey FROM contacts WHERE secp256k1_pubkey IS NOT NULL AND is_blocked = 0");
+    const { rows: known } = await db.execute("SELECT secp256k1_pubkey FROM contacts WHERE secp256k1_pubkey IS NOT NULL AND is_blocked = 0 AND request_status IS NULL");
     if (!known.some((r) => pubkeyMatches(r.secp256k1_pubkey, pk))) { log("room_join drop: unknown signer"); return; }
     const groupId = await ensureLocalRoomForUid(db, {
       roomUid: payload.room_uid, name: payload.room_name, hostCrowId: payload.host_crow_id,
@@ -33,7 +33,7 @@ export async function handleInboundRoomEnvelope({ db, nostrManager, identity, su
     if (Array.isArray(payload.members)) {
       for (const m of payload.members) {
         if (!m || !m.crow_id) continue;
-        const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [m.crow_id] });
+        const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ? AND request_status IS NULL", args: [m.crow_id] });
         if (rows[0]?.id != null) await db.execute({ sql: "INSERT OR IGNORE INTO contact_group_members (group_id, contact_id) VALUES (?,?)", args: [groupId, rows[0].id] });
       }
     }
@@ -52,7 +52,7 @@ export async function handleInboundRoomEnvelope({ db, nostrManager, identity, su
     const signerMember = members.find((m) => pubkeyMatches(m.secp256k1_pubkey, pk));
     let authorized = !!signerMember;
     if (!authorized && room.host_crow_id) {
-      const { rows } = await db.execute({ sql: "SELECT secp256k1_pubkey FROM contacts WHERE crow_id = ?", args: [room.host_crow_id] });
+      const { rows } = await db.execute({ sql: "SELECT secp256k1_pubkey FROM contacts WHERE crow_id = ? AND request_status IS NULL", args: [room.host_crow_id] });
       if (rows[0] && pubkeyMatches(rows[0].secp256k1_pubkey, pk)) authorized = true;
     }
     if (!authorized) { log("room_message drop: signer not member/host of " + payload.room_uid); return; }

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -242,11 +242,13 @@ export function registerContactsTools(server, ctx) {
       include_blocked: z.boolean().default(false).describe("Include blocked contacts"),
     },
     async ({ include_blocked }) => {
-      let sql = "SELECT * FROM contacts";
+      // request_status IS NOT NULL rows are partial message-request contacts
+      // (secp-only) — exclude them from the normal contact listing.
+      let sql = "SELECT * FROM contacts WHERE request_status IS NULL";
       const args = [];
 
       if (!include_blocked) {
-        sql += " WHERE is_blocked = 0";
+        sql += " AND is_blocked = 0";
       }
       sql += " ORDER BY last_seen DESC NULLS LAST";
 

--- a/servers/sharing/tools/messaging.js
+++ b/servers/sharing/tools/messaging.js
@@ -25,7 +25,9 @@ export function registerMessagingTools(server, ctx) {
       if (await isKioskActive(db)) return kioskBlockedResponse("crow_send_message");
       // Find contact
       const result = await db.execute({
-        sql: "SELECT * FROM contacts WHERE (crow_id = ? OR display_name = ?) AND is_blocked = 0",
+        // Messaging surface = NULL + 'accepted'. A still-'pending' request cannot
+        // be messaged by guessing its req:<pubkey> id; an accepted one can.
+        sql: "SELECT * FROM contacts WHERE (crow_id = ? OR display_name = ?) AND is_blocked = 0 AND (request_status IS NULL OR request_status = 'accepted')",
         args: [contact, contact],
       });
 

--- a/tests/bot-directory-badge.test.js
+++ b/tests/bot-directory-badge.test.js
@@ -10,7 +10,7 @@ test("getUnifiedConversationList carries isBot for bot contacts", async () => {
   await db.execute(`CREATE TABLE chat_messages (id INTEGER PRIMARY KEY, conversation_id INTEGER)`);
   // created_at is required: getUnifiedConversationList orders peers by c.created_at.
   // `origin` matches the real contacts schema (the peer query filters origin='local-bot').
-  await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, display_name TEXT, last_seen TEXT, is_blocked INTEGER DEFAULT 0, is_bot INTEGER DEFAULT 0, origin TEXT, created_at TEXT DEFAULT (datetime('now')))`);
+  await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, display_name TEXT, last_seen TEXT, is_blocked INTEGER DEFAULT 0, is_bot INTEGER DEFAULT 0, origin TEXT, request_status TEXT, created_at TEXT DEFAULT (datetime('now')))`);
   await db.execute(`CREATE TABLE messages (id INTEGER PRIMARY KEY, contact_id INTEGER, created_at TEXT, is_read INTEGER, direction TEXT)`);
   await db.execute(`INSERT INTO contacts (crow_id, display_name, is_bot) VALUES ('crow:bot','Helper',1)`);
   await db.execute(`INSERT INTO contacts (crow_id, display_name, is_bot) VALUES ('crow:human','Kevin',0)`);

--- a/tests/bot-directory-query.test.js
+++ b/tests/bot-directory-query.test.js
@@ -9,7 +9,7 @@ const PKA = "a".repeat(64), PKB = "b".repeat(64);
 
 async function seedDb(contactRows = []) {
   const db = createClient({ url: ":memory:" });
-  await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, secp256k1_pubkey TEXT, origin TEXT, is_bot INTEGER DEFAULT 0)`);
+  await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, secp256k1_pubkey TEXT, origin TEXT, is_bot INTEGER DEFAULT 0, request_status TEXT)`);
   for (const c of contactRows) {
     await db.execute({ sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, origin) VALUES (?,?,?)", args: [c.crow_id, c.pk, c.origin || null] });
   }

--- a/tests/message-request-actions.test.js
+++ b/tests/message-request-actions.test.js
@@ -1,0 +1,162 @@
+/**
+ * message-request-actions — L6 Task 4. Exercises the Messages "Requests (N)"
+ * inbox actions and its data query:
+ *   - getMessageRequests(db) returns ONLY 'pending' rows with the preview shape
+ *     (latest content, count, created_at, crow_id + short display), newest-first.
+ *   - accept_request flips request_status 'pending'→'accepted', marks the
+ *     request's messages read, and calls nostrManager.subscribeToContact.
+ *   - decline_request deletes the request contact (messages gone via CASCADE).
+ *   - an unknown / already-handled request_id is a safe no-op redirect.
+ *
+ * Deps are injected: nostrManager is a stub whose subscribeToContact just
+ * records its argument, so the test never touches live relays.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
+import { getMessageRequests } from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "msgreqact-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function fakeRes() {
+  return { _r: null, headersSent: false, redirectAfterPost(p) { this._r = p; this.headersSent = true; return true; } };
+}
+
+// Insert a 'pending' request contact + N received messages; returns contact id.
+async function seedRequest(db, pk, contents, createdAt) {
+  const ins = await db.execute({
+    sql: `INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, contact_type, request_status, created_at)
+          VALUES (?,?,?,?,'pending', ?)`,
+    args: ["req:" + pk, "", pk, "crow", createdAt || "2026-07-02 10:00:00"],
+  });
+  const id = Number(ins.lastInsertRowid);
+  let i = 0;
+  for (const content of contents) {
+    await db.execute({
+      sql: `INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
+            VALUES (?,?,?,'received',0,?)`,
+      args: [id, `evt-${pk.slice(0, 6)}-${i}`, content, createdAt || "2026-07-02 10:00:00"],
+    });
+    i++;
+  }
+  return id;
+}
+
+test("getMessageRequests returns only pending rows, newest-first, with preview shape", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    // A full (NULL) contact must NOT appear.
+    await db.execute({
+      sql: `INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, contact_type, request_status)
+            VALUES ('crow:full','ed','02${"f".repeat(64)}','crow',NULL)`,
+    });
+    // An accepted request must NOT appear (only 'pending' are requests).
+    await db.execute({
+      sql: `INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, contact_type, request_status)
+            VALUES ('req:${"c".repeat(64)}','','${"c".repeat(64)}','crow','accepted')`,
+    });
+    // Two pending requests at different times → newest-first.
+    const older = await seedRequest(db, "a".repeat(64), ["first ping"], "2026-07-02 09:00:00");
+    const newer = await seedRequest(db, "b".repeat(64), ["hello", "you there?"], "2026-07-02 11:00:00");
+
+    const reqs = await getMessageRequests(db);
+    assert.equal(reqs.length, 2, "only the two pending requests");
+    assert.equal(reqs[0].id, newer, "newest-first");
+    assert.equal(reqs[1].id, older);
+
+    const b = reqs[0];
+    assert.equal(b.crowId, "req:" + "b".repeat(64));
+    assert.equal(b.msgCount, 2, "message count");
+    assert.equal(b.preview, "you there?", "latest message content as preview");
+    assert.ok(b.shortId && b.shortId.length < b.crowId.length, "a short display shorter than the full crow_id");
+    assert.ok(b.createdAt, "created_at present");
+  } finally { cleanup(); }
+});
+
+test("accept_request → status 'accepted', messages marked read, subscribeToContact called", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const pk = "a".repeat(64);
+    const id = await seedRequest(db, pk, ["hey", "still here"]);
+    const subCalls = [];
+    const managers = { nostrManager: { subscribeToContact: async (c) => { subCalls.push(c); } } };
+
+    const req = { body: { action: "accept_request", request_id: String(id) } };
+    const res = fakeRes();
+    const handled = await handlePostAction(req, res, { db, _managers: managers });
+
+    assert.equal(handled, true);
+    assert.equal(res._r, "/dashboard/messages");
+
+    const { rows } = await db.execute({ sql: "SELECT request_status FROM contacts WHERE id = ?", args: [id] });
+    assert.equal(rows[0].request_status, "accepted", "flipped to accepted (NOT NULL)");
+
+    const { rows: unread } = await db.execute({ sql: "SELECT COUNT(*) AS c FROM messages WHERE contact_id = ? AND is_read = 0", args: [id] });
+    assert.equal(Number(unread[0].c), 0, "all request messages marked read");
+
+    assert.equal(subCalls.length, 1, "subscribeToContact called once");
+    assert.equal(subCalls[0].id, id);
+    assert.equal(subCalls[0].crow_id, "req:" + pk);
+    assert.equal(subCalls[0].secp256k1_pubkey, pk);
+  } finally { cleanup(); }
+});
+
+test("decline_request → contact deleted, messages gone via CASCADE", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const id = await seedRequest(db, "d".repeat(64), ["spam?", "buy now"]);
+    const req = { body: { action: "decline_request", request_id: String(id) } };
+    const res = fakeRes();
+    const handled = await handlePostAction(req, res, { db, _managers: null });
+
+    assert.equal(handled, true);
+    assert.equal(res._r, "/dashboard/messages");
+
+    const { rows: c } = await db.execute({ sql: "SELECT id FROM contacts WHERE id = ?", args: [id] });
+    assert.equal(c.length, 0, "request contact deleted");
+    const { rows: m } = await db.execute({ sql: "SELECT id FROM messages WHERE contact_id = ?", args: [id] });
+    assert.equal(m.length, 0, "its messages dropped via CASCADE");
+  } finally { cleanup(); }
+});
+
+test("unknown / already-handled request_id → safe no-op redirect", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    // No such contact.
+    const req1 = { body: { action: "accept_request", request_id: "99999" } };
+    const res1 = fakeRes();
+    assert.equal(await handlePostAction(req1, res1, { db, _managers: { nostrManager: { subscribeToContact: async () => { throw new Error("should not be called"); } } } }), true);
+    assert.equal(res1._r, "/dashboard/messages");
+
+    const req2 = { body: { action: "decline_request", request_id: "88888" } };
+    const res2 = fakeRes();
+    assert.equal(await handlePostAction(req2, res2, { db, _managers: null }), true);
+    assert.equal(res2._r, "/dashboard/messages");
+
+    // Accepting a NULL (full) contact by id must not flip it.
+    const ins = await db.execute({
+      sql: `INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, contact_type, request_status)
+            VALUES ('crow:full','ed','02${"e".repeat(64)}','crow',NULL)`,
+    });
+    const fullId = Number(ins.lastInsertRowid);
+    const req3 = { body: { action: "accept_request", request_id: String(fullId) } };
+    const res3 = fakeRes();
+    await handlePostAction(req3, res3, { db, _managers: { nostrManager: { subscribeToContact: async () => { throw new Error("should not subscribe a full contact"); } } } });
+    const { rows } = await db.execute({ sql: "SELECT request_status FROM contacts WHERE id = ?", args: [fullId] });
+    assert.equal(rows[0].request_status, null, "full contact untouched by accept_request");
+  } finally { cleanup(); }
+});

--- a/tests/message-request-e2e.test.js
+++ b/tests/message-request-e2e.test.js
@@ -1,0 +1,217 @@
+/**
+ * message-request-e2e — L6 Task 5. End-to-end proof that the operator's bug
+ * (an unknown-sender DM was silently dropped) is closed AND the trust
+ * boundary introduced to close it cannot be bypassed.
+ *
+ * Retention story (Step 1): unknown pubkey DMs us (handleIncomingRequest,
+ * Task 2) → a 'pending' request contact + the message are created, never
+ * lost → accept_request (Task 4's dashboard action) flips it to 'accepted'
+ * and marks messages read → the message now surfaces in the NORMAL thread
+ * via getPeerMessages and the contact appears in the unified conversation
+ * list (Task 3's gates). The message is present at every step.
+ *
+ * Security story (Step 2, so C1 can't ship green): the SAME unknown pubkey,
+ * first while 'pending' and again while 'accepted', tries a room_join
+ * crow_social envelope (servers/sharing/room-inbound.js) — this must be
+ * REJECTED (no room row, no member injection) because room-join trust is
+ * NULL-only. A NULL (full) contact host is a positive control that DOES
+ * pass. crow_send_message-style target lookup must refuse the 'pending'
+ * target but allow the 'accepted' one (messaging surface = NULL + accepted).
+ *
+ * Harness reused verbatim from tests/message-request-gates.test.js
+ * (freshLibsql / XO helpers) and tests/message-request-actions.test.js
+ * (handlePostAction + fakeRes for accept_request).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handleIncomingRequest } from "../servers/sharing/boot.js";
+import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
+import {
+  getPeerMessages, getUnifiedConversationList, getMessageRequests,
+} from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+import { handleInboundRoomEnvelope } from "../servers/sharing/room-inbound.js";
+import { getRoomByUid } from "../servers/gateway/dashboard/panels/messages/rooms-store.js";
+import { registerMessagingTools } from "../servers/sharing/tools/messaging.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "msgreq-e2e-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, "..") });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+const XO = (c) => c.repeat(64); // x-only signer pubkey, 64-hex (matches event.pubkey shape)
+const PK = (c) => "02" + c.repeat(64); // stored compressed contact pubkey (66-hex)
+
+function fakeRes() {
+  return { _r: null, headersSent: false, redirectAfterPost(p) { this._r = p; this.headersSent = true; return true; } };
+}
+
+function stubManagers(extra = {}) {
+  const notifCalls = [];
+  return {
+    createNotification: async (_db, opts) => { notifCalls.push(opts); return { id: notifCalls.length }; },
+    notifCalls,
+    ...extra,
+  };
+}
+
+async function acceptRequest(db, id, managers = { nostrManager: { subscribeToContact: async () => {} } }) {
+  const req = { body: { action: "accept_request", request_id: String(id) } };
+  const res = fakeRes();
+  const handled = await handlePostAction(req, res, { db, _managers: managers });
+  assert.equal(handled, true, "accept_request handled");
+  assert.equal(res._r, "/dashboard/messages");
+}
+
+// ─── Step 1: retention proof ────────────────────────────────────────────
+test("L6 retention: unknown-pubkey DM survives request→accept and lands in the normal thread", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const pk = XO("e"); // the unknown sender, simulated end-to-end
+    const mgrs = stubManagers();
+
+    // (1) Unknown pubkey "sends" a plaintext DM — the exact call the sharing
+    // receive path makes for anything not consumed by a real handler.
+    await handleIncomingRequest(db, mgrs, { senderPubkey: pk, content: "hey, are you there?", eventId: "evt-e-1" });
+
+    const { rows: c1 } = await db.execute({ sql: "SELECT * FROM contacts WHERE secp256k1_pubkey = ?", args: [pk] });
+    assert.equal(c1.length, 1, "a request contact was created (not dropped)");
+    const contactId = c1[0].id;
+    assert.equal(c1[0].request_status, "pending", "new contact starts 'pending'");
+    assert.equal(c1[0].crow_id, "req:" + pk);
+
+    const { rows: m1 } = await db.execute({ sql: "SELECT * FROM messages WHERE contact_id = ?", args: [contactId] });
+    assert.equal(m1.length, 1, "the DM was stored, not lost");
+    assert.equal(m1[0].content, "hey, are you there?");
+    assert.equal(m1[0].direction, "received");
+    assert.equal(Number(m1[0].is_read), 0);
+
+    // A second DM before any accept — still retained, still one contact row.
+    await handleIncomingRequest(db, mgrs, { senderPubkey: pk, content: "second message while pending", eventId: "evt-e-2" });
+    const { rows: c1b } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM contacts WHERE secp256k1_pubkey = ?", args: [pk] });
+    assert.equal(Number(c1b[0].n), 1, "still exactly one contact row (reused, not duplicated)");
+    const { rows: m1b } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM messages WHERE contact_id = ?", args: [contactId] });
+    assert.equal(Number(m1b[0].n), 2, "both messages retained while pending");
+
+    // Visible in the "Requests (N)" inbox while pending; NOT in the normal
+    // unified conversation list yet (Task 3 gate — pending is hidden there).
+    const reqs = await getMessageRequests(db);
+    assert.ok(reqs.some((r) => r.id === contactId), "request is visible in the Requests inbox");
+    const preAccept = await getUnifiedConversationList(db);
+    assert.ok(!preAccept.items.some((i) => i.type === "peer" && i.id === contactId), "not yet in the normal thread list while pending");
+
+    // (2) Accept it — the same steps the accept_request handler performs.
+    await acceptRequest(db, contactId);
+
+    const { rows: c2 } = await db.execute({ sql: "SELECT request_status FROM contacts WHERE id = ?", args: [contactId] });
+    assert.equal(c2[0].request_status, "accepted", "flipped 'pending' → 'accepted'");
+
+    const { rows: unread } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM messages WHERE contact_id = ? AND is_read = 0", args: [contactId] });
+    assert.equal(Number(unread[0].n), 0, "messages marked read on accept");
+
+    // (3) The message now appears in the NORMAL thread via getPeerMessages,
+    // and the contact shows up in the unified conversation list as accepted.
+    const thread = await getPeerMessages(db, contactId);
+    assert.equal(thread.length, 2, "both messages present in the normal thread after accept");
+    assert.deepEqual(thread.map((m) => m.content), ["hey, are you there?", "second message while pending"]);
+    assert.ok(thread.every((m) => Number(m.is_read) === 1), "surfaced messages are marked read");
+
+    const postAccept = await getUnifiedConversationList(db);
+    const peerEntry = postAccept.items.find((i) => i.type === "peer" && i.id === contactId);
+    assert.ok(peerEntry, "accepted contact now appears in the unified conversation list");
+
+    // The message was never lost across the whole flow: unknown DM → pending
+    // → accepted → normal thread.
+  } finally { cleanup(); }
+});
+
+// ─── Step 2: negative security proof (room-join trust boundary) ────────
+test("SECURITY: the same unknown pubkey cannot cross the room-join trust boundary while 'pending' OR 'accepted'", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const pk = XO("v"); // the same unknown sender from the retention story
+    const mgrs = stubManagers();
+
+    // Recreate the L6 sequence: unknown DM → 'pending' request contact.
+    await handleIncomingRequest(db, mgrs, { senderPubkey: pk, content: "let me in", eventId: "evt-v-1" });
+    const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE secp256k1_pubkey = ?", args: [pk] });
+    const contactId = rows[0].id;
+
+    const nostrManager = { async sendControl() {} };
+    const roomJoinPayload = {
+      room_uid: "u-e2e-attack",
+      room_name: "Attack Room",
+      host_crow_id: "req:" + pk,
+      members: [{ crow_id: "req:" + pk }],
+    };
+    const attemptJoin = () => handleInboundRoomEnvelope({
+      db, nostrManager, identity: { crowId: "crow:me" }, subtype: "room_join",
+      payload: roomJoinPayload, senderPubkey: pk,
+    });
+
+    // While 'pending': rejected.
+    await attemptJoin();
+    assert.equal(await getRoomByUid(db, "u-e2e-attack"), null, "'pending' signer: no room created");
+    const { rows: mem1 } = await db.execute("SELECT COUNT(*) AS n FROM contact_group_members");
+    assert.equal(Number(mem1[0].n), 0, "'pending' signer: no member injected");
+
+    // Accept the request (matches Step 1's flow) — messaging is now allowed,
+    // but trust surfaces must STILL reject it (trust = NULL only).
+    await acceptRequest(db, contactId);
+    const { rows: c2 } = await db.execute({ sql: "SELECT request_status FROM contacts WHERE id = ?", args: [contactId] });
+    assert.equal(c2[0].request_status, "accepted");
+
+    await attemptJoin();
+    assert.equal(await getRoomByUid(db, "u-e2e-attack"), null, "'accepted' signer: still no room created");
+    const { rows: mem2 } = await db.execute("SELECT COUNT(*) AS n FROM contact_group_members");
+    assert.equal(Number(mem2[0].n), 0, "'accepted' signer: still no member injected");
+
+    // Positive control: a NULL (full) contact host DOES pass room_join trust
+    // — proves the rejection above is the request-status gate, not a broken
+    // room_join path.
+    await db.execute({
+      sql: `INSERT INTO contacts (crow_id, display_name, secp256k1_pubkey, ed25519_pubkey, contact_type)
+            VALUES ('crow:fullhost', 'Full Host', ?, ?, 'crow')`,
+      args: [PK("g"), "f".repeat(64)],
+    });
+    await handleInboundRoomEnvelope({
+      db, nostrManager, identity: { crowId: "crow:me" }, subtype: "room_join",
+      payload: { room_uid: "u-e2e-ok", room_name: "Legit Room", host_crow_id: "crow:fullhost", members: [] },
+      senderPubkey: XO("g"),
+    });
+    assert.ok(await getRoomByUid(db, "u-e2e-ok"), "NULL (full) host DOES pass room_join trust (positive control)");
+
+    // crow_send_message-style target lookup: refuses 'pending', allows
+    // 'accepted' — drive it against the SAME contact across both states.
+    const { db: db2, cleanup: cleanup2 } = freshLibsql();
+    try {
+      const pk2 = XO("w");
+      await handleIncomingRequest(db2, stubManagers(), { senderPubkey: pk2, content: "hi", eventId: "evt-w-1" });
+      const { rows: r2 } = await db2.execute({ sql: "SELECT id, crow_id FROM contacts WHERE secp256k1_pubkey = ?", args: [pk2] });
+      const contact2Id = r2[0].id;
+      const crowId2 = r2[0].crow_id;
+
+      const sent = [];
+      const tools = {};
+      registerMessagingTools({ tool: (name, _d, _s, handler) => { tools[name] = handler; } }, {
+        db: db2, identity: {}, nostrManager: { sendMessage: async (row) => { sent.push(row.crow_id); return { relays: ["r1"] }; } },
+      });
+
+      const pendRes = await tools.crow_send_message({ contact: crowId2, message: "let me in early" });
+      assert.equal(pendRes.isError, true, "'pending' target refused by crow_send_message");
+      assert.equal(sent.length, 0, "no send while pending");
+
+      await acceptRequest(db2, contact2Id);
+      const accRes = await tools.crow_send_message({ contact: crowId2, message: "welcome" });
+      assert.ok(!accRes.isError, "'accepted' target allowed by crow_send_message");
+      assert.deepEqual(sent, [crowId2], "message sent once accepted");
+    } finally { cleanup2(); }
+  } finally { cleanup(); }
+});

--- a/tests/message-request-gates.test.js
+++ b/tests/message-request-gates.test.js
@@ -1,0 +1,216 @@
+/**
+ * message-request-gates — L6 Task 3. Proves request rows (request_status
+ * 'pending'/'accepted') are excluded from the COMPLETE set of normal surfaces,
+ * with the crisp model:
+ *   - trust / peer surfaces  = NULL only
+ *   - messaging surfaces     = NULL + 'accepted' (exclude 'pending')
+ *
+ * SECURITY (gate #4/#5): a remote sender who auto-created a request row by
+ * DMing us must NOT gain room-host trust via a room_join, must NOT be injected
+ * into contact_group_members via a room_join member list, and a partial row that
+ * somehow became a member must NOT pass the room_message signer-auth. Only a
+ * NULL (full) contact passes any trust surface.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handleInboundRoomEnvelope } from "../servers/sharing/room-inbound.js";
+import {
+  createRoom, getRoomByUid, listRoomMembers, addMember, getRoomMessages,
+} from "../servers/gateway/dashboard/panels/messages/rooms-store.js";
+import { getUnifiedConversationList } from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+import { getContacts } from "../servers/gateway/dashboard/panels/contacts/data-queries.js";
+import { registerContactsTools } from "../servers/sharing/tools/contacts.js";
+import { registerMessagingTools } from "../servers/sharing/tools/messaging.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "msgreq-gates-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, "..") });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+const PK = (c) => "02" + c.repeat(64); // stored compressed contact pubkey (66-hex)
+const XO = (c) => c.repeat(64);        // x-only signer (64-hex)
+
+// Insert a contact with a given request_status (NULL/'pending'/'accepted').
+async function mkContact(db, { crowId, name = null, isBot = 0, c, requestStatus = null }) {
+  const r = await db.execute({
+    sql: `INSERT INTO contacts (crow_id, display_name, is_bot, secp256k1_pubkey, ed25519_pubkey, contact_type, request_status)
+          VALUES (?,?,?,?,?, 'crow', ?)`,
+    args: [crowId, name, isBot, PK(c), "e".repeat(64), requestStatus],
+  });
+  return Number(r.lastInsertRowid);
+}
+async function addMessage(db, contactId, content) {
+  await db.execute({
+    sql: "INSERT INTO messages (contact_id, content, direction, is_read, created_at) VALUES (?,?, 'received', 0, datetime('now'))",
+    args: [contactId, content],
+  });
+}
+
+// Capture registered MCP tool handlers by name from a register* function.
+function captureTools(registerFn, ctx) {
+  const tools = {};
+  const server = { tool: (name, _desc, _schema, handler) => { tools[name] = handler; } };
+  registerFn(server, ctx);
+  return tools;
+}
+
+// --- (a) conversation list: pending hidden, accepted + NULL shown ---
+test("getUnifiedConversationList: hides 'pending', shows 'accepted' and NULL", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const full = await mkContact(db, { crowId: "crow:full", name: "Full", c: "f" });
+    const acc = await mkContact(db, { crowId: "req:" + XO("a"), c: "a", requestStatus: "accepted" });
+    const pend = await mkContact(db, { crowId: "req:" + XO("b"), c: "b", requestStatus: "pending" });
+    await addMessage(db, full, "hi full");
+    await addMessage(db, acc, "hi accepted");
+    await addMessage(db, pend, "hi pending");
+
+    const { items } = await getUnifiedConversationList(db);
+    const ids = items.filter((i) => i.type === "peer").map((i) => i.id);
+    assert.ok(ids.includes(full), "NULL (full) contact present");
+    assert.ok(ids.includes(acc), "'accepted' request present (messaging surface)");
+    assert.ok(!ids.includes(pend), "'pending' request hidden");
+  } finally { cleanup(); }
+});
+
+// --- (b) SECURITY: room_join trust boundary ---
+test("SECURITY: room_join from a 'pending'/'accepted' request signer is REJECTED (no room, no member injection)", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    // Two partial rows whose secp keys we control as signers.
+    await mkContact(db, { crowId: "req:" + XO("p"), c: "p", requestStatus: "pending" });
+    await mkContact(db, { crowId: "req:" + XO("q"), c: "q", requestStatus: "accepted" });
+    // A partial row named in the members[] injection attempt.
+    await mkContact(db, { crowId: "req:victim", c: "v", requestStatus: "pending" });
+
+    const nostrManager = { async sendControl() {} };
+    const join = (signer) => handleInboundRoomEnvelope({
+      db, nostrManager, identity: { crowId: "crow:me" }, subtype: "room_join",
+      payload: { room_uid: "u-atk", room_name: "Attack", host_crow_id: "req:evil", members: [{ crow_id: "req:victim" }] },
+      senderPubkey: signer,
+    });
+
+    await join(XO("p")); // pending signer
+    assert.equal(await getRoomByUid(db, "u-atk"), null, "'pending' signer cannot create a room");
+    await join(XO("q")); // accepted signer (still NOT trust-eligible)
+    assert.equal(await getRoomByUid(db, "u-atk"), null, "'accepted' signer cannot create a room either (trust = NULL only)");
+
+    // No partial contact injected into any room membership.
+    const { rows: mem } = await db.execute("SELECT COUNT(*) AS c FROM contact_group_members");
+    assert.equal(Number(mem[0].c), 0, "no member injection from a rejected room_join");
+  } finally { cleanup(); }
+});
+
+test("SECURITY: a NULL (full) host DOES pass room_join; members[] naming a partial row is NOT injected", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await mkContact(db, { crowId: "crow:host", name: "Host", c: "h" }); // full contact host
+    await mkContact(db, { crowId: "req:victim", c: "v", requestStatus: "pending" }); // partial named in members
+    await mkContact(db, { crowId: "crow:realmember", name: "Real", c: "r" }); // full contact member
+
+    const nostrManager = { async sendControl() {} };
+    await handleInboundRoomEnvelope({
+      db, nostrManager, identity: { crowId: "crow:me" }, subtype: "room_join",
+      payload: { room_uid: "u-ok", room_name: "Team", host_crow_id: "crow:host",
+        members: [{ crow_id: "req:victim" }, { crow_id: "crow:realmember" }] },
+      senderPubkey: XO("h"),
+    });
+
+    const room = await getRoomByUid(db, "u-ok");
+    assert.ok(room, "NULL host materialized the room");
+    const members = await listRoomMembers(db, room.id);
+    const crowIds = members.map((m) => m.crow_id);
+    assert.ok(crowIds.includes("crow:realmember"), "full contact member added");
+    assert.ok(!crowIds.includes("req:victim"), "partial contact NOT injected as a member");
+  } finally { cleanup(); }
+});
+
+test("SECURITY: listRoomMembers excludes a partial row even if force-added; room_message signer-auth fails for it", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    // Room hosted here with a legit member + a force-injected partial member.
+    const real = await mkContact(db, { crowId: "crow:real", name: "Real", c: "a" });
+    const partial = await mkContact(db, { crowId: "req:" + XO("z"), c: "z", requestStatus: "accepted" });
+    const { groupId, roomUid } = await createRoom(db, { name: "Team", memberContactIds: [real], mode: "addressed", hostCrowId: "crow:me" });
+    await addMember(db, groupId, partial); // simulate a stray membership row
+
+    const members = await listRoomMembers(db, groupId);
+    assert.ok(!members.some((m) => m.id === partial), "listRoomMembers excludes the partial row");
+
+    // A room_message signed by the partial's key must be dropped (not a member).
+    const nostrManager = { async sendControl() { throw new Error("should not fan"); } };
+    await handleInboundRoomEnvelope({
+      db, nostrManager, identity: { crowId: "crow:me" }, subtype: "room_message",
+      payload: { room_uid: roomUid, msg_uid: "m1", author: { kind: "human" }, text: "intruder", addressed_to: [] },
+      senderPubkey: XO("z"),
+    });
+    assert.equal((await getRoomMessages(db, groupId)).length, 0, "partial-signed room_message dropped");
+  } finally { cleanup(); }
+});
+
+// --- (c) getContacts + crow_list_contacts exclude partial rows ---
+test("getContacts excludes 'pending' and 'accepted' rows", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const full = await mkContact(db, { crowId: "crow:full", name: "Full", c: "f" });
+    await mkContact(db, { crowId: "req:" + XO("a"), c: "a", requestStatus: "accepted" });
+    await mkContact(db, { crowId: "req:" + XO("b"), c: "b", requestStatus: "pending" });
+
+    const rows = await getContacts(db);
+    const ids = rows.map((r) => Number(r.id));
+    assert.deepEqual(ids, [full], "only the NULL contact is returned");
+  } finally { cleanup(); }
+});
+
+test("crow_list_contacts excludes 'pending' and 'accepted' rows", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await mkContact(db, { crowId: "crow:full", name: "Full", c: "f" });
+    await mkContact(db, { crowId: "req:" + XO("a"), c: "a", requestStatus: "accepted" });
+    await mkContact(db, { crowId: "req:" + XO("b"), c: "b", requestStatus: "pending" });
+
+    const tools = captureTools(registerContactsTools, {
+      db, identity: {}, peerManager: { isConnected: () => false }, syncManager: {}, nostrManager: {},
+    });
+    const out = await tools.crow_list_contacts({ include_blocked: false });
+    const text = out.content.map((c) => c.text).join("\n");
+    assert.ok(text.includes("Full") || text.includes("crow:full"), "full contact listed");
+    assert.ok(!text.includes("req:"), "no req: partial rows in crow_list_contacts");
+  } finally { cleanup(); }
+});
+
+// --- (d) crow_send_message: refuse 'pending', allow 'accepted' + NULL ---
+test("crow_send_message refuses a 'pending' target but allows 'accepted'", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const pendCrow = "req:" + XO("b");
+    const accCrow = "req:" + XO("a");
+    await mkContact(db, { crowId: pendCrow, c: "b", requestStatus: "pending" });
+    await mkContact(db, { crowId: accCrow, name: "Accepted One", c: "a", requestStatus: "accepted" });
+    await mkContact(db, { crowId: "crow:full", name: "Full", c: "f" });
+
+    const sent = [];
+    const nostrManager = { sendMessage: async (row) => { sent.push(row.crow_id); return { relays: ["r1"] }; } };
+    const tools = captureTools(registerMessagingTools, { db, identity: {}, nostrManager });
+
+    const pendRes = await tools.crow_send_message({ contact: pendCrow, message: "let me in" });
+    assert.equal(pendRes.isError, true, "'pending' target refused");
+    assert.equal(sent.length, 0, "no send to a pending request");
+
+    const accRes = await tools.crow_send_message({ contact: accCrow, message: "hi back" });
+    assert.ok(!accRes.isError, "'accepted' target allowed");
+    assert.deepEqual(sent, [accCrow], "accepted request messaged");
+
+    const fullRes = await tools.crow_send_message({ contact: "Full", message: "yo" });
+    assert.ok(!fullRes.isError, "NULL (full) target allowed");
+    assert.deepEqual(sent, [accCrow, "crow:full"], "full contact messaged");
+  } finally { cleanup(); }
+});

--- a/tests/message-request-receive.test.js
+++ b/tests/message-request-receive.test.js
@@ -1,0 +1,166 @@
+/**
+ * message-request-receive — L6 core fix (Task 2). Exercises
+ * `handleIncomingRequest`: a decrypted plaintext DM from an unknown sender
+ * must become a `request_status='pending'` contact + a stored `received`
+ * message + a first-message-only notification, instead of being silently
+ * dropped. Also asserts dedup (same nostr_event_id → one message), no
+ * re-notify on subsequent messages, and an early-return for a sender that is
+ * already a full (NULL request_status) contact.
+ *
+ * Deps are injected: `createNotification` is stubbed via `managers` so the
+ * test asserts notification firing without touching push/email/ntfy.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { handleIncomingRequest } from "../servers/sharing/boot.js";
+
+let dir, db;
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "msgreq-test-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  process.env.CROW_DATA_DIR = dir;
+  db = createDbClient();
+});
+
+after(() => {
+  try { db.close(); } catch {}
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+// A managers object whose createNotification just counts invocations.
+function stubManagers() {
+  const calls = [];
+  return {
+    calls,
+    createNotification: async (_db, opts) => {
+      calls.push(opts);
+      return { id: calls.length };
+    },
+  };
+}
+
+async function contactsForPk(pk) {
+  const norm = String(pk).slice(-64).toLowerCase();
+  const { rows } = await db.execute({
+    sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ?",
+    args: [norm],
+  });
+  return rows;
+}
+
+async function messageCount(contactId) {
+  const { rows } = await db.execute({
+    sql: "SELECT COUNT(*) AS c FROM messages WHERE contact_id = ?",
+    args: [contactId],
+  });
+  return Number(rows[0].c);
+}
+
+test("unknown pubkey → ONE pending contact + ONE received message + ONE notification", async () => {
+  const pk = "a".repeat(64);
+  const mgrs = stubManagers();
+
+  await handleIncomingRequest(db, mgrs, {
+    senderPubkey: pk,
+    content: "hey, is this thing on?",
+    eventId: "evt-a-1",
+  });
+
+  const contacts = await contactsForPk(pk);
+  assert.equal(contacts.length, 1, "exactly one request contact created");
+  const c = contacts[0];
+  assert.equal(c.request_status, "pending", "request_status must be 'pending'");
+  assert.equal(c.crow_id, "req:" + pk, "crow_id is req:<FULL 64-hex>");
+  assert.equal(c.secp256k1_pubkey, pk);
+  assert.equal(c.ed25519_pubkey, "", "ed25519 placeholder is empty string");
+  assert.equal(c.contact_type, "crow");
+
+  assert.equal(await messageCount(c.id), 1, "one received message stored");
+  const { rows: msgs } = await db.execute({
+    sql: "SELECT * FROM messages WHERE contact_id = ?",
+    args: [c.id],
+  });
+  assert.equal(msgs[0].direction, "received");
+  assert.equal(Number(msgs[0].is_read), 0);
+  assert.equal(msgs[0].content, "hey, is this thing on?");
+  assert.equal(msgs[0].nostr_event_id, "evt-a-1");
+
+  assert.equal(mgrs.calls.length, 1, "exactly one notification fired");
+  assert.equal(mgrs.calls[0].source, "sharing:message_request");
+  assert.equal(mgrs.calls[0].action_url, "/dashboard/messages");
+});
+
+test("second message from same pubkey → +1 message, NO 2nd contact, NO 2nd notification", async () => {
+  const pk = "a".repeat(64); // same sender as the first test
+  const mgrs = stubManagers();
+
+  await handleIncomingRequest(db, mgrs, {
+    senderPubkey: pk,
+    content: "still here",
+    eventId: "evt-a-2",
+  });
+
+  const contacts = await contactsForPk(pk);
+  assert.equal(contacts.length, 1, "no second contact row");
+  assert.equal(await messageCount(contacts[0].id), 2, "second message appended");
+  assert.equal(mgrs.calls.length, 0, "no re-notify on a non-new request row");
+});
+
+test("same eventId twice → dedup to a single message", async () => {
+  const pk = "d".repeat(64);
+  const mgrs = stubManagers();
+
+  await handleIncomingRequest(db, mgrs, {
+    senderPubkey: pk,
+    content: "dup test",
+    eventId: "evt-d-dup",
+  });
+  await handleIncomingRequest(db, mgrs, {
+    senderPubkey: pk,
+    content: "dup test (retransmit)",
+    eventId: "evt-d-dup",
+  });
+
+  const contacts = await contactsForPk(pk);
+  assert.equal(contacts.length, 1, "one contact");
+  assert.equal(await messageCount(contacts[0].id), 1, "event-id dedup → single message");
+  // First call created the row → one notify; second call reused it → no notify.
+  assert.equal(mgrs.calls.length, 1, "notify only on the newly-created request");
+});
+
+test("sender that is already a full (NULL request_status) contact → NO request row, early return", async () => {
+  const xonly = "b".repeat(64);
+  const compressed = "02" + xonly; // stored 66-hex compressed form
+
+  await db.execute({
+    sql: `INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey, request_status)
+          VALUES (?,?,?,?,NULL)`,
+    args: ["crow:full-contact-b", "Full Contact", "ed25519-real", compressed],
+  });
+
+  const before = await contactsForPk(xonly);
+  assert.equal(before.length, 1, "only the seeded full contact exists");
+
+  const mgrs = stubManagers();
+  await handleIncomingRequest(db, mgrs, {
+    senderPubkey: xonly, // 32-byte x-only tail of the stored compressed key
+    content: "this should be handled by subscribeToContact, not the request path",
+    eventId: "evt-b-1",
+  });
+
+  const after = await contactsForPk(xonly);
+  assert.equal(after.length, 1, "no req: row created for an existing full contact");
+  assert.equal(after[0].crow_id, "crow:full-contact-b", "the existing full contact is untouched");
+  assert.equal(await messageCount(after[0].id), 0, "request path stored no message (early return)");
+  assert.equal(mgrs.calls.length, 0, "no notification for a full contact");
+});

--- a/tests/pubkey-util.test.js
+++ b/tests/pubkey-util.test.js
@@ -1,0 +1,87 @@
+/**
+ * pubkey-util — normalizePubkey + findContactByPubkey (L6 message-requests
+ * groundwork, Task 1). Exercises normalization of the 66-hex-compressed vs
+ * 64-hex-x-only secp256k1 pubkey mismatch, and the shared contacts lookup
+ * against a real init-db-built DB.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { normalizePubkey, findContactByPubkey } from "../servers/sharing/pubkey-util.js";
+
+test("normalizePubkey: 66-hex compressed and its 64-hex x-only tail normalize equal, case-insensitive", () => {
+  const xonly = "a1b2c3d4e5f6".padEnd(64, "0"); // 64 hex chars
+  const compressed02 = "02" + xonly; // 66 hex chars, 02-prefixed
+  const compressed03Upper = "03" + xonly.toUpperCase(); // 66 hex chars, different prefix + case
+
+  assert.equal(normalizePubkey(compressed02), xonly.toLowerCase());
+  assert.equal(normalizePubkey(xonly), xonly.toLowerCase());
+  assert.equal(normalizePubkey(compressed02), normalizePubkey(xonly));
+  assert.equal(normalizePubkey(compressed03Upper), normalizePubkey(xonly), "case-insensitive + prefix-agnostic");
+});
+
+test("normalizePubkey never throws on null/undefined/short input", () => {
+  assert.doesNotThrow(() => normalizePubkey(null));
+  assert.doesNotThrow(() => normalizePubkey(undefined));
+  assert.doesNotThrow(() => normalizePubkey(""));
+  assert.doesNotThrow(() => normalizePubkey("ab"));
+  assert.equal(typeof normalizePubkey(null), "string");
+  assert.equal(typeof normalizePubkey(undefined), "string");
+});
+
+let dir, db;
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "pubkeyutil-test-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  process.env.CROW_DATA_DIR = dir;
+  db = createDbClient();
+});
+
+after(() => {
+  try { db.close(); } catch {}
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+test("contacts table has a nullable request_status column", async () => {
+  const { rows } = await db.execute("PRAGMA table_info(contacts)");
+  const col = rows.find((r) => r.name === "request_status");
+  assert.ok(col, "request_status column missing");
+  assert.equal(Number(col.notnull), 0, "request_status must be nullable");
+});
+
+test("findContactByPubkey: 66-hex compressed key stored, found by its 64-hex x-only form; unknown key -> null", async () => {
+  const xonly = "b".repeat(64);
+  const compressed = "02" + xonly;
+
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
+    args: ["crow:pubkeyutil-test", "Test Contact", "ed25519-placeholder", compressed],
+  });
+
+  const found = await findContactByPubkey(db, xonly);
+  assert.ok(found, "expected contact to be found by x-only tail");
+  assert.equal(found.crow_id, "crow:pubkeyutil-test");
+  assert.equal(found.secp256k1_pubkey, compressed);
+
+  // Also findable by the stored compressed form itself.
+  const foundByCompressed = await findContactByPubkey(db, compressed);
+  assert.ok(foundByCompressed);
+  assert.equal(foundByCompressed.crow_id, "crow:pubkeyutil-test");
+
+  const notFound = await findContactByPubkey(db, "c".repeat(64));
+  assert.equal(notFound, null, "unknown key must resolve to null");
+});
+
+test("findContactByPubkey never throws on null/short input", async () => {
+  assert.equal(await findContactByPubkey(db, null), null);
+  assert.equal(await findContactByPubkey(db, ""), null);
+  assert.equal(await findContactByPubkey(db, "ab"), null);
+});


### PR DESCRIPTION
Fixes **L6**, the confirmed root cause of the "message never received" bug (reproduced in the Phase 1a harness). Plan (2-round adversarial review): `docs/superpowers/plans/2026-07-02-messages-p1b-l6-message-requests.md`.

## The bug
`subscribeToIncoming`'s `onevent` (`nostr.js`) decrypted an incoming DM but only acted on JSON `invite_accepted`/`crow_social` envelopes — **a plaintext human DM from anyone who isn't already a contact fell through and was silently discarded.** The message reached the relay and was thrown away by the recipient's own code, with zero signal to either party. A half-completed contact handshake (one side's contact row didn't land) therefore made every subsequent DM vanish.

## The fix — Message Requests
An unknown-sender DM now becomes a **message request**: a `request_status`-tagged partial contact + the stored message, surfaced in a Messages **"Requests (N)"** inbox with **Accept** / **Decline**. Nothing is dropped; Accept restores the conversation in one click; a first-message notification fires (deduped per sender).

**Three-state model** (`contacts.request_status`): `NULL` = full contact · `'pending'` = unaccepted request · `'accepted'` = accepted partial. A cold DM carries only the 32-byte secp key (no ed25519/crow_id), so an accepted request is a **partial** contact — it can send/receive DMs (secp-only is sufficient for Nostr) but is deliberately excluded from peer/DHT sync and room trust until a future R4 identity upgrade.

**Gating (security-critical, complete set):** trust/peer surfaces = **NULL only** — room-join host-trust, member-add, host-match (`room-inbound.js`), room_message signer-auth (`rooms-store.js listRoomMembers`), boot peer-join loop, bot directory, Contacts panel, `crow_list_contacts`, project-share people-picker. Messaging surfaces = **NULL + accepted** — conversation list, `crow_send_message`. This prevents a stranger who DMs (creating a request) from then gaining room trust — covered by an explicit negative security test (pending *and* accepted rejected; full contact passes).

## Tasks (each TDD, per-task reviewed)
1. `request_status` column + pubkey normalize/lookup helpers
2. Receive path: `handled`-flag restructure + `handleIncomingRequest` (throw-proof onevent, collision-safe `req:`+full-64-hex id)
3. The 7+ gates incl. the room-trust security fix
4. Requests (N) inbox UI + Accept/Decline (EN+ES) + people-picker gate
5. End-to-end retention proof + room-join trust-boundary proof

## Review gates
- Plan: 2-round adversarial review (round 2 hardened the room-trust surfaces).
- Dedicated security review of receive-path + gates: **SAFE**, trust boundary closed.
- Final whole-branch review (fable): **READY TO MERGE, no Critical/Important**; reply path verified to work on the secp-only key; onevent throw-proof after all commits.
- Tests: **894/894** (new: pubkey-util, receive, gates, actions, e2e). Full suite green.

## Follow-ups (non-blocking, scoped to R4/later)
- R4 promotion primitive: when a late `invite_accepted` completes a half-handshake, reconcile the stale request row into the full contact (event-id dedup prevents double-store today).
- Spam controls: pending-count cap / notification digest for unlimited fresh-key senders.
- Cosmetic: accepted requests display as `req:<pubkey>` until an identity/rename upgrade.

## Deploy
After merge, crow's gateway restart picks it up; fleet via pull-only auto-update. This is the top-priority fix from the Phase 1b delivery-reliability arc.