### PR TITLE
feat(nest): provider-residency health signal (F-HEALTH-1)

### DIFF
--- a/docs/superpowers/specs/2026-07-09-provider-residency-health-signal-design.md
+++ b/docs/superpowers/specs/2026-07-09-provider-residency-health-signal-design.md
@@ -1,0 +1,521 @@
+# F-HEALTH-1 — Provider-residency health signal (design)
+
+**Date:** 2026-07-09
+**Finding:** F-HEALTH-1 [S2-MAJOR, product] in `.superpowers/messages-plan/p4-findings.md`
+**Status:** design v3 — R1 + R2 adversarial reviews folded. R2 found no CRITICAL and no MAJOR;
+its empirical pass verified every load-bearing claim against the live fleet (see
+"Empirical verification").
+
+## Problem
+
+Crow has no health signal covering whether its `alwaysResident` inference providers are
+actually resident. On 2026-06-25 grackle's `vllm-cuda-embed` (its `alwaysResident` embed
+provider) stopped coming up: an old `llama-server.service` squatted 15.5 / 16 GiB of VRAM,
+so vLLM's engine init failed on every container start. Docker's `restart: unless-stopped`
+loop retried **57,604 times** over **12 days**. Nothing alerted. Semantic memory and search
+embeddings were silently degraded fleet-wide the entire time — the exact failure mode
+`gpu-orchestrator.js`'s own header comment warns about.
+
+It was found only because the PR #151 deploy made the orchestrator log its residency
+decisions, and a human happened to read the log.
+
+Three things had to line up for the outage to be invisible:
+
+1. `health-signals.js` has signals for disk, storage, agents, peers, updates, backup, sync
+   conflicts, logins, exposure, integrations, federation audit, and messages — and nothing
+   for provider residency.
+2. `gpu-orchestrator.js` only `console.log`s its ensure/skip/failure decisions.
+3. `probeReady()` runs exactly once per provider, at gateway boot, inside `ensureResident`.
+   **Nothing ever re-polls it.** A provider that dies at 09:00 on day 1 is indistinguishable
+   from a healthy one for the rest of the process lifetime.
+
+Item 3 is the root cause. Items 1 and 2 are why it never surfaced.
+
+## Goal
+
+A `providers` nest health signal that goes `warn` when an `alwaysResident` provider **this
+machine owns** has been unreachable for longer than a threshold, and that notifies through
+the existing health-monitor path (`post-listen.js` → `shouldNotify` 24h dedupe →
+`createNotification` → dashboard + ntfy).
+
+## Non-goals (explicitly declined, with reasons)
+
+- **Docker restart-loop counts.** Getting a `RestartCount` needs `docker compose ps
+  --format json` to map bundle → container id, then `docker inspect` per container: two
+  extra process spawns per unhealthy provider per poll, a hard dependency on the docker CLI
+  in a code path that must never throw, and a parse of an unstable JSON shape. The
+  *duration* of the outage ("unreachable ≥ 12h") is strictly more actionable than the
+  restart count and costs nothing.
+- **Self-heal (re-`ensureResident` on a stale provider).** In the grackle incident it would
+  have changed nothing — docker was already retrying every few seconds; the blocker was
+  VRAM. Calling `ensureResident` from a timer would take the single-flight swap lock and
+  block for up to `READINESS_TIMEOUT_MS` (4 min) on every tick of a persistent failure.
+  Detection is the fix here.
+- **A Fix-it Card.** The remedy is machine-specific (free VRAM, fix the bundle's env, start
+  docker) and has no safe one-click action.
+- **Flap detection.** See "Known limitations" — a rolling failure-ratio window is the right
+  tool and does not belong in this PR.
+
+## Architecture
+
+Three units, each independently testable.
+
+### 1. `servers/gateway/provider-health.js` — zero-import state module
+
+Exact shape of the `servers/sharing/receive-health.js` precedent: **zero imports**, so the
+nest signal can read it with a plain static import without dragging the orchestrator's
+`child_process` / `providers.js` / `db.js` chain into the dashboard render path (and into
+the test suite).
+
+State, per provider name:
+
+```
+{ owned, baseUrl, embed, ready, firstOwnedAt, lastReadyAt, lastError, checkedAt }
+```
+
+```js
+export function setResidencyInitialized()
+export function recordResidency(name, { ready, nowMs, baseUrl, embed, error })
+export function pruneResidency(declaredNames)   // only for providers no longer DECLARED
+export function getProviderHealth()
+export function _resetProviderHealth()          // test hook
+```
+
+`initialized: false` is the analogue of `receiveWired: null` — "the orchestrator never
+ran", render `off`, never a false warn.
+
+State is per-process and resets on gateway restart. That is correct, not a bug: a fresh
+boot legitimately gets a fresh warm-up window. The consequence is that a displayed age is
+"unreachable for **at least** X", and the copy says so.
+
+#### Sticky ownership (R1-CRITICAL fix)
+
+The first draft recomputed the local set every tick and pruned anything that fell out of
+it. That is a **defect that would have re-created the very outage this feature detects**.
+Both shipped `alwaysResident` providers bind a **Tailscale IP**, not loopback —
+`crow-voice` is `http://100.118.41.122:8011/v1` and `grackle-embed` is
+`http://100.121.254.89:9100/v1` — so `isLocallyOrchestratable()` is *conditional on
+`tailscale0` being present in `networkInterfaces()` at poll time*. A `tailscaled` restart,
+a `tailscale up/down`, or (on grackle, which runs on an mt7921u USB wifi adapter) a link
+flap makes the provider momentarily non-local. Prune-on-locality-loss would delete its
+outage clock and restart it from zero on the next tick — and if churn recurred faster than
+the threshold, the `warn` would **never** fire.
+
+Reviewer A proposed *freezing* the clock while non-local. That is also wrong: if
+`tailscale0` is down, the gateway genuinely cannot reach the provider over that IP, so
+embeddings really are broken and the operator should hear about it. Freezing hides a true
+outage.
+
+The correct model separates two questions:
+
+- **"Am I responsible for this provider?"** — locality, evaluated once. Sticky.
+- **"Can I reach it?"** — the probe, evaluated every tick.
+
+So: the first time a declared `alwaysResident` provider passes `isLocallyOrchestratable`,
+this process marks it `owned: true` and stamps `firstOwnedAt`. From then on it is probed
+every tick **regardless of interface churn**. A peer's provider is never owned and never
+probed (trap 1). A deferred provider is not owned until its interface appears, so its clock
+starts then, not at boot (trap 2).
+
+Ownership is re-evaluated only when the provider's `baseUrl` **changes** (stored in state
+and compared each tick), so an operator repointing a provider at a peer correctly releases
+ownership. `pruneResidency` drops only names no longer declared `alwaysResident` in the
+config at all.
+
+#### Clock semantics
+
+`lastReadyAt` is stamped on every successful probe. The provider is in outage when
+
+```
+!ready && (nowMs - (lastReadyAt ?? firstOwnedAt)) >= threshold
+```
+
+Using `lastReadyAt ?? firstOwnedAt` covers the grackle case exactly: a provider that has
+**never** answered in this process is clocked from the moment we took ownership of it.
+
+### 2. `gpu-orchestrator.js` — a residency poll that actually re-polls
+
+```js
+export function isSafeBundleId(id)                   // PURE — new
+export function localAlwaysResident(cfg, ownAddrs)   // PURE, no logging — new
+export async function pollResidency({ cfg, ownAddrs, probe, now, composeExists } = {})
+export function startResidencyMonitor()              // interval, unref'd, guarded
+```
+
+`localAlwaysResident(cfg, ownAddrs)` is a **new pure helper** with no `console.log`.
+`alwaysResidentProviders()` keeps its existing signature and its boot-time skip log, and is
+reimplemented on top of the helper so `tests/gpu-orchestrator-host-gate.test.js` stays
+green. **(R1-MAJOR: log spam.)** The first draft had `pollResidency` call
+`alwaysResidentProviders()` every tick; on every real fleet host the skipped set is always
+non-empty (crow always skips `grackle-embed`, grackle always skips `crow-voice`), so that
+would have written ~720 identical lines/day into the gateway log — a weekly-rotated file on
+crow (`/etc/logrotate.d/crow-inference`), journald on grackle. Not unbounded, but needless
+noise in the exact log that was used to find the original incident. **(R2 corrected the
+"unrotated / forever" claim; the pure-helper decision stands regardless of sink.)**
+
+Each tick, for every provider declared `alwaysResident` in `cfg`:
+
+1. Skip unless it has a `bundleId` that satisfies `isSafeBundleId` **and**
+   `bundles/<bundleId>/docker-compose.yml` exists on disk. **(R1-MAJOR: SSRF surface;
+   R2-MINOR: path traversal.)** The `providers` table syncs fleet-wide, and
+   `getOwnAddresses()` unconditionally contains `127.0.0.1` / `::1` / `localhost`. Without
+   the `bundleId` gate a paired peer could inject a bundle-less row with
+   `baseUrl: "http://127.0.0.1:<any-port>/v1"` and turn the new timer into a persistent
+   internal-service liveness oracle — a *broader* fetch surface than `acquireProvider` /
+   `maybeAcquireLocalProvider`, which both refuse a row with no `bundleId`.
+
+   The existence check alone is not enough: `composeFile()` is
+   `join(BUNDLES_DIR, bundleId, "docker-compose.yml")` with **no validation of `bundleId`
+   anywhere**, so `bundleId: ".."` resolves to the repo-root `docker-compose.yml`, which
+   exists and is tracked — the gate would pass. Hence `isSafeBundleId`: a single path
+   segment matching `/^[A-Za-z0-9][A-Za-z0-9._-]*$/`, rejecting `.`, `..`, and anything
+   containing `/` or `\`. It is enforced **inside `composeFile()` (throw)**, not only in the
+   poll, so it also hardens the pre-existing `bundleUp` / `bundleStop` `spawn` paths that
+   feed the same unvalidated value to docker. Failing closed there is safe: every caller
+   already runs inside a try/catch.
+
+   Requiring an orchestratable bundle is also just correct: a provider with no compose file
+   is not something this machine can bring up, so there is nothing to warn about.
+   (`probeReady` sends **no** headers — unlike `probeProvider` in
+   `servers/shared/providers.js` — so no `apiKey` is leaked either way. See "Trust
+   boundary".)
+2. Reset ownership if the stored `baseUrl` differs from the current one.
+3. If not yet owned and `isLocallyOrchestratable(p, ownAddrs)` → take ownership.
+4. If owned → `probeReady(p.baseUrl)` and `recordResidency(...)`. Otherwise skip silently.
+
+Then `pruneResidency(declaredNames)` where **`declaredNames` is every provider declared
+`alwaysResident` in `cfg`, regardless of locality** — *not* `localAlwaysResident`'s output.
+Passing the local set would drop a provider the moment its interface flapped, which is the
+R1 CRITICAL re-entering through the prune door. Peers' providers are never recorded, so
+including them in `declaredNames` is harmless.
+
+`composeExists` is injectable (defaulting to `existsSync(composeFile(id))`) so the poll's
+unit tests don't couple to repo layout.
+
+`startResidencyMonitor` runs its own interval (`CROW_PROVIDER_RESIDENCY_POLL_MS`, default
+120 s), **independent of `GPU_IDLE_REVERT_MS`**. Folding it into `startIdleRevertTimer`
+would make residency monitoring silently die whenever an operator set
+`GPU_IDLE_REVERT_MS=0`. Set the poll interval to `0` to disable. The interval is `unref()`d,
+guarded by `if (_residencyTimer) return` (mirroring `startIdleRevertTimer`), and guarded by
+an in-flight flag so a slow poll cannot stack.
+
+**Arming happens first.** `initOrchestrator` sets `_initialized = true` before any `await`,
+so a throw anywhere in its body permanently blocks retry — and the caller only
+`.catch()`es and logs (`post-listen.js:194`). If the monitor were wired at the *end*, any
+future throw in the ensure loop would leave detection silently disarmed for the process
+lifetime: the exact failure class this PR exists to eliminate. So `setResidencyInitialized()`
+and `startResidencyMonitor()` are called **immediately after `_initialized = true`, before
+anything that can throw**, and the rest of `initOrchestrator`'s body is wrapped in a
+try/catch. **(R2-NIT, promoted — it defends the feature's own liveness.)**
+
+A consequence worth stating plainly: the first poll therefore runs *concurrently with* the
+boot `ensureResident` loop rather than after it. That is fine and is why the threshold has
+margin — the poll stamps `firstOwnedAt` at t≈0 and `ensureResident`'s warm completes within
+`READINESS_INITIAL_DELAY_MS + READINESS_TIMEOUT_MS` = 241 s, well inside the 600 s
+threshold. (The v2 draft claimed the warm "elapses before the first poll". With
+end-of-init wiring that was true but fragile; with early arming it is simply irrelevant.)
+
+The monitor is started **unconditionally**, not "only when providers are declared": a
+provider can be added through the LLM settings UI after boot, and a monitor that never
+started would never notice. A tick with nothing declared is a no-op over a cached
+`loadProviders()` — the idle-revert timer already calls `loadProviders()` on the same
+cadence, so this adds no measurable cost.
+
+`pollResidency` is read-only: it calls `probeReady` and nothing else. It never takes the
+`_swapInFlight` lock, never starts or stops a container. A throw from `loadProviders()` is
+caught and the tick becomes a no-op, leaving prior state intact rather than wiping it.
+
+### 3. `providersSignal(lang, nowFn)` in `health-signals.js`
+
+Reads `getProviderHealth()` and formats. Zero I/O. Declared **`async`** — not because it
+awaits anything, but because `collectHealthSignals` builds its array by *eagerly invoking*
+each signal and only then wraps the results (`[…, providersSignal(…)].map(p =>
+Promise.resolve(p).catch(…))`). A synchronous throw would therefore escape the per-signal
+`.catch()` and reject the whole `Promise.all`, taking down **every** signal. `async` turns
+any future throw into a catchable rejection. **(R1-NIT, but a real latent trap — the
+existing sync `federationAuditSignal` has the same exposure.)**
+
+Registered in `collectHealthSignals`' `Promise.all` beside `messagesSignal`. Issue id is
+the stable string `"providers"`, which is all the existing 24h dedupe in
+`post-listen.js:215-239` needs.
+
+Severity precedence, mirroring `messagesSignal`:
+
+| Condition | state | severity | value |
+|---|---|---|---|
+| `initialized === false` | `off` | null | "not started" |
+| no owned providers | `off` | null | "none configured" |
+| any owned provider in outage (≥ threshold) | `warn` | `warn` | "`{name}` unreachable ≥`{age}`" · or "`{n}` providers unreachable" |
+| some not-ready, none past threshold | `ok` | null | "`{n}` resident · `{n}` warming" |
+| all ready | `ok` | null | "`{n}` resident" |
+
+Threshold: `CROW_PROVIDER_NOT_READY_WARN_MS`, default **10 minutes**, read at call time so
+tests can override it. Worst-case *legitimate* not-ready windows:
+
+- boot ensure: `READINESS_INITIAL_DELAY_MS` (1 s) + `READINESS_TIMEOUT_MS` (240 s) — and
+  this elapses *before* the first poll, since the monitor starts at the end of
+  `initOrchestrator`.
+- deferred resident: `IDLE_CHECK_INTERVAL_MS` (120 s) until `retryDeferredResidents` fires,
+  plus a 240 s warm — but the clock starts at *ownership*, i.e. after the interface
+  appears, so only the 240 s warm counts.
+
+600 s clears both with >2× margin, and satisfies trap 2's "N > 1 tick" by 5×.
+
+#### Warn copy is derived, not hardcoded
+
+The first draft's `issueLabel` said "embeddings and semantic search are degraded". That is
+**wrong on crow**: trap 1 means crow only ever owns `crow-voice`, whose single model has no
+`task: "embed"` — it is the fast voice/dispatch model. Only grackle owns an embed provider.
+A `crow-voice` outage announcing degraded embeddings would send the operator after the
+wrong subsystem. **(R1-MAJOR.)**
+
+So `recordResidency` stores an `embed` boolean (from the orchestrator's existing
+`providerHasEmbedModel(p)`), and the signal picks its copy from the down providers:
+
+- any down provider has `embed` → `downIssueEmbed`: new memories, sources and notes aren't
+  being embedded; semantic search and recall are degraded.
+- otherwise → `downIssue`: features that route to it (voice, chat) fall back or fail.
+- more than one down → `downIssueMulti`, naming them.
+
+`actionHref` is `/dashboard/settings?section=llm&tab=health` — verified: `llm.js:30` reads
+`?tab=`, and `health` is a real tab id (`llm.js:25`). Note this link is used **only** by the
+nest strip (`html.js:212-219`); the health-monitor notification hardcodes
+`action_url: "/dashboard/nest"` for every signal (`post-listen.js:248`). That is a
+pre-existing convention and this PR does not change it.
+
+## Data flow
+
+```
+boot: initOrchestrator()
+        ├── _initialized = true
+        ├── setResidencyInitialized()
+        ├── startResidencyMonitor()  ──┐   (armed FIRST; unconditional; guarded; unref'd)
+        │                              │
+        └── try {                      │  immediately, then every 120 s
+              alwaysResidentProviders(cfg, ownAddrs)  → local names (logs skip line ONCE)
+              ensureResident(name) for each           → docker compose up + waitForReady
+            } catch { log }            │
+                                       ▼
+                              pollResidency()
+                                 ├── localAlwaysResident(cfg, ownAddrs)   [PURE, no logging]
+                                 ├── require isSafeBundleId + compose file on disk
+                                 ├── reset ownership if baseUrl changed
+                                 ├── take ownership if newly local        (traps 1 + 2)
+                                 ├── probeReady(baseUrl) for OWNED providers only
+                                 ├── recordResidency(name, {ready, nowMs, baseUrl, embed})
+                                 └── pruneResidency(ALL declared alwaysResident names)
+                                       │
+                                       ▼
+                          provider-health.js  (per-process state, zero imports)
+                                       │
+                    ┌──────────────────┴──────────────────┐
+                    ▼                                     ▼
+        nest render (30 s cache)              health monitor (15 min)
+        collectHealthSignals                  collectHealthSignals
+             providersSignal                       → shouldNotify("providers", 24h)
+                                                   → createNotification (dashboard + ntfy)
+```
+
+Detection latency for a provider that dies at time T: the poll records not-ready within
+120 s; the signal turns `warn` at ≈ T+12 min; the next health-monitor cycle (≤ 15 min later)
+notifies. Worst case ≈ 27 minutes. Against a 12-day silent outage that is the right end of
+the trade-off — and both the threshold and the poll interval are env-tunable.
+
+## Error handling
+
+- `pollResidency` wraps each provider's probe in try/catch; `probeReady` already swallows
+  everything and returns `false`. A `loadProviders()` throw makes the tick a no-op.
+- `startResidencyMonitor`'s interval callback catches everything. A residency poll must
+  never be able to take down the gateway.
+- `providersSignal` is `async` and does no I/O; it is additionally wrapped by
+  `collectHealthSignals`' per-signal `.catch()` → `state: "off"`.
+- **Trap 4:** nothing here touches `shouldRunHealthMonitor`. A `--no-auth` gateway still
+  never runs the health monitor and so never notifies. It *will* run `initOrchestrator` and
+  therefore the residency poll — as it already runs `initOrchestrator` today — but polling
+  is read-only and notification stays gated. `tests/health-monitor-noauth-skip.test.js`
+  must stay green untouched.
+
+## Trust boundary
+
+`probeReady` issues an unauthenticated `GET {baseUrl}/models` from the gateway process, and
+the `providers` table syncs fleet-wide between paired instances. This PR turns a one-shot
+boot probe into a recurring one, so it is worth stating the boundary explicitly:
+
+- A provider is probed only if it is declared `alwaysResident`, **has a `bundleId` whose
+  compose file exists in this checkout**, and its `baseUrl` hostname is one of this host's
+  own non-virtual interface addresses (or loopback).
+- `probeReady` sends no headers, so no `apiKey` can be exfiltrated (contrast `probeProvider`
+  in `servers/shared/providers.js:120-124`, which does send `Authorization: Bearer`).
+- The residual surface is: a **trusted, already-paired** peer could point one of the two
+  shipped bundle ids at `http://127.0.0.1:<port>/v1` and learn whether that port answers,
+  every 120 s. Such a peer can already make this host run `docker compose up` on a shipped
+  bundle, so this is not a new trust level. Narrowing it further (an allowlist of probe
+  ports) is out of scope and would break `crow-voice`'s tailnet-IP `baseUrl`.
+
+## Known limitations (accepted, documented)
+
+- **Flapping providers.** The clock clears on any successful probe. A bundle that answers
+  one probe every ~8 minutes and is down the rest of the time never accumulates 10
+  continuous unreachable minutes and never warns. The motivating incident was a hard-down
+  (VRAM squatted, engine never initialised, 0 successful probes in 12 days) and is caught.
+  Catching the flapping class needs a rolling failure-ratio window; that is a separate
+  change with its own tuning, and is logged as a follow-up rather than smuggled in here.
+- **Co-resident gateways double-notify.** crow (`:3001`) and crow-mpa (`:3006`) run on the
+  same machine, share `getOwnAddresses()`, both own `crow-voice`, and both run the health
+  monitor into different DBs — so one outage produces two ntfy pushes. This is *already*
+  true today for every machine-scoped signal (`disk`, `storage`, `backup`), so `providers`
+  is consistent with the existing convention rather than introducing a new problem.
+- **24h dedupe on a stable id hides a second provider.** If provider A goes down (notifies)
+  and B goes down an hour later while A is still down, `lastMap["providers"]` suppresses B
+  for up to 24 h. Every fleet host today owns exactly one `alwaysResident` provider, so this
+  is unreachable in practice. (`post-listen.js` already drops the dedupe marker once an
+  issue clears, so a resolved-then-recurring outage does re-notify.)
+- **A stale hardcoded `baseUrl` is a silence mode.** `models.json` pins `crow-voice` to
+  `http://100.118.41.122:8011/v1` and `grackle-embed` to `http://100.121.254.89:9100/v1` —
+  the maintainer's current Tailscale IPs. If a host's tailnet IP ever changes (node re-key,
+  logout/rejoin, delete-and-re-add), its own provider stops matching `getOwnAddresses()`, is
+  never owned, and the signal reads `off` ("none configured") **forever** — while the
+  orchestrator has also silently stopped managing it. R2 proposed surfacing an `info` for
+  "declared `alwaysResident`, has a local-looking bundle, but not locally orchestratable."
+  **Rejected:** that predicate cannot distinguish *my provider whose address changed* from
+  *a peer's provider*, and the `host` column is known-untrustworthy (PR #151's comment:
+  fleet data violates its invariant). Such an `info` would fire on `grackle-embed` on crow
+  and `crow-voice` on grackle, on every tick, forever — design trap 1, exactly what the
+  physical-locality gate was added to prevent. The real fix is upstream: shipped defaults
+  must not hardcode one lab's IPs. Folded into the generalization + first-run theme below.
+- **Sticky ownership survives an IP hand-off.** Once owned, a provider is probed until its
+  `baseUrl` string changes. If this host's tailnet IP changed *and* Tailscale later recycled
+  the old address to a different node, we would keep probing a stranger's `:8011` every
+  120 s (no credentials are sent). Narrow — and it can only arise *after* the stale-baseUrl
+  blind spot above has already broken orchestration — so it is documented rather than coded
+  around. Same upstream fix.
+- **Shipped defaults must be reachable.** The "fresh install renders `off`" property holds
+  *because* the two shipped `alwaysResident` providers carry the maintainer's Tailscale IPs,
+  so `isLocallyOrchestratable` is false on anyone else's box. If the pending
+  generalization + first-run theme ever ships a `http://localhost:PORT/v1` always-resident
+  default, every install that hasn't started that Docker bundle will warn after 10 minutes.
+  That would be the *correct* behavior of this signal reporting a real packaging gap (the
+  known "extensions all need Docker that nothing installs" theme) — but the generalization
+  work must ship per-install provider discovery, not a shipped localhost default, or it will
+  turn this signal into first-run noise. Recorded here as a cross-theme dependency.
+
+## Testing
+
+Copying the shape of `tests/messages-health-signal.test.js` (drive `collectHealthSignals`,
+assert on `details`/`issues` by id, inject the clock via `opts.now`).
+
+**`tests/provider-health.test.js`** — the state module in isolation:
+- fresh state → `initialized:false`, empty providers
+- taking ownership stamps `firstOwnedAt` and `owned:true`
+- a not-ready observation leaves `lastReadyAt` null; a `ready` observation stamps it
+- a second not-ready observation does **not** move `firstOwnedAt` (records outage start)
+- `pruneResidency` drops undeclared names and keeps declared ones
+- `_resetProviderHealth` restores the initial shape
+
+**`tests/providers-health-signal.test.js`** — the signal:
+- not initialized → `off`, no issue
+- initialized, zero owned providers (MPA / fresh install / no GPU) → `off`, no issue
+- all ready → `ok`, no issue, value counts residents
+- unreachable for less than the threshold → `ok`, no issue (the deferred/warm window)
+- unreachable for more than the threshold → `warn` issue with id `providers`
+- never-ready-since-ownership uses `firstOwnedAt` as the clock origin (the grackle case)
+- an `embed` provider down → `downIssueEmbed` copy; a non-embed provider down →
+  `downIssue` copy (**the crow-voice mis-copy regression**)
+- two providers past the threshold → exactly **one** issue with id `providers`
+- `CROW_PROVIDER_NOT_READY_WARN_MS` override is honored
+- EN and ES both render, asserting the output **is not equal to the raw i18n key** (`t()`
+  returns the key on a miss, `i18n.js:1396`)
+
+**`tests/gpu-orchestrator-residency-poll.test.js`** — the poll, with injected `cfg`,
+`ownAddrs`, `probe`, `now`, `composeExists`:
+- probes only owned providers — a peer's provider (`grackle-embed` seen from crow's address
+  set) is never probed and never recorded **(trap 1)**
+- a provider that becomes locally orchestratable on a later tick stamps `firstOwnedAt` at
+  that tick, not at boot **(trap 2)**
+- **a provider that drops out of the local set (tailscale0 flap) is still probed and its
+  outage clock is NOT reset** — the R1-CRITICAL regression test. (The v1 test plan asserted
+  the opposite; it would have shipped the bug green.) This test must drive a **full
+  `pollResidency` tick including the `pruneResidency` call**, since passing the *local* set
+  as `declaredNames` is how the CRITICAL re-enters; a test that stops before prune would
+  miss it.
+- ownership is released and re-evaluated when `baseUrl` changes
+- a provider with no `bundleId`, or whose compose file is absent, is never probed
+  **(SSRF gate)**
+- `isSafeBundleId` rejects `..`, `.`, `a/b`, `a\b`, `""`; `composeFile("..")` **throws**
+  rather than resolving to the repo-root `docker-compose.yml` **(path-traversal gate)**
+- `pollResidency` emits no "skipping" log line **(log-spam regression)**
+- a probe that throws is recorded as not-ready, and the poll still records the others
+- a `loadProviders()` throw leaves prior state intact
+
+**Regression:** `tests/health-monitor-noauth-skip.test.js`, `tests/health-signals.test.js`,
+`tests/health-monitor-dedupe.test.js`, `tests/gpu-orchestrator-host-gate.test.js`,
+`tests/gpu-warm-resolve.test.js` all stay green. Full suite baseline: **1216 pass / 0 fail /
+1 skip** via `node --test tests/*.test.js`.
+
+## i18n
+
+EN + ES for 11 keys:
+`signals.providers.{label,notStarted,off,resident,warming,down,downMulti,downIssue,downIssueEmbed,downIssueMulti,action}`.
+
+## Files
+
+| File | Change |
+|---|---|
+| `servers/gateway/provider-health.js` | **new** — zero-import state module |
+| `servers/gateway/gpu-orchestrator.js` | `isSafeBundleId` (pure, enforced in `composeFile`), `localAlwaysResident` (pure), `pollResidency`, `startResidencyMonitor`, early-arm in `initOrchestrator` |
+| `servers/gateway/dashboard/panels/nest/health-signals.js` | `providersSignal` + register in `collectHealthSignals` |
+| `servers/gateway/dashboard/shared/i18n.js` | 11 keys × EN/ES |
+| `tests/provider-health.test.js` | **new** |
+| `tests/providers-health-signal.test.js` | **new** |
+| `tests/gpu-orchestrator-residency-poll.test.js` | **new** |
+
+No new host ports → `check-ports` is path-filtered and reports 0-applicable. No DB schema
+change → no `SCHEMA_GEN` bump.
+
+## R1 review disposition
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| `pruneResidency` wipes the outage clock on a tailscale0 flap | CRITICAL | **Fixed** — sticky ownership; prune only on config removal. Reviewer's "freeze the clock" rejected (it hides a true unreachability); we keep probing instead. |
+| Test plan enshrined the prune-wipe as correct | CRITICAL-adj | **Fixed** — test inverted. |
+| Warn copy hardcodes "embeddings degraded" but crow owns a non-embed provider | MAJOR | **Fixed** — copy derived from `providerHasEmbedModel`. |
+| `pollResidency` re-emits the skip log every 120 s | MAJOR | **Fixed** — pure `localAlwaysResident` helper; `alwaysResidentProviders` keeps the boot log. |
+| Recurring probe of a synced, attacker-settable `baseUrl` (SSRF/beacon) | MAJOR | **Fixed** — require `bundleId` + compose file on disk; trust boundary documented. `apiKey` confirmed not sent. |
+| Shipped-localhost-default would warn on every fresh install | MAJOR | **Documented** — cross-theme dependency on generalization/first-run. No shipped default is localhost today. |
+| Co-resident gateways double-notify | MINOR | **Accepted** — already true for `disk`/`storage`/`backup`; consistent with convention. |
+| 24h dedupe on stable id hides a 2nd provider | MINOR | **Accepted** — unreachable today (1 owned provider per host); documented. |
+| Clock clears on a single lucky probe → flapping never warns | MINOR | **Accepted** — documented as a limitation; ratio window is a separate change. |
+| Sync throw escapes the per-signal `.catch()` | NIT | **Fixed** — `providersSignal` is `async`. |
+| `startResidencyMonitor` needs its own idempotency guard | NIT | **Fixed**. |
+| Notification `action_url` ignores `actionHref`; tab should be `&tab=health` | NIT | **Fixed** (href) / **documented** (pre-existing `action_url` convention). |
+| `t()` returns the raw key on a miss | NIT | **Fixed** — i18n test asserts output ≠ key. |
+
+## Empirical verification (R2, against the live fleet — black-swan untouched)
+
+Every load-bearing claim was checked on the running systems, not just read in source.
+
+| Claim | Observed | Verdict |
+|---|---|---|
+| `bundles/<bundleId>/docker-compose.yml` exists on the owning host | `vllm-rocm-qwen35-4b` present on crow; `vllm-cuda-embed` present on grackle; both git-tracked, `bundles/` not gitignored. All prod gateways run from `/home/kh0pp/crow`, so `BUNDLES_DIR` resolves. | **Confirmed** — the gate does not disable the feature where it matters. |
+| DB `baseUrl` == `models.json` `baseUrl` | Identical byte-for-byte for both providers, in all three DBs. `config/models.json` does not exist. | **Confirmed** — a DB↔models.json cache flip cannot churn sticky ownership. |
+| crow owns only `crow-voice`; grackle owns only `grackle-embed` | Confirmed by evaluating `isLocallyOrchestratable` against each host's real `ip -o addr`. | **Confirmed** — trap 1 holds. |
+| crow-mpa co-owns `crow-voice` | Yes — same machine, same `getOwnAddresses()`, cwd `/home/kh0pp/crow`. | **Confirmed** — the documented double-notify limitation is real, and consistent with `disk`/`storage`/`backup`. |
+| Both providers reachable right now | `crow-voice :8011` → 200; `grackle-embed :9100` → 200. | **Confirmed** — the signal renders `ok` on deploy, not `warn`. |
+| Restart counts are a poor signal | grackle's `vllm-cuda-embed`: `RestartCount 57604` **while `state=running (healthy)`** and answering 200. Docker doesn't reset the counter until the container is recreated. | **Confirmed** — strong empirical support for choosing outage *duration* over restart count. |
+| `--no-auth` companion runs on grackle | Two gateway processes live; both call `initOrchestrator`, both will poll (read-only); only the auth one runs the health monitor. | **Confirmed** — trap 4 behavior is exactly as designed. |
+| gateway log is unrotated | **False.** crow rotates weekly (`/etc/logrotate.d/crow-inference`, `rotate 4`, `compress`, `copytruncate`); grackle has no such file and logs to journald. | **Corrected in prose.** The pure-helper decision stands on "needless noise in the incident-diagnosis log", not unboundedness. |
+
+## R2 review disposition
+
+| Finding | Severity | Disposition |
+|---|---|---|
+| Path traversal: unvalidated `bundleId: ".."` resolves to the tracked repo-root `docker-compose.yml`, passing the new compose-exists gate | MINOR | **Fixed** — `isSafeBundleId`, enforced inside `composeFile()` so it also hardens the pre-existing `bundleUp`/`bundleStop` spawn paths. |
+| `_initialized = true` before the wiring: a throw disarms detection for the process lifetime, un-retriably | NIT → **promoted** | **Fixed** — `setResidencyInitialized()` + `startResidencyMonitor()` moved ahead of anything that can throw; body wrapped in try/catch. |
+| `pruneResidency(declaredNames)` must receive the FULL declared set, not the local set | test gap | **Fixed** — made explicit in the design; the flap regression test now drives a full tick including prune. |
+| `composeExists` not injectable → poll tests couple to repo layout | test gap | **Fixed** — injectable, defaulting to `existsSync(composeFile(id))`. |
+| "First poll fires immediately" is misleading (monitor started after a serial ≤240 s×N ensure loop) | NIT | **Resolved by the early-arm fix** — the first poll now genuinely runs at t≈0, concurrently with the ensure loop. Threshold margin re-derived. |
+| Stale hardcoded tailnet-IP `baseUrl` → provider never owned → signal `off` forever | MINOR | **Documented as a blind spot.** Reviewer's `info`-signal fix **rejected**: the predicate cannot separate "my provider, changed address" from "a peer's provider", so it would fire on every peer's provider forever — design trap 1. Real fix is upstream (generalization theme: no shipped IP defaults). |
+| Sticky ownership + recycled tailnet IP → probe a stranger's port forever | MINOR | **Documented.** Reachable only *after* the blind spot above has already broken orchestration; no credentials are sent. Same upstream fix. |
+| Log-spam rationale factually wrong (file is rotated on crow; absent on grackle) | MINOR | **Prose corrected.** Decision unchanged. |
+| `wifi flap` is a weaker trigger than a `tailscaled` restart (tailscale0 /32 survives a link blip) | NIT | **Prose acknowledged** — sticky ownership is correct either way; a link blip fails the *probe*, which is precisely the "keep probing, don't reset the clock" path. |
+| `seedProvidersFromModelsJson` doesn't write `gpu_policy`; the boot reconciler backfills it | pre-existing | **Out of scope, noted.** Equally disables the existing `ensureResident`; both live DBs have `gpu_policy` populated today. |

