### PR TITLE
fix(install): P4 audit hardening — unattended-safe installer (F-INSTALL-1/2/5/6/7/9/11)

### DIFF
--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -94,7 +94,7 @@ ask_line() {
 # Self before Peer).
 ts_first_field() {
   local key="$1"
-  if [[ ${TS_JSON:-} =~ \"${key}\":\"([^\"]*)\" ]]; then
+  if [[ ${TS_JSON:-} =~ \"${key}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\" ]]; then
     printf "%s" "${BASH_REMATCH[1]}"
   fi
 }
@@ -344,7 +344,7 @@ if command -v tailscale &>/dev/null; then
 
     if [ "$CURRENT_TS_HOSTNAME" = "crow" ]; then
       log "Tailscale hostname is already set to 'crow'"
-    elif [[ $TS_JSON == *'"HostName":"crow"'* ]]; then
+    elif [[ $TS_JSON =~ \"HostName\"[[:space:]]*:[[:space:]]*\"crow\" ]]; then
       warn "Tailscale hostname 'crow' is already taken by another device on your tailnet."
       TS_HOSTNAME="$(ask_line "Enter a Tailscale hostname (or press Enter to skip): ")"
       if [ -n "$TS_HOSTNAME" ]; then

--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -311,9 +311,29 @@ fi
 sudo ufw default deny incoming
 sudo ufw default allow outgoing
 sudo ufw allow 22/tcp comment 'SSH'
-sudo ufw allow 443/tcp comment 'HTTPS (Caddy)'
+
+# 443 serves only Caddy's LAN vhost (https://${MDNS_HOST}); on a cloud VM
+# that is an unintended PUBLIC surface (F-INSTALL-2). Cloud heuristic: the
+# link-local metadata endpoint answers on AWS/Oracle/GCP/Azure/DO and never
+# on home LANs. (Local-address checks don't work — Oracle NATs a private IP.)
+IS_CLOUD_HOST=false
+if curl -s -m 2 -o /dev/null http://169.254.169.254/ 2>/dev/null; then
+  IS_CLOUD_HOST=true
+fi
+OPEN_443_DEFAULT=Y
+if [ "$IS_CLOUD_HOST" = true ]; then
+  OPEN_443_DEFAULT=N
+  warn "Cloud/VPS environment detected — opening 443 would expose it to the internet."
+fi
+if ask_yn "Open port 443 for LAN access to https://${MDNS_HOST}?" "$OPEN_443_DEFAULT"; then
+  sudo ufw allow 443/tcp comment 'HTTPS (Caddy)'
+  log "Port 443 open (LAN HTTPS via Caddy)"
+else
+  warn "Port 443 closed — use Tailscale for remote access"
+fi
+
 sudo ufw --force enable
-log "Firewall enabled (SSH + HTTPS only)"
+log "Firewall enabled"
 
 # Install ufw-docker to fix Docker/UFW conflict
 if [ ! -f /usr/local/bin/ufw-docker ]; then
@@ -369,6 +389,33 @@ if command -v tailscale &>/dev/null; then
         warn "Keeping Tailscale hostname '${CURRENT_TS_HOSTNAME:-unknown}'"
       fi
     fi
+
+    # ── F-INSTALL-1: wire Tailscale Serve so the dashboard is reachable over
+    # the tailnet with real HTTPS (and the gateway gets an HTTPS issuer URL —
+    # without it a cloud install has NO reachable dashboard at all).
+    # Serve is tailnet-only; this never touches Funnel (public exposure).
+    GATEWAY_HTTPS_URL=""
+    TS_DNSNAME="$(ts_first_field DNSName)"
+    TS_DNSNAME="${TS_DNSNAME%.}"   # strip trailing dot
+    if [ -n "$TS_DNSNAME" ]; then
+      if ask_yn "Serve the dashboard at https://${TS_DNSNAME}/ (tailnet-only, recommended)?" Y; then
+        if sudo tailscale serve --bg --https=443 http://127.0.0.1:3001 >/dev/null 2>&1; then
+          GATEWAY_HTTPS_URL="https://${TS_DNSNAME}"
+          log "Tailscale Serve wired: ${GATEWAY_HTTPS_URL}/ → localhost:3001 (tailnet only)"
+          if grep -q '^CROW_GATEWAY_URL=' "$CROW_HOME/.env" 2>/dev/null; then
+            sed -i "s|^CROW_GATEWAY_URL=.*|CROW_GATEWAY_URL=${GATEWAY_HTTPS_URL}|" "$CROW_HOME/.env"
+          else
+            printf '\nCROW_GATEWAY_URL=%s\n' "$GATEWAY_HTTPS_URL" >> "$CROW_HOME/.env"
+          fi
+          sudo systemctl restart crow-gateway
+          log "CROW_GATEWAY_URL=${GATEWAY_HTTPS_URL} written to $CROW_HOME/.env (gateway restarted)"
+        else
+          warn "tailscale serve failed — wire it later: sudo tailscale serve --bg --https=443 http://127.0.0.1:3001"
+        fi
+      else
+        warn "Skipped Tailscale Serve — remote HTTPS access not configured"
+      fi
+    fi
   else
     warn "Tailscale is installed but not authenticated"
     warn "Run 'sudo tailscale up' to log in, then re-run this step"
@@ -418,6 +465,9 @@ echo "  Crow is ready!"
 echo ""
 echo "  Open in your browser:"
 echo "    https://${MDNS_HOST}/setup"
+if [ -n "${GATEWAY_HTTPS_URL:-}" ]; then
+  echo "    ${GATEWAY_HTTPS_URL}/setup   (any device on your tailnet)"
+fi
 echo ""
 echo "  What's next:"
 echo "    1. Set your Crow's Nest password at /setup"

--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -203,13 +203,17 @@ fi
 # Set hostname to 'crow' for crow.local resolution
 CURRENT_HOSTNAME=$(hostname)
 if [ "$CURRENT_HOSTNAME" != "crow" ]; then
-  read -p "  Set hostname to 'crow' (enables crow.local)? [Y/n] " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+  # Renaming the machine is destructive under automation (F-INSTALL-11):
+  # default NO, headless never renames. When skipped, Caddy serves
+  # <hostname>.local instead of crow.local (below).
+  if ask_yn "Set hostname to 'crow' (enables crow.local)?" N; then
     sudo hostnamectl set-hostname crow
     log "Hostname set to 'crow' — accessible as crow.local on your network"
+  else
+    warn "Keeping hostname '$CURRENT_HOSTNAME' — Crow will be at https://${CURRENT_HOSTNAME}.local"
   fi
 fi
+MDNS_HOST="$(hostname).local"
 
 # ─── Step 6: Clone and Setup Crow ────────────────────────
 
@@ -260,14 +264,16 @@ header "Step 7/9: System Services"
 sudo tee /etc/systemd/system/crow-gateway.service > /dev/null << EOF
 [Unit]
 Description=Crow Gateway
-After=network.target
+Wants=network-online.target
+After=network-online.target docker.service tailscaled.service
+Requires=docker.service
 
 [Service]
 Type=simple
 User=$USER
 WorkingDirectory=$CROW_APP
 ExecStart=$(which node) servers/gateway/index.js
-Restart=unless-stopped
+Restart=on-failure
 RestartSec=5
 Environment=NODE_ENV=production
 Environment=CROW_DATA_DIR=$CROW_DATA
@@ -277,9 +283,9 @@ Environment=CROW_DB_PATH=$CROW_DATA/crow.db
 WantedBy=multi-user.target
 EOF
 
-# Caddy reverse proxy with self-signed cert for crow.local
-sudo tee /etc/caddy/Caddyfile > /dev/null << 'EOF'
-crow.local {
+# Caddy reverse proxy with self-signed cert for the actual hostname
+sudo tee /etc/caddy/Caddyfile > /dev/null << EOF
+${MDNS_HOST} {
     tls internal
     reverse_proxy localhost:3001
 }
@@ -289,7 +295,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now crow-gateway
 sudo systemctl restart caddy
 log "Gateway service enabled and started"
-log "Caddy configured for https://crow.local"
+log "Caddy configured for https://${MDNS_HOST}"
 
 # ─── Step 8: Security Hardening ──────────────────────────
 
@@ -411,7 +417,7 @@ echo ""
 echo "  Crow is ready!"
 echo ""
 echo "  Open in your browser:"
-echo "    https://crow.local/setup"
+echo "    https://${MDNS_HOST}/setup"
 echo ""
 echo "  What's next:"
 echo "    1. Set your Crow's Nest password at /setup"

--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -407,8 +407,11 @@ if command -v tailscale &>/dev/null; then
           else
             printf '\nCROW_GATEWAY_URL=%s\n' "$GATEWAY_HTTPS_URL" >> "$CROW_HOME/.env"
           fi
-          sudo systemctl restart crow-gateway
-          log "CROW_GATEWAY_URL=${GATEWAY_HTTPS_URL} written to $CROW_HOME/.env (gateway restarted)"
+          if sudo systemctl restart crow-gateway; then
+            log "CROW_GATEWAY_URL=${GATEWAY_HTTPS_URL} written to $CROW_HOME/.env (gateway restarted)"
+          else
+            warn "Gateway restart failed — restart manually: sudo systemctl restart crow-gateway"
+          fi
         else
           warn "tailscale serve failed — wire it later: sudo tailscale serve --bg --https=443 http://127.0.0.1:3001"
         fi

--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -35,6 +35,64 @@ header() {
   echo "═══════════════════════════════════════════════"
 }
 
+# ─── Prompt helpers (F-INSTALL-5/-7) ──────────────────────
+# The documented `curl … | bash` one-liner has no usable stdin (the script
+# body IS stdin), so prompts read /dev/tty when a terminal exists and resolve
+# to their DEFAULT when it does not (headless / cloud-init / CI).
+# `--yes` / `-y` / CROW_INSTALL_YES=1 forces defaults everywhere.
+ASSUME_YES=false
+for _arg in "$@"; do
+  case "$_arg" in
+    -y|--yes) ASSUME_YES=true ;;
+  esac
+done
+if [ "${CROW_INSTALL_YES:-}" = "1" ]; then ASSUME_YES=true; fi
+
+# Real tty detection (R1-I1): [ -r /dev/tty ] only tests the device node's
+# permission bits and is TRUE even with no controlling terminal. Actually
+# opening it is the reliable probe (fails with ENXIO when headless), and it
+# keeps genuinely-headless installs from spraying /dev/tty errors into logs.
+HAS_TTY=false
+if { exec 3</dev/tty; } 2>/dev/null; then
+  exec 3<&-
+  HAS_TTY=true
+fi
+
+# ask_yn <prompt> <default Y|N> — 0=yes, 1=no. Headless/--yes → default.
+ask_yn() {
+  local prompt="$1" default="$2" reply=""
+  if [ "$ASSUME_YES" = true ] || [ "$HAS_TTY" = false ]; then
+    [ "$default" = "Y" ] && return 0 || return 1
+  fi
+  if [ "$default" = "Y" ]; then
+    printf "  %s [Y/n] " "$prompt" > /dev/tty
+  else
+    printf "  %s [y/N] " "$prompt" > /dev/tty
+  fi
+  IFS= read -r reply < /dev/tty || reply=""
+  case "$reply" in
+    [Yy]*) return 0 ;;
+    [Nn]*) return 1 ;;
+    *) [ "$default" = "Y" ] && return 0 || return 1 ;;
+  esac
+}
+
+# ask_line <prompt> — prints the reply; empty when headless/--yes/EOF.
+ask_line() {
+  local prompt="$1" reply=""
+  if [ "$ASSUME_YES" = true ] || [ "$HAS_TTY" = false ]; then
+    return 0
+  fi
+  printf "  %s" "$prompt" > /dev/tty
+  IFS= read -r reply < /dev/tty || reply=""
+  printf "%s" "$reply"
+}
+
+# Test seam: tests source the helpers without executing the install.
+if [ "${CROW_INSTALL_SOURCE_ONLY:-}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 # Check if running as root (we don't want that)
 if [ "$(id -u)" -eq 0 ]; then
   error "Don't run this script as root. Run as your normal user."
@@ -59,9 +117,7 @@ echo "    - Crow"
 echo "    - Security hardening (UFW + fail2ban)"
 echo "    - Tailscale hostname setup (if Tailscale is installed)"
 echo ""
-read -p "  Continue? [Y/n] " -n 1 -r
-echo
-if [[ $REPLY =~ ^[Nn]$ ]]; then
+if ! ask_yn "Continue?" Y; then
   echo "  Cancelled."
   exit 0
 fi

--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -88,6 +88,17 @@ ask_line() {
   printf "%s" "$reply"
 }
 
+# ts_first_field <JsonKey> — first "<JsonKey>":"value" in $TS_JSON, no pipes
+# (F-INSTALL-6: piping through grep then head SIGPIPEs under pipefail on big tailnets).
+# The first match is always the Self block (tailscale status --json emits
+# Self before Peer).
+ts_first_field() {
+  local key="$1"
+  if [[ ${TS_JSON:-} =~ \"${key}\":\"([^\"]*)\" ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+  fi
+}
+
 # Test seam: tests source the helpers without executing the install.
 if [ "${CROW_INSTALL_SOURCE_ONLY:-}" = "1" ]; then
   return 0 2>/dev/null || exit 0
@@ -295,7 +306,7 @@ sudo ufw default deny incoming
 sudo ufw default allow outgoing
 sudo ufw allow 22/tcp comment 'SSH'
 sudo ufw allow 443/tcp comment 'HTTPS (Caddy)'
-echo "y" | sudo ufw enable
+sudo ufw --force enable
 log "Firewall enabled (SSH + HTTPS only)"
 
 # Install ufw-docker to fix Docker/UFW conflict
@@ -327,47 +338,31 @@ if command -v tailscale &>/dev/null; then
   if tailscale status &>/dev/null; then
     log "Tailscale is authenticated"
 
-    # Check if 'crow' hostname is already taken on the tailnet
-    CROW_HOSTNAME_TAKEN=false
-    CURRENT_TS_HOSTNAME=$(tailscale status --json 2>/dev/null | grep -o '"HostName":"[^"]*"' | head -1 | cut -d'"' -f4)
+    # Capture status JSON ONCE — never pipe it (F-INSTALL-6).
+    set +e
+    TS_JSON="$(tailscale status --json 2>/dev/null)"
+    set -e
+    CURRENT_TS_HOSTNAME="$(ts_first_field HostName)"
 
     if [ "$CURRENT_TS_HOSTNAME" = "crow" ]; then
       log "Tailscale hostname is already set to 'crow'"
-    else
-      # Check if another device on the tailnet is using 'crow'
-      if tailscale status --json 2>/dev/null | grep -q '"HostName":"crow"'; then
-        CROW_HOSTNAME_TAKEN=true
-      fi
-
-      if [ "$CROW_HOSTNAME_TAKEN" = true ]; then
-        warn "Tailscale hostname 'crow' is already taken by another device on your tailnet."
-        SUGGESTED="crow-$(hostname)"
-        echo ""
-        echo "  Suggested alternatives:"
-        echo "    - crow-2"
-        echo "    - $SUGGESTED"
-        echo ""
-        read -p "  Enter a Tailscale hostname (or press Enter to skip): " TS_HOSTNAME
-        echo
-        if [ -n "$TS_HOSTNAME" ]; then
-          sudo tailscale set --hostname="$TS_HOSTNAME"
-          log "Tailscale hostname set to '$TS_HOSTNAME' — access Crow at http://$TS_HOSTNAME/"
-        else
-          warn "Skipped Tailscale hostname setup"
-        fi
+    elif [[ $TS_JSON == *'"HostName":"crow"'* ]]; then
+      warn "Tailscale hostname 'crow' is already taken by another device on your tailnet."
+      TS_HOSTNAME="$(ask_line "Enter a Tailscale hostname (or press Enter to skip): ")"
+      if [ -n "$TS_HOSTNAME" ]; then
+        sudo tailscale set --hostname="$TS_HOSTNAME"
+        log "Tailscale hostname set to '$TS_HOSTNAME'"
       else
-        echo ""
-        echo "  Would you like to set this machine's Tailscale hostname to 'crow'?"
-        echo "  This lets you access Crow at http://crow/ from any device on your Tailnet."
-        echo ""
-        read -p "  Set Tailscale hostname to 'crow'? [Y/n] " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-          sudo tailscale set --hostname=crow
-          log "Tailscale hostname set to 'crow' — access Crow at http://crow/ from your Tailnet"
-        else
-          warn "Skipped Tailscale hostname setup"
-        fi
+        warn "Skipped Tailscale hostname setup"
+      fi
+    else
+      # Destructive rename: default NO; headless installs never rename
+      # (F-INSTALL-7 — the old default-Y renamed fresh nodes to 'crow').
+      if ask_yn "Set Tailscale hostname to 'crow'?" N; then
+        sudo tailscale set --hostname=crow
+        log "Tailscale hostname set to 'crow'"
+      else
+        warn "Keeping Tailscale hostname '${CURRENT_TS_HOSTNAME:-unknown}'"
       fi
     fi
   else

--- a/scripts/crow-install.sh
+++ b/scripts/crow-install.sh
@@ -339,9 +339,7 @@ if command -v tailscale &>/dev/null; then
     log "Tailscale is authenticated"
 
     # Capture status JSON ONCE — never pipe it (F-INSTALL-6).
-    set +e
-    TS_JSON="$(tailscale status --json 2>/dev/null)"
-    set -e
+    TS_JSON="$(tailscale status --json 2>/dev/null || true)"
     CURRENT_TS_HOSTNAME="$(ts_first_field HostName)"
 
     if [ "$CURRENT_TS_HOSTNAME" = "crow" ]; then

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -105,7 +105,26 @@ test("F-6/F-7: collision check matches indented `\"HostName\": \"crow\"` (real t
   assert.equal(miss.stdout.trim(), "MISS");
 });
 
-// NOTE(A4): the "no raw read -p remains" end-state pin is added by Task A4, after A2/A3 migrate the remaining prompts.
+test("F-1: Serve wiring present — serve command + CROW_GATEWAY_URL write + gateway restart", () => {
+  assert.match(src(), /tailscale serve --bg --https=443 http:\/\/127\.0\.0\.1:3001/);
+  assert.match(src(), /CROW_GATEWAY_URL=\$\{GATEWAY_HTTPS_URL\}|CROW_GATEWAY_URL=%s/);
+  assert.match(src(), /systemctl restart crow-gateway/);
+});
+
+test("F-2: 443 is prompted, with cloud-metadata heuristic flipping the default", () => {
+  assert.match(src(), /169\.254\.169\.254/);
+  assert.match(src(), /OPEN_443_DEFAULT/);
+  // The bare unconditional allow must be gone:
+  assert.doesNotMatch(src(), /^sudo ufw allow 443\/tcp/m);
+});
+
+test("F-5 end-state pin (deferred from A1): no raw read -p prompts remain anywhere", () => {
+  assert.doesNotMatch(src(), /read -p/);
+});
+
+test("collision elif stays whitespace-tolerant (pin for the A2 HIT/MISS test's regex copy)", () => {
+  assert.match(src(), /elif \[\[ \$TS_JSON =~ \\"HostName\\"\[\[:space:\]\]\*:\[\[:space:\]\]\*\\"crow\\" \]\]/);
+});
 
 test("F-9: systemd unit uses Restart=on-failure (unless-stopped is Docker, not systemd)", () => {
   assert.match(src(), /Restart=on-failure/);

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -8,10 +8,13 @@ const SCRIPT = resolve(import.meta.dirname, "..", "scripts", "crow-install.sh");
 const src = () => readFileSync(SCRIPT, "utf-8");
 
 /** Source the installer's helper layer (CROW_INSTALL_SOURCE_ONLY=1) and run a
- *  snippet against it. stdin is /dev/null → HAS_TTY=false (headless path). */
+ *  snippet against it. detached:true puts the child in a new session with no
+ *  controlling terminal, so the /dev/tty open-probe fails → HAS_TTY=false and
+ *  the headless path is exercised even from an interactive terminal. */
 function runWithHelpers(snippet, env = {}) {
   return spawnSync("bash", ["-c", `set -euo pipefail; CROW_INSTALL_SOURCE_ONLY=1 source "${SCRIPT}"; ${snippet}`], {
     stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
     env: { ...process.env, ...env },
     encoding: "utf-8",
   });

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -55,7 +55,11 @@ test("F-5: ask_line returns empty headlessly instead of failing under set -e", (
 });
 
 test("F-6: no pipeline consumes `tailscale status --json` (captured into TS_JSON instead)", () => {
-  assert.doesNotMatch(src(), /tailscale status --json[^\n]*\|/);
+  const tsLines = src().split("\n").filter((l) => l.includes("tailscale status --json"));
+  assert.ok(tsLines.length > 0, "TS_JSON capture exists");
+  for (const l of tsLines) {
+    assert.doesNotMatch(l.replaceAll("||", ""), /\|/, `pipeline on: ${l.trim()}`);
+  }
   assert.match(src(), /TS_JSON=/);
 });
 

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SCRIPT = resolve(import.meta.dirname, "..", "scripts", "crow-install.sh");
+const src = () => readFileSync(SCRIPT, "utf-8");
+
+/** Source the installer's helper layer (CROW_INSTALL_SOURCE_ONLY=1) and run a
+ *  snippet against it. stdin is /dev/null → HAS_TTY=false (headless path). */
+function runWithHelpers(snippet, env = {}) {
+  return spawnSync("bash", ["-c", `set -euo pipefail; CROW_INSTALL_SOURCE_ONLY=1 source "${SCRIPT}"; ${snippet}`], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+    encoding: "utf-8",
+  });
+}
+
+test("bash -n: installer parses", () => {
+  execFileSync("bash", ["-n", SCRIPT]);
+});
+
+test("shellcheck passes when available (skips otherwise)", (t) => {
+  const which = spawnSync("shellcheck", ["--version"], { stdio: "ignore" });
+  if (which.error) return t.skip("shellcheck not installed");
+  // SC2154/SC1090/SC1091: sourced-file + installer-pattern noise; everything else must pass
+  const r = spawnSync("shellcheck", ["-e", "SC1090,SC1091", SCRIPT], { encoding: "utf-8" });
+  assert.equal(r.status, 0, r.stdout);
+});
+
+test("F-5: headless ask_yn resolves to its default (Y and N)", () => {
+  const y = runWithHelpers(`if ask_yn "Continue?" Y; then echo YES; else echo NO; fi`);
+  assert.equal(y.status, 0, y.stderr);
+  assert.match(y.stdout, /YES/);
+  const n = runWithHelpers(`if ask_yn "Rename?" N; then echo YES; else echo NO; fi`);
+  assert.equal(n.status, 0, n.stderr);
+  assert.match(n.stdout, /NO/);
+});
+
+test("F-5: CROW_INSTALL_YES=1 forces defaults without a tty", () => {
+  const r = runWithHelpers(`if ask_yn "Continue?" Y; then echo YES; fi; if ask_yn "Rename?" N; then echo BAD; else echo SKIPPED; fi`, { CROW_INSTALL_YES: "1" });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /YES/);
+  assert.match(r.stdout, /SKIPPED/);
+});
+
+test("F-5: ask_line returns empty headlessly instead of failing under set -e", () => {
+  const r = runWithHelpers(`v="$(ask_line "name: ")"; echo "got:[\${v}]"`);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /got:\[\]/);
+});
+
+test("F-5: no raw read -p prompts remain (all prompts go through ask_yn/ask_line)", () => {
+  assert.doesNotMatch(src(), /read -p/);
+});

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -51,6 +51,4 @@ test("F-5: ask_line returns empty headlessly instead of failing under set -e", (
   assert.match(r.stdout, /got:\[\]/);
 });
 
-test("F-5: no raw read -p prompts remain (all prompts go through ask_yn/ask_line)", () => {
-  assert.doesNotMatch(src(), /read -p/);
-});
+// NOTE(A4): the "no raw read -p remains" end-state pin is added by Task A4, after A2/A3 migrate the remaining prompts.

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -106,3 +106,24 @@ test("F-6/F-7: collision check matches indented `\"HostName\": \"crow\"` (real t
 });
 
 // NOTE(A4): the "no raw read -p remains" end-state pin is added by Task A4, after A2/A3 migrate the remaining prompts.
+
+test("F-9: systemd unit uses Restart=on-failure (unless-stopped is Docker, not systemd)", () => {
+  assert.match(src(), /Restart=on-failure/);
+  assert.doesNotMatch(src(), /Restart=unless-stopped/);
+});
+
+test("R2-I1: unit ordering matches prod (gateway runs docker compose and keys residency on the tailscale IP)", () => {
+  assert.match(src(), /After=network-online\.target docker\.service tailscaled\.service/);
+  assert.match(src(), /Wants=network-online\.target/);
+  assert.match(src(), /Requires=docker\.service/);
+});
+
+test("F-11: OS hostname rename prompt defaults N", () => {
+  assert.match(src(), /ask_yn "Set hostname to 'crow' \(enables crow\.local\)\?" N/);
+});
+
+test("F-11: Caddy vhost and final URL follow the ACTUAL hostname (MDNS_HOST)", () => {
+  assert.match(src(), /MDNS_HOST="\$\(hostname\)\.local"/);
+  assert.match(src(), /\$\{MDNS_HOST\} \{/);          // Caddyfile vhost
+  assert.match(src(), /https:\/\/\$\{MDNS_HOST\}\/setup/); // final message
+});

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -54,4 +54,31 @@ test("F-5: ask_line returns empty headlessly instead of failing under set -e", (
   assert.match(r.stdout, /got:\[\]/);
 });
 
+test("F-6: no pipeline consumes `tailscale status --json` (captured into TS_JSON instead)", () => {
+  assert.doesNotMatch(src(), /tailscale status --json[^\n]*\|/);
+  assert.match(src(), /TS_JSON=/);
+});
+
+test("F-6: no `| head` pipelines remain in the installer", () => {
+  assert.doesNotMatch(src(), /\|\s*head\b/);
+});
+
+test("F-6: ufw enable is --force, not echo-piped", () => {
+  assert.doesNotMatch(src(), /echo[^\n]*\|\s*sudo ufw enable/);
+  assert.match(src(), /sudo ufw --force enable/);
+});
+
+test("F-7: tailscale rename prompt defaults N (never renames headlessly)", () => {
+  assert.match(src(), /ask_yn "Set Tailscale hostname to 'crow'\?" N/);
+});
+
+test("F-6/F-7: helper extraction — first HostName in TS_JSON via bash regex, no pipes", () => {
+  const fakeJson = JSON.stringify({ Self: { HostName: "black-swan", DNSName: "black-swan.tn.ts.net." }, Peer: { k: { HostName: "crow", DNSName: "crow.tn.ts.net." } } });
+  const r = runWithHelpers(`TS_JSON='${fakeJson}'; ts_first_field HostName; echo; ts_first_field DNSName`);
+  assert.equal(r.status, 0, r.stderr);
+  const [host, dns] = r.stdout.trim().split("\n");
+  assert.equal(host, "black-swan");
+  assert.equal(dns, "black-swan.tn.ts.net.");
+});
+
 // NOTE(A4): the "no raw read -p remains" end-state pin is added by Task A4, after A2/A3 migrate the remaining prompts.

--- a/tests/crow-install-script.test.js
+++ b/tests/crow-install-script.test.js
@@ -77,12 +77,32 @@ test("F-7: tailscale rename prompt defaults N (never renames headlessly)", () =>
 });
 
 test("F-6/F-7: helper extraction — first HostName in TS_JSON via bash regex, no pipes", () => {
-  const fakeJson = JSON.stringify({ Self: { HostName: "black-swan", DNSName: "black-swan.tn.ts.net." }, Peer: { k: { HostName: "crow", DNSName: "crow.tn.ts.net." } } });
-  const r = runWithHelpers(`TS_JSON='${fakeJson}'; ts_first_field HostName; echo; ts_first_field DNSName`);
+  const obj = { Self: { HostName: "black-swan", DNSName: "black-swan.tn.ts.net." }, Peer: { k: { HostName: "crow", DNSName: "crow.tn.ts.net." } } };
+  // Real `tailscale status --json` output is INDENTED (Go marshaler): `"HostName": "crow"`
+  // with a space after the colon. Fixture must match that shape or it masks regressions.
+  const indented = JSON.stringify(obj, null, 2);
+  // TS_JSON passed via env (visible to the sourced helpers) — sidesteps shell quoting of multi-line JSON.
+  const r = runWithHelpers(`ts_first_field HostName; echo; ts_first_field DNSName`, { TS_JSON: indented });
   assert.equal(r.status, 0, r.stderr);
   const [host, dns] = r.stdout.trim().split("\n");
   assert.equal(host, "black-swan");
   assert.equal(dns, "black-swan.tn.ts.net.");
+  // Compact JSON (no space after colon) must also work.
+  const compact = runWithHelpers(`ts_first_field HostName`, { TS_JSON: JSON.stringify(obj) });
+  assert.equal(compact.status, 0, compact.stderr);
+  assert.equal(compact.stdout.trim(), "black-swan");
+});
+
+test("F-6/F-7: collision check matches indented `\"HostName\": \"crow\"` (real tailscale JSON shape)", () => {
+  const check = `if [[ $TS_JSON =~ \\"HostName\\"[[:space:]]*:[[:space:]]*\\"crow\\" ]]; then echo HIT; else echo MISS; fi`;
+  const withCrow = JSON.stringify({ Self: { HostName: "black-swan" }, Peer: { k: { HostName: "crow" } } }, null, 2);
+  const hit = runWithHelpers(check, { TS_JSON: withCrow });
+  assert.equal(hit.status, 0, hit.stderr);
+  assert.equal(hit.stdout.trim(), "HIT");
+  const withoutCrow = JSON.stringify({ Self: { HostName: "black-swan" }, Peer: { k: { HostName: "crow-2" } } }, null, 2);
+  const miss = runWithHelpers(check, { TS_JSON: withoutCrow });
+  assert.equal(miss.status, 0, miss.stderr);
+  assert.equal(miss.stdout.trim(), "MISS");
 });
 
 // NOTE(A4): the "no raw read -p remains" end-state pin is added by Task A4, after A2/A3 migrate the remaining prompts.


### PR DESCRIPTION
Fixes the installer half of the P4 fresh-install audit. The documented `curl … | bash` one-liner now survives unattended, never renames hosts by default, and produces a reachable, HTTPS-configured install on tailnet hosts.

| Finding | Fix |
|---|---|
| F-INSTALL-5 (MAJOR) — `read -p` confirm dies under `curl\|bash` | `/dev/tty`-reading `ask_yn`/`ask_line` helpers; headless resolves to defaults; `--yes`/`-y`/`CROW_INSTALL_YES=1` |
| F-INSTALL-6 (MAJOR) — `set -euo pipefail` + `tailscale status --json \| grep \| head` SIGPIPE silently aborts Step 9; same class in `echo y \| ufw enable` | status JSON captured ONCE into `TS_JSON`, bash-regex extraction (`ts_first_field`), zero pipes; `ufw --force enable` |
| F-INSTALL-7 (CRITICAL, latent) — unattended default RENAMED the node's tailscale hostname to `crow` | rename prompts default **No**; headless never renames; collision check SIGPIPE-safe and whitespace-tolerant (real `tailscale status --json` is indented — the old grep never matched it) |
| F-INSTALL-9 (MINOR) — `Restart=unless-stopped` is Docker syntax, ignored by systemd | `Restart=on-failure` + prod-parity `[Unit]` ordering (`network-online.target docker.service tailscaled.service`, `Requires=docker.service`) |
| F-INSTALL-11 (MINOR) — OS hostname force-renamed to `crow` | opt-in (default No); Caddy vhost + final URLs follow the ACTUAL hostname (`MDNS_HOST`) |
| F-INSTALL-1 (CRITICAL) — installer never wires Tailscale Serve → cloud installs have NO reachable dashboard | offers Serve wiring (tailnet-only, never Funnel), writes `CROW_GATEWAY_URL=https://<MagicDNS>` into `~/.crow/.env`, restarts the gateway (guarded) |
| F-INSTALL-2 (MAJOR) — 443 opened to Anywhere on cloud VPSes | 443 is now a prompt; cloud-metadata heuristic (169.254.169.254 probe) flips the default to No with a warning |

Tests: new `tests/crow-install-script.test.js` — `bash -n`, shellcheck (skips if absent), a real sourcing harness (`CROW_INSTALL_SOURCE_ONLY=1`, detached from the controlling tty) driving `ask_yn`/`ask_line`/`ts_first_field` headlessly, plus invariant pins (no `read -p`, no status-JSON pipelines, unit ordering, vhost/final-URL). Full suite 1201 pass / 0 fail / 1 skip.

Plan: `docs/superpowers/plans/2026-07-07-p4-install-fix-prs.md` (2-round adversarial review + focused confirm; per-task reviews caught and fixed a real-world JSON-shape bug live-verified against this tailnet).

Note: this PR alone does not close F-INSTALL-8 (fresh gateway DOA without an HTTPS `CROW_GATEWAY_URL` when Tailscale is absent/declined) — that lands in the companion first-boot-viability PR.