### PR TITLE
fix(sharing): --no-auth gateways skip Hyperswarm P2P + per-contact feeds

### DIFF
--- a/servers/sharing/peer-manager.js
+++ b/servers/sharing/peer-manager.js
@@ -8,6 +8,7 @@
  */
 
 import Hyperswarm from "hyperswarm";
+import { shouldInitInstanceSync } from "./instance-sync.js";
 import { createHash, randomBytes } from "node:crypto";
 import { sign, verify } from "./identity.js";
 
@@ -37,12 +38,20 @@ export class PeerManager {
     this.onInstanceKeyReceived = null; // callback(remoteInstanceId, feedKeyHex) — peer advertised their outgoing Hypercore feed key
     this.getFeedKeyForInstance = null; // async (remoteInstanceId) => hex — our outgoing feed key to this specific peer instance
     this.localInstanceId = null; // wired by server.js — the local Crow instance id we advertise to peers
+
+    // A --no-auth companion gateway (e.g. grackle's loopback crow-mcp-bridge) is
+    // never a peer — it must NOT run the Hyperswarm P2P layer, or it steals the
+    // DHT-topic connection (and per-contact feed locks) from the PRIMARY gateway,
+    // starving the primary's cross-instance replication. Same signal as the
+    // instance-sync feed gate. See shouldInitInstanceSync().
+    this.p2pDisabled = !shouldInitInstanceSync({ argv: process.argv, env: process.env });
   }
 
   /**
    * Initialize Hyperswarm and start listening.
    */
   async start() {
+    if (this.p2pDisabled) return this; // --no-auth companion: no swarm
     this.swarm = new Hyperswarm();
 
     this.swarm.on("connection", (conn, info) => {
@@ -56,6 +65,7 @@ export class PeerManager {
    * Join the DHT topic for a specific contact.
    */
   async joinContact(contact) {
+    if (this.p2pDisabled) return null; // --no-auth companion: no DHT topics
     if (!this.swarm) throw new Error("PeerManager not started");
 
     const topic = computeTopic(
@@ -93,6 +103,7 @@ export class PeerManager {
    * topic = sha256(crowId + "instance-sync")
    */
   async joinInstanceSync() {
+    if (this.p2pDisabled) return null; // --no-auth companion: no instance-sync topic
     if (!this.swarm) throw new Error("PeerManager not started");
 
     this.instanceSyncTopic = createHash("sha256")

--- a/servers/sharing/sync.js
+++ b/servers/sharing/sync.js
@@ -13,6 +13,7 @@ import { mkdirSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { sign, encryptForPeer, decryptFromPeer } from "./identity.js";
+import { shouldInitInstanceSync } from "./instance-sync.js";
 import { resolveDataDir } from "../db.js";
 
 const PEERS_DIR = resolve(resolveDataDir(), "peers");
@@ -33,6 +34,8 @@ export class SyncManager {
     this.inFeeds = new Map(); // contactId -> Hypercore (their incoming feed)
     this.onEntry = null; // callback(contactId, entry)
     this._initLocks = new Map(); // contactId -> tail Promise (see initContact)
+    // --no-auth companion: no per-contact sync feeds (would grab the feed lock).
+    this.p2pDisabled = !shouldInitInstanceSync({ argv: process.argv, env: process.env });
   }
 
   /**
@@ -48,6 +51,7 @@ export class SyncManager {
    * See InstanceSyncManager.initInstance() for the same pattern.
    */
   async initContact(contactId, theirFeedKey) {
+    if (this.p2pDisabled) return null; // --no-auth companion: no per-contact feeds
     const prior = this._initLocks.get(contactId) || Promise.resolve();
     const next = prior
       .catch(() => {}) // a failed prior turn shouldn't block our attempt

--- a/tests/instance-sync-noauth-feeds.test.js
+++ b/tests/instance-sync-noauth-feeds.test.js
@@ -43,6 +43,24 @@ test("feedsDisabled manager: initInstance + emitChange are no-ops (no feed dir, 
   rmSync(dir, { recursive: true, force: true });
 });
 
+test("PeerManager: p2pDisabled skips swarm start + DHT joins", async () => {
+  const { PeerManager } = await import("../servers/sharing/peer-manager.js");
+  const pm = new PeerManager({ ed25519Pubkey: "ab".repeat(32), crowId: "crow:x" });
+  pm.p2pDisabled = true; // simulate --no-auth companion
+  await pm.start();
+  assert.equal(pm.swarm, null, "no Hyperswarm created");
+  assert.equal(await pm.joinContact({ crowId: "crow:y", ed25519Pubkey: "cd".repeat(32) }), null, "joinContact no-op");
+  assert.equal(await pm.joinInstanceSync(), null, "joinInstanceSync no-op");
+});
+
+test("SyncManager: p2pDisabled skips per-contact feed init", async () => {
+  const { SyncManager } = await import("../servers/sharing/sync.js");
+  const sm = new SyncManager({ ed25519Pubkey: "ab".repeat(32) });
+  sm.p2pDisabled = true;
+  assert.equal(await sm.initContact(123, null), null, "initContact no-op");
+  assert.equal(sm.outFeeds.size, 0, "no per-contact feed opened");
+});
+
 test("enabled manager still opens an outfeed (regression guard)", async () => {
   const dir = mkdtempSync(join(tmpdir(), "auth-isync-"));
   execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe" });


### PR DESCRIPTION
## Problem (follow-up to #142)

#142 stopped the `--no-auth` companion gateway from opening instance-sync **feeds**, and grackle's primary could then open them. But the companion still ran the **rest of the P2P layer**, leaving a second lock/contention:

- `PeerManager` joined the instance-sync **Hyperswarm DHT topic**, so a peer's (crow's) connection could route to the loopback **companion** instead of the **primary** → the primary's feeds open but never get a replication connection → **no block transfer** (grackle's applied-seq stayed frozen; a fresh contact on crow never arrived).
- `SyncManager.initContact` grabbed **per-contact sync feed** locks (`[sharing] Failed to join topic … File descriptor could not be locked`).

## Fix

Extend the #142 gate: a `--no-auth` loopback companion runs **no P2P** at all. `PeerManager.start` / `joinContact` / `joinInstanceSync` and `SyncManager.initContact` early-return on the same `shouldInitInstanceSync({argv, env})` signal (`p2pDisabled`). The companion needs `/llm` + MCP-over-the-shared-`crow.db` (memories/providers intact) — not the Hyperswarm/instance-sync/per-contact-feed layer.

The **enabled** (authed primary) path is byte-unchanged — the primary still runs full P2P.

## Tests

5 `--no-auth` gate tests (feeds + PeerManager + SyncManager); **full suite 1115/1115**. The ultimate validation is the live crow→grackle contact-sync E2E after deploy, which was blocked on exactly this.

## Deploy

`git pull` crow + grackle; restart grackle's `crow-mcp-bridge.service` (drops P2P) + `crow-gateway.service` (claims the swarm connection). Then the Phase 3 contacts-follow-user E2E should finally replicate.