### PR TITLE
fix(sharing): tailnet-sync dropped Noise frames racing the handshake teardown — replication deadlocked silently

### DIFF
--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -100,14 +100,24 @@ export function peerToWsUrlCandidates(peer, fallbackPort = 3002) {
  * Once the WS hands off to Hypercore (binary replication), call detach() to
  * stop intercepting frames so binary data flows through cleanly.
  */
-function attachFrameReader(ws) {
+export function attachFrameReader(ws) {
   const queue = [];
   const waiters = [];
+  const binaryBuffer = []; // binary frames that raced the handshake — replayed at handoff
   let closed = false;
   let closeReason = null;
 
   function onMsg(data, isBinary) {
-    if (isBinary) return; // binary frames aren't ours — let Hypercore take them
+    if (isBinary) {
+      // Binary frames belong to the post-handshake Noise/Hypercore stream.
+      // The peer's Noise initiator hello commonly lands while WE are still
+      // finishing handshake DB writes (feed-key persist, last_seen) — i.e.
+      // before detach(). Dropping it deadlocks replication silently (the
+      // responder waits forever for a hello that never re-sends), so buffer
+      // for replay instead.
+      binaryBuffer.push(data);
+      return;
+    }
     let parsed;
     try { parsed = JSON.parse(data.toString()); }
     catch { return; }
@@ -135,6 +145,10 @@ function attachFrameReader(ws) {
     ws.off("message", onMsg);
     ws.off("close", onClose);
     ws.off("error", onError);
+    // Hand any raced binary frames to the caller for replay into the
+    // post-handshake stream (see handoffToStream). Drain so a second
+    // detach can't double-replay.
+    return binaryBuffer.splice(0);
   }
   function readJsonFrame(timeoutMs) {
     if (closed) return Promise.reject(closeReason || new Error("socket closed"));
@@ -154,6 +168,23 @@ function attachFrameReader(ws) {
     });
   }
   return { readJsonFrame, detach };
+}
+
+/**
+ * Swap the WS from JSON-handshake framing to the binary replication stream
+ * without losing frames. The WS is paused across the consumer swap so no
+ * frame can slip between the frame reader detaching and the duplex
+ * attaching; binary frames that arrived DURING the handshake (buffered by
+ * attachFrameReader) are replayed, in order, ahead of live traffic.
+ */
+export function handoffToStream(ws, frameReader) {
+  try { ws.pause(); } catch { /* already closing — duplex teardown handles it */ }
+  const buffered = frameReader.detach();
+  const wsStream = createWebSocketStream(ws, { allowHalfOpen: false });
+  wsStream.on("error", () => {});
+  for (const frame of buffered) ws.emit("message", frame, true);
+  try { ws.resume(); } catch { /* already closing */ }
+  return wsStream;
 }
 
 /**
@@ -228,10 +259,9 @@ async function handleAcceptedConnection(ws, peerHandshake, frameReader, ctx) {
 
   // Hand the WS off to Hypercore for binary replication framing. Hypercore
   // expects a NoiseSecretStream; wrap the WS Duplex first. Server side =
-  // isInitiator: false (the dialer is the initiator).
-  frameReader.detach();
-  const wsStream = createWebSocketStream(ws, { allowHalfOpen: false });
-  wsStream.on("error", () => {});
+  // isInitiator: false (the dialer is the initiator). handoffToStream
+  // replays any Noise frames that raced our handshake DB writes.
+  const wsStream = handoffToStream(ws, frameReader);
   const noiseStream = new NoiseSecretStream(false, wsStream);
   noiseStream.on("error", () => {});
   await instanceSyncManager.replicate(remoteInstanceId, noiseStream);
@@ -407,9 +437,10 @@ class PeerDialer {
         this.attempt -= 1; // re-dial this same candidate next time
 
         // Hand off to Hypercore. Client side = isInitiator: true.
-        frameReader.detach();
-        const wsStream = createWebSocketStream(ws, { allowHalfOpen: false });
-        wsStream.on("error", () => {});
+        // handoffToStream replays any binary frames that raced the
+        // handshake (defensive — the responder shouldn't write first,
+        // but symmetric handling costs nothing).
+        const wsStream = handoffToStream(ws, frameReader);
         const noiseStream = new NoiseSecretStream(true, wsStream);
         noiseStream.on("error", () => {});
         await instanceSyncManager.replicate(remoteInstanceId, noiseStream);

--- a/tests/tailnet-sync-handshake-race.test.js
+++ b/tests/tailnet-sync-handshake-race.test.js
@@ -1,0 +1,140 @@
+/**
+ * tailnet-sync handshake→replication handoff race.
+ *
+ * Regression net for the second L3 defect (2026-07-06): attachFrameReader's
+ * message handler silently DROPPED binary frames (`if (isBinary) return`).
+ * After the JSON handshake the dialing side wraps the WS in
+ * NoiseSecretStream(true) and immediately sends the Noise initiator hello
+ * (binary) — while the accepting side is still persisting feed keys /
+ * last_seen (1-3 DB writes) before calling frameReader.detach(). If the
+ * hello lands in that window it was eaten, the Noise responder waited
+ * forever, and replication was silently dead on an otherwise-healthy
+ * connection. Whether you lost the race was a function of the accepting
+ * side's DB latency — which is why crow→MPA (quiet DB) replicated fine
+ * while crow→grackle (busy DB) never moved a block.
+ *
+ * The fix: buffer binary frames during the handshake and hand them off —
+ * ws paused across the consumer swap, buffered frames replayed in order —
+ * via handoffToStream().
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { WebSocketServer, WebSocket } from "ws";
+import { attachFrameReader, handoffToStream } from "../servers/sharing/tailnet-sync.js";
+
+function wsPair(t) {
+  const wss = new WebSocketServer({ port: 0 });
+  t.after(() => wss.close());
+  return new Promise((resolve) => {
+    wss.on("listening", () => {
+      const client = new WebSocket(`ws://127.0.0.1:${wss.address().port}`);
+      wss.on("connection", (serverWs) => {
+        client.on("open", () => resolve({ serverWs, client }));
+      });
+    });
+  });
+}
+
+test("binary frames arriving during the JSON handshake are buffered, not dropped", async (t) => {
+  const { serverWs, client } = await wsPair(t);
+  t.after(() => client.terminate());
+
+  const frameReader = attachFrameReader(client);
+
+  // Server sends a JSON handshake frame, then IMMEDIATELY a binary frame
+  // (the Noise-initiator-hello shape of the production race).
+  serverWs.send(JSON.stringify({ hello: "handshake" }));
+  serverWs.send(Buffer.from("noise-init-hello"));
+
+  const hs = await frameReader.readJsonFrame(2000);
+  assert.equal(hs.hello, "handshake");
+
+  // Give the binary frame time to arrive while the frame reader is attached.
+  await new Promise((r) => setTimeout(r, 150));
+
+  const wsStream = handoffToStream(client, frameReader);
+  const chunks = [];
+  wsStream.on("data", (d) => chunks.push(d));
+  await new Promise((r) => setTimeout(r, 150));
+
+  const received = Buffer.concat(chunks).toString();
+  assert.ok(
+    received.includes("noise-init-hello"),
+    `binary frame must survive the handoff (got: ${JSON.stringify(received)})`
+  );
+});
+
+test("buffered binary frames replay IN ORDER before later live frames", async (t) => {
+  const { serverWs, client } = await wsPair(t);
+  t.after(() => client.terminate());
+
+  const frameReader = attachFrameReader(client);
+  serverWs.send(JSON.stringify({ ok: 1 }));
+  serverWs.send(Buffer.from("first|"));
+  serverWs.send(Buffer.from("second|"));
+
+  await frameReader.readJsonFrame(2000);
+  await new Promise((r) => setTimeout(r, 150));
+
+  const wsStream = handoffToStream(client, frameReader);
+  serverWs.send(Buffer.from("third|"));
+
+  const chunks = [];
+  wsStream.on("data", (d) => chunks.push(d));
+  await new Promise((r) => setTimeout(r, 200));
+
+  assert.equal(Buffer.concat(chunks).toString(), "first|second|third|");
+});
+
+test("JSON frames still consumed by readJsonFrame; binary-free handoff works", async (t) => {
+  const { serverWs, client } = await wsPair(t);
+  t.after(() => client.terminate());
+
+  const frameReader = attachFrameReader(client);
+  serverWs.send(JSON.stringify({ a: 1 }));
+  serverWs.send(JSON.stringify({ b: 2 }));
+  assert.equal((await frameReader.readJsonFrame(2000)).a, 1);
+  assert.equal((await frameReader.readJsonFrame(2000)).b, 2);
+
+  const wsStream = handoffToStream(client, frameReader);
+  serverWs.send(Buffer.from("post-handoff"));
+  const chunks = [];
+  wsStream.on("data", (d) => chunks.push(d));
+  await new Promise((r) => setTimeout(r, 150));
+  assert.equal(Buffer.concat(chunks).toString(), "post-handoff");
+});
+
+test("full duplex after a raced handoff: bytes flow BOTH directions", async (t) => {
+  const { serverWs, client } = await wsPair(t);
+  t.after(() => client.terminate());
+
+  // Both ends run the production shape: frame reader → JSON → handoff.
+  const clientReader = attachFrameReader(client);
+  const serverReader = attachFrameReader(serverWs);
+
+  client.send(JSON.stringify({ side: "client" }));
+  serverWs.send(JSON.stringify({ side: "server" }));
+  assert.equal((await clientReader.readJsonFrame(2000)).side, "server");
+  assert.equal((await serverReader.readJsonFrame(2000)).side, "client");
+
+  // Client hands off first and immediately writes binary (initiator hello),
+  // racing the server's delayed handoff (simulated DB latency).
+  const clientStream = handoffToStream(client, clientReader);
+  clientStream.write(Buffer.from("initiator-hello"));
+
+  await new Promise((r) => setTimeout(r, 120)); // server "does DB work"
+  const serverStream = handoffToStream(serverWs, serverReader);
+
+  const serverGot = [];
+  serverStream.on("data", (d) => serverGot.push(d));
+  serverStream.write(Buffer.from("responder-reply"));
+
+  const clientGot = [];
+  clientStream.on("data", (d) => clientGot.push(d));
+
+  await new Promise((r) => setTimeout(r, 200));
+  assert.equal(Buffer.concat(serverGot).toString(), "initiator-hello");
+  assert.equal(Buffer.concat(clientGot).toString(), "responder-reply");
+});


### PR DESCRIPTION
## Problem

Second latent defect in the tailnet-sync transport, surfaced once PR #144 made the dial actually connect: `attachFrameReader`'s message handler **silently dropped binary frames** (`if (isBinary) return`).

After the JSON handshake, the dialing side wraps the WS in `NoiseSecretStream(true)` and immediately sends the Noise initiator hello (binary) — while the accepting side is still persisting feed keys / `last_seen` (1–3 DB writes) before calling `frameReader.detach()`. If the hello lands in that window it's eaten; the Noise responder waits forever for a hello that never re-sends, and replication is **silently dead on an otherwise-healthy, connected stream** (every error path swallowed).

Losing the race is a function of the accepting side's DB latency — which is why crow→MPA (quiet DB) replicated fine while crow→grackle (busy DB: blog engine + sync applies) never moved a single block: grackle's applied-seq frozen at 251 with 1,600+ entries pending. A clean probe client serving the same feed caught grackle up to 1,864 instantly (and Phase 3's `_applyContact` applied the test contact correctly), proving every other layer healthy.

## Fix

- `attachFrameReader` **buffers** binary frames instead of dropping them; `detach()` drains and returns them.
- New `handoffToStream(ws, frameReader)`: pauses the WS across the consumer swap (no frame can slip between the frame reader detaching and the duplex attaching), replays buffered frames **in order** ahead of live traffic, resumes. Both the server-accept and client-dial handoffs use it.

## Tests

4 new in `tests/tailnet-sync-handshake-race.test.js`, including a full-duplex raced-handoff case with a delayed responder handoff (the exact production shape). Full suite **1129/1129**.