--- a/servers/gateway/dashboard/panels/nest/health-signals.js
+++ b/servers/gateway/dashboard/panels/nest/health-signals.js
@@ -13,6 +13,7 @@
  *   peers     — crow_instances unseen >24h (info)
  *   updates   — auto_update_* version comparison (info if update available)
  *   backup    — newest file mtime in CROW_BACKUP_DIR (none → info; >7d → warn)
+ *   providers — alwaysResident provider residency (unreachable ≥threshold → warn)
  *
  * Pure export shouldNotify(lastMap, issueId, nowMs) — used by the health monitor
  * for 24-hour dedupe. No I/O.
@@ -26,6 +27,7 @@ import { t } from "../../shared/i18n.js";
 import { PUBLIC_FUNNEL_PREFIXES } from "../../../funnel.js";
 import { isAuditDegraded } from "../../../../shared/cross-host-auth.js";
 import { getReceiveHealth } from "../../../../sharing/receive-health.js";
+import { getProviderHealth } from "../../../provider-health.js";
 
 // ─── Module-level 30s cache ───────────────────────────────────────────────────
 
@@ -634,6 +636,78 @@ async function messagesSignal(db, lang, nowFn) {
   return { id: "messages", severity: null, state: "ok", label, value: parts.join(" · ") };
 }
 
