### PR TITLE
fix(sharing): tailnet-sync dialed Serve HTTPS ports as plain ws:// — fallback transport never worked

### DIFF
--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -53,43 +53,42 @@ function verifyHandshakePayload(payload, expectedPubkeyHex) {
 }
 
 /**
- * Derive a WebSocket URL for tailnet-sync from a peer's crow_instances row.
- * Prefers a direct tailnet-port endpoint over public Funnel URLs because the
- * Tailscale Funnel only proxies a curated public path-list (/blog etc.) — the
- * /api/instance-sync/stream path is deliberately not exposed publicly.
+ * Derive the ordered WebSocket dial candidates for a peer's crow_instances row.
  *
- * Resolution order:
- *   1. tailscale_ip + CROW_GATEWAY_PORT (default 3002) — the canonical tailnet path.
- *   2. host of gateway_url + CROW_GATEWAY_PORT — when tailscale_ip is unset
- *      but gateway_url's host is a magic-dns name we can re-port-target.
- *   3. gateway_url as-is (last resort; works only if the operator has wired
- *      Funnel/proxy to forward /api/instance-sync/stream — uncommon).
+ * Primary: gateway_url, honoring its scheme. On this fleet gateway_url is a
+ * Tailscale Serve HTTPS endpoint (e.g. https://grackle…ts.net:8444 → backend
+ * :3002) — tailscaled terminates TLS on the Serve port and proxies the
+ * upgrade to the plain-HTTP backend, so the correct dial is
+ * wss://<hostname>:<port>. The HOSTNAME is load-bearing: Serve needs SNI, so
+ * a raw-IP wss dial fails its TLS handshake. And plain ws:// against a Serve
+ * port is the bug this replaced (HTTP 400 / TLS alert, silently retried
+ * forever — the L3 outage of 2026-07-06). Port 443 is never dialed: that's
+ * public Funnel, which only proxies the curated public path-list and
+ * /api/instance-sync/stream is deliberately not on it.
+ *
+ * Fallback: ws://<tailscale_ip>:<fallbackPort> — a direct plain-WS dial of
+ * the standard backend gateway port for Serve-less peers. fallbackPort is a
+ * BACKEND port (the gateway listens plain HTTP), never a Serve HTTPS port.
  */
