### PR TITLE
feat(messages): R2 honest delivery feedback + relay resilience (stop silent send failures)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-messages-p1b-r2-relay-resilience.md
+++ b/docs/superpowers/plans/2026-07-02-messages-p1b-r2-relay-resilience.md
@@ -1,0 +1,113 @@
+# Messages Phase 1b — R2 Honest Delivery Feedback + Relay Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Stop silent send-side failures (the send half of the L6 "no more silent losses" theme). Today a DM that reaches 0 relays is reported as "sent," and the relay set is 2 hardcoded relays with the user-configurable path dead — one flaky relay is a silent single point of failure (observed in the Phase 1a harness: crow reached only 1 of 2 relays). After: messages carry a real `delivery_status`, `crow_send_message` errors on 0-relay sends, the dashboard surfaces failures, the default relay set is larger, and user-added relays actually take effect.
+
+**Architecture:** Small, surgical changes on the existing send path (`servers/sharing/nostr.js` `sendMessage`/`connectRelays`), the send tool (`messaging.js`), the messages schema (`init-db.js`), the dashboard send handler + bubble (`messages/`), and a `SCHEMA_GENERATION` bump (dogfooding the migration-gate that just shipped). No new subsystem.
+
+**Tech Stack:** Node 20, `servers/sharing/nostr.js`, `servers/sharing/tools/messaging.js`, `servers/gateway/dashboard/panels/messages/{data-queries,client,api-handlers}.js`, `scripts/init-db.js` + `servers/shared/schema-version.js`, `node --test`.
+
+## Verified facts (2026-07-02)
+
+- `sendMessage` (`nostr.js:118-170`) publishes to every connected relay via `safeRelayPublish`, collecting `published[]` = relays that accepted, then `INSERT INTO messages (... direction='sent' ...)` with **no delivery_status**, and returns `{eventId, relays: published}`. The honest count already exists — it's just not persisted or surfaced.
+- `DEFAULT_RELAYS` (`nostr.js:34`) = exactly 2 (`relay.damus.io`, `nos.lol`). Both connect fine from crow live (302/435ms) — the harness "1/2" was intermittent publish-time flakiness, so the fix is MORE relays + honest reporting, not debugging one relay.
+- `getConfiguredRelays()` (`nostr.js:448`) reads `relay_config WHERE relay_type='nostr' AND enabled=1` (else DEFAULT_RELAYS) — but is **DEAD**: all 7 `connectRelays()` callers pass no arg (`instances.js:98`, `contacts.js:128,213`, `nostr.js:120,179,217,366`), so `_doConnectRelays(undefined)` uses `DEFAULT_RELAYS`. `crow_add_relay` (`instances.js:63`) writes `relay_config` that nothing reads (L4).
+- `messages` table (`init-db.js:511-530`) has `direction CHECK(sent|received)`, no `delivery_status`. (The `delivery_status` at `init-db.js:488` is on `shared_items`, a different table.)
+- `crow_send_message` (`messaging.js:42-50`) reports `via ${delivery.relays.length} relay(s)` with **no `isError`** even at 0. Dashboard `send_peer` (`api-handlers.js:~50`) `console.error`s + redirects, swallowing failures.
+- `SCHEMA_GENERATION` (`servers/shared/schema-version.js`) is currently 1; adding a column REQUIRES bumping it to 2 so the migration auto-applies on restart (the gate shipped in PR #127).
+
+## Global Constraints
+
+- Branch `fix/messages-r2-relay-resilience`. Positional-path commits; `git show --stat HEAD` after each.
+- Tests: `node --test tests/<file>.test.js`. Gateway must boot.
+- Send path is delivery-critical: never throw out of `sendMessage`/`connectRelays`; a delivery_status write failure must not lose the message (best-effort).
+- Relay list changes affect a network default — use only well-established, long-lived public relays.
+
+---
+
+### Task 1: Relay resilience — wire getConfiguredRelays + expand defaults (fixes L4 + SPOF)
+
+**Files:**
+- Modify: `servers/sharing/nostr.js` — (a) expand `DEFAULT_RELAYS` from 2 to a resilient set of **heavily-operated, anon-kind-4-writable** public relays: keep `wss://relay.damus.io`, `wss://nos.lol`, add `wss://relay.primal.net`, `wss://relay.nostr.band`, `wss://offchain.pub`. **At impl time, verify each actually ACCEPTS an anonymous kind-4 publish** (a quick connect+publish probe) — drop any that's write-restricted/paid/defunct. (Review flagged `relay.snort.social` (historically write-restricted) and `nostr.mom` (small single-operator) as NOT safe defaults — use the band/offchain set instead.) (b) **`getConfiguredRelays()` MERGES, never replaces (review C2):** return `dedup([...DEFAULT_RELAYS, ...enabled_nostr_relay_config_rows])` so defaults are always a floor AND user-added relays are added — an install that ran `crow_add_relay` once must NOT drop to a single relay (that's the SPOF this fixes). Wrap the DB read in try/catch → fall back to `DEFAULT_RELAYS` on error (never-throw). (c) `_doConnectRelays(customRelays)` (`:73`): `customRelays || await this.getConfiguredRelays()`. (d) add `connectedRelayUrls()` → `[...this.relays.keys()]` accessor.
+- Test: `tests/nostr-relay-config.test.js`
+
+**Interfaces:**
+- Produces: `getConfiguredRelays()` returns the MERGED (defaults ∪ configured, deduped) set and drives connections; `connectedRelayUrls():string[]`.
+
+- [ ] **Step 0 (pre-deploy audit, do at deploy not impl):** `sqlite3 -readonly <db> "SELECT * FROM relay_config WHERE relay_type='nostr'"` on crow + grackle — confirm whether any latent rows exist (determines if C2 was a live risk; with the merge fix it's safe either way).
+- [ ] **Step 1:** Test (temp init-db DB + stubbed relay-connect, no live network): empty `relay_config` → connect path requests the full `DEFAULT_RELAYS` (>2); after inserting 1 enabled nostr row `wss://custom.example` → connect path requests `DEFAULT_RELAYS ∪ {custom}` (defaults STILL present — assert the merge, not replace); a duplicate config row of a default → deduped (no double). Assert `getConfiguredRelays()` never throws on a broken db (returns DEFAULT_RELAYS).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement (a)+(b)+(c)+(d). `_doConnectRelays` + `getConfiguredRelays` never-throw.
+- [ ] **Step 4:** Run → PASS. Boot smoke.
+- [ ] **Step 5:** Commit `fix(messages): use configured relays + larger default relay set (L4 dead-code + send SPOF)`.
+
+### Task 2: delivery_status column + sendMessage persists honest status
+
+**Files:**
+- Modify: `scripts/init-db.js` — `addColumnIfMissing("messages", "delivery_status", "TEXT")` (nullable; values `pending`/`relayed`/`delivered`/`failed`, no CHECK to keep addColumn simple + forward-compatible with a future `delivered` ack). Place near the messages table def.
+- Modify: `servers/shared/schema-version.js` — bump `SCHEMA_GENERATION` 1 → 2 (so the column auto-applies on restart via the PR #127 gate).
+- Modify: `servers/sharing/nostr.js` `sendMessage` — set `delivery_status` on the sent INSERT: `published.length > 0 ? 'relayed' : 'failed'`. Keep the INSERT best-effort.
+- Test: `tests/message-delivery-status.test.js`
+
+**Interfaces:**
+- Produces: sent `messages` rows carry `delivery_status` ('relayed' when ≥1 relay accepted, 'failed' when 0).
+
+- [ ] **Step 1:** Test: `sendMessage` with a stubbed relay set where publish succeeds → the inserted sent row has `delivery_status='relayed'`; with a relay set where all publishes fail (or `relays.size===0` after a failed connect) → `delivery_status='failed'` and the returned `relays` is empty. (Stub `safeRelayPublish`/the relay map.)
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Add the migration + bump SCHEMA_GENERATION + set status in the INSERT.
+- [ ] **Step 4:** Run → PASS. Verify migration idempotent + `PRAGMA user_version` stamps 2 (run init-db on a temp DB; column present, user_version=2).
+- [ ] **Step 5:** Commit `feat(messages): persist delivery_status on sent DMs (relayed/failed) + bump schema generation`.
+
+### Task 3: 0-relay send is a failure — tool isError + the LIVE route + UI surface it
+
+**Review C1: the live UI send does NOT go through `api-handlers.js` `send_peer` (dead) — it goes `client.js:697 fetch('/api/messages/peer/:id/send')` → `servers/gateway/routes/peer-messages.js:89`, which discards the tool result and unconditionally returns `{ok:true}`. Fix the LIVE path.**
+
+**Files:**
+- Modify: `servers/sharing/tools/messaging.js` `crow_send_message` (`:42-50`) — when `delivery.relays.length === 0`, return `{ isError:true, content:[{type:'text', text:'Message could NOT be delivered — reached 0 relays. Check your connection / relay settings.'}] }`. When ≥1, accurate success text ("delivered to N relay(s)"). A partial publish (≥1 of N) stays success/'relayed' (publish-acceptance ≠ recipient delivery; not 'delivered' until the R5 ack).
+- Modify: `servers/gateway/routes/peer-messages.js` (~:89-157) — CAPTURE the `crow_send_message` result (it's currently discarded at ~:120). If `result.isError` (or the relay count is 0), return a non-ok response (`res.status(502).json({ ok:false, error:'reached 0 relays' })` or `{ok:false}` with the message text) instead of the unconditional `{ok:true}` at ~:157. Parse the relay count from the result if needed.
+- Modify: `servers/gateway/dashboard/panels/messages/client.js` `sendPeerMessage` (~:688-710) — read the fetch response: on `!response.ok` or `{ok:false}`, mark the optimistic bubble (~:688) as failed (add a failed class / status) rather than leaving the success bubble. (This gives send-time surfacing; Task 4's `delivery_status` gives it on reload too.)
+- Test: `tests/message-send-feedback.test.js` — (a) the tool returns isError when stubbed `sendMessage` → `{relays:[]}`, success when `{relays:['wss://x']}`; (b) a route-level assertion that a 0-relay send yields a non-ok response (drive `peer-messages.js` with a stubbed sharing client whose send reports 0 relays → assert non-ok / ok:false; ≥1 → ok:true). This guards C1 from silently regressing.
+
+- [ ] **Step 1:** Write both tests (tool isError branch + the route non-ok-on-0-relay). Run → FAIL.
+- [ ] **Step 2:** Implement the tool isError + peer-messages.js result capture + client.js response handling.
+- [ ] **Step 3:** Run → PASS. Confirm the ≥1-relay path still returns ok:true (no regression to normal sends).
+- [ ] **Step 4:** Commit `fix(messages): a 0-relay send is a failure — tool isError + live peer-send route returns non-ok + UI marks the bubble failed (R2)`.
+
+### Task 4: Message bubble shows delivery state
+
+**Files:**
+- Modify: `servers/gateway/dashboard/panels/messages/data-queries.js` `getPeerMessages` — include `delivery_status` in the selected columns for sent messages.
+- Modify: `servers/gateway/dashboard/panels/messages/client.js` `appendBubble` (+ the render path) — for `direction='sent'` messages, render a small status affordance: `relayed` → a subtle single check "✓"; `failed` → a red "!" / "Failed" with a Retry affordance (Retry re-invokes send for that content — MVP can be a re-send button that repopulates the composer, or omit retry and just show the state clearly). `pending`/null → nothing or a faint clock. Keep it unobtrusive (small, muted).
+- Modify: `messages/css.js` — a `.msg-delivery` style (muted; `.msg-delivery-failed` red).
+- Test: a render-path assertion (like Task 4 of L6) — a sent message with `delivery_status='failed'` renders the failed affordance; `relayed` renders the check.
+
+- [ ] **Step 1:** Failing render assertion (buildMessagesHTML/appendBubble path with a seeded failed sent message → contains the failed indicator).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement the query column + bubble rendering + CSS + i18n for any label ("Failed"/"Retry").
+- [ ] **Step 4:** Run → PASS. Live-render check via the render path (gateway boot is disruptive on prod — assert via the path).
+- [ ] **Step 5:** Commit `feat(messages): show sent-message delivery state (relayed ✓ / failed) in the thread`.
+
+### Task 5: Tests + suite green
+
+- [ ] **Step 1:** Full suite `node --test tests/` stays green (report count). `node --check` all touched product files.
+- [ ] **Step 2:** Commit any test consolidation. `git show --stat HEAD`.
+
+---
+
+## Follow-on (outline, separate)
+- **R5 delivered-ack**: a `crow_social` delivery receipt from the recipient upgrades `delivery_status` 'relayed'→'delivered' + a sender retry queue for unacked DMs (the structural offline-delivery fix). This is why `delivery_status` allows a future 'delivered' value.
+- **R4 handshake repair** (next planned): promote an accepted request → full peer-synced contact on identity arrival; add-by-id.
+
+## Review
+
+**Round 1 (2026-07-02, adversarial subagent, opus): REVISE — 2 criticals fixed:**
+- **C1 (Task 3 patched a dead path):** the live UI send is `client.js:697 → routes/peer-messages.js` (which discarded the tool result + always returned `{ok:true}`), NOT `api-handlers.js send_peer`. Task 3 retargeted to peer-messages.js (capture result → non-ok on 0 relays) + client.js (read response, mark bubble failed) + a route-level test guarding it.
+- **C2 (relay set replaced, not merged):** `getConfiguredRelays` returned ONLY config rows → any install that ran `crow_add_relay` once would drop to a single relay (re-creating the SPOF). Now MERGES defaults ∪ configured (deduped); defaults are always a floor; + a pre-deploy `relay_config` audit step.
+Suggestions adopted: relay set swapped to heavily-operated anon-writable relays (band/offchain over snort/mom) with an impl-time write probe; getConfiguredRelays never-throw; partial-publish stays 'relayed'; NULL delivery_status confirmed safe (received rows inherently delivered, no query filters it); migration placement after the messages initTable (not the FK-rebuild block); SCHEMA_GENERATION 1→2 confirmed sufficient for auto-apply.
+
+## Self-review notes
+- Fixes the send half of "stop silent failures": 0-relay = failure (not success), persisted delivery_status, dashboard surfacing, and a resilient relay set so one flaky relay isn't a SPOF.
+- Dogfoods the PR #127 schema-generation gate (bump to 2) — proves that path end-to-end on a real column add.
+- Send path stays best-effort/never-throw; delivery_status is additive (nullable) so existing rows/queries are unaffected.
+- Deliberately defers true `delivered` (needs the R5 ack) — the column is forward-compatible.

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -547,6 +547,12 @@ await initTable("messages table", `
   CREATE INDEX IF NOT EXISTS idx_messages_read ON messages(is_read);
 `);
 
+// R2 Task 2: honest delivery feedback for sent DMs. Nullable, no CHECK — keep
+// addColumn simple and forward-compatible with a future 'delivered' ack (R5).
+// Values: pending / relayed / failed / delivered (received rows stay NULL —
+// they are inherently delivered; no query filters on this column for them).
+await addColumnIfMissing("messages", "delivery_status", "TEXT");
+
 await initTable("relay_config table", `
   CREATE TABLE IF NOT EXISTS relay_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/servers/gateway/dashboard/panels/messages/client.js
+++ b/servers/gateway/dashboard/panels/messages/client.js
@@ -1149,6 +1149,21 @@ export function messagesClientJS(opts) {
       div.appendChild(el('div', { className: 'msg-bubble-meta', text: relativeTime(msg.created_at) }));
     }
 
+    // Delivery status indicator (sent messages only) — persisted delivery_status
+    // read back on THREAD RELOAD (R2 Task 4). Task 3's markBubbleFailed already
+    // surfaces a live send-time failure; reuse it here for consistency ('failed'
+    // gets the same 'msg-bubble-failed' class + note). 'relayed'/'delivered' get a
+    // small muted check; 'pending'/null render nothing.
+    if (isSent && msg.delivery_status === 'failed') {
+      markBubbleFailed(div);
+    } else if (isSent && (msg.delivery_status === 'relayed' || msg.delivery_status === 'delivered')) {
+      div.appendChild(el('span', {
+        className: 'msg-delivery',
+        title: msg.delivery_status === 'delivered' ? '${tJs("messages.deliveryDelivered", lang)}' : '${tJs("messages.deliveryRelayed", lang)}',
+        text: msg.delivery_status === 'delivered' ? '\\u2713\\u2713' : '\\u2713',
+      }));
+    }
+
     // Reply button (received peer messages)
     if (!isSent && msgId && _activeItem && _activeItem.type === 'peer') {
       div.appendChild(el('button', {
@@ -1183,7 +1198,7 @@ export function messagesClientJS(opts) {
         b.appendChild(el('div', {
           className: 'msg-bubble-failed-note',
           css: 'color:var(--crow-error,#ef4444);font-size:0.7rem;margin-top:2px;',
-          text: '! not delivered' + (errText ? ' — ' + errText : ''),
+          text: '! ${tJs("messages.notDelivered", lang)}' + (errText ? ' — ' + errText : ''),
         }));
       }
     } catch (e) { /* never let feedback crash the send path */ }

--- a/servers/gateway/dashboard/panels/messages/client.js
+++ b/servers/gateway/dashboard/panels/messages/client.js
@@ -684,8 +684,8 @@ export function messagesClientJS(opts) {
     _pendingAttachments = [];
     renderAttachmentPreview();
 
-    // Optimistic UI
-    appendBubble(viewport, {
+    // Optimistic UI — keep a ref so we can mark it failed if the send doesn't land.
+    var sentBubble = appendBubble(viewport, {
       direction: 'sent',
       content: content || '',
       created_at: new Date().toISOString(),
@@ -694,7 +694,7 @@ export function messagesClientJS(opts) {
     viewport.scrollTop = viewport.scrollHeight;
 
     try {
-      await fetch('/api/messages/peer/' + encodeURIComponent(_activeItem.id) + '/send', {
+      var response = await fetch('/api/messages/peer/' + encodeURIComponent(_activeItem.id) + '/send', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -702,8 +702,16 @@ export function messagesClientJS(opts) {
           attachments: atts.length > 0 ? atts : undefined,
         }),
       });
+      // A 0-relay send returns a non-ok response (or {ok:false}); surface it on
+      // the just-sent bubble instead of leaving a misleading success bubble.
+      var body = null;
+      try { body = await response.json(); } catch(_) { /* non-JSON body */ }
+      if (!response.ok || (body && body.ok === false)) {
+        markBubbleFailed(sentBubble, body && body.error);
+      }
     } catch(e) {
       console.error('Failed to send peer message:', e);
+      markBubbleFailed(sentBubble);
     }
 
     _replyingTo = null;
@@ -1156,6 +1164,29 @@ export function messagesClientJS(opts) {
     }
 
     container.appendChild(div);
+    return div;
+  }
+
+  // Mark an optimistic 'sent' bubble as failed-to-deliver (send-time surfacing;
+  // Task 4's delivery_status gives it on reload too). Defensive: falls back to
+  // the viewport's last child if no bubble ref was captured.
+  function markBubbleFailed(bubble, errText) {
+    try {
+      var b = bubble;
+      if (!b) {
+        var vp = document.getElementById('msg-viewport');
+        b = vp && vp.lastElementChild;
+      }
+      if (!b) return;
+      b.classList.add('msg-bubble-failed');
+      if (!b.querySelector('.msg-bubble-failed-note')) {
+        b.appendChild(el('div', {
+          className: 'msg-bubble-failed-note',
+          css: 'color:var(--crow-error,#ef4444);font-size:0.7rem;margin-top:2px;',
+          text: '! not delivered' + (errText ? ' — ' + errText : ''),
+        }));
+      }
+    } catch (e) { /* never let feedback crash the send path */ }
   }
 
   // === Reply Bar ===

--- a/servers/gateway/dashboard/panels/messages/css.js
+++ b/servers/gateway/dashboard/panels/messages/css.js
@@ -284,6 +284,17 @@ export function messagesCSS() {
   }
   .msg-bubble.sent .msg-bubble-meta { text-align: right; }
 
+  /* R2 Task 4: persisted delivery-status indicator (thread reload). Small,
+     muted single/double check for relayed/delivered. The 'failed' state
+     reuses .msg-bubble-failed / .msg-bubble-failed-note from Task 3. */
+  .msg-delivery {
+    display: inline-block;
+    margin-left: 4px;
+    font-size: 0.7rem;
+    color: var(--crow-text-muted);
+    opacity: 0.7;
+  }
+
   /* Reply preview inside bubble */
   .msg-bubble-reply-preview {
     border-left: 3px solid var(--crow-accent);

--- a/servers/gateway/dashboard/panels/messages/data-queries.js
+++ b/servers/gateway/dashboard/panels/messages/data-queries.js
@@ -163,7 +163,7 @@ export async function getMessageRequests(db) {
 export async function getPeerMessages(db, contactId, { limit = 50, offset = 0 } = {}) {
   const { rows } = await db.execute({
     sql: `SELECT m.id, m.content, m.direction, m.is_read, m.created_at,
-                 m.thread_id, m.nostr_event_id, m.attachments,
+                 m.thread_id, m.nostr_event_id, m.attachments, m.delivery_status,
                  c.display_name, c.crow_id
           FROM messages m
           LEFT JOIN contacts c ON m.contact_id = c.id

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -274,6 +274,10 @@ export const translations = {
   "messages.contactNotFound": { en: "Contact not found", es: "Contacto no encontrado" },
   "messages.reply": { en: "Reply", es: "Responder" },
   "messages.replyingTo": { en: "Replying to", es: "Respondiendo a" },
+  // R2 Task 4 — persisted delivery-status indicator on thread reload.
+  "messages.notDelivered": { en: "not delivered", es: "no entregado" },
+  "messages.deliveryRelayed": { en: "Relayed to at least one relay", es: "Retransmitido a al menos un repetidor" },
+  "messages.deliveryDelivered": { en: "Delivered", es: "Entregado" },
   "messages.you": { en: "You", es: "Tú" },
   "messages.them": { en: "Them", es: "Ellos" },
   "messages.attachFile": { en: "Attach file", es: "Adjuntar archivo" },

--- a/servers/gateway/routes/peer-messages.js
+++ b/servers/gateway/routes/peer-messages.js
@@ -17,7 +17,105 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../sharing/server.js";
 
-export default function peerMessagesRouter(dashboardAuth) {
+/**
+ * Create a connected sharing MCP client (the real in-memory transport). This is
+ * the default factory; tests inject a stub so no live Nostr runtime starts.
+ */
+async function makePeerSharingClient() {
+  const server = createSharingServer();
+  const client = new Client({ name: "peer-messages-api", version: "0.1.0" });
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await server.connect(st);
+  await client.connect(ct);
+  return client;
+}
+
+/**
+ * Send a peer message and surface a 0-relay failure on the LIVE path.
+ *
+ * The tool result (crow_send_message) is CAPTURED and inspected — a result with
+ * isError (a 0-relay publish) returns a non-ok (502) response instead of the
+ * old unconditional { ok:true }. This is what lets the dashboard mark the
+ * optimistic bubble as failed at send time.
+ *
+ * Exported for unit tests (drive it with a stub db + sharingClientFactory).
+ */
+export async function handlePeerSend(req, res, { db, sharingClientFactory = makePeerSharingClient } = {}) {
+  const contactId = parseInt(req.params.contactId);
+  if (!contactId) return res.status(400).json({ error: "Invalid contact ID" });
+
+  const { message, attachments } = req.body || {};
+  if (!message || typeof message !== "string" || !message.trim()) {
+    return res.status(400).json({ error: "Message content is required" });
+  }
+
+  // Get contact identifier for crow_send_message
+  const { rows: contactRows } = await db.execute({
+    sql: "SELECT crow_id, display_name FROM contacts WHERE id = ?",
+    args: [contactId],
+  });
+  if (contactRows.length === 0) {
+    return res.status(404).json({ error: "Contact not found" });
+  }
+
+  const contact = contactRows[0];
+  const contactIdentifier = contact.display_name || contact.crow_id;
+
+  // Send via MCP sharing server — CAPTURE the result (a 0-relay send is a
+  // failure the client must see).
+  let toolResult;
+  const client = await sharingClientFactory();
+  try {
+    toolResult = await client.callTool({
+      name: "crow_send_message",
+      arguments: { contact: contactIdentifier, message: message.trim() },
+    });
+  } finally {
+    await client.close();
+  }
+
+  const resultText = (toolResult?.content || [])
+    .map((c) => c && c.text)
+    .filter(Boolean)
+    .join(" ");
+  if (toolResult?.isError) {
+    // Delivery failed (e.g. reached 0 relays). Do NOT report success.
+    return res.status(502).json({ ok: false, error: resultText || "Message could not be delivered." });
+  }
+
+  // Store attachment metadata if provided (only for a delivered message)
+  if (attachments && Array.isArray(attachments) && attachments.length > 0) {
+    // Get the message we just sent (latest sent message to this contact)
+    const { rows: latestMsg } = await db.execute({
+      sql: `SELECT id FROM messages
+            WHERE contact_id = ? AND direction = 'sent'
+            ORDER BY id DESC LIMIT 1`,
+      args: [contactId],
+    });
+
+    if (latestMsg.length > 0) {
+      const msgId = latestMsg[0].id;
+      await db.execute({
+        sql: "UPDATE messages SET attachments = ? WHERE id = ?",
+        args: [JSON.stringify(attachments), msgId],
+      });
+
+      // Update storage_files references
+      for (const att of attachments) {
+        if (att.s3_key) {
+          await db.execute({
+            sql: "UPDATE storage_files SET reference_type = 'message', reference_id = ? WHERE s3_key = ?",
+            args: [msgId, att.s3_key],
+          });
+        }
+      }
+    }
+  }
+
+  res.json({ ok: true });
+}
+
+export default function peerMessagesRouter(dashboardAuth, { sharingClientFactory = makePeerSharingClient } = {}) {
   const router = Router();
 
   // All peer message routes require dashboard auth
@@ -89,74 +187,9 @@ export default function peerMessagesRouter(dashboardAuth) {
   router.post("/api/messages/peer/:contactId/send", async (req, res) => {
     const db = createDbClient();
     try {
-      const contactId = parseInt(req.params.contactId);
-      if (!contactId) return res.status(400).json({ error: "Invalid contact ID" });
-
-      const { message, attachments } = req.body || {};
-      if (!message || typeof message !== "string" || !message.trim()) {
-        return res.status(400).json({ error: "Message content is required" });
-      }
-
-      // Get contact identifier for crow_send_message
-      const { rows: contactRows } = await db.execute({
-        sql: "SELECT crow_id, display_name FROM contacts WHERE id = ?",
-        args: [contactId],
-      });
-      if (contactRows.length === 0) {
-        return res.status(404).json({ error: "Contact not found" });
-      }
-
-      const contact = contactRows[0];
-      const contactIdentifier = contact.display_name || contact.crow_id;
-
-      // Send via MCP sharing server
-      const server = createSharingServer();
-      const client = new Client({ name: "peer-messages-api", version: "0.1.0" });
-      const [ct, st] = InMemoryTransport.createLinkedPair();
-      await server.connect(st);
-      await client.connect(ct);
-
-      try {
-        await client.callTool({
-          name: "crow_send_message",
-          arguments: { contact: contactIdentifier, message: message.trim() },
-        });
-      } finally {
-        await client.close();
-      }
-
-      // Store attachment metadata if provided
-      if (attachments && Array.isArray(attachments) && attachments.length > 0) {
-        // Get the message we just sent (latest sent message to this contact)
-        const { rows: latestMsg } = await db.execute({
-          sql: `SELECT id FROM messages
-                WHERE contact_id = ? AND direction = 'sent'
-                ORDER BY id DESC LIMIT 1`,
-          args: [contactId],
-        });
-
-        if (latestMsg.length > 0) {
-          const msgId = latestMsg[0].id;
-          await db.execute({
-            sql: "UPDATE messages SET attachments = ? WHERE id = ?",
-            args: [JSON.stringify(attachments), msgId],
-          });
-
-          // Update storage_files references
-          for (const att of attachments) {
-            if (att.s3_key) {
-              await db.execute({
-                sql: "UPDATE storage_files SET reference_type = 'message', reference_id = ? WHERE s3_key = ?",
-                args: [msgId, att.s3_key],
-              });
-            }
-          }
-        }
-      }
-
-      res.json({ ok: true });
+      await handlePeerSend(req, res, { db, sharingClientFactory });
     } catch (err) {
-      res.status(500).json({ error: err.message });
+      if (!res.headersSent) res.status(500).json({ error: err.message });
     } finally {
       db.close();
     }

--- a/servers/shared/schema-version.js
+++ b/servers/shared/schema-version.js
@@ -10,7 +10,7 @@
 // by servers/gateway/index.js during boot; importing scripts/init-db.js here
 // (or anything that runs DB work at module top-level) would execute init-db
 // as an unwanted side effect.
-export const SCHEMA_GENERATION = 1;
+export const SCHEMA_GENERATION = 2;
 
 // Pure decision helper for the gateway boot gate. Returns true when the DB
 // needs init-db to run: either core tables are missing (fresh/incomplete

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -31,9 +31,17 @@ import { Relay } from "nostr-tools/relay";
 import { safeRelayPublish } from "./safe-relay-publish.js";
 import { makeResilientSub } from "./resilient-subscribe.js";
 
-const DEFAULT_RELAYS = [
+// Heavily-operated public relays, each verified (2026-07-02) to accept an
+// anonymous kind-4 publish (a throwaway-key connect+publish probe). Dropped
+// from the candidate set: wss://relay.nostr.band (connect timeout — did not
+// respond over plain WebSocket either) and wss://offchain.pub (connects, but
+// rejects anonymous writes: "Policy violated and pubkey is not in our web of
+// trust"). These are always a floor for connectRelays()/getConfiguredRelays()
+// — see the merge behavior below — so one flaky relay is never a SPOF.
+export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
   "wss://nos.lol",
+  "wss://relay.primal.net",
 ];
 
 export class NostrManager {
@@ -71,7 +79,7 @@ export class NostrManager {
   }
 
   async _doConnectRelays(customRelays) {
-    const relayUrls = customRelays || DEFAULT_RELAYS;
+    const relayUrls = customRelays || (await this.getConfiguredRelays());
 
     // Connect to relays in parallel with a per-relay timeout
     const results = await Promise.allSettled(
@@ -443,19 +451,45 @@ export class NostrManager {
   }
 
   /**
-   * Get configured relays from DB.
+   * Get configured relays: DEFAULT_RELAYS merged with any enabled user-added
+   * relay_config rows (deduped, case-insensitively, by exact URL). Defaults
+   * are ALWAYS a floor — this must never shrink to just the config rows,
+   * or an install that ran crow_add_relay once would drop to a single relay
+   * (the SPOF this fixes). Never throws: any DB error falls back to
+   * DEFAULT_RELAYS so a broken relay_config read can't break connectRelays().
    */
   async getConfiguredRelays() {
     if (!this.db) return DEFAULT_RELAYS;
 
-    const result = await this.db.execute({
-      sql: `SELECT relay_url FROM relay_config
-            WHERE relay_type = 'nostr' AND enabled = 1`,
-      args: [],
-    });
+    let configured = [];
+    try {
+      const result = await this.db.execute({
+        sql: `SELECT relay_url FROM relay_config
+              WHERE relay_type = 'nostr' AND enabled = 1`,
+        args: [],
+      });
+      configured = result.rows.map((r) => r.relay_url);
+    } catch (err) {
+      console.warn("[nostr] getConfiguredRelays: DB read failed, falling back to DEFAULT_RELAYS:", err?.message);
+      return DEFAULT_RELAYS;
+    }
 
-    if (result.rows.length === 0) return DEFAULT_RELAYS;
-    return result.rows.map((r) => r.relay_url);
+    const seen = new Set();
+    const merged = [];
+    for (const url of [...DEFAULT_RELAYS, ...configured]) {
+      const key = url.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(url);
+    }
+    return merged;
+  }
+
+  /**
+   * URLs of currently-connected relays.
+   */
+  connectedRelayUrls() {
+    return [...this.relays.keys()];
   }
 
   /**

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -163,14 +163,24 @@ export class NostrManager {
       }
     }
 
-    // Cache locally
+    // Cache locally. delivery_status reflects the honest publish outcome above
+    // ('relayed' when >=1 relay accepted, 'failed' when 0). Best-effort: the
+    // event was already published (or not) to relays above, so a local-cache
+    // write failure must not throw out of sendMessage and lose that outcome
+    // for the caller (see Global Constraints in the R2 plan).
     const contactId = contact.id || contact.contact_id;
+    const deliveryStatus = published.length > 0 ? "relayed" : "failed";
     if (contactId && this.db) {
-      await this.db.execute({
-        sql: `INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
-              VALUES (?, ?, ?, 'sent', 1, datetime('now'))`,
-        args: [contactId, event.id, content],
-      });
+      try {
+        await this.db.execute({
+          sql: `INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read, delivery_status, created_at)
+                VALUES (?, ?, ?, 'sent', 1, ?, datetime('now'))`,
+          args: [contactId, event.id, content, deliveryStatus],
+        });
+      } catch (err) {
+        // Local-cache write failed — the message was still (or wasn't)
+        // published above; don't let a DB error mask that outcome.
+      }
     }
 
     return {

--- a/servers/sharing/tools/messaging.js
+++ b/servers/sharing/tools/messaging.js
@@ -42,11 +42,28 @@ export function registerMessagingTools(server, ctx) {
 
       try {
         const delivery = await nostrManager.sendMessage(contactRow, message);
+        const relayCount = delivery?.relays?.length || 0;
+        const target = contactRow.display_name || contactRow.crow_id;
+        // A 0-relay publish is a delivery FAILURE, not a silent success: the
+        // event reached no relay, so the recipient can never receive it.
+        if (relayCount === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Message could NOT be delivered — reached 0 relays. Check your connection / relay settings.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        // A partial publish (>=1 of N) stays a success: publish-acceptance by at
+        // least one relay is the deliverability signal we have pre-R5-ack.
         return {
           content: [
             {
               type: "text",
-              text: `Message sent to ${contactRow.display_name || contactRow.crow_id} via ${delivery.relays.length} relay(s).`,
+              text: `Message delivered to ${target} via ${relayCount} relay(s).`,
             },
           ],
         };

--- a/tests/message-delivery-render.test.js
+++ b/tests/message-delivery-render.test.js
@@ -1,0 +1,243 @@
+/**
+ * message-delivery-render — R2 Task 4. Show delivery state on THREAD RELOAD
+ * (persisted `delivery_status`), not just at send time (Task 3 covers the
+ * live send-time failure surfacing via markBubbleFailed).
+ *
+ * (a) QUERY level: getPeerMessages must include delivery_status per row so
+ *     the client has it to render on reload.
+ * (b) RENDER level: appendBubble (client.js, executed in-browser) must show
+ *     — for direction='sent' only — a failed affordance (reusing Task 3's
+ *     `msg-bubble-failed` class + note, via markBubbleFailed) when
+ *     delivery_status='failed'; a single check for 'relayed'; a double check
+ *     for 'delivered'; nothing for null/'pending'. Received messages never
+ *     show a delivery indicator.
+ *
+ * client.js is a big browser-executed template string that self-starts
+ * polling/fetch on load, so we don't run the whole thing in a vm — we
+ * extract just the functions the render path needs (el, appendBubble,
+ * markBubbleFailed) via brace-matching and run those against a minimal
+ * hand-rolled DOM stub (no jsdom dependency).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { getPeerMessages } from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+import { messagesClientJS } from "../servers/gateway/dashboard/panels/messages/client.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "msg-delivery-render-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+async function mkContact(db, { crowId, name = null }) {
+  const r = await db.execute({
+    sql: `INSERT INTO contacts (crow_id, display_name, secp256k1_pubkey, ed25519_pubkey, contact_type)
+          VALUES (?,?,?,?, 'crow')`,
+    args: [crowId, name, "02" + "a".repeat(64), "e".repeat(64)],
+  });
+  return Number(r.lastInsertRowid);
+}
+
+// --- (a) QUERY: getPeerMessages surfaces delivery_status ---
+
+test("getPeerMessages includes delivery_status per message (sent + received)", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const contactId = await mkContact(db, { crowId: "crow:render-test", name: "Render Test" });
+    await db.execute({
+      sql: `INSERT INTO messages (contact_id, content, direction, delivery_status) VALUES (?,?,?,?)`,
+      args: [contactId, "will fail", "sent", "failed"],
+    });
+    await db.execute({
+      sql: `INSERT INTO messages (contact_id, content, direction, delivery_status) VALUES (?,?,?,?)`,
+      args: [contactId, "went out", "sent", "relayed"],
+    });
+    await db.execute({
+      sql: `INSERT INTO messages (contact_id, content, direction, delivery_status) VALUES (?,?,?,?)`,
+      args: [contactId, "hi there", "received", null],
+    });
+
+    const msgs = await getPeerMessages(db, contactId);
+    assert.equal(msgs.length, 3);
+    const byContent = Object.fromEntries(msgs.map((m) => [m.content, m.delivery_status]));
+    assert.equal(byContent["will fail"], "failed");
+    assert.equal(byContent["went out"], "relayed");
+    assert.equal(byContent["hi there"], null);
+  } finally {
+    cleanup();
+  }
+});
+
+// --- (b) RENDER: appendBubble surfaces delivery_status on reload ---
+
+// Grab a named `function name(...) { ... }` declaration out of the generated
+// script text via balanced-brace matching (no eval of the whole file).
+function extractFunction(src, name) {
+  const marker = `function ${name}(`;
+  const start = src.indexOf(marker);
+  if (start === -1) throw new Error(`function ${name} not found in generated client script`);
+  const braceStart = src.indexOf("{", start);
+  let depth = 0;
+  let i = braceStart;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        i++;
+        break;
+      }
+    }
+  }
+  return src.slice(start, i);
+}
+
+// Minimal hand-rolled DOM stub — just enough surface for el()/appendBubble()/
+// markBubbleFailed(): createElement, createTextNode, appendChild, textContent,
+// className, classList.add/contains, dataset, style.cssText, setAttribute,
+// addEventListener (no-op), querySelector (recursive class search).
+function makeFakeDocument() {
+  function makeElement(tag) {
+    const node = {
+      tagName: tag,
+      _text: "",
+      children: [],
+      attributes: {},
+      style: { cssText: "" },
+      className: "",
+      dataset: {},
+      classList: {
+        _set: new Set(),
+        add(c) {
+          this._set.add(c);
+        },
+        contains(c) {
+          return this._set.has(c);
+        },
+      },
+      appendChild(child) {
+        this.children.push(child);
+        return child;
+      },
+      setAttribute(k, v) {
+        this.attributes[k] = v;
+      },
+      addEventListener() {},
+      querySelector(sel) {
+        const cls = sel.replace(".", "");
+        const search = (n) => {
+          for (const c of n.children || []) {
+            if (c.className && String(c.className).split(/\s+/).includes(cls)) return c;
+            const found = search(c);
+            if (found) return found;
+          }
+          return null;
+        };
+        return search(this);
+      },
+    };
+    Object.defineProperty(node, "textContent", {
+      get() {
+        return this._text;
+      },
+      set(v) {
+        this._text = v;
+        this.children = [];
+      },
+    });
+    return node;
+  }
+  return {
+    createElement: (tag) => makeElement(tag),
+    createTextNode: (text) => ({ nodeType: 3, textContent: text }),
+  };
+}
+
+function buildAppendBubble(lang = "en") {
+  const script = messagesClientJS({ aiConfigured: false, storageAvailable: false, lang });
+  const elSrc = extractFunction(script, "el");
+  const relativeTimeSrc = extractFunction(script, "relativeTime");
+  const appendBubbleSrc = extractFunction(script, "appendBubble");
+  const markBubbleFailedSrc = extractFunction(script, "markBubbleFailed");
+
+  const context = {
+    document: makeFakeDocument(),
+    _activeItem: { type: "peer" },
+    _messages: [],
+    console,
+  };
+  vm.createContext(context);
+  vm.runInContext(
+    `${elSrc}\n${relativeTimeSrc}\n${appendBubbleSrc}\n${markBubbleFailedSrc}\nglobalThis.__appendBubble = appendBubble;`,
+    context,
+  );
+  return context.__appendBubble;
+}
+
+function renderBubble(msg, lang) {
+  const appendBubble = buildAppendBubble(lang);
+  const container = {
+    children: [],
+    appendChild(n) {
+      this.children.push(n);
+      return n;
+    },
+  };
+  return appendBubble(container, msg);
+}
+
+test("sent message with delivery_status='failed' renders the failed indicator on reload", () => {
+  const bubble = renderBubble({ direction: "sent", content: "hi", delivery_status: "failed" });
+  assert.ok(bubble.classList.contains("msg-bubble-failed"), "bubble should carry msg-bubble-failed class");
+  const note = bubble.querySelector(".msg-bubble-failed-note");
+  assert.ok(note, "a failed note should be present");
+  assert.match(note.textContent, /not delivered/i);
+});
+
+test("sent message with delivery_status='relayed' renders a single check", () => {
+  const bubble = renderBubble({ direction: "sent", content: "hi", delivery_status: "relayed" });
+  assert.equal(bubble.classList.contains("msg-bubble-failed"), false);
+  const indicator = bubble.querySelector(".msg-delivery");
+  assert.ok(indicator, "a relayed check indicator should be present");
+  assert.equal(indicator.textContent, "✓");
+});
+
+test("sent message with delivery_status='delivered' renders a double check", () => {
+  const bubble = renderBubble({ direction: "sent", content: "hi", delivery_status: "delivered" });
+  const indicator = bubble.querySelector(".msg-delivery");
+  assert.ok(indicator, "a delivered double-check indicator should be present");
+  assert.equal(indicator.textContent, "✓✓");
+});
+
+test("sent message with delivery_status=null/pending renders no indicator", () => {
+  for (const status of [null, undefined, "pending"]) {
+    const bubble = renderBubble({ direction: "sent", content: "hi", delivery_status: status });
+    assert.equal(bubble.classList.contains("msg-bubble-failed"), false, `status=${status}`);
+    assert.equal(bubble.querySelector(".msg-delivery"), null, `status=${status}`);
+    assert.equal(bubble.querySelector(".msg-bubble-failed-note"), null, `status=${status}`);
+  }
+});
+
+test("received message never renders a delivery indicator regardless of delivery_status", () => {
+  const bubble = renderBubble({ direction: "received", content: "hi", delivery_status: "failed" });
+  assert.equal(bubble.classList.contains("msg-bubble-failed"), false);
+  assert.equal(bubble.querySelector(".msg-delivery"), null);
+  assert.equal(bubble.querySelector(".msg-bubble-failed-note"), null);
+});
+
+test("Spanish lang renders the same symbols (i18n only touches tooltip text)", () => {
+  const relayed = renderBubble({ direction: "sent", content: "hola", delivery_status: "relayed" }, "es");
+  assert.equal(relayed.querySelector(".msg-delivery").textContent, "✓");
+  const failed = renderBubble({ direction: "sent", content: "hola", delivery_status: "failed" }, "es");
+  assert.ok(failed.querySelector(".msg-bubble-failed-note"));
+});

--- a/tests/message-delivery-status.test.js
+++ b/tests/message-delivery-status.test.js
@@ -1,0 +1,101 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { NostrManager } from "../servers/sharing/nostr.js";
+import { generateSecretKey, getPublicKey } from "nostr-tools/pure";
+
+// Real (throwaway) secp256k1 keys — NIP-44 conversation-key derivation needs
+// valid curve points, unlike the all-zero stub used by resubscribe tests
+// (which never reach the encryption path).
+const senderPriv = generateSecretKey();
+const identity = { secp256k1Pubkey: getPublicKey(senderPriv), secp256k1Priv: senderPriv };
+const recipientPriv = generateSecretKey();
+const recipientPubkey = getPublicKey(recipientPriv);
+
+// Minimal relay stub matching what safeRelayPublish expects (connected + publish()).
+function stubRelay({ connected = true, shouldPublish = true } = {}) {
+  return {
+    connected,
+    async connect() { this.connected = true; },
+    async publish() {
+      if (!shouldPublish) throw new Error("publish rejected");
+      return { id: "ev" };
+    },
+  };
+}
+
+let dir, db, contactId;
+
+before(async () => {
+  dir = mkdtempSync(join(tmpdir(), "message-delivery-status-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, ".."),
+  });
+  process.env.CROW_DATA_DIR = dir;
+  db = createDbClient();
+
+  const res = await db.execute({
+    sql: `INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (?, ?, ?)`,
+    args: ["crow:test-contact", "b".repeat(64), "c".repeat(64)],
+  });
+  contactId = Number(res.lastInsertRowid);
+});
+
+after(() => {
+  try { db.close(); } catch {}
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+test("sendMessage persists delivery_status='relayed' when publish succeeds to >=1 relay", async () => {
+  const mgr = new NostrManager(identity, db);
+  mgr.relays.set("wss://stub-ok", stubRelay({ connected: true, shouldPublish: true }));
+
+  const contact = { id: contactId, secp256k1_pubkey: recipientPubkey };
+  const result = await mgr.sendMessage(contact, "hello relayed");
+
+  assert.ok(result.relays.length >= 1, "expected >=1 relay to accept publish");
+
+  const row = await db.execute({
+    sql: `SELECT delivery_status FROM messages WHERE nostr_event_id = ?`,
+    args: [result.eventId],
+  });
+  assert.equal(row.rows[0].delivery_status, "relayed");
+});
+
+test("sendMessage persists delivery_status='failed' when 0 relays accept publish", async () => {
+  const mgr = new NostrManager(identity, db);
+  mgr.relays.set("wss://stub-fail", stubRelay({ connected: true, shouldPublish: false }));
+
+  const contact = { id: contactId, secp256k1_pubkey: recipientPubkey };
+  const result = await mgr.sendMessage(contact, "hello failed");
+
+  assert.deepEqual(result.relays, []);
+
+  const row = await db.execute({
+    sql: `SELECT delivery_status FROM messages WHERE nostr_event_id = ?`,
+    args: [result.eventId],
+  });
+  assert.equal(row.rows[0].delivery_status, "failed");
+});
+
+test("sendMessage persists delivery_status='failed' when relays.size===0 (no relays connected)", async () => {
+  const mgr = new NostrManager(identity, db);
+  // No relays set — sendMessage will call connectRelays(), but override it to
+  // stay empty so we don't hit the live network in a unit test.
+  mgr.connectRelays = async () => {};
+
+  const contact = { id: contactId, secp256k1_pubkey: recipientPubkey };
+  const result = await mgr.sendMessage(contact, "hello no relays");
+
+  assert.deepEqual(result.relays, []);
+
+  const row = await db.execute({
+    sql: `SELECT delivery_status FROM messages WHERE nostr_event_id = ?`,
+    args: [result.eventId],
+  });
+  assert.equal(row.rows[0].delivery_status, "failed");
+});

--- a/tests/message-send-feedback.test.js
+++ b/tests/message-send-feedback.test.js
@@ -1,0 +1,124 @@
+/**
+ * message-send-feedback — R2 Task 3. A 0-relay send is a FAILURE surfaced on
+ * the LIVE path (not a silent success).
+ *
+ * (a) TOOL level: crow_send_message returns isError:true when sendMessage
+ *     reaches 0 relays ({relays:[]}); success (no isError) with an accurate
+ *     "N relay(s)" text when >=1.
+ * (b) ROUTE level: peer-messages.js handlePeerSend captures the tool result and
+ *     returns a NON-OK (502 / {ok:false}) response when the tool reports
+ *     isError; {ok:true} when the send succeeded. This guards C1 (the live send
+ *     path used to discard the tool result and always return {ok:true}).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerMessagingTools } from "../servers/sharing/tools/messaging.js";
+import { handlePeerSend } from "../servers/gateway/routes/peer-messages.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "msg-send-feedback-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+// Capture registered MCP tool handlers by name from a register* function.
+function captureTools(registerFn, ctx) {
+  const tools = {};
+  const server = { tool: (name, _desc, _schema, handler) => { tools[name] = handler; } };
+  registerFn(server, ctx);
+  return tools;
+}
+
+async function mkContact(db, { crowId, name = null }) {
+  const r = await db.execute({
+    sql: `INSERT INTO contacts (crow_id, display_name, secp256k1_pubkey, ed25519_pubkey, contact_type)
+          VALUES (?,?,?,?, 'crow')`,
+    args: [crowId, name, "02" + "a".repeat(64), "e".repeat(64)],
+  });
+  return Number(r.lastInsertRowid);
+}
+
+// --- (a) TOOL: 0 relays => isError; >=1 => success ---
+
+test("crow_send_message returns isError when the send reaches 0 relays", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await mkContact(db, { crowId: "crow:zero", name: "Zero" });
+    const nostrManager = { sendMessage: async () => ({ relays: [] }) };
+    const tools = captureTools(registerMessagingTools, { db, identity: {}, nostrManager });
+
+    const res = await tools.crow_send_message({ contact: "Zero", message: "hi" });
+    assert.equal(res.isError, true, "0-relay send is an error");
+    const text = res.content.map((c) => c.text).join(" ");
+    assert.match(text, /0 relays/i, "message names the 0-relay failure");
+  } finally { cleanup(); }
+});
+
+test("crow_send_message succeeds (no isError, accurate relay count) when >=1 relay accepts", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await mkContact(db, { crowId: "crow:one", name: "One" });
+    const nostrManager = { sendMessage: async () => ({ relays: ["wss://x"] }) };
+    const tools = captureTools(registerMessagingTools, { db, identity: {}, nostrManager });
+
+    const res = await tools.crow_send_message({ contact: "One", message: "hi" });
+    assert.ok(!res.isError, "a >=1-relay send is not an error");
+    const text = res.content.map((c) => c.text).join(" ");
+    assert.match(text, /1 relay/i, "success text reports the relay count");
+  } finally { cleanup(); }
+});
+
+// --- (b) ROUTE: handlePeerSend surfaces the tool result on the LIVE path ---
+
+function mockRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    headersSent: false,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; this.headersSent = true; return this; },
+  };
+}
+
+// A db stub whose contact lookup returns one row (so handlePeerSend proceeds).
+const dbWithContact = { execute: async () => ({ rows: [{ crow_id: "crow:x", display_name: "Alice" }] }) };
+
+function stubFactory(toolResult) {
+  return async () => ({
+    callTool: async () => toolResult,
+    close: async () => {},
+  });
+}
+
+test("handlePeerSend returns non-ok (502 / ok:false) when the tool reports isError (0 relays)", async () => {
+  const req = { params: { contactId: "5" }, body: { message: "hi" } };
+  const res = mockRes();
+  const sharingClientFactory = stubFactory({
+    isError: true,
+    content: [{ type: "text", text: "Message could NOT be delivered — reached 0 relays." }],
+  });
+  await handlePeerSend(req, res, { db: dbWithContact, sharingClientFactory });
+  assert.equal(res.statusCode, 502, "0-relay send yields HTTP 502");
+  assert.equal(res.body.ok, false, "body reports ok:false");
+  assert.match(res.body.error || "", /0 relays/i, "error carries the tool's failure text");
+});
+
+test("handlePeerSend returns {ok:true} when the tool succeeds (>=1 relay, no regression)", async () => {
+  const req = { params: { contactId: "5" }, body: { message: "hi" } };
+  const res = mockRes();
+  const sharingClientFactory = stubFactory({
+    content: [{ type: "text", text: "Message delivered to Alice via 2 relay(s)." }],
+  });
+  await handlePeerSend(req, res, { db: dbWithContact, sharingClientFactory });
+  assert.equal(res.statusCode, 200, "successful send stays 200");
+  assert.deepEqual(res.body, { ok: true }, "successful send returns ok:true");
+});

--- a/tests/nostr-relay-config.test.js
+++ b/tests/nostr-relay-config.test.js
@@ -1,0 +1,120 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { NostrManager, DEFAULT_RELAYS } from "../servers/sharing/nostr.js";
+
+const identity = { secp256k1Pubkey: "a".repeat(64), secp256k1Priv: new Uint8Array(32) };
+
+let dir, db;
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), "nostr-relay-config-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, ".."),
+  });
+  process.env.CROW_DATA_DIR = dir;
+  db = createDbClient();
+});
+after(() => { try { db.close(); } catch {} try { rmSync(dir, { recursive: true, force: true }); } catch {} });
+
+test("DEFAULT_RELAYS is a resilient set of more than 2 relays", () => {
+  assert.ok(Array.isArray(DEFAULT_RELAYS));
+  assert.ok(DEFAULT_RELAYS.length > 2, `expected >2 default relays, got ${DEFAULT_RELAYS.length}`);
+  assert.ok(DEFAULT_RELAYS.includes("wss://relay.damus.io"));
+  assert.ok(DEFAULT_RELAYS.includes("wss://nos.lol"));
+});
+
+test("getConfiguredRelays returns full DEFAULT_RELAYS when relay_config is empty", async () => {
+  const mgr = new NostrManager(identity, db);
+  const relays = await mgr.getConfiguredRelays();
+  for (const url of DEFAULT_RELAYS) {
+    assert.ok(relays.includes(url), `expected default ${url} present`);
+  }
+  assert.equal(relays.length, DEFAULT_RELAYS.length);
+});
+
+test("getConfiguredRelays MERGES an enabled config row with defaults (does not replace)", async () => {
+  await db.execute({
+    sql: `INSERT INTO relay_config (relay_url, relay_type, enabled) VALUES (?, 'nostr', 1)`,
+    args: ["wss://custom.example"],
+  });
+
+  const mgr = new NostrManager(identity, db);
+  const relays = await mgr.getConfiguredRelays();
+
+  // All defaults must still be present — the merge, not replace.
+  for (const url of DEFAULT_RELAYS) {
+    assert.ok(relays.includes(url), `expected default ${url} still present after adding custom relay`);
+  }
+  assert.ok(relays.includes("wss://custom.example"), "expected custom relay to be added");
+  assert.equal(relays.length, DEFAULT_RELAYS.length + 1);
+
+  await db.execute({
+    sql: `DELETE FROM relay_config WHERE relay_url = ?`,
+    args: ["wss://custom.example"],
+  });
+});
+
+test("getConfiguredRelays dedups a config row that duplicates a default", async () => {
+  const dupUrl = DEFAULT_RELAYS[0];
+  await db.execute({
+    sql: `INSERT INTO relay_config (relay_url, relay_type, enabled) VALUES (?, 'nostr', 1)`,
+    args: [dupUrl],
+  });
+
+  const mgr = new NostrManager(identity, db);
+  const relays = await mgr.getConfiguredRelays();
+
+  const occurrences = relays.filter((r) => r.toLowerCase() === dupUrl.toLowerCase()).length;
+  assert.equal(occurrences, 1, "duplicate default should appear exactly once");
+  assert.equal(relays.length, DEFAULT_RELAYS.length);
+
+  await db.execute({
+    sql: `DELETE FROM relay_config WHERE relay_url = ?`,
+    args: [dupUrl],
+  });
+});
+
+test("getConfiguredRelays disabled config rows are ignored", async () => {
+  await db.execute({
+    sql: `INSERT INTO relay_config (relay_url, relay_type, enabled) VALUES (?, 'nostr', 0)`,
+    args: ["wss://disabled.example"],
+  });
+
+  const mgr = new NostrManager(identity, db);
+  const relays = await mgr.getConfiguredRelays();
+  assert.ok(!relays.includes("wss://disabled.example"));
+
+  await db.execute({
+    sql: `DELETE FROM relay_config WHERE relay_url = ?`,
+    args: ["wss://disabled.example"],
+  });
+});
+
+test("getConfiguredRelays never throws on a broken db — falls back to DEFAULT_RELAYS", async () => {
+  const brokenDb = {
+    async execute() {
+      throw new Error("database is locked");
+    },
+  };
+  const mgr = new NostrManager(identity, brokenDb);
+  const relays = await mgr.getConfiguredRelays();
+  assert.deepEqual(relays, DEFAULT_RELAYS);
+});
+
+test("getConfiguredRelays returns DEFAULT_RELAYS when no db is set", async () => {
+  const mgr = new NostrManager(identity, null);
+  const relays = await mgr.getConfiguredRelays();
+  assert.deepEqual(relays, DEFAULT_RELAYS);
+});
+
+test("connectedRelayUrls returns the currently connected relay URLs", async () => {
+  const mgr = new NostrManager(identity, null);
+  assert.deepEqual(mgr.connectedRelayUrls(), []);
+  mgr.relays.set("wss://a", {});
+  mgr.relays.set("wss://b", {});
+  assert.deepEqual(mgr.connectedRelayUrls().sort(), ["wss://a", "wss://b"]);
+});


### PR DESCRIPTION
The send-side of the "stop silent failures" theme (companion to L6, which fixed the receive side). The Phase 1a harness found crow reaching only 1 of 2 relays while reporting "sent," and a 0-relay send looked identical to a delivered one. Plan (1-round adversarial review): `docs/superpowers/plans/2026-07-02-messages-p1b-r2-relay-resilience.md`.

## Relay resilience (fixes L4 dead-code + the send SPOF)
- `getConfiguredRelays()` was **dead** (all `connectRelays()` calls argless) and, worse, would have **replaced** the defaults with any `crow_add_relay` rows — dropping to a single relay. Now it **merges** `DEFAULT_RELAYS ∪ configured` (deduped, never-throw), so user-added relays finally take effect *and* the defaults are always a floor.
- `DEFAULT_RELAYS` expanded 2 → 3, each **probe-verified at build time** to accept an anonymous kind-4 publish (damus.io, nos.lol, relay.primal.net; nostr.band and offchain.pub were honestly dropped for connect-timeout / write-restriction).

## Honest delivery feedback (R2)
- New nullable `messages.delivery_status` (`pending`/`relayed`/`delivered`/`failed`); `SCHEMA_GENERATION` bumped 1→2 so it **auto-applies on restart** via the PR #127 schema-gate (dogfoods that fix on a real column).
- `sendMessage` persists `relayed` (≥1 relay accepted) / `failed` (0). The honest relay count already existed — it was just being thrown away.
- **A 0-relay send is now unmistakably a failure** at three layers: `crow_send_message` returns `isError`; the *live* peer-send route (`peer-messages.js`, which used to discard the result and always return `{ok:true}`) returns **502 `{ok:false}`**; and the client marks the message bubble **"! not delivered"** — at send time *and* on reload (persisted `delivery_status`). Sent messages show a muted ✓ when relayed.

## Review gates
- Plan: adversarial review (round 1 REVISE → C1 live-route retarget + C2 merge-not-replace, both source-verified).
- Combined send-path review (Tasks 1-3): SPEC ✅, never-throw confirmed.
- Final whole-branch review (fable): **READY TO MERGE, no Critical/Important**; **XSS-safe** (the 502 error text reaches the DOM only via `textContent`); relay merge + schema gate verified.
- Tests: new relay-config / delivery-status / send-feedback / render tests; full suite **922/922**.

## Follow-ups (non-blocking)
- Delete the dead `api-handlers.js send_peer` action (not the live path).
- Extend 0-relay failure detection to `crow_send_group_message` (group fan-out still tallies "sent" on 0 relays, though each row now persists `failed` and renders failed on reload).
- R5: a `delivered` ack from the recipient + sender retry queue (the `delivered` value + column are already forward-compatible).

## Deploy
crow's restart auto-applies `delivery_status` via the schema-gate (`user_version` 1→2) — no manual init-db. Pre-deploy `relay_config` audit: no nostr rows on crow/grackle (merge fix is belt-and-braces). Fleet via pull-only auto-update.