+// Provider residency (F-HEALTH-1). Reads the pure provider-health module —
+// zero-import state written by the orchestrator's residency poll. A provider is
+// "in outage" when it is not ready and has been so for >= notReadyWarnMs since
+// its last-ready (or, if never ready, since ownership was taken). The embed-vs
+// non-embed issue copy is DERIVED from the down providers' embed flags: crow
+// only ever owns crow-voice (no embed model), so a hardcoded "embeddings
+// degraded" line would send the operator after the wrong subsystem.
+function notReadyWarnMs() {
+  const n = Number(process.env.CROW_PROVIDER_NOT_READY_WARN_MS);
+  return Number.isFinite(n) && n > 0 ? n : 10 * 60 * 1000;
+}
+
+async function providersSignal(lang, nowFn) {
+  const health = getProviderHealth();
+  const label = t("signals.providers.label", lang);
+  const action = {
+    actionLabel: t("signals.providers.action", lang),
+    actionHref: "/dashboard/settings?section=llm&tab=health",
+  };
+
+  if (!health.initialized) {
+    return { id: "providers", severity: null, state: "off", label, value: t("signals.providers.notStarted", lang) };
+  }
+  const names = Object.keys(health.providers);
+  if (names.length === 0) {
+    return { id: "providers", severity: null, state: "off", label, value: t("signals.providers.off", lang) };
+  }
+
+  const now = nowFn();
+  const threshold = notReadyWarnMs();
+  const down = [];
+  let readyCount = 0;
+  let warmingCount = 0;
+  for (const name of names) {
+    const p = health.providers[name];
+    if (p.ready) { readyCount++; continue; }
+    const origin = p.lastReadyAt ?? p.firstOwnedAt;
+    if (now - origin >= threshold) {
+      down.push({ name, embed: !!p.embed, age: formatAge(now - origin) });
+    } else {
+      warmingCount++;
+    }
+  }
+
+  if (down.length > 0) {
+    const value = down.length === 1
+      ? t("signals.providers.down", lang).replace("{name}", down[0].name).replace("{age}", down[0].age)
+      : t("signals.providers.downMulti", lang).replace("{n}", String(down.length));
+
+    // Always NAME the provider when exactly one is down — this string becomes the
+    // notification title (post-listen.js sets title: issue.label). The embed-vs-voice
+    // split is derived from the provider's own embed flag, never hardcoded: crow only
+    // ever owns crow-voice, which carries no embed model.
+    let issueLabel;
+    if (down.length === 1) {
+      const key = down[0].embed ? "signals.providers.downIssueEmbed" : "signals.providers.downIssue";
+      issueLabel = t(key, lang).replace("{name}", down[0].name);
+    } else {
+      issueLabel = t("signals.providers.downIssueMulti", lang)
+        .replace("{n}", String(down.length))
+        .replace("{names}", down.map(d => d.name).join(", "));
+    }
+    return { id: "providers", severity: "warn", state: "warn", label, value, issueLabel, ...action };
+  }
+
+  const parts = [t("signals.providers.resident", lang).replace("{n}", String(readyCount))];
+  if (warmingCount > 0) {
+    parts.push(t("signals.providers.warming", lang).replace("{n}", String(warmingCount)));
+  }
+  return { id: "providers", severity: null, state: "ok", label, value: parts.join(" · ") };
+}
+
 // ─── Main export ──────────────────────────────────────────────────────────────
 
 /**
@@ -664,6 +738,7 @@ export async function collectHealthSignals(db, opts = {}) {
     integrationsSignal(db, lang),
     federationAuditSignal(lang),
     messagesSignal(db, lang, nowFn),
+    providersSignal(lang, nowFn),
   ].map(p => Promise.resolve(p).catch(err => ({
     id: "unknown",
     severity: null,

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -215,6 +215,18 @@ export const translations = {
   "signals.messages.pending": { en: "{n} pending out", es: "{n} salientes pendientes" },
   "signals.messages.undecryptable": { en: "{n} undecryptable", es: "{n} indescifrables" },
 
+  "signals.providers.label": { en: "Providers", es: "Proveedores" },
+  "signals.providers.notStarted": { en: "not started", es: "no iniciado" },
+  "signals.providers.off": { en: "none configured", es: "sin configurar" },
+  "signals.providers.resident": { en: "{n} resident", es: "{n} residente" },
+  "signals.providers.warming": { en: "{n} warming", es: "{n} iniciando" },
+  "signals.providers.down": { en: "{name} unreachable ≥{age}", es: "{name} inaccesible ≥{age}" },
+  "signals.providers.downMulti": { en: "{n} providers unreachable", es: "{n} proveedores inaccesibles" },
+  "signals.providers.downIssueEmbed": { en: "The embedding provider {name} has been unreachable, so new memories, sources and notes aren't being embedded; semantic search and recall are degraded until it recovers.", es: "El proveedor de incrustaciones {name} lleva un rato inaccesible, así que los nuevos recuerdos, fuentes y notas no se están incrustando; la búsqueda semántica y el recuerdo están degradados hasta que se recupere." },
+  "signals.providers.downIssue": { en: "The always-on model provider {name} has been unreachable; features that route to it (voice, chat) fall back or fail until it recovers.", es: "El proveedor de modelos siempre activo {name} lleva un rato inaccesible; las funciones que lo usan (voz, chat) recurren a alternativas o fallan hasta que se recupere." },
+  "signals.providers.downIssueMulti": { en: "{n} always-on model providers are unreachable ({names}); features that route to them fall back or fail until they recover.", es: "{n} proveedores de modelos siempre activos están inaccesibles ({names}); las funciones que los usan recurren a alternativas o fallan hasta que se recuperen." },
+  "signals.providers.action": { en: "Open model health", es: "Ver estado de modelos" },
+
   // ─── Nest Panel ───
   "nest.pinned": { en: "Pinned", es: "Fijados" },
   "nest.instances": { en: "Instances", es: "Instancias" },

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -39,10 +39,15 @@
  */
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname, resolve } from "node:path";
 import { networkInterfaces } from "node:os";
 import { loadProviders as loadCachedProviders } from "../shared/providers.js";