-function peerToWsUrl(peer, fallbackPort = 3002) {
-  // Prefer the peer's explicit port from gateway_url; only fall back to
-  // fallbackPort when the URL has none. (Each Crow may run on a different
-  // port — crow uses 3001, grackle uses 3002.)
-  let portFromUrl = null;
-  let hostFromUrl = null;
-  const raw = peer?.gateway_url;
+export function peerToWsUrlCandidates(peer, fallbackPort = 3002) {
+  const candidates = [];
+  const raw = peer?.gateway_url ? String(peer.gateway_url).trim() : "";
   if (raw) {
-    const noScheme = String(raw).replace(/^[a-z]+:\/\//, "").split("/")[0];
-    const colonIdx = noScheme.lastIndexOf(":");
-    if (colonIdx >= 0) {
-      hostFromUrl = noScheme.slice(0, colonIdx);
-      const p = parseInt(noScheme.slice(colonIdx + 1), 10);
-      if (!Number.isNaN(p)) portFromUrl = p;
-    } else {
-      hostFromUrl = noScheme;
+    let u = null;
+    try { u = new URL(raw.includes("://") ? raw : `https://${raw}`); } catch { /* malformed — fall through */ }
+    if (u?.hostname) {
+      const isHttp = u.protocol === "http:";
+      const port = u.port ? parseInt(u.port, 10) : (isHttp ? 80 : 443);
+      if (port !== 443) {
+        candidates.push(`${isHttp ? "ws" : "wss"}://${u.hostname}:${port}${WS_PATH}`);
+      }
     }
-    // Treat the public Funnel port (443) as "no usable port" — Funnel only
-    // proxies a public path-list, which excludes /api/instance-sync/stream.
-    if (portFromUrl === 443) portFromUrl = null;
   }
-  const port = portFromUrl || fallbackPort;
-  if (peer?.tailscale_ip) return `ws://${peer.tailscale_ip}:${port}${WS_PATH}`;
-  if (hostFromUrl) return `ws://${hostFromUrl}:${port}${WS_PATH}`;
-  return null;
+  if (peer?.tailscale_ip) {
+    const direct = `ws://${peer.tailscale_ip}:${fallbackPort}${WS_PATH}`;
+    if (!candidates.includes(direct)) candidates.push(direct);
+  }
+  return candidates;
 }
 
 /**
@@ -249,6 +248,15 @@ export function setupTailnetSyncServer(server, ctx) {
 
   server.on("upgrade", async (req, socket, head) => {
     if (!req.url || !req.url.startsWith(WS_PATH)) return; // let other handlers process
+    // Network-exposure invariant, defense-in-depth: instance-sync must never
+    // be reachable via Tailscale Funnel. The ed25519 mutual auth below would
+    // reject an outsider anyway, but a Funnel-tagged request shouldn't even
+    // get a handshake. (Upgrade requests bypass the Express middleware that
+    // enforces this for regular routes.)
+    if (req.headers["tailscale-funnel-request"]) {
+      try { socket.destroy(); } catch {}
+      return;
+    }
     wss.handleUpgrade(req, socket, head, async (ws) => {
       const frameReader = attachFrameReader(ws);
       try {
@@ -283,6 +291,18 @@ class PeerDialer {
     this.retryMs = RETRY_BASE_MS;
     this.timer = null;
     this.stopped = false;
+    this.attempt = 0; // rotates through dial candidates
+    this.failCount = 0; // consecutive failures, for rate-limited logging
+  }
+
+  // Dial failures land in ws.on("error") — historically swallowed, which hid
+  // a never-working dial URL for months. Log the first failure and every
+  // 10th thereafter so a dead transport is visible without spamming journald.
+  _noteDialFailure(wsUrl, err) {
+    this.failCount += 1;
+    if (this.failCount === 1 || this.failCount % 10 === 0) {
+      console.warn(`[tailnet-sync] dial ${wsUrl} failed (attempt ${this.failCount}): ${err?.message || err}`);
+    }
   }
 
   start() { this.connect(); }
@@ -302,11 +322,15 @@ class PeerDialer {
   async connect() {
     if (this.stopped) return;
     const { identity, instanceSyncManager, db } = this.ctx;
-    const wsUrl = peerToWsUrl(this.peer, this.ctx.gatewayPort);
-    if (!wsUrl) {
+    const candidates = peerToWsUrlCandidates(this.peer, this.ctx.gatewayPort);
+    if (candidates.length === 0) {
       // No tailnet endpoint to dial; leave for Hyperswarm.
       return;
     }
+    // Ladder through candidates across retries (Serve endpoint first, then
+    // the direct backend dial) so one broken path doesn't kill the transport.
+    const wsUrl = candidates[this.attempt % candidates.length];
+    this.attempt += 1;
     if (this.peer.id === instanceSyncManager.localInstanceId) return; // self
     // Deterministic dialer election: exactly one side dials, the other side
     // accepts. We dial only when our id sorts BEFORE the peer's id. This
@@ -376,8 +400,11 @@ class PeerDialer {
           args: [remoteInstanceId],
         }).catch(() => {});
 
-        // Reset retry backoff on successful auth.
+        // Reset retry backoff + failure counter on successful auth, and pin
+        // the winning candidate so reconnects go straight back to it.
         this.retryMs = RETRY_BASE_MS;
+        this.failCount = 0;
+        this.attempt -= 1; // re-dial this same candidate next time
 
         // Hand off to Hypercore. Client side = isInitiator: true.
         frameReader.detach();
@@ -398,7 +425,11 @@ class PeerDialer {
       this.ws = null;
       this.scheduleRetry();
     });
-    ws.on("error", () => { /* ignore — close will follow */ });
+    ws.on("error", (err) => {
+      // close will follow and schedule the retry; just make the failure
+      // visible (rate-limited) — a swallowed error here hid the L3 outage.
+      this._noteDialFailure(wsUrl, err);
+    });
   }
 }
 

