### PR TITLE
fix(settings): profile follows the user — sync-allowlist profile keys, heal stranded saves (F-SETTINGS-1 + F-CONTACT-5)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-cluster-b-profile-follows-user.md
+++ b/docs/superpowers/plans/2026-07-10-cluster-b-profile-follows-user.md
@@ -1,0 +1,801 @@
+# Cluster B — Profile Follows the User Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the dashboard profile save real (write the global scope, sync to the user's paired instances) so the profile page shows what you saved and handshakes carry one consistent name — fixing F-SETTINGS-1 and F-CONTACT-5.
+
+**Architecture:** Allowlist the three `profile_*` keys so `upsertSetting` writes the global `dashboard_settings` row and emits to peers (D1); clear stranded broken-era overrides on save (D2); a one-shot flag-guarded boot heal promotes non-empty stranded overrides to global (D3); bump the settings re-emit flag v1→v2 with an empty-profile-value skip so pre-existing global rows reconcile once (D4). Readers stay global-direct (D6). No handshake-ack dedupe (D5). Spec (2-round adversarially reviewed): `docs/superpowers/specs/2026-07-10-profile-follows-user-design.md`.
+
+**Tech Stack:** Node ESM, better-sqlite3 via libsql-style client (`db.execute`), node:test.
+
+## Global Constraints
+
+- **No SCHEMA_GENERATION bump** — this PR is code-only; no DDL anywhere.
+- **NEVER `git commit --amend`** (shared tree, parallel sessions). Commit with **positional paths only** (`git commit <paths> -m ...`; `git add <path>` first for NEW files). Verify with `git show --stat HEAD` after every commit.
+- The working tree carries unrelated WIP (`scripts/bench/**`, many untracked dirs) from a parallel session — never `git add -A`/`git add .`.
+- Branch: `fix/messages-cluster-b-profile-follows-user`. Suite baseline: **1376 pass / 0 fail / 1 skip** (`node --test tests/*.test.js`).
+- The heal flag row is written via **raw SQL** into `dashboard_settings`, never `upsertSetting` (spec R2 MINOR-B).
+- Heal ordering is crash-safety-critical: **promote before delete** (spec R2 MINOR-C).
+- Heal gate: **`feedsDisabled === true` → full no-op** (no promotion, no flag write) (spec R2 MAJOR-A).
+- Tests must not leak module state: always reset `setSettingsSyncManager(null)` and restore `process.env.CROW_DATA_DIR` in `finally`.
+
+---
+
+### Task 1: Sync-allowlist the profile keys + `PROFILE_SYNC_KEYS` + `writeSetting` docblock fix
+
+**Files:**
+- Modify: `servers/gateway/dashboard/settings/sync-allowlist.js`
+- Modify: `servers/gateway/dashboard/settings/registry.js` (docblock only, ~line 177-187)
+- Test: `tests/profile-sync-allowlist.test.js` (new)
+
+**Interfaces:**
+- Produces: `export const PROFILE_SYNC_KEYS = ["profile_display_name", "profile_avatar_url", "profile_bio"]` from `sync-allowlist.js` — consumed by Tasks 2, 3, 4.
+- Produces: `isSyncable("profile_display_name") === true` (and the other two) — Tasks 3/4 depend on it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/profile-sync-allowlist.test.js`:
+
+```js
+/**
+ * Cluster B (F-SETTINGS-1/F-CONTACT-5) — the three profile keys are
+ * sync-allowlisted so upsertSetting writes the GLOBAL scope and emits to
+ * peers, instead of silently downgrading to a local override no reader sees.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { isSyncable, PROFILE_SYNC_KEYS } from "../servers/gateway/dashboard/settings/sync-allowlist.js";
+import { upsertSetting, setSettingsSyncManager } from "../servers/gateway/dashboard/settings/registry.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "profile-allowlist-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("profile keys are sync-allowlisted (F-SETTINGS-1 root fix)", () => {
+  for (const k of ["profile_display_name", "profile_avatar_url", "profile_bio"]) {
+    assert.equal(isSyncable(k), true, `${k} must be syncable`);
+  }
+  assert.deepEqual(PROFILE_SYNC_KEYS, ["profile_display_name", "profile_avatar_url", "profile_bio"]);
+});
+
+test("explicit-entry posture: an unrelated profile_ key is NOT syncable", () => {
+  assert.equal(isSyncable("profile_zzz"), false);
+});
+
+test("upsertSetting on a profile key writes the GLOBAL row (no override) and emits", async () => {
+  const { dir, db, cleanup } = freshDb();
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const emitted = [];
+  setSettingsSyncManager({ emitChange: async (t, op, row) => { emitted.push({ t, op, row }); } });
+  try {
+    await upsertSetting(db, "profile_display_name", "Kevin");
+    const g = await db.execute("SELECT value FROM dashboard_settings WHERE key = 'profile_display_name'");
+    assert.equal(g.rows[0]?.value, "Kevin", "global row written");
+    const o = await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings_overrides WHERE key = 'profile_display_name'");
+    assert.equal(Number(o.rows[0].c), 0, "no local-override downgrade");
+    assert.ok(
+      emitted.some((e) => e.t === "dashboard_settings" && e.op === "update" && e.row.key === "profile_display_name" && e.row.instance_id === null),
+      "sync emit fired with instance_id null"
+    );
+  } finally {
+    setSettingsSyncManager(null);
+    if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevDataDir;
+    cleanup();
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/profile-sync-allowlist.test.js`
+Expected: FAIL — `PROFILE_SYNC_KEYS` is not exported (SyntaxError on import) / `isSyncable` returns false.
+
+- [ ] **Step 3: Implement**
+
+In `servers/gateway/dashboard/settings/sync-allowlist.js`, add to `SYNC_ALLOWLIST` (after `unified_dashboard_enabled`):
+
+```js
+  // Cluster B (F-SETTINGS-1/F-CONTACT-5): own-profile identity is user-level
+  // data — it follows the user across instances like contacts/groups do.
+  // SECURITY NOTE: the sync-apply path (_applyDashboardSetting) writes peer
+  // values RAW. The defense is (a) every dashboard render of profile values is
+  // escapeHtml'd and (b) both handshake readers re-sanitize via
+  // sanitizeDisplayName at READ time. Any future reader of profile_* must
+  // follow the same rule.
+  profile_display_name:      "Own profile — display name (sent in pairing handshakes)",
+  profile_avatar_url:        "Own profile — avatar URL",
+  profile_bio:               "Own profile — bio",
+```
+
+And export (near the bottom, after `checkSyncKeyDrift`):
+
+```js
+/**
+ * The three own-profile keys (explicit list, deliberately NOT a "profile_*"
+ * allowlist prefix — a future profile_ key must be consciously added).
+ * Consumed by the save-path override clear, the one-shot heal, and the
+ * re-emit empty-value guard.
+ */
+export const PROFILE_SYNC_KEYS = ["profile_display_name", "profile_avatar_url", "profile_bio"];
+```
+
+In `servers/gateway/dashboard/settings/registry.js`, fix the `writeSetting` docblock lie (R1): replace
+
+```js
+ *   - "global" → dashboard_settings row (synced if key in SYNC_ALLOWLIST).
+ *     Also clears any local override for this instance so the global row is effective.
+```
+
+with
+
+```js
+ *   - "global" → dashboard_settings row (synced if key in SYNC_ALLOWLIST).
+ *     Does NOT clear a local override — an existing override for this instance
+ *     keeps winning readSetting until deleteLocalSetting is called (the scope
+ *     route does that explicitly; see routes/settings-scope.js).
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/profile-sync-allowlist.test.js`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/profile-sync-allowlist.test.js
+git commit tests/profile-sync-allowlist.test.js servers/gateway/dashboard/settings/sync-allowlist.js servers/gateway/dashboard/settings/registry.js -m "feat(settings): sync-allowlist the profile keys (F-SETTINGS-1/F-CONTACT-5 root fix) + correct writeSetting docblock"
+git show --stat HEAD
+```
+
+---
+
+### Task 2: `save_profile` clears stranded overrides + D6 read-site comments
+
+**Files:**
+- Modify: `servers/gateway/dashboard/panels/contacts/api-handlers.js:352-368` (save_profile block; add `deleteLocalSetting` import at the top, next to the existing `upsertSetting` import from `../../settings/registry.js`)
+- Modify: `servers/gateway/dashboard/panels/contacts/data-queries.js:121-124` (comment), `servers/sharing/boot.js:30-34` (comment), `servers/sharing/tools/contacts.js:65-69` (comment)
+- Test: `tests/profile-save-clears-override.test.js` (new)
+
+**Interfaces:**
+- Consumes: `handleContactAction(req, db, opts)` (existing export), `deleteLocalSetting(db, key)` (registry.js:227), `getMyProfile(db)` (data-queries.js:124), `getOrCreateLocalInstanceId()` (instance-registry.js:333, respects `CROW_DATA_DIR` at call time).
+- Produces: nothing new for later tasks (behavioral change only).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/profile-save-clears-override.test.js`:
+
+```js
+/**
+ * Cluster B D2 — a profile save writes the global row AND clears the stranded
+ * broken-era local override, and the profile page reader (getMyProfile) sees
+ * the saved value on the very next read (the F-SETTINGS-1 symptom).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { getMyProfile } from "../servers/gateway/dashboard/panels/contacts/data-queries.js";
+import { setSettingsSyncManager } from "../servers/gateway/dashboard/settings/registry.js";
+import { getOrCreateLocalInstanceId } from "../servers/gateway/instance-registry.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "profile-save-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("save_profile writes global, clears the stranded override, and getMyProfile sees it", async () => {
+  const { dir, db, cleanup } = freshDb();
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  setSettingsSyncManager(null); // emits are not this test's subject
+  try {
+    const localId = getOrCreateLocalInstanceId();
+    // Seed the broken-era state: value stranded in the override, global empty.
+    await db.execute({
+      sql: "INSERT INTO dashboard_settings_overrides (key, instance_id, value, updated_at) VALUES ('profile_display_name', ?, 'Stranded', datetime('now'))",
+      args: [localId],
+    });
+
+    const req = { body: { action: "save_profile", display_name: "Kevin", bio: "Hello" } };
+    const out = await handleContactAction(req, db, {});
+    assert.ok(out && out.redirect, "save redirects");
+
+    const g = await db.execute("SELECT key, value FROM dashboard_settings WHERE key IN ('profile_display_name','profile_bio')");
+    const byKey = Object.fromEntries(g.rows.map((r) => [r.key, r.value]));
+    assert.equal(byKey.profile_display_name, "Kevin", "global name row written");
+    assert.equal(byKey.profile_bio, "Hello", "global bio row written");
+
+    const o = await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings_overrides WHERE key LIKE 'profile_%'");
+    assert.equal(Number(o.rows[0].c), 0, "stranded override cleared (D2)");
+
+    const profile = await getMyProfile(db);
+    assert.equal(profile.display_name, "Kevin", "the profile page reader sees the save immediately");
+    assert.equal(profile.bio, "Hello");
+  } finally {
+    setSettingsSyncManager(null);
+    if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevDataDir;
+    cleanup();
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/profile-save-clears-override.test.js`
+Expected: FAIL on "stranded override cleared (D2)" — count is 1 (Task 1 already makes the global write land; the override clear does not exist yet).
+
+- [ ] **Step 3: Implement**
+
+In `servers/gateway/dashboard/panels/contacts/api-handlers.js`:
+
+Change the import (line 9) from
+```js
+import { upsertSetting } from "../../settings/registry.js";
+```
+to
+```js
+import { upsertSetting, deleteLocalSetting } from "../../settings/registry.js";
+```
+
+Rewrite the `save_profile` block (keep the existing D5 comment; add the clears):
+
+```js
+  // --- Own profile ---
+  if (action === "save_profile") {
+    // F-SETTINGS-1 (Cluster B D2): each save also clears any stranded
+    // broken-era local override — during the era when these keys were not
+    // sync-allowlisted, upsertSetting silently downgraded profile saves to
+    // dashboard_settings_overrides rows that no reader consults. The global
+    // row (which readers use and peers sync) must be effective from this save.
+    if (req.body.display_name !== undefined) {
+      // This value is SENT on every handshake and syncs to all of the user's
+      // instances — cap + strip it at write (design §D5). sanitizeDisplayName
+      // returns null when nothing survives; store "" rather than the literal
+      // "null" so the setting is cleared, not poisoned.
+      await upsertSetting(db, "profile_display_name", sanitizeDisplayName(req.body.display_name) ?? "");
+      await deleteLocalSetting(db, "profile_display_name");
+    }
+    if (req.body.avatar_url !== undefined) {
+      await upsertSetting(db, "profile_avatar_url", req.body.avatar_url.trim());
+      await deleteLocalSetting(db, "profile_avatar_url");
+    }
+    if (req.body.bio !== undefined) {
+      await upsertSetting(db, "profile_bio", req.body.bio.trim());
+      await deleteLocalSetting(db, "profile_bio");
+    }
+    return { redirect: "/dashboard/contacts?view=profile" };
+  }
+```
+
+Add the D6 comment at each of the three read sites (adapt the first line to local context; the substance must be identical):
+
+`servers/gateway/dashboard/panels/contacts/data-queries.js`, above the `SELECT` in `getMyProfile` (line ~128):
+```js
+  // Reads the GLOBAL scope on purpose (Cluster B design D6): profile identity
+  // is user-level and follows the user across instances. Per-instance
+  // overrides of profile_* keys are intentionally inert — do not "fix" this
+  // to readSetting, and do not wire a scope toggle for these keys (the scope
+  // route would report "local" while behavior stays global).
+```
+
+`servers/sharing/boot.js`, inside the `readLocalDisplayName` docblock (after line 33's "Never throws."):
+```js
+ * Reads the GLOBAL scope on purpose (Cluster B design D6): profile identity is
+ * user-level; per-instance overrides of profile_* keys are intentionally inert.
+```
+
+`servers/sharing/tools/contacts.js`, extend the F-CONTACT-2 comment (line ~65-69) with:
+```js
+    // Reads the GLOBAL scope on purpose (Cluster B design D6): profile identity
+    // is user-level; per-instance overrides of profile_* keys are intentionally inert.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/profile-save-clears-override.test.js tests/profile-sync-allowlist.test.js tests/handshake-display-name.test.js`
+Expected: ALL PASS (the pre-existing handshake test proves the boot.js/tools readers still work; post-Task-1 they now read what the UI writes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/profile-save-clears-override.test.js
+git commit tests/profile-save-clears-override.test.js servers/gateway/dashboard/panels/contacts/api-handlers.js servers/gateway/dashboard/panels/contacts/data-queries.js servers/sharing/boot.js servers/sharing/tools/contacts.js -m "fix(contacts): profile save clears stranded broken-era overrides; pin global-direct reader semantics (D2+D6)"
+git show --stat HEAD
+```
+
+---
+
+### Task 3: Re-emit flag v1→v2 + empty-profile-value skip
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js` (`reemitSyncableSettingsOnce`, ~lines 470-533)
+- Test: `tests/settings-reemit-v2.test.js` (new)
+
+**Interfaces:**
+- Consumes: `PROFILE_SYNC_KEYS` from `servers/gateway/dashboard/settings/sync-allowlist.js` (Task 1). NOTE: instance-sync.js already imports `isSyncable` from that exact module (line 22) — extend that import.
+- Produces: `reemitSyncableSettingsOnce()` now keyed on flag `__sync_reemit_allowlist_v2`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/settings-reemit-v2.test.js` (harness mirrors `tests/messages-contacts-backfill.test.js`):
+
+```js
+/**
+ * Cluster B D4 — reemitSyncableSettingsOnce keyed on the v2 flag: a fleet
+ * instance whose v1 flag is 'done:' re-runs ONCE so pre-existing global rows
+ * for the newly-allowlisted profile keys reconcile; empty profile values are
+ * never re-emitted (they could win the lamport race and blank a peer's real
+ * value — R1 MAJOR-2).
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+function freshMgr(label, id) {
+  const d = mkdtempSync(join(tmpdir(), `crow-b-reemit-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: d }, stdio: "pipe", cwd: join(import.meta.dirname, "..") });
+  after(() => rmSync(d, { recursive: true, force: true }));
+  const m = new InstanceSyncManager(IDENTITY, createDbClient(join(d, "crow.db")), id);
+  m.feedsDisabled = false;
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  return m;
+}
+
+test("v2 flag: re-runs once even when the v1 flag is done:, then no-ops (v1 orphan ignored)", async () => {
+  const m = freshMgr("v2", "local-1"); const db = m.db;
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('__sync_reemit_allowlist_v1', 'done:9', datetime('now'))");
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_display_name', 'Kevin Hopper', datetime('now'))");
+  const emitted = [];
+  const orig = m.emitChange.bind(m);
+  m.emitChange = async (t, o, r) => { emitted.push(r.key); return orig(t, o, r); };
+
+  const n1 = await m.reemitSyncableSettingsOnce();
+  assert.ok(n1 >= 1, "re-ran despite done: v1 flag");
+  assert.ok(emitted.includes("profile_display_name"), "newly-allowlisted profile row re-emitted");
+  const flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__sync_reemit_allowlist_v2'");
+  assert.match(String(flag.rows[0]?.value), /^done:/, "v2 flag marked done");
+
+  emitted.length = 0;
+  const n2 = await m.reemitSyncableSettingsOnce();
+  assert.equal(n2, 0, "second run is a no-op");
+  assert.equal(emitted.length, 0);
+});
+
+test("apply side: a peer's profile_display_name entry is applied; a non-allowlisted key is dropped (spec test 7)", async () => {
+  const m = freshMgr("apply", "local-3"); const db = m.db;
+  const { sign } = await import("../servers/sharing/identity.js");
+  function signedEntry(table, op, row, lamport_ts) {
+    const entry = { table, op, row, lamport_ts, instance_id: "peer-1" };
+    entry.signature = sign(JSON.stringify(entry), TEST_PRIV);
+    return entry;
+  }
+  const fakeFeedWith = (entries) => ({ length: entries.length, async get(seq) { return entries[seq]; } });
+  // trustedKeys: _verifyEntry resolves the peer's ed25519 key — mirror the
+  // backfill test's approach of trusting our own test key for "peer-1".
+  m.trustedPeerKeys = m.trustedPeerKeys || new Map();
+  const entries = [
+    signedEntry("dashboard_settings", "update", { key: "profile_display_name", value: "Peer Name", instance_id: null }, 500),
+    signedEntry("dashboard_settings", "update", { key: "not_allowlisted_key", value: "evil", instance_id: null }, 501),
+  ];
+  await m._processNewEntriesInner("peer-1", fakeFeedWith(entries), TEST_PUB_HEX);
+  const g = await db.execute("SELECT value FROM dashboard_settings WHERE key = 'profile_display_name'");
+  assert.equal(g.rows[0]?.value, "Peer Name", "allowlisted profile row applied from a peer");
+  const bad = await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings WHERE key = 'not_allowlisted_key'");
+  assert.equal(Number(bad.rows[0].c), 0, "non-allowlisted key dropped by the apply-side gate");
+});
+// IMPLEMENTER NOTE: mirror tests/messages-contacts-backfill.test.js for the exact
+// _processNewEntriesInner invocation/signature-verification setup — if that file
+// passes a different peer-key wiring (e.g. a peers-table row or a keys argument),
+// copy ITS working pattern rather than the sketch above; the assertion pair
+// (applied vs dropped) is the requirement.
+
+test("empty-profile guard: empty/whitespace profile values are NOT re-emitted; non-profile empties still are", async () => {
+  const m = freshMgr("empty", "local-2"); const db = m.db;
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_bio', '', datetime('now'))");
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_avatar_url', '  ', datetime('now'))");
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_display_name', 'Kevin', datetime('now'))");
+  // Pins the DELIBERATE scoping: the guard is profile-only (an empty value for
+  // another allowlisted key is meaningful and still reconciles).
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('nav_groups', '', datetime('now'))");
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => { emitted.push(r.key); };
+
+  await m.reemitSyncableSettingsOnce();
+  assert.ok(!emitted.includes("profile_bio"), "empty bio NOT re-emitted (fleet-blanking hazard)");
+  assert.ok(!emitted.includes("profile_avatar_url"), "whitespace avatar NOT re-emitted");
+  assert.ok(emitted.includes("profile_display_name"), "non-empty profile value re-emitted");
+  assert.ok(emitted.includes("nav_groups"), "guard is scoped to profile keys only");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/settings-reemit-v2.test.js`
+Expected: FAIL — test 1: `n1` is 0 (the code still reads the v1 flag, which is `done:9`); test 2: `profile_bio` IS emitted.
+
+- [ ] **Step 3: Implement**
+
+In `servers/sharing/instance-sync.js`:
+
+Extend the existing import at line 22:
+```js
+import { isSyncable, PROFILE_SYNC_KEYS } from "../gateway/dashboard/settings/sync-allowlist.js";
+```
+
+In `reemitSyncableSettingsOnce()`, change the flag constant (~line 471) with a why-comment:
+```js
+    // v1 → v2 (Cluster B, 2026-07-10): the profile keys were added to the
+    // allowlist and every fleet instance's v1 flag is already done: — without a
+    // re-run, pre-existing global profile rows (written before the settings-
+    // scope refactor) would never replicate until the next manual save. The v1
+    // flag row remains as a harmless orphan.
+    const FLAG_KEY = "__sync_reemit_allowlist_v2";
+```
+
+In the emit loop (~line 505), after the `if (!isSyncable(row.key)) continue;` line, add:
+```js
+      // R1 MAJOR-2 (Cluster B): never re-emit an EMPTY profile value — a
+      // historical empty row (indistinguishable from "never set") would get a
+      // fresh lamport and could win LWW, blanking a peer's real value. A LIVE
+      // save of "" still emits via writeSetting (a deliberate clear propagates);
+      // this guard is scoped to the re-emit reconciliation only.
+      if (PROFILE_SYNC_KEYS.includes(row.key) && (typeof row.value !== "string" || row.value.trim() === "")) continue;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/settings-reemit-v2.test.js`
+Expected: PASS (2/2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/settings-reemit-v2.test.js
+git commit tests/settings-reemit-v2.test.js servers/sharing/instance-sync.js -m "feat(instance-sync): settings re-emit flag v2 + empty-profile-value guard (D4; R1 MAJOR-2)"
+git show --stat HEAD
+```
+
+---
+
+### Task 4: One-shot profile-override heal + boot wiring order
+
+**Files:**
+- Create: `servers/gateway/dashboard/settings/profile-heal.js`
+- Modify: `servers/gateway/boot/mcp-mounts.js` (move the `setSettingsSyncManager` block above the one-shots; insert the heal call)
+- Test: `tests/profile-heal.test.js` (new)
+
+**Interfaces:**
+- Consumes: `writeSetting`, `deleteLocalSetting` (registry.js), `PROFILE_SYNC_KEYS` (Task 1), `getOrCreateLocalInstanceId` (instance-registry.js).
+- Produces: `export async function healProfileOverridesOnce(db, { feedsDisabled = false } = {})` → returns the number of promoted keys. Called from `mcp-mounts.js` with `syncManager.db` and `syncManager.feedsDisabled`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/profile-heal.test.js`:
+
+```js
+/**
+ * Cluster B D3 — one-shot heal: values stranded in dashboard_settings_overrides
+ * by the broken-era save_profile are promoted (non-empty only) to the global
+ * scope once, flag-guarded, gated OFF for --no-auth companions (feedsDisabled).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { healProfileOverridesOnce } from "../servers/gateway/dashboard/settings/profile-heal.js";
+import { setSettingsSyncManager } from "../servers/gateway/dashboard/settings/registry.js";
+import { getOrCreateLocalInstanceId } from "../servers/gateway/instance-registry.js";
+
+function fresh() {
+  const dir = mkdtempSync(join(tmpdir(), "profile-heal-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+async function seedOverride(db, localId, key, value) {
+  await db.execute({
+    sql: "INSERT INTO dashboard_settings_overrides (key, instance_id, value, updated_at) VALUES (?, ?, ?, datetime('now'))",
+    args: [key, localId, value],
+  });
+}
+const globalValue = async (db, key) => (await db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [key] })).rows[0]?.value;
+const overrideCount = async (db) => Number((await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings_overrides WHERE key LIKE 'profile_%'")).rows[0].c);
+
+test("heal: promotes non-empty stranded overrides (override wins over global), deletes empties, one-shot flag, emits", async () => {
+  const { dir, db, cleanup } = fresh();
+  const prev = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const emitted = [];
+  setSettingsSyncManager({ emitChange: async (t, op, row) => { emitted.push(row.key); } });
+  try {
+    const localId = getOrCreateLocalInstanceId();
+    await seedOverride(db, localId, "profile_display_name", "Kevin");   // (a)+(c): promote, wins over global
+    await seedOverride(db, localId, "profile_bio", "");                 // (f): empty → delete only
+    await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_display_name', 'Old Global', datetime('now'))");
+    await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_bio', 'Real Bio', datetime('now'))");
+
+    const n = await healProfileOverridesOnce(db, { feedsDisabled: false });
+    assert.equal(n, 1, "exactly the one non-empty override promoted");
+    assert.equal(await globalValue(db, "profile_display_name"), "Kevin", "(c) override value wins over pre-existing global");
+    assert.equal(await globalValue(db, "profile_bio"), "Real Bio", "(f) empty override did NOT blank the real global value");
+    assert.equal(await overrideCount(db), 0, "all profile overrides cleared (incl. the empty one)");
+    assert.ok(emitted.includes("profile_display_name"), "(e) promotion emitted (manager wired)");
+    const flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__profile_override_heal_v1'");
+    assert.match(String(flag.rows[0]?.value), /^done:1$/, "flag row written to dashboard_settings via raw SQL");
+
+    // (b) second run is a flag-guarded no-op even with a fresh override present
+    await seedOverride(db, localId, "profile_display_name", "Deliberate Local");
+    emitted.length = 0;
+    const n2 = await healProfileOverridesOnce(db, { feedsDisabled: false });
+    assert.equal(n2, 0, "(b) flag-guarded second run no-ops");
+    assert.equal(await globalValue(db, "profile_display_name"), "Kevin", "deliberate post-heal override untouched");
+    assert.equal(emitted.length, 0);
+  } finally {
+    setSettingsSyncManager(null);
+    if (prev === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prev;
+    cleanup();
+  }
+});
+
+test("heal: no overrides → flag still set, nothing written (d); feedsDisabled → FULL no-op, no flag (5d)", async () => {
+  const { dir, db, cleanup } = fresh();
+  const prev = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  setSettingsSyncManager(null);
+  try {
+    // 5d: companion gateway (feedsDisabled) must not run NOR mark the flag —
+    // it shares the primary's DB and would make the primary skip its own heal.
+    const gated = await healProfileOverridesOnce(db, { feedsDisabled: true });
+    assert.equal(gated, 0);
+    let flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__profile_override_heal_v1'");
+    assert.equal(flag.rows.length, 0, "feedsDisabled run left NO flag row");
+
+    // (d): a clean primary marks the flag with zero promotions
+    const n = await healProfileOverridesOnce(db, { feedsDisabled: false });
+    assert.equal(n, 0);
+    flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__profile_override_heal_v1'");
+    assert.match(String(flag.rows[0]?.value), /^done:0$/);
+  } finally {
+    setSettingsSyncManager(null);
+    if (prev === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prev;
+    cleanup();
+  }
+});
+
+test("boot wiring order pin: setSettingsSyncManager is wired BEFORE the heal, which runs BEFORE the re-emit", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(join(import.meta.dirname, "..", "servers/gateway/boot/mcp-mounts.js"), "utf8");
+  const wireIdx = src.indexOf("setSettingsSyncManager(syncManager)");
+  const healIdx = src.indexOf("healProfileOverridesOnce");
+  const reemitIdx = src.indexOf("reemitSyncableSettingsOnce");
+  assert.ok(wireIdx > -1 && healIdx > -1 && reemitIdx > -1, "all three call sites present");
+  assert.ok(wireIdx < healIdx, "R1 MAJOR-1: manager wired before the heal (else the heal's emit hits a null manager)");
+  assert.ok(healIdx < reemitIdx, "heal before re-emit so a promoted value rides the same boot's re-emit");
+  assert.match(src, /feedsDisabled/, "heal call site carries the feedsDisabled gate");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/profile-heal.test.js`
+Expected: FAIL — cannot import `profile-heal.js` (module does not exist).
+
+- [ ] **Step 3: Implement the heal module**
+
+Create `servers/gateway/dashboard/settings/profile-heal.js`:
+
+```js
+/**
+ * profile-heal.js — Cluster B D3: one-shot heal for F-SETTINGS-1's stranded
+ * profile values.
+ *
+ * During the settings-scope era in which the profile keys were not
+ * sync-allowlisted, every UI profile save was silently downgraded to a
+ * dashboard_settings_overrides row that NO reader consults (all profile
+ * readers are global-direct by design, D6). Users' typed values are stranded
+ * there. This promotes them to the global scope once, so the name a user
+ * saved into the "broken" UI comes back — and starts syncing — at upgrade,
+ * with no re-save.
+ *
+ * Rules (spec §D3):
+ *  - non-empty override → promote to global (writeSetting, which emits to
+ *    peers when the sync manager is wired) THEN delete the override. Promote
+ *    strictly BEFORE delete: reversed, a crash between the two loses the
+ *    value forever (override gone, global never written, flag prevents retry).
+ *    Promote-first re-runs are idempotent.
+ *  - empty/whitespace override → delete only. Promoting "" could blank a
+ *    peer's real pre-refactor global value fleet-wide.
+ *  - flag row __profile_override_heal_v1 is RAW SQL into dashboard_settings
+ *    (NOT upsertSetting — a non-allowlisted flag key would silently downgrade
+ *    to an overrides row and never read back as done → heal re-runs forever).
+ *  - feedsDisabled=true (a --no-auth companion sharing the primary's DB) is a
+ *    FULL no-op — no promotion, no flag write — or the companion would mark
+ *    the flag and the primary would skip its own heal (R2 MAJOR-A). Gate on
+ *    feedsDisabled, NOT manager truthiness (the manager is constructed
+ *    unconditionally) and NOT outFeeds.size (a peerless single-instance
+ *    install still needs the local half of the heal).
+ */
+import { writeSetting, deleteLocalSetting } from "./registry.js";
+import { PROFILE_SYNC_KEYS } from "./sync-allowlist.js";
+import { getOrCreateLocalInstanceId } from "../../instance-registry.js";
+
+const FLAG_KEY = "__profile_override_heal_v1";
+
+export async function healProfileOverridesOnce(db, { feedsDisabled = false } = {}) {
+  if (feedsDisabled) return 0;
+
+  try {
+    const { rows } = await db.execute({
+      sql: "SELECT value FROM dashboard_settings WHERE key = ?",
+      args: [FLAG_KEY],
+    });
+    if (typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:")) return 0;
+  } catch {
+    return 0; // unreadable flag → do nothing rather than risk a re-run loop
+  }
+
+  const localId = getOrCreateLocalInstanceId();
+  let promoted = 0;
+  for (const key of PROFILE_SYNC_KEYS) {
+    try {
+      const { rows } = await db.execute({
+        sql: "SELECT value FROM dashboard_settings_overrides WHERE key = ? AND instance_id = ?",
+        args: [key, localId],
+      });
+      if (rows.length === 0) continue;
+      const value = rows[0].value;
+      if (typeof value === "string" && value.trim() !== "") {
+        await writeSetting(db, key, value, { scope: "global" });
+        promoted++;
+      }
+      await deleteLocalSetting(db, key);
+    } catch (err) {
+      console.warn(`[settings] profile heal for ${key} failed: ${err.message}`);
+    }
+  }
+
+  try {
+    await db.execute({
+      sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+      args: [FLAG_KEY, `done:${promoted}`],
+    });
+  } catch {}
+
+  if (promoted > 0) {
+    console.log(`[settings] profile heal: promoted ${promoted} stranded profile value(s) to the global scope`);
+  }
+  return promoted;
+}
+```
+
+- [ ] **Step 4: Rewire boot order in `mcp-mounts.js`**
+
+DELETE the existing block at lines 102-107:
+```js
+  // Scoped-settings sync: wire the registry's writeSetting to emitChange so
+  // operator edits on one instance propagate to paired peers.
+  try {
+    const { setSettingsSyncManager } = await import("../dashboard/settings/registry.js");
+    setSettingsSyncManager(syncManager);
+  } catch {}
+```
+
+INSERT in its place order — directly AFTER the `eagerInitPairedPeers` try-block (line 66) and BEFORE the `reemitSyncableSettingsOnce` block (line 68):
+```js
+  // Scoped-settings sync: wire the registry's writeSetting to emitChange so
+  // operator edits on one instance propagate to paired peers. MUST happen
+  // BEFORE the heal/re-emit one-shots below (R1 MAJOR-1): the heal promotes
+  // via writeSetting, whose emit is a silent no-op — and whose promoted row
+  // never gets a lamport stamp — while the manager is unwired.
+  try {
+    const { setSettingsSyncManager } = await import("../dashboard/settings/registry.js");
+    setSettingsSyncManager(syncManager);
+  } catch {}
+
+  // Cluster B D3: one-shot heal — promote profile values stranded in
+  // dashboard_settings_overrides by the broken-era save_profile. Gated on
+  // !feedsDisabled: a --no-auth companion shares the primary's DB and must
+  // not run it or mark its flag (R2 MAJOR-A). Runs BEFORE the settings
+  // re-emit so a promoted value also rides this boot's reconciliation.
+  try {
+    if (syncManager && !syncManager.feedsDisabled) {
+      const { healProfileOverridesOnce } = await import("../dashboard/settings/profile-heal.js");
+      await healProfileOverridesOnce(syncManager.db, { feedsDisabled: syncManager.feedsDisabled });
+    }
+  } catch (err) {
+    console.warn(`[settings] healProfileOverridesOnce failed: ${err.message}`);
+  }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test tests/profile-heal.test.js`
+Expected: PASS (3/3, including the source-order pin).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add servers/gateway/dashboard/settings/profile-heal.js tests/profile-heal.test.js
+git commit servers/gateway/dashboard/settings/profile-heal.js tests/profile-heal.test.js servers/gateway/boot/mcp-mounts.js -m "feat(settings): one-shot heal for stranded broken-era profile overrides + wire settings sync manager before the boot one-shots (D3; R1 MAJOR-1, R2 MAJOR-A)"
+git show --stat HEAD
+```
+
+---
+
+### Task 5: Full suite, boot check, mutation-test evidence
+
+**Files:**
+- No new files (evidence recorded in `.superpowers/sdd/progress.md` — git-IGNORED, never `git add`).
+
+- [ ] **Step 1: Full suite**
+
+Run: `node --test tests/*.test.js 2>&1 | tail -5`
+Expected: ≥ 1376+new pass / 0 fail / 1 skip. Any failure → fix before proceeding (bisect against the four commits above).
+
+- [ ] **Step 2: Boot check**
+
+Run: `timeout 25 node servers/gateway/index.js --no-auth` (Ctrl-C/timeout after "listening")
+Expected: boots clean; NO `[settings] profile heal` promotion line (feedsDisabled gate — a `--no-auth` boot must not heal), no new warnings.
+
+- [ ] **Step 3: Mutation-test every guard** (apply each mutation, run the named test, verify RED, revert):
+
+| # | Mutation | Test that must go RED |
+|---|---|---|
+| M1 | profile-heal.js: delete the `startsWith("done:")` flag check | profile-heal.test.js "(b) flag-guarded second run no-ops" |
+| M2 | profile-heal.js: drop the `value.trim() !== ""` guard (always promote) | profile-heal.test.js "(f) empty override did NOT blank the real global value" |
+| M3 | profile-heal.js: change `if (feedsDisabled) return 0;` to `if (false)` | profile-heal.test.js "feedsDisabled run left NO flag row" |
+| M4 | instance-sync.js: revert `FLAG_KEY` to `__sync_reemit_allowlist_v1` | settings-reemit-v2.test.js "re-ran despite done: v1 flag" |
+| M5 | instance-sync.js: delete the empty-profile `continue` guard | settings-reemit-v2.test.js "empty bio NOT re-emitted" |
+| M6 | mcp-mounts.js: move the `setSettingsSyncManager` block back below the one-shots | profile-heal.test.js "boot wiring order pin" |
+
+Expected: each mutation reddens exactly the named assertion; reverting restores green. Record the six results in the progress ledger.
+
+- [ ] **Step 4: Update the progress ledger** (`.superpowers/sdd/progress.md` — append Task summaries + mutation evidence; never `git add` this file).
+
+---
+
+## Post-implementation (controller, not subagents)
+
+1. CDP browser verification on a scratch pair (Task tracker #3): real-browser profile save → page re-renders the saved name (F-SETTINGS-1 symptom), global row written, override cleared. Recipes: `~/.crow/p4/cluster-a-evidence/` (distinct host IPs 10.0.0.237 vs 100.118.41.122; `CROW_AUTO_UPDATE=0`; `CROW_DISABLE_HEALTH_MONITOR=1`; real passwords/sessions).
+2. Final whole-branch Opus review → fold → PR → check-runs (curl; port-allocation.yml is path-filtered → total_count 0 is normal; run `node scripts/check-port-allocation.js` locally, ignore the untracked capstone-tracker 8090 flag from another session).
+3. Kevin gates the merge. Then deploy crow+MPA+grackle **together** (old-code peers drop profile rows AND advance their checkpoint — spec §D4), then black-swan; expect the one-time `storage.shared.*` `_scheduleStorageReset` blip at first boot.
+4. Prod reconciliation: CDP product-path save `display_name='Kevin'` on crow → verify fleet convergence (~3s), grackle's March bio propagated, crow's stale override gone, per-instance `SELECT value FROM dashboard_settings WHERE key='profile_display_name'` all return 'Kevin'.

--- a/docs/superpowers/specs/2026-07-10-profile-follows-user-design.md
+++ b/docs/superpowers/specs/2026-07-10-profile-follows-user-design.md
@@ -87,9 +87,14 @@ Alternatives considered:
 
 Security: same trust class as existing synced settings (`ai_profiles` is far more
 sensitive). A compromised paired instance could already rewrite synced settings;
-display name adds nothing new. Values remain sanitized at write
-(`sanitizeDisplayName`, api-handlers.js:359) and at handshake-apply
-(boot.js:296, tools/contacts.js:76).
+display name adds nothing new. **The real defense in depth (R1 MINOR-2):** the
+sync-apply path (`_applyDashboardSetting`, instance-sync.js:1067) writes peer
+values RAW — the protections are (a) every dashboard render of profile values is
+escapeHtml'd (contacts/html.js, components.js formField), and (b) both handshake
+readers re-sanitize via `sanitizeDisplayName` at READ time (boot.js:42,
+tools/contacts.js:76), so a raw synced value never reaches a handshake or an
+unescaped sink. Any future reader of `profile_*` must follow the same rule
+(comment at the allowlist entries).
 
 ### D2 — `save_profile` clears stranded local overrides
 
@@ -129,30 +134,65 @@ of the three profile keys, if a local override row exists for this instance:
   keys are allowlisted, via POST /api/settings/scope) is never clobbered by a later
   boot. (Note: local overrides of profile keys have no effect anyway — readers are
   global-direct, D6 — but the heal must still not eat them.)
-- Runs in gateway boot (servers/gateway/boot/mcp-mounts.js) immediately **before**
-  `reemitSyncableSettingsOnce()` so a promoted value also rides D4's re-emit; the
-  `writeSetting` emit covers the case where the re-emit already ran.
+- **Ordering (R1 MAJOR-1):** `setSettingsSyncManager(syncManager)` is currently
+  wired at mcp-mounts.js:105 — AFTER the reemit call at :73 — so a heal placed
+  before the reemit would emit into a null manager (registry.js:129 early-return)
+  and its "writeSetting emit covers it" fallback would be dead code. Fix: move
+  `setSettingsSyncManager(syncManager)` ABOVE the heal/reemit block (nothing
+  between :73 and :105 needs it late — the contacts/groups backfills call
+  `syncManager.emitChange` directly), then run the heal, then
+  `reemitSyncableSettingsOnce()`. The heal's `writeSetting` emit is then real, so
+  correctness no longer depends on the two one-shot flags staying coupled.
+- **Gating (R1 MINOR-5):** the heal runs inside the same guarded block that owns
+  `syncManager` (i.e. only when instance-sync is actually initialized) — a
+  `--no-auth` companion gateway sharing the primary's DB must not race the flag
+  write or double-run the heal.
 - Fix-the-product rationale: a user who typed their name into the silently-broken
   UI gets it restored (and syncing, and in handshakes) at upgrade with no re-save.
 
 ### D4 — Re-emit flag bump v1 → v2
 
 Rename `reemitSyncableSettingsOnce`'s `FLAG_KEY` to `__sync_reemit_allowlist_v2`
-(instance-sync.js:471). The v1 flag is `done:` on every fleet instance, so
-**pre-existing global rows** for the newly-allowlisted keys (grackle's March name +
-bio; any pre-refactor install in the wild) would otherwise never replicate until
-the next manual save. The re-emit is idempotent on the apply side
-(`_applyDashboardSetting` skips stale-lamport and unchanged-value rows) and small
-(re-emits only allowlisted keys, ~a dozen rows). Divergent values across instances
-resolve by LWW (last boot's emit wins) — same conflict class the settings sync
-already accepts; the operator's next save settles it deterministically. The v1 flag
-row remains as a harmless orphan.
+(instance-sync.js:471). The v1 flag is `done:` on every fleet instance (crow live:
+`done:9`), so **pre-existing global rows** for the newly-allowlisted keys
+(grackle's March name + bio; any pre-refactor install in the wild) would otherwise
+never replicate until the next manual save. The re-emit is idempotent on the apply
+side (`_applyDashboardSetting` skips stale-lamport and unchanged-value rows) and
+small (re-emits only allowlisted keys, ~a dozen rows).
+
+**Empty-value guard (R1 MAJOR-2):** the re-emit loop SKIPS profile keys whose
+global value is empty/whitespace. Without this, any instance holding an
+empty-string global `profile_bio`/`profile_avatar_url` row (grackle has an empty
+avatar row live) could win the lamport race and blank a peer's real value —
+exactly the data (grackle's March bio) the deploy plan promises to preserve. The
+asymmetry is deliberate: the re-emit is a *historical reconciliation* where an
+empty row is indistinguishable from "never set", while a **live** save of `""`
+(D2 path) still emits — a deliberate clear propagates.
+
+**LWW characterization (R1 MINOR-1):** each re-emit gets a fresh per-instance
+lamport from `_nextLamport`, so divergent values resolve to whichever instance
+holds the higher sync counter — a function of sync history, not boot order; an
+equal-counter tie is non-commutative ("incoming wins", instance-sync.js:1054) and
+can transiently swap values. Accepted: same conflict class the settings sync
+already carries, bounded, and the deploy plan's operator save settles it
+deterministically. The v1 flag row remains as a harmless orphan.
+
+**Deploy-together constraint (R1 noted):** an old-code peer silently DROPS a
+profile sync row (shouldSyncRow gate, instance-sync.js:925) and still advances its
+checkpoint — it will not re-read that entry after upgrading. crow/MPA/grackle must
+deploy together; a late upgrader needs one fresh source-side save. Re-emitting
+`storage.shared.*` rows with fresh lamports also re-fires `_scheduleStorageReset()`
+on peers at the deploy boot (R1 MINOR-4) — a one-time storage-client reconnect
+blip, noted in the deploy plan.
 
 ### D5 — No handshake-ack dedup (F-CONTACT-5 optional half — rejected, YAGNI)
 
 Multi-instance `handshake_complete` acks stay. They are idempotent
 (`markDelivered` + name applied only over a placeholder, boot.js:297) and, post-D1,
-identical in content. Deduping would require cross-instance coordination on the
+identical in content **in steady state** (R1 MINOR-3: during the ~3s window after a
+rename the three acks can diverge, and the acceptor's first non-placeholder
+application is permanent — narrow, cosmetic, acceptor can rename; documented, not
+engineered around). Deduping would require cross-instance coordination on the
 receive path for zero user-visible gain. Documented here as the deliberate
 disposition of the finding's "optionally dedupe" clause.
 
@@ -184,6 +224,12 @@ site.
    re-emits an existing global `profile_display_name` row exactly once —
    **mutation test**: reverting FLAG_KEY to v1 with a `done:` v1 row present must
    redden this.
+5b. D4 empty-value guard: an empty-string global `profile_bio`/`profile_avatar_url`
+   row is NOT re-emitted while a non-empty one is — **mutation test**: dropping the
+   guard must redden this (the fleet-blanking hazard made explicit).
+5c. D3/D4 ordering: `setSettingsSyncManager` is wired before the heal runs — a
+   heal promotion with the manager wired emits a `dashboard_settings` change
+   (asserts MAJOR-1's fix; reddens if the wiring moves back below the block).
 6. End-to-end read path: after a UI-style save, `readLocalDisplayName` (boot.js)
    and the tools/contacts.js acceptor read return the saved, sanitized name
    (extends tests/handshake-display-name.test.js).

--- a/docs/superpowers/specs/2026-07-10-profile-follows-user-design.md
+++ b/docs/superpowers/specs/2026-07-10-profile-follows-user-design.md
@@ -1,0 +1,246 @@
+# Profile follows the user — Cluster B design (F-SETTINGS-1 + F-CONTACT-5)
+
+Date: 2026-07-10 · Arc: Crow Messages usability overhaul, P4 walkthrough Cluster B
+Findings: F-SETTINGS-1 [S4-MAJOR] (UI profile save is a silent no-op), F-CONTACT-5
+[S4-MAJOR] (shared-identity fleet answers one invite in triplicate with divergent
+self-names). Independent of Clusters C/D.
+
+## 1. Problem
+
+`save_profile` (servers/gateway/dashboard/panels/contacts/api-handlers.js:359-365)
+writes `profile_display_name` / `profile_avatar_url` / `profile_bio` via
+`upsertSetting` → `writeSetting(scope:"global", allowLocalFallback:true)`
+(settings/registry.js:262). None of the three keys is in `SYNC_ALLOWLIST`
+(settings/sync-allowlist.js), so `writeSetting` silently downgrades the write to a
+**local** `dashboard_settings_overrides` row (registry.js:192-210).
+
+Every reader queries the global `dashboard_settings` table directly and can never
+see that row:
+
+- `getMyProfile` — contacts/data-queries.js:129 (the profile page re-renders EMPTY
+  right after saving);
+- `readLocalDisplayName` — servers/sharing/boot.js:39 (the inviter-side
+  `handshake_complete` ack name, shipped in #155);
+- the acceptor-side `invite_accepted` name — servers/sharing/tools/contacts.js:73.
+
+So the UI save appears to do nothing, and #155's name-in-handshake is inert via the
+product UI. Empirically confirmed live 2026-07-10 (p4-findings.md F-SETTINGS-1).
+
+The write site's own comment says the value "is SENT on every handshake and syncs
+to all of the user's instances" — the intent was global+synced; the allowlist entry
+was never added when the settings-scope refactor introduced the downgrade.
+Corroboration: grackle carries **pre-refactor** global rows written 2026-03-22
+(`profile_display_name='Kevin Hopper'`, a real `profile_bio`, empty
+`profile_avatar_url`) — the profile UI used to write the global table.
+
+**F-CONTACT-5** is the same defect observed fleet-wide: crow, MPA and grackle (one
+shared identity, all subscribed on the same key) each independently process an
+acceptor's `invite_accepted` and each replies `handshake_complete` carrying **its
+own** `dashboard_settings` value — crow='Kevin' (SQL workaround), MPA=unset,
+grackle='Kevin Hopper' (the March row). Relay race decides which name the acceptor
+stores.
+
+## 2. Non-goals
+
+- No change to Clusters C (F-BLOCK-1) or D (F-HEALTH-2).
+- No handshake-ack dedup (see §3 D5).
+- No fix for the 12+ *other* keys the audit found broken by the same refactor
+  (§6) — dedicated follow-up PR; per-key judgment required.
+- No schema change. `SYNC_ALLOWLIST` is code; the heal and re-emit use existing
+  tables. **SCHEMA_GENERATION stays 6** (verified: no DDL anywhere in this design).
+
+## 3. Design
+
+### D1 — Sync-allowlist the three profile keys (the root fix)
+
+Add to `SYNC_ALLOWLIST` (sync-allowlist.js) as **explicit entries** (no `profile_*`
+prefix — keeps the curated-list posture; a future key named `profile_...` must be
+consciously added):
+
+```js
+profile_display_name: "Own profile — display name (sent in pairing handshakes)",
+profile_avatar_url:   "Own profile — avatar URL",
+profile_bio:          "Own profile — bio",
+```
+
+Consequences, all mechanical from existing machinery:
+- `upsertSetting` now writes the **global** `dashboard_settings` row and emits via
+  `emitSettingsSync` → `InstanceSyncManager.emitChange` (registry.js:220). The
+  emit-side gate (instance-sync.js:207-211) and apply-side gate
+  (instance-sync.js:923, `_applyDashboardSetting`) both key on `isSyncable`, so
+  allowlisting enables replication in both directions with no sync-code change.
+- All three direct readers become correct **unchanged**.
+- F-CONTACT-5 root fix: all instances of a shared identity converge on one name, so
+  the triplicate `handshake_complete` acks carry identical `displayName` and the
+  acceptor race becomes harmless.
+
+Alternatives considered:
+- *(b) effective-value read helper for all three readers* (readSetting): rejected as
+  the primary fix — it repairs the local symptom but NOT F-CONTACT-5 (each instance
+  would still hold a divergent private value), and profile identity is user-level
+  data that should follow the user like contacts/groups do (S7-proven pattern).
+- *display_name only*: rejected — avatar/bio saves would remain silent no-ops
+  against the same global-reading `getMyProfile`. All three are user-level profile
+  fields. Caveat noted: a synced `profile_avatar_url` that points at
+  instance-local storage renders broken images on peers — pre-existing class,
+  out of scope (noted for the generalization theme).
+
+Security: same trust class as existing synced settings (`ai_profiles` is far more
+sensitive). A compromised paired instance could already rewrite synced settings;
+display name adds nothing new. Values remain sanitized at write
+(`sanitizeDisplayName`, api-handlers.js:359) and at handshake-apply
+(boot.js:296, tools/contacts.js:76).
+
+### D2 — `save_profile` clears stranded local overrides
+
+After each `upsertSetting` in `save_profile`, call `deleteLocalSetting(db, key)`
+for that key. Rationale: every install that used the profile UI during the broken
+era has a stranded `dashboard_settings_overrides` row (crow does, live). Overrides
+shadow `readSetting`-based reads forever; clearing on save makes the global row
+authoritative from the next user action.
+
+Deliberately **not** changing `writeSetting`'s global branch to clear overrides
+globally: sections UI + scope-route interactions for other keys (e.g. a user who
+deliberately demoted an allowlisted key to local) would silently lose their
+demotion on any global write. Targeted beats global here. The `writeSetting`
+docblock (registry.js:181) currently **claims** the global path "clears any local
+override" — the code never has (only the scope route does, settings-scope.js:76).
+Fix the docblock to match reality.
+
+### D3 — One-shot boot heal for stranded broken-era values
+
+Flag-guarded one-shot (`dashboard_settings` flag row `__profile_override_heal_v1`,
+same pattern as `__sync_reemit_allowlist_v1` / `__contacts_backfill_v1`): for each
+of the three profile keys, if a local override row exists for this instance:
+- override value **non-empty** (after trim) → promote it to the global scope
+  (`writeSetting` global — which now emits) and delete the override;
+- override value **empty** → delete the override only (never promote `""`).
+  Rationale: `save_profile` writes every submitted field, so a broken-era save
+  that set only the name may have stranded empty avatar/bio overrides — promoting
+  those would blank a peer's real pre-refactor global values (grackle's live bio)
+  fleet-wide. Conservative trade: a deliberate broken-era *clear* is not healed;
+  the user re-clears via the now-working UI.
+
+- A non-empty override wins over any existing global row: the override is by
+  construction the user's **latest** intent (it can only have been written by the
+  broken-era `save_profile`; post-refactor override > pre-refactor global by
+  construction of the bug — no clock comparison needed).
+- Flag-guarded so a **deliberate** post-upgrade local demotion (possible once the
+  keys are allowlisted, via POST /api/settings/scope) is never clobbered by a later
+  boot. (Note: local overrides of profile keys have no effect anyway — readers are
+  global-direct, D6 — but the heal must still not eat them.)
+- Runs in gateway boot (servers/gateway/boot/mcp-mounts.js) immediately **before**
+  `reemitSyncableSettingsOnce()` so a promoted value also rides D4's re-emit; the
+  `writeSetting` emit covers the case where the re-emit already ran.
+- Fix-the-product rationale: a user who typed their name into the silently-broken
+  UI gets it restored (and syncing, and in handshakes) at upgrade with no re-save.
+
+### D4 — Re-emit flag bump v1 → v2
+
+Rename `reemitSyncableSettingsOnce`'s `FLAG_KEY` to `__sync_reemit_allowlist_v2`
+(instance-sync.js:471). The v1 flag is `done:` on every fleet instance, so
+**pre-existing global rows** for the newly-allowlisted keys (grackle's March name +
+bio; any pre-refactor install in the wild) would otherwise never replicate until
+the next manual save. The re-emit is idempotent on the apply side
+(`_applyDashboardSetting` skips stale-lamport and unchanged-value rows) and small
+(re-emits only allowlisted keys, ~a dozen rows). Divergent values across instances
+resolve by LWW (last boot's emit wins) — same conflict class the settings sync
+already accepts; the operator's next save settles it deterministically. The v1 flag
+row remains as a harmless orphan.
+
+### D5 — No handshake-ack dedup (F-CONTACT-5 optional half — rejected, YAGNI)
+
+Multi-instance `handshake_complete` acks stay. They are idempotent
+(`markDelivered` + name applied only over a placeholder, boot.js:297) and, post-D1,
+identical in content. Deduping would require cross-instance coordination on the
+receive path for zero user-visible gain. Documented here as the deliberate
+disposition of the finding's "optionally dedupe" clause.
+
+### D6 — Readers stay global-direct
+
+`getMyProfile`, `readLocalDisplayName`, and the acceptor-side read keep querying
+`dashboard_settings` directly. Post-D1 the global row IS the value; user-level
+identity should not vary per instance, so ignoring per-instance overrides is the
+*correct* semantic, not an accident. Documented via a short comment at each read
+site.
+
+## 4. Tests (TDD; mutation-test every guard)
+
+1. `isSyncable("profile_display_name"|"profile_avatar_url"|"profile_bio")` → true;
+   an unrelated `profile_zzz` → false (explicit-entry posture).
+2. Write-scope integration: `save_profile`-equivalent `upsertSetting` on a profile
+   key lands in `dashboard_settings` (not overrides) and emits a
+   `dashboard_settings` sync change with `instance_id:null`.
+3. D2: a stranded override + a save → override row gone, global row set.
+4. D3 heal: (a) override-only state → promoted to global + override deleted + flag
+   `done`; (b) second run is a no-op (flag) — **mutation test**: removing the flag
+   check must redden this; (c) override + pre-existing global → override value
+   wins; (d) no overrides → flag still set, nothing written; (e) promoted value is
+   emitted (or picked up by re-emit when ordered before it); (f) **empty-string
+   override → deleted, NOT promoted, existing global untouched** — **mutation
+   test**: dropping the non-empty guard must redden this on the global-value
+   assertion (the fleet-blanking hazard made explicit).
+5. D4: with the new allowlist, `reemitSyncableSettingsOnce` under the v2 flag
+   re-emits an existing global `profile_display_name` row exactly once —
+   **mutation test**: reverting FLAG_KEY to v1 with a `done:` v1 row present must
+   redden this.
+6. End-to-end read path: after a UI-style save, `readLocalDisplayName` (boot.js)
+   and the tools/contacts.js acceptor read return the saved, sanitized name
+   (extends tests/handshake-display-name.test.js).
+7. Apply side: `_applyDashboardSetting` accepts a peer's `profile_display_name`
+   row (allowlist gate) and a non-allowlisted key is still rejected.
+8. Full suite ≥ baseline 1376/0/1; gateway boots clean.
+
+## 5. Verification beyond the suite (HARD REQ: browser-click)
+
+- **CDP scratch pair** (Cluster-A recipe: distinct host IPs 10.0.0.237 vs
+  100.118.41.122, `CROW_AUTO_UPDATE=0`, `CROW_DISABLE_HEALTH_MONITOR=1`, real
+  sessions): drive the real profile form save in the browser → the page re-renders
+  showing the saved name/bio (the exact F-SETTINGS-1 symptom), DB shows the global
+  row, override cleared.
+- **Post-deploy prod reconciliation** (this closes the lab's live divergence and IS
+  the product-path heal): deploy fleet → boots run D3+D4 → CDP product-path save
+  `display_name='Kevin'` on crow → verify grackle+MPA converge (~3s), grackle's
+  March bio has propagated fleet-wide, each instance's
+  `SELECT value FROM dashboard_settings WHERE key='profile_display_name'` returns
+  'Kevin', crow's stale override is gone. ('Kevin' = Kevin's most recent intent,
+  set 2026-07-10; trivially changeable via the now-working UI — flagged at the PR
+  gate.)
+- Black Swan pairing (crow contact 11) untouched; a live re-handshake is NOT
+  required — the name-carry mechanism was live-proven in the walkthrough; what was
+  broken was only the value's source.
+
+## 6. Audit outcome (F-SETTINGS-1 mandate): the bug class is much bigger
+
+Repo-wide audit of every `upsertSetting` caller (2026-07-10, this session): the
+same write-local/read-global mismatch breaks **12+ more keys**. NOT fixed in this
+PR — each needs per-key judgment (a blanket `upsertSetting`→global revert would
+break `feature_flags`, whose local scope is intentional and consistently read via
+`readSetting`). Queued as a dedicated **"settings-scope coherence"** follow-up PR.
+
+| key | broken reader(s) | impact |
+|---|---|---|
+| onboarding_completed_at | dashboard/index.js:207 | login redirect keeps routing to /onboarding |
+| notification_prefs | shared/notifications.js:44, memory/server.js:1376 (+dual global writer :1398) | UI notification toggles don't affect delivery |
+| discovery_enabled / discovery_name | boot/peer-public-api.js:45,54,90 | enabling discovery in UI never reaches the peer API |
+| blog_title/tagline/author/listed (+blog_theme_*) | servers/blog/server.js:68,411,470,614; routes/blog-public.js:573 (+dual writer blog/server.js:522) | gateway blog settings never reach the public blog / MCP server |
+| auto_update_enabled / auto_update_interval_hours | scripts→gateway auto-update.js:41→:213,:224 | **disabling auto-update in the UI is inert** — ship with F-UPDATE-1 |
+| tts_voice | bundles/media/server.js:676, media/panel/routes.js:411,631 (+dual writer migrations.js:135) | media TTS uses stale voice |
+| language | setup-page.js:65, help-setup.js:23 | mitigated by crow_lang cookie |
+| dashboard_theme, llm_chat_default_provider_id | none found | write-only/vestigial — confirm in follow-up |
+
+CONSISTENT (no action): feature_flags, kiosk_mode, migration flags — all readers
+use `readSetting`.
+
+## 7. Risks / review focus
+
+- D4 LWW nondeterminism between divergent pre-existing rows (crow 'Kevin' vs
+  grackle 'Kevin Hopper') until the operator's next save — accepted, bounded, and
+  the deploy plan performs that save.
+- D3 must never run per-boot without the flag (would clobber deliberate future
+  demotions) — mutation-tested.
+- Synced avatar URL may reference instance-local storage — cosmetic, pre-existing
+  class, documented.
+- `save_profile` writes `""` (not delete) for cleared fields — post-D1 an empty
+  string syncs and blanks peers' values: that is the correct "clear everywhere"
+  semantic.

--- a/docs/superpowers/specs/2026-07-10-profile-follows-user-design.md
+++ b/docs/superpowers/specs/2026-07-10-profile-follows-user-design.md
@@ -143,10 +143,24 @@ of the three profile keys, if a local override row exists for this instance:
   `syncManager.emitChange` directly), then run the heal, then
   `reemitSyncableSettingsOnce()`. The heal's `writeSetting` emit is then real, so
   correctness no longer depends on the two one-shot flags staying coupled.
-- **Gating (R1 MINOR-5):** the heal runs inside the same guarded block that owns
-  `syncManager` (i.e. only when instance-sync is actually initialized) — a
-  `--no-auth` companion gateway sharing the primary's DB must not race the flag
-  write or double-run the heal.
+- **Gating (R1 MINOR-5, corrected by R2 MAJOR-A):** gate the heal on
+  `!syncManager.feedsDisabled` — NOT on `syncManager` truthiness (the manager is
+  constructed unconditionally, so it is truthy even on a `--no-auth` companion
+  gateway sharing the primary's DB, which would run the heal and mark the flag,
+  making the primary skip its own) and NOT on `outFeeds.size` (a genuinely
+  peerless single-instance install still needs the *local* half of the heal — an
+  `outFeeds` backstop would strand its profile forever). Test: heal is a no-op
+  when `feedsDisabled` is true.
+- **Flag mechanics (R2 MINOR-B):** the `__profile_override_heal_v1` flag row is
+  written via raw `INSERT ... ON CONFLICT(key)` into `dashboard_settings` and read
+  via raw `SELECT` — mirroring `reemitSyncableSettingsOnce`
+  (instance-sync.js:521-524, 477-480) — and explicitly NOT via
+  `upsertSetting`/`writeSetting` (the non-allowlisted flag key would silently
+  downgrade to an overrides row and never read back as done).
+- **Crash ordering (R2 MINOR-C):** promote (`writeSetting` global) strictly BEFORE
+  `deleteLocalSetting`. Reversed, a crash between the two loses the value forever
+  (override gone, global never written, flag guard prevents retry). Promote-first
+  re-runs are idempotent (already-promoted keys have no override → skipped).
 - Fix-the-product rationale: a user who typed their name into the silently-broken
   UI gets it restored (and syncing, and in handshakes) at upgrade with no re-save.
 
@@ -202,7 +216,11 @@ disposition of the finding's "optionally dedupe" clause.
 `dashboard_settings` directly. Post-D1 the global row IS the value; user-level
 identity should not vary per instance, so ignoring per-instance overrides is the
 *correct* semantic, not an accident. Documented via a short comment at each read
-site.
+site, which must also state (R2 MINOR-D): per-instance overrides of the profile
+keys are **intentionally inert** — the generic scope route
+(POST /api/settings/scope) can create one and `getSettingScope` would then report
+"local" while behavior stays global; a future maintainer wiring a scope toggle for
+these keys must not ship that lie.
 
 ## 4. Tests (TDD; mutation-test every guard)
 
@@ -230,6 +248,9 @@ site.
 5c. D3/D4 ordering: `setSettingsSyncManager` is wired before the heal runs — a
    heal promotion with the manager wired emits a `dashboard_settings` change
    (asserts MAJOR-1's fix; reddens if the wiring moves back below the block).
+5d. D3 gating (R2 MAJOR-A): heal is a no-op (no promotion, no flag write) when
+   `feedsDisabled` is true — **mutation test**: relaxing the gate to `syncManager`
+   truthiness must redden this.
 6. End-to-end read path: after a UI-style save, `readLocalDisplayName` (boot.js)
    and the tools/contacts.js acceptor read return the saved, sanitized name
    (extends tests/handshake-display-name.test.js).

--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -65,6 +65,30 @@ export async function mountMcpServers(app, deps) {
     console.warn(`[instance-sync] eagerInitPairedPeers at boot failed: ${err.message}`);
   }
 
+  // Scoped-settings sync: wire the registry's writeSetting to emitChange so
+  // operator edits on one instance propagate to paired peers. MUST happen
+  // BEFORE the heal/re-emit one-shots below (R1 MAJOR-1): the heal promotes
+  // via writeSetting, whose emit is a silent no-op — and whose promoted row
+  // never gets a lamport stamp — while the manager is unwired.
+  try {
+    const { setSettingsSyncManager } = await import("../dashboard/settings/registry.js");
+    setSettingsSyncManager(syncManager);
+  } catch {}
+
+  // Cluster B D3: one-shot heal — promote profile values stranded in
+  // dashboard_settings_overrides by the broken-era save_profile. Gated on
+  // !feedsDisabled: a --no-auth companion shares the primary's DB and must
+  // not run it or mark its flag (R2 MAJOR-A). Runs BEFORE the settings
+  // re-emit so a promoted value also rides this boot's reconciliation.
+  try {
+    if (syncManager && !syncManager.feedsDisabled) {
+      const { healProfileOverridesOnce } = await import("../dashboard/settings/profile-heal.js");
+      await healProfileOverridesOnce(syncManager.db, { feedsDisabled: syncManager.feedsDisabled });
+    }
+  } catch (err) {
+    console.warn(`[settings] healProfileOverridesOnce failed: ${err.message}`);
+  }
+
   // One-shot backfill: re-emit sync-allowlisted dashboard_settings so peers
   // whose pre-fix outFeed silently dropped entries can catch up. Guarded by
   // a flag row; idempotent on subsequent boots.
@@ -98,13 +122,6 @@ export async function mountMcpServers(app, deps) {
   } catch (err) {
     console.warn(`[instance-sync] backfillGroupsOnce failed: ${err.message}`);
   }
-
-  // Scoped-settings sync: wire the registry's writeSetting to emitChange so
-  // operator edits on one instance propagate to paired peers.
-  try {
-    const { setSettingsSyncManager } = await import("../dashboard/settings/registry.js");
-    setSettingsSyncManager(syncManager);
-  } catch {}
 
   // Bundle asset repair: when a bundle is marked installed but its ~/.crow/bundles/<id>/
   // directory is missing user-visible files (settings-section.js, panel/, manifest.json),

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -6,7 +6,7 @@
 
 import { randomUUID } from "crypto";
 import { parseVCard, generateVCard, parseCsv } from "./vcard.js";
-import { upsertSetting } from "../../settings/registry.js";
+import { upsertSetting, deleteLocalSetting } from "../../settings/registry.js";
 import { getContacts } from "./data-queries.js";
 import { getManagersOrNull } from "../../../../sharing/managers.js";
 import { emitContactChange } from "../../../../sharing/contact-sync.js";
@@ -351,18 +351,26 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
 
   // --- Own profile ---
   if (action === "save_profile") {
+    // F-SETTINGS-1 (Cluster B D2): each save also clears any stranded
+    // broken-era local override — during the era when these keys were not
+    // sync-allowlisted, upsertSetting silently downgraded profile saves to
+    // dashboard_settings_overrides rows that no reader consults. The global
+    // row (which readers use and peers sync) must be effective from this save.
     if (req.body.display_name !== undefined) {
       // This value is SENT on every handshake and syncs to all of the user's
       // instances — cap + strip it at write (design §D5). sanitizeDisplayName
       // returns null when nothing survives; store "" rather than the literal
       // "null" so the setting is cleared, not poisoned.
       await upsertSetting(db, "profile_display_name", sanitizeDisplayName(req.body.display_name) ?? "");
+      await deleteLocalSetting(db, "profile_display_name");
     }
     if (req.body.avatar_url !== undefined) {
       await upsertSetting(db, "profile_avatar_url", req.body.avatar_url.trim());
+      await deleteLocalSetting(db, "profile_avatar_url");
     }
     if (req.body.bio !== undefined) {
       await upsertSetting(db, "profile_bio", req.body.bio.trim());
+      await deleteLocalSetting(db, "profile_bio");
     }
     return { redirect: "/dashboard/contacts?view=profile" };
   }

--- a/servers/gateway/dashboard/panels/contacts/data-queries.js
+++ b/servers/gateway/dashboard/panels/contacts/data-queries.js
@@ -125,6 +125,11 @@ export async function getMyProfile(db) {
   const keys = ["profile_display_name", "profile_avatar_url", "profile_bio"];
   const profile = {};
   try {
+    // Reads the GLOBAL scope on purpose (Cluster B design D6): profile identity
+    // is user-level and follows the user across instances. Per-instance
+    // overrides of profile_* keys are intentionally inert — do not "fix" this
+    // to readSetting, and do not wire a scope toggle for these keys (the scope
+    // route would report "local" while behavior stays global).
     const { rows } = await db.execute(
       `SELECT key, value FROM dashboard_settings WHERE key IN ('profile_display_name', 'profile_avatar_url', 'profile_bio')`
     );

--- a/servers/gateway/dashboard/settings/profile-heal.js
+++ b/servers/gateway/dashboard/settings/profile-heal.js
@@ -1,0 +1,81 @@
+/**
+ * profile-heal.js — Cluster B D3: one-shot heal for F-SETTINGS-1's stranded
+ * profile values.
+ *
+ * During the settings-scope era in which the profile keys were not
+ * sync-allowlisted, every UI profile save was silently downgraded to a
+ * dashboard_settings_overrides row that NO reader consults (all profile
+ * readers are global-direct by design, D6). Users' typed values are stranded
+ * there. This promotes them to the global scope once, so the name a user
+ * saved into the "broken" UI comes back — and starts syncing — at upgrade,
+ * with no re-save.
+ *
+ * Rules (spec §D3):
+ *  - non-empty override → promote to global (writeSetting, which emits to
+ *    peers when the sync manager is wired) THEN delete the override. Promote
+ *    strictly BEFORE delete: reversed, a crash between the two loses the
+ *    value forever (override gone, global never written, flag prevents retry).
+ *    Promote-first re-runs are idempotent.
+ *  - empty/whitespace override → delete only. Promoting "" could blank a
+ *    peer's real pre-refactor global value fleet-wide.
+ *  - flag row __profile_override_heal_v1 is RAW SQL into dashboard_settings
+ *    (NOT upsertSetting — a non-allowlisted flag key would silently downgrade
+ *    to an overrides row and never read back as done → heal re-runs forever).
+ *  - feedsDisabled=true (a --no-auth companion sharing the primary's DB) is a
+ *    FULL no-op — no promotion, no flag write — or the companion would mark
+ *    the flag and the primary would skip its own heal (R2 MAJOR-A). Gate on
+ *    feedsDisabled, NOT manager truthiness (the manager is constructed
+ *    unconditionally) and NOT outFeeds.size (a peerless single-instance
+ *    install still needs the local half of the heal).
+ */
+import { writeSetting, deleteLocalSetting } from "./registry.js";
+import { PROFILE_SYNC_KEYS } from "./sync-allowlist.js";
+import { getOrCreateLocalInstanceId } from "../../instance-registry.js";
+
+const FLAG_KEY = "__profile_override_heal_v1";
+
+export async function healProfileOverridesOnce(db, { feedsDisabled = false } = {}) {
+  if (feedsDisabled) return 0;
+
+  try {
+    const { rows } = await db.execute({
+      sql: "SELECT value FROM dashboard_settings WHERE key = ?",
+      args: [FLAG_KEY],
+    });
+    if (typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:")) return 0;
+  } catch {
+    return 0; // unreadable flag → do nothing rather than risk a re-run loop
+  }
+
+  const localId = getOrCreateLocalInstanceId();
+  let promoted = 0;
+  for (const key of PROFILE_SYNC_KEYS) {
+    try {
+      const { rows } = await db.execute({
+        sql: "SELECT value FROM dashboard_settings_overrides WHERE key = ? AND instance_id = ?",
+        args: [key, localId],
+      });
+      if (rows.length === 0) continue;
+      const value = rows[0].value;
+      if (typeof value === "string" && value.trim() !== "") {
+        await writeSetting(db, key, value, { scope: "global" });
+        promoted++;
+      }
+      await deleteLocalSetting(db, key);
+    } catch (err) {
+      console.warn(`[settings] profile heal for ${key} failed: ${err.message}`);
+    }
+  }
+
+  try {
+    await db.execute({
+      sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+      args: [FLAG_KEY, `done:${promoted}`],
+    });
+  } catch {}
+
+  if (promoted > 0) {
+    console.log(`[settings] profile heal: promoted ${promoted} stranded profile value(s) to the global scope`);
+  }
+  return promoted;
+}

--- a/servers/gateway/dashboard/settings/registry.js
+++ b/servers/gateway/dashboard/settings/registry.js
@@ -178,7 +178,9 @@ export async function readSettings(db, pattern) {
  *
  * scope:
  *   - "global" → dashboard_settings row (synced if key in SYNC_ALLOWLIST).
- *     Also clears any local override for this instance so the global row is effective.
+ *     Does NOT clear a local override — an existing override for this instance
+ *     keeps winning readSetting until deleteLocalSetting is called (the scope
+ *     route does that explicitly; see routes/settings-scope.js).
  *   - "local"  → dashboard_settings_overrides row keyed by (key, instance_id).
  *     Never syncs. Takes precedence over the global row on reads.
  *

--- a/servers/gateway/dashboard/settings/sync-allowlist.js
+++ b/servers/gateway/dashboard/settings/sync-allowlist.js
@@ -21,6 +21,16 @@ export const SYNC_ALLOWLIST = {
   nav_panel_assignments:     "Panel-to-group assignments",
   "storage.shared.*":        "Shared MinIO / S3 object-store config (secrets sealed via secret-box)",
   unified_dashboard_enabled: "Unified multi-instance dashboard opt-in",
+  // Cluster B (F-SETTINGS-1/F-CONTACT-5): own-profile identity is user-level
+  // data — it follows the user across instances like contacts/groups do.
+  // SECURITY NOTE: the sync-apply path (_applyDashboardSetting) writes peer
+  // values RAW. The defense is (a) every dashboard render of profile values is
+  // escapeHtml'd and (b) both handshake readers re-sanitize via
+  // sanitizeDisplayName at READ time. Any future reader of profile_* must
+  // follow the same rule.
+  profile_display_name:      "Own profile — display name (sent in pairing handshakes)",
+  profile_avatar_url:        "Own profile — avatar URL",
+  profile_bio:               "Own profile — bio",
   // companion_wm_federation removed — the kiosk button's federation is
   // driven by real-time overview availability now, not a separate opt-in
   // flag. Rollback to local-only kiosk is CROW_UNIFIED_DASHBOARD=0.
@@ -83,3 +93,11 @@ export function checkSyncKeyDrift(sections) {
   }
   return drift;
 }
+
+/**
+ * The three own-profile keys (explicit list, deliberately NOT a "profile_*"
+ * allowlist prefix — a future profile_ key must be consciously added).
+ * Consumed by the save-path override clear, the one-shot heal, and the
+ * re-emit empty-value guard.
+ */
+export const PROFILE_SYNC_KEYS = ["profile_display_name", "profile_avatar_url", "profile_bio"];

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -31,6 +31,8 @@ import { sanitizeDisplayName } from "./display-name.js";
  * Read the local user's own display name (dashboard_settings.profile_display_name),
  * sanitized (design §D5). Returns null when unset, empty, rejected, or on any DB
  * error — the caller then omits the field entirely (no placeholder). Never throws.
+ * Reads the GLOBAL scope on purpose (Cluster B design D6): profile identity is
+ * user-level; per-instance overrides of profile_* keys are intentionally inert.
  */
 async function readLocalDisplayName(db) {
   try {

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -19,7 +19,7 @@ import { createHash } from "node:crypto";
 import { sign, verify } from "./identity.js";
 import { emitGroupUpsert } from "./group-sync.js";
 import { resolveDataDir } from "../db.js";
-import { isSyncable } from "../gateway/dashboard/settings/sync-allowlist.js";
+import { isSyncable, PROFILE_SYNC_KEYS } from "../gateway/dashboard/settings/sync-allowlist.js";
 import { normalizePubkey } from "./pubkey-util.js";
 import { readTombstone, writeTombstone, clearTombstone } from "./contact-delete.js";
 import { sanitizeDisplayName } from "./display-name.js";
@@ -468,7 +468,12 @@ export class InstanceSyncManager {
    * safe even when the peer already has current data.
    */
   async reemitSyncableSettingsOnce() {
-    const FLAG_KEY = "__sync_reemit_allowlist_v1";
+    // v1 → v2 (Cluster B, 2026-07-10): the profile keys were added to the
+    // allowlist and every fleet instance's v1 flag is already done: — without a
+    // re-run, pre-existing global profile rows (written before the settings-
+    // scope refactor) would never replicate until the next manual save. The v1
+    // flag row remains as a harmless orphan.
+    const FLAG_KEY = "__sync_reemit_allowlist_v2";
     // Same race class as backfillContactsOnce: the boot call runs concurrently
     // with the async sharing boot that arms outFeeds, so 'no-peers' must be
     // retryable, and only a real completed run ('done:<n>') is terminal.
@@ -503,6 +508,12 @@ export class InstanceSyncManager {
     let emitted = 0;
     for (const row of rows) {
       if (!isSyncable(row.key)) continue;
+      // R1 MAJOR-2 (Cluster B): never re-emit an EMPTY profile value — a
+      // historical empty row (indistinguishable from "never set") would get a
+      // fresh lamport and could win LWW, blanking a peer's real value. A LIVE
+      // save of "" still emits via writeSetting (a deliberate clear propagates);
+      // this guard is scoped to the re-emit reconciliation only.
+      if (PROFILE_SYNC_KEYS.includes(row.key) && (typeof row.value !== "string" || row.value.trim() === "")) continue;
       try {
         await this.emitChange("dashboard_settings", "update", {
           key: row.key,

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -67,6 +67,8 @@ async function acceptInviteCore({ invite_code, display_name }, { db, identity, s
     // dashboard_settings.profile_display_name, sanitized. When unset or rejected
     // the key is OMITTED entirely — byte-identical to today, no placeholder. A
     // settings-read failure must not abort the acceptance, so it is guarded.
+    // Reads the GLOBAL scope on purpose (Cluster B design D6): profile identity
+    // is user-level; per-instance overrides of profile_* keys are intentionally inert.
     let selfName = null;
     try {
       const { rows } = await db.execute({

--- a/tests/messages-contacts-backfill.test.js
+++ b/tests/messages-contacts-backfill.test.js
@@ -154,13 +154,13 @@ test("reemitSyncableSettingsOnce: stale 'no-peers' flag row is healed (UPSERT do
     args: [],
   });
   await m.db.execute({
-    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('__sync_reemit_allowlist_v1', 'no-peers', datetime('now'))",
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('__sync_reemit_allowlist_v2', 'no-peers', datetime('now'))", // v2 since Cluster B (v1 orphaned by the profile-keys allowlist re-run)
     args: [],
   });
   const emitted = [];
   m.emitChange = async (_t, _o, r) => emitted.push(r.key);
   assert.ok((await m.reemitSyncableSettingsOnce()) >= 1, "stale no-peers is not terminal");
-  const { rows } = await m.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key='__sync_reemit_allowlist_v1'" });
+  const { rows } = await m.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key='__sync_reemit_allowlist_v2'" }); // v2 since Cluster B (v1 orphaned by the profile-keys allowlist re-run)
   assert.match(rows[0].value, /^done:\d+$/, "done-mark UPSERTs over the stale row");
   const before = emitted.length;
   assert.equal(await m.reemitSyncableSettingsOnce(), 0, "terminal — no per-boot re-emit thrash");

--- a/tests/profile-heal.test.js
+++ b/tests/profile-heal.test.js
@@ -1,0 +1,107 @@
+/**
+ * Cluster B D3 — one-shot heal: values stranded in dashboard_settings_overrides
+ * by the broken-era save_profile are promoted (non-empty only) to the global
+ * scope once, flag-guarded, gated OFF for --no-auth companions (feedsDisabled).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { healProfileOverridesOnce } from "../servers/gateway/dashboard/settings/profile-heal.js";
+import { setSettingsSyncManager } from "../servers/gateway/dashboard/settings/registry.js";
+import { getOrCreateLocalInstanceId } from "../servers/gateway/instance-registry.js";
+
+function fresh() {
+  const dir = mkdtempSync(join(tmpdir(), "profile-heal-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+async function seedOverride(db, localId, key, value) {
+  await db.execute({
+    sql: "INSERT INTO dashboard_settings_overrides (key, instance_id, value, updated_at) VALUES (?, ?, ?, datetime('now'))",
+    args: [key, localId, value],
+  });
+}
+const globalValue = async (db, key) => (await db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [key] })).rows[0]?.value;
+const overrideCount = async (db) => Number((await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings_overrides WHERE key LIKE 'profile_%'")).rows[0].c);
+
+test("heal: promotes non-empty stranded overrides (override wins over global), deletes empties, one-shot flag, emits", async () => {
+  const { dir, db, cleanup } = fresh();
+  const prev = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const emitted = [];
+  setSettingsSyncManager({ emitChange: async (t, op, row) => { emitted.push(row.key); } });
+  try {
+    const localId = getOrCreateLocalInstanceId();
+    await seedOverride(db, localId, "profile_display_name", "Kevin");   // (a)+(c): promote, wins over global
+    await seedOverride(db, localId, "profile_bio", "");                 // (f): empty → delete only
+    await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_display_name', 'Old Global', datetime('now'))");
+    await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_bio', 'Real Bio', datetime('now'))");
+
+    const n = await healProfileOverridesOnce(db, { feedsDisabled: false });
+    assert.equal(n, 1, "exactly the one non-empty override promoted");
+    assert.equal(await globalValue(db, "profile_display_name"), "Kevin", "(c) override value wins over pre-existing global");
+    assert.equal(await globalValue(db, "profile_bio"), "Real Bio", "(f) empty override did NOT blank the real global value");
+    assert.equal(await overrideCount(db), 0, "all profile overrides cleared (incl. the empty one)");
+    assert.ok(emitted.includes("profile_display_name"), "(e) promotion emitted (manager wired)");
+    const flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__profile_override_heal_v1'");
+    assert.match(String(flag.rows[0]?.value), /^done:1$/, "flag row written to dashboard_settings via raw SQL");
+
+    // (b) second run is a flag-guarded no-op even with a fresh override present
+    await seedOverride(db, localId, "profile_display_name", "Deliberate Local");
+    emitted.length = 0;
+    const n2 = await healProfileOverridesOnce(db, { feedsDisabled: false });
+    assert.equal(n2, 0, "(b) flag-guarded second run no-ops");
+    assert.equal(await globalValue(db, "profile_display_name"), "Kevin", "deliberate post-heal override untouched");
+    assert.equal(emitted.length, 0);
+  } finally {
+    setSettingsSyncManager(null);
+    if (prev === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prev;
+    cleanup();
+  }
+});
+
+test("heal: no overrides → flag still set, nothing written (d); feedsDisabled → FULL no-op, no flag (5d)", async () => {
+  const { dir, db, cleanup } = fresh();
+  const prev = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  setSettingsSyncManager(null);
+  try {
+    // 5d: companion gateway (feedsDisabled) must not run NOR mark the flag —
+    // it shares the primary's DB and would make the primary skip its own heal.
+    const gated = await healProfileOverridesOnce(db, { feedsDisabled: true });
+    assert.equal(gated, 0);
+    let flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__profile_override_heal_v1'");
+    assert.equal(flag.rows.length, 0, "feedsDisabled run left NO flag row");
+
+    // (d): a clean primary marks the flag with zero promotions
+    const n = await healProfileOverridesOnce(db, { feedsDisabled: false });
+    assert.equal(n, 0);
+    flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__profile_override_heal_v1'");
+    assert.match(String(flag.rows[0]?.value), /^done:0$/);
+  } finally {
+    setSettingsSyncManager(null);
+    if (prev === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prev;
+    cleanup();
+  }
+});
+
+test("boot wiring order pin: setSettingsSyncManager is wired BEFORE the heal, which runs BEFORE the re-emit", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(join(import.meta.dirname, "..", "servers/gateway/boot/mcp-mounts.js"), "utf8");
+  const wireIdx = src.indexOf("setSettingsSyncManager(syncManager)");
+  const healIdx = src.indexOf("healProfileOverridesOnce");
+  const reemitIdx = src.indexOf("reemitSyncableSettingsOnce");
+  assert.ok(wireIdx > -1 && healIdx > -1 && reemitIdx > -1, "all three call sites present");
+  assert.ok(wireIdx < healIdx, "R1 MAJOR-1: manager wired before the heal (else the heal's emit hits a null manager)");
+  assert.ok(healIdx < reemitIdx, "heal before re-emit so a promoted value rides the same boot's re-emit");
+  assert.match(src, /feedsDisabled/, "heal call site carries the feedsDisabled gate");
+});

--- a/tests/profile-save-clears-override.test.js
+++ b/tests/profile-save-clears-override.test.js
@@ -1,0 +1,61 @@
+/**
+ * Cluster B D2 — a profile save writes the global row AND clears the stranded
+ * broken-era local override, and the profile page reader (getMyProfile) sees
+ * the saved value on the very next read (the F-SETTINGS-1 symptom).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { getMyProfile } from "../servers/gateway/dashboard/panels/contacts/data-queries.js";
+import { setSettingsSyncManager } from "../servers/gateway/dashboard/settings/registry.js";
+import { getOrCreateLocalInstanceId } from "../servers/gateway/instance-registry.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "profile-save-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("save_profile writes global, clears the stranded override, and getMyProfile sees it", async () => {
+  const { dir, db, cleanup } = freshDb();
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  setSettingsSyncManager(null); // emits are not this test's subject
+  try {
+    const localId = getOrCreateLocalInstanceId();
+    // Seed the broken-era state: value stranded in the override, global empty.
+    await db.execute({
+      sql: "INSERT INTO dashboard_settings_overrides (key, instance_id, value, updated_at) VALUES ('profile_display_name', ?, 'Stranded', datetime('now'))",
+      args: [localId],
+    });
+
+    const req = { body: { action: "save_profile", display_name: "Kevin", bio: "Hello" } };
+    const out = await handleContactAction(req, db, {});
+    assert.ok(out && out.redirect, "save redirects");
+
+    const g = await db.execute("SELECT key, value FROM dashboard_settings WHERE key IN ('profile_display_name','profile_bio')");
+    const byKey = Object.fromEntries(g.rows.map((r) => [r.key, r.value]));
+    assert.equal(byKey.profile_display_name, "Kevin", "global name row written");
+    assert.equal(byKey.profile_bio, "Hello", "global bio row written");
+
+    const o = await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings_overrides WHERE key LIKE 'profile_%'");
+    assert.equal(Number(o.rows[0].c), 0, "stranded override cleared (D2)");
+
+    const profile = await getMyProfile(db);
+    assert.equal(profile.display_name, "Kevin", "the profile page reader sees the save immediately");
+    assert.equal(profile.bio, "Hello");
+  } finally {
+    setSettingsSyncManager(null);
+    if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevDataDir;
+    cleanup();
+  }
+});

--- a/tests/profile-sync-allowlist.test.js
+++ b/tests/profile-sync-allowlist.test.js
@@ -1,0 +1,58 @@
+/**
+ * Cluster B (F-SETTINGS-1/F-CONTACT-5) — the three profile keys are
+ * sync-allowlisted so upsertSetting writes the GLOBAL scope and emits to
+ * peers, instead of silently downgrading to a local override no reader sees.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { isSyncable, PROFILE_SYNC_KEYS } from "../servers/gateway/dashboard/settings/sync-allowlist.js";
+import { upsertSetting, setSettingsSyncManager } from "../servers/gateway/dashboard/settings/registry.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "profile-allowlist-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { dir, db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("profile keys are sync-allowlisted (F-SETTINGS-1 root fix)", () => {
+  for (const k of ["profile_display_name", "profile_avatar_url", "profile_bio"]) {
+    assert.equal(isSyncable(k), true, `${k} must be syncable`);
+  }
+  assert.deepEqual(PROFILE_SYNC_KEYS, ["profile_display_name", "profile_avatar_url", "profile_bio"]);
+});
+
+test("explicit-entry posture: an unrelated profile_ key is NOT syncable", () => {
+  assert.equal(isSyncable("profile_zzz"), false);
+});
+
+test("upsertSetting on a profile key writes the GLOBAL row (no override) and emits", async () => {
+  const { dir, db, cleanup } = freshDb();
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const emitted = [];
+  setSettingsSyncManager({ emitChange: async (t, op, row) => { emitted.push({ t, op, row }); } });
+  try {
+    await upsertSetting(db, "profile_display_name", "Kevin");
+    const g = await db.execute("SELECT value FROM dashboard_settings WHERE key = 'profile_display_name'");
+    assert.equal(g.rows[0]?.value, "Kevin", "global row written");
+    const o = await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings_overrides WHERE key = 'profile_display_name'");
+    assert.equal(Number(o.rows[0].c), 0, "no local-override downgrade");
+    assert.ok(
+      emitted.some((e) => e.t === "dashboard_settings" && e.op === "update" && e.row.key === "profile_display_name" && e.row.instance_id === null),
+      "sync emit fired with instance_id null"
+    );
+  } finally {
+    setSettingsSyncManager(null);
+    if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevDataDir;
+    cleanup();
+  }
+});

--- a/tests/settings-reemit-v2.test.js
+++ b/tests/settings-reemit-v2.test.js
@@ -1,0 +1,94 @@
+/**
+ * Cluster B D4 — reemitSyncableSettingsOnce keyed on the v2 flag: a fleet
+ * instance whose v1 flag is 'done:' re-runs ONCE so pre-existing global rows
+ * for the newly-allowlisted profile keys reconcile; empty profile values are
+ * never re-emitted (they could win the lamport race and blank a peer's real
+ * value — R1 MAJOR-2).
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+// Mirrors tests/messages-contacts-backfill.test.js exactly: signedEntry / fakeFeedWith,
+// and _processNewEntriesInner's real 2-arg contract (remoteInstanceId, feed). Signature
+// verification is against this.identity.ed25519Pubkey (shared-identity model — see
+// _applyEntry in instance-sync.js), so signing with TEST_PRIV (== IDENTITY.ed25519Priv)
+// is sufficient; no separate peer-trust wiring exists or is needed.
+import { sign } from "../servers/sharing/identity.js";
+function signedEntry(table, op, row, lamport_ts) {
+  const entry = { table, op, row, lamport_ts, instance_id: "peer-1" };
+  entry.signature = sign(JSON.stringify(entry), IDENTITY.ed25519Priv);
+  return entry;
+}
+const fakeFeedWith = (entries) => ({ length: entries.length, async get(seq) { return entries[seq]; } });
+
+function freshMgr(label, id) {
+  const d = mkdtempSync(join(tmpdir(), `crow-b-reemit-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: d }, stdio: "pipe", cwd: join(import.meta.dirname, "..") });
+  after(() => rmSync(d, { recursive: true, force: true }));
+  const m = new InstanceSyncManager(IDENTITY, createDbClient(join(d, "crow.db")), id);
+  m.feedsDisabled = false;
+  m.outFeeds.set("peer-1", { append: async () => {} });
+  return m;
+}
+
+test("v2 flag: re-runs once even when the v1 flag is done:, then no-ops (v1 orphan ignored)", async () => {
+  const m = freshMgr("v2", "local-1"); const db = m.db;
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('__sync_reemit_allowlist_v1', 'done:9', datetime('now'))");
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_display_name', 'Kevin Hopper', datetime('now'))");
+  const emitted = [];
+  const orig = m.emitChange.bind(m);
+  m.emitChange = async (t, o, r) => { emitted.push(r.key); return orig(t, o, r); };
+
+  const n1 = await m.reemitSyncableSettingsOnce();
+  assert.ok(n1 >= 1, "re-ran despite done: v1 flag");
+  assert.ok(emitted.includes("profile_display_name"), "newly-allowlisted profile row re-emitted");
+  const flag = await db.execute("SELECT value FROM dashboard_settings WHERE key = '__sync_reemit_allowlist_v2'");
+  assert.match(String(flag.rows[0]?.value), /^done:/, "v2 flag marked done");
+
+  emitted.length = 0;
+  const n2 = await m.reemitSyncableSettingsOnce();
+  assert.equal(n2, 0, "second run is a no-op");
+  assert.equal(emitted.length, 0);
+});
+
+test("apply side: a peer's profile_display_name entry is applied; a non-allowlisted key is dropped (spec test 7)", async () => {
+  const m = freshMgr("apply", "local-3"); const db = m.db;
+  const entries = [
+    signedEntry("dashboard_settings", "update", { key: "profile_display_name", value: "Peer Name", instance_id: null }, 500),
+    signedEntry("dashboard_settings", "update", { key: "not_allowlisted_key", value: "evil", instance_id: null }, 501),
+  ];
+  await m._processNewEntriesInner("peer-1", fakeFeedWith(entries));
+  const g = await db.execute("SELECT value FROM dashboard_settings WHERE key = 'profile_display_name'");
+  assert.equal(g.rows[0]?.value, "Peer Name", "allowlisted profile row applied from a peer");
+  const bad = await db.execute("SELECT COUNT(*) AS c FROM dashboard_settings WHERE key = 'not_allowlisted_key'");
+  assert.equal(Number(bad.rows[0].c), 0, "non-allowlisted key dropped by the apply-side gate");
+});
+
+test("empty-profile guard: empty/whitespace profile values are NOT re-emitted; non-profile empties still are", async () => {
+  const m = freshMgr("empty", "local-2"); const db = m.db;
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_bio', '', datetime('now'))");
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_avatar_url', '  ', datetime('now'))");
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('profile_display_name', 'Kevin', datetime('now'))");
+  // Pins the DELIBERATE scoping: the guard is profile-only (an empty value for
+  // another allowlisted key is meaningful and still reconciles).
+  await db.execute("INSERT INTO dashboard_settings (key, value, updated_at) VALUES ('nav_groups', '', datetime('now'))");
+  const emitted = [];
+  m.emitChange = async (_t, _o, r) => { emitted.push(r.key); };
+
+  await m.reemitSyncableSettingsOnce();
+  assert.ok(!emitted.includes("profile_bio"), "empty bio NOT re-emitted (fleet-blanking hazard)");
+  assert.ok(!emitted.includes("profile_avatar_url"), "whitespace avatar NOT re-emitted");
+  assert.ok(emitted.includes("profile_display_name"), "non-empty profile value re-emitted");
+  assert.ok(emitted.includes("nav_groups"), "guard is scoped to profile keys only");
+});


### PR DESCRIPTION
## Cluster B — "Profile follows the user" (P4 walkthrough findings)

**F-SETTINGS-1 [MAJOR]:** the dashboard profile save was a silent no-op — `save_profile` wrote via `upsertSetting`, which silently downgraded the non-allowlisted `profile_*` keys to local `dashboard_settings_overrides` rows, while every reader (profile page `getMyProfile`, both handshake name sources from #155) queries the global `dashboard_settings` table directly. The page re-rendered empty right after saving, and the name-in-handshake shipped in #155 was inert via the UI.

**F-CONTACT-5 [MAJOR]:** a shared-identity fleet answered one invite in triplicate with divergent self-names (crow='Kevin', MPA=unset, grackle='Kevin Hopper') — each instance's ack carried its own private value; a relay race decided the acceptor's contact name.

### What this ships
- **D1 (root fix):** sync-allowlist `profile_display_name` / `profile_avatar_url` / `profile_bio` (explicit entries). Saves now write the global row and replicate to the user's paired instances; all three readers become correct unchanged; the triplicate handshake acks become identical, so the race is harmless.
- **D2:** `save_profile` clears the stranded broken-era override per key (+ corrected `writeSetting`'s docblock, which falsely claimed the global path clears overrides).
- **D3:** one-shot flag-guarded boot heal (`profile-heal.js`) promotes non-empty stranded overrides to global — a user who typed their name into the silently-broken UI gets it back (and syncing, and in handshakes) at upgrade, no re-save. Empty overrides are deleted, never promoted (fleet-blanking hazard). Full no-op under `feedsDisabled` (`--no-auth` companions share the primary's DB).
- **D4:** settings re-emit flag `v1`→`v2` so pre-existing global rows for the newly-allowlisted keys (e.g. pre-refactor March-2026 rows) reconcile once at the post-deploy boot — with an empty-profile-value guard on the re-emit.
- **Boot fix (design-review MAJOR):** `setSettingsSyncManager` is now wired **before** the boot one-shots — previously the heal's emit would have hit a null manager and the promoted row would never get a lamport stamp.

### Audit (F-SETTINGS-1 mandate)
Every `upsertSetting` caller was audited: the same write-local/read-global mismatch breaks **12+ more keys** (notably `auto_update_enabled` — disabling auto-update in the UI is inert; `notification_prefs`; `discovery_enabled`; `onboarding_completed_at`; the `blog_*` family with dual writers). Deliberately **not** fixed here — each needs per-key judgment (a blanket revert would break `feature_flags`' intentional local scope). Full table in the spec §6; queued as a dedicated "settings-scope coherence" follow-up PR (`auto_update_*` should ship with the F-UPDATE-1 auto-update hardening).

### Rigor
- Spec `docs/superpowers/specs/2026-07-10-profile-follows-user-design.md`, 2-round adversarial review (R1: 2 MAJOR — dead-emit boot ordering, re-emit could blank a real bio; R2: 1 MAJOR — the `--no-auth` gate had to key on `feedsDisabled`, not manager truthiness — all folded, R2 confirmed R1's folds).
- TDD per task with per-task reviews; **6/6 mutation tests** RED-then-reverted (flag guard, empty-promote guard, feedsDisabled gate, v1→v2, re-emit empty guard, boot-order pin).
- Suite **1385 pass / 1 fail / 1 skip** — the 1 failure is `bundle-contract.test.js` registry drift, **pre-existing on main** at the merge-base (reproduced in an isolated worktree; caused by an unrelated session's untracked bundle).
- **Live proofs:** scratch gateway boot healed a seeded stranded override (log line + global row with real lamport = emit fired, flag `done:1`); real-browser CDP drive — profile save re-renders the saved name/bio (the exact F-SETTINGS-1 symptom), all three keys land global, overrides empty. `--no-auth` boot proven NOT to heal via DB pre/post diff.
- Final whole-branch review: **READY TO MERGE, 0 Critical / 0 Important** (seams traced; `javascript:` avatar-URL question adjudicated safe — `<img src>` never executes it and `escapeHtml` blocks attribute breakout).

### Deploy notes (after merge)
- Deploy crow+MPA+grackle **together** (an old-code peer drops profile sync rows and still advances its checkpoint — it will not re-read them after upgrading).
- Expect a one-time `storage.shared.*` `_scheduleStorageReset` reconnect blip at the first post-deploy boot (fresh-lamport re-emit).
- Post-deploy reconciliation: product-path save of the display name on crow settles LWW fleet-wide. **Operator input:** reconciling to `Kevin` (your most recent intent, 2026-07-10) — trivially changeable afterward via the now-working UI.
- No schema bump — `SCHEMA_GENERATION` stays 6.

### Follow-up pool (logged, not in this PR)
Settings-scope coherence PR (the 12-key audit table); re-emit docblock v2 note; null-`syncManager` boots never heal (self-heals on next save); full-form save during the ~3s sync window can propagate an intended-blank field (pre-existing clear-everywhere semantic).