### PR TITLE
feat(messages): invite links + QR + one add-peer surface (Phase 2 PR1, C1+C3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,6 +211,10 @@ CROW_DB_PATH=./data/crow.db
 # CROW_ENROLL_ENABLED=0
 # CROW_ENROLL_OTC=
 
+# Optional: override the public static page invite share-links point at
+# (default: https://maestro.press/software/crow/invite/). Self-hosters only.
+# CROW_INVITE_PAGE_URL=
+
 # Full reference for every variable (including advanced/dev flags):
 # https://maestro.press/software/crow/developers/configuration
 

--- a/docs/public/invite/index.html
+++ b/docs/public/invite/index.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Crow invite</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         max-width: 560px; margin: 0 auto; padding: 24px 16px; line-height: 1.5;
+         background: #0f1115; color: #e6e6e6; }
+  @media (prefers-color-scheme: light) { body { background: #fafafa; color: #1a1a1a; } .card { background:#fff !important; border-color:#ddd !important; } code { background:#eee !important; } }
+  h1 { font-size: 1.3rem; } h2 { font-size: 1rem; margin-top: 1.4rem; }
+  .card { background: #181b22; border: 1px solid #2a2f3a; border-radius: 10px; padding: 16px; margin: 14px 0; }
+  code, .code { font-family: ui-monospace, Menlo, Consolas, monospace; }
+  .code { display: block; word-break: break-all; background: #10131a; border-radius: 8px;
+          padding: 10px; font-size: 0.85rem; margin: 8px 0; }
+  button { font-size: 0.9rem; padding: 8px 16px; border-radius: 8px; border: 1px solid #3a4150;
+           background: #232838; color: inherit; cursor: pointer; }
+  .muted { opacity: 0.7; font-size: 0.85rem; }
+  .hidden { display: none; }
+  a { color: #7aa2ff; }
+  .langbtn { float: right; font-size: 0.75rem; padding: 4px 10px; }
+</style>
+</head>
+<body>
+<button class="langbtn" id="langToggle" type="button">ES</button>
+
+<div data-lang="en">
+  <h1>🐦‍⬛ You've been invited to connect on Crow</h1>
+  <div id="codeCard-en" class="card hidden">
+    <div class="muted">Invite code (expires 24 hours after it was created, single acceptance):</div>
+    <span class="code" id="code-en"></span>
+    <button type="button" onclick="copyCode(this)" data-done="Copied ✓">Copy code</button>
+  </div>
+  <div id="noCode-en" class="card hidden">
+    <strong>This link has no invite code attached.</strong>
+    <p class="muted">Ask the person who invited you to send the full link (it ends with <code>#crow:…</code>).</p>
+  </div>
+  <div id="expired-en" class="card hidden">
+    <strong>This invite looks expired.</strong>
+    <p class="muted">Invite codes last 24 hours — ask for a fresh one.</p>
+  </div>
+  <h2>Have Crow already?</h2>
+  <p>Open your Crow dashboard → <strong>Messages</strong> → <strong>+</strong> → <strong>Accept an invite</strong> → paste the code.</p>
+  <p class="muted">Or open it directly on your Crow (enter your dashboard address — this stays on your device):</p>
+  <div class="card"><input id="gw-en" placeholder="https://your-crow.example.ts.net:8444" style="width:100%;padding:8px;border-radius:8px;border:1px solid #3a4150;background:transparent;color:inherit">
+  <button type="button" style="margin-top:8px" onclick="openOnCrow('en')">Open my Crow</button></div>
+  <h2>New to Crow?</h2>
+  <p>Crow is a private, self-hosted AI + messaging hub. <a href="https://maestro.press/software/crow/getting-started/">Install Crow</a>, then come back to this link.</p>
+  <p class="muted">Privacy: the code lives only in this link (after the <code>#</code>) — this page sends nothing anywhere. Whoever carried the link could see the code, which is why it expires. After connecting, compare <strong>safety numbers</strong> to verify each other.</p>
+</div>
+
+<div data-lang="es" class="hidden">
+  <h1>🐦‍⬛ Te han invitado a conectar en Crow</h1>
+  <div id="codeCard-es" class="card hidden">
+    <div class="muted">Código de invitación (caduca 24 horas después de crearse, un solo uso):</div>
+    <span class="code" id="code-es"></span>
+    <button type="button" onclick="copyCode(this)" data-done="Copiado ✓">Copiar código</button>
+  </div>
+  <div id="noCode-es" class="card hidden">
+    <strong>Este enlace no lleva ningún código de invitación.</strong>
+    <p class="muted">Pide a quien te invitó que envíe el enlace completo (termina en <code>#crow:…</code>).</p>
+  </div>
+  <div id="expired-es" class="card hidden">
+    <strong>Esta invitación parece caducada.</strong>
+    <p class="muted">Los códigos duran 24 horas — pide uno nuevo.</p>
+  </div>
+  <h2>¿Ya tienes Crow?</h2>
+  <p>Abre tu panel de Crow → <strong>Mensajes</strong> → <strong>+</strong> → <strong>Aceptar una invitación</strong> → pega el código.</p>
+  <p class="muted">O ábrelo directamente en tu Crow (escribe la dirección de tu panel — no sale de tu dispositivo):</p>
+  <div class="card"><input id="gw-es" placeholder="https://tu-crow.example.ts.net:8444" style="width:100%;padding:8px;border-radius:8px;border:1px solid #3a4150;background:transparent;color:inherit">
+  <button type="button" style="margin-top:8px" onclick="openOnCrow('es')">Abrir mi Crow</button></div>
+  <h2>¿Nuevo en Crow?</h2>
+  <p>Crow es un centro privado y autoalojado de IA + mensajería. <a href="https://maestro.press/software/crow/getting-started/">Instala Crow</a> y vuelve a este enlace.</p>
+  <p class="muted">Privacidad: el código vive solo en este enlace (tras el <code>#</code>) — esta página no envía nada a ningún sitio. Quien llevó el enlace pudo ver el código; por eso caduca. Tras conectar, comparen los <strong>números de seguridad</strong> para verificarse.</p>
+</div>
+
+<script>
+(function () {
+  var code = "";
+  try { code = decodeURIComponent((location.hash || "").slice(1)); } catch (e) { code = (location.hash || "").slice(1); }
+  var valid = /^crow:[a-z0-9]{10}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(code);
+  var expired = false;
+  if (valid) {
+    try {
+      var payload = JSON.parse(atob(code.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+      if (payload && payload.expires && Date.now() > payload.expires) expired = true;
+    } catch (e) { /* payload undecodable — let the accepting Crow judge it */ }
+  }
+  ["en", "es"].forEach(function (l) {
+    if (valid && !expired) {
+      document.getElementById("code-" + l).textContent = code;
+      document.getElementById("codeCard-" + l).classList.remove("hidden");
+    } else if (valid && expired) {
+      document.getElementById("expired-" + l).classList.remove("hidden");
+    } else {
+      document.getElementById("noCode-" + l).classList.remove("hidden");
+    }
+  });
+  window.copyCode = function (btn) {
+    var text = btn.previousElementSibling.textContent;
+    if (navigator.clipboard) navigator.clipboard.writeText(text).then(function () { btn.textContent = btn.getAttribute("data-done"); });
+  };
+  window.openOnCrow = function (l) {
+    var gw = (document.getElementById("gw-" + l).value || "").trim().replace(/\/+$/, "");
+    if (!gw) return;
+    if (!/^https?:\/\//.test(gw)) gw = "https://" + gw;
+    location.href = gw + "/dashboard/messages?invite=" + encodeURIComponent(code) ;
+  };
+  var showing = (navigator.language || "").toLowerCase().indexOf("es") === 0 ? "es" : "en";
+  function render() {
+    document.querySelectorAll("[data-lang]").forEach(function (el) {
+      el.classList.toggle("hidden", el.getAttribute("data-lang") !== showing);
+    });
+    document.getElementById("langToggle").textContent = showing === "en" ? "ES" : "EN";
+    document.documentElement.lang = showing;
+  }
+  document.getElementById("langToggle").onclick = function () { showing = showing === "en" ? "es" : "en"; render(); };
+  render();
+})();
+</script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-03-messages-p2-pr1-invite-links.md
+++ b/docs/superpowers/plans/2026-07-03-messages-p2-pr1-invite-links.md
@@ -1157,3 +1157,18 @@ Verified clean by the reviewer: CODE_RE vs real base36 output (always lowercase,
 Round-1 fixes re-verified correct against live source (`db` in scope via `registerContactsTools` ctx destructure `:33`; guard imports present `:9`; all import depths; `handleContactAction` signature `:33`). Explicitly cleared: atob unpadded base64url is safe (WHATWG forgiving-base64; length%4==1 impossible for valid payloads); only 2 tests import `buildMessagesHTML`, neither touches the changed forms; zero tests import `renderContactList`; no tool-text consumers parse the generate output; no i18n/CSS collisions; `?invite=` conflicts none; re-render-on-false path confirmed (`messages.js:34` gates on `res.headersSent`).
 
 *(Execution record to be appended by Task 6.)*
+
+## Execution & Final Review (2026-07-03)
+
+Executed via subagent-driven development on `feat/messages-p2-invite-links` (base `dbf5efbf`), fresh sonnet implementer + sonnet reviewer per task:
+- Task 1 `1368df13` — invite-url.js + tool wiring + NEW crow_accept_invite kiosk guard + .env.example (SPEC ✅, QUALITY Approved, zero findings, 16/16).
+- Task 2 `695e0e58` — peer-invite-ui.js + 14 i18n keys EN+ES (SPEC ✅, Approved, zero findings, 7/7 + full 996/996).
+- Task 3 `6d672c71` — messages panel: share block, ?invite= card, honest accept errors, tray→shared forms (SPEC ✅ 7/7 items, Approved, zero findings, 6/6 + 68/68 widened net).
+- Task 4 `ee69f6ba` — contacts add-peer section via injectable factory (SPEC ✅, Approved, zero findings, 6/6 incl. regression).
+- Task 5 `2b5157e0` + fix `d5947cf4` — static page + integrity test; reviewer's Important (weak external-ref guard regex) FIXED and re-review RESOLVED (hardened: any-quote/case/protocol-relative/formaction/css-url/meta-refresh, catch-capability proven).
+
+Controller verification: **full suite 1009/1009** (982 baseline + 27 new, exact); isolated gateway boot clean (`listening` + `[nostr] Subscribed to incoming` + `[sharing] Subscribed to incoming Nostr messages`).
+
+**FINAL whole-branch review (opus, dbf5efbf..d5947cf4): READY TO MERGE — Yes. 0 Critical / 0 Important / 3 Minor follow-ups.** Security: invite-code lifecycle traced exfiltration-clean end-to-end (no server log echoes the code; only query-param appearance is the user-initiated `?invite=` into the recipient's own gateway; every HTML sink escaped; static page fully self-contained, scheme-forced deep link). Kiosk: BOTH tools now guard (the pre-existing accept gap is closed by this PR); all four panel paths route through the tools. Trust boundaries L6/R4/R5 untouched. CSRF strictly improved (tray/contacts/card forms now Turbo-off-safe). Round-1's critical `./shared/` import bug confirmed fixed. Independent verification: 27/27 new + 17/17 neighbors + all 7 modules import clean.
+
+Minor follow-ups (non-blocking): M1 tighten the test's maestro.press exemption to `maestro\.press\/` (prefix-match nit); M2 optionally unify the Contacts share-null fallback with Messages' raw-code fallback; M3 remove 3 orphaned `messages.*` i18n keys (generateInviteCode / acceptInviteButton / pasteInvitePlaceholder).

--- a/servers/gateway/dashboard/panels/contacts.js
+++ b/servers/gateway/dashboard/panels/contacts.js
@@ -14,6 +14,8 @@ import { getContacts, getContact, getContactActivity, getGroups, getMyProfile } 
 import { handleContactAction } from "./contacts/api-handlers.js";
 import { section } from "../shared/components.js";
 import { t } from "../shared/i18n.js";
+import { buildInviteShare } from "../shared/peer-invite-ui.js";
+import { csrfInput } from "../shared/csrf.js";
 
 export default {
   id: "contacts",
@@ -25,6 +27,7 @@ export default {
 
   async handler(req, res, { db, layout, lang }) {
     // --- Handle POST actions ---
+    let peerAdd = {};
     if (req.method === "POST") {
       const result = await handleContactAction(req, db);
       if (result?.redirect) return res.redirectAfterPost(result.redirect);
@@ -33,7 +36,13 @@ export default {
         res.setHeader("Content-Disposition", "attachment; filename=contacts.vcf");
         return res.send(result.download);
       }
+      if (result?.inviteResult) {
+        try { peerAdd.inviteShare = await buildInviteShare(result.inviteResult); } catch {}
+        if (!peerAdd.inviteShare) peerAdd.inviteError = "Invite generated but could not be rendered — use the Messages panel.";
+      }
+      if (result?.inviteError) peerAdd.inviteError = result.inviteError;
     }
+    peerAdd.csrf = csrfInput(req);
 
     // --- Determine view ---
     const view = req.query.view || "all";
@@ -77,7 +86,7 @@ export default {
         type: req.query.type || "all",
       };
       const contacts = await getContacts(db, filters);
-      bodyHtml = renderContactList(contacts, groups, filters, lang);
+      bodyHtml = renderContactList(contacts, groups, filters, lang, peerAdd);
     }
 
     // Build tabs HTML

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -13,6 +13,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
 import { markContactIsBot } from "../../shared/mark-contact-bot.js";
+import { extractInviteCode } from "../../../../sharing/invite-url.js";
 
 /**
  * Create a connected sharing MCP client.
@@ -114,6 +115,38 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
       } finally { try { await client.close?.(); } catch {} }
     } catch (err) {
       console.error("[contacts] add_by_id failed:", err.message);
+    }
+    return { redirect: "/dashboard/contacts" };
+  }
+
+  // P2/C1+C3: full peer-add from the Contacts panel — generate an invite…
+  if (action === "generate_invite") {
+    try {
+      const client = await sharingClientFactory();
+      try {
+        const result = await client.callTool({ name: "crow_generate_invite", arguments: {} });
+        const text = result.content?.[0]?.text || "";
+        if (result?.isError) return { inviteError: text || "Could not generate invite." };
+        return { inviteResult: text };
+      } finally { try { await client.close?.(); } catch {} }
+    } catch (err) {
+      console.error("[contacts] generate_invite failed:", err.message);
+      return { inviteError: err.message };
+    }
+  }
+
+  // …and accept one (forgiving: raw code or full share URL).
+  if (action === "accept_invite" && req.body.invite_code) {
+    try {
+      const code = extractInviteCode(req.body.invite_code);
+      const client = await sharingClientFactory();
+      try {
+        const result = await client.callTool({ name: "crow_accept_invite", arguments: { invite_code: code } });
+        if (result?.isError) return { inviteError: result.content?.[0]?.text || "Invite could not be accepted." };
+      } finally { try { await client.close?.(); } catch {} }
+    } catch (err) {
+      console.error("[contacts] accept_invite failed"); // never echo the code
+      return { inviteError: err.message };
     }
     return { redirect: "/dashboard/contacts" };
   }

--- a/servers/gateway/dashboard/panels/contacts/html.js
+++ b/servers/gateway/dashboard/panels/contacts/html.js
@@ -7,6 +7,7 @@
 
 import { escapeHtml, badge, formField } from "../../shared/components.js";
 import { t } from "../../shared/i18n.js";
+import { renderInviteShare, renderPeerInviteForms } from "../../shared/peer-invite-ui.js";
 
 /** Color palette for contact avatars (deterministic by contact ID) */
 const AVATAR_COLORS = [
@@ -72,7 +73,7 @@ function renderTabs(activeView, lang) {
 // Contact List (card grid)
 // ──────────────────────────────────────────────
 
-export function renderContactList(contacts, groups, filters, lang) {
+export function renderContactList(contacts, groups, filters, lang, peerAdd = {}) {
   const { search = "", groupId = "", type = "all" } = filters;
 
   const toolbar = `<div class="contacts-toolbar">
@@ -125,6 +126,20 @@ export function renderContactList(contacts, groups, filters, lang) {
     </form>
   </details>`;
 
+  const peerForms = renderPeerInviteForms({ lang, csrf: peerAdd.csrf || "" });
+  const peerAddSection = `<details class="contacts-add-peer" style="margin-bottom:1rem"${peerAdd.inviteShare || peerAdd.inviteError ? " open" : ""}>
+    <summary style="cursor:pointer;font-size:0.85rem;color:var(--crow-accent);font-weight:500">${t("contacts.addPeer", lang)}</summary>
+    <div style="margin-top:0.75rem;padding:1rem;background:var(--crow-bg-elevated);border:1px solid var(--crow-border);border-radius:8px">
+      <p style="font-size:0.8rem;color:var(--crow-text-muted);margin:0 0 0.75rem">${t("contacts.addPeerDesc", lang)}</p>
+      ${peerAdd.inviteError ? `<div style="font-size:0.8rem;color:var(--crow-error);margin-bottom:0.5rem">${escapeHtml(peerAdd.inviteError)}</div>` : ""}
+      ${peerAdd.inviteShare ? renderInviteShare(peerAdd.inviteShare, lang) : ""}
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-top:0.5rem">
+        <div>${peerForms.generateForm}</div>
+        <div>${peerForms.acceptForm}</div>
+      </div>
+    </div>
+  </details>`;
+
   let gridHtml;
   if (contacts.length === 0) {
     gridHtml = `<div class="contacts-empty">
@@ -157,7 +172,7 @@ export function renderContactList(contacts, groups, filters, lang) {
   // Import modal
   const importModal = renderImportModal(lang);
 
-  return toolbar + addForm + addByIdForm + gridHtml + importModal;
+  return toolbar + addForm + peerAddSection + addByIdForm + gridHtml + importModal;
 }
 
 // ──────────────────────────────────────────────

--- a/servers/gateway/dashboard/panels/messages.js
+++ b/servers/gateway/dashboard/panels/messages.js
@@ -16,6 +16,8 @@ import { messagesClientJS } from "./messages/client.js";
 import { handlePostAction } from "./messages/api-handlers.js";
 import { getUnifiedConversationList, getBotDirectory, getMessageRequests } from "./messages/data-queries.js";
 import { csrfInput } from "../shared/csrf.js";
+import { buildInviteShare } from "../shared/peer-invite-ui.js";
+import { extractInviteCode } from "../../../sharing/invite-url.js";
 
 export default {
   id: "messages",
@@ -78,7 +80,25 @@ export default {
       botInvite = { code: biCode, name: botName, csrf: csrfInput(req) };
     }
 
+    // --- Person-invite landing (?invite=<code or full URL>) — P2/C1 deep link.
+    let personInvite = null;
+    const piRaw = (req.query && req.query.invite) || null;
+    if (piRaw) {
+      const code = extractInviteCode(String(piRaw));
+      let fromId = null;
+      try {
+        const { parseInviteCode } = await import("../../../sharing/identity.js");
+        fromId = parseInviteCode(code).crowId;
+      } catch { /* invalid/expired — card renders the invalid notice */ }
+      personInvite = { code, fromId, csrf: csrfInput(req) };
+    }
+
     // --- Build page ---
+    let inviteShare = null;
+    if (req._inviteResult) {
+      try { inviteShare = await buildInviteShare(req._inviteResult); } catch {}
+    }
+
     const css = messagesCSS();
     const html = buildMessagesHTML({
       items,
@@ -92,6 +112,8 @@ export default {
       botDirectory,
       requests,
       csrf: csrfInput(req),
+      inviteShare,
+      personInvite,
     });
     const js = messagesClientJS({ aiConfigured, storageAvailable, lang });
 

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -12,6 +12,7 @@ import { getManagersOrNull } from "../../../../sharing/managers.js";
 import { markContactIsBot } from "../../shared/mark-contact-bot.js";
 import { createRoom, listRoomMembers } from "./rooms-store.js";
 import { buildRoomJoinEnvelope, fanOut } from "../../../../sharing/room-fanout.js";
+import { extractInviteCode } from "../../../../sharing/invite-url.js";
 
 /**
  * Create a connected sharing MCP client.
@@ -120,14 +121,23 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
 
   if (action === "accept_invite" && req.body.invite_code) {
     try {
+      const code = extractInviteCode(req.body.invite_code);
       const client = await sharingClientFactory();
-      await client.callTool({
-        name: "crow_accept_invite",
-        arguments: { invite_code: req.body.invite_code.trim() },
-      });
-      await client.close();
+      let result;
+      try {
+        result = await client.callTool({
+          name: "crow_accept_invite",
+          arguments: { invite_code: code },
+        });
+      } finally { try { await client.close?.(); } catch {} }
+      if (result?.isError) {
+        req._inviteError = result.content?.[0]?.text || "Invite could not be accepted.";
+        return false; // re-render with the error banner
+      }
     } catch (err) {
-      console.error("[messages] Failed to accept invite:", err.message);
+      console.error("[messages] Failed to accept invite"); // never echo the code
+      req._inviteError = err.message;
+      return false;
     }
     return res.redirectAfterPost("/dashboard/messages");
   }

--- a/servers/gateway/dashboard/panels/messages/html.js
+++ b/servers/gateway/dashboard/panels/messages/html.js
@@ -8,6 +8,7 @@
 import { escapeHtml } from "../../shared/components.js";
 import { t } from "../../shared/i18n.js";
 import { buildBotDirectory } from "../../shared/bot-directory.js";
+import { renderInviteShare, renderPeerInviteForms } from "../../shared/peer-invite-ui.js";
 
 /** Color palette for peer avatars (deterministic by contact ID) */
 const PEER_COLORS = [
@@ -30,7 +31,9 @@ function initials(name) {
  * Build the full messages panel HTML.
  */
 export function buildMessagesHTML(data) {
-  const { items, totalUnread, aiConfigured, storageAvailable, inviteResult, inviteError, lang, botInvite, csrf } = data;
+  const { items, totalUnread, aiConfigured, storageAvailable, inviteResult, inviteError, lang, botInvite, csrf, inviteShare, personInvite } = data;
+
+  const peerForms = renderPeerInviteForms({ lang, csrf: csrf || "" });
 
   // Bot-invite "Add & message" card (data pre-parsed in messages.js).
   let botInviteCard = "";
@@ -45,6 +48,22 @@ export function buildMessagesHTML(data) {
       `${botInvite.csrf}` +
       `<button type="submit" class="msg-btn-primary">Add &amp; message</button>` +
       `</form></div>`;
+  }
+
+  // Person-invite deep link (?invite=<code>) opened on THIS instance (P2/C1).
+  let personInviteCard = "";
+  if (personInvite) {
+    personInviteCard = personInvite.fromId
+      ? `<div class="msg-person-invite-card" style="margin:12px;padding:12px;background:var(--crow-bg-elevated);border:1px solid var(--crow-border);border-radius:8px">` +
+        `<div style="font-size:0.85rem;font-weight:600;margin-bottom:6px">${t("invite.connectWith", lang)} ${escapeHtml(personInvite.fromId)}?</div>` +
+        `<form method="POST" action="/dashboard/messages">` +
+        `<input type="hidden" name="action" value="accept_invite">` +
+        `<input type="hidden" name="invite_code" value="${escapeHtml(personInvite.code)}">` +
+        `${personInvite.csrf || ""}` +
+        `<button type="submit" class="msg-send-btn" style="font-size:0.8rem;padding:6px 14px">${t("invite.acceptBtn", lang)}</button>` +
+        `</form></div>`
+      : `<div class="msg-person-invite-card" style="margin:12px;padding:12px;background:var(--crow-bg-elevated);border:1px solid var(--crow-error);border-radius:8px">` +
+        `<div style="font-size:0.8rem;color:var(--crow-error)">${t("invite.invalidCode", lang)}</div></div>`;
   }
 
   // Collapsed "browse bots on your other Crows" entry + the directory modal.
@@ -140,9 +159,12 @@ export function buildMessagesHTML(data) {
   // Invite result banner
   let inviteBanner = "";
   if (inviteResult) {
-    inviteBanner = `<div style="position:absolute;top:0;left:0;right:0;z-index:50;padding:12px;background:var(--crow-bg-elevated);border-bottom:1px solid var(--crow-border)">
+    const body = inviteShare
+      ? renderInviteShare(inviteShare, lang)
+      : `<pre style="font-size:0.75rem;white-space:pre-wrap;word-break:break-all;background:var(--crow-bg-deep);padding:8px;border-radius:6px;max-height:120px;overflow-y:auto">${escapeHtml(inviteResult)}</pre>`;
+    inviteBanner = `<div style="position:absolute;top:0;left:0;right:0;z-index:50;padding:12px;background:var(--crow-bg-elevated);border-bottom:1px solid var(--crow-border);max-height:70%;overflow-y:auto">
       <div style="font-size:0.8rem;color:var(--crow-text-muted);margin-bottom:4px">${t("messages.inviteGenerated", lang)}</div>
-      <pre style="font-size:0.75rem;white-space:pre-wrap;word-break:break-all;background:var(--crow-bg-deep);padding:8px;border-radius:6px;max-height:120px;overflow-y:auto">${escapeHtml(inviteResult)}</pre>
+      ${body}
       <button onclick="this.parentElement.remove()" style="margin-top:6px;font-size:0.75rem;background:none;border:1px solid var(--crow-border);border-radius:4px;color:var(--crow-text-muted);cursor:pointer;padding:3px 8px">${t("messages.dismiss", lang)}</button>
     </div>`;
   }
@@ -155,7 +177,7 @@ export function buildMessagesHTML(data) {
 
   const noChatsLabel = escapeHtml(t("messages.noChats", lang));
 
-  return botInviteCard + requestsBlock + browseEntry + `
+  return botInviteCard + personInviteCard + requestsBlock + browseEntry + `
     <div class="msg-hub" style="position:relative">
       ${inviteBanner}
       ${botDirModal}
@@ -221,17 +243,10 @@ export function buildMessagesHTML(data) {
           <div class="msg-room-hint">${t("messages.roomLeaveHint", lang)}</div>
         </div>
         <div class="msg-invite-dialog" id="invite-generate">
-          <form method="POST">
-            <input type="hidden" name="action" value="generate_invite">
-            <button type="submit" class="msg-send-btn" style="width:100%;font-size:0.8rem;padding:6px">${t("messages.generateInviteCode", lang)}</button>
-          </form>
+          ${peerForms.generateForm}
         </div>
         <div class="msg-invite-dialog" id="invite-accept">
-          <form method="POST">
-            <input type="hidden" name="action" value="accept_invite">
-            <textarea name="invite_code" placeholder="${t("messages.pasteInvitePlaceholder", lang)}" rows="3" required></textarea>
-            <button type="submit" class="msg-send-btn" style="width:100%;font-size:0.8rem;padding:6px">${t("messages.acceptInviteButton", lang)}</button>
-          </form>
+          ${peerForms.acceptForm}
         </div>
         <div class="msg-invite-dialog" id="invite-bot">
           <form method="POST">

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -336,6 +336,24 @@ export const translations = {
   "messages.acceptRequest": { en: "Accept", es: "Aceptar" },
   "messages.declineRequest": { en: "Decline", es: "Rechazar" },
 
+  // ─── Peer invite share (Messages Phase 2 PR1) ───
+  "invite.shareLabel": { en: "Share this link", es: "Comparte este enlace" },
+  "invite.shareHint": {
+    en: "Anyone who sees this link can use the code inside it — send it over a channel you trust. It expires in 24 hours.",
+    es: "Cualquiera que vea este enlace puede usar el código que contiene: envíalo por un canal de confianza. Caduca en 24 horas.",
+  },
+  "invite.copyLink": { en: "Copy link", es: "Copiar enlace" },
+  "invite.rawCode": { en: "Or share the raw code", es: "O comparte el código directamente" },
+  "invite.generateBtn": { en: "Create invite link", es: "Crear enlace de invitación" },
+  "invite.acceptTitle": { en: "Accept an invite", es: "Aceptar una invitación" },
+  "invite.pastePlaceholder": { en: "Paste an invite link or code...", es: "Pega un enlace o código de invitación..." },
+  "invite.acceptBtn": { en: "Accept invite", es: "Aceptar invitación" },
+  "invite.connectWith": { en: "Connect with", es: "Conectar con" },
+  "invite.invalidCode": { en: "This invite looks invalid or has expired. Ask for a new one.", es: "Esta invitación parece inválida o ha caducado. Pide una nueva." },
+  "invite.verifyLater": { en: "After connecting, compare safety numbers to verify each other.", es: "Después de conectar, comparen los números de seguridad para verificarse." },
+  "contacts.addPeer": { en: "Add a Crow peer", es: "Añadir un par de Crow" },
+  "contacts.addPeerDesc": { en: "Invite someone with a link or accept theirs", es: "Invita a alguien con un enlace o acepta el suyo" },
+
   // ─── Blog Panel ───
   "blog.pageTitle": { en: "Blog", es: "Blog" },
   "blog.total": { en: "Total", es: "Total" },

--- a/servers/gateway/dashboard/shared/peer-invite-ui.js
+++ b/servers/gateway/dashboard/shared/peer-invite-ui.js
@@ -1,0 +1,67 @@
+/**
+ * Peer-invite shared component (Messages Phase 2 PR1 / C1+C3).
+ *
+ * The ONE component both the Messages tray and the Contacts "Add a peer"
+ * section render. Pure sync renderers (no sharing-client imports — the QW2
+ * trap); the async QR/share building happens in panel loaders/handlers.
+ */
+
+import { escapeHtml } from "./components.js";
+import { t } from "./i18n.js";
+import { buildInviteUrl } from "../../../sharing/invite-url.js";
+
+const CODE_RE = /crow:[a-z0-9]{10}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
+
+/** Find the invite code inside crow_generate_invite's text output. */
+export function parseInviteCodeFromText(text) {
+  if (typeof text !== "string") return null;
+  const m = text.match(CODE_RE);
+  return m ? m[0] : null;
+}
+
+/** Build { code, url, qrDataUrl } from the tool text. QR optional; never throws. */
+export async function buildInviteShare(toolText, env = process.env) {
+  const code = parseInviteCodeFromText(toolText);
+  if (!code) return null;
+  const url = buildInviteUrl(code, env);
+  let qrDataUrl = null;
+  try {
+    const QRCode = (await import("qrcode")).default;
+    qrDataUrl = await QRCode.toDataURL(url, { width: 220, margin: 1 });
+  } catch { /* qr optional */ }
+  return { code, url, qrDataUrl };
+}
+
+/** Sync HTML share block: link + copy button + QR + raw-code fallback. */
+export function renderInviteShare(share, lang) {
+  if (!share || !share.url) return "";
+  const url = escapeHtml(share.url);
+  const qr = share.qrDataUrl
+    ? `<div style="margin:.5rem 0"><img src="${escapeHtml(share.qrDataUrl)}" alt="QR" width="220" height="220" style="image-rendering:pixelated;border-radius:8px;background:#fff;padding:6px"></div>`
+    : "";
+  return `<div class="invite-share">
+    <div style="font-size:0.8rem;font-weight:600;margin-bottom:4px">${t("invite.shareLabel", lang)}</div>
+    <p style="font-size:0.75rem;color:var(--crow-text-muted);margin:0 0 6px">${t("invite.shareHint", lang)}</p>
+    <textarea readonly rows="2" onclick="this.select()" style="width:100%;font-size:0.75rem;word-break:break-all;background:var(--crow-bg-deep);border:1px solid var(--crow-border);border-radius:6px;padding:8px;color:var(--crow-text)">${url}</textarea>
+    <button type="button" style="margin-top:4px;font-size:0.75rem;padding:4px 10px;border:1px solid var(--crow-border);border-radius:6px;background:var(--crow-bg-elevated);color:var(--crow-text);cursor:pointer" onclick="var u=this.previousElementSibling.value;(navigator.clipboard?navigator.clipboard.writeText(u):Promise.reject()).then(()=>{this.textContent=this.dataset.done},()=>{this.previousElementSibling.select()})" data-done="${escapeHtml(t("invite.copyLink", lang))} ✓">${t("invite.copyLink", lang)}</button>
+    ${qr}
+    <details style="margin-top:6px"><summary style="cursor:pointer;font-size:0.75rem;color:var(--crow-text-muted)">${t("invite.rawCode", lang)}</summary>
+      <pre style="font-size:0.7rem;white-space:pre-wrap;word-break:break-all;background:var(--crow-bg-deep);padding:8px;border-radius:6px;margin:4px 0 0">${escapeHtml(share.code)}</pre>
+    </details>
+    <p style="font-size:0.7rem;color:var(--crow-text-muted);margin:6px 0 0">${t("invite.verifyLater", lang)}</p>
+  </div>`;
+}
+
+/** Sync generate + accept form strings both panels embed. */
+export function renderPeerInviteForms({ lang, csrf = "", prefillCode = "" }) {
+  const generateForm = `<form method="POST">
+    <input type="hidden" name="action" value="generate_invite">${csrf}
+    <button type="submit" class="btn btn-primary" style="width:100%;font-size:0.8rem;padding:6px">${t("invite.generateBtn", lang)}</button>
+  </form>`;
+  const acceptForm = `<form method="POST">
+    <input type="hidden" name="action" value="accept_invite">${csrf}
+    <textarea name="invite_code" placeholder="${escapeHtml(t("invite.pastePlaceholder", lang))}" rows="3" required style="width:100%;font-size:0.75rem;background:var(--crow-bg-deep);border:1px solid var(--crow-border);border-radius:6px;padding:8px;color:var(--crow-text)">${escapeHtml(prefillCode)}</textarea>
+    <button type="submit" class="btn btn-primary" style="width:100%;font-size:0.8rem;padding:6px;margin-top:4px">${t("invite.acceptBtn", lang)}</button>
+  </form>`;
+  return { generateForm, acceptForm };
+}

--- a/servers/sharing/invite-url.js
+++ b/servers/sharing/invite-url.js
@@ -1,0 +1,42 @@
+/**
+ * Invite URL helpers (Messages Phase 2 PR1 / C1).
+ *
+ * The share link points at a PUBLIC STATIC page (docs site — never a gateway)
+ * with the invite code in the URL FRAGMENT, so no server ever receives or
+ * logs the code. Pure module: no sharing-client imports, safe anywhere.
+ */
+
+export const DEFAULT_INVITE_PAGE_URL = "https://maestro.press/software/crow/invite/";
+
+/** Resolve the invite-page base URL (env override for self-hosters). */
+export function invitePageBase(env = process.env) {
+  const raw = (env && typeof env.CROW_INVITE_PAGE_URL === "string") ? env.CROW_INVITE_PAGE_URL.trim() : "";
+  if (!raw) return DEFAULT_INVITE_PAGE_URL;
+  // A configured base must not itself carry a fragment.
+  const hash = raw.indexOf("#");
+  return hash === -1 ? raw : raw.slice(0, hash);
+}
+
+/** Build the shareable invite URL: base + '#' + encoded code. */
+export function buildInviteUrl(code, env = process.env) {
+  return `${invitePageBase(env)}#${encodeURIComponent(String(code))}`;
+}
+
+/**
+ * Forgiving code extraction: users paste either a raw invite code OR a full
+ * invite URL. If the input contains '#', take what follows the LAST '#'
+ * (decoded); otherwise return the trimmed input. Never throws.
+ */
+export function extractInviteCode(input) {
+  if (typeof input !== "string") return "";
+  const s = input.trim();
+  const hash = s.lastIndexOf("#");
+  if (hash === -1) return s;
+  const frag = s.slice(hash + 1).trim();
+  if (!frag) return "";
+  try {
+    return decodeURIComponent(frag);
+  } catch {
+    return frag; // malformed percent-encoding — hand back the raw fragment
+  }
+}

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { isKioskActive, kioskBlockedResponse } from "../../shared/kiosk-guard.js";
 import { generateInviteCode, parseInviteCode, parseBotInviteCode, computeSafetyNumber } from "../identity.js";
 import { upsertFullContact } from "../contact-promote.js";
+import { buildInviteUrl, extractInviteCode } from "../invite-url.js";
 
 /**
  * Build the DM payload a recipient sends to a bot to accept its invite.
@@ -43,6 +44,7 @@ export function registerContactsTools(server, ctx) {
     async ({ display_name }) => {
       if (await isKioskActive(db)) return kioskBlockedResponse("crow_generate_invite");
       const code = generateInviteCode(identity);
+      const url = buildInviteUrl(code);
       return {
         content: [
           {
@@ -51,6 +53,9 @@ export function registerContactsTools(server, ctx) {
               `Invite code generated (expires in 24 hours):`,
               ``,
               `\`${code}\``,
+              ``,
+              `Share link (opens a page with the code and instructions):`,
+              url,
               ``,
               `Share this code with the person you want to connect with.`,
               `They should use \`crow_accept_invite\` with this code.`,
@@ -72,6 +77,8 @@ export function registerContactsTools(server, ctx) {
       display_name: z.string().max(100).optional().describe("Name for this contact"),
     },
     async ({ invite_code, display_name }) => {
+      if (await isKioskActive(db)) return kioskBlockedResponse("crow_accept_invite");
+      invite_code = extractInviteCode(invite_code);
       try {
         const peer = parseInviteCode(invite_code);
 

--- a/tests/contacts-peer-add.test.js
+++ b/tests/contacts-peer-add.test.js
@@ -1,0 +1,34 @@
+// tests/contacts-peer-add.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { renderContactList } from "../servers/gateway/dashboard/panels/contacts/html.js";
+
+const CODE = "crow:abc123def0.eyJmYWtlIjoxfQ.c2ln";
+const SHARE = { code: CODE, url: `https://maestro.press/software/crow/invite/#x`, qrDataUrl: null };
+
+test("contact list renders an Add-a-peer section with generate + accept forms", () => {
+  const html = renderContactList([], [], {}, "en");
+  const start = html.indexOf("contacts-add-peer");
+  assert.notEqual(start, -1, "add-peer section present");
+  const block = html.slice(start);
+  assert.ok(block.includes('value="generate_invite"'), "generate form");
+  assert.ok(block.includes('value="accept_invite"'), "accept form");
+  assert.ok(block.includes("Add a Crow peer"), "i18n title");
+});
+
+test("share result renders inside the add-peer section", () => {
+  const html = renderContactList([], [], {}, "en", { inviteShare: SHARE });
+  assert.ok(html.includes(SHARE.url), "share url shown");
+  assert.ok(html.includes("Copy link"), "share block rendered");
+});
+
+test("invite error renders", () => {
+  const html = renderContactList([], [], {}, "en", { inviteError: "expired" });
+  assert.ok(html.includes("expired"), "error surfaced");
+});
+
+test("spanish strings resolve", () => {
+  const html = renderContactList([], [], {}, "es");
+  assert.ok(html.includes("Añadir un par de Crow"), "es title");
+  assert.ok(!html.includes("contacts.addPeer"), "no raw keys");
+});

--- a/tests/invite-page.test.js
+++ b/tests/invite-page.test.js
@@ -1,0 +1,30 @@
+// tests/invite-page.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { DEFAULT_INVITE_PAGE_URL } from "../servers/sharing/invite-url.js";
+
+const PAGE = new URL("../docs/public/invite/index.html", import.meta.url).pathname;
+
+test("static invite page exists where DEFAULT_INVITE_PAGE_URL points", () => {
+  assert.ok(existsSync(PAGE), "docs/public/invite/index.html present");
+  // The URL path (…/software/crow/invite/) must map to docs/public/invite/
+  // under the VitePress base /software/crow/.
+  assert.ok(DEFAULT_INVITE_PAGE_URL.endsWith("/software/crow/invite/"), "URL matches public dir layout");
+});
+
+test("page is self-contained and reads the fragment client-side only", () => {
+  const html = readFileSync(PAGE, "utf-8");
+  assert.ok(html.includes("location.hash"), "reads the fragment");
+  assert.ok(!/\b(src|href)\s*=\s*"https?:\/\//.test(html.replace(/href="https:\/\/maestro\.press[^"]*"/g, "")),
+    "no external scripts/styles/images (own-domain install links exempt)");
+  assert.ok(!html.includes("fetch("), "no network calls");
+  assert.ok(!html.includes("XMLHttpRequest"), "no network calls");
+  assert.ok(html.includes("navigator.clipboard"), "copy button");
+});
+
+test("page is bilingual", () => {
+  const html = readFileSync(PAGE, "utf-8");
+  assert.ok(html.includes("Copy code"), "EN copy");
+  assert.ok(html.includes("Copiar código"), "ES copy");
+});

--- a/tests/invite-page.test.js
+++ b/tests/invite-page.test.js
@@ -16,8 +16,10 @@ test("static invite page exists where DEFAULT_INVITE_PAGE_URL points", () => {
 test("page is self-contained and reads the fragment client-side only", () => {
   const html = readFileSync(PAGE, "utf-8");
   assert.ok(html.includes("location.hash"), "reads the fragment");
-  assert.ok(!/\b(src|href)\s*=\s*"https?:\/\//.test(html.replace(/href="https:\/\/maestro\.press[^"]*"/g, "")),
-    "no external scripts/styles/images (own-domain install links exempt)");
+  const stripped = html.replace(/href="https:\/\/maestro\.press[^"]*"/g, "");
+  const externalRef = /(?:\b(?:src|href|formaction)\s*=\s*["']?\s*(?:https?:)?\/\/)|url\(\s*["']?\s*(?:https?:)?\/\//i;
+  assert.ok(!externalRef.test(stripped), "no external scripts/styles/images (own-domain install links exempt)");
+  assert.ok(!/http-equiv\s*=\s*["']?refresh/i.test(html), "no meta refresh");
   assert.ok(!html.includes("fetch("), "no network calls");
   assert.ok(!html.includes("XMLHttpRequest"), "no network calls");
   assert.ok(html.includes("navigator.clipboard"), "copy button");

--- a/tests/invite-url.test.js
+++ b/tests/invite-url.test.js
@@ -1,0 +1,50 @@
+// tests/invite-url.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_INVITE_PAGE_URL,
+  invitePageBase,
+  buildInviteUrl,
+  extractInviteCode,
+} from "../servers/sharing/invite-url.js";
+
+const CODE = "crow:abc123def0.eyJmYWtlIjoxfQ.c2ln"; // shape: crowId.payload.hmac
+
+test("default base is the product invite page", () => {
+  assert.equal(DEFAULT_INVITE_PAGE_URL, "https://maestro.press/software/crow/invite/");
+  assert.equal(invitePageBase({}), DEFAULT_INVITE_PAGE_URL);
+});
+
+test("CROW_INVITE_PAGE_URL overrides the base (trimmed, fragment stripped)", () => {
+  assert.equal(invitePageBase({ CROW_INVITE_PAGE_URL: " https://my.site/inv " }), "https://my.site/inv");
+  assert.equal(invitePageBase({ CROW_INVITE_PAGE_URL: "https://my.site/inv#old" }), "https://my.site/inv");
+  assert.equal(invitePageBase({ CROW_INVITE_PAGE_URL: "" }), DEFAULT_INVITE_PAGE_URL);
+});
+
+test("buildInviteUrl puts the code in the fragment, encoded", () => {
+  const url = buildInviteUrl(CODE, {});
+  assert.equal(url, `${DEFAULT_INVITE_PAGE_URL}#${encodeURIComponent(CODE)}`);
+  assert.ok(!url.includes("?"), "no query string — fragment only");
+});
+
+test("extractInviteCode: raw code passes through trimmed", () => {
+  assert.equal(extractInviteCode(`  ${CODE}\n`), CODE);
+});
+
+test("extractInviteCode: full invite URL yields the code", () => {
+  assert.equal(extractInviteCode(buildInviteUrl(CODE, {})), CODE);
+});
+
+test("extractInviteCode: percent-encoded fragment is decoded", () => {
+  assert.equal(extractInviteCode(`https://x/inv#${encodeURIComponent(CODE)}`), CODE);
+});
+
+test("extractInviteCode: edge cases never throw", () => {
+  assert.equal(extractInviteCode(null), "");
+  assert.equal(extractInviteCode(undefined), "");
+  assert.equal(extractInviteCode(""), "");
+  assert.equal(extractInviteCode("https://x/inv#"), "");
+  assert.equal(extractInviteCode("no-hash-here"), "no-hash-here");
+  // Bad percent-encoding: falls back to the raw fragment, does not throw.
+  assert.equal(extractInviteCode("https://x/inv#%E0%A4%A"), "%E0%A4%A");
+});

--- a/tests/messages-invite-share.test.js
+++ b/tests/messages-invite-share.test.js
@@ -1,0 +1,64 @@
+// tests/messages-invite-share.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildMessagesHTML } from "../servers/gateway/dashboard/panels/messages/html.js";
+
+const BASE = {
+  items: [], totalUnread: 0, aiConfigured: false, storageAvailable: false,
+  inviteResult: null, inviteError: null, lang: "en", botInvite: null,
+  botDirectory: { groups: [], total: 0, notAddedCount: 0 },
+  requests: [],
+  csrf: '<input type="hidden" name="_csrf" value="tok">',
+  inviteShare: null, personInvite: null,
+};
+const CODE = "crow:abc123def0.eyJmYWtlIjoxfQ.c2ln";
+const SHARE = { code: CODE, url: `https://maestro.press/software/crow/invite/#${encodeURIComponent(CODE)}`, qrDataUrl: "data:image/png;base64,AAAA" };
+
+test("inviteShare renders the share block (url + QR), not the raw pre dump", () => {
+  const html = buildMessagesHTML({ ...BASE, inviteResult: "Invite code generated...", inviteShare: SHARE });
+  assert.ok(html.includes(SHARE.url), "share url");
+  assert.ok(html.includes('src="data:image/'), "QR");
+  assert.ok(html.includes("Copy link"), "copy button");
+});
+
+test("inviteResult without a share still renders as before (fallback)", () => {
+  const html = buildMessagesHTML({ ...BASE, inviteResult: "some tool text" });
+  assert.ok(html.includes("some tool text"), "raw fallback preserved");
+});
+
+test("personInvite renders a pre-filled accept card with preview", () => {
+  const html = buildMessagesHTML({ ...BASE, personInvite: { code: CODE, fromId: "crow:abc123def0", csrf: BASE.csrf } });
+  const start = html.indexOf("msg-person-invite-card");
+  assert.notEqual(start, -1, "card present");
+  const card = html.slice(start, html.indexOf("</form>", start));
+  assert.ok(card.includes('value="accept_invite"'), "posts accept_invite");
+  assert.ok(card.includes(CODE), "code carried");
+  assert.ok(card.includes("crow:abc123def0"), "peer preview");
+  assert.ok(card.includes('name="_csrf"'), "csrf");
+  assert.ok(html.includes("Connect with"), "i18n title");
+});
+
+test("personInvite with fromId=null shows invalid notice, no accept form", () => {
+  const html = buildMessagesHTML({ ...BASE, personInvite: { code: "junk", fromId: null, csrf: BASE.csrf } });
+  assert.ok(html.includes("invalid or has expired"), "invalid notice");
+  const start = html.indexOf("msg-person-invite-card");
+  const card = html.slice(start, start + 800);
+  assert.ok(!card.includes('value="accept_invite"'), "no accept form for invalid code");
+});
+
+test("tray dialogs use the shared forms (same actions as before)", () => {
+  const html = buildMessagesHTML({ ...BASE });
+  const gen = html.indexOf('id="invite-generate"');
+  const acc = html.indexOf('id="invite-accept"');
+  assert.notEqual(gen, -1); assert.notEqual(acc, -1);
+  assert.ok(html.slice(gen, acc).includes('value="generate_invite"'), "generate action kept");
+  const accBlock = html.slice(acc, html.indexOf("</form>", acc));
+  assert.ok(accBlock.includes('value="accept_invite"'), "accept action kept");
+  assert.ok(accBlock.includes("Paste an invite link or code"), "shared placeholder");
+});
+
+test("spanish strings resolve", () => {
+  const html = buildMessagesHTML({ ...BASE, lang: "es", personInvite: { code: CODE, fromId: "crow:abc123def0", csrf: BASE.csrf } });
+  assert.ok(html.includes("Conectar con"), "es connectWith");
+  assert.ok(!html.includes("invite.connectWith"), "no raw keys");
+});

--- a/tests/peer-invite-ui.test.js
+++ b/tests/peer-invite-ui.test.js
@@ -1,0 +1,78 @@
+// tests/peer-invite-ui.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseInviteCodeFromText,
+  buildInviteShare,
+  renderInviteShare,
+  renderPeerInviteForms,
+} from "../servers/gateway/dashboard/shared/peer-invite-ui.js";
+import { buildInviteUrl } from "../servers/sharing/invite-url.js";
+
+const CODE = "crow:abc123def0.eyJmYWtlIjoxfQ.c2ln";
+const TOOL_TEXT = [
+  "Invite code generated (expires in 24 hours):", "",
+  `\`${CODE}\``, "",
+  "Share link (opens a page with the code and instructions):",
+  buildInviteUrl(CODE, {}), "",
+  "Your Crow ID: crow:abc123def0",
+].join("\n");
+
+test("parseInviteCodeFromText finds the backticked code", () => {
+  assert.equal(parseInviteCodeFromText(TOOL_TEXT), CODE);
+  assert.equal(parseInviteCodeFromText("no code here"), null);
+  assert.equal(parseInviteCodeFromText(null), null);
+});
+
+test("buildInviteShare returns code+url (+ qr data URL) and never throws", async () => {
+  const share = await buildInviteShare(TOOL_TEXT, {});
+  assert.equal(share.code, CODE);
+  assert.equal(share.url, buildInviteUrl(CODE, {}));
+  // qrcode dep is installed in this repo — expect a data URL.
+  assert.ok(share.qrDataUrl && share.qrDataUrl.startsWith("data:image/"), "QR data URL");
+  assert.equal(await buildInviteShare("nothing", {}), null);
+});
+
+test("renderInviteShare renders url, QR, raw-code fallback, honest hint (en+es)", async () => {
+  const share = await buildInviteShare(TOOL_TEXT, {});
+  const en = renderInviteShare(share, "en");
+  assert.ok(en.includes(share.url), "url shown");
+  assert.ok(en.includes('src="data:image/'), "QR img");
+  assert.ok(en.includes(CODE), "raw code fallback");
+  assert.ok(en.includes("channel you trust"), "honest copy");
+  assert.ok(en.includes("Copy link"), "copy button");
+  const es = renderInviteShare(share, "es");
+  assert.ok(es.includes("Copiar enlace"), "es copy button");
+  assert.ok(!es.includes("invite.copyLink"), "no raw i18n keys");
+  assert.equal(renderInviteShare(null, "en"), "");
+});
+
+test("renderInviteShare omits the QR img when qrDataUrl is null", () => {
+  const html = renderInviteShare({ code: CODE, url: "https://x/#c", qrDataUrl: null }, "en");
+  assert.ok(!html.includes("<img"), "no img without QR");
+});
+
+test("renderInviteShare escapes hostile values", () => {
+  const html = renderInviteShare({ code: '<script>x</script>', url: '"><img onerror=1>', qrDataUrl: null }, "en");
+  assert.ok(!html.includes("<script>"), "code escaped");
+  assert.ok(!html.includes('"><img onerror'), "url escaped");
+});
+
+test("renderPeerInviteForms returns generate + accept forms with csrf and prefill", () => {
+  const { generateForm, acceptForm } = renderPeerInviteForms({
+    lang: "en", csrf: '<input type="hidden" name="_csrf" value="tok">', prefillCode: CODE,
+  });
+  assert.ok(generateForm.includes('value="generate_invite"'), "generate action");
+  assert.ok(generateForm.includes('name="_csrf"'), "csrf in generate form");
+  assert.ok(acceptForm.includes('value="accept_invite"'), "accept action");
+  assert.ok(acceptForm.includes('name="invite_code"'), "accept field");
+  assert.ok(acceptForm.includes(CODE), "prefill present");
+  assert.ok(acceptForm.includes("Paste an invite link or code"), "placeholder resolved");
+  const es = renderPeerInviteForms({ lang: "es" });
+  assert.ok(es.acceptForm.includes("Pega un enlace"), "es placeholder");
+});
+
+test("renderPeerInviteForms escapes a hostile prefill", () => {
+  const { acceptForm } = renderPeerInviteForms({ lang: "en", prefillCode: '</textarea><script>x</script>' });
+  assert.ok(!acceptForm.includes("<script>"), "prefill escaped");
+});


### PR DESCRIPTION
## What

Phase 2 PR1 of the Messages usability arc — person invites become shareable **links + QR codes**, and the Contacts panel gains the full peer-add flow through **one shared component** (C1+C3 of the approved design spec `docs/superpowers/specs/2026-07-03-messages-phase2-contact-add-ux-design.md`).

- **`servers/sharing/invite-url.js`** — invite share URLs: `https://maestro.press/software/crow/invite/#<code>` (code in the **fragment** — no server ever sees it; `CROW_INVITE_PAGE_URL` override for self-hosters) + forgiving `extractInviteCode` (paste a whole URL anywhere a code is expected).
- **`crow_generate_invite`** returns the share link alongside the code; **`crow_accept_invite` gains the missing kiosk guard** (pre-existing gap — generate was guarded, accept was not) and URL-tolerant input.
- **`servers/gateway/dashboard/shared/peer-invite-ui.js`** — the one shared component: share block (link + copy + QR via existing `qrcode` dep + raw-code fallback + honest copy), generate/accept forms. EN+ES i18n.
- **Messages panel** — share block on generate, `?invite=` deep-link pre-filled accept card (bot-invite pattern), and accept errors now surface in the banner instead of a silent redirect.
- **Contacts panel** — new "Add a Crow peer" section (previously couldn't add peers at all).
- **`docs/public/invite/index.html`** — self-contained bilingual static landing page (served by the docs site; reads `location.hash` client-side only; zero external resources, enforced by test).

## Security / invariants

- **No new gateway routes, no Funnel change** — the public landing page is a docs-site static file; the network-exposure invariant is untouched.
- Invite-code lifecycle traced exfiltration-clean end-to-end in the final review (no log echoes the code; only query-param appearance is the user-initiated deep link into the recipient's own gateway; every HTML sink escaped).
- Trust boundaries from Phase 1 (L6 request gating, R4 authenticated promotion, R5 receipts) untouched.
- CSRF: tray/contacts/card forms now carry `_csrf` (Turbo-off-safe — strictly better).
- **No schema change** (SCHEMA_GENERATION stays 3) — plain-restart deploy.

## Verification

- Full suite **1009/1009** (982 baseline + 27 new).
- Isolated gateway boot clean (both subscribe lines).
- Plan 2-round adversarial review (round 1 caught a critical import-path bug pre-code) + per-task spec/quality reviews (all clean) + **final whole-branch review: READY TO MERGE, 0 Critical / 0 Important** (3 cosmetic minors logged as follow-ups in the plan).

Plan with full review record: `docs/superpowers/plans/2026-07-03-messages-p2-pr1-invite-links.md`

## Deploy note

The static page goes live via the Deploy Docs workflow on merge (known cosmetic Pages-publish flake — re-run clears; build-green is what matters). Gateway: plain restart.