--- a/tests/tailnet-sync-dial.test.js
+++ b/tests/tailnet-sync-dial.test.js
@@ -1,0 +1,123 @@
+/**
+ * tailnet-sync dial-URL derivation + Funnel upgrade guard.
+ *
+ * Regression net for the L3 outage (2026-07-06): peerToWsUrl preferred the
+ * port embedded in gateway_url — on this fleet that's a Tailscale Serve
+ * HTTPS port (e.g. grackle 8444 → backend 3002) — and dialed it as plain
+ * ws:// on the raw tailnet IP. Plain WS into a TLS-terminating Serve
+ * listener fails (HTTP 400 / TLS alert), the error lands in a swallowed
+ * ws.on("error"), and the dialer retries silently forever. Net effect: the
+ * NAT-independent fallback transport never carried a single byte, so when
+ * Hyperswarm's same-NAT hole-punch broke at the router, crow↔grackle
+ * instance sync went fully dark.
+ *
+ * The fix derives the dial from gateway_url's scheme: https → wss://host:port
+ * (Serve terminates TLS and proxies the upgrade to the backend; the HOSTNAME
+ * is required — Serve needs SNI, raw-IP wss fails its handshake), http →
+ * ws://host:port, port 443 skipped (public Funnel proxies only the curated
+ * public path-list, which excludes /api/instance-sync/stream). A direct
+ * ws://<tailscale_ip>:<backend fallbackPort> candidate is kept as a ladder
+ * fallback for Serve-less peers.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { peerToWsUrlCandidates, setupTailnetSyncServer } from "../servers/sharing/tailnet-sync.js";
+
+const WS_PATH = "/api/instance-sync/stream";
+
+test("https gateway_url with Serve port → wss on the HOSTNAME (grackle row shape)", () => {
+  const urls = peerToWsUrlCandidates({
+    gateway_url: "https://grackle.dachshund-chromatic.ts.net:8444",
+    tailscale_ip: "100.121.254.89",
+  });
+  assert.equal(urls[0], `wss://grackle.dachshund-chromatic.ts.net:8444${WS_PATH}`);
+  // Never the broken combination: plain ws into the Serve HTTPS port.
+  assert.ok(!urls.includes(`ws://100.121.254.89:8444${WS_PATH}`));
+});
+
+test("tailnet-IP fallback candidate uses the backend fallbackPort, not the Serve port", () => {
+  const urls = peerToWsUrlCandidates(
+    {
+      gateway_url: "https://grackle.dachshund-chromatic.ts.net:8444",
+      tailscale_ip: "100.121.254.89",
+    },
+    3002
+  );
+  assert.deepEqual(urls, [
+    `wss://grackle.dachshund-chromatic.ts.net:8444${WS_PATH}`,
+    `ws://100.121.254.89:3002${WS_PATH}`,
+  ]);
+});
+
+test("http gateway_url dials plain ws on its own port", () => {
+  const urls = peerToWsUrlCandidates({ gateway_url: "http://10.0.0.21:3002" });
+  assert.equal(urls[0], `ws://10.0.0.21:3002${WS_PATH}`);
+});
+
+test("port 443 (public Funnel) is never dialed — falls back to tailnet IP", () => {
+  const urls = peerToWsUrlCandidates(
+    { gateway_url: "https://grackle.dachshund-chromatic.ts.net", tailscale_ip: "100.121.254.89" },
+    3002
+  );
+  assert.deepEqual(urls, [`ws://100.121.254.89:3002${WS_PATH}`]);
+});
+
+test("no gateway_url → tailnet IP + fallbackPort only", () => {
+  const urls = peerToWsUrlCandidates({ tailscale_ip: "100.118.41.122" }, 3001);
+  assert.deepEqual(urls, [`ws://100.118.41.122:3001${WS_PATH}`]);
+});
+
+test("neither gateway_url nor tailscale_ip → no candidates", () => {
+  assert.deepEqual(peerToWsUrlCandidates({}), []);
+  assert.deepEqual(peerToWsUrlCandidates(null), []);
+});
+
+test("malformed gateway_url falls back to the tailnet IP candidate", () => {
+  const urls = peerToWsUrlCandidates(
+    { gateway_url: "not a url ::", tailscale_ip: "100.121.254.89" },
+    3002
+  );
+  assert.deepEqual(urls, [`ws://100.121.254.89:3002${WS_PATH}`]);
+});
+
+test("candidates are deduped when gateway_url already IS the tailnet-IP dial", () => {
+  const urls = peerToWsUrlCandidates(
+    { gateway_url: "http://100.121.254.89:3002", tailscale_ip: "100.121.254.89" },
+    3002
+  );
+  assert.deepEqual(urls, [`ws://100.121.254.89:3002${WS_PATH}`]);
+});
+
+test("upgrade handler destroys Funnel-tagged sockets before any handshake", () => {
+  const server = new EventEmitter();
+  setupTailnetSyncServer(server, {
+    identity: { ed25519Pubkey: "00".repeat(32), ed25519Priv: "00".repeat(64) },
+    instanceSyncManager: { localInstanceId: "test-local" },
+    db: { execute: async () => ({ rows: [] }) },
+  });
+
+  let destroyed = false;
+  const socket = { destroy: () => { destroyed = true; }, write: () => {}, end: () => {} };
+  server.emit(
+    "upgrade",
+    { url: WS_PATH, headers: { "tailscale-funnel-request": "1" }, socket: { remoteAddress: "1.2.3.4" } },
+    socket,
+    Buffer.alloc(0)
+  );
+  assert.equal(destroyed, true, "Funnel-tagged upgrade must be destroyed (network-exposure invariant)");
+});
+
+test("upgrade handler ignores non-matching paths (leaves socket alone)", () => {
+  const server = new EventEmitter();
+  setupTailnetSyncServer(server, {
+    identity: { ed25519Pubkey: "00".repeat(32), ed25519Priv: "00".repeat(64) },
+    instanceSyncManager: { localInstanceId: "test-local" },
+    db: { execute: async () => ({ rows: [] }) },
+  });
+  let destroyed = false;
+  const socket = { destroy: () => { destroyed = true; } };
+  server.emit("upgrade", { url: "/other/ws", headers: {}, socket: {} }, socket, Buffer.alloc(0));
+  assert.equal(destroyed, false);
+});


### PR DESCRIPTION
## Problem

The tailnet-sync WebSocket transport — the NAT-independent fallback for cross-instance sync, built precisely because "Hyperswarm's UDP-hole-punching DHT works for some NATs and fails for others" — has been dead fleet-wide since it shipped:

- `peerToWsUrl()` preferred the port embedded in `gateway_url`, which on a standard install is a **Tailscale Serve HTTPS port** (e.g. `https://grackle…ts.net:8444` → backend `:3002`), and dialed it as **plain `ws://` on the raw tailnet IP**.
- Plain WS into a TLS-terminating Serve listener fails (HTTP 400); the error landed in a swallowed `ws.on("error")` → **silent infinite retry, zero log lines**.

This surfaced as a full crow↔grackle instance-sync blackout: Hyperswarm's same-NAT hole-punch between the two hosts broke at the router (~Jun 30 — verified with a clean pair-probe: DHT peers visible, 0 connections; external peer connects instantly), and there was no working fallback. Grackle's applied-seq froze at 251; contacts/memories/settings sync went dark.

## Fix

- **`peerToWsUrlCandidates()`**: derive the dial from `gateway_url`'s scheme — `https → wss://hostname:port` (Serve terminates TLS and proxies the upgrade to the backend; the *hostname* is load-bearing since Serve needs SNI), `http → ws://host:port`, port 443 (public Funnel) never dialed. Direct `ws://<tailscale_ip>:<backend fallbackPort>` kept as a ladder fallback, deduped, rotated across retries, pinned once a candidate succeeds.
- **Rate-limited dial-failure logging** (first + every 10th attempt) — the silent swallow hid a never-working transport for months.
- **Defense-in-depth for the network-exposure invariant**: the upgrade handler destroys `Tailscale-Funnel-Request`-tagged sockets before any handshake (upgrade requests bypass the Express middleware that enforces this on regular routes; the ed25519 mutual auth would reject outsiders anyway).

Verified live before coding: `wss://grackle…ts.net:8444/api/instance-sync/stream` upgrades OPEN through Serve; `ws://100.121.254.89:3002` (direct backend) also OPEN; the old combination 400s.

## Tests

10 new tests in `tests/tailnet-sync-dial.test.js` (regression-pins the broken `ws://ip:ServePort` combination, Funnel-guard, ladder/dedupe/malformed-URL cases). Full suite **1125/1125**.