### PR TITLE
Messages Phase 3 PR-A: contacts + blocks follow the user (D1)

### DIFF
--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -36,6 +36,17 @@ export async function mountMcpServers(app, deps) {
     setProviderSyncManager(syncManager);
   } catch {}
 
+  // Phase 3 (contacts follow the user): when a contact syncs in from a paired
+  // instance, wire it live (subscribe to its DMs / join its topic) so it can
+  // receive messages. Guarded; never throws into the apply loop.
+  try {
+    if (syncManager) {
+      const { wireSyncedContact } = await import("../../sharing/contact-promote.js");
+      const { getManagersOrNull } = await import("../../sharing/managers.js");
+      syncManager.onContactSynced = (row) => { wireSyncedContact(getManagersOrNull(), row); };
+    }
+  } catch {}
+
   // CRITICAL: open outFeeds for every paired peer BEFORE any emitChange can
   // fire. Without this, emissions before the first WebSocket handshake land
   // on an empty outFeeds map and are silently dropped while _localCounter

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -9,6 +9,7 @@ import { parseVCard, generateVCard, parseCsv } from "./vcard.js";
 import { upsertSetting } from "../../settings/registry.js";
 import { getContacts } from "./data-queries.js";
 import { getManagersOrNull } from "../../../../sharing/managers.js";
+import { emitContactChange, emitContactDelete } from "../../../../sharing/contact-sync.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
@@ -62,14 +63,18 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
         }
       } catch {}
     }
+    // Phase 3: a block follows the user across their instances.
+    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
     return { redirect: "/dashboard/contacts" };
   }
 
   if (action === "unblock" && req.body.contact_id) {
+    const contactId = parseInt(req.body.contact_id);
     await db.execute({
       sql: "UPDATE contacts SET is_blocked = 0 WHERE id = ?",
-      args: [parseInt(req.body.contact_id)],
+      args: [contactId],
     });
+    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
     return { redirect: "/dashboard/contacts" };
   }
 
@@ -80,6 +85,8 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
       sql: "UPDATE contacts SET verified = ? WHERE id = ?",
       args: [req.body.verified === "1" ? 1 : 0, contactId],
     });
+    // Phase 3: deliberately NO emit — `verified` is a per-device attestation
+    // (in EXCLUDED_COLUMNS.contacts); each device verifies independently.
     return { redirect: "/dashboard/contacts?view=contact&contact=" + contactId };
   }
 
@@ -100,6 +107,9 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
         (req.body.notes || "").trim(),
       ],
     });
+    // Phase 3: the manual address-book entry follows the user (no secp key, so
+    // the receiver's onContactSynced hook won't try to subscribe).
+    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [manualCrowId] }); if (rows[0]) await emitContactChange("insert", rows[0]); } catch {}
     return { redirect: "/dashboard/contacts" };
   }
 
@@ -223,11 +233,14 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
     }
 
     if (fields.length > 0) {
-      args.push(parseInt(req.body.contact_id));
+      const editId = parseInt(req.body.contact_id);
+      args.push(editId);
       await db.execute({
         sql: `UPDATE contacts SET ${fields.join(", ")} WHERE id = ?`,
         args,
       });
+      // Phase 3: profile edits follow the user.
+      try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [editId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
     }
 
     return { redirect: `/dashboard/contacts?view=contact&contact=${req.body.contact_id}` };
@@ -235,10 +248,17 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
 
   // --- Delete contact ---
   if (action === "delete_contact" && req.body.contact_id) {
-    await db.execute({
+    const delId = parseInt(req.body.contact_id);
+    // Fetch crow_id BEFORE the delete; emit ONLY if a row was actually deleted
+    // (the WHERE clause is manual-only, so a crow: contact delete is a no-op and
+    // must NOT propagate a destructive delete to peers).
+    let delCrowId = null;
+    try { const { rows } = await db.execute({ sql: "SELECT crow_id FROM contacts WHERE id = ?", args: [delId] }); delCrowId = rows[0]?.crow_id || null; } catch {}
+    const result = await db.execute({
       sql: "DELETE FROM contacts WHERE id = ? AND contact_type = 'manual'",
-      args: [parseInt(req.body.contact_id)],
+      args: [delId],
     });
+    if (Number(result.rowsAffected) > 0 && delCrowId) { try { await emitContactDelete(delCrowId); } catch {} }
     return { redirect: "/dashboard/contacts" };
   }
 
@@ -336,6 +356,9 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
             args: [manualCrowId, name, c.email || "", c.phone || "", c.notes || ""],
           });
           imported++;
+          // Phase 3: an imported address book follows the user (guarded; a slow
+          // import must not stall on emit).
+          try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [manualCrowId] }); if (rows[0]) await emitContactChange("insert", rows[0]); } catch {}
         } catch (err) {
           console.warn("[contacts] Import error for", name, err.message);
         }
@@ -364,6 +387,10 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
         if (!accepted?.isError && botCrowId) {
           if (wasNew) await db.execute({ sql: "UPDATE contacts SET origin = 'advertised' WHERE crow_id = ?", args: [botCrowId] });
           await markContactIsBot(db, botCrowId);
+          // Phase 3: propagate the final advertised-bot state (origin + is_bot)
+          // to the user's other instances. (The accept tool emits the base row;
+          // this update carries the advertised/is_bot flags set just above.)
+          try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [botCrowId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
         }
       } finally { await client.close(); }
     } catch (err) { console.error("[contacts] dir_add_bot failed:", err.message); }

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -9,6 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
 import { getManagersOrNull } from "../../../../sharing/managers.js";
+import { emitContactChange } from "../../../../sharing/contact-sync.js";
 import { markContactIsBot } from "../../shared/mark-contact-bot.js";
 import { createRoom, listRoomMembers } from "./rooms-store.js";
 import { buildRoomJoinEnvelope, fanOut } from "../../../../sharing/room-fanout.js";
@@ -88,6 +89,8 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
         }
       } catch {}
     }
+    // Phase 3: a block follows the user across their instances.
+    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [req.body.crow_id] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
     return res.redirectAfterPost("/dashboard/messages");
   }
 
