### PR TITLE
feat(messages): short-code pairing — scrypt rendezvous, single-use, 10-min expiry (Phase 2 PR2, C2)

### DIFF
--- a/docs/superpowers/plans/2026-07-03-messages-p2-pr2-short-codes.md
+++ b/docs/superpowers/plans/2026-07-03-messages-p2-pr2-short-codes.md
@@ -762,3 +762,18 @@ git show --stat HEAD
 Round-2 confirmed correct (unchanged): 32-symbol alphabet with no I/L/O/U (60 bits, no collision loss); bias-free bit extraction; C1 HMAC coherence; I2 clean after-auth insertion point (`boot.js:140` auth return, `:141` first side effect); I1 "distinct inviteCode payloads" is the right fail-closed trigger; no PR1 anchor drift at `3a36c256`.
 
 **Both rounds resolved. Plan APPROVED for execution.**
+
+## Execution & Final Security Review (2026-07-03)
+
+Executed via subagent-driven development on `feat/messages-p2-short-codes` (base `91d1fcdf`), fresh sonnet implementer + sonnet reviewer per task:
+- Task 1 `83c7b682` — short-code.js (12-char/60-bit Crockford, async scrypt + single-flight, NIP-44 rendezvous). Review SPEC ✅ Approved zero findings; crypto independently verified (32-sym alphabet, bias-free extraction, async-only, lock). 9/9.
+- Task 2 `4f8d2302` + fix `fcf7c634` — shortcode-ledger.js + inviteId/expiresInMs + consume-after-auth gate. Review caught a **CRITICAL remote prototype-pollution** (attacker `inviteId` as object key, empirically reproduced) → FIXED (null-proto ledger + `__proto__`/`constructor`/`prototype` reject-set + hasOwnProperty + identity typeof guard + 2 regression tests); controller directly re-verified + reviewer re-review **Approved** (both ⚠️ resolved). Gate-after-auth verified structurally + by I2 negative test. 19/19.
+- Task 3 `2695f20a` — acceptInviteCore VERBATIM extract (independently re-diffed: only delta = inviteId spread) + publishRendezvousEvent/fetchRendezvousByAuthor (wait-all-EOSE, never first) + 2 tools + I1 fail-closed. randomUUID inviteId + expiresInMs wired. Review Approved zero crit/imp. 8/8 + 42/42 neighbors.
+- Task 4 `9db4814e` — short-code UI both panels (progressive-disclosure `<details>`). 3-group regex test-guarded (round-2 CRITICAL not regressed); i18n "12-character" EN+ES. Review Approved 0/0/0. 16/16 + 82/82 regression.
+- Polish `7cebd5ff` — I1 comment clarified (tripwire not flood-proof) per final review.
+
+Controller verification: **full suite 1052/1052**; isolated gateway boot clean (4 relays, both subscribe lines); NO schema change (user_version stays 3).
+
+**FINAL SECURITY REVIEW (opus, 91d1fcdf..9db4814e): READY TO MERGE — Yes. 0 Critical / 0 Important / 3 Minor** (all within the conceded cracked-code threat model: I1 flood-evadable tripwire; consume-before-promote token-strand on promote-throw; ledger load-check-save TOCTOU — none escalate beyond "code already cracked → safety-number backstop"). Independently re-audited: crypto math (60-bit bias-free, async-only memory-hard scrypt, non-wedging lock, NIP-44 MAC carries confidentiality/integrity vs relay+observer); consume strictly after R4 auth + before promote; proto-pollution closed both layers; expiry enforced on EVERY accept path; verbatim acceptInviteCore behavior-preserving; L6/R4/R5 trust boundaries intact; no schema change; log hygiene clean; kiosk on both tools.
+
+PR2 follow-ups (non-blocking, all conceded-threat-model): I1 flood evasion (safety-number backstop covers it); consume-before-promote strand (recoverable via add-by-id); ledger TOCTOU (single-use is best-effort by design). PR3 hard requirement carried: emit `handshake_complete` ack on the ledger `"replayed"` verdict too (idempotent) so a lost first-ack doesn't strand the acceptor's ~60h retry.

--- a/servers/gateway/dashboard/panels/contacts.js
+++ b/servers/gateway/dashboard/panels/contacts.js
@@ -14,7 +14,7 @@ import { getContacts, getContact, getContactActivity, getGroups, getMyProfile } 
 import { handleContactAction } from "./contacts/api-handlers.js";
 import { section } from "../shared/components.js";
 import { t } from "../shared/i18n.js";
-import { buildInviteShare } from "../shared/peer-invite-ui.js";
+import { buildInviteShare, parseShortCodeResult } from "../shared/peer-invite-ui.js";
 import { csrfInput } from "../shared/csrf.js";
 
 export default {
@@ -39,6 +39,10 @@ export default {
       if (result?.inviteResult) {
         try { peerAdd.inviteShare = await buildInviteShare(result.inviteResult); } catch {}
         if (!peerAdd.inviteShare) peerAdd.inviteError = "Invite generated but could not be rendered — use the Messages panel.";
+      }
+      if (result?.shortCodeResult) {
+        try { peerAdd.shortCodeShare = parseShortCodeResult(result.shortCodeResult); } catch {}
+        if (!peerAdd.shortCodeShare) peerAdd.inviteError = "Short code generated but could not be rendered — try again.";
       }
       if (result?.inviteError) peerAdd.inviteError = result.inviteError;
     }

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -151,6 +151,37 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
     return { redirect: "/dashboard/contacts" };
   }
 
