### PR TITLE
fix(sharing): --no-auth gateways skip instance-sync feed init

### DIFF
--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -179,6 +179,21 @@ function shouldSyncRow(table, row) {
 // Test-only alias (keeps the function module-private for production callers).
 export function shouldSyncRowForTest(table, row) { return shouldSyncRow(table, row); }
 
+/**
+ * Whether this process should participate in cross-instance sync feeds.
+ * A `--no-auth` gateway is a loopback companion (e.g. grackle's crow-mcp-bridge),
+ * NEVER the primary instance — it must NOT open the instance-sync Hypercore feeds,
+ * or it grabs the on-disk feed lock and starves the PRIMARY gateway ("File
+ * descriptor could not be locked"), silently breaking the primary's replication.
+ * Same class as shouldRunHealthMonitor (QW1). Pure + injectable for tests.
+ * @param {{argv?: string[], env?: object}} opts
+ */
+export function shouldInitInstanceSync({ argv = [], env = {} } = {}) {
+  if (env.CROW_DISABLE_INSTANCE_SYNC === "1") return false;
+  if (Array.isArray(argv) && argv.includes("--no-auth")) return false;
+  return true;
+}
+
 export class InstanceSyncManager {
   /**
    * @param {object} identity - Crow identity (from loadOrCreateIdentity)
@@ -207,6 +222,12 @@ export class InstanceSyncManager {
 
     // Whether the manager has been started
     this.started = false;
+
+    // A --no-auth companion gateway must not open instance-sync feeds (it would
+    // steal the primary's feed lock). Detected from the process flags at
+    // construction so ALL feed-open paths (eagerInitPairedPeers, tailnet-sync,
+    // boot.js) are gated uniformly. See shouldInitInstanceSync().
+    this.feedsDisabled = !shouldInitInstanceSync({ argv: process.argv, env: process.env });
   }
 
   /**
@@ -285,6 +306,8 @@ export class InstanceSyncManager {
    * @param {Buffer|null} theirFeedKey - The remote instance's outgoing feed key (null if unknown yet)
    */
   async initInstance(remoteInstanceId, theirFeedKey) {
+    // --no-auth companion: never open feeds (would steal the primary's lock).
+    if (this.feedsDisabled) return null;
     // Serialize per-peer to prevent concurrent fd-lock contention on
     // <feed-dir>/db/LOCK. Multiple startup paths converge here for the
     // same peer (boot loop at server.js, eagerInitPairedPeers, the
@@ -362,6 +385,7 @@ export class InstanceSyncManager {
    * catch up entries that mirrored during a previous session.
    */
   async eagerInitPairedPeers() {
+    if (this.feedsDisabled) return 0; // --no-auth companion: skip feed init entirely
     let rows = [];
     try {
       const r = await this.db.execute({
@@ -508,6 +532,8 @@ export class InstanceSyncManager {
    * @param {object} row - The row data (for insert/update) or { id } (for delete)
    */
   async emitChange(table, op, row) {
+    // --no-auth companion doesn't drive fleet sync (and has no outFeeds).
+    if (this.feedsDisabled) return;
     if (!SYNCED_TABLES.includes(table)) return;
     if (!shouldSyncRow(table, row)) return; // local-only row; don't broadcast
 

--- a/tests/instance-sync-noauth-feeds.test.js
+++ b/tests/instance-sync-noauth-feeds.test.js
@@ -1,0 +1,61 @@
+/**
+ * A --no-auth companion gateway (e.g. grackle's loopback crow-mcp-bridge) must
+ * NOT initialize instance-sync Hypercore feeds — otherwise it grabs the feed
+ * lock and starves the PRIMARY gateway ("File descriptor could not be locked"),
+ * so the primary can't receive cross-instance sync. Same class as QW1
+ * (shouldRunHealthMonitor). This gates feed init + emit on the --no-auth flag.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager, shouldInitInstanceSync } from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+test("shouldInitInstanceSync: enabled by default, disabled on --no-auth or kill-switch", () => {
+  assert.equal(shouldInitInstanceSync({ argv: ["node", "index.js"], env: {} }), true, "default enabled");
+  assert.equal(shouldInitInstanceSync({ argv: ["node", "index.js", "--no-auth"], env: {} }), false, "--no-auth disables");
+  assert.equal(shouldInitInstanceSync({ argv: ["node", "index.js"], env: { CROW_DISABLE_INSTANCE_SYNC: "1" } }), false, "env kill-switch disables");
+});
+
+test("feedsDisabled manager: initInstance + emitChange are no-ops (no feed dir, no throw)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "noauth-isync-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe" });
+  const db = createDbClient(join(dir, "crow.db"));
+  const priv = Buffer.alloc(32, 0x11);
+  const identity = { ed25519Priv: priv, ed25519Pubkey: Buffer.from(await ed.getPublicKey(priv)).toString("hex") };
+  const mgr = new InstanceSyncManager(identity, db, "local-0000");
+  mgr.feedsDisabled = true; // simulate --no-auth
+  const peerId = "peer-1111-2222-3333-444444444444";
+
+  const r = await mgr.initInstance(peerId, null);
+  assert.equal(r, null, "initInstance returns null when feeds disabled");
+  assert.equal(mgr.outFeeds.size, 0, "no outfeed opened");
+  assert.equal(mgr.inFeeds.size, 0, "no infeed opened");
+  assert.equal(existsSync(join(dir, "instance-sync", peerId)), false, "no on-disk feed dir created");
+
+  // emitChange must be a guarded no-op (does not advance lamport or throw)
+  await mgr.emitChange("contacts", "insert", { crow_id: "crow:x", secp256k1_pubkey: "a".repeat(64), ed25519_pubkey: "" });
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("enabled manager still opens an outfeed (regression guard)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "auth-isync-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe" });
+  const db = createDbClient(join(dir, "crow.db"));
+  const priv = Buffer.alloc(32, 0x22);
+  const identity = { ed25519Priv: priv, ed25519Pubkey: Buffer.from(await ed.getPublicKey(priv)).toString("hex") };
+  const mgr = new InstanceSyncManager(identity, db, "local-0000");
+  mgr.dataDir = join(dir, "instance-sync"); // isolate from process default
+  mgr.feedsDisabled = false;
+  const peerId = "peer-5555-6666-7777-888888888888";
+  await mgr.initInstance(peerId, null);
+  assert.equal(mgr.outFeeds.size, 1, "outfeed opened when enabled");
+  // close to release the lock so the tmp dir can be removed cleanly
+  try { await mgr.outFeeds.get(peerId)?.close(); } catch {}
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Problem

A `--no-auth` companion gateway (grackle's loopback `crow-mcp-bridge`, PID-confirmed running as `node servers/gateway/index.js --no-auth`) was **opening the instance-sync Hypercore feeds and grabbing the on-disk feed lock**, starving the **primary** gateway. Grackle's journal:

```
[sharing] Failed to init sync feed for instance 0867ac28 (crow): File descriptor could not be locked
```

Both processes share one data dir (`/home/kh0pp/.crow/data`), so the `--no-auth` companion (started first) held the lock and the primary couldn't open crow's in-feed → **the primary silently received no cross-instance sync** (contacts, memories, providers, settings). This is why Phase 3's contacts-follow-user E2E couldn't replicate crow→grackle.

## Fix

Same class as QW1 (`shouldRunHealthMonitor`): a `--no-auth` gateway is a loopback companion, never the primary, and must not participate in instance-sync feeds.

- Pure, injectable `shouldInitInstanceSync({argv, env})` — `false` when `argv` has `--no-auth` or `env.CROW_DISABLE_INSTANCE_SYNC=1`.
- `InstanceSyncManager` sets `this.feedsDisabled` from it at construction.
- Early-return guards on the single feed-open choke point `initInstance` (which every caller funnels through — boot loop, `eagerInitPairedPeers`, tailnet-sync, key-handshake), plus `eagerInitPairedPeers` and `emitChange`.

The **enabled** (authed primary) path is byte-unchanged. The companion still reads sync'd data from the shared crow.db the primary populates — it just no longer steals the lock.

## Review & tests

Focused adversarial Opus review: **READY TO DEPLOY, no Critical/Important** (confirmed `initInstance` is the sole `new Hypercore` choke point, primary path unchanged, signal matches the existing QW1 discriminator, no caller breaks on the early-returns). 3 new tests; **full suite 1113/1113**. `--no-auth` isolated boot confirmed to skip feed creation; enabled manager still opens feeds (unit-proven).

## Deploy

`git pull` on crow + grackle; on grackle restart **both** gateways (the `--no-auth` bridge releases the lock under the new code; the primary then claims the feeds). Then verify crow→grackle sync resumes.

Non-blocking follow-ups (from review): note the companion-doesn't-drive-sync behavior in `docs/architecture/sharing-server.md`; document `CROW_DISABLE_INSTANCE_SYNC` in the env reference.