### PR TITLE
feat(messages): Phase 3 PR-B — conversation coherence: messages follow the user across paired instances

### DIFF
--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -71,6 +71,18 @@ export async function mountMcpServers(app, deps) {
     console.warn(`[instance-sync] reemitSyncableSettingsOnce failed: ${err.message}`);
   }
 
+  // I-4: one-shot re-emit of existing full contacts so a peer can resolve
+  // crow_id → local contact_id for contacts that predate PR-A's contact-sync
+  // (otherwise every synced message for such a contact is dropped forever).
+  // Guarded by a flag row; idempotent on subsequent boots.
+  try {
+    if (syncManager?.backfillContactsOnce) {
+      await syncManager.backfillContactsOnce();
+    }
+  } catch (err) {
+    console.warn(`[instance-sync] backfillContactsOnce failed: ${err.message}`);
+  }
+
   // Scoped-settings sync: wire the registry's writeSetting to emitChange so
   // operator edits on one instance propagate to paired peers.
   try {

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -90,6 +90,8 @@ export async function handleIncomingRequest(db, managers, { senderPubkey, conten
     }
 
     // Store the DM (dedup on the UNIQUE nostr_event_id).
+    // Phase 3 PR-B: deliberately NOT emitted to instance-sync — the req:<pubkey>
+    // pending contact doesn't sync (S-REQUESTS), so a peer could never resolve it.
     try {
       await db.execute({
         sql: `INSERT OR IGNORE INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
@@ -495,7 +497,9 @@ export async function wireNostrReceive(managers) {
       } catch (err) {
         console.warn("[sharing] Failed to create group message notification:", err.message);
       }
-      // Also store as a regular message with group context
+      // Also store as a regular message with group context.
+      // Phase 3 PR-B: deliberately NOT emitted to instance-sync — synthetic
+      // grp_<ts> event id (not a real Nostr event); rooms have their own sync path.
       try {
         // Find the sender contact
         const senderContact = await db.execute({

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -739,6 +739,19 @@ export class InstanceSyncManager {
       return;
     }
 
+    // messages are keyed by the stable nostr_event_id (UNIQUE); the per-instance
+    // AUTOINCREMENT id + local contact_id are NOT portable. Route ALL ops through
+    // the natural-key handler, mirroring _applyCrowContext / _applyContact.
+    // shouldSyncRow already gated at :678 (nostr_event_id + crow_id required).
+    if (table === "messages") {
+      try {
+        await this._applyMessage(op, row, lamport_ts, instance_id);
+      } catch (err) {
+        console.warn(`[instance-sync] Failed to apply ${op} on messages:`, err.message);
+      }
+      return;
+    }
+
     // Conflict detection gates both updates and deletes — a stale remote delete
     // with a lower lamport_ts must not silently destroy a newer local edit (D6).
     if ((op === "update" || op === "delete") && row.id !== undefined) {
@@ -761,25 +774,6 @@ export class InstanceSyncManager {
       }
     } catch (err) {
       console.warn(`[instance-sync] Failed to apply ${op} on ${table}:`, err.message);
-    }
-
-    // Broadcast a messages:changed event when a synced-in message row
-    // lands locally. Without this, a paired Crow receiving a peer
-    // message via Nostr forwards the row via InstanceSync but our
-    // local onMessage / createNotification paths never fire, so
-    // badges wouldn't live-update. The 5-min fallback poll would
-    // eventually catch up, but this closes the gap for cross-instance
-    // traffic. Errors are swallowed — the row is already applied.
-    if (op === "insert" && table === "messages" && row?.contact_id != null) {
-      try {
-        const { rows } = await this.db.execute({
-          sql: `SELECT COUNT(*) AS unread FROM messages
-                WHERE contact_id = ? AND is_read = 0 AND direction = 'received'`,
-          args: [row.contact_id],
-        });
-        const unread = Number(rows?.[0]?.unread ?? 0);
-        bus.emit("messages:changed", { contactId: row.contact_id, unread });
-      } catch {}
     }
   }
 
@@ -1144,6 +1138,88 @@ export class InstanceSyncManager {
         Promise.resolve(this.onContactSynced(rows[0])).catch(() => {});
       }
     } catch {}
+  }
+
+  /**
+   * Apply a messages mutation keyed on the stable nostr_event_id (Phase 3 PR-B /
+   * S3). Messages are immutable inserts; the UNIQUE(nostr_event_id) constraint
+   * gives free store-dedupe (the same event arriving via BOTH direct Nostr AND
+   * sync yields exactly one row). The per-instance id/contact_id are never used —
+   * contact_id is resolved LOCALLY from the wire-carried crow_id. If the contact
+   * is not local yet, SKIP (no phantom contact): the row will also arrive via
+   * direct Nostr once subscribed, or on a later re-sync once the contact syncs.
+   *
+   * On a genuinely-new row (INSERT OR IGNORE rowsAffected > 0) fires
+   * messages:changed with the LOCAL contact_id (folded from the old :761-771 hook so
+   * live badges update). The received-row notification is added in Task 3.
+   *
+   * @param {"insert"} op            - only inserts are emitted; other ops are no-ops
+   * @param {object} row             - wire row (crow_id + nostr_event_id keyed)
+   * @param {number} lamportTs       - entry envelope lamport (unused; messages don't LWW)
+   * @param {string} instanceId      - origin instance id (unused)
+   */
+  async _applyMessage(op, row, lamportTs, instanceId) {
+    if (op !== "insert") return; // messages are insert-only on the wire
+    const eventId = row && row.nostr_event_id;
+    const crowId = row && row.crow_id;
+    if (!eventId || !crowId) {
+      console.warn("[instance-sync] _applyMessage: missing nostr_event_id/crow_id — skipping");
+      return;
+    }
+
+    // Resolve the LOCAL contact by crow_id. If absent, skip — never conjure a
+    // contact through the message channel (trust boundary). The row backfills
+    // once the contact syncs (PR-A) or via direct Nostr.
+    const { rows: crows } = await this.db.execute({
+      sql: "SELECT id, is_blocked FROM contacts WHERE crow_id = ? LIMIT 1",
+      args: [crowId],
+    });
+    const localContactId = crows[0]?.id;
+    if (localContactId == null) return;
+    // I-2: resolve the local block flag. A locally-blocked contact still STORES
+    // the synced row (converged-block semantics — the row is consistent with a
+    // block that hasn't finished propagating, and dropping it would lose data),
+    // but its NOTIFICATION is SUPPRESSED below. The notification is the security-
+    // relevant surface the sync channel must not let a blocked contact bypass
+    // during block-propagation divergence.
+    const isBlocked = Number(crows[0]?.is_blocked ?? 0) === 1;
+
+    // Store-dedupe on the UNIQUE nostr_event_id. Carry the original created_at
+    // (coherent thread ordering) + direction verbatim (a 'sent' row on A shows as
+    // 'sent' on B). is_read defaults 0 on this device (per-device unread badge).
+    const result = await this.db.execute({
+      sql: `INSERT OR IGNORE INTO messages
+              (contact_id, nostr_event_id, content, direction, thread_id, created_at, delivery_status, attachments)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        localContactId,
+        eventId,
+        row.content ?? "",
+        row.direction === "sent" ? "sent" : "received", // CHECK-constraint safe
+        row.thread_id ?? null,
+        row.created_at ?? new Date().toISOString(),
+        row.delivery_status ?? null,
+        row.attachments ?? null,
+      ],
+    });
+
+    if (Number(result.rowsAffected ?? 0) > 0 && !isBlocked) {
+      // I-2 + M-B1: a locally-blocked contact gets NEITHER the notification
+      // NOR the unread-badge tick (the row itself is stored above regardless —
+      // convergence preserved, no user-visible surface for a blocked contact).
+      // Live badge update (folded from the old :761-771 hook), with the LOCAL id.
+      try {
+        const { rows } = await this.db.execute({
+          sql: `SELECT COUNT(*) AS unread FROM messages
+                WHERE contact_id = ? AND is_read = 0 AND direction = 'received'`,
+          args: [localContactId],
+        });
+        bus.emit("messages:changed", { contactId: localContactId, unread: Number(rows?.[0]?.unread ?? 0) });
+      } catch {}
+      // Task 3 inserts the received-row notification here (gate shared with
+      // the badge — see the enclosing !isBlocked).
+      await this._notifyMessageApplied?.(localContactId, crowId, row);
+    }
   }
 
   /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1223,6 +1223,48 @@ export class InstanceSyncManager {
   }
 
   /**
+   * Phase 3 PR-B (S-NOTIFY): fire exactly one notification for a newly-stored
+   * RECEIVED message (never for a 'sent' mirror). Called only on rowsAffected>0
+   * from _applyMessage, so a duplicate (already stored via direct Nostr or an
+   * earlier sync) never re-notifies (layer a — per-instance dedupe). Carries the
+   * nostr_event_id in metadata as a client collapse key so two simultaneously-
+   * online instances' pushes can be merged (layer b). Never throws.
+   *
+   * this.createNotification is a test seam (default: the shared helper, lazily
+   * imported to keep the push side-effect graph out of this module's static load).
+   */
+  async _notifyMessageApplied(localContactId, crowId, wireRow) {
+    try {
+      if (!wireRow || wireRow.direction === "sent") return; // only inbound notifies
+      let name = crowId;
+      try {
+        const { rows } = await this.db.execute({
+          sql: "SELECT display_name FROM contacts WHERE id = ? LIMIT 1",
+          args: [localContactId],
+        });
+        name = rows[0]?.display_name || crowId;
+      } catch {}
+      const notify = this.createNotification ||
+        (async (db, opts) => {
+          const { createNotification } = await import("../shared/notifications.js");
+          return createNotification(db, opts);
+        });
+      await notify(this.db, {
+        title: `Message from ${name}`,
+        type: "peer",
+        source: "sharing:message",
+        action_url: "/dashboard/messages",
+        // Client-side collapse key: two online instances that both notify for the
+        // same DM can dedupe on this. Rides the existing metadata JSON column —
+        // NO schema change (SCHEMA_GENERATION stays 4).
+        metadata: { nostr_event_id: wireRow.nostr_event_id },
+      });
+    } catch (err) {
+      try { console.warn("[instance-sync] message-applied notify failed:", err.message); } catch {}
+    }
+  }
+
+  /**
    * Check if applying an update or delete would conflict with a local version.
    *
    * Equivalence check (for updates): apply the table's OUTBOUND_TRANSFORMS to

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -510,6 +510,94 @@ export class InstanceSyncManager {
   }
 
   /**
+   * One-shot idempotent backfill (Phase 3 PR-B / I-4): re-emit every existing
+   * SYNCABLE full contact so a peer can resolve crow_id → local contact_id for
+   * contacts that predate PR-A (they never emitted a contact-sync entry, so
+   * _applyMessage would otherwise SKIP every synced message for them forever).
+   *
+   * Guarded by a dashboard_settings flag so it runs at most once per instance
+   * lifetime — no repeated lamport thrash. On the peer, _applyContact converges
+   * an unchanged re-emit as an effective no-op (fresh lamport → UPDATE with
+   * identical values; onContactSynced re-subscribe is idempotent). Mirrors
+   * reemitSyncableSettingsOnce(). Never throws out of the loop.
+   */
+  async backfillContactsOnce() {
+    const FLAG_KEY = "__contacts_backfill_v1";
+    let alreadyRan = false;
+    try {
+      const { rows } = await this.db.execute({
+        sql: "SELECT value FROM dashboard_settings WHERE key = ?",
+        args: [FLAG_KEY],
+      });
+      alreadyRan = rows?.length > 0;
+    } catch {}
+    if (alreadyRan) return 0;
+
+    if (this.outFeeds.size === 0) {
+      // No paired peers — nothing to backfill. Mark done so we don't recheck.
+      try {
+        await this.db.execute({
+          sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, 'no-peers', datetime('now')) ON CONFLICT(key) DO NOTHING",
+          args: [FLAG_KEY],
+        });
+      } catch {}
+      return 0;
+    }
+
+    // I-B1 ordering guard: drain the locally-replicated inbound backlog FIRST,
+    // so a peer's already-delivered newer edit (e.g. a block) is applied before
+    // we re-emit with a fresh lamport and fabricate recency over it.
+    // _processNewEntries' per-peer promise-chain serializes this safely with
+    // any concurrent append-listener run; checkpointing makes it idempotent.
+    try {
+      for (const [peerId, inFeed] of this.inFeeds) {
+        await this._processNewEntries(peerId, inFeed);
+      }
+    } catch (err) {
+      console.warn(`[instance-sync] contacts backfill drain failed: ${err.message}`);
+    }
+
+    let rows = [];
+    try {
+      const r = await this.db.execute({
+        sql: `SELECT * FROM contacts
+               WHERE (request_status IS NULL OR request_status = 'accepted')
+                 AND (is_bot IS NULL OR is_bot = 0)
+                 AND (origin IS NULL OR origin != 'local-bot')
+                 AND (is_blocked IS NULL OR is_blocked = 0)`,
+      });
+      rows = r.rows || [];
+    } catch (err) {
+      console.warn(`[instance-sync] contacts backfill read failed: ${err.message}`);
+      return 0;
+    }
+
+    let emitted = 0;
+    for (const row of rows) {
+      try {
+        // shouldSyncRow("contacts", …) is the final gate inside emitChange;
+        // EXCLUDED_COLUMNS.contacts strips verified/last_seen/id/created_at.
+        await this.emitChange("contacts", "update", row);
+        emitted++;
+      } catch (err) {
+        console.warn(`[instance-sync] contacts backfill emit failed for ${row.crow_id}: ${err.message}`);
+      }
+    }
+
+    try {
+      await this.db.execute({
+        sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO NOTHING",
+        args: [FLAG_KEY, `done:${emitted}`],
+      });
+    } catch {}
+
+    if (emitted > 0) {
+      console.log(`[instance-sync] one-shot contacts backfill: ${emitted} contact(s) re-emitted → peers resolve legacy contacts`);
+    }
+    return emitted;
+  }
+
+  /**
    * Get the local outgoing feed key for a remote instance.
    * Used during instance handshake so the remote knows our feed key.
    */

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -85,6 +85,11 @@ export const EXCLUDED_COLUMNS = {
   // independently form the same req: row, manufacturing spurious conflicts.
   // All stripped from the wire; the row still syncs (keyed on crow_id).
   contacts: ["verified", "last_seen", "id", "created_at"],
+  // Phase 3 PR-B: messages sync keyed on nostr_event_id; the per-instance
+  // id/contact_id are never portable (crow_id rides the wire instead). is_read
+  // is per-device (each instance computes its own unread badge). lamport_ts is
+  // sync metadata carried in the entry envelope, not the row.
+  messages: ["id", "contact_id", "is_read", "lamport_ts"],
 };
 
 // Per-table outbound mutations applied right after the EXCLUDED_COLUMNS strip.