+import {
+  setResidencyInitialized, recordResidency, releaseResidency,
+  pruneResidency, getProviderHealth,
+} from "./provider-health.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const BUNDLES_DIR = resolve(dirname(__filename), "..", "..", "bundles");
@@ -99,17 +104,41 @@ const PROBE_TIMEOUT_MS = 2_000;
 
 const IDLE_REVERT_MS = Number(process.env.GPU_IDLE_REVERT_MS ?? 20 * 60 * 1000);
 const IDLE_CHECK_INTERVAL_MS = Number(process.env.GPU_IDLE_CHECK_INTERVAL_MS ?? 2 * 60 * 1000);
+const RESIDENCY_POLL_MS = Number(process.env.CROW_PROVIDER_RESIDENCY_POLL_MS ?? 120_000);
 
 let _swapInFlight = Promise.resolve();
 let _initialized = false;
 let _idleRevertTimer = null;
+let _residencyTimer = null;
+let _residencyInFlight = false;
 const _lastUsedAt = new Map(); // providerName -> epoch ms of last acquireProvider success
 
 // -----------------------------------------------------------------------
 // Bundle control
 // -----------------------------------------------------------------------
 
-function composeFile(bundleId) {
+/**
+ * A bundleId is safe iff it is a single path segment: matches
+ * /^[A-Za-z0-9][A-Za-z0-9._-]*$/ and is neither "." nor "..". Rejects empty,
+ * non-strings, "..", ".", anything with a "/" or "\", and leading "-"/".".
+ *
+ * `bundleId` arrives from the fleet-synced providers.bundle_id column, so it
+ * is attacker-influenceable. join(BUNDLES_DIR, "..", "docker-compose.yml")
+ * resolves to the git-tracked repo-root compose file — a compose-exists gate
+ * alone would pass for bundleId "..". Enforced INSIDE composeFile so it also
+ * hardens the pre-existing bundleUp/bundleStop spawn paths.
+ */
+export function isSafeBundleId(id) {
+  return typeof id === "string"
+    && id !== "."
+    && id !== ".."
+    && /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id);
+}
+
+export function composeFile(bundleId) {
+  if (!isSafeBundleId(bundleId)) {
+    throw new Error(`orchestrator: unsafe bundleId ${JSON.stringify(bundleId)}`);
+  }
   return join(BUNDLES_DIR, bundleId, "docker-compose.yml");
 }
 
@@ -195,14 +224,34 @@ function getMutexSiblings(name) {
     .map(([n]) => n);
 }
 
+function isAlwaysResident(v) {
+  return v?.gpuPolicy?.alwaysResident === true || v?.alwaysResident === true;
+}
+
+/** Every provider name declared alwaysResident in cfg, REGARDLESS of locality.
+ *  PURE, no logging. The residency poll needs this for pruneResidency. */
+export function declaredAlwaysResident(cfg = loadProviders()) {
+  return Object.entries(cfg.providers || {})
+    .filter(([, v]) => isAlwaysResident(v))
+    .map(([n]) => n);
+}
+
+/** Declared alwaysResident AND locally orchestratable. PURE, no logging —
+ *  so the 120s poll doesn't re-emit the boot skip line on every tick. */
+export function localAlwaysResident(cfg = loadProviders(), ownAddrs = getOwnAddresses()) {
+  return Object.entries(cfg.providers || {})
+    .filter(([, v]) => isAlwaysResident(v) && isLocallyOrchestratable(v, ownAddrs))
+    .map(([n]) => n);
+}
+
 export function alwaysResidentProviders(cfg = loadProviders(), ownAddrs = getOwnAddresses()) {
-  const entries = Object.entries(cfg.providers || {})
-    .filter(([, v]) => v.gpuPolicy?.alwaysResident === true || v.alwaysResident === true);
-  const skipped = entries.filter(([, v]) => !isLocallyOrchestratable(v, ownAddrs)).map(([n]) => n);
+  const local = new Set(localAlwaysResident(cfg, ownAddrs));
+  const declared = declaredAlwaysResident(cfg);
+  const skipped = declared.filter((n) => !local.has(n));
   if (skipped.length) {
     console.log(`[gpu-orchestrator] skipping alwaysResident provider(s) not hosted on this machine: ${skipped.join(", ")}`);
   }
-  return entries.filter(([, v]) => isLocallyOrchestratable(v, ownAddrs)).map(([n]) => n);
+  return declared.filter((n) => local.has(n));
 }
 
 // Map<mutexGroup, { default: string|null, members: Array<{name, baseUrl, bundleId}> }>
