### PR TITLE
fix(schema): user_version boot gate — column migrations auto-apply on out-of-band update + restart

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -5,6 +5,7 @@ import { randomBytes } from "node:crypto";
 import { resolve } from "path";
 import { slugify, workspacePathFor, storagePrefixFor } from "../servers/shared/slugify.js";
 import { BOT_JOBS_DDL } from "./pi-bots/bot-jobs-schema.mjs";
+import { SCHEMA_GENERATION } from "../servers/shared/schema-version.js";
 
 // Ensure data directory exists
 const dataDir = process.env.CROW_DB_PATH
@@ -2657,6 +2658,12 @@ await addColumnIfMissing("bot_message_invites", "kind", "TEXT"); // NULL=normal,
 // "add a person" uniformly. Backfill the reliably-known bots (origin='advertised').
 await addColumnIfMissing("contacts", "is_bot", "INTEGER DEFAULT 0");
 await db.execute({ sql: "UPDATE contacts SET is_bot = 1 WHERE origin = 'advertised' AND is_bot = 0" });
+
+// Stamp the schema generation so the gateway boot gate can detect when an
+// out-of-band code update introduced migrations that a plain restart missed.
+// (PRAGMA values can't be bound params — interpolate the coerced Number.)
+await db.execute("PRAGMA user_version = " + Number(SCHEMA_GENERATION));
+console.log(`Schema generation set to ${SCHEMA_GENERATION}`);
 
 console.log("Database initialized successfully (local file)");
 db.close();

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -106,15 +106,34 @@ if (process.env.CROW_DASHBOARD_PUBLIC === "true") {
 // Initialize OAuth tables
 await initOAuthTables();
 
-// Verify core schema exists — auto-initialize if missing (Docker first run)
+// Verify core schema exists / is current — auto-initialize if missing (Docker
+// first run) OR if the persisted schema generation is behind the code (an
+// out-of-band `git pull`/rollback/merge-then-restart that added migrations but
+// never re-ran init-db; the 6h auto-updater runs init-db post-pull, this covers
+// the manual path). See servers/shared/schema-version.js.
 try {
+  const { SCHEMA_GENERATION, needsSchemaInit } = await import("../shared/schema-version.js");
   const _schemaDb = createDbClient();
   const { rows } = await _schemaDb.execute(
     "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('memories', 'dashboard_settings', 'crow_context')"
   );
+  let userVersion = 0;
+  try {
+    const uvRes = await _schemaDb.execute("PRAGMA user_version");
+    userVersion = Number(uvRes.rows?.[0]?.user_version ?? 0);
+  } catch {
+    userVersion = 0;
+  }
   _schemaDb.close();
-  if (rows.length < 3) {
-    console.log("Database schema incomplete — running init-db...");
+  const driftOnly = rows.length >= 3 && userVersion < SCHEMA_GENERATION;
+  if (needsSchemaInit({ coreTableCount: rows.length, userVersion, schemaGeneration: SCHEMA_GENERATION })) {
+    if (driftOnly) {
+      console.log(
+        `Schema version drift (db user_version=${userVersion} < code SCHEMA_GENERATION=${SCHEMA_GENERATION}) — running init-db to apply pending migrations...`
+      );
+    } else {
+      console.log("Database schema incomplete — running init-db...");
+    }
     const { execFileSync } = await import("node:child_process");
     const { dirname } = await import("node:path");
     const { fileURLToPath } = await import("node:url");

--- a/servers/shared/schema-version.js
+++ b/servers/shared/schema-version.js
@@ -1,0 +1,23 @@
+// Schema generation version — a pure, side-effect-free constant module.
+//
+// BUMP this by 1 whenever you add a schema migration to scripts/init-db.js
+// (a new table, addColumnIfMissing, index, or data migration). On the next
+// gateway boot, any install whose DB PRAGMA user_version is lower re-runs
+// init-db (idempotent) to apply it. This closes the gap where out-of-band
+// code updates + a plain restart didn't apply new columns.
+//
+// IMPORTANT: keep this module free of side-effecting imports. It is imported
+// by servers/gateway/index.js during boot; importing scripts/init-db.js here
+// (or anything that runs DB work at module top-level) would execute init-db
+// as an unwanted side effect.
+export const SCHEMA_GENERATION = 1;
+
+// Pure decision helper for the gateway boot gate. Returns true when the DB
+// needs init-db to run: either core tables are missing (fresh/incomplete
+// install) OR the persisted schema stamp is behind the current generation
+// (out-of-band code update that added migrations).
+export function needsSchemaInit({ coreTableCount, userVersion, schemaGeneration }) {
+  if (coreTableCount < 3) return true;
+  if (userVersion < schemaGeneration) return true;
+  return false;
+}

--- a/tests/schema-version-gate.test.js
+++ b/tests/schema-version-gate.test.js
@@ -1,0 +1,87 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "../node_modules/better-sqlite3/lib/index.js";
+import { SCHEMA_GENERATION, needsSchemaInit } from "../servers/shared/schema-version.js";
+
+// --- (a) needsSchemaInit truth table (pure helper) ---
+test("needsSchemaInit: coreTableCount < 3 → true (missing tables)", () => {
+  assert.equal(
+    needsSchemaInit({ coreTableCount: 2, userVersion: SCHEMA_GENERATION, schemaGeneration: SCHEMA_GENERATION }),
+    true,
+  );
+});
+
+test("needsSchemaInit: userVersion < schemaGeneration → true (schema drift)", () => {
+  assert.equal(
+    needsSchemaInit({ coreTableCount: 3, userVersion: 0, schemaGeneration: 1 }),
+    true,
+  );
+});
+
+test("needsSchemaInit: tables=3 & userVersion > schemaGeneration → false", () => {
+  assert.equal(
+    needsSchemaInit({ coreTableCount: 3, userVersion: 5, schemaGeneration: 1 }),
+    false,
+  );
+});
+
+test("needsSchemaInit: tables=3 & userVersion === schemaGeneration → false", () => {
+  assert.equal(
+    needsSchemaInit({ coreTableCount: 3, userVersion: 1, schemaGeneration: 1 }),
+    false,
+  );
+});
+
+// --- (b) + (c) integration against a real temp DB ---
+const dir = mkdtempSync(join(tmpdir(), "schema-version-gate-"));
+const dbPath = join(dir, "crow.db");
+
+function runInitDb() {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DB_PATH: dbPath },
+    stdio: "pipe",
+  });
+}
+
+after(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("(b) init-db sets PRAGMA user_version to SCHEMA_GENERATION", () => {
+  runInitDb();
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const uv = db.pragma("user_version", { simple: true });
+    assert.equal(uv, SCHEMA_GENERATION);
+  } finally {
+    db.close();
+  }
+});
+
+test("(c) drift is detected, and re-running init-db restores user_version", () => {
+  // Simulate an out-of-band code update: DB predates the version stamp.
+  const w = new Database(dbPath);
+  w.pragma("user_version = 0");
+  const drifted = w.pragma("user_version", { simple: true });
+  w.close();
+  assert.equal(drifted, 0);
+
+  // The gate must say "re-init needed" when the stamp is behind.
+  assert.equal(
+    needsSchemaInit({ coreTableCount: 3, userVersion: drifted, schemaGeneration: SCHEMA_GENERATION }),
+    true,
+  );
+
+  // Re-running init-db (idempotent) re-stamps the version.
+  runInitDb();
+  const r = new Database(dbPath, { readonly: true });
+  try {
+    assert.equal(r.pragma("user_version", { simple: true }), SCHEMA_GENERATION);
+  } finally {
+    r.close();
+  }
+});


### PR DESCRIPTION
## The gap (found while deploying the L6 fix)
`scripts/init-db.js` applies column migrations via `addColumnIfMissing`, but the gateway's boot schema check (`servers/gateway/index.js`) only re-runs init-db when core **tables** are missing — a new **column** never triggers it. So an out-of-band code update (manual `git pull`, a rollback, or a merge-then-restart) followed by a plain gateway restart leaves new columns un-applied until the next 6h auto-update cycle. This just bit the L6 `request_status` column: after merging, a manual gateway restart did **not** apply it (had to run `init-db` by hand).

(The in-process auto-updater already runs init-db post-pull — `auto-update.js:150` — so this only affects out-of-band-update-then-restart, but that's exactly the deploy/rollback path.)

## The fix — a schema-generation gate
- New side-effect-free `servers/shared/schema-version.js`: `SCHEMA_GENERATION` constant (bump by 1 whenever you add any schema migration) + a pure `needsSchemaInit({coreTableCount, userVersion, schemaGeneration})` helper.
- `scripts/init-db.js` stamps `PRAGMA user_version = SCHEMA_GENERATION` as its **last** statement (only after all migrations succeed).
- The boot gate now runs init-db when `coreTableCount < 3` **OR** `user_version < SCHEMA_GENERATION`. init-db is idempotent, stamps the version, and the next boot skips — so it's an O(1) `PRAGMA` read on the common path (no per-boot cost).

**Convergence:** an existing install (user_version=0) runs init-db once on next restart → applies every pending `addColumnIfMissing` → stamps the version. A fresh install stamps it via the table-check path. Both converge; no every-boot re-init.

Going forward: bumping `SCHEMA_GENERATION` when you add a migration guarantees it lands on every install's next restart — not just on the 6h auto-update.

## Review
- Boot-critical review: **SAFE to merge+deploy**, 0 Critical/Important; convergence + no-infinite-loop + fail-safe-on-read-error verified empirically. `needsSchemaInit` truth table + PRAGMA placement (end, on-success only) confirmed.
- Tests: new `tests/schema-version-gate.test.js` 6/6; full suite **900/900**.

Deploy: crow already has `request_status` (applied manually); this ensures grackle/crow-mpa apply it (and every future column migration) on their next restart rather than needing a manual `init-db`. Fleet gets it via pull-only auto-update. Relates to the "fix the product, not the instance" directive.