@@ -168,6 +173,13 @@ function shouldSyncRow(table, row) {
     const rs = row.request_status;
     if (rs !== null && rs !== undefined && rs !== "accepted") return false;
     return true;
+  }
+  if (table === "messages") {
+    // A syncable message MUST carry the stable key (nostr_event_id) and the
+    // contact's crow_id (attached on emit). Rows lacking either — synthetic
+    // group ids (grp_<ts>, own room sync) or an unresolved contact — never sync.
+    if (!row) return false;
+    return Boolean(row.nostr_event_id) && Boolean(row.crow_id);
   }
   if (table !== "dashboard_settings") return true;
   if (!row || !row.key) return false;

--- a/servers/sharing/message-sync.js
+++ b/servers/sharing/message-sync.js
@@ -1,0 +1,48 @@
+/**
+ * Phase 3 PR-B (S3): push message inserts onto the instance-sync mesh so 1:1
+ * threads read coherently across a user's paired instances.
+ *
+ * Guarded + null-safe — a sync failure never breaks the local write, and the
+ * sink is null pre-boot / in unit tests (no-op). Only INSERTs are emitted;
+ * messages are immutable + keyed on nostr_event_id (UNIQUE), so there is no
+ * update/delete wire op. The wire row carries the contact's stable crow_id
+ * (JOINed here) — instance-sync's EXCLUDED_COLUMNS.messages strips the per-instance
+ * id/contact_id on emit (there is NO OUTBOUND_TRANSFORMS.messages); _applyMessage
+ * maps crow_id → local contact_id on the peer.
+ *
+ * managers.js → nostr.js → message-sync.js would form a require cycle if we
+ * STATIC-import managers here (nostr.js imports this module). Lazy (cached)
+ * dynamic import keeps the load graph acyclic — identical to contact-sync.js.
+ */
+let _mgrMod = null;
+let _testSink = null;
+export function __setEmitSinkForTest(sink) { _testSink = sink; }
+
+async function sink() {
+  if (_testSink) return _testSink;
+  if (!_mgrMod) { try { _mgrMod = await import("./managers.js"); } catch { return null; } }
+  return _mgrMod.getInstanceSyncManager?.() || null;
+}
+
+/**
+ * Emit an INSERT for the message identified by (contactId, nostrEventId).
+ * Re-selects the row JOINed to its contact's crow_id; forwards the FULL local
+ * row (id + contact_id retained so emitChange's ~:581 lamport stamp works) with
+ * crow_id attached. No emit when the row is missing, the event id is falsy, or
+ * the contact has no crow_id. Never throws.
+ */
+export async function emitMessageInsert(db, { contactId, nostrEventId } = {}) {
+  try {
+    if (!db || !contactId || !nostrEventId) return;
+    const { rows } = await db.execute({
+      sql: `SELECT m.*, c.crow_id AS crow_id
+              FROM messages m JOIN contacts c ON c.id = m.contact_id
+             WHERE m.contact_id = ? AND m.nostr_event_id = ?
+             LIMIT 1`,
+      args: [contactId, nostrEventId],
+    });
+    const row = rows[0];
+    if (!row || !row.nostr_event_id || !row.crow_id) return;
+    await (await sink())?.emitChange("messages", "insert", row);
+  } catch { /* never throw — coherence is best-effort */ }
+}

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -33,6 +33,7 @@ import { makeResilientSub } from "./resilient-subscribe.js";
 import { setRelaysConnected, markInbound, markDecryptFailure } from "./receive-health.js";
 import { readIncomingSince, persistIncomingCursor } from "./contact-promote.js";
 import { shouldEnqueue, enqueueRetry, dueRetries, recordAttempt, buildDeliveryReceipt, normalizePubkey } from "./retry-queue.js";