@@ -96,6 +99,7 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
       sql: "UPDATE contacts SET is_blocked = 0 WHERE crow_id = ?",
       args: [req.body.crow_id],
     });
+    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [req.body.crow_id] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
     return res.redirectAfterPost("/dashboard/messages");
   }
 
@@ -277,6 +281,10 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
         const c = rows[0];
         await db.execute({ sql: "UPDATE contacts SET request_status = 'accepted' WHERE id = ?", args: [id] });
         await db.execute({ sql: "UPDATE messages SET is_read = 1 WHERE contact_id = ?", args: [id] });
+        // Phase 3: pending→accepted is the transition that makes the contact
+        // established — now it follows the user (shouldSyncRow lets 'accepted'
+        // through; a peer with no prior row upserts it via _applyContact).
+        try { const { rows: cr } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [id] }); if (cr[0]) await emitContactChange("update", cr[0]); } catch {}
         if (managers?.nostrManager) {
           try {
             await managers.nostrManager.subscribeToContact({

--- a/servers/sharing/contact-promote.js
+++ b/servers/sharing/contact-promote.js
@@ -84,6 +84,29 @@ async function wireFullContact(managers, row) {
   } catch {}
 }
 
+/**
+ * Phase 3: wire a contact that arrived via instance-sync into the live layer.
+ *   - blocked   → unsubscribe (close feeds + leave DHT topic), no Nostr sub
+ *   - local-bot → no-op (hosted elsewhere; never subscribe on a peer)
+ *   - keyless   → no-op (manual address-book entry has no secp key)
+ *   - otherwise → wireFullContact (initContact + joinContact + subscribeToContact)
+ * Fully guarded — the sync apply loop must never throw.
+ */
+export async function wireSyncedContact(managers, row) {
+  try {
+    if (!managers || !row) return;
+    const { syncManager, peerManager } = managers;
+    if (row.is_blocked) {
+      try { if (syncManager && row.id != null) await syncManager.closeContactFeeds(row.id); } catch {}
+      try { if (peerManager && row.crow_id) await peerManager.leaveContact(row.crow_id); } catch {}
+      return;
+    }
+    if (row.origin === "local-bot") return;
+    if (!row.secp256k1_pubkey || !HEX_KEY.test(String(row.secp256k1_pubkey))) return; // manual/keyless
+    await wireFullContact(managers, row);
+  } catch { /* never throw into the sync apply loop */ }
+}
+
 function isPlaceholderName(name) {
   return name == null || name === "" || String(name).startsWith("req:") || String(name).startsWith("crow:");
 }

--- a/servers/sharing/contact-promote.js
+++ b/servers/sharing/contact-promote.js
@@ -66,6 +66,7 @@ export async function persistIncomingCursor(db, createdAtSec) {
 }
 
 import { normalizePubkey } from "./pubkey-util.js";
+import { emitContactChange, emitContactDelete } from "./contact-sync.js";
 
 const HEX_KEY = /^[0-9a-fA-F]{64}(?:[0-9a-fA-F]{2})?$/; // 64 x-only or 66 compressed
 
@@ -151,6 +152,10 @@ export async function upsertFullContact(db, managers, { crowId, ed25519Pub, secp
     });
     const row = (await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [byCrow.id] })).rows[0];
     await wireFullContact(managers, row);
+    // Phase 3: the folded row is gone on this instance; propagate its delete +
+    // the merged owner to the user's other instances.
+    await emitContactDelete(otherSecp.crow_id);
+    await emitContactChange("update", row);
     return { contactId: row.id, outcome: "merged" };
   }
 
@@ -193,6 +198,7 @@ export async function upsertFullContact(db, managers, { crowId, ed25519Pub, secp
     });
     const row = (await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [target.id] })).rows[0];
     await wireFullContact(managers, row);
+    await emitContactChange("update", row); // Phase 3: promoted contact follows the user
     return { contactId: row.id, outcome: "promoted" };
   }
 
@@ -204,5 +210,6 @@ export async function upsertFullContact(db, managers, { crowId, ed25519Pub, secp
   });
   const row = (await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [Number(ins.lastInsertRowid)] })).rows[0];
   await wireFullContact(managers, row);
+  await emitContactChange("insert", row); // Phase 3: new contact follows the user
   return { contactId: row.id, outcome: "created" };
 }

--- a/servers/sharing/contact-sync.js
+++ b/servers/sharing/contact-sync.js
@@ -1,0 +1,35 @@
+/**
+ * Phase 3 (D1): push contact mutations onto the instance-sync mesh.
+ * Guarded + null-safe — a sync failure never breaks the local write, and the
+ * sink is null pre-boot / in unit tests (no-op). Emits carry the FULL row for
+ * insert/update; deletes carry only { crow_id } (the natural key). Carve-outs
+ * (verified/last_seen/id/created_at columns, local-bot/pending rows) are
+ * enforced downstream by EXCLUDED_COLUMNS.contacts + shouldSyncRow in
+ * instance-sync.js.
+ *
+ * NOTE (R1): managers.js → nostr.js → contact-promote.js → contact-sync.js would
+ * form an import cycle if we STATIC-imported managers here. A cached lazy dynamic
+ * import keeps the static module graph acyclic; the import resolves once, before
+ * any emit fires at runtime. Do NOT "simplify" this to a static import.
+ */
+
+let _mgrMod = null;
+let _testSink = null;
+
+/** Test seam: inject a spy sink ({ emitChange }), or null to reset. */
+export function __setEmitSinkForTest(sink) { _testSink = sink; }
+
+async function sink() {
+  if (_testSink) return _testSink;
+  if (!_mgrMod) { try { _mgrMod = await import("./managers.js"); } catch { return null; } }
+  return _mgrMod.getInstanceSyncManager?.() || null;
+}
+
+export async function emitContactChange(op, row) {
+  try { (await sink())?.emitChange("contacts", op, row); } catch { /* never throw */ }
+}
+
+export async function emitContactDelete(crowId) {
+  if (!crowId) return;
+  try { (await sink())?.emitChange("contacts", "delete", { crow_id: crowId }); } catch { /* never throw */ }
+}

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -18,6 +18,7 @@ import { resolve } from "node:path";
 import { sign, verify } from "./identity.js";
 import { resolveDataDir } from "../db.js";
 import { isSyncable } from "../gateway/dashboard/settings/sync-allowlist.js";
