### PR TITLE
feat(messages): Phase 3 groups — contact groups follow the user across paired instances (SCHEMA_GENERATION 4→5)

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1886,6 +1886,39 @@ await db.execute(
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_groups_room_uid ON contact_groups(room_uid) WHERE room_uid IS NOT NULL"
 );
 
+// --- Phase 3 groups-follow-user: stable portable key + LWW clock for plain
+// contact groups (room_uid IS NULL). group_uid is the cross-instance natural key
+// (contact_groups.id is per-instance AUTOINCREMENT; room_uid is NULL for non-rooms).
+// SQLite ALTER ADD COLUMN cannot take a randomblob() default nor a column-level
+// UNIQUE, so: add nullable → UNIQUE index → AFTER-INSERT trigger to auto-populate
+// NEW rows with a random uid (rooms get one too — harmless, rooms never sync here).
+//
+// C1 (split-brain fix): we DELIBERATELY DO NOT randomblob-fill PRE-EXISTING rows here.
+// A random per-instance uid would give the SAME logical group (e.g. "Family" created
+// independently on crow AND grackle before this feature) a DIFFERENT uid on each host,
+// so the one-shot backfill would cross-INSERT and permanently duplicate every shared
+// legacy group. Pre-existing rows are left group_uid IS NULL (SQLite UNIQUE permits
+// multiple NULLs); backfillGroupsOnce() assigns them a DETERMINISTIC, FROZEN uid derived
+// from the shared identity + group name (Task 4) so both instances converge on ONE uid.
+// (This deterministic hash needs the DECRYPTED shared identity + a sha256 — neither is
+// available to init-db, so it lives in the manager, not here. See Task 4's decision box.)
+//
+// lamport_ts gives groups the same last-write-wins clock contacts already have.
+// SCHEMA_GENERATION 4 -> 5.
+await addColumnIfMissing("contact_groups", "group_uid", "TEXT");
+await addColumnIfMissing("contact_groups", "lamport_ts", "INTEGER DEFAULT 0");
+await db.execute(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_contact_groups_group_uid ON contact_groups(group_uid)"
+);
+await db.execute(`
+  CREATE TRIGGER IF NOT EXISTS contact_groups_group_uid_ai
+  AFTER INSERT ON contact_groups
+  WHEN NEW.group_uid IS NULL
+  BEGIN
+    UPDATE contact_groups SET group_uid = lower(hex(randomblob(16))) WHERE id = NEW.id;
+  END
+`);
+
 await initTable("room_messages table", `
   CREATE TABLE IF NOT EXISTS room_messages (
     id                INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -83,6 +83,17 @@ export async function mountMcpServers(app, deps) {
     console.warn(`[instance-sync] backfillContactsOnce failed: ${err.message}`);
   }
 
+  // Phase 3 groups: one-shot re-emit of existing plain groups so peers resolve
+  // groups that predate this feature. AFTER contacts backfill so member contacts
+  // have a chance to land first. Guarded by a flag row; idempotent on later boots.
+  try {
+    if (syncManager?.backfillGroupsOnce) {
+      await syncManager.backfillGroupsOnce();
+    }
+  } catch (err) {
+    console.warn(`[instance-sync] backfillGroupsOnce failed: ${err.message}`);
+  }
+
   // Scoped-settings sync: wire the registry's writeSetting to emitChange so
   // operator edits on one instance propagate to paired peers.
   try {

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -10,6 +10,7 @@ import { upsertSetting } from "../../settings/registry.js";
 import { getContacts } from "./data-queries.js";
 import { getManagersOrNull } from "../../../../sharing/managers.js";
 import { emitContactChange, emitContactDelete } from "../../../../sharing/contact-sync.js";
+import { emitGroupUpsert, emitGroupDelete } from "../../../../sharing/group-sync.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
@@ -267,10 +268,12 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
     const name = (req.body.group_name || "").trim();
     const color = (req.body.group_color || "#6366f1").trim();
     if (name) {
-      await db.execute({
+      const gRes = await db.execute({
         sql: "INSERT INTO contact_groups (name, color) VALUES (?, ?)",
         args: [name, color],
       });
+      // M2: keep this emit INSIDE if(name) — gRes.lastInsertRowid is only valid here.
+      try { await emitGroupUpsert(db, Number(gRes.lastInsertRowid)); } catch {}
     }
     return { redirect: "/dashboard/contacts?view=groups" };
   }
@@ -282,15 +285,17 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
         sql: "UPDATE contact_groups SET name = ? WHERE id = ?",
         args: [name, parseInt(req.body.group_id)],
       });
+      try { await emitGroupUpsert(db, parseInt(req.body.group_id)); } catch {}
     }
     return { redirect: "/dashboard/contacts?view=groups" };
   }
 
   if (action === "delete_group" && req.body.group_id) {
-    await db.execute({
-      sql: "DELETE FROM contact_groups WHERE id = ?",
-      args: [parseInt(req.body.group_id)],
-    });
+    const gid = parseInt(req.body.group_id);
+    let gUid = null;
+    try { const { rows } = await db.execute({ sql: "SELECT group_uid FROM contact_groups WHERE id = ?", args: [gid] }); gUid = rows[0]?.group_uid || null; } catch {}
+    await db.execute({ sql: "DELETE FROM contact_groups WHERE id = ?", args: [gid] });
+    if (gUid) { try { await emitGroupDelete(gUid); } catch {} }
     return { redirect: "/dashboard/contacts?view=groups" };
   }
 
@@ -301,6 +306,7 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
         args: [parseInt(req.body.group_id), parseInt(req.body.contact_id)],
       });
     } catch {}
+    try { await emitGroupUpsert(db, parseInt(req.body.group_id)); } catch {}
     const returnView = req.body.return_view || "contact";
     const returnContact = req.body.contact_id;
     return { redirect: `/dashboard/contacts?view=${returnView}&contact=${returnContact}` };
@@ -311,6 +317,7 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
       sql: "DELETE FROM contact_group_members WHERE group_id = ? AND contact_id = ?",
       args: [parseInt(req.body.group_id), parseInt(req.body.contact_id)],
     });
+    try { await emitGroupUpsert(db, parseInt(req.body.group_id)); } catch {}
     const returnView = req.body.return_view || "contact";
     const returnContact = req.body.contact_id;
     return { redirect: `/dashboard/contacts?view=${returnView}&contact=${returnContact}` };

--- a/servers/gateway/dashboard/panels/messages/rooms-store.js
+++ b/servers/gateway/dashboard/panels/messages/rooms-store.js
@@ -8,6 +8,8 @@ import { randomBytes } from "node:crypto";
 function normMode(mode) { return mode === "always" ? "always" : "addressed"; }
 
 /** Create a host-side room. Assigns a stable room_uid. Returns { groupId, roomUid }. */
+// NOTE: rooms (room_uid NOT NULL) are NOT synced via group-sync — they have
+// their own hub-and-spoke Nostr fan-out (room_messages / room-inbound.js).
 export async function createRoom(db, { name, memberContactIds = [], mode = "addressed", hostCrowId = null }) {
   const roomUid = randomBytes(16).toString("hex"); // 32 hex chars
   const res = await db.execute({
@@ -22,6 +24,8 @@ export async function createRoom(db, { name, memberContactIds = [], mode = "addr
 }
 
 /** Materialize a local room row for a room hosted elsewhere (participant side). Idempotent on room_uid. Returns groupId. */
+// NOTE: rooms (room_uid NOT NULL) are NOT synced via group-sync — they have
+// their own hub-and-spoke Nostr fan-out (room_messages / room-inbound.js).
 export async function ensureLocalRoomForUid(db, { roomUid, name = "Room", hostCrowId = null, mode = "addressed" }) {
   const { rows } = await db.execute({ sql: "SELECT id FROM contact_groups WHERE room_uid = ?", args: [roomUid] });
   if (rows.length) return Number(rows[0].id);

--- a/servers/shared/schema-version.js
+++ b/servers/shared/schema-version.js
@@ -10,7 +10,7 @@
 // by servers/gateway/index.js during boot; importing scripts/init-db.js here
 // (or anything that runs DB work at module top-level) would execute init-db
 // as an unwanted side effect.
-export const SCHEMA_GENERATION = 4;
+export const SCHEMA_GENERATION = 5;
 
 // Pure decision helper for the gateway boot gate. Returns true when the DB
 // needs init-db to run: either core tables are missing (fresh/incomplete

--- a/servers/sharing/group-sync.js
+++ b/servers/sharing/group-sync.js
@@ -1,0 +1,65 @@
+/**
+ * Phase 3 (groups follow the user): push PLAIN contact-group mutations onto the
+ * instance-sync mesh so a user's organizational groups + membership appear on
+ * every paired instance.
+ *
+ * Guarded + null-safe — a sync failure never breaks the local write, and the
+ * sink is null pre-boot / in unit tests (no-op). Groups are keyed on the stable
+ * group_uid; membership travels as a wire-map of member contact crow_ids attached
+ * here via a JOIN (the per-instance group_id/contact_id are never portable).
+ *
+ * ROOMS ARE EXCLUDED: a contact_groups row with a non-NULL room_uid IS a
+ * multi-party Crow Messages room with its OWN Nostr fan-out (room_messages /
+ * room-inbound.js). emitGroupUpsert no-ops on such rows; shouldSyncRow drops them
+ * again both directions (defense in depth).
+ *
+ * managers.js → nostr.js → group-sync.js would form a require cycle under a
+ * static import; the cached lazy dynamic import keeps the graph acyclic — identical
+ * to contact-sync.js / message-sync.js. Do NOT "simplify" to a static import.
+ */
+let _mgrMod = null;
+let _testSink = null;
+export function __setEmitSinkForTest(sink) { _testSink = sink; }
+
+async function sink() {
+  if (_testSink) return _testSink;
+  if (!_mgrMod) { try { _mgrMod = await import("./managers.js"); } catch { return null; } }
+  return _mgrMod.getInstanceSyncManager?.() || null;
+}
+
+/**
+ * Emit an upsert for a plain group: re-select it, skip if it is a room or lacks a
+ * group_uid, attach the full member-crow_id wire-map, forward the FULL local row
+ * (id retained for emitChange's lamport stamp). Never throws.
+ */
+export async function emitGroupUpsert(db, groupId) {
+  try {
+    if (!db || !groupId) return;
+    const { rows } = await db.execute({
+      sql: "SELECT * FROM contact_groups WHERE id = ? LIMIT 1",
+      args: [groupId],
+    });
+    const row = rows[0];
+    if (!row || row.room_uid != null || !row.group_uid) return; // room / keyless → skip
+    // I2: attach ONLY syncable members — exclude local-bot origin and pending
+    // (unestablished) memberships, which the peer must never learn about.
+    const { rows: mem } = await db.execute({
+      sql: `SELECT c.crow_id AS crow_id
+              FROM contact_group_members gm JOIN contacts c ON c.id = gm.contact_id
+             WHERE gm.group_id = ?
+               AND c.crow_id IS NOT NULL
+               AND (c.origin IS NULL OR c.origin != 'local-bot')
+               AND (c.request_status IS NULL OR c.request_status = 'accepted')`,
+      args: [groupId],
+    });
+    row.members = mem.map((r) => r.crow_id).filter(Boolean);
+    await (await sink())?.emitChange("contact_groups", "update", row);
+  } catch { /* never throw — group sync is best-effort */ }
+}
+
+/** Emit a group delete by its stable group_uid. Capture the uid BEFORE the local DELETE. */
+export async function emitGroupDelete(groupUid) {
+  if (!groupUid) return;
+  try { await (await sink())?.emitChange("contact_groups", "delete", { group_uid: groupUid }); }
+  catch { /* never throw */ }
+}

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -69,6 +69,11 @@ export const SYNCED_TABLES = [
   // below, which NULLs project_id on the wire.
   "research_notes",
   "glasses_note_sessions",
+  // Phase 3 (groups follow the user): PLAIN contact groups (room_uid IS NULL)
+  // sync so a user's organizational groups + membership follow them across
+  // instances. Multi-party ROOMS (room_uid NOT NULL) are gated OUT by
+  // shouldSyncRow — they have their own Nostr fan-out.
+  "contact_groups",
 ];
 
 // Columns to exclude from sync payloads (security-sensitive or instance-local)
@@ -90,6 +95,13 @@ export const EXCLUDED_COLUMNS = {
   // is per-device (each instance computes its own unread badge). lamport_ts is
   // sync metadata carried in the entry envelope, not the row.
   messages: ["id", "contact_id", "is_read", "lamport_ts"],
+  // Phase 3 groups: group_uid is the stable wire key; id is per-instance
+  // AUTOINCREMENT (never portable); created_at differs when two instances form
+  // the same group independently (spurious conflicts). room_uid/host_crow_id/mode
+  // are LEFT on the wire (NULL for a plain group) so the apply-side shouldSyncRow
+  // can still reject a malicious room-bearing entry; lamport_ts rides the row and
+  // is dropped on apply. Membership rides the attached `members` wire-map.
+  contact_groups: ["id", "created_at"],
 };
 
 // Per-table outbound mutations applied right after the EXCLUDED_COLUMNS strip.
@@ -180,6 +192,13 @@ function shouldSyncRow(table, row) {
     // group ids (grp_<ts>, own room sync) or an unresolved contact — never sync.
     if (!row) return false;
     return Boolean(row.nostr_event_id) && Boolean(row.crow_id);
+  }
+  if (table === "contact_groups") {
+    if (!row) return false;
+    // Rooms (room_uid NOT NULL) sync via their own Nostr fan-out — never here.
+    // `!= null` catches both null and undefined (a delete row omits room_uid).
+    if (row.room_uid != null) return false;
+    return Boolean(row.group_uid);
   }
   if (table !== "dashboard_settings") return true;
   if (!row || !row.key) return false;

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -15,7 +15,9 @@
 import Hypercore from "hypercore";
 import { mkdirSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { createHash } from "node:crypto";
 import { sign, verify } from "./identity.js";
+import { emitGroupUpsert } from "./group-sync.js";
 import { resolveDataDir } from "../db.js";
 import { isSyncable } from "../gateway/dashboard/settings/sync-allowlist.js";
 import { normalizePubkey } from "./pubkey-util.js";
@@ -615,6 +617,140 @@ export class InstanceSyncManager {
     if (emitted > 0) {
       console.log(`[instance-sync] one-shot contacts backfill: ${emitted} contact(s) re-emitted → peers resolve legacy contacts`);
     }
+    return emitted;
+  }
+
+  /**
+   * C1: assign a DETERMINISTIC, FROZEN group_uid to every pre-existing PLAIN group
+   * the migration left NULL, so the SAME logical group on two instances (same shared
+   * identity) converges on ONE uid instead of duplicating. uid = first-32-hex of
+   * sha256(<shared ed25519 pubkey> ":" lower(trim(name))). Local same-name collisions
+   * are resolved COLLISION-DRIVEN (R2 F1): a UNIQUE rejection retries with a
+   * "\x1f"-suffixed key (base\x1f1, base\x1f2, …, bound 16 then warn+skip). The \x1f
+   * unit separator cannot survive lower(trim(name)) of any real group name, so a
+   * suffixed key can never collide with a literal name's base key; and probing the DB
+   * instead of pre-counting makes the assignment crash-idempotent (a partial run
+   * strands nothing — the retry walks past whatever already landed).
+   * Idempotent: only touches NULL-uid rows; a frozen uid is never re-derived on rename.
+   * Never throws. Returns the count assigned.
+   */
+  deterministicGroupUid(name, n = 0) {
+    const base = String(name ?? "").trim().toLowerCase();
+    // n=0 → base hash; n>0 → collision-retry slot. "\x1f" is a control char no real
+    // group name contains — unlike "#2", a slot key can never equal a literal name.
+    const keyed = n > 0 ? `${base}\x1f${n}` : base;
+    return createHash("sha256")
+      .update(`${this.identity.ed25519Pubkey}:${keyed}`)
+      .digest("hex")
+      .slice(0, 32);
+  }
+
+  async _assignDeterministicGroupUids() {
+    const MAX_COLLISION_RETRIES = 16;
+    let assigned = 0;
+    let rows = [];
+    try {
+      const r = await this.db.execute({ sql: "SELECT id, name FROM contact_groups WHERE room_uid IS NULL AND group_uid IS NULL ORDER BY id ASC" });
+      rows = r.rows || [];
+    } catch (err) {
+      console.warn(`[instance-sync] deterministic group_uid read failed: ${err.message}`);
+      return 0;
+    }
+    for (const row of rows) {
+      // COLLISION-DRIVEN (R2 F1): try the base hash; every UNIQUE rejection bumps n
+      // and retries the \x1f-suffixed slot. No in-memory counter → crash-idempotent:
+      // the retry walks past hashes that already landed (this run, a previous
+      // interrupted run, or a peer's identical deterministic uid).
+      let settled = false;
+      for (let n = 0; n <= MAX_COLLISION_RETRIES && !settled; n++) {
+        const uid = this.deterministicGroupUid(row.name, n);
+        try {
+          // group_uid IS NULL guard makes the UPDATE a no-op if a concurrent path already set it.
+          await this.db.execute({ sql: "UPDATE contact_groups SET group_uid = ? WHERE id = ? AND group_uid IS NULL", args: [uid, row.id] });
+          assigned++;
+          settled = true;
+        } catch (err) {
+          if (!/unique|constraint/i.test(err.message || "")) {
+            // Non-UNIQUE failure — skip this row, never throw (re-attempted next boot,
+            // since assignment runs before the flag gate — R2 F2).
+            console.warn(`[instance-sync] deterministic group_uid assign failed for group ${row.id}: ${err.message}`);
+            settled = true;
+          }
+          // UNIQUE collision → loop retries with n+1.
+        }
+      }
+      if (!settled) {
+        console.warn(`[instance-sync] deterministic group_uid: ${MAX_COLLISION_RETRIES} collisions for group ${row.id} — left NULL (re-attempted next boot)`);
+      }
+    }
+    if (assigned > 0) console.log(`[instance-sync] assigned ${assigned} deterministic group_uid(s) to pre-existing groups`);
+    return assigned;
+  }
+
+  /**
+   * One-shot idempotent backfill (Phase 3 groups-follow-user): re-emit every
+   * existing PLAIN contact group (room_uid IS NULL) so a peer can resolve it for
+   * groups that predate this feature. Rooms are excluded (own Nostr sync). The
+   * RE-EMIT is guarded by a flag so it runs once per instance lifetime; C1
+   * deterministic uid assignment runs BEFORE that gate — every boot (R2 F2) — so
+   * pre-existing groups converge (not duplicate) and a NULL-uid row introduced
+   * later (restore/import/interrupted run) self-heals on the next boot. Then it
+   * drains the inbound backlog (I-B1) so a peer's already-delivered newer group
+   * edit wins before we re-emit with a fresh lamport. Mirrors
+   * backfillContactsOnce(). Never throws.
+   */
+  async backfillGroupsOnce() {
+    // C1: assign deterministic frozen uids to legacy NULL-uid plain groups BEFORE the
+    // flag gate (R2 F2 — every boot; usually 0 rows) and BEFORE the peer gate — so even
+    // a peerless instance gets stable, convergent uids and stranded NULLs self-heal.
+    await this._assignDeterministicGroupUids();
+
+    const FLAG_KEY = "__groups_backfill_v1";
+    let alreadyRan = false;
+    try {
+      const { rows } = await this.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [FLAG_KEY] });
+      alreadyRan = typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:");
+    } catch {}
+    if (alreadyRan) return 0;
+
+    if (this.outFeeds.size === 0) return 0; // no peers armed yet — retry next boot; do NOT mark
+
+    // I-B1 ordering guard: apply the peer's already-replicated backlog first.
+    try {
+      for (const [peerId, inFeed] of this.inFeeds) {
+        await this._processNewEntries(peerId, inFeed);
+      }
+    } catch (err) {
+      console.warn(`[instance-sync] groups backfill drain failed: ${err.message}`);
+    }
+
+    let rows = [];
+    try {
+      const r = await this.db.execute({ sql: "SELECT id FROM contact_groups WHERE room_uid IS NULL" });
+      rows = r.rows || [];
+    } catch (err) {
+      console.warn(`[instance-sync] groups backfill read failed: ${err.message}`);
+      return 0;
+    }
+
+    let emitted = 0;
+    for (const row of rows) {
+      try {
+        await emitGroupUpsert(this.db, row.id); // shouldSyncRow + room skip are the final gate
+        emitted++;
+      } catch (err) {
+        console.warn(`[instance-sync] groups backfill emit failed for group ${row.id}: ${err.message}`);
+      }
+    }
+
+    try {
+      await this.db.execute({
+        sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+        args: [FLAG_KEY, `done:${emitted}`],
+      });
+    } catch {}
+
+    if (emitted > 0) console.log(`[instance-sync] one-shot groups backfill: ${emitted} group(s) re-emitted → peers resolve legacy groups`);
     return emitted;
   }
 

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1563,7 +1563,7 @@ export class InstanceSyncManager {
       filtered[k] = v;
     }
 
-    const { rows: localRows } = await this.db.execute({ sql: "SELECT * FROM contact_groups WHERE group_uid = ?", args: [groupUid] });
+    const { rows: localRows } = await this.db.execute({ sql: "SELECT * FROM contact_groups WHERE group_uid = ? AND room_uid IS NULL", args: [groupUid] });
     const localRow = localRows[0] ?? null;
     const localTs = localRow?.lamport_ts || 0;
     const rowIdJson = JSON.stringify({ group_uid: groupUid });
@@ -1573,7 +1573,7 @@ export class InstanceSyncManager {
       if (!localRow) return;
       if (lamportTs > localTs) {
         // ON DELETE CASCADE reaps contact_group_members.
-        await this.db.execute({ sql: "DELETE FROM contact_groups WHERE group_uid = ?", args: [groupUid] });
+        await this.db.execute({ sql: "DELETE FROM contact_groups WHERE group_uid = ? AND room_uid IS NULL", args: [groupUid] });
         return;
       }
       try {
@@ -1629,7 +1629,7 @@ export class InstanceSyncManager {
   }
 
   async _groupIdByUid(groupUid) {
-    const { rows } = await this.db.execute({ sql: "SELECT id FROM contact_groups WHERE group_uid = ? LIMIT 1", args: [groupUid] });
+    const { rows } = await this.db.execute({ sql: "SELECT id FROM contact_groups WHERE group_uid = ? AND room_uid IS NULL LIMIT 1", args: [groupUid] });
     return rows[0]?.id ?? null;
   }
 

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -861,6 +861,19 @@ export class InstanceSyncManager {
       return;
     }
 
+    // contact_groups (plain groups only — rooms gated by shouldSyncRow) are keyed
+    // on the stable group_uid; the per-instance AUTOINCREMENT id + join-table FKs
+    // are NOT portable. Route ALL ops through the natural-key handler, mirroring
+    // _applyContact. shouldSyncRow already dropped room_uid/keyless rows at :787.
+    if (table === "contact_groups") {
+      try {
+        await this._applyGroup(op, row, lamport_ts, instance_id);
+      } catch (err) {
+        console.warn(`[instance-sync] Failed to apply ${op} on contact_groups:`, err.message);
+      }
+      return;
+    }
+
     // Conflict detection gates both updates and deletes — a stale remote delete
     // with a lower lamport_ts must not silently destroy a newer local edit (D6).
     if ((op === "update" || op === "delete") && row.id !== undefined) {
@@ -1370,6 +1383,170 @@ export class InstanceSyncManager {
       });
     } catch (err) {
       try { console.warn("[instance-sync] message-applied notify failed:", err.message); } catch {}
+    }
+  }
+
+  /**
+   * Apply a PLAIN contact-group mutation keyed on the stable group_uid (Phase 3
+   * groups-follow-user). Rooms (room_uid NOT NULL) are dropped upstream by
+   * shouldSyncRow. Group metadata (name/color; sort_order forward-looking, M1) is
+   * LWW by lamport_ts, exactly like _applyContact; membership is WHOLE-SET replaced
+   * (I1) from the wire-map of member crow_ids on a winning apply — a concurrent
+   * removal on the losing side is reverted, not merged — but ONLY when the wire row
+   * carries a `members` key (absent != empty, R2 F3: a metadata-only emit skips the
+   * reconcile; an explicit [] replaces). Members are resolved to LOCAL
+   * contact ids, bounded to the syncable domain (unresolvable OR local-bot/pending
+   * members skipped — never conjure a contact, never add a local-bot the peer named).
+   * A synced group can never become a room: room_uid/host_crow_id/mode are dropped
+   * from every applied write.
+   */
+  async _applyGroup(op, row, lamportTs, instanceId) {
+    const groupUid = row && row.group_uid;
+    if (!groupUid) {
+      console.warn("[instance-sync] _applyGroup: missing group_uid — skipping");
+      return;
+    }
+
+    if (!this._groupCols) {
+      try {
+        const { rows: pragma } = await this.db.execute({ sql: "PRAGMA table_info(contact_groups)", args: [] });
+        this._groupCols = new Set(pragma.map((r) => r.name));
+      } catch { this._groupCols = null; }
+    }
+    if (!this._groupCols) {
+      console.warn("[instance-sync] _applyGroup: contact_groups columns unavailable — skipping");
+      return;
+    }
+    // Never write id/lamport/created_at, never turn a synced group into a room,
+    // never treat the `members` pseudo-column as a real column.
+    const ALWAYS_DROP = new Set(["id", "lamport_ts", "instance_id", "created_at", "room_uid", "host_crow_id", "mode", "members"]);
+    const filtered = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (ALWAYS_DROP.has(k)) continue;
+      if (!this._groupCols.has(k)) continue;
+      filtered[k] = v;
+    }
+
+    const { rows: localRows } = await this.db.execute({ sql: "SELECT * FROM contact_groups WHERE group_uid = ?", args: [groupUid] });
+    const localRow = localRows[0] ?? null;
+    const localTs = localRow?.lamport_ts || 0;
+    const rowIdJson = JSON.stringify({ group_uid: groupUid });
+
+    // ── delete ──────────────────────────────────────────────────────────────
+    if (op === "delete") {
+      if (!localRow) return;
+      if (lamportTs > localTs) {
+        // ON DELETE CASCADE reaps contact_group_members.
+        await this.db.execute({ sql: "DELETE FROM contact_groups WHERE group_uid = ?", args: [groupUid] });
+        return;
+      }
+      try {
+        await this._insertConflictRow("contact_groups", rowIdJson,
+          localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
+          JSON.stringify(localRow), JSON.stringify(filtered), "delete");
+        await this._notifyConflict();
+      } catch (err) {
+        console.warn("[instance-sync] contact_groups delete conflict LOGGING failed (local kept):", err.message);
+      }
+      return;
+    }
+
+    // ── insert / update (LWW) ───────────────────────────────────────────────
+    if (!localRow) {
+      const cols = Object.keys(filtered).filter((k) => filtered[k] !== undefined);
+      if (!cols.includes("group_uid")) cols.push("group_uid");
+      const insertCols = [...new Set(cols)];
+      const placeholders = insertCols.map(() => "?").join(", ");
+      const values = insertCols.map((k) => (k === "group_uid" ? groupUid : filtered[k] ?? null));
+      await this.db.execute({
+        sql: `INSERT INTO contact_groups (${insertCols.join(", ")}, lamport_ts) VALUES (${placeholders}, ?)`,
+        args: [...values, lamportTs],
+      });
+      const gid = await this._groupIdByUid(groupUid);
+      await this._reconcileGroupMembers(gid, row.members);
+      return;
+    }
+
+    if (lamportTs > localTs) {
+      const updateKeys = Object.keys(filtered).filter((k) => k !== "group_uid");
+      const setClauses = updateKeys.map((k) => `${k} = ?`);
+      const vals = updateKeys.map((k) => filtered[k] ?? null);
+      setClauses.push("lamport_ts = ?"); vals.push(lamportTs);
+      await this.db.execute({ sql: `UPDATE contact_groups SET ${setClauses.join(", ")} WHERE group_uid = ?`, args: [...vals, groupUid] });
+      await this._reconcileGroupMembers(localRow.id, row.members);
+      return;
+    }
+
+    // incomingTs <= localTs — local wins wholesale (metadata AND membership).
+    // M3: on a metadata-equal tie we return WITHOUT reconciling membership, so a
+    // concurrent membership divergence at equal metadata persists silently (documented
+    // in Known limitations — acceptable for a single user's low-contention groups).
+    if (rowsEquivalent(localRow, filtered)) return; // re-delivery noise
+    try {
+      await this._insertConflictRow("contact_groups", rowIdJson,
+        localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
+        JSON.stringify(localRow), JSON.stringify(filtered), op || "update");
+      await this._notifyConflict();
+    } catch (err) {
+      console.warn("[instance-sync] contact_groups conflict LOGGING failed (local kept):", err.message);
+    }
+  }
+
+  async _groupIdByUid(groupUid) {
+    const { rows } = await this.db.execute({ sql: "SELECT id FROM contact_groups WHERE group_uid = ? LIMIT 1", args: [groupUid] });
+    return rows[0]?.id ?? null;
+  }
+
+  /**
+   * Whole-set replace (I1) of group membership from a wire-map of member crow_ids,
+   * bounded to the SHARED, SYNCABLE contact domain. Absent != empty (R2 F3): a wire
+   * row WITHOUT a members key (metadata-only emit) skips the reconcile entirely —
+   * only an EXPLICIT array (including []) replaces. A winning apply overwrites the
+   * entire local membership: adds resolvable-and-SYNCABLE-and-missing members (never
+   * creates a contact, never adds a local-bot/pending contact the peer named — I2);
+   * removes only SYNCABLE members (origin != local-bot, established) whose crow_id is
+   * absent from the wire-map. Local-only / local-bot / pending memberships are NEVER
+   * touched — the emitting peer can't know about them, so a whole-set replace must not
+   * wipe them (and a concurrent removal on the LOSING side IS reverted — I1).
+   */
+  async _reconcileGroupMembers(groupId, wireCrowIds) {
+    if (groupId == null) return;
+    // R2 F3: members ABSENT (undefined) is a metadata-only emit, NOT an empty group —
+    // treating it as [] would wipe every syncable member. Skip; explicit [] still honored.
+    if (wireCrowIds === undefined) return;
+    const wireSet = new Set((Array.isArray(wireCrowIds) ? wireCrowIds : []).filter(Boolean));
+
+    // Add: resolvable + SYNCABLE + missing (I2 — symmetric with the remove branch).
+    for (const crowId of wireSet) {
+      try {
+        const { rows } = await this.db.execute({ sql: "SELECT id, origin, request_status FROM contacts WHERE crow_id = ? LIMIT 1", args: [crowId] });
+        const c = rows[0];
+        if (c == null || c.id == null) continue; // unresolved — never create a contact
+        const syncable = c.origin !== "local-bot" &&
+          (c.request_status == null || c.request_status === "accepted");
+        if (!syncable) continue; // peer cannot pull a local-bot/pending contact into a synced group
+        await this.db.execute({ sql: "INSERT OR IGNORE INTO contact_group_members (group_id, contact_id) VALUES (?, ?)", args: [groupId, c.id] });
+      } catch (err) {
+        console.warn(`[instance-sync] _reconcileGroupMembers add ${crowId} failed: ${err.message}`);
+      }
+    }
+
+    // Remove: syncable members no longer in the wire-map.
+    try {
+      const { rows: locals } = await this.db.execute({
+        sql: `SELECT gm.contact_id, c.crow_id, c.origin, c.request_status
+                FROM contact_group_members gm JOIN contacts c ON c.id = gm.contact_id
+               WHERE gm.group_id = ?`, args: [groupId],
+      });
+      for (const lm of locals) {
+        const syncable = lm.origin !== "local-bot" &&
+          (lm.request_status == null || lm.request_status === "accepted");
+        if (!syncable) continue;                 // local-only membership — peer can't know it
+        if (wireSet.has(lm.crow_id)) continue;   // still a member
+        await this.db.execute({ sql: "DELETE FROM contact_group_members WHERE group_id = ? AND contact_id = ?", args: [groupId, lm.contact_id] });
+      }
+    } catch (err) {
+      console.warn(`[instance-sync] _reconcileGroupMembers remove failed: ${err.message}`);
     }
   }
 

--- a/servers/sharing/room-inbound.js
+++ b/servers/sharing/room-inbound.js
@@ -34,6 +34,8 @@ export async function handleInboundRoomEnvelope({ db, nostrManager, identity, su
       for (const m of payload.members) {
         if (!m || !m.crow_id) continue;
         const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ? AND request_status IS NULL", args: [m.crow_id] });
+        // NOTE: rooms (room_uid NOT NULL) are NOT synced via group-sync — they have
+        // their own hub-and-spoke Nostr fan-out (room_messages / room-inbound.js).
         if (rows[0]?.id != null) await db.execute({ sql: "INSERT OR IGNORE INTO contact_group_members (group_id, contact_id) VALUES (?,?)", args: [groupId, rows[0].id] });
       }
     }

--- a/servers/sharing/tools/messaging.js
+++ b/servers/sharing/tools/messaging.js
@@ -8,6 +8,7 @@
 
 import { z } from "zod";
 import { isKioskActive, kioskBlockedResponse } from "../../shared/kiosk-guard.js";
+import { emitGroupUpsert } from "../group-sync.js";
 
 export function registerMessagingTools(server, ctx) {
   const { db, identity, nostrManager } = ctx;
@@ -115,6 +116,10 @@ export function registerMessagingTools(server, ctx) {
           notFound.push(member);
         }
       }
+
+      // Phase 3 (groups follow the user): ONE emit after the member loop — the
+      // wire-map is a full membership replace, so per-member emits are redundant.
+      try { await emitGroupUpsert(db, groupId); } catch {}
 
       let text = `Created group "${name}" (ID: ${groupId}) with ${added.length} member(s): ${added.join(", ")}`;
       if (notFound.length > 0) text += `\nNot found: ${notFound.join(", ")}`;

--- a/tests/contact-verified-column.test.js
+++ b/tests/contact-verified-column.test.js
@@ -4,8 +4,11 @@ import assert from "node:assert/strict";
 import { SCHEMA_GENERATION } from "../servers/shared/schema-version.js";
 import { upsertFullContact } from "../servers/sharing/contact-promote.js";
 
-test("SCHEMA_GENERATION is bumped to 4 for the verified column", () => {
-  assert.equal(SCHEMA_GENERATION, 4);
+test("SCHEMA_GENERATION covers the verified column (gen >= 4)", () => {
+  // The verified column shipped in generation 4; later features bump further
+  // (5 = contact_groups.group_uid/lamport_ts). Exact-equality here broke on
+  // every subsequent legitimate bump — assert the floor instead.
+  assert.ok(SCHEMA_GENERATION >= 4, `expected >= 4, got ${SCHEMA_GENERATION}`);
 });
 
 // In-memory contacts+messages db stub (contact-promote.test.js pattern).

--- a/tests/groups-backfill.test.js
+++ b/tests/groups-backfill.test.js
@@ -1,0 +1,133 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { __setEmitSinkForTest } from "../servers/sharing/group-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+function freshMgr(label, id) {
+  const d = mkdtempSync(join(tmpdir(), `crow-p3g-backfill-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: d }, stdio: "pipe" });
+  after(() => rmSync(d, { recursive: true, force: true }));
+  const m = new InstanceSyncManager(IDENTITY, createDbClient(join(d, "crow.db")), id);
+  m.feedsDisabled = false;
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  // Route group-sync's lazy sink at THIS manager: in a unit test
+  // managers.getInstanceSyncManager() is null (ensureSharedManagers never ran),
+  // so without this the backfill's emitGroupUpsert calls would silently no-op
+  // and the patched m.emitChange would never observe them. Tests run serially
+  // (node:test per-file default), so re-pointing the module-global sink per
+  // freshMgr is safe.
+  __setEmitSinkForTest(m);
+  return m;
+}
+after(() => __setEmitSinkForTest(null));
+
+test("backfillGroupsOnce: re-emits plain groups once, no-ops on re-run (idempotent)", async () => {
+  const m = freshMgr("idem", "local-1"); const db = m.db;
+  const emitted = [];
+  const orig = m.emitChange.bind(m);
+  m.emitChange = async (t, o, r) => { if (t === "contact_groups") emitted.push(r.group_uid); return orig(t, o, r); };
+  await db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('Family','gb1')" });
+  const n1 = await m.backfillGroupsOnce();
+  assert.equal(n1, 1);
+  assert.deepEqual(emitted, ["gb1"]);
+  emitted.length = 0;
+  assert.equal(await m.backfillGroupsOnce(), 0, "flag-guarded second run is a no-op");
+  assert.equal(emitted.length, 0);
+});
+
+test("backfillGroupsOnce: excludes ROOM groups (room_uid NOT NULL)", async () => {
+  const m = freshMgr("rooms", "local-2"); const db = m.db;
+  const emitted = [];
+  m.emitChange = async (t, _o, r) => { if (t === "contact_groups") emitted.push(r.group_uid); };
+  await db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('Plain','gb2')" });
+  await db.execute({ sql: "INSERT INTO contact_groups (name, group_uid, room_uid) VALUES ('Room','gb3','ruid')" });
+  const n = await m.backfillGroupsOnce();
+  assert.equal(n, 1);
+  assert.deepEqual(emitted, ["gb2"], "only the plain group re-emitted");
+});
+
+test("backfillGroupsOnce: no peers → returns 0 and does NOT mark the flag (retryable)", async () => {
+  const m = freshMgr("nopeers", "local-3");
+  m.outFeeds.clear();
+  await m.db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('Solo','gb4')" });
+  assert.equal(await m.backfillGroupsOnce(), 0);
+  const { rows } = await m.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key='__groups_backfill_v1'" });
+  assert.equal(rows.length, 0, "flag NOT written when peerless — retry next boot");
+});
+
+test("C1: a pre-existing NULL-uid plain group is assigned the DETERMINISTIC uid (frozen)", async () => {
+  const m = freshMgr("det", "local-4"); const db = m.db;
+  // Legacy row: insert then force NULL past the trigger (mirrors a pre-feature group).
+  await db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('  Family  ', 'seed')" });
+  await db.execute("UPDATE contact_groups SET group_uid = NULL WHERE name='  Family  '");
+  await m._assignDeterministicGroupUids();
+  const expect = createHash("sha256").update(`${TEST_PUB_HEX}:family`).digest("hex").slice(0, 32);
+  const { rows } = await db.execute({ sql: "SELECT group_uid FROM contact_groups WHERE name='  Family  '" });
+  assert.equal(rows[0].group_uid, expect, "uid = sha256(pubkey:lower(trim(name)))[:32]");
+  // Idempotent + frozen: a rename does NOT change the assigned uid; a re-run is a no-op.
+  await db.execute("UPDATE contact_groups SET name='Renamed' WHERE name='  Family  '");
+  assert.equal(await m._assignDeterministicGroupUids(), 0, "no NULL-uid rows left → no-op");
+  const { rows: r2 } = await db.execute({ sql: "SELECT group_uid FROM contact_groups WHERE name='Renamed'" });
+  assert.equal(r2[0].group_uid, expect, "uid frozen across rename");
+});
+
+test("C1 convergence: two instances (same shared identity) derive the SAME uid for the same-named group", async () => {
+  const a = freshMgr("convA", "inst-A"); const b = freshMgr("convB", "inst-B");
+  for (const m of [a, b]) {
+    await m.db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('Family','seed')" });
+    await m.db.execute("UPDATE contact_groups SET group_uid = NULL WHERE name='Family'");
+    await m._assignDeterministicGroupUids();
+  }
+  const ua = (await a.db.execute("SELECT group_uid FROM contact_groups WHERE name='Family'")).rows[0].group_uid;
+  const ub = (await b.db.execute("SELECT group_uid FROM contact_groups WHERE name='Family'")).rows[0].group_uid;
+  assert.equal(ua, ub, "same shared identity + same name → identical deterministic uid → converges, not duplicates");
+});
+
+test("C1 tie-break (R2 F1): two same-name plain groups on ONE instance get DISTINCT collision-driven uids (no UNIQUE crash) + a partial run self-heals", async () => {
+  const m = freshMgr("tie", "local-5"); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contact_groups (id, name, group_uid) VALUES (1,'Family','s1'),(2,'Family','s2')" });
+  await db.execute("UPDATE contact_groups SET group_uid = NULL WHERE name='Family'");
+  const n = await m._assignDeterministicGroupUids();
+  assert.equal(n, 2, "both rows assigned, no UNIQUE-index crash");
+  const first = createHash("sha256").update(`${TEST_PUB_HEX}:family`).digest("hex").slice(0, 32);
+  const second = createHash("sha256").update(`${TEST_PUB_HEX}:family\x1f1`).digest("hex").slice(0, 32);
+  const u1 = (await db.execute("SELECT group_uid FROM contact_groups WHERE id=1")).rows[0].group_uid;
+  const u2 = (await db.execute("SELECT group_uid FROM contact_groups WHERE id=2")).rows[0].group_uid;
+  assert.equal(u1, first, "lowest id lands the base hash");
+  assert.equal(u2, second, "second (by id ASC) collides on base, retries → \\x1f1 slot hash");
+  assert.notEqual(u1, u2);
+  // Crash-idempotency (R2 F1b): simulate a partial run — strand row 2 back to NULL.
+  // The retry loop re-probes from the base hash, walks past the already-taken slot,
+  // and re-lands \x1f1 — no permanent UNIQUE-stranding (the R1 counter design's bug).
+  await db.execute("UPDATE contact_groups SET group_uid = NULL WHERE id = 2");
+  assert.equal(await m._assignDeterministicGroupUids(), 1, "stranded row re-assigned on the next run");
+  const u2b = (await db.execute("SELECT group_uid FROM contact_groups WHERE id=2")).rows[0].group_uid;
+  assert.equal(u2b, second, "partial-run retry converges on the same \\x1f1 slot, no crash");
+});
+
+test("C1 no literal-name mismerge (R2 F1a): a group literally named 'Family#2' coexists with two 'Family' groups — three DISTINCT uids, idempotent re-run", async () => {
+  const m = freshMgr("lit", "local-6"); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contact_groups (id, name, group_uid) VALUES (1,'Family','s1'),(2,'Family','s2'),(3,'Family#2','s3')" });
+  await db.execute("UPDATE contact_groups SET group_uid = NULL");
+  assert.equal(await m._assignDeterministicGroupUids(), 3, "all three assigned");
+  const uids = (await db.execute("SELECT group_uid FROM contact_groups ORDER BY id ASC")).rows.map((r) => r.group_uid);
+  assert.equal(new Set(uids).size, 3, "three DISTINCT uids — no cross-group mismerge");
+  const literal = createHash("sha256").update(`${TEST_PUB_HEX}:family#2`).digest("hex").slice(0, 32);
+  assert.equal(uids[2], literal, "'Family#2' keeps ITS OWN base hash — never confused with dup-slot-2 of 'Family' (which is \\x1f-keyed)");
+  assert.equal(uids[1], createHash("sha256").update(`${TEST_PUB_HEX}:family\x1f1`).digest("hex").slice(0, 32), "dup-slot-2 of 'Family' is \\x1f1, disjoint from the literal name's hash");
+  // Idempotent re-run: nothing left NULL, nothing re-derived.
+  assert.equal(await m._assignDeterministicGroupUids(), 0, "re-run is a no-op");
+  const again = (await db.execute("SELECT group_uid FROM contact_groups ORDER BY id ASC")).rows.map((r) => r.group_uid);
+  assert.deepEqual(again, uids, "uids stable across re-runs");
+});