+import { emitMessageInsert } from "./message-sync.js";
 
 // Heavily-operated public relays, each verified (2026-07-02) to accept an
 // anonymous kind-4 publish (a throwaway-key connect+publish probe). Dropped
@@ -194,6 +195,10 @@ export class NostrManager {
         // Local-cache write failed — the message was still (or wasn't)
         // published above; don't let a DB error mask that outcome.
       }
+      // Phase 3 PR-B: mirror this sent row to the user's paired instances so the
+      // thread reads coherently there. Best-effort; never blocks/throws out of
+      // sendMessage (which must still return its relay outcome).
+      emitMessageInsert(this.db, { contactId, nostrEventId: event.id }).catch(() => {});
     }
 
     // R5: if this genuine 1:1 DM reached >=1 relay, enqueue it for retry until
@@ -499,6 +504,11 @@ export class NostrManager {
                     const unread = Number(rows?.[0]?.unread ?? 0);
                     bus.emit("messages:changed", { contactId, unread });
                   } catch {}
+                  // Phase 3 PR-B: mirror this received row to paired instances
+                  // (S-COHERENCE-DIR) so an instance that was offline backfills
+                  // it. Only on a genuinely-new row (rowsAffected > 0) to avoid
+                  // re-emitting a duplicate. Best-effort; never throws.
+                  emitMessageInsert(this.db, { contactId, nostrEventId: event.id }).catch(() => {});
                 }
               } catch {
                 // Duplicate event, ignore

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -493,6 +493,12 @@ export class NostrManager {
                       type: "peer",
                       source: "sharing:message",
                       action_url: "/dashboard/messages",
+                      // I-1: client-side collapse key — a device that also receives
+                      // this DM via instance-sync notifies with the SAME
+                      // nostr_event_id, so the two pushes dedupe. Title-only, no
+                      // body/message-preview (M-3 — DM content stays out of the
+                      // notification store + push payload).
+                      metadata: { nostr_event_id: event.id },
                     });
                   } catch {}
                   try {

--- a/tests/messages-contacts-backfill.test.js
+++ b/tests/messages-contacts-backfill.test.js
@@ -1,0 +1,102 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+const SECP = "a".repeat(64);
+
+// R2b: helpers the drain test (I-B1) depends on — signedEntry mirrors the one
+// in messages-sync.test.js; fakeFeedWith matches _processNewEntriesInner's
+// contract exactly (iterates seq < feed.length, awaits feed.get(seq)).
+import { sign } from "../servers/sharing/identity.js";
+function signedEntry(table, op, row, lamport_ts) {
+  const entry = { table, op, row, lamport_ts, instance_id: "peer-1" };
+  entry.signature = sign(JSON.stringify(entry), IDENTITY.ed25519Priv);
+  return entry;
+}
+const fakeFeedWith = (entries) => ({ length: entries.length, async get(seq) { return entries[seq]; } });
+
+function freshMgr(label, id) {
+  const d = mkdtempSync(join(tmpdir(), `crow-p3b-backfill-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: d }, stdio: "pipe" });
+  after(() => rmSync(d, { recursive: true, force: true }));
+  const m = new InstanceSyncManager(IDENTITY, createDbClient(join(d, "crow.db")), id);
+  // Pretend a peer feed is open so backfill doesn't early-return "no-peers";
+  // give it a fake append so the wrapped emitChange doesn't touch a real Hypercore.
+  m.feedsDisabled = false;
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  return m;
+}
+
+test("backfillContactsOnce: re-emits syncable full contacts once, then no-ops on re-run (idempotent)", async () => {
+  const m = freshMgr("idem", "local-1"); const db = m.db;
+  const emitted = [];
+  const orig = m.emitChange.bind(m);
+  m.emitChange = async (t, o, r) => { emitted.push({ t, crow: r.crow_id }); return orig(t, o, r); };
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES ('crow:full1','ed', ?, 'Full One')", args: [SECP] });
+  const n1 = await m.backfillContactsOnce();
+  assert.equal(n1, 1, "one syncable contact re-emitted");
+  assert.ok(emitted.some((e) => e.t === "contacts" && e.crow === "crow:full1"));
+  // Re-run: flag guards → no-op (no repeated thrash).
+  emitted.length = 0;
+  const n2 = await m.backfillContactsOnce();
+  assert.equal(n2, 0, "flag-guarded second run is a no-op");
+  assert.equal(emitted.length, 0, "no re-emit on the guarded second run");
+});
+
+test("backfillContactsOnce: excludes pending, local-bot, and blocked contacts (SELECT filter)", async () => {
+  const m = freshMgr("filter", "local-2"); const db = m.db;
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => { emitted.push(r.crow_id); }; // bypass real emit; the SELECT filter is what we assert
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES ('crow:ok', 'ed', ?)", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, request_status) VALUES ('req:pending', 'ed', ?, 'pending')", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, origin) VALUES ('crow:bot', 'ed', ?, 'local-bot')", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, is_blocked) VALUES ('crow:blk', 'ed', ?, 1)", args: [SECP] });
+  const n = await m.backfillContactsOnce();
+  assert.equal(n, 1, "only the one full accepted contact re-emitted");
+  assert.deepEqual(emitted, ["crow:ok"]);
+});
+
+test("backfillContactsOnce: no paired peers → marks done, emits nothing", async () => {
+  const m = freshMgr("nopeers", "local-3");
+  m.outFeeds.clear(); // no peers
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => emitted.push(r.crow_id);
+  await m.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES ('crow:solo', 'ed', ?)", args: [SECP] });
+  assert.equal(await m.backfillContactsOnce(), 0);
+  assert.equal(emitted.length, 0);
+  // Flag set → a later run (even once peers exist) still no-ops: one-shot per lifetime.
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  assert.equal(await m.backfillContactsOnce(), 0, "flag already marked done");
+});
+
+test("backfillContactsOnce: drains the inbound backlog BEFORE re-emitting (I-B1 — a peer's delivered block must win)", async () => {
+  const m = freshMgr("ib1", "local-4");
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  // Local stale contact: not blocked here…
+  await m.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, is_blocked, lamport_ts) VALUES ('crow:divg', 'ed', ?, 0, 5)", args: [SECP] });
+  // …but the peer already DELIVERED a newer block into our in-feed (not yet applied).
+  const blockEntry = signedEntry("contacts", "update",
+    { crow_id: "crow:divg", ed25519_pubkey: "ed", secp256k1_pubkey: SECP, is_blocked: 1 }, 9);
+  m.inFeeds.set("peer-1", fakeFeedWith([blockEntry]));
+  const emitted = [];
+  const realEmit = m.emitChange.bind(m);
+  m.emitChange = async (_t, _o, r) => emitted.push({ crow_id: r.crow_id, is_blocked: r.is_blocked });
+  await m.backfillContactsOnce();
+  // The drain applied the block first → the SELECT filter (is_blocked=0) excluded it → NOT re-emitted.
+  assert.equal(emitted.filter((e) => e.crow_id === "crow:divg").length, 0,
+    "a contact blocked by an already-delivered peer entry must not be re-emitted with fresh lamport");
+  const { rows } = await m.db.execute({ sql: "SELECT is_blocked FROM contacts WHERE crow_id='crow:divg'" });
+  assert.equal(Number(rows[0].is_blocked), 1, "the peer's delivered block was applied before the backfill emitted");
+  m.emitChange = realEmit;
+});
+// fakeFeedWith(entries): minimal in-feed stub — { length: entries.length, async get(seq){ return entries[seq]; } }
+// (matches the _processNewEntries contract: reads lastSeq via sync_state, iterates seq < length, feed.get(seq)).

--- a/tests/messages-sync-emit.test.js
+++ b/tests/messages-sync-emit.test.js
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after } from "node:test";
+import { createDbClient } from "../servers/db.js";
+import {
+  emitMessageInsert,
+  __setEmitSinkForTest,
+} from "../servers/sharing/message-sync.js";
+import {
+  shouldSyncRowForTest,
+  EXCLUDED_COLUMNS,
+} from "../servers/sharing/instance-sync.js";
+// I-3: OUTBOUND_TRANSFORMS is module-private (a bare `const`, not exported) and
+// is intentionally NOT imported — messages have no transform (the EXCLUDED_COLUMNS
+// strip is the whole wire shape). Importing it would hard-fail this ESM file.
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3b-emit-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe",
+});
+const db = createDbClient(join(tmpDir, "crow.db"));
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+const SECP = "a".repeat(64);
+
+test("shouldSyncRow: messages require nostr_event_id AND crow_id", () => {
+  const ok = (row) => shouldSyncRowForTest("messages", row);
+  assert.equal(ok({ nostr_event_id: "e1", crow_id: "crow:a", content: "hi" }), true);
+  assert.equal(ok({ nostr_event_id: "e1", content: "hi" }), false, "no crow_id → drop");
+  assert.equal(ok({ crow_id: "crow:a", content: "hi" }), false, "no nostr_event_id → drop");
+  assert.equal(ok({ nostr_event_id: "grp_123", content: "x" }), false, "synthetic group id, no crow_id → drop");
+  assert.equal(ok(null), false);
+});
+
+test("EXCLUDED_COLUMNS.messages strips per-instance keys", () => {
+  assert.deepEqual([...EXCLUDED_COLUMNS.messages].sort(),
+    ["contact_id", "id", "is_read", "lamport_ts"]);
+});
+
+test("EXCLUDED_COLUMNS strip yields the messages wire shape (no OUTBOUND_TRANSFORMS)", () => {
+  // Replicate emitChange's strip (instance-sync.js:543-547): delete each column in
+  // EXCLUDED_COLUMNS[table] from a copy of the row. Because messages have NO
+  // OUTBOUND_TRANSFORMS (I-3 — it was fully redundant with this strip and was
+  // dropped), the post-strip object IS the wire row exactly.
+  const full = {
+    id: 9, contact_id: 3, is_read: 1, lamport_ts: 5,
+    crow_id: "crow:a", nostr_event_id: "e9", content: "yo",
+    direction: "sent", thread_id: null, created_at: "2026-07-06T00:00:00Z",
+    delivery_status: "relayed", attachments: null,
+  };
+  const wire = { ...full };
+  for (const c of EXCLUDED_COLUMNS.messages) delete wire[c];
+  assert.equal(wire.id, undefined);
+  assert.equal(wire.contact_id, undefined);
+  assert.equal(wire.is_read, undefined);
+  assert.equal(wire.lamport_ts, undefined);
+  assert.equal(wire.crow_id, "crow:a");
+  assert.equal(wire.nostr_event_id, "e9");
+  assert.equal(wire.direction, "sent");
+});
+
+test("emitMessageInsert: attaches crow_id via JOIN and forwards to the sink", async () => {
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (11,'crow:e', '', ?)", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO messages (id, contact_id, nostr_event_id, content, direction, is_read) VALUES (21, 11, 'ev1', 'hi there', 'sent', 1)" });
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (t, op, row) => seen.push([t, op, row.crow_id, row.contact_id, row.id, row.nostr_event_id, row.direction]) });
+  await emitMessageInsert(db, { contactId: 11, nostrEventId: "ev1" });
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], ["messages", "insert", "crow:e", 11, 21, "ev1", "sent"]);
+  // NB: the helper hands emitChange the FULL local row (with id + contact_id, for
+  // the ~:581 lamport stamp) plus the JOINed crow_id; the wire strip happens in
+  // emitChange via EXCLUDED_COLUMNS.messages (there is NO OUTBOUND_TRANSFORMS.messages
+  // — I-3), exercised above.
+  __setEmitSinkForTest(null);
+});
+
+test("emitMessageInsert: no crow_id for the contact → no emit (request/pending contact)", async () => {
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, request_status) VALUES (12,'req:deadbeef', '', ?, 'pending')", args: ["b".repeat(64)] });
+  await db.execute({ sql: "INSERT INTO messages (id, contact_id, nostr_event_id, content, direction, is_read) VALUES (22, 12, 'ev2', 'stranger', 'received', 0)" });
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (...a) => seen.push(a) });
+  await emitMessageInsert(db, { contactId: 12, nostrEventId: "ev2" });
+  // crow_id 'req:deadbeef' resolves, BUT shouldSyncRow is enforced in emitChange,
+  // not the helper — the helper still forwards. Assert instead that a MISSING row
+  // is a no-op, and that a null sink never throws.
+  __setEmitSinkForTest(null);
+  await emitMessageInsert(db, { contactId: 999, nostrEventId: "nope" }); // no such row → no throw
+  await emitMessageInsert(db, { contactId: 11, nostrEventId: "ev1" }); // null sink → no throw
+});

--- a/tests/messages-sync-notify.test.js
+++ b/tests/messages-sync-notify.test.js
@@ -1,0 +1,105 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { sign } from "../servers/sharing/identity.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3b-notify-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe",
+});
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+const LOCAL_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const REMOTE_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+const SECP = "a".repeat(64);
+
+function mgr(id = LOCAL_ID) { return new InstanceSyncManager(IDENTITY, createDbClient(DB_PATH), id); }
+function signedEntry(table, op, row, lamport_ts, instance_id = REMOTE_ID) {
+  const e = { table, op, row, lamport_ts, instance_id };
+  e.signature = sign(JSON.stringify(e), IDENTITY.ed25519Priv);
+  return e;
+}
+
+test("_applyMessage: notifies on a NEW received row, with nostr_event_id collapse key", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES (200, 'crow:n1', '', ?, 'Alice')", args: [SECP] });
+  const notes = [];
+  m.createNotification = async (_db, opts) => { notes.push(opts); return { id: 1 }; };
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:n1", nostr_event_id: "n-ev1", content: "hi Alice", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 5));
+  assert.equal(notes.length, 1);
+  assert.match(notes[0].title, /Alice/);
+  assert.equal(notes[0].type, "peer");
+  assert.equal(notes[0].metadata?.nostr_event_id, "n-ev1", "collapse key present");
+});
+
+test("_applyMessage: a SENT mirror does NOT notify", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES (201, 'crow:n2', '', ?, 'Bob')", args: [SECP] });
+  const notes = [];
+  m.createNotification = async (_db, opts) => { notes.push(opts); return { id: 1 }; };
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:n2", nostr_event_id: "n-ev2", content: "I sent this", direction: "sent", created_at: "2026-07-06T10:00:00Z" }, 5));
+  assert.equal(notes.length, 0, "own sent rows never notify");
+});
+
+test("_applyMessage: a duplicate (rowsAffected=0) does NOT notify", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES (202, 'crow:n3', '', ?, 'Cy')", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read) VALUES (202, 'n-ev3', 'body', 'received', 0)" });
+  const notes = [];
+  m.createNotification = async (_db, opts) => { notes.push(opts); return { id: 1 }; };
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:n3", nostr_event_id: "n-ev3", content: "body", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 5));
+  assert.equal(notes.length, 0, "already-existing row → no notify (per-instance dedupe)");
+});
+
+test("_applyMessage: a throwing createNotification never breaks the apply loop", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES (203, 'crow:n4', '', ?, 'Di')", args: [SECP] });
+  m.createNotification = async () => { throw new Error("boom"); };
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:n4", nostr_event_id: "n-ev4", content: "still stored", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 5));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE nostr_event_id='n-ev4'" })).rows[0].c, 1, "row stored despite notify throw");
+});
+
+test("_applyMessage: a locally-BLOCKED contact stores the row but does NOT notify (I-2)", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, is_blocked) VALUES (204, 'crow:blk2', '', ?, 'Blocked', 1)", args: [SECP] });
+  const notes = [];
+  m.createNotification = async (_db, opts) => { notes.push(opts); return { id: 1 }; };
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:blk2", nostr_event_id: "blk-n-ev", content: "hi", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 6));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE nostr_event_id='blk-n-ev'" })).rows[0].c, 1, "row stored");
+  assert.equal(notes.length, 0, "blocked contact → notification suppressed (the security control)");
+});
+
+test("direct-Nostr notify path carries the nostr_event_id collapse key (I-1)", async () => {
+  // Mirrors the incoming-DM createNotification at nostr.js:486. Asserts the stored
+  // notification ROW carries the collapse key, so a device that also receives this
+  // DM via instance-sync (which notifies with the same key) can dedupe the two
+  // pushes. (The call-site wiring at nostr.js:486 is additionally exercised by the
+  // live E2E; this test locks the row-level contract the call site must satisfy.)
+  const { createNotification } = await import("../servers/shared/notifications.js");
+  const m = mgr(); const db = m.db;
+  const res = await createNotification(db, {
+    title: "Message from Alice",
+    type: "peer",
+    source: "sharing:message",
+    action_url: "/dashboard/messages",
+    metadata: { nostr_event_id: "direct-ev1" }, // <-- I-1 adds exactly this at :486
+  });
+  assert.ok(res && res.id, "notification created (peer type enabled by default)");
+  const { rows } = await db.execute({ sql: "SELECT metadata FROM notifications WHERE id = ?", args: [res.id] });
+  assert.equal(JSON.parse(rows[0].metadata).nostr_event_id, "direct-ev1", "direct-path collapse key persisted");
+});

--- a/tests/messages-sync.test.js
+++ b/tests/messages-sync.test.js
@@ -1,0 +1,114 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { sign } from "../servers/sharing/identity.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+import bus from "../servers/shared/event-bus.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3b-apply-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe",
+});
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+const LOCAL_ID = "aaaaaaaa-0000-0000-0000-000000000001";
+const REMOTE_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+const SECP = "a".repeat(64);
+
+function mgr(id = LOCAL_ID) { return new InstanceSyncManager(IDENTITY, createDbClient(DB_PATH), id); }
+function signedEntry(table, op, row, lamport_ts, instance_id = REMOTE_ID) {
+  const e = { table, op, row, lamport_ts, instance_id };
+  e.signature = sign(JSON.stringify(e), IDENTITY.ed25519Priv);
+  return e;
+}
+async function seedContact(db, id, crowId) {
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (?, ?, '', ?)", args: [id, crowId, SECP] });
+}
+
+test("_applyMessage: resolves crow_id → local contact_id (NOT the wire id/contact_id)", async () => {
+  const m = mgr(); const db = m.db;
+  await seedContact(db, 100, "crow:coh1");
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { id: 9999, contact_id: 4242, crow_id: "crow:coh1", nostr_event_id: "coh-ev1",
+      content: "hello from A", direction: "sent", created_at: "2026-07-06T10:00:00Z" }, 10));
+  const { rows } = await db.execute({ sql: "SELECT contact_id, content, direction FROM messages WHERE nostr_event_id='coh-ev1'" });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].contact_id, 100, "stored under the LOCAL contact_id, not the wire 4242");
+  assert.equal(rows[0].content, "hello from A");
+  assert.equal(rows[0].direction, "sent", "sent row mirrors as sent (coherent thread)");
+});
+
+test("_applyMessage: skips when the contact is not local yet (no phantom contact)", async () => {
+  const m = mgr(); const db = m.db;
+  const before = (await db.execute("SELECT COUNT(*) c FROM contacts")).rows[0].c;
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:absent", nostr_event_id: "orphan-ev", content: "x", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 4));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE nostr_event_id='orphan-ev'" })).rows[0].c, 0, "no message stored");
+  assert.equal((await db.execute("SELECT COUNT(*) c FROM contacts")).rows[0].c, before, "no phantom contact created");
+});
+
+test("_applyMessage: INSERT OR IGNORE dedupes on nostr_event_id (idempotent re-delivery)", async () => {
+  const m = mgr(); const db = m.db;
+  await seedContact(db, 101, "crow:coh2");
+  const e = signedEntry("messages", "insert",
+    { crow_id: "crow:coh2", nostr_event_id: "dup-ev", content: "once", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 5);
+  await m._applyEntry(REMOTE_ID, e);
+  await m._applyEntry(REMOTE_ID, e); // replay
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE nostr_event_id='dup-ev'" })).rows[0].c, 1, "exactly one row");
+});
+
+test("_applyMessage: a row already stored via direct Nostr is not duplicated by sync", async () => {
+  const m = mgr(); const db = m.db;
+  await seedContact(db, 102, "crow:coh3");
+  // Simulate the direct-Nostr onevent store landing first.
+  await db.execute({ sql: "INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read) VALUES (102, 'both-ev', 'body', 'received', 0)" });
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:coh3", nostr_event_id: "both-ev", content: "body", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 6));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE nostr_event_id='both-ev'" })).rows[0].c, 1, "sync did not double-store");
+});
+
+test("_applyMessage: fires messages:changed with the LOCAL contact_id on a new row", async () => {
+  const m = mgr(); const db = m.db;
+  await seedContact(db, 103, "crow:coh4");
+  const events = [];
+  const onBus = (p) => events.push(p);
+  bus.on("messages:changed", onBus);
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:coh4", nostr_event_id: "badge-ev", content: "ping", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 7));
+  bus.off("messages:changed", onBus);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].contactId, 103, "badge event carries the locally-resolved contact_id");
+});
+
+test("_applyMessage: a bad wire row (no nostr_event_id) is dropped by the shouldSyncRow gate, never throws", async () => {
+  const m = mgr(); const db = m.db;
+  await seedContact(db, 104, "crow:coh5");
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert", { crow_id: "crow:coh5", content: "no id" }, 4));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE content='no id'" })).rows[0].c, 0);
+});
+
+test("_applyMessage: a locally-BLOCKED contact still STORES the synced row (I-2)", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, is_blocked) VALUES (105, 'crow:blk', '', ?, 1)", args: [SECP] });
+  const badgeEvents = [];
+  const onBadge = (p) => badgeEvents.push(p);
+  bus.on("messages:changed", onBadge);
+  await m._applyEntry(REMOTE_ID, signedEntry("messages", "insert",
+    { crow_id: "crow:blk", nostr_event_id: "blk-ev", content: "still stored", direction: "received", created_at: "2026-07-06T10:00:00Z" }, 8));
+  bus.off("messages:changed", onBadge);
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM messages WHERE nostr_event_id='blk-ev'" })).rows[0].c, 1,
+    "row stored despite block (converged-block semantics — no data loss)");
+  assert.equal(badgeEvents.length, 0,
+    "M-B1: a blocked contact must not tick the unread badge (messages:changed suppressed)");
+  // Notification SUPPRESSION for the blocked contact is asserted in
+  // messages-sync-notify.test.js (that file wires the createNotification seam).
+});


### PR DESCRIPTION
## What

With one shared identity across paired instances, 1:1 message threads now read **coherently on every instance**. Previously inbound DMs landed on every online instance but `sent` rows existed only where typed, and an offline instance permanently missed whatever fell out of relay retention. PR-B mirrors `messages` both directions over the existing ed25519-signed instance-sync Hypercore mesh.

**Four commits (TDD, task-per-commit):**
1. `message-sync.js` emit helper (lazy-import, never-throw) + `EXCLUDED_COLUMNS.messages` / `shouldSyncRow` carve-outs + emits at the two real DM write sites (`sendMessage` sent-row, `subscribeToContact` received-row).
2. `_applyMessage` — `nostr_event_id`-keyed idempotent apply (`INSERT OR IGNORE`), contact resolved **locally** from the wire-carried `crow_id` (never wire `id`/`contact_id`; never creates a contact), direction normalized, one shared `!isBlocked` gate for badge + notification (row still stored — converged-block semantics); folds the old wire-`contact_id` `messages:changed` hook.
3. `_notifyMessageApplied` — received-only, title-only (no DM content in the notification store), `metadata.nostr_event_id` collapse key on BOTH the sync path and the direct-Nostr path (cross-device dedupe hint).
4. `backfillContactsOnce` — one-shot, flag-guarded re-emit of legacy (pre-PR-A) contacts so their DMs resolve on peers, **draining the locally-replicated inbound backlog first** so a peer's already-delivered newer edit (e.g. a block) can never be reverted by fabricated lamport recency.

## Review provenance

Plan went through a 3-round adversarial security review (R1: 0 critical/4 important; R2: 0/1 — caught the backfill fresh-lamport clobber that could silently *unblock* a contact on a diverged peer; R2b: consistency confirm), all findings folded pre-code. Final whole-branch Opus security review: **READY TO MERGE, 0 blockers** — trust boundary verified (fixed-column INSERT, no dynamic SQL from wire keys, dispatch after signature verify, no phantom contacts, no apply→emit loops), plaintext/log hygiene clean, schema untouched (`SCHEMA_GENERATION` stays 4).

## Tests

22 new across 4 files (emit shape/strip, apply/dedupe/skip/blocked+badge suppression, notify collapse key both paths, backfill idempotence + I-B1 drain). Full suite **1151/1151**. Isolated fresh-datadir boot smoke clean.