### PR TITLE
fix(messages): mobile bot-chat composer no longer collapses the text input to 1 char

### DIFF
--- a/servers/gateway/dashboard/panels/messages/css.js
+++ b/servers/gateway/dashboard/panels/messages/css.js
@@ -368,6 +368,9 @@ export function messagesCSS() {
     gap: 0.5rem;
     align-items: flex-end;
     flex-shrink: 0;
+    /* Wrap so the AI/bot model-picker + Pin controls drop to a second row on
+       narrow (mobile) widths instead of crowding the textarea to ~0px. */
+    flex-wrap: wrap;
   }
 
   .msg-attach-btn {
@@ -387,7 +390,11 @@ export function messagesCSS() {
   }
 
   .msg-textarea {
-    flex: 1;
+    /* flex-basis 60% + a hard min-width keeps the input usable even when the
+       bot compose-bar adds a model-picker + Pin; with .msg-chat-input wrapping,
+       the controls drop to their own row rather than collapsing the input. */
+    flex: 1 1 60%;
+    min-width: 140px;
     resize: none;
     border: 1px solid var(--crow-border);
     border-radius: 8px;


### PR DESCRIPTION
**Reported (with screenshot):** chatting with a bot in Crow Messages on a phone, the text field is a tiny vertical sliver — the "Text" placeholder renders one letter per row. Can't type.

**Root cause:** the compose row `.msg-chat-input` is `display:flex` with **no `flex-wrap`**, and the textarea is `flex:1` (shrinkable). On **AI/bot** conversations only, the client appends a model-picker `<select>` + "Pin" control between the input and Send. On a narrow phone the fixed-width attach + model-select + Pin + Send consume the whole row, squeezing the flex-shrinkable textarea to ~0px. (Peer/human chats have no model picker, so they were unaffected — which is why it only showed "when chatting with a bot".)

**Fix (CSS only):** `.msg-chat-input { flex-wrap: wrap }` + `.msg-textarea { flex: 1 1 60%; min-width: 140px }`. The input keeps a usable width; the model/Pin controls drop to a second row on narrow screens. Desktop/wide layout is unchanged (wrap only triggers when crowded; the textarea still flex-grows to fill).

Verified: `css.js` compiles and both rules emit. Visual confirmation on the phone after deploy recommended (headless CSS render isn't feasible here). Part of the Messages "stupidly simple to use" arc.