--- a/tests/groups-schema.test.js
+++ b/tests/groups-schema.test.js
@@ -1,0 +1,67 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { SCHEMA_GENERATION } from "../servers/shared/schema-version.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3g-schema-"));
+function initDb() {
+  execFileSync(process.execPath, ["scripts/init-db.js"],
+    { env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe" });
+  return createDbClient(join(tmpDir, "crow.db"));
+}
+const db = initDb();
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+test("SCHEMA_GENERATION bumped to 5 and stamped on the db", async () => {
+  assert.equal(SCHEMA_GENERATION, 5);
+  const { rows } = await db.execute("PRAGMA user_version");
+  assert.equal(Number(rows[0].user_version), 5);
+});
+
+test("contact_groups has group_uid + lamport_ts", async () => {
+  const { rows } = await db.execute("PRAGMA table_info(contact_groups)");
+  const cols = new Set(rows.map((r) => r.name));
+  assert.ok(cols.has("group_uid"), "group_uid column present");
+  assert.ok(cols.has("lamport_ts"), "lamport_ts column present");
+});
+
+test("a bare INSERT gets a group_uid via the auto-populate trigger", async () => {
+  await db.execute({ sql: "INSERT INTO contact_groups (name) VALUES ('Family')" });
+  const { rows } = await db.execute("SELECT group_uid FROM contact_groups WHERE name='Family'");
+  assert.match(String(rows[0].group_uid), /^[0-9a-f]{32}$/, "trigger populated a 16-byte hex uid");
+});
+
+test("group_uid is UNIQUE-indexed", async () => {
+  const uid = "d".repeat(32);
+  await db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('A', ?)", args: [uid] });
+  await assert.rejects(
+    db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('B', ?)", args: [uid] }),
+    /UNIQUE|constraint/i,
+    "duplicate group_uid rejected",
+  );
+});
+
+test("C1: re-running init-db does NOT randomblob-fill a pre-existing NULL group_uid", async () => {
+  // Simulate a legacy row: force group_uid NULL past the trigger. The migration must
+  // LEAVE it NULL — the deterministic uid is assigned by the manager at backfill (Task 4),
+  // NOT by init-db (a random per-instance fill is the C1 split-brain bug).
+  await db.execute({ sql: "INSERT INTO contact_groups (name, group_uid) VALUES ('Legacy', ?)", args: ["e".repeat(32)] });
+  await db.execute("UPDATE contact_groups SET group_uid = NULL WHERE name='Legacy'");
+  initDb(); // re-run migrations against the same data dir (idempotent)
+  const db2 = createDbClient(join(tmpDir, "crow.db"));
+  const { rows } = await db2.execute("SELECT group_uid FROM contact_groups WHERE name='Legacy'");
+  assert.equal(rows[0].group_uid, null, "pre-existing NULL uid is NOT filled by init-db (deterministic assignment is the manager's job)");
+});
+
+test("the auto-populate trigger + UNIQUE index survive an init-db re-run (idempotent)", async () => {
+  initDb();
+  const db3 = createDbClient(join(tmpDir, "crow.db"));
+  const { rows: trg } = await db3.execute("SELECT name FROM sqlite_master WHERE type='trigger' AND name='contact_groups_group_uid_ai'");
+  assert.equal(trg.length, 1, "trigger present after re-run");
+  const { rows: idx } = await db3.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_contact_groups_group_uid'");
+  assert.equal(idx.length, 1, "UNIQUE index present after re-run");
+});

--- a/tests/groups-sync-emit.test.js
+++ b/tests/groups-sync-emit.test.js
@@ -1,0 +1,77 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import {
+  emitGroupUpsert,
+  emitGroupDelete,
+  __setEmitSinkForTest,
+} from "../servers/sharing/group-sync.js";
+import {
+  shouldSyncRowForTest,
+  EXCLUDED_COLUMNS,
+  SYNCED_TABLES,
+} from "../servers/sharing/instance-sync.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3g-emit-"));
+execFileSync(process.execPath, ["scripts/init-db.js"],
+  { env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe" });
+const db = createDbClient(join(tmpDir, "crow.db"));
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+const SECP = "a".repeat(64);
+
+test("contact_groups is a synced table", () => {
+  assert.ok(SYNCED_TABLES.includes("contact_groups"));
+});
+
+test("EXCLUDED_COLUMNS.contact_groups strips only id + created_at", () => {
+  assert.deepEqual([...EXCLUDED_COLUMNS.contact_groups].sort(), ["created_at", "id"]);
+});
+
+test("shouldSyncRow: plain group with group_uid syncs; rooms + keyless drop", () => {
+  const ok = (r) => shouldSyncRowForTest("contact_groups", r);
+  assert.equal(ok({ group_uid: "g1", name: "Family" }), true);
+  assert.equal(ok({ group_uid: "g1", room_uid: "r1", name: "Room" }), false, "room drops");
+  assert.equal(ok({ name: "no uid" }), false, "keyless drops");
+  assert.equal(ok({ group_uid: "g2" }), true, "delete-shaped {group_uid} passes (room_uid absent)");
+  assert.equal(ok(null), false);
+});
+
+test("emitGroupUpsert: attaches ONLY syncable members (I2: local-bot + pending excluded) and forwards to the sink", async () => {
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (1,'crow:m1','', ?)", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (2,'crow:m2','', ?)", args: [SECP] });
+  // A local-bot member and a pending member must NOT ride the wire (I2).
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, origin) VALUES (3,'crow:bot','', ?, 'local-bot')", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, request_status) VALUES (4,'crow:pending','', ?, 'pending')", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contact_groups (id, name, group_uid) VALUES (10,'Family','g10')" });
+  await db.execute({ sql: "INSERT INTO contact_group_members (group_id, contact_id) VALUES (10,1),(10,2),(10,3),(10,4)" });
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (t, op, row) => seen.push([t, op, row.group_uid, [...(row.members || [])].sort(), row.id]) });
+  await emitGroupUpsert(db, 10);
+  assert.equal(seen.length, 1);
+  assert.deepEqual(seen[0], ["contact_groups", "update", "g10", ["crow:m1", "crow:m2"], 10], "local-bot + pending members excluded from the wire-map");
+  __setEmitSinkForTest(null);
+});
+
+test("emitGroupUpsert: a ROOM group is never emitted", async () => {
+  await db.execute({ sql: "INSERT INTO contact_groups (id, name, group_uid, room_uid) VALUES (11,'Room','g11','room-uid-1')" });
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (...a) => seen.push(a) });
+  await emitGroupUpsert(db, 11);
+  assert.equal(seen.length, 0, "room_uid != null → helper skips");
+  __setEmitSinkForTest(null);
+});
+
+test("emitGroupDelete + missing-row + null-sink are all no-throw", async () => {
+  const seen = [];
+  __setEmitSinkForTest({ emitChange: async (t, op, row) => seen.push([t, op, row.group_uid]) });
+  await emitGroupDelete("g10");
+  assert.deepEqual(seen[0], ["contact_groups", "delete", "g10"]);
+  __setEmitSinkForTest(null);
+  await emitGroupUpsert(db, 9999); // no such group → no throw
+  await emitGroupDelete("");       // empty uid → no-op, no throw
+  await emitGroupUpsert(db, 10);   // null sink → no throw
+});