@@ -494,6 +543,107 @@ export async function retryDeferredResidents({
 }
 
 /**
+ * Residency poll — the re-poll the original outage lacked. Read-only: probes
+ * OWNED alwaysResident providers' baseUrls and records the result into
+ * provider-health.js. Never takes the swap lock, never starts/stops a
+ * container, and MUST NEVER THROW (the interval callback relies on it).
+ *
+ * All five inputs are injectable so unit tests never touch the network or the
+ * real filesystem.
+ *
+ * Sticky ownership: once owned, a provider is probed every tick regardless of
+ * whether it still passes the locality check — a tailscale0 restart must NOT
+ * reset its outage clock, because if tailscale0 is down the provider genuinely
+ * is unreachable. Ownership is re-evaluated ONLY when its baseUrl changes.
+ */
+export async function pollResidency(opts = {}) {
+  const probed = [];
+  try {
+    const cfg = opts.cfg !== undefined ? opts.cfg : loadProviders();
+    const ownAddrs = opts.ownAddrs !== undefined ? opts.ownAddrs : getOwnAddresses();
+    const probe = opts.probe || probeReady;
+    const now = opts.now || Date.now;
+    const composeExists = opts.composeExists || ((id) => existsSync(composeFile(id)));
+
+    // Accessing cfg.providers may throw (a getter over a failed DB read); doing
+    // it inside this try makes the whole tick a no-op that leaves state intact.
+    const declared = declaredAlwaysResident(cfg);
+    const local = new Set(localAlwaysResident(cfg, ownAddrs));
+
+    for (const name of declared) {
+      const p = cfg.providers[name];
+      if (!p) continue;
+
+      // SSRF / path-traversal gate: only providers this machine can actually
+      // orchestrate (a safe bundleId whose compose file exists) are probed.
+      if (!p.bundleId || !isSafeBundleId(p.bundleId)) { releaseResidency(name); continue; }
+      let exists = false;
+      try { exists = composeExists(p.bundleId); } catch { exists = false; }
+      if (!exists) { releaseResidency(name); continue; }
+
+      let prev = getProviderHealth().providers[name];
+      // Operator repointed the provider — release and re-evaluate ownership
+      // against the new address.
+      if (prev?.owned && prev.baseUrl !== p.baseUrl) {
+        releaseResidency(name);
+        prev = undefined;
+      }
+
+      const owned = prev?.owned === true || local.has(name);
+      // Not ours (a peer's provider — trap 1) or not yet local (a deferred
+      // resident whose interface hasn't come up — trap 2): skip SILENTLY.
+      if (!owned) continue;
+
+      let ready = false, error = null;
+      try { ready = await probe(p.baseUrl); } catch (e) { error = e; }
+      recordResidency(name, { ready, nowMs: now(), baseUrl: p.baseUrl, embed: providerHasEmbedModel(p), error });
+      probed.push(name);
+    }
+
+    // Prune ONLY names no longer DECLARED alwaysResident — the FULL declared
+    // set, NOT `local`. Passing `local` would delete a provider's outage clock
+    // the instant its interface flapped; that was the reviewed CRITICAL.
+    pruneResidency(declared);
+  } catch {
+    return probed;
+  }
+  return probed;
+}
+
+/**
+ * Start the residency monitor: an unref'd interval (CROW_PROVIDER_RESIDENCY_POLL_MS,
+ * default 120s) that runs pollResidency. Fires once immediately, then on the
+ * interval. Idempotent; in-flight guarded so a slow poll can't stack; the
+ * callback catches everything. Set the interval <= 0 to disable.
+ */
+export function startResidencyMonitor() {
+  if (_residencyTimer) return;
+  if (!(RESIDENCY_POLL_MS > 0) || !Number.isFinite(RESIDENCY_POLL_MS)) {
+    console.log("[gpu-orchestrator] residency monitor disabled");
+    return;
+  }
+  const tick = () => {
+    if (_residencyInFlight) return;
+    _residencyInFlight = true;
+    Promise.resolve()
+      .then(() => pollResidency())
+      .catch(() => {})
+      .finally(() => { _residencyInFlight = false; });
+  };
+  tick(); // fire one poll immediately (fire-and-forget)
+  _residencyTimer = setInterval(() => {
+    try { tick(); } catch {}
+  }, RESIDENCY_POLL_MS);
+  _residencyTimer.unref?.();
+}
+
+/** Test hook — clear and null the interval so the suite doesn't leak it. */
+export function _stopResidencyMonitor() {
+  if (_residencyTimer) { clearInterval(_residencyTimer); _residencyTimer = null; }
+  _residencyInFlight = false;
+}
+
+/**
  * Startup — ensure all alwaysResident providers are up.
  * Non-fatal: logs and continues on error. Call from gateway init.
  *
@@ -504,29 +654,39 @@ export async function retryDeferredResidents({
 export async function initOrchestrator() {
   if (_initialized) return;
   _initialized = true;
-  const cfg = loadProviders();
-  const ownAddrs = getOwnAddresses();
-  const residents = alwaysResidentProviders(cfg, ownAddrs); // logs the skip line
-  _deferredResidents = new Set(
-    Object.entries(cfg.providers || {})
-      .filter(([, v]) => (v.gpuPolicy?.alwaysResident === true || v.alwaysResident === true)
-        && !isLocallyOrchestratable(v, ownAddrs))
-      .map(([n]) => n)
-  );
-  if (residents.length === 0 && _deferredResidents.size === 0) {
-    console.log("[gpu-orchestrator] no alwaysResident providers declared");
+  // ARM FIRST — before anything that can throw. _initialized is already set,
+  // and the caller (post-listen.js) only .catch()es, so a throw below would
+  // otherwise leave residency detection permanently disarmed (the exact
+  // failure class this feature exists to eliminate).
+  setResidencyInitialized();
+  startResidencyMonitor();
+  try {
+    const cfg = loadProviders();
+    const ownAddrs = getOwnAddresses();
+    const residents = alwaysResidentProviders(cfg, ownAddrs); // logs the skip line
+    _deferredResidents = new Set(
+      Object.entries(cfg.providers || {})
+        .filter(([, v]) => (v.gpuPolicy?.alwaysResident === true || v.alwaysResident === true)
+          && !isLocallyOrchestratable(v, ownAddrs))
+        .map(([n]) => n)
+    );
+    if (residents.length === 0 && _deferredResidents.size === 0) {
+      console.log("[gpu-orchestrator] no alwaysResident providers declared");
+      startIdleRevertTimer();
+      return;
+    }
+    if (residents.length) {
+      console.log(`[gpu-orchestrator] ensuring alwaysResident: ${residents.join(", ")}`);
+    }
+    let embedRecovered = false;
+    for (const name of residents) {
+      if (await ensureResident(name, cfg)) embedRecovered = true;
+    }
     startIdleRevertTimer();
-    return;
-  }
-  if (residents.length) {
-    console.log(`[gpu-orchestrator] ensuring alwaysResident: ${residents.join(", ")}`);
-  }
-  let embedRecovered = false;
-  for (const name of residents) {
-    if (await ensureResident(name, cfg)) embedRecovered = true;
-  }
-  startIdleRevertTimer();
-  if (embedRecovered) {
-    triggerEmbedBackfill(); // fire-and-forget — don't block gateway startup
+    if (embedRecovered) {
+      triggerEmbedBackfill(); // fire-and-forget — don't block gateway startup
+    }
+  } catch (err) {
+    console.warn(`[gpu-orchestrator] initOrchestrator body failed: ${err.message}`);
   }
 }

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -111,6 +111,7 @@ let _initialized = false;
 let _idleRevertTimer = null;
 let _residencyTimer = null;
 let _residencyInFlight = false;
+let _residencyPollFailing = false; // edge-trigger for the poll's failure warn
 const _lastUsedAt = new Map(); // providerName -> epoch ms of last acquireProvider success
 
 // -----------------------------------------------------------------------
@@ -569,6 +570,9 @@ export async function pollResidency(opts = {}) {
     // it inside this try makes the whole tick a no-op that leaves state intact.
     const declared = declaredAlwaysResident(cfg);
     const local = new Set(localAlwaysResident(cfg, ownAddrs));
+    // One snapshot: entries are per-provider independent, and releaseResidency
+    // below only ever affects the name being handled.
+    const health = getProviderHealth();
 
     for (const name of declared) {
       const p = cfg.providers[name];
@@ -581,7 +585,7 @@ export async function pollResidency(opts = {}) {
       try { exists = composeExists(p.bundleId); } catch { exists = false; }
       if (!exists) { releaseResidency(name); continue; }
 
-      let prev = getProviderHealth().providers[name];
+      let prev = health.providers[name];
       // Operator repointed the provider — release and re-evaluate ownership
       // against the new address.
       if (prev?.owned && prev.baseUrl !== p.baseUrl) {
@@ -603,10 +607,26 @@ export async function pollResidency(opts = {}) {
     // Prune ONLY names no longer DECLARED alwaysResident — the FULL declared
     // set, NOT `local`. Passing `local` would delete a provider's outage clock
     // the instant its interface flapped; that was the reviewed CRITICAL.
-    pruneResidency(declared);
-  } catch {
+    // Prune only when we actually READ a config. loadProviders() returns
+    // {providers:{}} when both the DB and models.json are unreadable, and an
+    // empty map is indistinguishable from "every provider was deleted" — so
+    // pruning on it would wipe every outage clock and restart the 10-min warn
+    // window on each bad tick. Note the gate is "any provider present", not
+    // "any alwaysResident present": a config that legitimately drops its last
+    // alwaysResident provider still prunes. Defence-in-depth; loadProviders()
+    // falls back to the git-tracked models.json.
+    if (Object.keys(cfg.providers || {}).length > 0) pruneResidency(declared);
+  } catch (err) {
+    // Edge-triggered so a persistently broken config warns once, not every
+    // 120s. Staying silent here would reproduce, inside the silence detector,
+    // exactly the silent failure it exists to catch.
+    if (!_residencyPollFailing) {
+      _residencyPollFailing = true;
+      console.warn(`[gpu-orchestrator] residency poll failed: ${err.message}`);
+    }
     return probed;
   }
+  _residencyPollFailing = false;
   return probed;
 }
 
@@ -641,6 +661,7 @@ export function startResidencyMonitor() {
 export function _stopResidencyMonitor() {
   if (_residencyTimer) { clearInterval(_residencyTimer); _residencyTimer = null; }
   _residencyInFlight = false;
+  _residencyPollFailing = false;
 }
 
 /**

--- a/servers/gateway/provider-health.js
+++ b/servers/gateway/provider-health.js
@@ -1,0 +1,108 @@
+/**
+ * provider-health — per-process residency state for alwaysResident inference
+ * providers (F-HEALTH-1).
+ *
+ * Written by gpu-orchestrator.js's residency poll (pollResidency): each tick it
+ * records, for every provider THIS machine owns, whether the last probe of its
+ * baseUrl succeeded. Read by the gateway's nest `providersSignal` with a PLAIN
+ * IMPORT — this module has ZERO imports so pulling it into the dashboard render
+ * path (and the test suite) can never drag in the orchestrator's child_process
+ * / providers.js / db.js chain. Same per-process-singleton discipline as
+ * receive-health.js and isAuditDegraded() in servers/shared/cross-host-auth.js.
+ *
+ * initialized: false = the orchestrator never ran (e.g. a throw before arming,
+ * or a --no-auth boot that hasn't polled yet) — the signal renders "off", never
+ * a false warn. It is the analogue of receive-health's receiveWired:null.
+ *
+ * State is per-process and resets on gateway restart. That is correct: a fresh
+ * boot legitimately earns a fresh warm-up window, so a displayed outage age is
+ * "unreachable for AT LEAST X".
+ *
+ * The outage clock: a provider is in outage when
+ *   !ready && (nowMs - (lastReadyAt ?? firstOwnedAt)) >= threshold.
+ * firstOwnedAt is stamped once, when ownership is taken, and NEVER moves on a
+ * repeat not-ready — it is the origin for a provider that has never answered in
+ * this process (the grackle case). lastReadyAt is stamped on every success and
+ * is what the clock restarts from once the provider has answered at least once.
+ */
+
+const INITIAL = () => ({
+  initialized: false,
+  providers: Object.create(null),
+});
+
+let _state = INITIAL();
+
+export function setResidencyInitialized() {
+  _state.initialized = true;
+}
+
+/**
+ * Record one probe result for a provider this machine has decided it OWNS.
+ * Creates the entry (owned:true, firstOwnedAt stamped, lastReadyAt:null) on
+ * first sight. Always advances baseUrl/embed/ready/checkedAt. On ready: stamps
+ * lastReadyAt and clears lastError. On not-ready: records lastError (or null)
+ * WITHOUT touching firstOwnedAt or lastReadyAt, so the outage clock survives.
+ */
+export function recordResidency(name, { ready, nowMs, baseUrl, embed = false, error = null } = {}) {
+  let p = _state.providers[name];
+  if (!p) {
+    p = _state.providers[name] = {
+      owned: true,
+      baseUrl,
+      embed: !!embed,
+      ready: false,
+      firstOwnedAt: nowMs,
+      lastReadyAt: null,
+      lastError: null,
+      checkedAt: nowMs,
+    };
+  }
+  p.baseUrl = baseUrl;
+  p.embed = !!embed;
+  p.ready = !!ready;
+  p.checkedAt = nowMs;
+  if (ready) {
+    p.lastReadyAt = nowMs;
+    p.lastError = null;
+  } else {
+    p.lastError = error != null ? (error?.message ?? String(error)) : null;
+  }
+}
+
+/**
+ * Drop a provider entirely. Used by the poll when a provider's baseUrl changes
+ * (ownership must be re-evaluated from scratch) or when it stops being
+ * orchestratable — a fresh recordResidency then stamps a new firstOwnedAt.
+ */
+export function releaseResidency(name) {
+  delete _state.providers[name];
+}
+
+/**
+ * Drop entries whose name is NOT in declaredNames (an array or a Set of every
+ * provider still declared alwaysResident in the config). Nothing else — it
+ * NEVER prunes on locality: a provider that fails a locality check for one tick
+ * (tailscale0 restart) must KEEP its outage clock. Pruning on locality was the
+ * reviewed CRITICAL.
+ */
+export function pruneResidency(declaredNames) {
+  const declared = declaredNames instanceof Set ? declaredNames : new Set(declaredNames);
+  for (const name of Object.keys(_state.providers)) {
+    if (!declared.has(name)) delete _state.providers[name];
+  }
+}
+
+/** Read a copy safe to mutate — mutating it does not touch module state. */
+export function getProviderHealth() {
+  const providers = {};
+  for (const name of Object.keys(_state.providers)) {
+    providers[name] = { ..._state.providers[name] };
+  }
+  return { initialized: _state.initialized, providers };
+}
+
+/** Test hook — restore the initial shape (mirrors _resetReceiveHealth). */
+export function _resetProviderHealth() {
+  _state = INITIAL();
+}

--- a/tests/gpu-orchestrator-residency-poll.test.js
+++ b/tests/gpu-orchestrator-residency-poll.test.js
@@ -235,9 +235,28 @@ test("prune via full tick: a provider removed from cfg entirely is dropped from 
   await pollResidency({ cfg: cfg1, ownAddrs: CROW, probe: makeProbe(true), now: () => 1000, composeExists: yes });
   assert.ok(getProviderHealth().providers.p);
 
-  const cfg2 = { providers: {} }; // p is gone
+  // p is gone, but the config still READS (another provider remains), so this
+  // is a real removal rather than a failed load.
+  const other = { ...prov(`http://${CROW_IP}:9999/v1`), gpuPolicy: { alwaysResident: false } };
+  const cfg2 = { providers: { other } };
   await pollResidency({ cfg: cfg2, ownAddrs: CROW, probe: makeProbe(true), now: () => 2000, composeExists: yes });
   assert.equal(getProviderHealth().providers.p, undefined, "pruned when no longer declared");
+});
+
+test("an UNREADABLE config ({providers:{}}) does not wipe outage clocks", async () => {
+  // loadProviders() returns {providers:{}} when the DB and models.json are both
+  // unreadable. That is indistinguishable from "all providers deleted", so it
+  // must NOT prune — otherwise every bad tick restarts the 10-min warn window
+  // and a long outage stays silent forever (the bug this feature exists to fix).
+  const cfg1 = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  await pollResidency({ cfg: cfg1, ownAddrs: CROW, probe: makeProbe(false), now: () => 1000, composeExists: yes });
+  const clock = getProviderHealth().providers.p.firstOwnedAt;
+  assert.equal(clock, 1000);
+
+  await pollResidency({ cfg: { providers: {} }, ownAddrs: CROW, probe: makeProbe(false), now: () => 500_000, composeExists: yes });
+  const after = getProviderHealth().providers.p;
+  assert.ok(after, "entry survives an unreadable config");
+  assert.equal(after.firstOwnedAt, clock, "outage clock NOT reset by an unreadable config");
 });
 
 // --- monitor lifecycle --------------------------------------------------