+  // Short-code pairing (P2/C2): generate a 12-char code to read aloud/type...
+  if (action === "generate_short_invite") {
+    try {
+      const client = await sharingClientFactory();
+      try {
+        const result = await client.callTool({ name: "crow_generate_short_invite", arguments: {} });
+        const text = result.content?.[0]?.text || "";
+        if (result?.isError) return { inviteError: text || "Could not generate a short code." };
+        return { shortCodeResult: text };
+      } finally { try { await client.close?.(); } catch {} }
+    } catch (err) {
+      console.error("[contacts] generate_short_invite failed:", err.message);
+      return { inviteError: err.message };
+    }
+  }
+
+  // ...and accept one.
+  if (action === "accept_short_invite" && req.body.short_code) {
+    try {
+      const client = await sharingClientFactory();
+      try {
+        const result = await client.callTool({ name: "crow_accept_short_invite", arguments: { short_code: req.body.short_code } });
+        if (result?.isError) return { inviteError: result.content?.[0]?.text || "Code could not be accepted." };
+      } finally { try { await client.close?.(); } catch {} }
+    } catch (err) {
+      console.error("[contacts] accept_short_invite failed"); // never echo the code
+      return { inviteError: err.message };
+    }
+    return { redirect: "/dashboard/contacts" };
+  }
+
   // --- Edit contact ---
   if (action === "edit_contact" && req.body.contact_id) {
     const fields = [];

--- a/servers/gateway/dashboard/panels/contacts/html.js
+++ b/servers/gateway/dashboard/panels/contacts/html.js
@@ -7,7 +7,7 @@
 
 import { escapeHtml, badge, formField } from "../../shared/components.js";
 import { t } from "../../shared/i18n.js";
-import { renderInviteShare, renderPeerInviteForms } from "../../shared/peer-invite-ui.js";
+import { renderInviteShare, renderPeerInviteForms, renderShortCodeShare, renderShortCodeForms } from "../../shared/peer-invite-ui.js";
 
 /** Color palette for contact avatars (deterministic by contact ID) */
 const AVATAR_COLORS = [
@@ -127,16 +127,25 @@ export function renderContactList(contacts, groups, filters, lang, peerAdd = {})
   </details>`;
 
   const peerForms = renderPeerInviteForms({ lang, csrf: peerAdd.csrf || "" });
-  const peerAddSection = `<details class="contacts-add-peer" style="margin-bottom:1rem"${peerAdd.inviteShare || peerAdd.inviteError ? " open" : ""}>
+  const shortCodeForms = renderShortCodeForms({ lang, csrf: peerAdd.csrf || "" });
+  const peerAddSection = `<details class="contacts-add-peer" style="margin-bottom:1rem"${peerAdd.inviteShare || peerAdd.inviteError || peerAdd.shortCodeShare ? " open" : ""}>
     <summary style="cursor:pointer;font-size:0.85rem;color:var(--crow-accent);font-weight:500">${t("contacts.addPeer", lang)}</summary>
     <div style="margin-top:0.75rem;padding:1rem;background:var(--crow-bg-elevated);border:1px solid var(--crow-border);border-radius:8px">
       <p style="font-size:0.8rem;color:var(--crow-text-muted);margin:0 0 0.75rem">${t("contacts.addPeerDesc", lang)}</p>
       ${peerAdd.inviteError ? `<div style="font-size:0.8rem;color:var(--crow-error);margin-bottom:0.5rem">${escapeHtml(peerAdd.inviteError)}</div>` : ""}
       ${peerAdd.inviteShare ? renderInviteShare(peerAdd.inviteShare, lang) : ""}
+      ${peerAdd.shortCodeShare ? renderShortCodeShare(peerAdd.shortCodeShare, lang) : ""}
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-top:0.5rem">
         <div>${peerForms.generateForm}</div>
         <div>${peerForms.acceptForm}</div>
       </div>
+      <details style="margin-top:0.75rem">
+        <summary style="cursor:pointer;font-size:0.75rem;color:var(--crow-text-muted)">${t("invite.shortCodeToggle", lang)}</summary>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-top:0.5rem">
+          <div>${shortCodeForms.generateForm}</div>
+          <div>${shortCodeForms.acceptForm}</div>
+        </div>
+      </details>
     </div>
   </details>`;
 

--- a/servers/gateway/dashboard/panels/messages.js
+++ b/servers/gateway/dashboard/panels/messages.js
@@ -16,7 +16,7 @@ import { messagesClientJS } from "./messages/client.js";
 import { handlePostAction } from "./messages/api-handlers.js";
 import { getUnifiedConversationList, getBotDirectory, getMessageRequests } from "./messages/data-queries.js";
 import { csrfInput } from "../shared/csrf.js";
-import { buildInviteShare } from "../shared/peer-invite-ui.js";
+import { buildInviteShare, parseShortCodeResult } from "../shared/peer-invite-ui.js";
 import { extractInviteCode } from "../../../sharing/invite-url.js";
 
 export default {
@@ -99,6 +99,12 @@ export default {
       try { inviteShare = await buildInviteShare(req._inviteResult); } catch {}
     }
 
+    // Short-code pairing result (P2/C2) — parsed sync, no QR/network involved.
+    let shortCodeShare = null;
+    if (req._shortCodeResult) {
+      try { shortCodeShare = parseShortCodeResult(req._shortCodeResult); } catch {}
+    }
+
     const css = messagesCSS();
     const html = buildMessagesHTML({
       items,
@@ -114,6 +120,7 @@ export default {
       csrf: csrfInput(req),
       inviteShare,
       personInvite,
+      shortCodeShare,
     });
     const js = messagesClientJS({ aiConfigured, storageAvailable, lang });
 

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -142,6 +142,50 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
     return res.redirectAfterPost("/dashboard/messages");
   }
 
+  // Short-code pairing (P2/C2): generate a 12-char code to read aloud/type.
+  if (action === "generate_short_invite") {
+    try {
+      const client = await sharingClientFactory();
+      let result;
+      try {
+        result = await client.callTool({ name: "crow_generate_short_invite", arguments: {} });
+      } finally { try { await client.close?.(); } catch {} }
+      const text = result.content?.[0]?.text || "";
+      if (result?.isError) {
+        req._inviteError = text || "Could not generate a short code.";
+      } else {
+        req._shortCodeResult = text;
+      }
+    } catch (err) {
+      console.error("[messages] Failed to generate short invite:", err.message);
+      req._inviteError = err.message;
+    }
+    // Don't redirect — let the panel render with the short-code result
+    return false;
+  }
+
+  if (action === "accept_short_invite" && req.body.short_code) {
+    try {
+      const client = await sharingClientFactory();
+      let result;
+      try {
+        result = await client.callTool({
+          name: "crow_accept_short_invite",
+          arguments: { short_code: req.body.short_code },
+        });
+      } finally { try { await client.close?.(); } catch {} }
+      if (result?.isError) {
+        req._inviteError = result.content?.[0]?.text || "Code could not be accepted.";
+        return false; // re-render with the error banner
+      }
+    } catch (err) {
+      console.error("[messages] Failed to accept short code"); // never echo the code
+      req._inviteError = err.message;
+      return false;
+    }
+    return res.redirectAfterPost("/dashboard/messages");
+  }
+
   if (action === "accept_bot_invite" && req.body.invite_code) {
     try {
       const client = await sharingClientFactory();

--- a/servers/gateway/dashboard/panels/messages/html.js
+++ b/servers/gateway/dashboard/panels/messages/html.js
@@ -8,7 +8,7 @@
 import { escapeHtml } from "../../shared/components.js";
 import { t } from "../../shared/i18n.js";
 import { buildBotDirectory } from "../../shared/bot-directory.js";
-import { renderInviteShare, renderPeerInviteForms } from "../../shared/peer-invite-ui.js";
+import { renderInviteShare, renderPeerInviteForms, renderShortCodeShare, renderShortCodeForms } from "../../shared/peer-invite-ui.js";
 
 /** Color palette for peer avatars (deterministic by contact ID) */
 const PEER_COLORS = [
@@ -31,9 +31,10 @@ function initials(name) {
  * Build the full messages panel HTML.
  */
 export function buildMessagesHTML(data) {
-  const { items, totalUnread, aiConfigured, storageAvailable, inviteResult, inviteError, lang, botInvite, csrf, inviteShare, personInvite } = data;
+  const { items, totalUnread, aiConfigured, storageAvailable, inviteResult, inviteError, lang, botInvite, csrf, inviteShare, personInvite, shortCodeShare } = data;
 
   const peerForms = renderPeerInviteForms({ lang, csrf: csrf || "" });
+  const shortCodeForms = renderShortCodeForms({ lang, csrf: csrf || "" });
 
   // Bot-invite "Add & message" card (data pre-parsed in messages.js).
   let botInviteCard = "";
@@ -168,6 +169,13 @@ export function buildMessagesHTML(data) {
       <button onclick="this.parentElement.remove()" style="margin-top:6px;font-size:0.75rem;background:none;border:1px solid var(--crow-border);border-radius:4px;color:var(--crow-text-muted);cursor:pointer;padding:3px 8px">${t("messages.dismiss", lang)}</button>
     </div>`;
   }
+  if (shortCodeShare) {
+    inviteBanner = `<div style="position:absolute;top:0;left:0;right:0;z-index:50;padding:12px;background:var(--crow-bg-elevated);border-bottom:1px solid var(--crow-border);max-height:70%;overflow-y:auto">
+      <div style="font-size:0.8rem;color:var(--crow-text-muted);margin-bottom:4px">${t("invite.shortCodeTitle", lang)}</div>
+      ${renderShortCodeShare(shortCodeShare, lang)}
+      <button onclick="this.parentElement.remove()" style="margin-top:6px;font-size:0.75rem;background:none;border:1px solid var(--crow-border);border-radius:4px;color:var(--crow-text-muted);cursor:pointer;padding:3px 8px">${t("messages.dismiss", lang)}</button>
+    </div>`;
+  }
   if (inviteError) {
     inviteBanner = `<div style="position:absolute;top:0;left:0;right:0;z-index:50;padding:12px;background:var(--crow-bg-elevated);border-bottom:1px solid var(--crow-border)">
       <div style="font-size:0.8rem;color:var(--crow-error)">${t("messages.inviteError", lang)} ${escapeHtml(inviteError)}</div>
@@ -244,9 +252,17 @@ export function buildMessagesHTML(data) {
         </div>
         <div class="msg-invite-dialog" id="invite-generate">
           ${peerForms.generateForm}
+          <details style="margin-top:8px">
+            <summary style="cursor:pointer;font-size:0.75rem;color:var(--crow-text-muted)">${t("invite.shortCodeToggle", lang)}</summary>
+            <div style="margin-top:6px">${shortCodeForms.generateForm}</div>
+          </details>
         </div>
         <div class="msg-invite-dialog" id="invite-accept">
           ${peerForms.acceptForm}
+          <details style="margin-top:8px">
+            <summary style="cursor:pointer;font-size:0.75rem;color:var(--crow-text-muted)">${t("invite.shortCodeToggle", lang)}</summary>
+            <div style="margin-top:6px">${shortCodeForms.acceptForm}</div>
+          </details>
         </div>
         <div class="msg-invite-dialog" id="invite-bot">
           <form method="POST">

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -351,6 +351,19 @@ export const translations = {
   "invite.connectWith": { en: "Connect with", es: "Conectar con" },
   "invite.invalidCode": { en: "This invite looks invalid or has expired. Ask for a new one.", es: "Esta invitación parece inválida o ha caducado. Pide una nueva." },
   "invite.verifyLater": { en: "After connecting, compare safety numbers to verify each other.", es: "Después de conectar, comparen los números de seguridad para verificarse." },
+
+  // ─── Short-code pairing (Messages Phase 2 PR2 / C2) ───
+  "invite.shortCodeToggle": { en: "Use a short code instead", es: "Usar un código corto en su lugar" },
+  "invite.shortCodeTitle": { en: "Short pairing code", es: "Código corto de emparejamiento" },
+  "invite.shortCodeGenerateBtn": { en: "Generate a short code", es: "Generar un código corto" },
+  "invite.shortCodeHint": {
+    en: "Read it aloud or type it — anyone who hears it can use it until it expires.",
+    es: "Léelo en voz alta o escríbelo: cualquiera que lo escuche puede usarlo hasta que caduque.",
+  },
+  "invite.shortCodeExpiry": { en: "Expires in about 10 minutes", es: "Caduca en unos 10 minutos" },
+  "invite.shortCodeAcceptPlaceholder": { en: "Enter the 12-character code…", es: "Ingresa el código de 12 caracteres…" },
+  "invite.shortCodeAcceptBtn": { en: "Accept short code", es: "Aceptar código corto" },
+
   "contacts.addPeer": { en: "Add a Crow peer", es: "Añadir un par de Crow" },
   "contacts.addPeerDesc": { en: "Invite someone with a link or accept theirs", es: "Invita a alguien con un enlace o acepta el suyo" },
 

--- a/servers/gateway/dashboard/shared/peer-invite-ui.js
+++ b/servers/gateway/dashboard/shared/peer-invite-ui.js
@@ -65,3 +65,61 @@ export function renderPeerInviteForms({ lang, csrf = "", prefillCode = "" }) {
   </form>`;
   return { generateForm, acceptForm };
 }
+
+// ──────────────────────────────────────────────
+// Short-code pairing (Messages Phase 2 PR2 / C2)
+// ──────────────────────────────────────────────
+
+// THREE groups (4+4+4 = 12 chars) — the code is 12 chars (K7Q4-M2X9-3FHT). A
+// two-group (8-char) pattern would truncate the match and make the
+// acceptor's normalizeShortCode reject it, breaking the happy path
+// (round-2 security review CRITICAL — do not regress to two groups).
+const SHORT_CODE_RE = /\b[0-9A-HJKMNP-TV-Z]{4}(?:-[0-9A-HJKMNP-TV-Z]{4}){2}\b/;
+
+/**
+ * Find the 12-char short code inside crow_generate_short_invite's text
+ * output and compute a display-only expiry (10 min from render time — the
+ * server enforces the real expiry regardless of this display value).
+ */
+export function parseShortCodeResult(text) {
+  if (typeof text !== "string") return null;
+  const m = text.match(SHORT_CODE_RE);
+  if (!m) return null;
+  return { formattedCode: m[0], expiresAt: Date.now() + 10 * 60 * 1000 };
+}
+
+/**
+ * Sync HTML share block: the code BIG (monospace, letter-spaced), a
+ * server-rendered expiry time (no live countdown — kept dependency-free per
+ * M5), the speak-don't-post hint, and the safety-number backstop pointer.
+ */
+export function renderShortCodeShare(share, lang) {
+  if (!share || !share.formattedCode) return "";
+  const code = escapeHtml(share.formattedCode);
+  let timeStr = "";
+  if (share.expiresAt) {
+    try {
+      timeStr = new Date(share.expiresAt).toLocaleTimeString(lang === "es" ? "es-ES" : "en-US", { hour: "2-digit", minute: "2-digit" });
+    } catch { /* display-only — never throws */ }
+  }
+  return `<div class="short-code-share">
+    <div style="font-size:1.6rem;font-weight:700;letter-spacing:0.15em;font-family:monospace;text-align:center;margin:8px 0;background:var(--crow-bg-deep);border:1px solid var(--crow-border);border-radius:8px;padding:12px 6px">${code}</div>
+    <p style="font-size:0.75rem;color:var(--crow-text-muted);margin:0 0 4px">${t("invite.shortCodeExpiry", lang)}${timeStr ? ` (${escapeHtml(timeStr)})` : ""}</p>
+    <p style="font-size:0.75rem;color:var(--crow-text-muted);margin:0 0 6px">${t("invite.shortCodeHint", lang)}</p>
+    <p style="font-size:0.7rem;color:var(--crow-text-muted);margin:6px 0 0">${t("invite.verifyLater", lang)}</p>
+  </div>`;
+}
+
+/** Sync generate + accept form strings for the short-code alternative. */
+export function renderShortCodeForms({ lang, csrf = "" }) {
+  const generateForm = `<form method="POST">
+    <input type="hidden" name="action" value="generate_short_invite">${csrf}
+    <button type="submit" class="btn btn-primary" style="width:100%;font-size:0.8rem;padding:6px">${t("invite.shortCodeGenerateBtn", lang)}</button>
+  </form>`;
+  const acceptForm = `<form method="POST">
+    <input type="hidden" name="action" value="accept_short_invite">${csrf}
+    <input type="text" name="short_code" maxlength="20" required placeholder="${escapeHtml(t("invite.shortCodeAcceptPlaceholder", lang))}" style="width:100%;font-size:0.85rem;letter-spacing:0.05em;background:var(--crow-bg-deep);border:1px solid var(--crow-border);border-radius:6px;padding:8px;color:var(--crow-text)">
+    <button type="submit" class="btn btn-primary" style="width:100%;font-size:0.8rem;padding:6px;margin-top:4px">${t("invite.shortCodeAcceptBtn", lang)}</button>
+  </form>`;
+  return { generateForm, acceptForm };
+}

--- a/servers/gateway/tool-manifests.js
+++ b/servers/gateway/tool-manifests.js
@@ -106,6 +106,8 @@ export const TOOL_MANIFESTS = {
     tools: {
       crow_generate_invite: { params: "display_name?", desc: "Generate invite code" },
       crow_accept_invite: { params: "invite_code, display_name?", desc: "Accept invite code" },
+      crow_generate_short_invite: { params: "", desc: "Generate a short 12-character pairing code to read aloud or type (expires in 10 minutes)" },
+      crow_accept_short_invite: { params: "short_code, display_name?", desc: "Accept a short pairing code someone read aloud or typed to you" },
       crow_add_contact: { params: "crow_id, secp256k1_pubkey, ed25519_pubkey?, display_name?", desc: "Repair/add a contact by Crow ID + keys (completes a half-finished handshake without a fresh invite)" },
       crow_accept_bot_invite: { params: "invite_code, display_name?", desc: "Accept a Crow Messages bot invite (adds the bot to Messages + authorizes you)" },
       crow_list_contacts: { params: "include_blocked?", desc: "List contacts" },

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -138,6 +138,32 @@ export async function handleInviteAccepted(db, managers, payload, senderPubkey) 
     // secp key must equal the event's cryptographically-bound pubkey, else a
     // stranger could forge an invite_accepted to promote/hijack a gated contact.
     if (normalizePubkey(payload.secp256k1Pub) !== normalizePubkey(senderPubkey)) return;
+
+    // P2/C2 single-use gate (runs ONLY after the R4 auth check above, so an
+    // unauthenticated forged invite_accepted cannot burn the token — "first
+    // AUTHENTICATED wins", spec §PR2.4). A short-code acceptance echoes the
+    // inviteId; the first authenticated echo consumes it. Fail OPEN on unknown
+    // (instance-local ledger; sibling instances legitimately miss it) and on
+    // ledger errors (never let the ledger break honest pairing).
+    if (payload && typeof payload.inviteId === "string" && payload.inviteId) {
+      try {
+        const { consumeShortInvite } = await import("./shortcode-ledger.js");
+        const verdict = await consumeShortInvite(db, payload.inviteId);
+        if (verdict === "replayed") {
+          // I4: PR3's handshake_complete ack must still fire for this verdict
+          // (idempotent) — the retained 72h ledger TTL keeps the row available.
+          console.warn("[sharing] short-code invite replay rejected");
+          return;
+        }
+        if (verdict === "expired") {
+          console.warn("[sharing] short-code invite expired");
+          return;
+        }
+      } catch {
+        console.warn("[sharing] short-code ledger check failed — proceeding");
+      }
+    }
+
     await upsertFullContact(db, managers, {
       crowId: payload.crowId,
       ed25519Pub: payload.ed25519Pub,

--- a/servers/sharing/identity.js
+++ b/servers/sharing/identity.js
@@ -301,7 +301,7 @@ export function generateInviteCode(identity, opts = {}) {
     crowId: identity.crowId,
     expires,
   };
-  if (opts.inviteId) payloadObj.inviteId = String(opts.inviteId);
+  if (typeof opts.inviteId === "string" && opts.inviteId) payloadObj.inviteId = String(opts.inviteId);
   const payload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
 
   const hmac = createHmac("sha256", identity.ed25519Priv)

--- a/servers/sharing/identity.js
+++ b/servers/sharing/identity.js
@@ -282,18 +282,27 @@ export function parseBotInviteCode(code) {
 /**
  * Generate a single-use invite code with 24h expiry.
  * Format: <crowId>.<payload>.<hmac>
- * Payload: base64url({ ed25519Pub, secp256k1Pub, expires })
+ * Payload: base64url({ ed25519Pub, secp256k1Pub, expires[, inviteId] })
+ *
+ * opts.inviteId (string, optional) — additive; when present, echoes through
+ * parseInviteCode for short-code single-use ledger tracking (P2/C2).
+ * opts.expiresInMs (positive number, optional) — overrides the default 24h
+ * expiry window (used by short-code's 10-min inner-code window). Legacy
+ * callers (no opts) are byte-identical to today's behavior.
  */
-export function generateInviteCode(identity) {
-  const expires = Date.now() + 24 * 60 * 60 * 1000; // 24 hours
-  const payload = Buffer.from(
-    JSON.stringify({
-      ed25519Pub: identity.ed25519Pubkey,
-      secp256k1Pub: identity.secp256k1Pubkey,
-      crowId: identity.crowId,
-      expires,
-    })
-  ).toString("base64url");
+export function generateInviteCode(identity, opts = {}) {
+  const ttlMs = (typeof opts.expiresInMs === "number" && opts.expiresInMs > 0)
+    ? opts.expiresInMs
+    : 24 * 60 * 60 * 1000; // default 24h (unchanged for plain invites)
+  const expires = Date.now() + ttlMs;
+  const payloadObj = {
+    ed25519Pub: identity.ed25519Pubkey,
+    secp256k1Pub: identity.secp256k1Pubkey,
+    crowId: identity.crowId,
+    expires,
+  };
+  if (opts.inviteId) payloadObj.inviteId = String(opts.inviteId);
+  const payload = Buffer.from(JSON.stringify(payloadObj)).toString("base64url");
 
   const hmac = createHmac("sha256", identity.ed25519Priv)
     .update(payload)
@@ -333,6 +342,7 @@ export function parseInviteCode(code) {
     crowId: data.crowId,
     ed25519Pubkey: data.ed25519Pub,
     secp256k1Pubkey: data.secp256k1Pub,
+    inviteId: data.inviteId,
   };
 }
 

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -222,6 +222,87 @@ export class NostrManager {
   }
 
   /**
+   * Publish a one-shot rendezvous event (short-code pairing, P2/C2) to every
+   * connected relay. Reuses the same safeRelayPublish loop as sendMessage, but
+   * there is NO local message cache and NO retry enqueue — a rendezvous event
+   * is not a DM, it's a public artifact under a code-derived key that either
+   * side can re-publish/re-fetch within the code's own expiry window.
+   */
+  async publishRendezvousEvent(event) {
+    if (this.relays.size === 0) {
+      await this.connectRelays();
+    }
+    const published = [];
+    for (const [url, relay] of this.relays) {
+      try {
+        if (await safeRelayPublish(relay, event)) published.push(url);
+      } catch (err) {
+        // Publishing failed to this relay
+      }
+    }
+    return published;
+  }
+
+  /**
+   * One-shot fetch of rendezvous events (kind:4) authored by a code-derived
+   * key, across every connected relay. `limit:4` (NOT 1) is deliberate — I1:
+   * a single event could be an attacker's; the caller must SEE a competing
+   * event under the same key to fail closed. Waits for EVERY relay's `oneose`
+   * (relays send stored events then EOSE; they do NOT close the socket, so
+   * `onclose` alone would never resolve this) or the `timeoutMs` cap, whichever
+   * comes first — NEVER resolves on the first relay's EOSE alone, or a
+   * slightly-later competing publish (the I1 signal) could be missed. Each
+   * relay's subscribe is wrapped in try/catch so one dead socket can't throw
+   * or block the wait on the others.
+   */
+  async fetchRendezvousByAuthor(authorHex, timeoutMs = 5000) {
+    if (this.relays.size === 0) {
+      await this.connectRelays();
+    }
+    const filter = { kinds: [4], authors: [authorHex], limit: 4 };
+    const events = new Map(); // dedupe by event.id
+    const subs = [];
+
+    await new Promise((resolve) => {
+      let done = false;
+      let remaining = this.relays.size;
+      let timer;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        if (timer) clearTimeout(timer);
+        resolve();
+      };
+      if (remaining === 0) { finish(); return; }
+      timer = setTimeout(finish, timeoutMs);
+      if (timer.unref) timer.unref();
+
+      for (const [, relay] of this.relays) {
+        try {
+          const sub = relay.subscribe([filter], {
+            onevent: (event) => { if (event && event.id) events.set(event.id, event); },
+            oneose: () => {
+              remaining -= 1;
+              if (remaining <= 0) finish();
+            },
+          });
+          subs.push(sub);
+        } catch (err) {
+          // Dead/unreachable relay — count it as already-EOSE'd so it can't
+          // block the wait for the others.
+          remaining -= 1;
+        }
+      }
+      if (remaining <= 0) finish();
+    });
+
+    for (const sub of subs) {
+      try { sub.close(); } catch {}
+    }
+    return { events: [...events.values()] };
+  }
+
+  /**
    * Send an encrypted DM WITHOUT caching it into the 1:1 `messages` table. Used
    * for control/room envelopes (crow_social) that must not appear as 1:1 chat rows.
    */

--- a/servers/sharing/short-code.js
+++ b/servers/sharing/short-code.js
@@ -1,0 +1,113 @@
+/**
+ * Short-code pairing (Messages Phase 2 PR2 / C2) — pure crypto module.
+ *
+ * A 12-char Crockford-base32 code (60 bits from crypto.randomBytes) is the
+ * ONLY shared secret. Both sides derive a secp256k1 keypair from it via
+ * memory-hard scrypt; the inviter publishes a kind:4 self-DM under that key
+ * (kind:4 so the self-hosted relay's allowlist carries it) whose NIP-44
+ * content wraps a SHORT-EXPIRY invite code. THREAT MODEL: the event is public
+ * and the derived key also signs it — a cracked code within the window =
+ * pairing MITM. The salt is a FIXED product constant (the code is the only
+ * shared input), so the memory-hard cost is a ONE-TIME precomputation over
+ * the whole code space, NOT a per-guess cost — 60 bits (not the spec's 40-bit
+ * floor) is chosen so that one-time table is infeasible (~10^10 core-years,
+ * ~32-exabyte) rather than merely expensive. Layered defenses: 60-bit
+ * entropy x memory-hard scrypt x ~10-min expiry (envelope + short inner code
+ * + ledger cutoff) x authenticated single-use x acceptor fail-closed on a
+ * duplicate-event code x the safety number as the named (PR3) backstop.
+ *
+ * Pure module: no manager imports, no logging, never logs a code.
+ */
+
+import { randomBytes, scrypt as _scrypt } from "crypto";
+import { promisify } from "util";
+import { finalizeEvent, getPublicKey } from "nostr-tools/pure";
+import * as nip44 from "nostr-tools/nip44";
+
+const scrypt = promisify(_scrypt);
+
+export const SHORTCODE_EXPIRY_MS = 10 * 60 * 1000; // minutes-scale, per guardrail
+
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"; // Crockford: no I, L, O, U
+const SALT = "crow-shortcode-invite-v1"; // FIXED product constant — the code is the
+  // only shared secret, so no per-invite salt is possible. This makes the KDF cost a
+  // ONE-TIME precomputation over the whole code space, which is exactly why CODE_LEN is
+  // 12 (60 bits), not the spec's 40-bit floor: a 2^40 table is buildable by a funded
+  // adversary; a 2^60 one is not (see the plan's THREAT MODEL header).
+const CODE_LEN = 12; // 12 x 5 bits = 60 bits
+const SCRYPT_PARAMS = { N: 2 ** 17, r: 8, p: 1, maxmem: 256 * 1024 * 1024 };
+
+/** CODE_LEN symbols x 5 bits = 60 bits, drawn bias-free from 8 random bytes (64 bits). */
+export function generateShortCode() {
+  const bytes = randomBytes(8); // 64 random bits; we consume the top 60
+  let bits = 0n;
+  for (const b of bytes) bits = (bits << 8n) | BigInt(b);
+  bits >>= 4n; // drop the low 4 bits → exactly 60 bits, no modulo bias (32 | 2^60)
+  let code = "";
+  for (let i = 0; i < CODE_LEN; i++) {
+    code = ALPHABET[Number(bits & 31n)] + code; // low 5 bits → prepend → MSB-first order
+    bits >>= 5n;
+  }
+  return code;
+}
+
+/** Display grouping in 4s: K7Q4-M2X9-3FHT. */
+export function formatShortCode(code) {
+  return code.match(/.{1,4}/g).join("-");
+}
+
+/**
+ * Uppercase, strip separators, map Crockford confusables (I/L→1, O→0).
+ * Returns "" unless the result is EXACTLY 12 alphabet chars (U stays invalid).
+ */
+export function normalizeShortCode(input) {
+  if (typeof input !== "string") return "";
+  const up = input.toUpperCase().replace(/[-\s]/g, "")
+    .replace(/I/g, "1").replace(/L/g, "1").replace(/O/g, "0");
+  if (up.length !== CODE_LEN) return "";
+  for (const ch of up) if (!ALPHABET.includes(ch)) return "";
+  return up;
+}
+
+/**
+ * Derive the rendezvous keypair from the code. ASYNC scrypt only — the
+ * ~128MB/~1s derivation must never block the event loop. `opts.N` exists
+ * FOR TESTS ONLY (full-strength derivation in every production call).
+ */
+let _derivChain = Promise.resolve(); // M4: single-flight — one 128MB scrypt at a time
+export async function deriveShortCodeKeys(code, opts = {}) {
+  const norm = normalizeShortCode(code);
+  if (!norm) throw new Error("invalid short code");
+  const params = { ...SCRYPT_PARAMS, ...(opts.N ? { N: opts.N } : {}) };
+  const run = _derivChain.then(async () => {
+    const priv = await scrypt(norm, SALT, 32, params);
+    return { priv: Buffer.from(priv), pub: getPublicKey(priv) };
+  });
+  // Chain regardless of this call's outcome so one failure doesn't wedge the queue.
+  _derivChain = run.then(() => {}, () => {});
+  return run;
+}
+
+/** Kind:4 self-DM under the code key; content = NIP-44({ inviteCode, expires }). */
+export function buildRendezvousEvent(keys, payload) {
+  const conversationKey = nip44.v2.utils.getConversationKey(keys.priv, keys.pub);
+  const content = nip44.v2.encrypt(JSON.stringify(payload), conversationKey);
+  return finalizeEvent({
+    kind: 4,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [["p", keys.pub]],
+    content,
+  }, keys.priv);
+}
+
+/** Inverse of buildRendezvousEvent; throws on wrong key, tamper, or expiry. */
+export function parseRendezvousEvent(event, keys) {
+  if (!event || event.pubkey !== keys.pub) throw new Error("not a rendezvous event");
+  const conversationKey = nip44.v2.utils.getConversationKey(keys.priv, keys.pub);
+  const payload = JSON.parse(nip44.v2.decrypt(event.content, conversationKey));
+  if (!payload || typeof payload.inviteCode !== "string" || typeof payload.expires !== "number") {
+    throw new Error("malformed rendezvous payload");
+  }
+  if (Date.now() > payload.expires) throw new Error("short code expired");
+  return { inviteCode: payload.inviteCode, expires: payload.expires };
+}

--- a/servers/sharing/shortcode-ledger.js
+++ b/servers/sharing/shortcode-ledger.js
@@ -18,16 +18,31 @@
 const KEY = "sharing:shortcode_invites";
 export const LEDGER_TTL_MS = 72 * 60 * 60 * 1000;
 
+// inviteId is attacker-controlled (echoed from a NIP-44-decrypted invite_accepted
+// payload sent by any authenticated contact). It must never be used to index a
+// plain object: an id of "__proto__"/"constructor"/"prototype" would let a
+// sender pollute Object.prototype process-wide (CWE-1321). Defense in depth:
+// (1) the ledger itself is a null-prototype object below, so even a magic key
+// can't resolve onto Object.prototype, and (2) these ids are rejected outright
+// before ever touching the ledger.
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isValidInviteId(inviteId) {
+  return typeof inviteId === "string" && inviteId.length > 0 && !DANGEROUS_KEYS.has(inviteId);
+}
+
 async function loadLedger(db) {
   try {
     const res = await db.execute({
       sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [KEY],
     });
-    if (!res.rows.length) return {};
+    if (!res.rows.length) return Object.create(null);
     const parsed = JSON.parse(res.rows[0].value);
-    return parsed && typeof parsed === "object" ? parsed : {};
+    return parsed && typeof parsed === "object"
+      ? Object.assign(Object.create(null), parsed)
+      : Object.create(null);
   } catch {
-    return {}; // corrupt/missing → self-heal empty
+    return Object.create(null); // corrupt/missing → self-heal empty
   }
 }
 
@@ -50,6 +65,7 @@ async function saveLedger(db, ledger) {
 }
 
 export async function recordShortInvite(db, inviteId, codeExpiresAt) {
+  if (!isValidInviteId(inviteId)) return; // bogus/dangerous id: caller bug, not a use case
   const now = Date.now();
   const ledger = prune(await loadLedger(db), now);
   ledger[inviteId] = { state: "outstanding", codeExpiresAt, recordedAt: now };
@@ -57,9 +73,11 @@ export async function recordShortInvite(db, inviteId, codeExpiresAt) {
 }
 
 export async function consumeShortInvite(db, inviteId) {
+  if (!isValidInviteId(inviteId)) return "unknown"; // never index the ledger with a dangerous key
   const now = Date.now();
   const ledger = prune(await loadLedger(db), now);
-  const entry = ledger[inviteId];
+  const hasEntry = Object.prototype.hasOwnProperty.call(ledger, inviteId);
+  const entry = hasEntry ? ledger[inviteId] : undefined;
   if (!entry) { await saveLedger(db, ledger); return "unknown"; }
   if (entry.state === "consumed") { await saveLedger(db, ledger); return "replayed"; }
   // C1(b): the inviter stops honoring a short code after its 10-min window,

--- a/servers/sharing/shortcode-ledger.js
+++ b/servers/sharing/shortcode-ledger.js
@@ -1,0 +1,74 @@
+/**
+ * Short-code single-use ledger (Messages Phase 2 PR2 / C2).
+ *
+ * Backed by dashboard_settings (key below) — NO schema change. The key is NOT
+ * in the instance-sync allowlist, so the ledger is INSTANCE-LOCAL by design:
+ * the fleet shares one Nostr identity, so an invite_accepted echo may land on
+ * a sibling instance that never saw the inviteId → callers treat "unknown" as
+ * fail-open (proceed as a normal invite). That is safe: replaying a captured
+ * invite_accepted only re-promotes the same authenticated contact (R4 gate,
+ * idempotent). Single-use here is a best-effort EXTRA layer on the generating
+ * instance; entropy x scrypt x expiry carry the real MITM defense.
+ *
+ * TTL is ~72h — far beyond the 10-minute CODE expiry — because PR3 retries
+ * invite_accepted for up to ~60h (offline inviter) and a legit late echo must
+ * still find its row. The code window is enforced elsewhere (envelope expires).
+ */
+
+const KEY = "sharing:shortcode_invites";
+export const LEDGER_TTL_MS = 72 * 60 * 60 * 1000;
+
+async function loadLedger(db) {
+  try {
+    const res = await db.execute({
+      sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [KEY],
+    });
+    if (!res.rows.length) return {};
+    const parsed = JSON.parse(res.rows[0].value);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {}; // corrupt/missing → self-heal empty
+  }
+}
+
+function prune(ledger, now) {
+  for (const [id, entry] of Object.entries(ledger)) {
+    if (!entry || typeof entry.recordedAt !== "number" || now - entry.recordedAt > LEDGER_TTL_MS) {
+      delete ledger[id];
+    }
+  }
+  return ledger;
+}
+
+async function saveLedger(db, ledger) {
+  await db.execute({
+    sql: `INSERT INTO dashboard_settings (key, value, updated_at)
+          VALUES (?, ?, datetime('now'))
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    args: [KEY, JSON.stringify(ledger)],
+  });
+}
+
+export async function recordShortInvite(db, inviteId, codeExpiresAt) {
+  const now = Date.now();
+  const ledger = prune(await loadLedger(db), now);
+  ledger[inviteId] = { state: "outstanding", codeExpiresAt, recordedAt: now };
+  await saveLedger(db, ledger);
+}
+
+export async function consumeShortInvite(db, inviteId) {
+  const now = Date.now();
+  const ledger = prune(await loadLedger(db), now);
+  const entry = ledger[inviteId];
+  if (!entry) { await saveLedger(db, ledger); return "unknown"; }
+  if (entry.state === "consumed") { await saveLedger(db, ledger); return "replayed"; }
+  // C1(b): the inviter stops honoring a short code after its 10-min window,
+  // even though the ledger row is retained (72h TTL) for replay discrimination.
+  if (typeof entry.codeExpiresAt === "number" && now > entry.codeExpiresAt) {
+    await saveLedger(db, ledger);
+    return "expired";
+  }
+  entry.state = "consumed";
+  await saveLedger(db, ledger);
+  return "consumed";
+}

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -295,7 +295,12 @@ export function registerContactsTools(server, ctx) {
 
         // I1 FAIL-CLOSED: two DISTINCT rendezvous payloads under one code key
         // means someone else published under the same derived key — a MITM
-        // attempt. Refuse rather than newest-wins.
+        // attempt. Refuse rather than newest-wins. This is a TRIPWIRE, not a
+        // guarantee: a code-cracker who floods >limit relays with their OWN
+        // single payload can bury the honest event so only one distinct code is
+        // seen. That regime already presupposes a cracked code, where the
+        // safety number (PR3) is the real backstop; this catches the naive
+        // competing-publish, which is the common accidental/low-effort case.
         const distinctCodes = new Set(parsed.map((p) => p.inviteCode));
         if (distinctCodes.size > 1) {
           console.warn("[sharing] short-code: multiple distinct rendezvous events — refusing");

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -1,15 +1,122 @@
 /**
  * Crow Sharing — Contacts Tools
  *
- * Registers: crow_generate_invite, crow_accept_invite, crow_list_contacts
- * (tool registration order #1-3)
+ * Registers: crow_generate_invite, crow_accept_invite, crow_generate_short_invite,
+ * crow_accept_short_invite, crow_add_contact, crow_accept_bot_invite, crow_list_contacts
  */
 
 import { z } from "zod";
+import { randomUUID } from "crypto";
 import { isKioskActive, kioskBlockedResponse } from "../../shared/kiosk-guard.js";
 import { generateInviteCode, parseInviteCode, parseBotInviteCode, computeSafetyNumber } from "../identity.js";
 import { upsertFullContact } from "../contact-promote.js";
 import { buildInviteUrl, extractInviteCode } from "../invite-url.js";
+import {
+  generateShortCode, formatShortCode, normalizeShortCode, deriveShortCodeKeys,
+  buildRendezvousEvent, parseRendezvousEvent, SHORTCODE_EXPIRY_MS,
+} from "../short-code.js";
+import { recordShortInvite } from "../shortcode-ledger.js";
+
+/**
+ * Core of "accept an invite and pair with the peer it names." VERBATIM
+ * extraction of the former crow_accept_invite handler body (from `const peer =
+ * parseInviteCode…` through the success return) — see the P2/C2 plan's Task 3
+ * Interfaces. The ONLY two deltas from that inherited body: (a) the
+ * acceptancePayload gains `...(peer.inviteId ? { inviteId: peer.inviteId } :
+ * {})` so the short-code single-use ledger can consume the token; (b) nothing
+ * else — same `{ content: [...] }` shapes, same control flow, same error
+ * surface. Module-level (not a closure over registerContactsTools) so both
+ * crow_accept_invite and crow_accept_short_invite can share it; the
+ * previously-in-closure collaborators are passed explicitly instead.
+ */
+async function acceptInviteCore({ invite_code, display_name }, { db, identity, syncManager, peerManager, nostrManager }) {
+  const peer = parseInviteCode(invite_code);
+
+  // Check if already a contact
+  const existing = await db.execute({
+    sql: "SELECT id FROM contacts WHERE crow_id = ?",
+    args: [peer.crowId],
+  });
+
+  if (existing.rows.length > 0) {
+    return {
+      content: [{ type: "text", text: `Already connected to ${peer.crowId}` }],
+    };
+  }
+
+  // Add to contacts
+  const result = await db.execute({
+    sql: `INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey)
+          VALUES (?, ?, ?, ?)`,
+    args: [
+      peer.crowId,
+      display_name || peer.crowId,
+      peer.ed25519Pubkey,
+      peer.secp256k1Pubkey,
+    ],
+  });
+
+  const contactId = Number(result.lastInsertRowid);
+
+  // Initialize sync feeds
+  await syncManager.initContact(contactId, null);
+
+  // Join Hyperswarm topic for this contact
+  await peerManager.joinContact({
+    crowId: peer.crowId,
+    ed25519Pubkey: peer.ed25519Pubkey,
+  });
+
+  // Subscribe to Nostr messages
+  await nostrManager.subscribeToContact({
+    id: contactId,
+    crowId: peer.crowId,
+    secp256k1_pubkey: peer.secp256k1Pubkey,
+  });
+
+  // Compute safety number
+  const safetyNumber = computeSafetyNumber(
+    identity.ed25519Pubkey,
+    peer.ed25519Pubkey
+  );
+
+  // Send acceptance back to inviter so they auto-add us
+  try {
+    if (nostrManager.relays.size === 0) {
+      await nostrManager.connectRelays();
+    }
+    const acceptancePayload = JSON.stringify({
+      type: "invite_accepted",
+      crowId: identity.crowId,
+      ed25519Pub: identity.ed25519Pubkey,
+      secp256k1Pub: identity.secp256k1Pubkey,
+      ...(peer.inviteId ? { inviteId: peer.inviteId } : {}),
+    });
+    await nostrManager.sendMessage(
+      { secp256k1_pubkey: peer.secp256k1Pubkey },
+      acceptancePayload
+    );
+  } catch {
+    // Non-fatal — inviter can still add us manually
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Connected to ${display_name || peer.crowId}!`,
+          ``,
+          `Crow ID: ${peer.crowId}`,
+          `Safety Number: ${safetyNumber}`,
+          ``,
+          `Verify this safety number with your contact through a separate channel`,
+          `(in person, phone call, etc.) to confirm the connection is secure.`,
+        ].join("\n"),
+      },
+    ],
+  };
+}
 
 /**
  * Build the DM payload a recipient sends to a bot to accept its invite.
@@ -80,94 +187,141 @@ export function registerContactsTools(server, ctx) {
       if (await isKioskActive(db)) return kioskBlockedResponse("crow_accept_invite");
       invite_code = extractInviteCode(invite_code);
       try {
-        const peer = parseInviteCode(invite_code);
+        return await acceptInviteCore(
+          { invite_code, display_name },
+          { db, identity, syncManager, peerManager, nostrManager }
+        );
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Failed to accept invite: ${err.message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
 
-        // Check if already a contact
-        const existing = await db.execute({
-          sql: "SELECT id FROM contacts WHERE crow_id = ?",
-          args: [peer.crowId],
-        });
+  // --- Tool: crow_generate_short_invite (P2/C2) ---
 
-        if (existing.rows.length > 0) {
+  server.tool(
+    "crow_generate_short_invite",
+    "Generate a short 12-character pairing code to read aloud or type to someone right now (in person, on a call). Expires in 10 minutes. For longer-lived sharing (email, chat, no time pressure) use crow_generate_invite instead.",
+    {},
+    async () => {
+      if (await isKioskActive(db)) return kioskBlockedResponse("crow_generate_short_invite");
+      try {
+        const code = generateShortCode();
+        const keys = await deriveShortCodeKeys(code); // full-strength — production, no N override
+        const inviteId = randomUUID();
+        const expires = Date.now() + SHORTCODE_EXPIRY_MS;
+        // C1 fix (a): the inner code MUST carry expiresInMs so it dies in 10
+        // min via ANY accept path — without it, it silently reverts to the
+        // 24h default and reopens the acceptor-side leak window.
+        const innerCode = generateInviteCode(identity, { inviteId, expiresInMs: SHORTCODE_EXPIRY_MS });
+        await recordShortInvite(db, inviteId, expires);
+        const event = buildRendezvousEvent(keys, { inviteCode: innerCode, expires: Date.now() + SHORTCODE_EXPIRY_MS });
+        const published = await nostrManager.publishRendezvousEvent(event);
+
+        if (published.length === 0) {
           return {
-            content: [{ type: "text", text: `Already connected to ${peer.crowId}` }],
+            content: [{ type: "text", text: "Could not reach any relay — try again or use an invite link (crow_generate_invite)." }],
+            isError: true,
           };
         }
 
-        // Add to contacts
-        const result = await db.execute({
-          sql: `INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey)
-                VALUES (?, ?, ?, ?)`,
-          args: [
-            peer.crowId,
-            display_name || peer.crowId,
-            peer.ed25519Pubkey,
-            peer.secp256k1Pubkey,
-          ],
-        });
-
-        const contactId = Number(result.lastInsertRowid);
-
-        // Initialize sync feeds
-        await syncManager.initContact(contactId, null);
-
-        // Join Hyperswarm topic for this contact
-        await peerManager.joinContact({
-          crowId: peer.crowId,
-          ed25519Pubkey: peer.ed25519Pubkey,
-        });
-
-        // Subscribe to Nostr messages
-        await nostrManager.subscribeToContact({
-          id: contactId,
-          crowId: peer.crowId,
-          secp256k1_pubkey: peer.secp256k1Pubkey,
-        });
-
-        // Compute safety number
-        const safetyNumber = computeSafetyNumber(
-          identity.ed25519Pubkey,
-          peer.ed25519Pubkey
-        );
-
-        // Send acceptance back to inviter so they auto-add us
-        try {
-          if (nostrManager.relays.size === 0) {
-            await nostrManager.connectRelays();
-          }
-          const acceptancePayload = JSON.stringify({
-            type: "invite_accepted",
-            crowId: identity.crowId,
-            ed25519Pub: identity.ed25519Pubkey,
-            secp256k1Pub: identity.secp256k1Pubkey,
-          });
-          await nostrManager.sendMessage(
-            { secp256k1_pubkey: peer.secp256k1Pubkey },
-            acceptancePayload
-          );
-        } catch {
-          // Non-fatal — inviter can still add us manually
-        }
-
+        const formatted = formatShortCode(code);
+        const minutes = Math.round(SHORTCODE_EXPIRY_MS / 60000);
         return {
           content: [
             {
               type: "text",
               text: [
-                `Connected to ${display_name || peer.crowId}!`,
+                `Short pairing code (expires in ${minutes} minutes):`,
                 ``,
-                `Crow ID: ${peer.crowId}`,
-                `Safety Number: ${safetyNumber}`,
+                formatted,
                 ``,
-                `Verify this safety number with your contact through a separate channel`,
-                `(in person, phone call, etc.) to confirm the connection is secure.`,
+                `Speak it aloud or type it to the other person — don't post it anywhere public.`,
+                `They should use \`crow_accept_short_invite\` with this code.`,
+                `Once connected, verify the safety number through a separate channel to confirm the connection is secure.`,
               ].join("\n"),
             },
           ],
         };
       } catch (err) {
         return {
-          content: [{ type: "text", text: `Failed to accept invite: ${err.message}` }],
+          content: [{ type: "text", text: `Failed to generate short invite: ${err.message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // --- Tool: crow_accept_short_invite (P2/C2) ---
+
+  server.tool(
+    "crow_accept_short_invite",
+    "Accept a short pairing code someone read aloud or typed to you. Looks up the pairing rendezvous on the relay network and completes the connection. Shows a safety number for out-of-band verification.",
+    {
+      short_code: z.string().max(24).describe("The short pairing code (e.g. K7Q4-M2X9-3FHT)"),
+      display_name: z.string().max(100).optional().describe("Name for this contact"),
+    },
+    async ({ short_code, display_name }) => {
+      if (await isKioskActive(db)) return kioskBlockedResponse("crow_accept_short_invite");
+      const normalized = normalizeShortCode(short_code);
+      if (!normalized) {
+        return {
+          content: [{ type: "text", text: "That doesn't look like a Crow short code." }],
+          isError: true,
+        };
+      }
+      try {
+        const keys = await deriveShortCodeKeys(normalized); // full-strength — production, no N override
+        const { events } = await nostrManager.fetchRendezvousByAuthor(keys.pub);
+
+        const parsed = [];
+        for (const event of events) {
+          try {
+            parsed.push(parseRendezvousEvent(event, keys));
+          } catch {
+            // Expired/tampered/wrong-key event — dropped, not thrown.
+          }
+        }
+
+        if (parsed.length === 0) {
+          return {
+            content: [{ type: "text", text: "Code not found or expired — ask for a fresh one." }],
+            isError: true,
+          };
+        }
+
+        // I1 FAIL-CLOSED: two DISTINCT rendezvous payloads under one code key
+        // means someone else published under the same derived key — a MITM
+        // attempt. Refuse rather than newest-wins.
+        const distinctCodes = new Set(parsed.map((p) => p.inviteCode));
+        if (distinctCodes.size > 1) {
+          console.warn("[sharing] short-code: multiple distinct rendezvous events — refusing");
+          return {
+            content: [{ type: "text", text: "This code may be compromised — ask for a fresh one and verify the safety number after connecting." }],
+            isError: true,
+          };
+        }
+
+        const result = await acceptInviteCore(
+          { invite_code: parsed[0].inviteCode, display_name },
+          { db, identity, syncManager, peerManager, nostrManager }
+        );
+        if (result.isError) return result;
+
+        // Append the safety-number backstop caveat to the (verbatim, shared)
+        // success text without altering acceptInviteCore itself.
+        const caveat = "\n\n(A safety-number comparison UI is coming in a future update — for now, read the numbers aloud to your contact through a separate channel.)";
+        return {
+          content: result.content.map((c, i) =>
+            i === 0 && c.type === "text" ? { ...c, text: c.text + caveat } : c
+          ),
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Failed to accept short invite: ${err.message}` }],
           isError: true,
         };
       }

--- a/tests/invite-accepted-promote.test.js
+++ b/tests/invite-accepted-promote.test.js
@@ -13,6 +13,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleInviteAccepted } from "../servers/sharing/boot.js";
+import { recordShortInvite, consumeShortInvite } from "../servers/sharing/shortcode-ledger.js";
 
 function freshDb() {
   const dir = mkdtempSync(join(tmpdir(), "invacc-"));
@@ -113,5 +114,47 @@ test("does NOT promote when the payload secp key != the authenticated sender key
       sql: "SELECT * FROM contacts WHERE crow_id = ?", args: ["crow:realpeer9"],
     });
     assert.equal(crowIdRows.length, 0);
+  } finally { cleanup(); }
+});
+
+test("I2: an unauthenticated (forged-sender) invite_accepted carrying a valid inviteId must NOT consume the short-code ledger token", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    // Seed a gated (accepted) message-request row for the VICTIM secp key,
+    // same shape as the forgery test above.
+    await db.execute({
+      sql: `INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, contact_type, request_status)
+            VALUES (?, '', ?, 'crow', 'accepted')`,
+      args: ["req:" + PK_XONLY, PK],
+    });
+
+    // A real, still-outstanding short-code ledger row for this inviteId.
+    const inviteId = "test-inviteid-i2";
+    await recordShortInvite(db, inviteId, Date.now() + 600000);
+
+    // Forged payload: claims the VICTIM's secp key AND rides a valid
+    // inviteId, but the Nostr event was actually signed by the ATTACKER's key.
+    const forged = {
+      type: "invite_accepted",
+      crowId: "crow:realpeer9",
+      ed25519Pub: "f".repeat(64),
+      secp256k1Pub: PK,
+      inviteId,
+    };
+
+    await handleInviteAccepted(db, stubMgrs(), forged, ATTACKER_PK);
+
+    // Not promoted (same assertion shape as the forgery test above).
+    const { rows } = await db.execute({
+      sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ?", args: [PK_XONLY],
+    });
+    assert.equal(rows.length, 1);
+    assert.notEqual(rows[0].request_status, null);
+
+    // The ledger gate must run ONLY after the auth check — since auth failed
+    // here, the row must still be outstanding. Consuming it now for the
+    // FIRST time must return "consumed" (not "replayed"), proving the forged
+    // call never touched it.
+    assert.equal(await consumeShortInvite(db, inviteId), "consumed");
   } finally { cleanup(); }
 });

--- a/tests/short-code-ui.test.js
+++ b/tests/short-code-ui.test.js
@@ -1,0 +1,179 @@
+// tests/short-code-ui.test.js
+//
+// Messages Phase 2 PR2 (short-code pairing) Task 4 — dashboard UI.
+// Mirrors the fixture patterns in tests/peer-invite-ui.test.js,
+// tests/messages-invite-share.test.js and tests/contacts-peer-add.test.js.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  renderShortCodeShare,
+  renderShortCodeForms,
+  parseShortCodeResult,
+} from "../servers/gateway/dashboard/shared/peer-invite-ui.js";
+import { buildMessagesHTML } from "../servers/gateway/dashboard/panels/messages/html.js";
+import { renderContactList } from "../servers/gateway/dashboard/panels/contacts/html.js";
+
+const FORMATTED_CODE = "K7Q4-M2X9-3FHT";
+const TOOL_TEXT = [
+  "Short pairing code (expires in 10 minutes):",
+  "",
+  FORMATTED_CODE,
+  "",
+  "Speak it aloud or type it to the other person — don't post it anywhere public.",
+  "They should use `crow_accept_short_invite` with this code.",
+  "Once connected, verify the safety number through a separate channel to confirm the connection is secure.",
+].join("\n");
+
+// ──────────────────────────────────────────────
+// parseShortCodeResult
+// ──────────────────────────────────────────────
+
+test("parseShortCodeResult finds the 12-char (3-group) code and round-trips", () => {
+  const parsed = parseShortCodeResult(TOOL_TEXT);
+  assert.ok(parsed, "parsed non-null");
+  assert.equal(parsed.formattedCode, FORMATTED_CODE);
+  assert.ok(typeof parsed.expiresAt === "number" && parsed.expiresAt > Date.now(), "expiresAt is a future timestamp");
+});
+
+test("parseShortCodeResult returns null on garbage / two-group-only / non-string input", () => {
+  assert.equal(parseShortCodeResult("no code here"), null);
+  assert.equal(parseShortCodeResult(null), null);
+  assert.equal(parseShortCodeResult(undefined), null);
+  // Two-group (8-char) fragment must NOT match — regression guard for the
+  // round-2 CRITICAL: a two-group regex would truncate the 12-char code.
+  assert.equal(parseShortCodeResult("Your code: K7Q4-M2X9 use it now"), null);
+});
+
+test("parseShortCodeResult ignores an unrelated crow: invite code inside the same text", () => {
+  // Sanity: the short-code regex must not accidentally match invite-link tokens.
+  const mixed = `${TOOL_TEXT}\nAlso see crow:abc123def0.eyJmYWtlIjoxfQ.c2ln`;
+  const parsed = parseShortCodeResult(mixed);
+  assert.equal(parsed.formattedCode, FORMATTED_CODE);
+});
+
+// ──────────────────────────────────────────────
+// renderShortCodeShare
+// ──────────────────────────────────────────────
+
+test("renderShortCodeShare shows the code big, the expiry hint, and the speak-don't-post hint (en)", () => {
+  const html = renderShortCodeShare({ formattedCode: FORMATTED_CODE, expiresAt: Date.now() + 10 * 60 * 1000 }, "en");
+  assert.ok(html.includes(FORMATTED_CODE), "code shown");
+  assert.ok(html.includes("10 minutes"), "expiry text");
+  assert.ok(html.includes("Read it aloud or type it"), "hint text");
+  assert.ok(html.includes("safety number") || html.includes("safety numbers"), "safety-number backstop pointer");
+});
+
+test("renderShortCodeShare resolves Spanish strings", () => {
+  const html = renderShortCodeShare({ formattedCode: FORMATTED_CODE, expiresAt: Date.now() + 10 * 60 * 1000 }, "es");
+  assert.ok(!html.includes("invite.shortCode"), "no raw i18n keys");
+  assert.ok(html.includes(FORMATTED_CODE), "code shown (es)");
+});
+
+test("renderShortCodeShare escapes a hostile formattedCode (XSS)", () => {
+  const html = renderShortCodeShare({ formattedCode: "<script>x</script>", expiresAt: Date.now() }, "en");
+  assert.ok(!html.includes("<script>"), "code escaped");
+});
+
+test("renderShortCodeShare returns empty string for a null/incomplete share", () => {
+  assert.equal(renderShortCodeShare(null, "en"), "");
+  assert.equal(renderShortCodeShare({}, "en"), "");
+});
+
+// ──────────────────────────────────────────────
+// renderShortCodeForms
+// ──────────────────────────────────────────────
+
+test("renderShortCodeForms returns generate + accept forms with correct actions/fields/csrf", () => {
+  const { generateForm, acceptForm } = renderShortCodeForms({
+    lang: "en", csrf: '<input type="hidden" name="_csrf" value="tok">',
+  });
+  assert.ok(generateForm.includes('value="generate_short_invite"'), "generate action");
+  assert.ok(generateForm.includes('name="_csrf"'), "csrf in generate form");
+  assert.ok(acceptForm.includes('value="accept_short_invite"'), "accept action");
+  assert.ok(acceptForm.includes('name="short_code"'), "short_code field present");
+  assert.ok(acceptForm.includes('maxlength="20"'), "maxlength 20 (hyphens/spaces tolerant)");
+  assert.ok(acceptForm.includes("12-character code"), "placeholder resolved (en)");
+  assert.ok(acceptForm.includes('name="_csrf"'), "csrf in accept form");
+});
+
+test("renderShortCodeForms resolves Spanish placeholder", () => {
+  const { acceptForm } = renderShortCodeForms({ lang: "es" });
+  assert.ok(!acceptForm.includes("invite.shortCode"), "no raw i18n keys");
+});
+
+// ──────────────────────────────────────────────
+// Messages panel wiring
+// ──────────────────────────────────────────────
+
+const MSG_BASE = {
+  items: [], totalUnread: 0, aiConfigured: false, storageAvailable: false,
+  inviteResult: null, inviteError: null, lang: "en", botInvite: null,
+  botDirectory: { groups: [], total: 0, notAddedCount: 0 },
+  requests: [],
+  csrf: '<input type="hidden" name="_csrf" value="tok">',
+  inviteShare: null, personInvite: null,
+};
+
+test("buildMessagesHTML renders the short-code share block when shortCodeShare is set", () => {
+  const html = buildMessagesHTML({
+    ...MSG_BASE,
+    shortCodeShare: { formattedCode: FORMATTED_CODE, expiresAt: Date.now() + 10 * 60 * 1000 },
+  });
+  assert.ok(html.includes(FORMATTED_CODE), "generated code shown");
+});
+
+test("invite-generate dialog gains a 'use a short code instead' toggle posting generate_short_invite", () => {
+  const html = buildMessagesHTML({ ...MSG_BASE });
+  const gen = html.indexOf('id="invite-generate"');
+  const acc = html.indexOf('id="invite-accept"');
+  assert.notEqual(gen, -1); assert.notEqual(acc, -1);
+  const genBlock = html.slice(gen, acc);
+  assert.ok(genBlock.includes('value="generate_invite"'), "PR1 generate form still present");
+  assert.ok(genBlock.includes('value="generate_short_invite"'), "short-code generate action added");
+  assert.ok(genBlock.includes("Use a short code instead"), "toggle label");
+});
+
+test("invite-accept dialog gains a short-code accept form posting accept_short_invite", () => {
+  const html = buildMessagesHTML({ ...MSG_BASE });
+  const acc = html.indexOf('id="invite-accept"');
+  const nextDialog = html.indexOf('id="invite-bot"');
+  assert.notEqual(acc, -1); assert.notEqual(nextDialog, -1);
+  const accBlock = html.slice(acc, nextDialog);
+  assert.ok(accBlock.includes('value="accept_invite"'), "PR1 accept form still present");
+  assert.ok(accBlock.includes('value="accept_short_invite"'), "short-code accept action added");
+  assert.ok(accBlock.includes('name="short_code"'), "short_code field present");
+});
+
+test("no shortCodeShare set → no leftover code text, dialogs still render", () => {
+  const html = buildMessagesHTML({ ...MSG_BASE });
+  assert.ok(html.includes('id="invite-generate"'));
+  assert.ok(!html.includes(FORMATTED_CODE));
+});
+
+// ──────────────────────────────────────────────
+// Contacts panel wiring
+// ──────────────────────────────────────────────
+
+test("renderContactList's add-peer section gains a 'use a short code instead' toggle", () => {
+  const html = renderContactList([], [], {}, "en");
+  const start = html.indexOf("contacts-add-peer");
+  assert.notEqual(start, -1, "add-peer section present");
+  const block = html.slice(start);
+  assert.ok(block.includes('value="generate_short_invite"'), "short-code generate form");
+  assert.ok(block.includes('value="accept_short_invite"'), "short-code accept form");
+  assert.ok(block.includes('name="short_code"'), "short_code field present");
+  assert.ok(block.includes("Use a short code instead"), "toggle label");
+});
+
+test("renderContactList shows the short-code share result when peerAdd.shortCodeShare is set", () => {
+  const html = renderContactList([], [], {}, "en", {
+    shortCodeShare: { formattedCode: FORMATTED_CODE, expiresAt: Date.now() + 10 * 60 * 1000 },
+  });
+  assert.ok(html.includes(FORMATTED_CODE), "generated short code shown");
+});
+
+test("renderContactList resolves Spanish short-code toggle", () => {
+  const html = renderContactList([], [], {}, "es");
+  assert.ok(!html.includes("invite.shortCode"), "no raw i18n keys");
+});

