### PR TITLE
fix(sharing): one-shot boot reconciliations raced feed-init — 'no-peers' was terminal, permanently skipping peered instances

### DIFF
--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -523,24 +523,25 @@ export class InstanceSyncManager {
    */
   async backfillContactsOnce() {
     const FLAG_KEY = "__contacts_backfill_v1";
+    // Only a real completed run ("done:<n>") is terminal. The boot call races
+    // the async sharing boot that opens the sync feeds — on a slow host the
+    // peers exist but outFeeds is still empty when we run (observed live on
+    // grackle 2026-07-06: flag stuck at 'no-peers' with 4 paired peers).
+    // Treating no-peers as retryable makes the next boot backfill correctly;
+    // a genuinely peer-less instance just re-runs two cheap queries per boot.
     let alreadyRan = false;
     try {
       const { rows } = await this.db.execute({
         sql: "SELECT value FROM dashboard_settings WHERE key = ?",
         args: [FLAG_KEY],
       });
-      alreadyRan = rows?.length > 0;
+      alreadyRan = typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:");
     } catch {}
     if (alreadyRan) return 0;
 
     if (this.outFeeds.size === 0) {
-      // No paired peers — nothing to backfill. Mark done so we don't recheck.
-      try {
-        await this.db.execute({
-          sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, 'no-peers', datetime('now')) ON CONFLICT(key) DO NOTHING",
-          args: [FLAG_KEY],
-        });
-      } catch {}
+      // No paired peers armed (yet) — nothing to backfill NOW. Deliberately
+      // do NOT mark the flag: feeds may simply not have opened yet this boot.
       return 0;
     }
 
@@ -585,8 +586,11 @@ export class InstanceSyncManager {
     }
 
     try {
+      // UPSERT, not DO NOTHING: a stale 'no-peers' row (written by the pre-fix
+      // code when boot raced feed-init) must be overwritten, or the done-mark
+      // silently no-ops and the backfill re-emits every boot (lamport thrash).
       await this.db.execute({
-        sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO NOTHING",
+        sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
         args: [FLAG_KEY, `done:${emitted}`],
       });
     } catch {}

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -446,25 +446,21 @@ export class InstanceSyncManager {
    */
   async reemitSyncableSettingsOnce() {
     const FLAG_KEY = "__sync_reemit_allowlist_v1";
+    // Same race class as backfillContactsOnce: the boot call runs concurrently
+    // with the async sharing boot that arms outFeeds, so 'no-peers' must be
+    // retryable, and only a real completed run ('done:<n>') is terminal.
     let alreadyRan = false;
     try {
       const { rows } = await this.db.execute({
         sql: "SELECT value FROM dashboard_settings WHERE key = ?",
         args: [FLAG_KEY],
       });
-      alreadyRan = rows?.length > 0;
+      alreadyRan = typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:");
     } catch {}
     if (alreadyRan) return 0;
 
     if (this.outFeeds.size === 0) {
-      // No paired peers — nothing to reconcile with. Still mark done so we
-      // don't keep checking on every boot.
-      try {
-        await this.db.execute({
-          sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, 'no-peers', datetime('now')) ON CONFLICT(key) DO NOTHING",
-          args: [FLAG_KEY],
-        });
-      } catch {}
+      // No paired peers armed (yet) — retry next boot; do NOT mark the flag.
       return 0;
     }
 
@@ -497,8 +493,10 @@ export class InstanceSyncManager {
     }
 
     try {
+      // UPSERT: a stale 'no-peers' row from the pre-fix code must be
+      // overwritten or this done-mark silently no-ops (per-boot re-emit).
       await this.db.execute({
-        sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO NOTHING",
+        sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
         args: [FLAG_KEY, `done:${emitted}`],
       });
     } catch {}

--- a/tests/messages-contacts-backfill.test.js
+++ b/tests/messages-contacts-backfill.test.js
@@ -124,3 +124,45 @@ test("backfillContactsOnce: drains the inbound backlog BEFORE re-emitting (I-B1 
 });
 // fakeFeedWith(entries): minimal in-feed stub — { length: entries.length, async get(seq){ return entries[seq]; } }
 // (matches the _processNewEntries contract: reads lastSeq via sync_state, iterates seq < length, feed.get(seq)).
+
+// ---- reemitSyncableSettingsOnce: same boot-vs-feed-init race class, same fix (ported) ----
+
+test("reemitSyncableSettingsOnce: no armed peers → stays RETRYABLE; runs once feeds arm; then terminal", async () => {
+  const m = freshMgr("reemit-race", "local-6");
+  m.outFeeds.clear();
+  await m.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('nav_groups', '[]', datetime('now'))",
+    args: [],
+  });
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => emitted.push(r.key);
+  assert.equal(await m.reemitSyncableSettingsOnce(), 0);
+  assert.equal(emitted.length, 0, "no-peers path must not emit");
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  assert.ok((await m.reemitSyncableSettingsOnce()) >= 1, "retry with armed feeds must re-emit");
+  assert.ok(emitted.includes("nav_groups"));
+  const before = emitted.length;
+  assert.equal(await m.reemitSyncableSettingsOnce(), 0, "terminal after the real run");
+  assert.equal(emitted.length, before);
+});
+
+test("reemitSyncableSettingsOnce: stale 'no-peers' flag row is healed (UPSERT done-mark)", async () => {
+  const m = freshMgr("reemit-heal", "local-7");
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  await m.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('nav_groups', '[]', datetime('now'))",
+    args: [],
+  });
+  await m.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('__sync_reemit_allowlist_v1', 'no-peers', datetime('now'))",
+    args: [],
+  });
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => emitted.push(r.key);
+  assert.ok((await m.reemitSyncableSettingsOnce()) >= 1, "stale no-peers is not terminal");
+  const { rows } = await m.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key='__sync_reemit_allowlist_v1'" });
+  assert.match(rows[0].value, /^done:\d+$/, "done-mark UPSERTs over the stale row");
+  const before = emitted.length;
+  assert.equal(await m.reemitSyncableSettingsOnce(), 0, "terminal — no per-boot re-emit thrash");
+  assert.equal(emitted.length, before);
+});