--- a/tests/gpu-orchestrator-residency-poll.test.js
+++ b/tests/gpu-orchestrator-residency-poll.test.js
@@ -1,0 +1,251 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isSafeBundleId, composeFile, localAlwaysResident,
+  pollResidency, startResidencyMonitor, _stopResidencyMonitor,
+} from "../servers/gateway/gpu-orchestrator.js";
+import {
+  _resetProviderHealth, getProviderHealth,
+} from "../servers/gateway/provider-health.js";
+
+// --- helpers ------------------------------------------------------------
+
+const CROW_IP = "100.118.41.122";
+const GRACKLE_IP = "100.121.254.89";
+const OTHER_IP = "10.9.9.9";
+
+const own = (...ips) => new Set(["localhost", "127.0.0.1", "::1", ...ips]);
+const CROW = own(CROW_IP);
+
+// A declared alwaysResident provider with a safe bundle by default.
+const prov = (baseUrl, extra = {}) => ({
+  baseUrl,
+  bundleId: "safe-bundle",
+  gpuPolicy: { alwaysResident: true },
+  ...extra,
+});
+
+// A probe recorder — remembers which baseUrls it was asked about.
+function makeProbe(result = true) {
+  const seen = [];
+  const fn = async (url) => {
+    seen.push(url);
+    if (typeof result === "function") return result(url);
+    return result;
+  };
+  fn.seen = seen;
+  return fn;
+}
+
+const yes = () => true; // composeExists that always says the file exists
+
+beforeEach(() => { _resetProviderHealth(); _stopResidencyMonitor(); });
+afterEach(() => { _stopResidencyMonitor(); });
+
+// --- isSafeBundleId / composeFile ---------------------------------------
+
+test("isSafeBundleId accepts single safe path segments", () => {
+  for (const ok of ["vllm-cuda-embed", "a1", "a.b_c-d", "Z", "9x"]) {
+    assert.equal(isSafeBundleId(ok), true, `expected accept: ${ok}`);
+  }
+});
+
+test("isSafeBundleId rejects empty, non-strings, traversal, separators, leading . or -", () => {
+  for (const bad of ["", null, undefined, 123, {}, [], "123/x", "..", ".", "a/b", "a\\b", "-x", ".hidden", "../foo", "/abs"]) {
+    assert.equal(isSafeBundleId(bad), false, `expected reject: ${JSON.stringify(bad)}`);
+  }
+});
+
+test('composeFile("..") throws instead of resolving to the repo-root docker-compose.yml', () => {
+  assert.throws(() => composeFile(".."), /unsafe|bundleId/i);
+  assert.throws(() => composeFile("a/b"), /unsafe|bundleId/i);
+  // a safe id still returns a path
+  assert.ok(composeFile("safe-bundle").endsWith("/safe-bundle/docker-compose.yml"));
+});
+
+// --- localAlwaysResident ------------------------------------------------
+
+test("localAlwaysResident returns only declared+locally-orchestratable names, and does not log", () => {
+  const cfg = { providers: {
+    "crow-voice": prov(`http://${CROW_IP}:8011/v1`),
+    "grackle-embed": prov(`http://${GRACKLE_IP}:9100/v1`),
+  } };
+  const logs = [];
+  const orig = console.log; console.log = (m) => logs.push(String(m));
+  try {
+    assert.deepEqual(localAlwaysResident(cfg, CROW), ["crow-voice"]);
+  } finally { console.log = orig; }
+  assert.equal(logs.length, 0, "localAlwaysResident must not log");
+});
+
+// --- pollResidency: ownership + traps -----------------------------------
+
+test("trap 1: probes only owned providers; a peer's provider is never probed nor recorded", async () => {
+  const cfg = { providers: {
+    "crow-voice": prov(`http://${CROW_IP}:8011/v1`),
+    "grackle-embed": prov(`http://${GRACKLE_IP}:9100/v1`),
+  } };
+  const probe = makeProbe(true);
+  const probed = await pollResidency({ cfg, ownAddrs: CROW, probe, now: () => 1000, composeExists: yes });
+  assert.deepEqual(probed, ["crow-voice"]);
+  assert.deepEqual(probe.seen, [`http://${CROW_IP}:8011/v1`]);
+  const h = getProviderHealth().providers;
+  assert.ok(h["crow-voice"], "crow-voice recorded");
+  assert.equal(h["grackle-embed"], undefined, "peer provider never recorded");
+});
+
+test("trap 2: a provider that becomes local on tick 2 is stamped firstOwnedAt at tick 2's clock", async () => {
+  const cfg1 = { providers: { p: prov(`http://${OTHER_IP}:8080/v1`) } };
+  await pollResidency({ cfg: cfg1, ownAddrs: CROW, probe: makeProbe(false), now: () => 1000, composeExists: yes });
+  assert.equal(getProviderHealth().providers.p, undefined, "not owned on tick 1 → not recorded");
+
+  const cfg2 = { providers: { p: prov(`http://${OTHER_IP}:8080/v1`) } };
+  await pollResidency({ cfg: cfg2, ownAddrs: own(OTHER_IP), probe: makeProbe(false), now: () => 5000, composeExists: yes });
+  const p = getProviderHealth().providers.p;
+  assert.ok(p, "owned on tick 2 → recorded");
+  assert.equal(p.firstOwnedAt, 5000, "clock starts at tick 2, not boot");
+});
+
+test("CRITICAL: a provider that drops out of the local set (tailscale0 flap) is STILL probed and its clock is NOT reset", async () => {
+  const cfg = { providers: { "crow-voice": prov(`http://${CROW_IP}:8011/v1`) } };
+  // tick 1: local, not ready → clock starts at T=1000
+  await pollResidency({ cfg, ownAddrs: CROW, probe: makeProbe(false), now: () => 1000, composeExists: yes });
+  const after1 = getProviderHealth().providers["crow-voice"];
+  assert.ok(after1, "recorded on tick 1");
+  assert.equal(after1.firstOwnedAt, 1000);
+
+  // tick 2: ownAddrs NO LONGER contains the address (tailscale0 restart).
+  // Full tick, INCLUDING the internal pruneResidency call.
+  const probe2 = makeProbe(false);
+  const probed = await pollResidency({ cfg, ownAddrs: own(), probe: probe2, now: () => 9999, composeExists: yes });
+  assert.deepEqual(probed, ["crow-voice"], "still probed despite failing the locality check");
+  assert.deepEqual(probe2.seen, [`http://${CROW_IP}:8011/v1`]);
+  const after2 = getProviderHealth().providers["crow-voice"];
+  assert.ok(after2, "entry still exists after prune");
+  assert.equal(after2.firstOwnedAt, 1000, "outage clock unchanged");
+});
+
+test("ownership is released and re-evaluated when baseUrl changes", async () => {
+  // own at url A
+  const cfgA = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  await pollResidency({ cfg: cfgA, ownAddrs: CROW, probe: makeProbe(false), now: () => 1000, composeExists: yes });
+  assert.equal(getProviderHealth().providers.p.firstOwnedAt, 1000);
+
+  // tick with url B that is NOT local → entry gone, not probed
+  const cfgB = { providers: { p: prov(`http://${OTHER_IP}:9000/v1`) } };
+  const probeB = makeProbe(false);
+  await pollResidency({ cfg: cfgB, ownAddrs: CROW, probe: probeB, now: () => 2000, composeExists: yes });
+  assert.equal(getProviderHealth().providers.p, undefined, "released on baseUrl change to a non-local url");
+  assert.deepEqual(probeB.seen, [], "not probed");
+
+  // tick with url B that IS local → fresh firstOwnedAt
+  await pollResidency({ cfg: cfgB, ownAddrs: own(OTHER_IP), probe: makeProbe(false), now: () => 3000, composeExists: yes });
+  assert.equal(getProviderHealth().providers.p.firstOwnedAt, 3000, "fresh ownership stamp");
+});
+
+// --- pollResidency: SSRF / compose gates --------------------------------
+
+test("a provider with no bundleId is never probed and any existing entry is released", async () => {
+  // seed an entry
+  const seeded = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  await pollResidency({ cfg: seeded, ownAddrs: CROW, probe: makeProbe(false), now: () => 1000, composeExists: yes });
+  assert.ok(getProviderHealth().providers.p);
+
+  const cfg = { providers: { p: prov(`http://${CROW_IP}:8011/v1`, { bundleId: null }) } };
+  const probe = makeProbe(true);
+  const probed = await pollResidency({ cfg, ownAddrs: CROW, probe, now: () => 2000, composeExists: yes });
+  assert.deepEqual(probed, []);
+  assert.deepEqual(probe.seen, []);
+  assert.equal(getProviderHealth().providers.p, undefined, "released when bundleId disappears");
+});
+
+test("a provider whose compose file is absent is never probed, and an existing entry is released", async () => {
+  const cfg = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  await pollResidency({ cfg, ownAddrs: CROW, probe: makeProbe(false), now: () => 1000, composeExists: yes });
+  assert.ok(getProviderHealth().providers.p);
+
+  const probe = makeProbe(true);
+  const probed = await pollResidency({ cfg, ownAddrs: CROW, probe, now: () => 2000, composeExists: () => false });
+  assert.deepEqual(probed, []);
+  assert.deepEqual(probe.seen, []);
+  assert.equal(getProviderHealth().providers.p, undefined, "released when compose file vanishes");
+});
+
+test("a composeExists that throws is treated as not-orchestratable (guarded, no throw)", async () => {
+  const cfg = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  const probe = makeProbe(true);
+  const probed = await pollResidency({
+    cfg, ownAddrs: CROW, probe, now: () => 1000,
+    composeExists: () => { throw new Error("stat boom"); },
+  });
+  assert.deepEqual(probed, []);
+  assert.deepEqual(probe.seen, []);
+});
+
+// --- pollResidency: log-spam regression ---------------------------------
+
+test("pollResidency emits NO '[gpu-orchestrator] skipping' log line", async () => {
+  const cfg = { providers: {
+    "crow-voice": prov(`http://${CROW_IP}:8011/v1`),
+    "grackle-embed": prov(`http://${GRACKLE_IP}:9100/v1`), // skipped from crow
+  } };
+  const logs = [];
+  const orig = console.log; console.log = (m) => logs.push(String(m));
+  try {
+    await pollResidency({ cfg, ownAddrs: CROW, probe: makeProbe(true), now: () => 1000, composeExists: yes });
+  } finally { console.log = orig; }
+  assert.ok(!logs.some((l) => l.includes("[gpu-orchestrator] skipping")), `unexpected skip log: ${logs.join(" | ")}`);
+});
+
+// --- pollResidency: error isolation -------------------------------------
+
+test("a probe that rejects is recorded as not-ready with lastError; other providers still recorded", async () => {
+  const cfg = { providers: {
+    a: prov(`http://${CROW_IP}:8011/v1`),
+    b: prov(`http://${CROW_IP}:8012/v1`),
+  } };
+  const probe = async (url) => {
+    if (url.includes(":8011")) throw new Error("connect ECONNREFUSED");
+    return true;
+  };
+  const probed = await pollResidency({ cfg, ownAddrs: CROW, probe, now: () => 1000, composeExists: yes });
+  assert.deepEqual(probed.sort(), ["a", "b"]);
+  const h = getProviderHealth().providers;
+  assert.equal(h.a.ready, false);
+  assert.match(h.a.lastError, /ECONNREFUSED/);
+  assert.equal(h.b.ready, true);
+});
+
+test("a cfg whose providers getter throws does not throw and leaves prior state intact", async () => {
+  // seed known-good state
+  const seeded = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  await pollResidency({ cfg: seeded, ownAddrs: CROW, probe: makeProbe(true), now: () => 1000, composeExists: yes });
+  const before = getProviderHealth();
+
+  const throwing = { get providers() { throw new Error("db down"); } };
+  const probed = await pollResidency({ cfg: throwing, ownAddrs: CROW, probe: makeProbe(true), now: () => 2000, composeExists: yes });
+  assert.deepEqual(probed, [], "no work done");
+  assert.deepEqual(getProviderHealth(), before, "prior state untouched");
+});
+
+// --- pollResidency: prune via a full tick -------------------------------
+
+test("prune via full tick: a provider removed from cfg entirely is dropped from state", async () => {
+  const cfg1 = { providers: { p: prov(`http://${CROW_IP}:8011/v1`) } };
+  await pollResidency({ cfg: cfg1, ownAddrs: CROW, probe: makeProbe(true), now: () => 1000, composeExists: yes });
+  assert.ok(getProviderHealth().providers.p);
+
+  const cfg2 = { providers: {} }; // p is gone
+  await pollResidency({ cfg: cfg2, ownAddrs: CROW, probe: makeProbe(true), now: () => 2000, composeExists: yes });
+  assert.equal(getProviderHealth().providers.p, undefined, "pruned when no longer declared");
+});
+
+// --- monitor lifecycle --------------------------------------------------
+
+test("startResidencyMonitor is idempotent and _stopResidencyMonitor clears it (no leaked interval)", () => {
+  startResidencyMonitor();
+  startResidencyMonitor(); // second call is a no-op
+  _stopResidencyMonitor();
+  // if the interval leaked, the test suite would hang; reaching here is the assertion
+  assert.ok(true);
+});