--- a/tests/short-code.test.js
+++ b/tests/short-code.test.js
@@ -1,0 +1,92 @@
+// tests/short-code.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SHORTCODE_EXPIRY_MS,
+  generateShortCode,
+  formatShortCode,
+  normalizeShortCode,
+  deriveShortCodeKeys,
+  buildRendezvousEvent,
+  parseRendezvousEvent,
+} from "../servers/sharing/short-code.js";
+
+// Small-N derivation for tests (documented test-only override) — full-strength
+// N=2^17 would cost ~1s & 128MB per call; the derivation path is identical.
+const T = { N: 2 ** 14 };
+
+const ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+const C1 = "K7Q4M2X93FHT"; // 12 Crockford chars
+const C2 = "K7Q4M2X93FHW"; // differs in the last symbol
+
+test("generateShortCode: 12 chars of the Crockford alphabet, no I/L/O/U", () => {
+  for (let i = 0; i < 50; i++) {
+    const c = generateShortCode();
+    assert.equal(c.length, 12);
+    for (const ch of c) assert.ok(ALPHABET.includes(ch), `bad char ${ch}`);
+  }
+});
+
+test("formatShortCode groups in 4s", () => {
+  assert.equal(formatShortCode(C1), "K7Q4-M2X9-3FHT");
+});
+
+test("normalizeShortCode: case, separators, confusables", () => {
+  assert.equal(normalizeShortCode(" k7q4-m2x9-3fht "), "K7Q4M2X93FHT");
+  assert.equal(normalizeShortCode("k7q4 m2x9 3fht"), "K7Q4M2X93FHT");
+  assert.equal(normalizeShortCode("il0o23456789"), "11002345678" + "9", "I/L→1, O→0");
+  assert.equal(normalizeShortCode("K7Q4M2X93FHU"), "", "U is not in the alphabet");
+  assert.equal(normalizeShortCode("K7Q4M2X93FH"), "", "too short (11)");
+  assert.equal(normalizeShortCode("K7Q4M2X93FHTT"), "", "too long (13)");
+  assert.equal(normalizeShortCode(null), "");
+});
+
+test("deriveShortCodeKeys: deterministic, normalization-invariant, x-only pub", async () => {
+  const a = await deriveShortCodeKeys(C1, T);
+  const b = await deriveShortCodeKeys(" k7q4-m2x9-3fht ", T);
+  assert.equal(a.pub, b.pub, "same code (post-normalization) → same key");
+  assert.equal(a.pub.length, 64, "x-only hex pubkey");
+  assert.ok(Buffer.isBuffer(a.priv) && a.priv.length === 32);
+  const c = await deriveShortCodeKeys(C2, T);
+  assert.notEqual(a.pub, c.pub, "different code → different key");
+});
+
+test("deriveShortCodeKeys rejects invalid codes", async () => {
+  await assert.rejects(() => deriveShortCodeKeys("nope", T), /invalid short code/);
+});
+
+test("rendezvous envelope round-trips and binds to the code key", async () => {
+  const keys = await deriveShortCodeKeys(C1, T);
+  const payload = { inviteCode: "crow:abc123def0.eyJ4IjoxfQ.c2ln", expires: Date.now() + SHORTCODE_EXPIRY_MS };
+  const event = buildRendezvousEvent(keys, payload);
+  assert.equal(event.kind, 4, "kind:4 (relay allowlist)");
+  assert.equal(event.pubkey, keys.pub, "authored by the code key");
+  assert.deepEqual(event.tags, [["p", keys.pub]], "self p-tag");
+  assert.ok(!event.content.includes(payload.inviteCode), "content is encrypted");
+  const out = parseRendezvousEvent(event, keys);
+  assert.deepEqual(out, payload);
+});
+
+test("wrong code cannot read the envelope", async () => {
+  const keys = await deriveShortCodeKeys(C1, T);
+  const wrong = await deriveShortCodeKeys(C2, T);
+  const event = buildRendezvousEvent(keys, { inviteCode: "x", expires: Date.now() + 1000 });
+  assert.throws(() => parseRendezvousEvent(event, wrong));
+});
+
+test("expired envelope is rejected", async () => {
+  const keys = await deriveShortCodeKeys(C1, T);
+  const event = buildRendezvousEvent(keys, { inviteCode: "x", expires: Date.now() - 1 });
+  assert.throws(() => parseRendezvousEvent(event, keys), /expired/);
+});
+
+test("concurrent derivations resolve correctly (single-flight lock)", async () => {
+  const [a, b] = await Promise.all([
+    deriveShortCodeKeys(C1, T),
+    deriveShortCodeKeys(C2, T),
+  ]);
+  assert.equal(a.pub.length, 64);
+  assert.equal(b.pub.length, 64);
+  assert.notEqual(a.pub, b.pub);
+});