+import { normalizePubkey } from "./pubkey-util.js";
 import bus from "../shared/event-bus.js";
 
 /**
@@ -71,11 +72,19 @@ export const SYNCED_TABLES = [
 ];
 
 // Columns to exclude from sync payloads (security-sensitive or instance-local)
-const EXCLUDED_COLUMNS = {
+export const EXCLUDED_COLUMNS = {
   crow_instances: ["auth_token_hash"],
   // apiKey can be sensitive for some deployments; keep in sync by default for
   // local-lab scenarios but flag here as the place to exclude if paranoid.
   providers: [],
+  // Phase 3 (contacts follow the user): `verified` is a per-device attestation
+  // ("I compared the safety number on THIS device") — never assert it on a
+  // device that didn't check. `last_seen` is bumped on every inbound DM
+  // (boot.js) — syncing it would firehose the feed. `id` is the per-instance
+  // AUTOINCREMENT key (never portable). `created_at` differs when two instances
+  // independently form the same req: row, manufacturing spurious conflicts.
+  // All stripped from the wire; the row still syncs (keyed on crow_id).
+  contacts: ["verified", "last_seen", "id", "created_at"],
 };
 
 // Per-table outbound mutations applied right after the EXCLUDED_COLUMNS strip.
@@ -149,12 +158,26 @@ function _scheduleStorageReset() {
 }
 
 function shouldSyncRow(table, row) {
+  if (table === "contacts") {
+    if (!row) return false;
+    // local-bot contacts are hosted on THIS instance (instance-local secp key);
+    // a phantom on a peer would point at a bot that isn't there.
+    if (row.origin === "local-bot") return false;
+    // Only established contacts sync. `pending` message-requests are a
+    // per-instance inbox each instance forms from the shared inbound stream.
+    const rs = row.request_status;
+    if (rs !== null && rs !== undefined && rs !== "accepted") return false;
+    return true;
+  }
   if (table !== "dashboard_settings") return true;
   if (!row || !row.key) return false;
   // dashboard_settings holds only the global scope; per-instance overrides live
   // in dashboard_settings_overrides (never synced). Allowlist gates the key.
   return isSyncable(row.key);
 }
+
+// Test-only alias (keeps the function module-private for production callers).
+export function shouldSyncRowForTest(table, row) { return shouldSyncRow(table, row); }
 
 export class InstanceSyncManager {
   /**
@@ -664,6 +687,20 @@ export class InstanceSyncManager {
       return;
     }
 
+    // contacts is keyed by the stable crow_id (per-instance AUTOINCREMENT id is
+    // NOT portable). Route ALL ops through the natural-key handler, mirroring
+    // _applyCrowContext. shouldSyncRow already gated inbound at :639 (before the
+    // signature verify + dispatch), so a peer-injected pending/local-bot row
+    // never reaches here.
+    if (table === "contacts") {
+      try {
+        await this._applyContact(op, row, lamport_ts, instance_id);
+      } catch (err) {
+        console.warn(`[instance-sync] Failed to apply ${op} on contacts:`, err.message);
+      }
+      return;
+    }
+
     // Conflict detection gates both updates and deletes — a stale remote delete
     // with a lower lamport_ts must not silently destroy a newer local edit (D6).
     if ((op === "update" || op === "delete") && row.id !== undefined) {
@@ -908,6 +945,160 @@ export class InstanceSyncManager {
     } catch (err) {
       console.warn(`[instance-sync] crow_context conflict LOGGING failed (local data preserved):`, err.message);
     }
+  }
+
+  /**
+   * Apply a contacts mutation keyed on the stable crow_id (Phase 3 / D1).
+   * Per-instance AUTOINCREMENT id is never used. LWW by lamport_ts, matching
+   * _applyCrowContext / _checkConflict (W4-1) semantics. After any insert/update
+   * that leaves a live row, fires this.onContactSynced(localRow) so the receiver
+   * subscribes to the contact (boot-injected; undefined in tests/pre-boot).
+   *
+   * @param {"insert"|"update"|"delete"} op
+   * @param {object} row - wire row (no local id; keyed by crow_id)
+   * @param {number} lamportTs
+   * @param {string} instanceId - origin instance id
+   */
+  async _applyContact(op, row, lamportTs, instanceId) {
+    const crowId = row && row.crow_id;
+    if (!crowId) {
+      console.warn("[instance-sync] _applyContact: missing crow_id — skipping");
+      return;
+    }
+
+    // PRAGMA-filter incoming keys to live columns; always drop id/lamport_ts/
+    // instance_id and the never-synced verified/last_seen/created_at (defense on
+    // apply — these are stripped on emit too).
+    if (!this._contactCols) {
+      try {
+        const { rows: pragma } = await this.db.execute({ sql: "PRAGMA table_info(contacts)", args: [] });
+        this._contactCols = new Set(pragma.map((r) => r.name));
+      } catch { this._contactCols = null; }
+    }
+    const ALWAYS_DROP = new Set(["id", "lamport_ts", "instance_id", "verified", "last_seen", "created_at"]);
+    const filtered = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (ALWAYS_DROP.has(k)) continue;
+      if (this._contactCols && !this._contactCols.has(k)) continue;
+      filtered[k] = v;
+    }
+
+    const { rows: localRows } = await this.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [crowId] });
+    const localRow = localRows[0] ?? null;
+    const localTs = localRow?.lamport_ts || 0;
+    const rowIdJson = JSON.stringify({ crow_id: crowId });
+
+    // ── delete ──────────────────────────────────────────────────────────────
+    if (op === "delete") {
+      if (!localRow) return;
+      if (lamportTs > localTs) {
+        await this.db.execute({ sql: "DELETE FROM contacts WHERE crow_id = ?", args: [crowId] });
+        return;
+      }
+      try {
+        await this._insertConflictRow("contacts", rowIdJson,
+          localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
+          JSON.stringify(localRow), JSON.stringify(filtered), "delete");
+        await this._notifyConflict();
+      } catch (err) {
+        console.warn("[instance-sync] contacts delete conflict LOGGING failed (local kept):", err.message);
+      }
+      return;
+    }
+
+    // ── insert / update ────────────────────────────────────────────────────
+    if (!localRow) {
+      // NOT NULL parity (ed25519_pubkey, secp256k1_pubkey are NOT NULL). A
+      // partial old-sender row would throw; skip with a warning instead
+      // (mirrors _applyCrowContext's required-column guard). Empty string '' is
+      // fine — manual/keyless contacts carry ''; only a truly-absent column skips.
+      if (filtered.secp256k1_pubkey == null || filtered.ed25519_pubkey == null) {
+        console.warn("[instance-sync] _applyContact: insert skipped — NOT NULL pubkey column absent");
+        return;
+      }
+
+      // Same-secp REBIND (spec §A2 "upsertFullContact-style merge"). The
+      // handshake rebinds a placeholder `req:<secp>` contact to a real
+      // `crow:<id>` (contact-promote.js). An instance offline across the
+      // handshake catches up as update(req:x) then update(crow:y) — same secp,
+      // different crow_id. Keying only on crow_id would insert BOTH → a split
+      // contact. So on a crow_id miss, if a local row already holds this secp
+      // under a DIFFERENT crow_id, REBIND it instead of inserting a duplicate.
+      // Safe: the entry is ed25519-signed by the shared identity, a secp match =
+      // same key-holder = same peer, and the incoming crow_id is unowned here.
+      const secpNorm = filtered.secp256k1_pubkey ? normalizePubkey(String(filtered.secp256k1_pubkey)) : "";
+      const secpRow = secpNorm ? (await this.db.execute({
+        sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ? ORDER BY id ASC LIMIT 1",
+        args: [secpNorm],
+      })).rows[0] || null : null;
+      if (secpRow) {
+        // Never relabel a real `crow:` id DOWN to a `req:` placeholder (a 3+-
+        // instance cross-feed reorder could otherwise un-promote). One-directional.
+        if (String(crowId).startsWith("req:") && !String(secpRow.crow_id).startsWith("req:")) return;
+        // LWW: only rebind if the incoming entry is at least as new as the local
+        // same-secp row (a stale re-delivery must not relabel a fresher row).
+        if (lamportTs >= (secpRow.lamport_ts || 0)) {
+          const rebindKeys = Object.keys(filtered).filter((k) => k !== "crow_id");
+          const setClauses = ["crow_id = ?", ...rebindKeys.map((k) => `${k} = ?`), "verified = 0", "lamport_ts = ?"];
+          const vals = [crowId, ...rebindKeys.map((k) => filtered[k] ?? null), lamportTs];
+          await this.db.execute({ sql: `UPDATE contacts SET ${setClauses.join(", ")} WHERE id = ?`, args: [...vals, secpRow.id] });
+          await this._afterContactApplied(crowId);
+        }
+        return;
+      }
+
+      const cols = Object.keys(filtered).filter((k) => filtered[k] !== undefined);
+      if (!cols.includes("crow_id")) cols.push("crow_id");
+      const insertCols = [...new Set(cols)];
+      const placeholders = insertCols.map(() => "?").join(", ");
+      const values = insertCols.map((k) => (k === "crow_id" ? crowId : filtered[k] ?? null));
+      await this.db.execute({
+        sql: `INSERT INTO contacts (${insertCols.join(", ")}, lamport_ts) VALUES (${placeholders}, ?)`,
+        args: [...values, lamportTs],
+      });
+      await this._afterContactApplied(crowId);
+      return;
+    }
+
+    if (lamportTs > localTs) {
+      const updateKeys = Object.keys(filtered).filter((k) => k !== "crow_id");
+      // PR3 parity: a synced key rebind invalidates a local safety-number check.
+      // `verified` is excluded from the wire (only ever set by a local device
+      // comparison), so a secp/ed change MUST reset it to 0 — matching the local
+      // promote/merge path (contact-promote.js).
+      const secpChanged = filtered.secp256k1_pubkey != null &&
+        normalizePubkey(String(filtered.secp256k1_pubkey)) !== normalizePubkey(String(localRow.secp256k1_pubkey || ""));
+      const edChanged = filtered.ed25519_pubkey != null &&
+        String(filtered.ed25519_pubkey) !== String(localRow.ed25519_pubkey || "");
+      const setClauses = updateKeys.map((k) => `${k} = ?`);
+      const vals = updateKeys.map((k) => filtered[k] ?? null);
+      if (secpChanged || edChanged) setClauses.push("verified = 0");
+      setClauses.push("lamport_ts = ?"); vals.push(lamportTs);
+      await this.db.execute({ sql: `UPDATE contacts SET ${setClauses.join(", ")} WHERE crow_id = ?`, args: [...vals, crowId] });
+      await this._afterContactApplied(crowId);
+      return;
+    }
+
+    // incomingTs <= localTs
+    if (rowsEquivalent(localRow, filtered)) return; // re-delivery noise
+    try {
+      await this._insertConflictRow("contacts", rowIdJson,
+        localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
+        JSON.stringify(localRow), JSON.stringify(filtered), op || "update");
+      await this._notifyConflict();
+    } catch (err) {
+      console.warn("[instance-sync] contacts conflict LOGGING failed (local kept):", err.message);
+    }
+  }
+
+  /** Re-select the applied contact row and hand it to the subscribe hook (guarded). */
+  async _afterContactApplied(crowId) {
+    try {
+      const { rows } = await this.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [crowId] });
+      if (rows[0] && typeof this.onContactSynced === "function") {
+        Promise.resolve(this.onContactSynced(rows[0])).catch(() => {});
+      }
+    } catch {}
   }
 
   /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -975,11 +975,18 @@ export class InstanceSyncManager {
         this._contactCols = new Set(pragma.map((r) => r.name));
       } catch { this._contactCols = null; }
     }