--- a/tests/provider-health.test.js
+++ b/tests/provider-health.test.js
@@ -1,0 +1,162 @@
+/**
+ * provider-health — the zero-import per-process residency state module
+ * (F-HEALTH-1 Task 1). Mirrors tests/messages-health-signal.test.js in shape:
+ * reset the singleton at the top of every test, inject the clock explicitly via
+ * `nowMs`, and assert on the shape returned by getProviderHealth().
+ *
+ * The load-bearing invariants under test: firstOwnedAt records the START of
+ * ownership and never moves on a repeat not-ready; lastReadyAt records the LAST
+ * success and is what the outage clock restarts from; pruneResidency drops only
+ * UNDECLARED names (never a declared-but-not-ready one — the reviewed CRITICAL);
+ * and getProviderHealth() hands back a copy that callers cannot use to mutate
+ * module state.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  setResidencyInitialized, recordResidency, releaseResidency,
+  pruneResidency, getProviderHealth, _resetProviderHealth,
+} from "../servers/gateway/provider-health.js";
+
+test("fresh state → initialized:false, providers empty", () => {
+  _resetProviderHealth();
+  const h = getProviderHealth();
+  assert.equal(h.initialized, false);
+  assert.deepEqual(h.providers, {});
+});
+
+test("setResidencyInitialized() flips initialized", () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  assert.equal(getProviderHealth().initialized, true);
+});
+
+test("first recordResidency ready:false → owned, firstOwnedAt stamped, lastReadyAt null", () => {
+  _resetProviderHealth();
+  recordResidency("crow-voice", {
+    ready: false, nowMs: 1000, baseUrl: "http://x:8011/v1",
+  });
+  const p = getProviderHealth().providers["crow-voice"];
+  assert.equal(p.owned, true);
+  assert.equal(p.firstOwnedAt, 1000);
+  assert.equal(p.lastReadyAt, null);
+  assert.equal(p.ready, false);
+  assert.equal(p.checkedAt, 1000);
+  assert.equal(p.baseUrl, "http://x:8011/v1");
+});
+
+test("second ready:false does not move firstOwnedAt or lastReadyAt, but advances checkedAt", () => {
+  _resetProviderHealth();
+  recordResidency("crow-voice", { ready: false, nowMs: 1000, baseUrl: "http://x/v1" });
+  recordResidency("crow-voice", { ready: false, nowMs: 5000, baseUrl: "http://x/v1" });
+  const p = getProviderHealth().providers["crow-voice"];
+  assert.equal(p.firstOwnedAt, 1000); // outage clock keeps running from the start
+  assert.equal(p.lastReadyAt, null);
+  assert.equal(p.checkedAt, 5000);
+});
+
+test("ready:true stamps lastReadyAt and clears lastError", () => {
+  _resetProviderHealth();
+  recordResidency("crow-voice", {
+    ready: false, nowMs: 1000, baseUrl: "http://x/v1", error: new Error("boom"),
+  });
+  assert.equal(getProviderHealth().providers["crow-voice"].lastError, "boom");
+  recordResidency("crow-voice", { ready: true, nowMs: 2000, baseUrl: "http://x/v1" });
+  const p = getProviderHealth().providers["crow-voice"];
+  assert.equal(p.ready, true);
+  assert.equal(p.lastReadyAt, 2000);
+  assert.equal(p.lastError, null);
+});
+
+test("later ready:false leaves lastReadyAt at the last success time", () => {
+  _resetProviderHealth();
+  recordResidency("crow-voice", { ready: false, nowMs: 1000, baseUrl: "http://x/v1" });
+  recordResidency("crow-voice", { ready: true, nowMs: 2000, baseUrl: "http://x/v1" });
+  recordResidency("crow-voice", { ready: false, nowMs: 9000, baseUrl: "http://x/v1" });
+  const p = getProviderHealth().providers["crow-voice"];
+  // clock restarts from the last success (2000), not firstOwnedAt (1000)
+  assert.equal(p.firstOwnedAt, 1000);
+  assert.equal(p.lastReadyAt, 2000);
+  assert.equal(p.ready, false);
+});
+
+test("error recorded as string from Error and from bare string; cleared on success", () => {
+  _resetProviderHealth();
+  recordResidency("a", { ready: false, nowMs: 1, baseUrl: "u", error: new Error("kaboom") });
+  assert.equal(getProviderHealth().providers["a"].lastError, "kaboom");
+  recordResidency("a", { ready: false, nowMs: 2, baseUrl: "u", error: "plain string" });
+  assert.equal(getProviderHealth().providers["a"].lastError, "plain string");
+  recordResidency("a", { ready: false, nowMs: 3, baseUrl: "u" }); // no error given
+  assert.equal(getProviderHealth().providers["a"].lastError, null);
+  recordResidency("a", { ready: false, nowMs: 4, baseUrl: "u", error: "again" });
+  recordResidency("a", { ready: true, nowMs: 5, baseUrl: "u" });
+  assert.equal(getProviderHealth().providers["a"].lastError, null);
+});
+
+test("embed is stored and coerced to boolean", () => {
+  _resetProviderHealth();
+  recordResidency("emb", { ready: true, nowMs: 1, baseUrl: "u", embed: 1 });
+  assert.equal(getProviderHealth().providers["emb"].embed, true);
+  recordResidency("emb", { ready: true, nowMs: 2, baseUrl: "u", embed: 0 });
+  assert.equal(getProviderHealth().providers["emb"].embed, false);
+  recordResidency("emb2", { ready: true, nowMs: 1, baseUrl: "u" }); // default
+  assert.equal(getProviderHealth().providers["emb2"].embed, false);
+});
+
+test("releaseResidency deletes the entry; next record stamps a FRESH firstOwnedAt", () => {
+  _resetProviderHealth();
+  recordResidency("crow-voice", { ready: true, nowMs: 1000, baseUrl: "http://x/v1" });
+  releaseResidency("crow-voice");
+  assert.equal(getProviderHealth().providers["crow-voice"], undefined);
+  recordResidency("crow-voice", { ready: false, nowMs: 7000, baseUrl: "http://y/v1" });
+  const p = getProviderHealth().providers["crow-voice"];
+  assert.equal(p.firstOwnedAt, 7000);
+  assert.equal(p.lastReadyAt, null);
+});
+
+test("pruneResidency drops undeclared names, keeps declared (array and Set)", () => {
+  _resetProviderHealth();
+  recordResidency("a", { ready: true, nowMs: 1, baseUrl: "u" });
+  recordResidency("b", { ready: true, nowMs: 1, baseUrl: "u" });
+  recordResidency("c", { ready: true, nowMs: 1, baseUrl: "u" });
+  pruneResidency(["a", "b"]);
+  assert.ok(getProviderHealth().providers["a"]);
+  assert.ok(getProviderHealth().providers["b"]);
+  assert.equal(getProviderHealth().providers["c"], undefined);
+  pruneResidency(new Set(["a"]));
+  assert.ok(getProviderHealth().providers["a"]);
+  assert.equal(getProviderHealth().providers["b"], undefined);
+});
+
+test("pruneResidency does NOT drop a declared name that is currently not-ready", () => {
+  _resetProviderHealth();
+  recordResidency("down", { ready: false, nowMs: 1000, baseUrl: "u" });
+  pruneResidency(["down"]);
+  const p = getProviderHealth().providers["down"];
+  assert.ok(p, "declared-but-down provider must survive prune (reviewed CRITICAL)");
+  assert.equal(p.firstOwnedAt, 1000); // outage clock intact
+  assert.equal(p.ready, false);
+});
+
+test("getProviderHealth returns a copy: mutating or deleting does not affect state", () => {
+  _resetProviderHealth();
+  recordResidency("a", { ready: true, nowMs: 1, baseUrl: "u" });
+  const first = getProviderHealth();
+  first.providers["a"].ready = false;
+  delete first.providers["a"];
+  first.initialized = true;
+  const second = getProviderHealth();
+  assert.ok(second.providers["a"], "entry must still exist");
+  assert.equal(second.providers["a"].ready, true, "ready must be untouched");
+  assert.equal(second.initialized, false, "top-level must be untouched");
+});
+
+test("_resetProviderHealth restores the initial shape", () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("a", { ready: true, nowMs: 1, baseUrl: "u" });
+  _resetProviderHealth();
+  const h = getProviderHealth();
+  assert.equal(h.initialized, false);
+  assert.deepEqual(h.providers, {});
+});

--- a/tests/providers-health-signal.test.js
+++ b/tests/providers-health-signal.test.js
@@ -1,0 +1,200 @@
+/**
+ * providersSignal (F-HEALTH-1) — nest health signal for alwaysResident provider
+ * residency. Drives collectHealthSignals and asserts on the `providers` detail /
+ * issue, mirroring tests/messages-health-signal.test.js. Clock injected via
+ * opts.now; state driven through the provider-health.js state module.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  collectHealthSignals, invalidateHealthCache,
+} from "../servers/gateway/dashboard/panels/nest/health-signals.js";
+import {
+  setResidencyInitialized, recordResidency, _resetProviderHealth,
+} from "../servers/gateway/provider-health.js";
+import { _resetReceiveHealth } from "../servers/sharing/receive-health.js";
+import { t } from "../servers/gateway/dashboard/shared/i18n.js";
+
+const NOW = 1_800_000_000_000;
+const MIN = 60_000;
+const THRESHOLD = 10 * MIN;
+
+// Stub db: every query returns empty rows. messagesSignal short-circuits to
+// "off" while receiveWired is null (we reset it), so it never reads db here.
+const db = { execute: async () => ({ rows: [] }) };
+
+async function providers(opts = {}) {
+  _resetReceiveHealth(); // keep the messages signal quiet / non-interfering
+  invalidateHealthCache(); // 30s module cache + _cacheLang
+  const r = await collectHealthSignals(db, opts);
+  return {
+    detail: r.details.find((d) => d.id === "providers"),
+    issue: r.issues.find((i) => i.id === "providers"),
+    all: r,
+  };
+}
+
+const at = (ms) => () => ms;
+
+test("not initialized → off, no issue", async () => {
+  _resetProviderHealth();
+  const { detail, issue } = await providers({ now: at(NOW) });
+  assert.equal(detail.state, "off");
+  assert.equal(issue, undefined);
+});
+
+test("initialized, zero providers → off, no issue", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  const { detail, issue } = await providers({ now: at(NOW) });
+  assert.equal(detail.state, "off");
+  assert.equal(issue, undefined);
+});
+
+test("all ready → ok, no issue, value mentions the resident count", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("crow-voice", { ready: true, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+  const { detail, issue } = await providers({ now: at(NOW) });
+  assert.equal(detail.state, "ok");
+  assert.equal(issue, undefined);
+  assert.match(detail.value, /1/);
+  assert.match(detail.value, /resident/i);
+});
+
+test("not-ready UNDER the threshold → ok, no issue (warm/deferred window)", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  // firstOwnedAt stamped at NOW, never answered
+  recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+  const { detail, issue } = await providers({ now: at(NOW + 1 * MIN) });
+  assert.equal(detail.state, "ok");
+  assert.equal(issue, undefined);
+});
+
+test("not-ready OVER the threshold → one warn issue id=providers", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+  const { detail, issue } = await providers({ now: at(NOW + THRESHOLD + MIN) });
+  assert.equal(detail.state, "warn");
+  assert.ok(issue);
+  assert.equal(issue.id, "providers");
+  assert.equal(issue.severity, "warn");
+});
+
+test("never-ready-since-ownership clocks from firstOwnedAt (grackle case)", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  // lastReadyAt stays null; firstOwnedAt = NOW
+  recordResidency("grackle-embed", { ready: false, nowMs: NOW, baseUrl: "http://y:9100/v1", embed: true });
+  const { detail, issue } = await providers({ now: at(NOW + THRESHOLD + MIN) });
+  assert.equal(detail.state, "warn");
+  assert.ok(issue);
+});
+
+test("was-ready-then-down: clock runs from lastReadyAt, not firstOwnedAt", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  const url = "http://x:8011/v1";
+  // firstOwnedAt = NOW (never-ready), then a success at NOW+20m, then down at NOW+21m
+  recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: url, embed: false });
+  recordResidency("crow-voice", { ready: true, nowMs: NOW + 20 * MIN, baseUrl: url, embed: false });
+  recordResidency("crow-voice", { ready: false, nowMs: NOW + 21 * MIN, baseUrl: url, embed: false });
+  // now: 25m past NOW (> threshold from firstOwnedAt) but only 5m past lastReadyAt
+  const { detail, issue } = await providers({ now: at(NOW + 25 * MIN) });
+  assert.equal(detail.state, "ok", "must NOT warn: now - lastReadyAt < threshold");
+  assert.equal(issue, undefined);
+});
+
+test("embed vs non-embed down → different issue copy; non-embed omits 'embed'", async () => {
+  // embed provider down → EMBED issue copy
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("grackle-embed", { ready: false, nowMs: NOW, baseUrl: "http://y:9100/v1", embed: true });
+  const embedIssue = (await providers({ now: at(NOW + THRESHOLD + MIN) })).issue;
+  assert.ok(embedIssue);
+  const embedLabel = embedIssue.label;
+
+  // non-embed provider down → NON-embed issue copy
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+  const voiceIssue = (await providers({ now: at(NOW + THRESHOLD + MIN) })).issue;
+  assert.ok(voiceIssue);
+  const voiceLabel = voiceIssue.label;
+
+  assert.notEqual(embedLabel, voiceLabel);
+  assert.doesNotMatch(voiceLabel, /embed/i, "non-embed issue copy must not mention embedding");
+  // The issue label becomes the notification title, so a lone down provider
+  // must be named in it — no unresolved {name} placeholder either.
+  assert.match(embedLabel, /grackle-embed/);
+  assert.match(voiceLabel, /crow-voice/);
+  for (const l of [embedLabel, voiceLabel]) assert.doesNotMatch(l, /\{name\}/);
+});
+
+test("two providers over threshold → exactly ONE issue, multi copy", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+  recordResidency("other-model", { ready: false, nowMs: NOW, baseUrl: "http://x:8012/v1", embed: false });
+  const { detail, all } = await providers({ now: at(NOW + THRESHOLD + MIN) });
+  assert.equal(detail.state, "warn");
+  const providerIssues = all.issues.filter((i) => i.id === "providers");
+  assert.equal(providerIssues.length, 1);
+  assert.match(detail.value, /2/); // downMulti mentions the count
+});
+
+test("CROW_PROVIDER_NOT_READY_WARN_MS override is honored", async () => {
+  const prev = process.env.CROW_PROVIDER_NOT_READY_WARN_MS;
+  try {
+    _resetProviderHealth();
+    setResidencyInitialized();
+    recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+    // 5 min out: OK at the 10-min default...
+    let r = await providers({ now: at(NOW + 5 * MIN) });
+    assert.equal(r.detail.state, "ok");
+    // ...but WARN once the threshold is lowered to 1 min.
+    process.env.CROW_PROVIDER_NOT_READY_WARN_MS = String(1 * MIN);
+    r = await providers({ now: at(NOW + 5 * MIN) });
+    assert.equal(r.detail.state, "warn");
+    assert.ok(r.issue);
+  } finally {
+    if (prev === undefined) delete process.env.CROW_PROVIDER_NOT_READY_WARN_MS;
+    else process.env.CROW_PROVIDER_NOT_READY_WARN_MS = prev;
+  }
+});
+
+test("EN and ES render for all 11 keys (output never equals the raw key)", () => {
+  const keys = [
+    "signals.providers.label",
+    "signals.providers.notStarted",
+    "signals.providers.off",
+    "signals.providers.resident",
+    "signals.providers.warming",
+    "signals.providers.down",
+    "signals.providers.downMulti",
+    "signals.providers.downIssue",
+    "signals.providers.downIssueEmbed",
+    "signals.providers.downIssueMulti",
+    "signals.providers.action",
+  ];
+  assert.equal(keys.length, 11);
+  for (const key of keys) {
+    for (const lang of ["en", "es"]) {
+      const rendered = t(key, lang);
+      assert.notEqual(rendered, key, `missing i18n for ${key} (${lang})`);
+      assert.ok(rendered && rendered.length > 0);
+    }
+  }
+});
+
+test("providersSignal never breaks its siblings (warn state still yields other signals)", async () => {
+  _resetProviderHealth();
+  setResidencyInitialized();
+  recordResidency("crow-voice", { ready: false, nowMs: NOW, baseUrl: "http://x:8011/v1", embed: false });
+  const { detail, all } = await providers({ now: at(NOW + THRESHOLD + MIN) });
+  assert.equal(detail.state, "warn");
+  assert.ok(all.details.length > 1);
+  assert.ok(all.details.some((d) => d.id === "disk"), "disk signal still present");
+});


### PR DESCRIPTION
## The gap

grackle's `alwaysResident` embed provider (`vllm-cuda-embed`) was **down for 12 days** — its container crash-looped **57,604 times** — and nothing ever alerted. Semantic memory and search embeddings were silently degraded fleet-wide the whole time, which is the exact failure mode `gpu-orchestrator.js`'s own header comment warns about.

Root cause: `probeReady()` is called **once**, at gateway boot, inside `ensureResident`. Nothing ever re-polls it. A provider that dies on day 1 is indistinguishable from a healthy one for the rest of the process lifetime. Docker's `restart: unless-stopped` loop masked the hard failure as perpetual "starting", and the orchestrator only `console.log`s its decisions.

It was found only because a human happened to read the log after an unrelated deploy.

## The fix

- **`servers/gateway/provider-health.js`** (new) — a zero-import, per-process residency state module, following the `servers/sharing/receive-health.js` precedent so the nest signal can read it without dragging `child_process`/`db.js` into the dashboard render path.
- **`pollResidency()`** on a 120 s unref'd interval re-probes every `alwaysResident` provider this machine **owns**, recording ready / last-ready. This is the re-poll the original outage lacked.
- **`providersSignal`** warns once an owned provider has been unreachable for `>= CROW_PROVIDER_NOT_READY_WARN_MS` (default 10 min), notifying through the existing health-monitor path (24 h dedupe -> dashboard + ntfy).

Rendering what should have fired on day 1 of the incident:

```
chip   : warn  "grackle-embed unreachable ≥12d"
notif  : "The embedding provider grackle-embed has been unreachable, so new memories,
          sources and notes aren't being embedded; semantic search and recall are
          degraded until it recovers."
action : "Open model health" -> /dashboard/settings?section=llm&tab=health
```

## Design decisions that took two rounds of review to get right

**Sticky ownership.** The first draft recomputed the local provider set every tick and pruned anything that fell out of it. That would have **re-created the very outage this feature detects**: both shipped providers bind *Tailscale IPs*, so `isLocallyOrchestratable` is conditional on `tailscale0` being present in `networkInterfaces()`. A `tailscaled` restart would have deleted the outage clock and restarted it from zero. If churn recurred faster than the threshold, the warn would never fire.

Ownership is now taken the first time a provider passes the locality check and released only when its `baseUrl` changes. Once owned, it is probed every tick regardless of interface churn — because if `tailscale0` is down, the provider genuinely *is* unreachable. (A reviewer proposed *freezing* the clock instead; that was rejected because it hides a true outage.) Pruning keys on the **full declared set**, never on locality.

**A machine never warns about a peer's provider.** `crow` owns `crow-voice`; `grackle` owns `grackle-embed`; each skips the other's, reusing `isLocallyOrchestratable` from #151. Verified live on both hosts.

**The warn copy is derived, not hardcoded.** An earlier draft said "embeddings and semantic search are degraded". That is wrong on crow, which only ever owns `crow-voice` — a voice/dispatch model with no `task: "embed"`. The copy is now selected from the down provider's own `embed` flag.

**Arm before anything can throw.** `initOrchestrator` sets `_initialized = true` before any `await`, and its caller only `.catch()`es. Wiring the monitor at the *end* would mean any throw in the ensure loop silently disarmed detection for the process lifetime — the exact failure class this PR exists to eliminate. It is armed first; the body is wrapped.

**A failed config read must not wipe the clocks.** `loadProviders()` returns `{providers:{}}` when both the DB and `models.json` are unreadable, which is indistinguishable from "every provider was deleted". Pruning on that restarted the 10-minute warn window on every bad tick. Now we prune only when a config was actually read.

**Restart counts were considered and declined.** Empirically: grackle's container *right now* reports `RestartCount 57604` while `state=running (healthy)` and answering 200 — Docker doesn't reset the counter until the container is recreated. A huge count coexists with a healthy provider. Outage *duration* is the honest signal.

## Security

- `isSafeBundleId`, enforced **inside `composeFile()`**. `bundle_id` arrives from the fleet-synced `providers` table, and `join(BUNDLES_DIR, "..", "docker-compose.yml")` resolves to the tracked repo-root compose file — so a compose-exists gate alone would have passed for `bundleId: ".."`. Enforcing it in `composeFile` also hardens the **pre-existing** `bundleUp`/`bundleStop` `spawn` paths, where `bundleUp("../x")` was previously reachable.
- The poll refuses providers with no `bundleId` (matching `acquireProvider`), closing a bundle-less-row beacon.
- `probeReady` sends no headers, so no `apiKey` is exposed (contrast `probeProvider`).
- A fleet-synced provider *name* flows into `value` / `issueLabel` / the notification title; all sinks were traced and are escaped (`escapeHtml`, `textContent`). No stored XSS.
- `--no-auth` gateways still never run the health monitor (design trap 4, `tests/health-monitor-noauth-skip.test.js` untouched and green).

## Verification

- Suite **1258 pass / 0 fail / 1 skip** (+42), run repeatedly, no flake, no leaked interval.
- **Mutation-tested** twice, because a regression test that passes vacuously is worse than none: flipping `pruneResidency(declared)` -> the local set fails the tailscale-flap test; removing the empty-config guard fails the unreadable-config test.
- **Live on crow**: declares both providers, owns only `crow-voice`, probes it, `ready: true` -> renders `ok`, no issue. Both providers are up fleet-wide, so this deploys green rather than as a false warn.
- i18n EN + ES. No new host ports (`check-ports` path-filtered, 0-applicable). No schema change, no `SCHEMA_GEN` bump.

Design doc, including both adversarial-review disposition tables and the documented blind spots: `docs/superpowers/specs/2026-07-09-provider-residency-health-signal-design.md`

Closes F-HEALTH-1.