--- a/tests/short-invite-tools.test.js
+++ b/tests/short-invite-tools.test.js
@@ -1,0 +1,298 @@
+/**
+ * short-invite-tools — P2/C2 Task 3. Proves the two new MCP tools
+ * (crow_generate_short_invite, crow_accept_short_invite) wire short-code.js +
+ * shortcode-ledger.js + the two new NostrManager rendezvous methods correctly,
+ * and that the extracted acceptInviteCore is a VERBATIM, behavior-preserving
+ * move (crow_accept_invite still works identically, with no inviteId key).
+ *
+ * Stub-driven: nostrManager.publishRendezvousEvent / fetchRendezvousByAuthor /
+ * sendMessage are method-stubbed (delivery-receipt-emit.test.js pattern) — no
+ * live relays. The MCP tool harness follows message-request-gates.test.js's
+ * captureTools() + freshLibsql() pattern (the lightest existing harness for
+ * registerContactsTools).
+ *
+ * Test-speed note: crow_generate_short_invite / crow_accept_short_invite use
+ * FULL-STRENGTH scrypt internally (no N override — that's production-only).
+ * Empirically ~150-250ms per derivation on this hardware (the module's "~1-2s"
+ * docstring figure is a conservative upper bound for weaker hardware), so
+ * every test that reaches deriveShortCodeKeys pays that cost. Only the garbage
+ * -code case (normalizeShortCode fails before any derivation) is derivation-
+ * free. A module-level FIXED_CODE/fixedKeys pair amortizes one derivation
+ * across all the accept-path tests that need to build a matching rendezvous
+ * event (buildRendezvousEvent needs keys derived at the SAME strength the tool
+ * will re-derive, or parseRendezvousEvent's pubkey check silently drops the
+ * event as "not ours").
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { registerContactsTools } from "../servers/sharing/tools/contacts.js";
+import { deriveInstanceIdentity, generateInviteCode, parseInviteCode } from "../servers/sharing/identity.js";
+import {
+  SHORTCODE_EXPIRY_MS,
+  normalizeShortCode,
+  deriveShortCodeKeys,
+  buildRendezvousEvent,
+} from "../servers/sharing/short-code.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "short-invite-tools-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+// Capture registered MCP tool handlers by name (message-request-gates.test.js pattern).
+function captureTools(registerFn, ctx) {
+  const tools = {};
+  const server = { tool: (name, _desc, _schema, handler) => { tools[name] = handler; } };
+  registerFn(server, ctx);
+  return tools;
+}
+
+function makeNostrStub(overrides = {}) {
+  return {
+    relays: new Map([["stub://r1", {}]]), // non-empty: sendMessage/acceptInviteCore skip reconnect
+    async connectRelays() { return [...this.relays.keys()]; },
+    async subscribeToContact() {},
+    sendMessage: overrides.sendMessage || (async () => ({ eventId: "e", relays: ["stub://r1"] })),
+    publishRendezvousEvent: overrides.publishRendezvousEvent || (async () => ["stub://r1"]),
+    fetchRendezvousByAuthor: overrides.fetchRendezvousByAuthor || (async () => ({ events: [] })),
+  };
+}
+
+const stubPeerManager = { joinContact: async () => {} };
+const stubSyncManager = { initContact: async () => {} };
+
+// Shared fixed code for the accept-path tests (derived ONCE at module scope,
+// full-strength, so buildRendezvousEvent's keys match what the tool itself
+// re-derives for the SAME code).
+const FIXED_CODE = "K7Q4M2X93FHT";
+const fixedKeys = await deriveShortCodeKeys(FIXED_CODE);
+
+// --- 1. generate: formatted code + ledger + rendezvous publish, 10-min inner expiry ---
+test("crow_generate_short_invite: formatted code, ledger record, rendezvous publish w/ 10-min inner expiry", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const published = [];
+    const nostrManager = makeNostrStub({
+      publishRendezvousEvent: async (event) => { published.push(event); return ["stub://r1"]; },
+    });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+
+    const res = await tools.crow_generate_short_invite({});
+    assert.ok(!res.isError, `generate should succeed: ${res.content?.[0]?.text}`);
+    const text = res.content.map((c) => c.text).join("\n");
+
+    const m = text.match(/[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}/);
+    assert.ok(m, "a formatted XXXX-XXXX-XXXX code appears in the tool output");
+    const normalized = normalizeShortCode(m[0]);
+    assert.equal(normalized.length, 12, "displayed code parses via normalizeShortCode");
+
+    assert.equal(published.length, 1, "exactly one rendezvous event published");
+    const event = published[0];
+    assert.equal(event.kind, 4, "rendezvous event is kind:4");
+    const identityXOnly = identity.secp256k1Pubkey.length === 66
+      ? identity.secp256k1Pubkey.slice(2) : identity.secp256k1Pubkey;
+    assert.notEqual(event.pubkey, identityXOnly, "authored by the derived code key, NOT the identity's own key");
+    assert.equal(event.pubkey.length, 64, "x-only 64-hex pubkey");
+
+    // Independently re-derive the same code's keys (deterministic) to decrypt
+    // the envelope and verify the inner invite code's expiry is short.
+    const { parseRendezvousEvent } = await import("../servers/sharing/short-code.js");
+    const keys = await deriveShortCodeKeys(normalized);
+    const parsedEnvelope = parseRendezvousEvent(event, keys);
+    const envelopeTtl = parsedEnvelope.expires - Date.now();
+    assert.ok(envelopeTtl > 8 * 60 * 1000 && envelopeTtl <= SHORTCODE_EXPIRY_MS, "envelope expires ~10 min out");
+
+    const innerParsed = parseInviteCode(parsedEnvelope.inviteCode); // validates + returns {crowId, ed25519Pubkey, secp256k1Pubkey, inviteId} — no `expires` (see identity.js:340-345)
+    assert.ok(innerParsed.inviteId, "inner invite carries an inviteId");
+    // parseInviteCode doesn't expose `expires` on its return value (shortcode-ledger.test.js
+    // pattern: read it straight off the base64url payload instead).
+    const innerRaw = JSON.parse(Buffer.from(parsedEnvelope.inviteCode.split(".")[1], "base64url").toString());
+    const innerTtl = innerRaw.expires - Date.now();
+    assert.ok(innerTtl > 8 * 60 * 1000 && innerTtl <= 10 * 60 * 1000,
+      "inner invite code expires in ~10 min, NOT 24h — proves C1 fix (a) is wired (finding 9a)");
+
+    const ledgerRow = await db.execute({
+      sql: "SELECT value FROM dashboard_settings WHERE key = 'sharing:shortcode_invites'", args: [],
+    });
+    assert.equal(ledgerRow.rows.length, 1, "ledger row recorded");
+    const ledger = JSON.parse(ledgerRow.rows[0].value);
+    assert.ok(ledger[innerParsed.inviteId], "ledger tracks the generated inviteId");
+    assert.equal(ledger[innerParsed.inviteId].state, "outstanding");
+  } finally { cleanup(); }
+});
+
+// --- 2. generate with 0-relay publish → isError ---
+test("crow_generate_short_invite: 0-relay publish → isError", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const nostrManager = makeNostrStub({ publishRendezvousEvent: async () => [] });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+    const res = await tools.crow_generate_short_invite({});
+    assert.equal(res.isError, true, "0-relay publish is an error result");
+  } finally { cleanup(); }
+});
+
+// --- 3. accept happy path ---
+test("crow_accept_short_invite: happy path — contact inserted, invite_accepted carries inviteId", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const inviter = deriveInstanceIdentity(randomBytes(32));
+    const inviteId = "short-happy-1";
+    const innerCode = generateInviteCode(inviter, { inviteId, expiresInMs: SHORTCODE_EXPIRY_MS });
+    const envelopePayload = { inviteCode: innerCode, expires: Date.now() + SHORTCODE_EXPIRY_MS };
+    const event = buildRendezvousEvent(fixedKeys, envelopePayload);
+
+    const sent = [];
+    const nostrManager = makeNostrStub({
+      fetchRendezvousByAuthor: async (authorHex) => {
+        assert.equal(authorHex, fixedKeys.pub, "fetch queried by the derived code pubkey");
+        return { events: [event] };
+      },
+      sendMessage: async (contact, content) => { sent.push({ contact, content }); return { eventId: "e", relays: ["stub://r1"] }; },
+    });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+
+    const res = await tools.crow_accept_short_invite({ short_code: FIXED_CODE });
+    assert.ok(!res.isError, `accept should succeed: ${res.content?.[0]?.text}`);
+
+    const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [inviter.crowId] });
+    assert.equal(rows.length, 1, "contact inserted");
+    assert.equal(rows[0].secp256k1_pubkey, inviter.secp256k1Pubkey);
+
+    assert.equal(sent.length, 1, "invite_accepted sent back to the inviter");
+    const acceptancePayload = JSON.parse(sent[0].content);
+    assert.equal(acceptancePayload.type, "invite_accepted");
+    assert.equal(acceptancePayload.inviteId, inviteId, "acceptancePayload echoes the generated inviteId");
+  } finally { cleanup(); }
+});
+
+// --- 4. accept with garbage code → isError, no derivation attempted (fast) ---
+test("crow_accept_short_invite: garbage code → isError, no derivation attempted (fast)", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const nostrManager = makeNostrStub();
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+    const start = Date.now();
+    const res = await tools.crow_accept_short_invite({ short_code: "not-a-real-code!!" });
+    const elapsed = Date.now() - start;
+    assert.equal(res.isError, true);
+    const text = res.content.map((c) => c.text).join("\n");
+    assert.match(text, /doesn't look like a Crow short code/i);
+    assert.ok(elapsed < 400, `garbage code should short-circuit before scrypt derivation (took ${elapsed}ms)`);
+  } finally { cleanup(); }
+});
+
+// --- 5. accept when fetch returns { events: [] } ---
+test("crow_accept_short_invite: fetch returns no events → isError not found/expired", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const nostrManager = makeNostrStub({ fetchRendezvousByAuthor: async () => ({ events: [] }) });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+    const res = await tools.crow_accept_short_invite({ short_code: FIXED_CODE });
+    assert.equal(res.isError, true);
+    const text = res.content.map((c) => c.text).join("\n");
+    assert.match(text, /not found|expired/i);
+  } finally { cleanup(); }
+});
+
+// --- 6. accept when envelope expired ---
+test("crow_accept_short_invite: expired rendezvous envelope → isError", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const event = buildRendezvousEvent(fixedKeys, { inviteCode: "crow:whatever.eyJ4IjoxfQ.sig", expires: Date.now() - 1000 });
+    const nostrManager = makeNostrStub({ fetchRendezvousByAuthor: async () => ({ events: [event] }) });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+    const res = await tools.crow_accept_short_invite({ short_code: FIXED_CODE });
+    assert.equal(res.isError, true);
+    const text = res.content.map((c) => c.text).join("\n");
+    assert.match(text, /not found|expired/i);
+  } finally { cleanup(); }
+});
+
+// --- 6b. I1 FAIL-CLOSED: two distinct rendezvous payloads under one code key ---
+test("crow_accept_short_invite: I1 FAIL-CLOSED — two distinct rendezvous payloads under one code key → isError, no contact inserted", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const inviterA = deriveInstanceIdentity(randomBytes(32));
+    const inviterB = deriveInstanceIdentity(randomBytes(32));
+    const codeA = generateInviteCode(inviterA, { inviteId: "a1", expiresInMs: SHORTCODE_EXPIRY_MS });
+    const codeB = generateInviteCode(inviterB, { inviteId: "b1", expiresInMs: SHORTCODE_EXPIRY_MS });
+    const e1 = buildRendezvousEvent(fixedKeys, { inviteCode: codeA, expires: Date.now() + SHORTCODE_EXPIRY_MS });
+    const e2 = buildRendezvousEvent(fixedKeys, { inviteCode: codeB, expires: Date.now() + SHORTCODE_EXPIRY_MS });
+
+    const nostrManager = makeNostrStub({ fetchRendezvousByAuthor: async () => ({ events: [e1, e2] }) });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+
+    const res = await tools.crow_accept_short_invite({ short_code: FIXED_CODE });
+    assert.equal(res.isError, true, "fails closed on a competing rendezvous event");
+    const text = res.content.map((c) => c.text).join("\n");
+    assert.match(text, /compromis/i);
+
+    const { rows } = await db.execute({ sql: "SELECT COUNT(*) AS c FROM contacts", args: [] });
+    assert.equal(Number(rows[0].c), 0, "no contact row inserted on the fail-closed path");
+  } finally { cleanup(); }
+});
+
+// --- 7. VERBATIM guard: crow_accept_invite still works end-to-end on a plain invite ---
+test("crow_accept_invite (plain, non-short) still works end-to-end — VERBATIM guard", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const identity = deriveInstanceIdentity(randomBytes(32));
+    const inviter = deriveInstanceIdentity(randomBytes(32));
+    const plainCode = generateInviteCode(inviter); // legacy call: no opts → no inviteId, 24h expiry
+
+    const sent = [];
+    const nostrManager = makeNostrStub({
+      sendMessage: async (contact, content) => { sent.push({ contact, content }); return { eventId: "e", relays: ["stub://r1"] }; },
+    });
+    const tools = captureTools(registerContactsTools, {
+      db, identity, peerManager: stubPeerManager, syncManager: stubSyncManager, nostrManager,
+    });
+
+    const res = await tools.crow_accept_invite({ invite_code: plainCode });
+    assert.ok(!res.isError, `plain accept should succeed: ${res.content?.[0]?.text}`);
+    const text = res.content.map((c) => c.text).join("\n");
+    assert.match(text, /Safety Number/i, "safety number shown, same as today");
+
+    const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [inviter.crowId] });
+    assert.equal(rows.length, 1, "contact inserted");
+
+    assert.equal(sent.length, 1);
+    const acceptancePayload = JSON.parse(sent[0].content);
+    assert.equal(acceptancePayload.type, "invite_accepted");
+    assert.ok(!("inviteId" in acceptancePayload), "plain accept: acceptancePayload carries NO inviteId key");
+  } finally { cleanup(); }
+});

--- a/tests/shortcode-ledger.test.js
+++ b/tests/shortcode-ledger.test.js
@@ -82,6 +82,27 @@ test("corrupt ledger JSON self-heals to empty", async () => {
   assert.equal(await consumeShortInvite(db, "y"), "consumed");
 });
 
+// CWE-1321 regression: inviteId is attacker-controlled (echoed from a
+// NIP-44-decrypted invite_accepted payload). "__proto__"/"constructor" must
+// never be usable to pollute Object.prototype, whether via the read side
+// (ledger["__proto__"] silently resolving to Object.prototype) or the write
+// side (ledger["__proto__"] = {...} landing on Object.prototype globally).
+test("proto-pollution: __proto__ inviteId is rejected, never pollutes Object.prototype", async () => {
+  const db = makeDb();
+  await recordShortInvite(db, "__proto__", Date.now() + 1000);
+  assert.equal(await consumeShortInvite(db, "__proto__"), "unknown");
+  assert.equal(Object.prototype.state, undefined);
+  assert.equal(({}).state, undefined);
+});
+
+test("proto-pollution: constructor inviteId is rejected, never pollutes Object.prototype", async () => {
+  const db = makeDb();
+  await recordShortInvite(db, "constructor", Date.now() + 1000);
+  assert.equal(await consumeShortInvite(db, "constructor"), "unknown");
+  assert.equal(Object.prototype.state, undefined);
+  assert.equal(({}).state, undefined);
+});
+
 test("generateInviteCode: additive inviteId + expiresInMs round-trip", async () => {
   // Identity fixture pattern from tests/crow-messages-editor.test.js:18-19 —
   // DATA_DIR is resolved at module load, so set CROW_DATA_DIR then dynamic-import.

--- a/tests/shortcode-ledger.test.js
+++ b/tests/shortcode-ledger.test.js
@@ -1,0 +1,113 @@
+// tests/shortcode-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  LEDGER_TTL_MS,
+  recordShortInvite,
+  consumeShortInvite,
+} from "../servers/sharing/shortcode-ledger.js";
+import { generateInviteCode, parseInviteCode } from "../servers/sharing/identity.js";
+
+// Minimal in-memory dashboard_settings stub (contact-promote.test.js pattern).
+function makeDb() {
+  const store = new Map();
+  return {
+    async execute({ sql, args }) {
+      if (/SELECT value FROM dashboard_settings/.test(sql)) {
+        const v = store.get(args[0]);
+        return { rows: v === undefined ? [] : [{ value: v }] };
+      }
+      if (/INSERT INTO dashboard_settings/.test(sql)) {
+        store.set(args[0], args[1]);
+        return { rows: [] };
+      }
+      throw new Error("unexpected sql: " + sql);
+    },
+    _store: store,
+  };
+}
+
+test("record → consume → replayed", async () => {
+  const db = makeDb();
+  await recordShortInvite(db, "id-1", Date.now() + 600000);
+  assert.equal(await consumeShortInvite(db, "id-1"), "consumed");
+  assert.equal(await consumeShortInvite(db, "id-1"), "replayed");
+});
+
+test("unknown inviteId", async () => {
+  const db = makeDb();
+  assert.equal(await consumeShortInvite(db, "never-seen"), "unknown");
+});
+
+test("a past-codeExpiresAt row returns 'expired', not 'consumed'", async () => {
+  const db = makeDb();
+  await recordShortInvite(db, "stale", Date.now() - 1000); // codeExpiresAt already past
+  assert.equal(await consumeShortInvite(db, "stale"), "expired");
+});
+
+// I2 ordering property (finding 9b): the ledger is consumed only AFTER the R4
+// auth check, so an UNAUTHENTICATED invite_accepted that carries a valid
+// inviteId must NOT burn the token. This is verified at the handleInviteAccepted
+// level in tests/invite-accepted-promote.test.js (see Task 2 Step 6): add a case
+// there where payload.inviteId is set but normalizePubkey(payload.secp) !=
+// normalizePubkey(senderPubkey) — assert the contact is NOT promoted AND (drive
+// a real ledger stub) the inviteId row remains 'outstanding' (consume NOT called
+// before the auth bail). Keep the ledger-unit cases above for record/consume/
+// expire/replay/prune semantics.
+
+test("entries older than LEDGER_TTL_MS are pruned; consumed survives within TTL", async () => {
+  const db = makeDb();
+  await recordShortInvite(db, "old", Date.now() + 600000);
+  // Backdate the entry beyond TTL by editing the stored JSON directly.
+  const raw = JSON.parse(db._store.get("sharing:shortcode_invites"));
+  raw["old"].recordedAt = Date.now() - LEDGER_TTL_MS - 1000;
+  db._store.set("sharing:shortcode_invites", JSON.stringify(raw));
+  assert.equal(await consumeShortInvite(db, "old"), "unknown", "pruned → unknown");
+});
+
+test("ledger TTL is much longer than the code expiry (late honest echo survives)", async () => {
+  const db = makeDb();
+  await recordShortInvite(db, "late", Date.now() + 600000);
+  const raw = JSON.parse(db._store.get("sharing:shortcode_invites"));
+  raw["late"].recordedAt = Date.now() - 60 * 60 * 60 * 1000; // 60h ago (PR3 retry horizon)
+  db._store.set("sharing:shortcode_invites", JSON.stringify(raw));
+  assert.equal(await consumeShortInvite(db, "late"), "consumed", "60h-late echo still consumes");
+});
+
+test("corrupt ledger JSON self-heals to empty", async () => {
+  const db = makeDb();
+  db._store.set("sharing:shortcode_invites", "{not json");
+  assert.equal(await consumeShortInvite(db, "x"), "unknown");
+  await recordShortInvite(db, "y", Date.now() + 1000); // must not throw
+  assert.equal(await consumeShortInvite(db, "y"), "consumed");
+});
+
+test("generateInviteCode: additive inviteId + expiresInMs round-trip", async () => {
+  // Identity fixture pattern from tests/crow-messages-editor.test.js:18-19 —
+  // DATA_DIR is resolved at module load, so set CROW_DATA_DIR then dynamic-import.
+  const { mkdtempSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  process.env.CROW_DATA_DIR = mkdtempSync(join(tmpdir(), "crow-id-"));
+  const { loadOrCreateIdentity } = await import("../servers/sharing/identity.js");
+  const id = loadOrCreateIdentity();
+
+  // legacy: no opts → no inviteId, ~24h expiry
+  assert.equal(parseInviteCode(generateInviteCode(id)).inviteId, undefined);
+
+  // inviteId echoes through
+  assert.equal(parseInviteCode(generateInviteCode(id, { inviteId: "n-1" })).inviteId, "n-1");
+
+  // short expiry: a 10-min inner code is accepted now but its expires is <1h out
+  const short = generateInviteCode(id, { inviteId: "n-2", expiresInMs: 10 * 60 * 1000 });
+  const parsed = parseInviteCode(short);
+  assert.equal(parsed.inviteId, "n-2");
+  // The short inner-invite expiry is ~10 min out, not 24h.
+  assert.ok(parsed.inviteId === "n-2");
+  const ttl = JSON.parse(Buffer.from(short.split(".")[1], "base64url")).expires - Date.now();
+  assert.ok(ttl > 8 * 60 * 1000 && ttl <= 10 * 60 * 1000, "inner code expires in ~10 min");
+  // parseInviteCode enforces expiry; a 1ms window elapses to already-expired.
+  const brief = generateInviteCode(id, { expiresInMs: 1 });
+  await new Promise((r) => setTimeout(r, 5));
+  assert.throws(() => parseInviteCode(brief), /expire/i);
+});


### PR DESCRIPTION
## What

Phase 2 PR2 of the Messages usability arc — pair with someone by **speaking or typing a 12-character code**, no link or copy-paste. No rendezvous server: the inviter's Crow publishes a NIP-44-encrypted event under a key **derived from the code**; the acceptor types the code, derives the same key, fetches, decrypts, and runs the existing (unchanged) accept path (C2 of the approved spec).

- **`servers/sharing/short-code.js`** — 12-char Crockford-base32 code (60 bits, bias-free), memory-hard `crypto.scrypt` key derivation (async-only, N=2¹⁷, single-flight lock), NIP-44 self-DM rendezvous envelope (kind:4 so the self-hosted relay's allowlist carries it).
- **`servers/sharing/shortcode-ledger.js`** — single-use ledger on `dashboard_settings` (no schema change), null-prototype-hardened.
- **`identity.js`** — additive `inviteId` (CSPRNG UUID) + `expiresInMs` on the invite format (legacy invites byte-identical).
- **`boot.js`** — replay/expiry gate that runs **strictly after** the R4 authentication check ("first authenticated wins").
- **`nostr.js`** — `publishRendezvousEvent` + `fetchRendezvousByAuthor` (waits all-relays-EOSE, never first).
- **`tools/contacts.js`** — `crow_generate_short_invite` / `crow_accept_short_invite` (kiosk-guarded); the accept body extracted verbatim into a shared `acceptInviteCore`.
- **Dashboard UI** — "Use a short code instead" in both Messages and Contacts (progressive disclosure), EN+ES.

## Security (this is the crypto component — reviewed hardest)

Layered defenses, honestly costed in the code: **60-bit entropy** (raised above the spec's 40-bit floor because the KDF salt is a fixed constant, making a lower-entropy space one-time-precomputable) × **memory-hard scrypt** × **~10-min expiry** enforced on the acceptor envelope, the inner invite code (dead via *any* accept path), AND the inviter ledger × **authenticated single-use** × **fail-closed** when ≥2 distinct rendezvous payloads appear under one code key × **safety number** named as the backstop (with the honest caveat that its comparison UI arrives in PR3).

- **2-round adversarial security review of the plan** (round 1 caught a 24h-inner-code expiry blowout, a newest-wins MITM, and consume-before-auth; round 2 caught a code-truncating regex CRITICAL — all fixed pre-code).
- **Per-task review caught and fixed a remote prototype-pollution vuln** (CWE-1321 via attacker-controlled `inviteId` as an object key) — closed with a null-prototype ledger + dangerous-key rejection + regression tests.
- **Final whole-branch security review (opus): READY TO MERGE, 0 Critical / 0 Important.** 3 Minors, all within the conceded "code was cracked → safety-number backstop" model.
- `acceptInviteCore` is a behavior-preserving verbatim extraction (plain-invite path byte-identical); L6/R4/R5 trust boundaries untouched; both new tools kiosk-guarded; no code ever logged.

## Verification

- Full suite **1052/1052**. Isolated gateway boot clean (4 relays, both subscribe lines).
- **No schema change** (SCHEMA_GENERATION stays 3; ledger lives in `dashboard_settings`) — plain-restart deploy.

Plan with full review record: `docs/superpowers/plans/2026-07-03-messages-p2-pr2-short-codes.md`

## PR3 hard requirement (carried forward)

PR3 must emit its `handshake_complete` ack on the ledger `"replayed"` verdict too (idempotent), so a lost first ack doesn't strand the acceptor's retry loop.