--- a/tests/groups-sync.test.js
+++ b/tests/groups-sync.test.js
@@ -1,0 +1,149 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { sign } from "../servers/sharing/identity.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-p3g-apply-"));
+execFileSync(process.execPath, ["scripts/init-db.js"],
+  { env: { ...process.env, CROW_DATA_DIR: tmpDir }, stdio: "pipe" });
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+const REMOTE_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+const SECP = "a".repeat(64);
+
+function mgr(id = "aaaaaaaa-0000-0000-0000-000000000001") {
+  return new InstanceSyncManager(IDENTITY, createDbClient(DB_PATH), id);
+}
+function signedEntry(table, op, row, lamport_ts, instance_id = REMOTE_ID) {
+  const e = { table, op, row, lamport_ts, instance_id };
+  e.signature = sign(JSON.stringify(e), IDENTITY.ed25519Priv);
+  return e;
+}
+async function members(db, gUid) {
+  const { rows } = await db.execute({
+    sql: `SELECT c.crow_id FROM contact_group_members gm
+            JOIN contacts c ON c.id = gm.contact_id
+            JOIN contact_groups g ON g.id = gm.group_id
+           WHERE g.group_uid = ? ORDER BY c.crow_id`, args: [gUid],
+  });
+  return rows.map((r) => r.crow_id);
+}
+
+test("_applyGroup: inserts a plain group keyed on group_uid + resolves members to LOCAL ids", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (50,'crow:a','', ?),(51,'crow:b','', ?)", args: [SECP, SECP] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update",
+    { id: 999, group_uid: "gg1", name: "Family", color: "#f00", members: ["crow:a", "crow:b"] }, 10));
+  const { rows } = await db.execute({ sql: "SELECT id, name, color FROM contact_groups WHERE group_uid='gg1'" });
+  assert.equal(rows.length, 1);
+  assert.notEqual(Number(rows[0].id), 999, "stored under a LOCAL id, not the wire 999");
+  assert.equal(rows[0].name, "Family");
+  assert.deepEqual(await members(db, "gg1"), ["crow:a", "crow:b"]);
+});
+
+test("_applyGroup: a ROOM entry (room_uid set) is rejected by shouldSyncRow", async () => {
+  const m = mgr(); const db = m.db;
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update",
+    { group_uid: "gg-room", room_uid: "R1", name: "Should not land", members: [] }, 11));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg-room'" })).rows[0].c, 0);
+});
+
+test("_applyGroup: an unresolvable member is skipped (never creates a contact)", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (52,'crow:known','', ?)", args: [SECP] });
+  const before = (await db.execute("SELECT COUNT(*) c FROM contacts")).rows[0].c;
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update",
+    { group_uid: "gg2", name: "Mix", members: ["crow:known", "crow:ghost"] }, 12));
+  assert.deepEqual(await members(db, "gg2"), ["crow:known"], "only the resolvable member joined");
+  assert.equal((await db.execute("SELECT COUNT(*) c FROM contacts")).rows[0].c, before, "no phantom contact");
+});
+
+test("_applyGroup: LWW — a newer entry updates name + reconciles membership; a stale entry is skipped", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (60,'crow:x','', ?),(61,'crow:y','', ?)", args: [SECP, SECP] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg3", name: "V1", members: ["crow:x"] }, 5));
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg3", name: "V2", members: ["crow:x", "crow:y"] }, 9));
+  assert.equal((await db.execute({ sql: "SELECT name FROM contact_groups WHERE group_uid='gg3'" })).rows[0].name, "V2");
+  assert.deepEqual(await members(db, "gg3"), ["crow:x", "crow:y"]);
+  // Stale replay (lower lamport) must not revert.
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg3", name: "STALE", members: ["crow:x"] }, 3));
+  assert.equal((await db.execute({ sql: "SELECT name FROM contact_groups WHERE group_uid='gg3'" })).rows[0].name, "V2", "stale entry ignored");
+  assert.deepEqual(await members(db, "gg3"), ["crow:x", "crow:y"], "stale membership ignored");
+});
+
+test("_applyGroup: reconcile REMOVES a syncable member absent from the wire-map", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (70,'crow:p','', ?),(71,'crow:q','', ?)", args: [SECP, SECP] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg4", name: "G", members: ["crow:p", "crow:q"] }, 5));
+  assert.deepEqual(await members(db, "gg4"), ["crow:p", "crow:q"]);
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg4", name: "G", members: ["crow:p"] }, 9));
+  assert.deepEqual(await members(db, "gg4"), ["crow:p"], "crow:q removed by full-replace");
+});
+
+test("_applyGroup: reconcile does NOT remove a LOCAL-BOT member the peer can't know about", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (80,'crow:human','', ?)", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, origin) VALUES (81,'crow:localbot','', ?, 'local-bot')", args: [SECP] });
+  // Group exists locally with a human + a local-bot member.
+  await db.execute({ sql: "INSERT INTO contact_groups (id, name, group_uid, lamport_ts) VALUES (200,'G','gg5',5)" });
+  await db.execute({ sql: "INSERT INTO contact_group_members (group_id, contact_id) VALUES (200,80),(200,81)" });
+  // A peer that only knows the human re-emits {crow:human}.
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg5", name: "G", members: ["crow:human"] }, 9));
+  assert.deepEqual(await members(db, "gg5"), ["crow:human", "crow:localbot"], "local-bot membership preserved (not wiped by peer full-replace)");
+});
+
+test("_applyGroup: I2 — a wire-map naming a LOCAL-BOT contact does NOT add it (add-branch bounded to syncable)", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (85,'crow:h2','', ?)", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, origin) VALUES (86,'crow:bot2','', ?, 'local-bot')", args: [SECP] });
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey, request_status) VALUES (87,'crow:pend','', ?, 'pending')", args: [SECP] });
+  // Peer's wire-map names a human, a local-bot, and a pending contact — only the human joins.
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update",
+    { group_uid: "gg5b", name: "G", members: ["crow:h2", "crow:bot2", "crow:pend"] }, 5));
+  assert.deepEqual(await members(db, "gg5b"), ["crow:h2"], "resolved-but-non-syncable members (local-bot, pending) skipped on add");
+});
+
+test("_applyGroup: delete is lamport-gated + cascades membership; stale delete logs a conflict and keeps local", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (90,'crow:z','', ?)", args: [SECP] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg6", name: "Doomed", members: ["crow:z"] }, 5));
+  // Stale delete (lower lamport) → kept.
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "delete", { group_uid: "gg6" }, 3));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg6'" })).rows[0].c, 1, "stale delete ignored");
+  // Newer delete → removed + membership cascade-reaped.
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "delete", { group_uid: "gg6" }, 9));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg6'" })).rows[0].c, 0);
+  assert.deepEqual(await members(db, "gg6"), [], "membership cascade-reaped on delete");
+});
+
+test("_applyGroup: a forged wire id/room_uid cannot hijack — id ignored, room dropped, never throws", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contact_groups (id, name, group_uid) VALUES (300,'Existing','gg7')" });
+  // Attacker copies an existing local id + tries to inject room_uid.
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update",
+    { id: 300, group_uid: "gg-new", room_uid: "HIJACK", name: "evil", members: [] }, 20));
+  // room_uid present → shouldSyncRow drops the whole entry (nothing lands).
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg-new'" })).rows[0].c, 0);
+  assert.equal((await db.execute({ sql: "SELECT name FROM contact_groups WHERE id=300" })).rows[0].name, "Existing", "existing row untouched (wire id ignored)");
+});
+
+test("_applyGroup: members ABSENT (no key) skips reconcile — a metadata-only emit cannot wipe members; explicit [] still empties (R2 F3)", async () => {
+  const m = mgr(); const db = m.db;
+  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (95,'crow:keep','', ?)", args: [SECP] });
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg8", name: "G", members: ["crow:keep"] }, 5));
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg8", name: "G2" }, 9)); // no members key
+  assert.equal((await db.execute({ sql: "SELECT name FROM contact_groups WHERE group_uid='gg8'" })).rows[0].name, "G2", "metadata applied");
+  assert.deepEqual(await members(db, "gg8"), ["crow:keep"], "absent members key → membership untouched");
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg8", name: "G3", members: [] }, 12));
+  assert.deepEqual(await members(db, "gg8"), [], "explicit [] honored — legit empty group");
+});