+    // Defense-in-depth: dynamic column names below are built from `filtered`'s
+    // keys, so they MUST be whitelisted against the live schema. If the PRAGMA
+    // failed we cannot whitelist — skip rather than build SQL from raw wire keys.
+    if (!this._contactCols) {
+      console.warn("[instance-sync] _applyContact: contacts columns unavailable — skipping");
+      return;
+    }
     const ALWAYS_DROP = new Set(["id", "lamport_ts", "instance_id", "verified", "last_seen", "created_at"]);
     const filtered = {};
     for (const [k, v] of Object.entries(row)) {
       if (ALWAYS_DROP.has(k)) continue;
-      if (this._contactCols && !this._contactCols.has(k)) continue;
+      if (!this._contactCols.has(k)) continue;
       filtered[k] = v;
     }
 

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -10,6 +10,7 @@ import { randomUUID } from "crypto";
 import { isKioskActive, kioskBlockedResponse } from "../../shared/kiosk-guard.js";
 import { generateInviteCode, parseInviteCode, parseBotInviteCode, computeSafetyNumber } from "../identity.js";
 import { upsertFullContact } from "../contact-promote.js";
+import { emitContactChange } from "../contact-sync.js";
 import { buildInviteUrl, extractInviteCode } from "../invite-url.js";
 import {
   generateShortCode, formatShortCode, normalizeShortCode, deriveShortCodeKeys,
@@ -376,6 +377,13 @@ export function registerContactsTools(server, ctx) {
               id: contactId, crowId: bot.botCrowId, secp256k1_pubkey: bot.secp256k1Pubkey,
             });
           } catch { /* non-fatal — re-subscribed on next restart */ }
