### PR TITLE
feat(messages): add self-hosted long-retention relay to DEFAULT_RELAYS (R5 Task 6)

### DIFF
--- a/docs/architecture/sharing-server.md
+++ b/docs/architecture/sharing-server.md
@@ -132,8 +132,12 @@ Messages and social interactions use the Nostr protocol:
 
 - **NIP-44 encryption** (ChaCha20-Poly1305) for all direct messages
 - **NIP-59 gift wraps** for sender anonymity on public relays
-- **Free public relays** provide guaranteed async delivery (messages persist on relays until fetched)
-- Default relays: `wss://relay.damus.io`, `wss://nos.lol`, `wss://relay.nostr.band`
+- **Public relays** provide async delivery (messages persist on relays until fetched)
+- **Default relays** (`DEFAULT_RELAYS` in `servers/sharing/nostr.js`): `wss://relay.damus.io`, `wss://nos.lol`, `wss://relay.primal.net`, and the self-hosted `wss://nostr.crow.maestro.press`. `getConfiguredRelays()` always merges these defaults with any user-configured relays, so the defaults are a floor and one flaky relay is never a single point of failure.
+
+**Self-hosted long-retention relay.** Public relays evict events by age, so a DM sent while the recipient is offline for a long window can be dropped before they reconnect (loss-mode L1). To close this, one default is a self-hosted `nostr-rs-relay` on the maestro.press droplet at `wss://nostr.crow.maestro.press`, configured to retain events long enough to outlast the R5 retry horizon. It is **restricted to `kind:4`** (the only kind Crow uses — all DMs, invites, receipts, group messages, and control envelopes are encrypted kind:4) and write-rate-limited, which bounds abuse on an open-write endpoint.
+
+> **Network-exposure note.** This relay is a **separate service** (its own container behind nginx on maestro.press), *not* a Crow gateway route. It therefore does **not** fall under the gateway's Tailscale-Funnel exposure invariant (which governs dashboard/MCP/private routes on the gateway itself). It is a deliberate, operator-approved public surface that carries only NIP-44-encrypted `kind:4` events the relay cannot read.
 
 The Nostr identity (secp256k1 key) is derived from the same master seed as the Hypercore identity, so users have a single Crow ID for everything.
 

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -44,6 +44,14 @@ export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
   "wss://nos.lol",
   "wss://relay.primal.net",
+  // Self-hosted, long-retention relay (nostr-rs-relay on the maestro.press
+  // droplet) — holds an offline recipient's DMs until they reconnect, which
+  // completes the R5 delivery guarantee for arbitrary offline windows
+  // (loss-mode L1; public relays evict by age). Restricted to kind:4 (all Crow
+  // traffic) and write-rate-limited. Verified 2026-07-02 with a throwaway-key
+  // connect+publish+fetch probe. It is a separate service behind nginx, not a
+  // gateway route, so it does not touch the Funnel network-exposure invariant.
+  "wss://nostr.crow.maestro.press",
 ];
 
 export class NostrManager {

--- a/tests/nostr-relay-config.test.js
+++ b/tests/nostr-relay-config.test.js
@@ -25,6 +25,12 @@ test("DEFAULT_RELAYS is a resilient set of more than 2 relays", () => {
   assert.ok(DEFAULT_RELAYS.length > 2, `expected >2 default relays, got ${DEFAULT_RELAYS.length}`);
   assert.ok(DEFAULT_RELAYS.includes("wss://relay.damus.io"));
   assert.ok(DEFAULT_RELAYS.includes("wss://nos.lol"));
+  // The self-hosted long-retention relay ships as a default so every install
+  // gets offline-message retention (R5 / loss-mode L1) with no config.
+  assert.ok(
+    DEFAULT_RELAYS.includes("wss://nostr.crow.maestro.press"),
+    "self-hosted long-retention relay present in defaults",
+  );
 });
 
 test("getConfiguredRelays returns full DEFAULT_RELAYS when relay_config is empty", async () => {


### PR DESCRIPTION
## Summary

Completes **R5 Task 6** of the Messages usability arc: adds a **self-hosted long-retention Nostr relay** — `wss://nostr.crow.maestro.press` — to `DEFAULT_RELAYS`, so every Crow install gets offline-message retention with zero configuration.

Public relays evict events by age, so a DM sent while the recipient is offline for a long window can be dropped before they reconnect (**loss-mode L1**). R5's delivery receipts + sender retry queue (#131) recover the recipient-restart case but re-publish with the original `created_at`, which age-based eviction can still filter. A relay we control that retains events past the retry horizon is what completes the full offline guarantee.

## Changes (3 files, +20/-2)

- **`servers/sharing/nostr.js`** — one entry appended to `DEFAULT_RELAYS`. `getConfiguredRelays()` already **merges** defaults with user relays, so this is purely additive; the defaults remain a floor and no single relay is a SPOF.
- **`tests/nostr-relay-config.test.js`** — assert the self-hosted relay is present in the defaults.
- **`docs/architecture/sharing-server.md`** — corrected the stale default-relay list and documented the self-hosted relay + its network-exposure status.

## The relay (operator-gated infra, already live on maestro.press)

- `nostr-rs-relay` 0.10.0, dockerized (digest-pinned), bound to `127.0.0.1:8880`, behind the existing nginx (TLS via the `*.crow.maestro.press` wildcard cert). `restart: unless-stopped` + docker enabled at boot → reboot-durable.
- **Restricted to `kind:4`** — the only kind Crow uses (all DMs, invites, receipts, group messages, control envelopes are encrypted kind:4). Plus per-connection write rate-limits and an event-size cap → bounds abuse on an open-write endpoint.
- Weekly 14-day age-prune cron caps storage (the binary has no native TTL; 14d ≫ the ~60h retry horizon).

## Network-exposure note

The relay is a **separate service** behind nginx, **not a Crow gateway route** — it does **not** fall under the gateway's Tailscale-Funnel exposure invariant. It is a deliberate, operator-approved public surface carrying only NIP-44-encrypted `kind:4` events the relay cannot read. Documented in `sharing-server.md`.

## Verification

- ✅ Live throwaway-key probe against `wss://nostr.crow.maestro.press`: connect → publish `kind:4` → **fetch back by id** succeeds → **`kind:1` rejected** by the allowlist (`blocked: event kind is blocked by relay`).
- ✅ Isolated gateway boot subscribes across **4 relay(s)** (was 3), clean `[sharing] Subscribed to incoming`, no relay errors.
- ✅ `tests/nostr-relay-config.test.js` 8/8; focused nostr/relay/retry suite 23/23.

## CI note

Touches `docs/**`, so the **Deploy Docs** workflow will run (its recurring transient Pages-publish flake is not a code failure — build-green is what matters). The `check-ports` gate is path-filtered to bundle port docs and won't trigger.

## Deploy (post-merge)

`git checkout main && git pull --rebase` on crow → `sudo systemctl restart crow-gateway.service` → verify `/health` 200 + `[nostr] Subscribed to incoming on 4 relay(s)`. Fleet self-applies via pull-only auto-update. Then the offline-then-wake E2E via the two-instance harness (black-swan DUT).

Merge is operator-gated.