### PR DESCRIPTION
## What

Plain contact groups (name, color, membership) now sync across a user's paired instances over the ed25519-signed instance-sync mesh — completing the Phase 3 "everything follows the user" set (contacts #141, messages #146, now groups). Multi-party **rooms** (`room_uid` set) are explicitly carved out at three layers — they have their own hub-and-spoke sync and never ride this path.

**Six commits (TDD, task-per-commit):**
1. Schema: `contact_groups.group_uid TEXT` (UNIQUE index) + `lamport_ts` + an `AFTER INSERT … WHEN NEW.group_uid IS NULL` random-uid trigger for new rows — **`SCHEMA_GENERATION` 4→5**, applied fleet-wide by the boot drift gate. Pre-existing rows deliberately stay NULL (see 4).
2. `group-sync.js` emit helper + carve-outs + emits at all 6 plain-group mutation sites; the member wire-map carries contact `crow_id`s only (local FKs never portable), filtered to syncable contacts.
3. `_applyGroup`: `group_uid`-keyed LWW apply with PRAGMA-whitelisted columns, `ALWAYS_DROP` on room/identity columns, whole-set membership reconcile bounded to syncable contacts (absent ≠ empty), lamport-gated hard-delete + conflict rows, never creates contacts.
4. **The convergence linchpin:** pre-existing groups get **deterministic** uids — `sha256(shared-identity-pubkey : lower(name))[:32]`, assigned by the manager every boot via a **collision-driven retry** (`\x1f`-keyed slots, crash-idempotent by construction) — so "Family" created on two instances pre-feature converges to ONE group instead of duplicating fleet-wide. Backfill follows the #147 pattern (only `done:<n>` terminal, drain-inbound-first, UPSERT done-mark).
5. Test-hygiene: a Phase-2 test asserted `SCHEMA_GENERATION === 4` exactly; now floor-asserts.
6. Final-review hardening: all `group_uid` lookups gated `AND room_uid IS NULL`.

## Review provenance

Plan: 2-round adversarial Opus review — **R1 caught a critical** (random-uid backfill would permanently duplicate every pre-existing shared group) and **R2 caught the fix's own flaw** (the `name#2` tie-break collided with literally-named groups + wasn't crash-idempotent); both folded pre-code. Final whole-branch security review: **READY TO MERGE, 0 blockers** — all ten closure checks confirmed in code, UNIQUE-error regex verified against live libsql output, no injection/pollution/ping-pong surfaces, Funnel invariant intact (auth-network 15/15).

## Tests

29 new across 4 files. Full suite **1183/1183**. Fresh-datadir init: `user_version=5`, index + trigger present, boot smoke clean.