--- a/tests/messages-contacts-backfill.test.js
+++ b/tests/messages-contacts-backfill.test.js
@@ -65,17 +65,41 @@ test("backfillContactsOnce: excludes pending, local-bot, and blocked contacts (S
   assert.deepEqual(emitted, ["crow:ok"]);
 });
 
-test("backfillContactsOnce: no paired peers → marks done, emits nothing", async () => {
+test("backfillContactsOnce: no armed peers → emits nothing but stays RETRYABLE (boot can race feed-init)", async () => {
   const m = freshMgr("nopeers", "local-3");
-  m.outFeeds.clear(); // no peers
+  m.outFeeds.clear(); // feeds not armed (yet) — e.g. the sharing boot hasn't opened them
   const emitted = [];
   m.emitChange = async (_t, _o, r) => emitted.push(r.crow_id);
   await m.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES ('crow:solo', 'ed', ?)", args: [SECP] });
   assert.equal(await m.backfillContactsOnce(), 0);
   assert.equal(emitted.length, 0);
-  // Flag set → a later run (even once peers exist) still no-ops: one-shot per lifetime.
+  // Observed live on grackle 2026-07-06: peers existed but boot raced feed-init,
+  // and the old code marked 'no-peers' TERMINALLY — backfill never ran. Now the
+  // no-peers path must NOT set the flag: once feeds arm, a later run backfills.
   m.outFeeds.set("peer-1", { append: async () => {} });
-  assert.equal(await m.backfillContactsOnce(), 0, "flag already marked done");
+  assert.equal(await m.backfillContactsOnce(), 1, "retry with armed feeds must backfill");
+  assert.deepEqual(emitted, ["crow:solo"]);
+  // And only THEN is it terminal (done:<n> written as an UPSERT).
+  assert.equal(await m.backfillContactsOnce(), 0, "now marked done — one-shot per lifetime");
+  assert.equal(emitted.length, 1);
+});
+
+test("backfillContactsOnce: a stale 'no-peers' flag row from the pre-fix code is healed (UPSERT, no per-boot re-emit)", async () => {
+  const m = freshMgr("staleflag", "local-5");
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  await m.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES ('crow:heal', 'ed', ?)", args: [SECP] });
+  // Simulate the pre-fix state: flag stuck at 'no-peers' despite paired peers.
+  await m.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('__contacts_backfill_v1', 'no-peers', datetime('now'))",
+    args: [],
+  });
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => emitted.push(r.crow_id);
+  assert.equal(await m.backfillContactsOnce(), 1, "stale no-peers is not terminal — backfill runs");
+  const { rows } = await m.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key='__contacts_backfill_v1'" });
+  assert.equal(rows[0].value, "done:1", "done-mark UPSERTs over the stale row");
+  assert.equal(await m.backfillContactsOnce(), 0, "terminal after the real run — no per-boot re-emit thrash");
+  assert.equal(emitted.length, 1);
 });
 
 test("backfillContactsOnce: drains the inbound backlog BEFORE re-emitting (I-B1 — a peer's delivered block must win)", async () => {


### PR DESCRIPTION
## Problem (observed live minutes after PR #146 deployed)

`backfillContactsOnce`'s boot call runs concurrently with the async sharing boot that arms `outFeeds`. On a slow host the peers exist but `outFeeds` is still empty when the backfill runs — the old code then wrote the flag as `no-peers` and treated **any** flag row as terminal, so the backfill never ran on that instance (grackle: 4 paired peers, flag stuck at `no-peers`; crow won the race with `done:2`).

The focused review confirmed `reemitSyncableSettingsOnce` has the identical bug — a peered instance losing the race can permanently skip its settings reconciliation too.

## Fix (both functions)

- Only a completed run (`done:<n>`) is terminal; the no-peers path writes **no flag** — a raced boot retries next boot with feeds armed; a genuinely peer-less instance just re-runs one cheap query per boot.
- The done-mark is now an **UPSERT** (was `ON CONFLICT DO NOTHING`): a stale `no-peers` row from the pre-fix code must be overwritten, or the done-mark silently no-ops and the one-shot re-emits **every boot** (lamport thrash — the exact fabricated-recency exposure the I-B1 drain guards against).
- Existing stuck instances (grackle) self-heal on their next restart.

## Tests

4 new (retry-after-race + stale-flag-heal, mirrored for both functions). Full suite **1154/1154**. Focused Opus review on the backfill fix: READY TO MERGE; the reemit port implements its named follow-up verbatim.