+          // Phase 3: an accepted remote bot is a real cross-instance contact —
+          // propagate it to the user's other instances (advertised/remote bots
+          // sync per S-BOTS; a local-bot would be gated by shouldSyncRow).
+          try {
+            const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
+            if (rows[0]) await emitContactChange("insert", rows[0]);
+          } catch { /* never blocks the accept */ }
         }
 
         // Tell the bot we accepted (carries the token it validates).

--- a/tests/contacts-sync-emit.test.js
+++ b/tests/contacts-sync-emit.test.js
@@ -1,0 +1,36 @@
+/**
+ * Phase 3 PR-A — Task 4a: the emitContactChange helper (push side).
+ * Guarded + null-safe; a test seam injects a spy sink.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { emitContactChange, emitContactDelete, __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
+
+test("emitContactChange forwards op+row to the sync manager", async () => {
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (t, op, row) => seen.push([t, op, row.crow_id]) });
+  await emitContactChange("insert", { crow_id: "crow:e1" });
+  await emitContactChange("update", { crow_id: "crow:e2", is_blocked: 1 });
+  await emitContactDelete("crow:e3");
+  assert.deepEqual(seen, [
+    ["contacts", "insert", "crow:e1"],
+    ["contacts", "update", "crow:e2"],
+    ["contacts", "delete", "crow:e3"],
+  ]);
+  __setEmitSinkForTest(null);
+});
+
+test("emitContactChange is a no-op with no manager (pre-boot / tests)", async () => {
+  __setEmitSinkForTest(null);
+  await emitContactChange("insert", { crow_id: "crow:none" }); // must not throw
+  await emitContactDelete("crow:none");
+});
+
+test("emitContactDelete ignores an empty crowId", async () => {
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (...a) => seen.push(a) });
+  await emitContactDelete("");
+  await emitContactDelete(null);
+  assert.equal(seen.length, 0);
+  __setEmitSinkForTest(null);
+});

--- a/tests/contacts-sync-hook.test.js
+++ b/tests/contacts-sync-hook.test.js
@@ -1,0 +1,45 @@
+/**
+ * Phase 3 PR-A — Task 3: the onContactSynced wire hook.
+ * wireSyncedContact(managers, row): subscribes a keyed non-blocked non-local-bot
+ * contact; unsubscribes a newly-blocked one; no-ops keyless (manual); never throws.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { wireSyncedContact } from "../servers/sharing/contact-promote.js";
+
+function spyManagers() {
+  const calls = { subscribe: [], join: [], init: [], close: [], leave: [] };
+  return {
+    calls,
+    nostrManager: { subscribeToContact: async (c) => { calls.subscribe.push(c.crow_id); } },
+    peerManager: { joinContact: async (c) => { calls.join.push(c.crowId); }, leaveContact: async (id) => { calls.leave.push(id); } },
+    syncManager: { initContact: async (id) => { calls.init.push(id); }, closeContactFeeds: async (id) => { calls.close.push(id); } },
+  };
+}
+const SECP = "a".repeat(64);
+
+test("wireSyncedContact: subscribes a keyed, non-blocked contact", async () => {
+  const m = spyManagers();
+  await wireSyncedContact(m, { id: 1, crow_id: "crow:x", secp256k1_pubkey: SECP, ed25519_pubkey: "e", is_blocked: 0 });
+  assert.deepEqual(m.calls.subscribe, ["crow:x"]);
+  assert.deepEqual(m.calls.join, ["crow:x"]);
+});
+
+test("wireSyncedContact: newly-blocked contact unsubscribes, does not subscribe", async () => {
+  const m = spyManagers();
+  await wireSyncedContact(m, { id: 2, crow_id: "crow:b", secp256k1_pubkey: SECP, is_blocked: 1 });
+  assert.deepEqual(m.calls.subscribe, []);
+  assert.deepEqual(m.calls.close, [2]);
+  assert.deepEqual(m.calls.leave, ["crow:b"]);
+});
+
+test("wireSyncedContact: keyless (manual) + local-bot contacts do not subscribe", async () => {
+  const m = spyManagers();
+  await wireSyncedContact(m, { id: 3, crow_id: "manual:x", secp256k1_pubkey: "", contact_type: "manual" });
+  await wireSyncedContact(m, { id: 4, crow_id: "crow:lb", secp256k1_pubkey: SECP, origin: "local-bot" });
+  assert.deepEqual(m.calls.subscribe, []);
+});
+
+test("wireSyncedContact: never throws on null managers", async () => {
+  await wireSyncedContact(null, { id: 5, crow_id: "crow:n", secp256k1_pubkey: SECP });
+});

--- a/tests/contacts-sync-panel-emit.test.js
+++ b/tests/contacts-sync-panel-emit.test.js
@@ -1,0 +1,127 @@
+/**
+ * Phase 3 PR-A — Task 4b: dashboard panels emit contact mutations (push side).
+ * Drives handleContactAction / handlePostAction against a real init-db DB with
+ * the contact-sync emit sink spied. Asserts each mutating action emits the right
+ * op, and that verified/decline/pending do NOT emit.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
+import { __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "p3panel-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: join(import.meta.dirname, "..") });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+function spy() {
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (t, op, row) => seen.push({ op, crow_id: row.crow_id, is_blocked: row.is_blocked, request_status: row.request_status }) });
+  return seen;
+}
+const res = { redirectAfterPost: (u) => ({ redirect: u }) };
+async function seedContact(db, { crow_id, contact_type = "crow", secp = "a".repeat(64), request_status = null }) {
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey, contact_type, request_status) VALUES (?, 'N', '', ?, ?, ?)", args: [crow_id, secp, contact_type, request_status] });
+  return Number((await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [crow_id] })).rows[0].id);
+}
+
+test("contacts panel: block emits update with is_blocked=1", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const id = await seedContact(db, { crow_id: "crow:blk" });
+    const seen = spy();
+    await handleContactAction({ body: { action: "block", contact_id: String(id) } }, db);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].op, "update");
+    assert.equal(seen[0].crow_id, "crow:blk");
+    assert.equal(Number(seen[0].is_blocked), 1);
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});
+
+test("contacts panel: unblock emits update with is_blocked=0", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const id = await seedContact(db, { crow_id: "crow:unblk" });
+    await db.execute({ sql: "UPDATE contacts SET is_blocked = 1 WHERE id = ?", args: [id] });
+    const seen = spy();
+    await handleContactAction({ body: { action: "unblock", contact_id: String(id) } }, db);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].op, "update");
+    assert.equal(Number(seen[0].is_blocked), 0);
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});
+
+test("contacts panel: add_manual emits insert; set_verified emits nothing", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const seen = spy();
+    await handleContactAction({ body: { action: "add_manual", name: "Bob", email: "b@x.io" } }, db);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].op, "insert");
+    assert.ok(seen[0].crow_id.startsWith("manual:"));
+    // set_verified: no emit
+    const id = await seedContact(db, { crow_id: "crow:ver" });
+    seen.length = 0;
+    await handleContactAction({ body: { action: "set_verified", contact_id: String(id), verified: "1" } }, db);
+    assert.equal(seen.length, 0, "verified is per-device — never synced");
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});
+
+test("contacts panel: edit emits update", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const id = await seedContact(db, { crow_id: "crow:edit" });
+    const seen = spy();
+    await handleContactAction({ body: { action: "edit_contact", contact_id: String(id), notes: "hello" } }, db);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].op, "update");
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});
+
+test("contacts panel: delete emits delete for a manual row, nothing for a crow: row", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const manualId = await seedContact(db, { crow_id: "manual:d1", contact_type: "manual", secp: "" });
+    const crowId = await seedContact(db, { crow_id: "crow:d2", contact_type: "crow" });
+    const seen = spy();
+    await handleContactAction({ body: { action: "delete_contact", contact_id: String(manualId) } }, db);
+    await handleContactAction({ body: { action: "delete_contact", contact_id: String(crowId) } }, db); // no-op (not manual)
+    assert.equal(seen.length, 1, "only the manual delete emitted");
+    assert.equal(seen[0].op, "delete");
+    assert.equal(seen[0].crow_id, "manual:d1");
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});
+
+test("messages panel: block/unblock emit update", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    await seedContact(db, { crow_id: "crow:mblk" });
+    const seen = spy();
+    await handlePostAction({ body: { action: "block", crow_id: "crow:mblk" } }, res, { db });
+    await handlePostAction({ body: { action: "unblock", crow_id: "crow:mblk" } }, res, { db });
+    assert.equal(seen.length, 2);
+    assert.equal(seen[0].op, "update"); assert.equal(Number(seen[0].is_blocked), 1);
+    assert.equal(seen[1].op, "update"); assert.equal(Number(seen[1].is_blocked), 0);
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});
+
+test("messages panel: accept_request emits update; decline emits nothing", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const accId = await seedContact(db, { crow_id: "req:acc", request_status: "pending" });
+    const decId = await seedContact(db, { crow_id: "req:dec", request_status: "pending" });
+    const seen = spy();
+    await handlePostAction({ body: { action: "accept_request", request_id: String(accId) } }, res, { db });
+    await handlePostAction({ body: { action: "decline_request", request_id: String(decId) } }, res, { db });
+    assert.equal(seen.length, 1, "only accept emitted");
+    assert.equal(seen[0].op, "update");
+    assert.equal(seen[0].request_status, "accepted");
+  } finally { __setEmitSinkForTest(null); cleanup(); }
+});

--- a/tests/contacts-sync.test.js
+++ b/tests/contacts-sync.test.js
@@ -1,0 +1,158 @@
+/**
+ * Phase 3 PR-A — contacts follow the user.
+ * Task 1: carve-out gates (shouldSyncRow contacts branch + EXCLUDED_COLUMNS).
+ * Task 2: _applyContact crow_id-keyed inbound apply (LWW, secp-rebind, hook).
+ *
+ * Harness mirrors tests/instance-sync.test.js: real init-db into a tmpdir, plain
+ * signed entries fed through _applyEntry, shared single identity so verify passes.
+ * NOTE: all tests share ONE db file (rows persist across tests) — so each test
+ * uses a UNIQUE secp key via secp(n) to avoid cross-test secp-rebind collisions.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager, shouldSyncRowForTest, EXCLUDED_COLUMNS } from "../servers/sharing/instance-sync.js";
+import { sign } from "../servers/sharing/identity.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3-test-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe" });
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+const LOCAL_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const REMOTE_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+
+function mgr(id = LOCAL_ID) { return new InstanceSyncManager(IDENTITY, createDbClient(DB_PATH), id); }
+function signedEntry(table, op, row, lamport_ts, instance_id = REMOTE_ID) {
+  const e = { table, op, row, lamport_ts, instance_id };
+  e.signature = sign(JSON.stringify(e), IDENTITY.ed25519Priv);
+  return e;
+}
+// Unique 64-hex secp per test (digits are valid hex; padded to 64).
+const secp = (n) => String(n).padStart(64, "0");
+const bySecp = (db, s) => db.execute({ sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64))=?", args: [s.toLowerCase()] });
+
+// ── Task 1: carve-out gates ────────────────────────────────────────────────
+test("shouldSyncRow: contacts carve-outs", () => {
+  const ok = (row) => shouldSyncRowForTest("contacts", row);
+  assert.equal(ok({ crow_id: "crow:a", request_status: null }), true, "full contact syncs");
+  assert.equal(ok({ crow_id: "crow:a", request_status: "accepted" }), true, "accepted syncs");
+  assert.equal(ok({ crow_id: "manual:x", contact_type: "manual" }), true, "manual address-book syncs");
+  assert.equal(ok({ crow_id: "crow:a", is_blocked: 1 }), true, "blocked still syncs (block follows user)");
+  assert.equal(ok({ crow_id: "crow:a", request_status: "pending" }), false, "pending stays local");
+  assert.equal(ok({ crow_id: "crow:a", origin: "local-bot" }), false, "local-bot never syncs");
+});
+
+test("EXCLUDED_COLUMNS.contacts strips id + created_at + verified + last_seen", () => {
+  assert.deepEqual([...EXCLUDED_COLUMNS.contacts].sort(), ["created_at", "id", "last_seen", "verified"]);
+});
+
+// ── Task 2: _applyContact ──────────────────────────────────────────────────
+test("_applyContact: insert keys on crow_id, not per-instance id", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (7,'crow:local','', ?)", args: [secp(1)] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert",
+    { id: 7, crow_id: "crow:remote", ed25519_pubkey: "", secp256k1_pubkey: secp(2), display_name: "Remote" }, 10));
+  const local = (await db.execute({ sql: "SELECT crow_id FROM contacts WHERE crow_id='crow:local'" })).rows;
+  const remote = (await db.execute({ sql: "SELECT crow_id, display_name FROM contacts WHERE crow_id='crow:remote'" })).rows;
+  assert.equal(local.length, 1, "local row untouched (id collision did NOT clobber)");
+  assert.equal(remote.length, 1, "remote contact created under its own crow_id");
+  assert.equal(remote[0].display_name, "Remote");
+});
+
+test("_applyContact: LWW update — newer applies, stale skips + logs conflict", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:lww','', ?, 'Old', 5)", args: [secp(3)] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update", { crow_id: "crow:lww", display_name: "New", secp256k1_pubkey: secp(3) }, 9));
+  assert.equal((await db.execute({ sql: "SELECT display_name FROM contacts WHERE crow_id='crow:lww'" })).rows[0].display_name, "New");
+  const before = (await db.execute({ sql: "SELECT COUNT(*) c FROM sync_conflicts" })).rows[0].c;
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update", { crow_id: "crow:lww", display_name: "Stale", secp256k1_pubkey: secp(3) }, 3));
+  assert.equal((await db.execute({ sql: "SELECT display_name FROM contacts WHERE crow_id='crow:lww'" })).rows[0].display_name, "New", "stale ignored");
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM sync_conflicts" })).rows[0].c, before + 1, "conflict logged");
+});
+
+test("_applyContact: delete is lamport-gated by crow_id", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, lamport_ts) VALUES ('crow:del','', ?, 5)", args: [secp(4)] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "delete", { crow_id: "crow:del" }, 3)); // stale
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:del'" })).rows[0].c, 1, "stale delete kept local");
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "delete", { crow_id: "crow:del" }, 9)); // newer
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:del'" })).rows[0].c, 0, "newer delete applied");
+});
+
+test("_applyContact: a synced key-rebind resets verified to 0 (PR3 parity)", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, verified, lamport_ts) VALUES ('crow:rebind','e', ?, 1, 5)", args: [secp(5)] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update", { crow_id: "crow:rebind", secp256k1_pubkey: secp(6) }, 9));
+  const row = (await db.execute({ sql: "SELECT secp256k1_pubkey, verified FROM contacts WHERE crow_id='crow:rebind'" })).rows[0];
+  assert.equal(row.secp256k1_pubkey, secp(6), "key rebound");
+  assert.equal(row.verified, 0, "verified reset on key change");
+});
+
+test("_applyContact: a same-key update preserves verified", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, verified, lamport_ts) VALUES ('crow:keep','e', ?, 'X', 1, 5)", args: [secp(7)] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update", { crow_id: "crow:keep", secp256k1_pubkey: secp(7), display_name: "Y" }, 9));
+  const row = (await db.execute({ sql: "SELECT display_name, verified FROM contacts WHERE crow_id='crow:keep'" })).rows[0];
+  assert.equal(row.display_name, "Y", "display updated");
+  assert.equal(row.verified, 1, "verified preserved when key unchanged");
+});
+
+test("_applyContact: req:→crow: rebind by secp does not split the contact (R2)", async () => {
+  const m = mgr(); const db = m.db; const s = secp(8);
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update",
+    { crow_id: "req:" + s, ed25519_pubkey: "", secp256k1_pubkey: s, request_status: "accepted", display_name: "Stranger" }, 5));
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update",
+    { crow_id: "crow:real", ed25519_pubkey: "e", secp256k1_pubkey: s, request_status: null, display_name: "Alice" }, 9));
+  const rows = (await bySecp(db, s)).rows;
+  assert.equal(rows.length, 1, "exactly one row for the secp (rebound, not split)");
+  assert.equal(rows[0].crow_id, "crow:real");
+  assert.equal(rows[0].display_name, "Alice");
+});
+
+test("_applyContact: rebind converges an independently-formed local req: row", async () => {
+  const m = mgr(); const db = m.db; const s = secp(9);
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, request_status, lamport_ts) VALUES (?, '', ?, 'accepted', 4)", args: ["req:" + s, s] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update", { crow_id: "crow:b", ed25519_pubkey: "e", secp256k1_pubkey: s }, 9));
+  const rows = (await bySecp(db, s)).rows;
+  assert.equal(rows.length, 1, "local req: row rebound to crow:b, not duplicated");
+  assert.equal(rows[0].crow_id, "crow:b");
+});
+
+test("_applyContact: rebind never un-promotes a real crow: id to a req: placeholder (R2b)", async () => {
+  const m = mgr(); const db = m.db; const s = secp(10);
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, request_status, lamport_ts) VALUES ('crow:promoted','e', ?, NULL, 5)", args: [s] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update", { crow_id: "req:" + s, secp256k1_pubkey: s, request_status: "accepted" }, 99));
+  const rows = (await bySecp(db, s)).rows;
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].crow_id, "crow:promoted", "stayed promoted");
+});
+
+test("_applyContact: apply drops verified/last_seen and honors carve-outs", async () => {
+  const m = mgr(); const db = m.db;
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert",
+    { crow_id: "crow:carve", ed25519_pubkey: "", secp256k1_pubkey: secp(11), verified: 1, last_seen: "2020-01-01" }, 4));
+  const row = (await db.execute({ sql: "SELECT verified, last_seen FROM contacts WHERE crow_id='crow:carve'" })).rows[0];
+  assert.equal(row.verified, 0, "verified not set from wire (local default)");
+  assert.equal(row.last_seen, null, "last_seen not set from wire");
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert", { crow_id: "crow:reqx", secp256k1_pubkey: secp(12), ed25519_pubkey: "", request_status: "pending" }, 4));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:reqx'" })).rows[0].c, 0, "pending not applied");
+});
+
+test("_applyContact: fires onContactSynced with the local row; never throws on junk", async () => {
+  const m = mgr(); const seen = [];
+  m.onContactSynced = (r) => seen.push(r);
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert", { crow_id: "crow:hook", ed25519_pubkey: "", secp256k1_pubkey: secp(13) }, 4));
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].crow_id, "crow:hook");
+  assert.equal(typeof seen[0].id, "number", "hook receives the local row with a local id");
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert", { nonsense: true }, 4)); // no crow_id → no throw
+});

--- a/tests/contacts-sync.test.js
+++ b/tests/contacts-sync.test.js
@@ -147,6 +147,14 @@ test("_applyContact: apply drops verified/last_seen and honors carve-outs", asyn
   assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:reqx'" })).rows[0].c, 0, "pending not applied");
 });
 
+test("_applyContact: a bad-signature contacts entry is dropped before apply", async () => {
+  const m = mgr(); const db = m.db;
+  const e = { table: "contacts", op: "insert", row: { crow_id: "crow:badsig", ed25519_pubkey: "", secp256k1_pubkey: secp(14) }, lamport_ts: 4, instance_id: REMOTE_ID };
+  e.signature = "00".repeat(64); // invalid signature
+  await m._applyEntry(REMOTE_ID, e);
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:badsig'" })).rows[0].c, 0, "unverified entry not applied");
+});
+
 test("_applyContact: fires onContactSynced with the local row; never throws on junk", async () => {
   const m = mgr(); const seen = [];
   m.onContactSynced = (r) => seen.push(r);


### PR DESCRIPTION
## What

The user's **contact list + blocks now sync across their own paired instances** (shared ed25519 identity) via the existing instance-sync mesh. Adding, editing, blocking, or deleting a contact on one instance applies on all of them, and a synced-in contact becomes *live* (subscribed) on the receiver. This is **Phase 3 PR-A** of the Crow Messages usability arc (decision **D1**, "contacts follow the user") — it fixes the operator's "contacts are per-instance today, which is wrong for multi-instance users."

Spec: `docs/superpowers/specs/2026-07-06-messages-phase3-contacts-follow-user-design.md`
Plan: `docs/superpowers/plans/2026-07-06-messages-p3-pr-a-contacts-follow-user.md`

## How

- **Pull side — `_applyContact`** (instance-sync.js): a self-contained inbound handler keyed on the stable `crow_id` (never the per-instance `AUTOINCREMENT id`), dispatched before the generic id-path, mirroring `_applyCrowContext`. LWW by `lamport_ts`. A **same-secp rebind** converges the `req:`→`crow:` handshake so an offline-catch-up instance never ends up with a split contact; a guard prevents un-promoting `crow:`→`req:`. `verified` resets to 0 on a synced key-rebind (PR3 parity).
- **Push side** — `emitChange("contacts", …)` at every mutation site through a guarded `contact-sync.js` helper (lazy-imports `managers.js` to avoid an import cycle): `upsertFullContact` outcomes, bot-accept, and the contacts + messages panels (block/unblock/add/edit/import/delete/accept). `delete_contact` emits only when a row was actually deleted (`rowsAffected > 0`) so a no-op local delete can't propagate a destructive one.
- **Subscribe hook** — `onContactSynced` (injected at boot) wires a synced contact live (initContact + joinContact + subscribeToContact), **skipping** blocked (and unsubscribing), local-bot, and keyless/manual contacts.
- **Carve-outs** — `EXCLUDED_COLUMNS.contacts = [verified, last_seen, id, created_at]`; `shouldSyncRow` drops `local-bot` and non-`accepted` request rows on **both** emit and apply.

**No schema change** — `SCHEMA_GENERATION` stays 4.

## Review

- Plan reviewed adversarially in **2 rounds + a focused R2b** (Opus): R1 caught the verified-reset gap + an import cycle; R2 caught the `req:`→`crow:` split-contact bug (fixed via the secp-rebind) + the `delete` rowsAffected gate; R2b confirmed the rebind is UNIQUE-safe/LWW-correct.
- **Final whole-branch Opus security review: READY TO MERGE, no Critical/Important.** The two hardening MINORs it raised are folded in (skip apply on PRAGMA failure rather than build SQL from un-whitelisted wire keys; a bad-signature negative test).

## Tests

**1109/1109** full suite (baseline 1083 + 26 new across `contacts-sync`, `contacts-sync-hook`, `contacts-sync-emit`, `contacts-sync-panel-emit`). Isolated boot clean (4 relays, both subscribe lines, `user_version=4`, integrity ok).

## Deploy

Plain gateway restart on **both** crow and grackle (contacts-follow-user needs the whole shared-seed pair on the new code). grackle also applies PR3's `verified` migration (`user_version` 3→4) on this restart. Live E2E to follow: add a contact on crow → confirm it appears + is subscribed on grackle.