### PR TITLE
fix(messages): block actually blocks — live teardown on block, lazy re-wire on unblock, receive-time guards (F-BLOCK-1)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-cluster-c-block-teardown.md
+++ b/docs/superpowers/plans/2026-07-10-cluster-c-block-teardown.md
@@ -1,0 +1,713 @@
+# Cluster C — Block Actually Blocks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Blocking a contact tears down its live wiring immediately (no restart), unblocking re-wires it, and no receive path can store/notify/ack a blocked contact's inbound — fixing F-BLOCK-1 and its unread-badge addendum.
+
+**Architecture:** Both block handlers call the #155 delete-path teardown primitive `unwireContact` (Nostr unsub + Hypercore feeds + DHT); both unblock handlers call `wireSyncedContact` (lazy re-wire); the sync-apply blocked branch upgrades to full `unwireContact` (cross-instance leg); four receive-time guards (per-contact `onevent`, `handleIncomingRequest`, `group_message`, `handleInviteAccepted` + `wireFullContact` belt) make the receive path unable to store/notify/ack blocked inbound even during races. Spec (2-round adversarially reviewed): `docs/superpowers/specs/2026-07-10-block-teardown-design.md`.
+
+**Tech Stack:** Node ESM, libsql-style client (`db.execute`), node:test, nostr-tools NIP-44.
+
+## Global Constraints
+
+- **No SCHEMA_GENERATION bump** — code-only; no DDL.
+- **NEVER `git commit --amend`.** Commit with **positional paths only** (`git add <path>` first for NEW files); verify `git show --stat HEAD` after every commit. Tree has unrelated WIP — never `git add -A`/`git add .`.
+- Branch: `fix/messages-cluster-c-block-teardown`. Suite baseline: **1385 pass / 1 pre-existing fail (bundle-contract, foreign) / 1 skip**.
+- Blocking is SILENT toward the blocked party: no store, no notification, no unread emit, no instance-sync mirror emit, no delivery receipt, no handshake ack, no `onMessage`.
+- D4d's early-return placement is load-bearing: **before** the `wasProcessed` ack branch AND the short-code `"replayed"` ack branch.
+- D4c is a **reorder** (sender resolve moves above the unconditional notification); the guard is `found && is_blocked===1`, never `!found` — an unknown group sender must still notify exactly as today.
+- Receive-path guards must never throw (a throw kills the subscription); every new lookup is try/caught with fail-open-to-current-behavior.
+
+---
+
+### Task 1: D4a — fresh `is_blocked` check in `subscribeToContact.onevent`
+
+**Files:**
+- Modify: `servers/sharing/nostr.js` (inside `subscribeToContact`'s `onevent`, before the messages INSERT at ~line 483)
+- Test: `tests/block-onevent-guard.test.js` (new)
+
+**Interfaces:**
+- Consumes: nothing new. Produces: nothing exported — behavioral guard only.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/block-onevent-guard.test.js` (harness mirrors `tests/nostr-receive-health-hooks.test.js` — stub relay + real NIP-44):
+
+```js
+/**
+ * Cluster C D4a — a per-contact subscription that is still live when the
+ * contact is blocked (block→teardown race, or a future wiring path that
+ * forgets teardown) must NOT store, receipt, or surface the inbound DM.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { getPublicKey, nip44 } from "nostr-tools";
+import { NostrManager } from "../servers/sharing/nostr.js";
+
+function stubRelay() {
+  const r = {
+    connected: true, subscribeCalls: [], closed: false,
+    subscribe(filters, { onevent, onclose }) {
+      r.subscribeCalls.push({ filters, onevent, onclose });
+      const s = { onevent, onclose, closed: false, close() { this.closed = true; } };
+      return s;
+    },
+    async connect() { r.connected = true; },
+    close() { r.closed = true; },
+  };
+  return r;
+}
+
+const ourPriv = new Uint8Array(32).fill(1);
+const theirPriv = new Uint8Array(32).fill(2);
+const ourPub = getPublicKey(ourPriv);
+const theirPub = getPublicKey(theirPriv);
+const identity = { secp256k1Pubkey: ourPub, secp256k1Priv: ourPriv };
+const encryptToUs = (pt) => nip44.v2.encrypt(pt, nip44.v2.utils.getConversationKey(theirPriv, ourPub));
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "block-onevent-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("onevent: blocked contact's DM is silently dropped (no row, no receipt); unblocked stores", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const ins = await db.execute({
+      sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES ('crow:blockee', 'ed', ?, 'Blockee')",
+      args: [theirPub],
+    });
+    const contactId = Number(ins.lastInsertRowid);
+
+    const mgr = new NostrManager(identity, db);
+    let receipts = 0;
+    mgr._sendDeliveryReceipt = async () => { receipts++; };
+    const relay = stubRelay();
+    mgr.relays.set("wss://stub", relay);
+    await mgr.subscribeToContact({ id: contactId, crow_id: "crow:blockee", secp256k1_pubkey: theirPub, display_name: "Blockee" });
+    const onevent = relay.subscribeCalls[0].onevent;
+
+    // Block AFTER subscribe — the sub is live (the F-BLOCK-1 shape).
+    await db.execute({ sql: "UPDATE contacts SET is_blocked = 1 WHERE id = ?", args: [contactId] });
+    await onevent({ id: "evt-blocked", pubkey: theirPub, created_at: 1_700_000_000, content: encryptToUs("while blocked") });
+    let n = await db.execute({ sql: "SELECT COUNT(*) AS c FROM messages WHERE contact_id = ?", args: [contactId] });
+    assert.equal(Number(n.rows[0].c), 0, "blocked inbound must NOT store");
+    assert.equal(receipts, 0, "blocked inbound must NOT be receipted (silence)");
+
+    // Unblock — the same live sub stores again (fresh check each event).
+    await db.execute({ sql: "UPDATE contacts SET is_blocked = 0 WHERE id = ?", args: [contactId] });
+    await onevent({ id: "evt-unblocked", pubkey: theirPub, created_at: 1_700_000_001, content: encryptToUs("after unblock") });
+    n = await db.execute({ sql: "SELECT COUNT(*) AS c FROM messages WHERE contact_id = ?", args: [contactId] });
+    assert.equal(Number(n.rows[0].c), 1, "unblocked inbound stores");
+    assert.equal(receipts, 1, "unblocked inbound is receipted");
+    await mgr.destroy();
+  } finally { cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/block-onevent-guard.test.js`
+Expected: FAIL — "blocked inbound must NOT store" (count 1) and receipts 1.
+
+- [ ] **Step 3: Implement**
+
+In `servers/sharing/nostr.js`, inside `onevent`, AFTER the `invite_accepted`/`crow_social` JSON early-return block and BEFORE the `if (contactId && this.db)` store block, insert:
+
+```js
+            // F-BLOCK-1 D4a: fresh block check. The sub is torn down on block,
+            // but an in-flight event — or a future wiring path that forgets
+            // teardown — must not store, notify, bump unread, mirror, receipt,
+            // or surface a blocked contact's DM. Silent drop (no receipt: we
+            // deliberately stop confirming receipt to a blocked party).
+            if (contactId && this.db) {
+              try {
+                const { rows: blockRows } = await this.db.execute({
+                  sql: "SELECT is_blocked FROM contacts WHERE id = ?",
+                  args: [contactId],
+                });
+                if (Number(blockRows?.[0]?.is_blocked ?? 0) === 1) return;
+              } catch { /* an unreadable check must not break delivery */ }
+            }
+```
+
+(`markInbound()` above it still runs — the relay IS healthy; only the contact is blocked.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/block-onevent-guard.test.js tests/nostr-receive-health-hooks.test.js tests/nostr-resubscribe.test.js`
+Expected: ALL PASS (the two pre-existing receive-path suites prove no regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/block-onevent-guard.test.js
+git commit tests/block-onevent-guard.test.js servers/sharing/nostr.js -m "fix(sharing): blocked contact's inbound DM is dropped at receive time — fresh is_blocked check in the per-contact onevent (F-BLOCK-1 D4a)"
+git show --stat HEAD
+```
+
+---
+
+### Task 2: D4b + D4c — `handleIncomingRequest` early-return + `group_message` reorder
+
+**Files:**
+- Modify: `servers/sharing/boot.js` (`handleIncomingRequest` ~line 83; `group_message` branch ~lines 548-578)
+- Test: `tests/block-receive-guards.test.js` (new)
+
+**Interfaces:**
+- Consumes: `handleIncomingRequest(db, managers, {senderPubkey, content, eventId})` — already exported; `managers.createNotification` injectable (existing test hook).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/block-receive-guards.test.js`:
+
+```js
+/**
+ * Cluster C D4b + D4c — the catch-all receive paths drop a blocked contact's
+ * inbound: message-requests (any request_status) and group_message fan-outs
+ * (no notification, no store). An UNKNOWN group sender still notifies.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { handleIncomingRequest, handleSocialMessage } from "../servers/sharing/boot.js";
+
+const SECP = "b".repeat(64);
+
+function freshDb(tag) {
+  const dir = mkdtempSync(join(tmpdir(), `block-guards-${tag}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("D4b: blocked request contact (pending/accepted/full) → no store, no notification", async () => {
+  const { db, cleanup } = freshDb("d4b");
+  try {
+    const cases = [
+      { secp: "a".repeat(64), status: "pending" },
+      { secp: "c".repeat(64), status: "accepted" },
+      { secp: "d".repeat(64), status: null },
+    ];
+    let notifications = 0;
+    const managers = { createNotification: async () => { notifications++; } };
+    for (const c of cases) {
+      await db.execute({
+        sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, request_status, is_blocked) VALUES (?, ?, '', ?, 1)",
+        args: [`req:${c.secp}`, c.secp, c.status],
+      });
+      await handleIncomingRequest(db, managers, { senderPubkey: c.secp, content: "hi", eventId: `e-${c.secp.slice(0, 4)}` });
+      const { rows } = await db.execute("SELECT COUNT(*) AS c FROM messages");
+      assert.equal(Number(rows[0].c), 0, `blocked ${c.status ?? "full"} contact must not store`);
+    }
+    assert.equal(notifications, 0, "no notifications for blocked senders");
+
+    // Control: an UNblocked pending request still stores (existing behavior).
+    const okSecp = "e".repeat(64);
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, request_status, is_blocked) VALUES (?, ?, '', 'pending', 0)",
+      args: [`req:${okSecp}`, okSecp],
+    });
+    await handleIncomingRequest(db, managers, { senderPubkey: okSecp, content: "hello", eventId: "e-ok" });
+    const { rows } = await db.execute("SELECT COUNT(*) AS c FROM messages");
+    assert.equal(Number(rows[0].c), 1, "unblocked pending request still stores");
+  } finally { cleanup(); }
+});
+```
+
+NOTE FOR THE IMPLEMENTER on D4c's test: check whether the `group_message` branch is reachable through an exported function (the `onSocialMessage` dispatcher in boot.js — find its export or the smallest exported wrapper). If the subtype dispatcher is NOT exported, export the smallest testable unit the same way `handleIncomingRequest` already is (a `handleGroupMessageNotify(db, payload)` extraction is acceptable if the inline branch can't be driven), then add these three cases to this test file:
+1. blocked sender (`sender_crow_id` of a contact with `is_blocked=1`) → NO notification, NO messages row;
+2. unblocked sender → notification + stored row (existing behavior);
+3. UNKNOWN sender (`sender_crow_id` matches no contact) → notification fires, no row (pins the reorder against a `!found` mistake).
+Inject the notification counter the same way (`managers.createNotification` or the extraction's parameter). Assertions are fixed; mechanics may adapt. The `handleSocialMessage` import in the sketch is a GUESS — replace it with whatever exported symbol actually reaches the `group_message` branch.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/block-receive-guards.test.js`
+Expected: FAIL — blocked cases store rows / fire notifications.
+
+- [ ] **Step 3: Implement D4b**
+
+In `servers/sharing/boot.js`, in `handleIncomingRequest`, immediately after `const existing = await findContactByPubkey(db, senderPubkey);`:
+
+```js
+    // F-BLOCK-1 D4b: a blocked contact — ANY request_status (full, pending,
+    // accepted) — is silently dropped on the catch-all path: no store, no
+    // notification. This was the S5.4 live store path.
+    if (existing && Number(existing.is_blocked) === 1) return;
+```
+
+- [ ] **Step 4: Implement D4c (reorder)**
+
+Replace the `group_message` branch body with (notification content and store content byte-identical; only the sender resolve MOVES above the notification):
+
+```js
+    } else if (subtype === "group_message") {
+      const { group_name, sender_name, message: msgText } = payload;
+      if (!msgText) return;
+      // F-BLOCK-1 D4c: resolve the sender BEFORE the notification — a blocked
+      // group member must neither notify nor store (their fan-out includes us;
+      // send-side filters only cover members WE blocked when WE fan out). An
+      // UNKNOWN (non-contact) sender still notifies exactly as before — the
+      // guard is found&&blocked, never !found.
+      let senderRow = null;
+      try {
+        const senderContact = await db.execute({
+          sql: "SELECT id, is_blocked FROM contacts WHERE crow_id = ?",
+          args: [payload.sender_crow_id || ""],
+        });
+        senderRow = senderContact.rows[0] || null;
+      } catch { /* lookup failure degrades to today's behavior */ }
+      if (senderRow && Number(senderRow.is_blocked) === 1) return;
+      try {
+        await createNotification(db, {
+          title: `[${group_name || "Group"}] ${sender_name || "Someone"}`,
+          body: msgText.length > 200 ? msgText.slice(0, 200) + "..." : msgText,
+          type: "peer",
+          source: "sharing:group_message",
+          priority: "high",
+        });
+      } catch (err) {
+        console.warn("[sharing] Failed to create group message notification:", err.message);
+      }
+      // Also store as a regular message with group context.
+      // Phase 3 PR-B: deliberately NOT emitted to instance-sync — synthetic
+      // grp_<ts> event id (not a real Nostr event); rooms have their own sync path.
+      try {
+        if (senderRow) {
+          await db.execute({
+            sql: `INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
+                  VALUES (?, ?, ?, 'received', 0, datetime('now'))`,
+            args: [senderRow.id, `grp_${Date.now()}`, `[${group_name}] ${msgText}`],
+          });
+        }
+      } catch {}
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `node --test tests/block-receive-guards.test.js tests/message-request-actions.test.js`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/block-receive-guards.test.js
+git commit tests/block-receive-guards.test.js servers/sharing/boot.js -m "fix(sharing): blocked contacts dropped on the catch-all receive paths — message-requests + group_message (F-BLOCK-1 D4b/D4c; unknown group sender still notifies)"
+git show --stat HEAD
+```
+
+---
+
+### Task 3: D3 + D4d — sync-apply full teardown, blocked-handshake silence, `wireFullContact` belt
+
+**Files:**
+- Modify: `servers/sharing/contact-promote.js` (blocked branch of `wireSyncedContact` ~line 101; export + belt-guard `wireFullContact` ~line 77)
+- Modify: `servers/sharing/boot.js` (`handleInviteAccepted` — insert after the auth check at ~line 182)
+- Test: `tests/block-rewire-guards.test.js` (new)
+
+**Interfaces:**
+- Consumes: `unwireContact(managers, row)` from `./contact-delete.js` (contact-promote.js already imports from that module — extend the import; acyclic).
+- Produces: `wireFullContact` becomes an export of contact-promote.js (belt-guarded on `row.is_blocked`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/block-rewire-guards.test.js`:
+
+```js
+/**
+ * Cluster C D3 + D4d — the sync-apply blocked branch performs the FULL
+ * teardown (incl. the Nostr unsub the old inline pair missed); a blocked
+ * contact's invite_accepted is silenced (no upsert, no ack — even on the
+ * ~60h replay of an already-processed event); wireFullContact refuses to
+ * wire a blocked row.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { getPublicKey } from "nostr-tools";
+import { wireSyncedContact, wireFullContact } from "../servers/sharing/contact-promote.js";
+import { handleInviteAccepted } from "../servers/sharing/boot.js";
+import { recordProcessedEvent } from "../servers/sharing/processed-events.js";
+
+const theirPriv = new Uint8Array(32).fill(7);
+const theirPub = getPublicKey(theirPriv);
+
+function freshDb(tag) {
+  const dir = mkdtempSync(join(tmpdir(), `block-rewire-${tag}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function stubManagers() {
+  const calls = [];
+  return {
+    calls,
+    nostrManager: {
+      unsubscribeFromContact: (crowId) => calls.push(["unsub", crowId]),
+      subscribeToContact: async (c) => calls.push(["sub", c.crow_id || c.crowId]),
+      sendControl: async () => calls.push(["ack"]),
+      relays: new Map([["wss://stub", {}]]),
+      connectRelays: async () => {},
+      sendInviteAccepted: async () => {},
+    },
+    syncManager: {
+      closeContactFeeds: async (id) => calls.push(["closeFeeds", id]),
+      initContact: async (id) => calls.push(["initContact", id]),
+    },
+    peerManager: {
+      leaveContact: async (crowId) => calls.push(["leave", crowId]),
+      joinContact: async (c) => calls.push(["join", c.crowId]),
+    },
+  };
+}
+
+test("D3: wireSyncedContact on a blocked row performs the FULL teardown (incl. Nostr unsub)", async () => {
+  const m = stubManagers();
+  await wireSyncedContact(m, { id: 7, crow_id: "crow:blocked1", is_blocked: 1, secp256k1_pubkey: theirPub, ed25519_pubkey: "ed" });
+  const kinds = m.calls.map((c) => c[0]);
+  assert.ok(kinds.includes("unsub"), "Nostr unsubscribe — the leg the old inline pair missed");
+  assert.ok(kinds.includes("closeFeeds"), "feeds closed");
+  assert.ok(kinds.includes("leave"), "DHT topic left");
+  assert.ok(!kinds.includes("sub"), "never subscribes a blocked row");
+});
+
+test("D4d belt: wireFullContact refuses a blocked row", async () => {
+  const m = stubManagers();
+  await wireFullContact(m, { id: 8, crow_id: "crow:blocked2", is_blocked: 1, secp256k1_pubkey: theirPub, ed25519_pubkey: "ed" });
+  assert.equal(m.calls.length, 0, "no initContact/joinContact/subscribeToContact for a blocked row");
+});
+
+test("D4d: blocked sender's invite_accepted → no upsert, no ack — even for an already-processed event.id", async () => {
+  const { db, cleanup } = freshDb("d4d");
+  try {
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, display_name, is_blocked) VALUES ('crow:blocked3', ?, 'ed', 'Blocked3', 1)",
+      args: [theirPub],
+    });
+    // The common blocked shape: the handshake WAS processed once, THEN the
+    // user blocked. The sender's ~60h retry re-sends the same event.id.
+    await recordProcessedEvent(db, "evt-replayed", "invite_accepted");
+
+    const m = stubManagers();
+    const payload = { type: "invite_accepted", crowId: "crow:blocked3", ed25519Pub: "ed", secp256k1Pub: theirPub, displayName: "Evil Rename" };
+    await handleInviteAccepted(db, m, payload, theirPub, { id: "evt-replayed" });
+
+    assert.ok(!m.calls.some((c) => c[0] === "ack"), "NO handshake ack to a blocked sender (placement before the replay branch)");
+    const { rows } = await db.execute("SELECT display_name FROM contacts WHERE crow_id = 'crow:blocked3'");
+    assert.equal(rows[0].display_name, "Blocked3", "no upsert mutation");
+    assert.ok(!m.calls.some((c) => c[0] === "sub" || c[0] === "initContact"), "no re-wire");
+  } finally { cleanup(); }
+});
+```
+
+NOTE FOR THE IMPLEMENTER: `handleInviteAccepted`'s ack goes through `ackHandshake` → `managers.nostrManager.sendControl` — verify the stub surface matches the real call (open boot.js:150-160) and adapt the stub so an ack WOULD be recorded if the code reached it (the assertion must be capable of failing). If `recordProcessedEvent`'s signature differs, mirror its real usage from boot.js:232.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/block-rewire-guards.test.js`
+Expected: FAIL — test 1 (no `unsub` recorded), test 2 (import error: `wireFullContact` not exported), test 3 (ack recorded on the replay branch).
+
+- [ ] **Step 3: Implement**
+
+`servers/sharing/contact-promote.js`:
+1. Extend the existing contact-delete import: `import { readTombstone, clearTombstone, unwireContact } from "./contact-delete.js";`
+2. Export + belt-guard `wireFullContact`:
+```js
+export async function wireFullContact(managers, row) {
+  // F-BLOCK-1 D4d belt: no upsert path (tool, accept, invite_accepted) may
+  // wire a blocked contact. The wiring returns on unblock (wireSyncedContact).
+  if (row?.is_blocked) return;
+  const { syncManager, peerManager, nostrManager } = managers || {};
+  ...unchanged body...
+```
+3. Replace the blocked branch of `wireSyncedContact`:
+```js
+    if (row.is_blocked) {
+      // F-BLOCK-1 D3: FULL teardown. The old inline pair closed feeds + left
+      // the DHT but LEFT THE LIVE NOSTR SUB — the cross-instance leg of the
+      // finding (a synced block must silence this instance too).
+      // unwireContact is the single teardown owner (delete + block paths).
+      await unwireContact(managers, row);
+      return;
+    }
+```
+
+`servers/sharing/boot.js`, in `handleInviteAccepted`, IMMEDIATELY after the auth check (`if (normalizePubkey(payload.secp256k1Pub) !== normalizePubkey(senderPubkey)) return;`) and BEFORE the `wasProcessed` branch:
+```js
+    // F-BLOCK-1 D4d: silence toward a blocked contact. Resolve BEFORE the
+    // replay-hygiene and short-code branches below — BOTH of those ack, and
+    // the common blocked case ("handshake processed, then blocked") re-sends
+    // the same event.id for ~60h, which would keep acking a blocked party.
+    // No upsert, no ack, no wiring. Skipping consumeShortInvite is safe: the
+    // invite was consumed on the pre-block accept, and an unconsumed row
+    // expires at the 72h ledger TTL.
+    try {
+      const senderContact = await findContactByPubkey(db, senderPubkey);
+      if (senderContact && Number(senderContact.is_blocked) === 1) return;
+    } catch { /* resolution failure must not break honest handshakes */ }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/block-rewire-guards.test.js tests/contacts-sync-hook.test.js tests/invite-accepted-promote.test.js tests/accept-idempotent.test.js tests/contact-promote.test.js tests/handshake-complete.test.js`
+Expected: ALL PASS (the five pre-existing suites prove the promote/handshake paths are unregressed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/block-rewire-guards.test.js
+git commit tests/block-rewire-guards.test.js servers/sharing/contact-promote.js servers/sharing/boot.js -m "fix(sharing): synced block tears down the live Nostr sub; blocked handshakes are silenced before the ack branches; wireFullContact refuses blocked rows (F-BLOCK-1 D3/D4d)"
+git show --stat HEAD
+```
+
+---
+
+### Task 4: D1 + D2 — block tears down, unblock re-wires (both panels) + D5 seam
+
+**Files:**
+- Modify: `servers/gateway/dashboard/panels/contacts/api-handlers.js` (block/unblock actions, lines ~42-83; imports; options seam)
+- Modify: `servers/gateway/dashboard/panels/messages/api-handlers.js` (block/unblock actions, lines ~89-127; imports)
+- Test: `tests/block-handler-teardown.test.js` (new)
+
+**Interfaces:**
+- Consumes: `unwireContact` (contact-delete.js), `wireSyncedContact` (contact-promote.js), the messages handler's existing `_managers` seam (`handlePostAction(req, res, { db, sharingClientFactory, _managers })`).
+- Produces: `handleContactAction(req, db, { sharingClientFactory, managers })` — new optional `managers` (default `getManagersOrNull()`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/block-handler-teardown.test.js`:
+
+```js
+/**
+ * Cluster C D1/D2 — the block actions tear down ALL live wiring (Nostr unsub +
+ * feeds + DHT) via unwireContact; the unblock actions lazily re-wire via
+ * wireSyncedContact. Both panels; includes the S5.4 req:-accepted shape.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
+
+const SECP = "02" + "a".repeat(64);
+
+function freshDb(tag) {
+  const dir = mkdtempSync(join(tmpdir(), `block-handlers-${tag}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function stubManagers() {
+  const calls = [];
+  return {
+    calls,
+    nostrManager: {
+      unsubscribeFromContact: (crowId) => calls.push(["unsub", crowId]),
+      subscribeToContact: async (c) => calls.push(["sub", c.crow_id || c.crowId]),
+    },
+    syncManager: {
+      closeContactFeeds: async (id) => calls.push(["closeFeeds", id]),
+      initContact: async (id) => calls.push(["initContact", id]),
+    },
+    peerManager: {
+      leaveContact: async (crowId) => calls.push(["leave", crowId]),
+      joinContact: async (c) => calls.push(["join", c.crowId]),
+    },
+  };
+}
+
+test("contacts panel: block → full teardown; unblock → re-wire; keyless manual stays inert", async () => {
+  const { db, cleanup } = freshDb("contacts");
+  try {
+    const ins = await db.execute({
+      sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES ('crow:t1', 'ed', ?, 'T1')",
+      args: [SECP],
+    });
+    const id = Number(ins.lastInsertRowid);
+
+    const m1 = stubManagers();
+    const out1 = await handleContactAction({ body: { action: "block", contact_id: String(id) } }, db, { managers: m1 });
+    assert.ok(out1?.redirect, "block redirects");
+    const k1 = m1.calls.map((c) => c[0]);
+    assert.ok(k1.includes("unsub"), "block tears down the Nostr sub (the F-BLOCK-1 leg)");
+    assert.ok(k1.includes("closeFeeds") && k1.includes("leave"), "feeds + DHT teardown preserved");
+    const b = await db.execute({ sql: "SELECT is_blocked FROM contacts WHERE id = ?", args: [id] });
+    assert.equal(Number(b.rows[0].is_blocked), 1);
+
+    const m2 = stubManagers();
+    await handleContactAction({ body: { action: "unblock", contact_id: String(id) } }, db, { managers: m2 });
+    const k2 = m2.calls.map((c) => c[0]);
+    assert.ok(k2.includes("initContact") && k2.includes("join") && k2.includes("sub"), "unblock re-wires (no restart needed)");
+
+    // Keyless manual contact: block+unblock never touch wiring, never throw.
+    const insM = await db.execute("INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, contact_type) VALUES ('manual:x', '', '', 'M', 'manual')");
+    const mid = Number(insM.lastInsertRowid);
+    const m3 = stubManagers();
+    await handleContactAction({ body: { action: "block", contact_id: String(mid) } }, db, { managers: m3 });
+    await handleContactAction({ body: { action: "unblock", contact_id: String(mid) } }, db, { managers: m3 });
+    assert.ok(!m3.calls.some((c) => c[0] === "sub" || c[0] === "join" || c[0] === "initContact"), "keyless manual is never wired");
+  } finally { cleanup(); }
+});
+
+test("messages panel: block/unblock by crow_id incl. the req:-accepted stranger shape", async () => {
+  const { db, cleanup } = freshDb("messages");
+  try {
+    const reqSecp = "f".repeat(64);
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, request_status) VALUES (?, ?, '', 'accepted')",
+      args: [`req:${reqSecp}`, reqSecp],
+    });
+    const res = { redirected: null, redirectAfterPost(u) { this.redirected = u; return u; } };
+
+    const m1 = stubManagers();
+    await handlePostAction({ body: { action: "block", crow_id: `req:${reqSecp}` } }, res, { db, _managers: m1 });
+    assert.ok(m1.calls.some((c) => c[0] === "unsub" && c[1] === `req:${reqSecp}`), "req: accepted stranger's live sub torn down (S5.4)");
+
+    const m2 = stubManagers();
+    await handlePostAction({ body: { action: "unblock", crow_id: `req:${reqSecp}` } }, res, { db, _managers: m2 });
+    assert.ok(m2.calls.some((c) => c[0] === "sub"), "unblock re-subscribes");
+  } finally { cleanup(); }
+});
+```
+
+NOTE FOR THE IMPLEMENTER: open `tests/message-request-actions.test.js` first and mirror its exact `handlePostAction` invocation shape (res stub, opts). If `handlePostAction` requires more of `res` (e.g. `redirect`), extend the stub from that precedent. The assertions are fixed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/block-handler-teardown.test.js`
+Expected: FAIL — no `unsub` recorded on block (old inline pair), nothing recorded on unblock, and `managers` opt not honored by `handleContactAction`.
+
+- [ ] **Step 3: Implement**
+
+`servers/gateway/dashboard/panels/contacts/api-handlers.js`:
+1. Imports: extend `import { deleteContactLocal } from "../../../../sharing/contact-delete.js";` → `import { deleteContactLocal, unwireContact } from ...`; extend the contact-promote import (or add) with `wireSyncedContact`.
+2. Signature: `export async function handleContactAction(req, db, { sharingClientFactory = makeSharingClient, managers: injectedManagers = null } = {})`, then first lines:
+```js
+  const { action } = req.body;
+  const managers = injectedManagers || getManagersOrNull();
+```
+3. Replace the block action body:
+```js
+  if (action === "block" && req.body.contact_id) {
+    const contactId = parseInt(req.body.contact_id);
+    await db.execute({
+      sql: "UPDATE contacts SET is_blocked = 1 WHERE id = ?",
+      args: [contactId],
+    });
+    // F-BLOCK-1 D1: tear down ALL live wiring — the Nostr relay sub (the leg
+    // the old inline pair missed; inbound kept storing until restart), the
+    // Hypercore feeds, and the DHT topic — via the delete-path primitive.
+    // unwireContact is the single teardown owner.
+    let row = null;
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
+      row = rows[0] || null;
+    } catch {}
+    if (managers && row) { try { await unwireContact(managers, row); } catch {} }
+    // Phase 3: a block follows the user across their instances.
+    try { if (row) await emitContactChange("update", row); } catch {}
+    return { redirect: "/dashboard/contacts" };
+  }
+```
+4. Replace the unblock action body:
+```js
+  if (action === "unblock" && req.body.contact_id) {
+    const contactId = parseInt(req.body.contact_id);
+    await db.execute({
+      sql: "UPDATE contacts SET is_blocked = 0 WHERE id = ?",
+      args: [contactId],
+    });
+    // F-BLOCK-1 D2: lazy re-wire (initContact + joinContact + subscribeToContact
+    // via wireSyncedContact's guards — keyless/local-bot rows stay inert). The
+    // old "no lazy re-init path exists" note predates R4/#155's wireFullContact.
+    let row = null;
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
+      row = rows[0] || null;
+    } catch {}
+    if (managers && row) { try { await wireSyncedContact(managers, row); } catch {} }
+    try { if (row) await emitContactChange("update", row); } catch {}
+    return { redirect: "/dashboard/contacts" };
+  }
+```
+`servers/gateway/dashboard/panels/messages/api-handlers.js`: same two rewrites keyed by `crow_id` (SELECT * by crow_id; `unwireContact(managers, row)` / `wireSyncedContact(managers, row)`; keep `res.redirectAfterPost("/dashboard/messages")` and the existing `emitContactChange` lines; the handler's existing `managers` variable already honors `_managers`). Add the two imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/block-handler-teardown.test.js tests/contacts-sync-panel-emit.test.js tests/message-request-actions.test.js tests/contacts-add-by-id-action.test.js`
+Expected: ALL PASS (S7 block-follow emit behavior unregressed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/block-handler-teardown.test.js
+git commit tests/block-handler-teardown.test.js servers/gateway/dashboard/panels/contacts/api-handlers.js servers/gateway/dashboard/panels/messages/api-handlers.js -m "fix(dashboard): block tears down the live subscription, unblock re-wires — both panels, no restart needed (F-BLOCK-1 D1/D2)"
+git show --stat HEAD
+```
+
+---
+
+### Task 5: Full suite, boot check, mutation-test evidence
+
+**Files:** none (evidence to `.superpowers/sdd/progress.md` — git-IGNORED, never `git add`).
+
+- [ ] **Step 1: Full suite** — `node --test tests/*.test.js 2>&1 | tail -6`. Expected: ≥ current baseline (1385+new / the 1 pre-existing bundle-contract fail / 1 skip).
+- [ ] **Step 2: Boot check** — `timeout 25 node servers/gateway/index.js --no-auth 2>&1 | head -50`: boots clean, no new warnings.
+- [ ] **Step 3: Mutations** (apply → run named test → RED → revert → `git status --short` clean):
+
+| # | Mutation | Test that must go RED |
+|---|---|---|
+| M1 | nostr.js: remove the D4a fresh-check block | block-onevent-guard "blocked inbound must NOT store" |
+| M2 | boot.js: remove the D4b early-return | block-receive-guards "blocked … must not store" |
+| M3a | boot.js: remove the D4c guard line | block-receive-guards blocked-sender case |
+| M3b | boot.js: flip D4c guard to `if (!senderRow) return;` | block-receive-guards "unknown sender still notifies" |
+| M4 | boot.js: move the D4d early-return to just before `upsertFullContact` (after the ack branches) | block-rewire-guards "NO handshake ack … (placement)" |
+| M5 | contact-promote.js: remove the wireFullContact belt guard | block-rewire-guards "refuses a blocked row" |
+| M6 | contact-promote.js: revert the blocked branch to the old inline pair | block-rewire-guards "FULL teardown (incl. Nostr unsub)" |
+| M7 | contacts/api-handlers.js: replace unwireContact call with the old inline pair (no unsub) | block-handler-teardown "block tears down the Nostr sub" |
+| M8 | contacts/api-handlers.js: remove the unblock wireSyncedContact call | block-handler-teardown "unblock re-wires" |
+
+- [ ] **Step 4: Append evidence to the progress ledger.**
+
+---
+
+## Post-implementation (controller, not subagents)
+
+1. CDP scratch check: block a seeded contact via the real UI → conversation drops from the messages list, `is_blocked=1`; unblock → returns. (Live subscription behavior needs a real peer — next step.)
+2. Final whole-branch Opus review → PR → Kevin gate.
+3. Post-merge deploy fleet; live E2E crow↔black-swan: block Black Swan on crow via UI → DM from black-swan → NO new row on crow, unread unchanged, sender stays `relayed`; unblock → next DM arrives live. (Spec §5.)

--- a/docs/superpowers/specs/2026-07-10-block-teardown-design.md
+++ b/docs/superpowers/specs/2026-07-10-block-teardown-design.md
@@ -57,7 +57,10 @@ The missing pieces:
   (Phase 3, live-proven in S7 7.2).
 - Receipts/acks FROM a blocked contact for messages we previously sent still
   process (`handleDeliveryReceipt` is contact-bound and harmless); only their
-  inbound DMs are silenced.
+  inbound DMs are silenced. Likewise `handleHandshakeComplete` (boot.js:285)
+  from a blocked contact can still apply a sanitized display name over a
+  PLACEHOLDER name (R2 F5) — cosmetic, placeholder-only, and the conversation
+  is `is_blocked`-filtered out of the list; dispositioned harmless, not gated.
 
 ## 3. Design
 
@@ -121,21 +124,41 @@ wiring path that forgets teardown:
   pending, accepted) is silently dropped on the catch-all path. This kills the
   S5.4 store path.
 - **(c) `group_message` handler** (boot.js:548-577, R1 MAJOR-1): the
-  `onSocialMessage` branch fires a notification UNCONDITIONALLY and stores a
-  `direction='received'` row with no `is_blocked` check — a blocked contact who
-  shares a group can still ping the notification tray via
+  `onSocialMessage` branch fires a notification UNCONDITIONALLY (:552) and
+  stores a `direction='received'` row (:573) with no `is_blocked` check — a
+  blocked contact who shares a group can still ping the notification tray via
   `crow_send_group_message` (they didn't block us; their fan-out includes us).
-  Fix: extend the existing sender lookup to `SELECT id, is_blocked` and
-  early-return BEFORE the notification and the store when blocked.
+  Fix (R2 F2 — this is a REORDER, not an in-place extension: the sender lookup
+  currently sits at :567, AFTER the notification): move the sender resolve
+  (`SELECT id, is_blocked FROM contacts WHERE crow_id = ?`) ABOVE the
+  notification, and early-return ONLY when the resolved row exists AND
+  `is_blocked === 1`. An UNKNOWN (non-contact) group sender must still notify
+  exactly as today — the guard is `found && blocked`, never `!found` (test
+  pins this).
 - **(d) blocked re-wire guard (R1 MINOR-2):** a blocked contact's
   `invite_accepted` (or its ~60h retry re-send) currently flows
   `handleInviteAccepted` → `upsertFullContact` → `wireFullContact`, recreating
   the sub/feeds/DHT state this design tears down. Fix in two layers:
   `handleInviteAccepted` early-returns (no upsert, no ack — silence toward the
-  blocked party; `recordProcessedEvent` hygiene untouched) when the resolved
-  sender contact is blocked, AND `wireFullContact` itself skips wiring when
-  `row.is_blocked` (belt: no upsert path — tool, accept, handshake — can wire a
-  blocked contact; the wiring returns on unblock via D2).
+  blocked party) when the resolved sender contact is blocked, AND
+  `wireFullContact` itself skips wiring when `row.is_blocked` (belt: no upsert
+  path — tool, accept, handshake — can wire a blocked contact; the wiring
+  returns on unblock via D2).
+  **Placement is load-bearing (R2 F1 MAJOR):** the early-return (resolve via
+  `findContactByPubkey(senderPubkey)` + blocked check) goes IMMEDIATELY after
+  the R4 auth check (boot.js:182) and BEFORE the `wasProcessed` replay branch
+  (:190) and the short-code `"replayed"` branch (:209) — both of those branches
+  ACK. The common blocked case is "added via a processed invite_accepted, then
+  blocked": its ~60h retry re-sends the same event.id, which hits `wasProcessed`
+  → ack. Placed after :190, the guard's sole unique contribution (ack silence)
+  silently fails. Mutation test: a blocked sender whose event.id is already in
+  processed_control_events produces NO sendControl/ack call.
+  **Ledger note (R2 F6):** skipping `consumeShortInvite` for a blocked sender is
+  safe — the invite was consumed on the pre-block accept (a retry verdicts
+  "replayed" and changes nothing) and any genuinely-unconsumed row expires at
+  the 72h ledger TTL. No outstanding-forever leak.
+  **Export note (R2 F3):** `wireFullContact` is currently module-private —
+  export it so the belt-guard test can drive it directly.
 
 ### D5 — Testability seam
 
@@ -172,12 +195,16 @@ unchanged.
    `is_blocked=1` AFTER subscribe → no messages row, no receipt attempt; flip
    back → stores. **Mutation:** removing the fresh check reddens the blocked case.
 7. D4c group_message guard: blocked sender's group_message → no notification, no
-   stored row; unblocked sender's still notifies+stores. **Mutation:** removing
-   the guard reddens the blocked case on both assertions.
+   stored row; unblocked sender's still notifies+stores; **unknown (non-contact)
+   sender still notifies** (pins the reorder against a `!found` mistake).
+   **Mutation:** removing the guard reddens the blocked case on both assertions.
 8. D4d blocked re-wire: `handleInviteAccepted` from a blocked sender → no upsert
-   mutation, no ack, no wiring; `wireFullContact` with a blocked row → none of
-   initContact/joinContact/subscribeToContact called. **Mutation:** each layer's
-   removal reddens its own test.
+   mutation, no ack, no wiring — INCLUDING the replay case: blocked sender +
+   event.id already recorded in processed_control_events → NO sendControl/ack
+   (pins the guard's placement before the ack branches). `wireFullContact`
+   (exported) with a blocked row → none of initContact/joinContact/
+   subscribeToContact called. **Mutation:** each layer's removal reddens its
+   own test.
 9. Full suite ≥ current baseline (1385/1 pre-existing/1 skip); gateway boots
    clean.
 
@@ -209,10 +236,14 @@ unchanged.
 - `unwireContact` also closes sync feeds; a blocked contact therefore stops
   message-mirroring too — same semantics the block handlers already had
   (closeContactFeeds was already inline).
-- **R1 MINOR-3 (accepted):** unblock over-wires a `req:` accepted stranger —
+- **R1 MINOR-3 + R2 F4 (accepted):** unblock over-wires `req:` rows —
   `wireFullContact` creates an out-feed + DHT topic where `accept_request` only
-  ever subscribed. Harmless waste (all guarded, stranger can't replicate);
-  documented asymmetry, not engineered around. Note `req:` rows have no synced
+  ever subscribed, and a keyed PENDING request row gains a per-contact sub that
+  boot deliberately omits (boot.js:479 skips pending). Harmless: all steps
+  guarded, the stranger can't replicate, and `INSERT OR IGNORE` on
+  nostr_event_id dedupes any double-store vs the incoming catch-all; block on a
+  pending row is not reachable from the UI (only Accept/Decline render).
+  Documented asymmetry, not engineered around. Note `req:` rows have no synced
   echo (they don't sync), so the "matches the sync-applied echo" argument
   applies only to full contacts.
 - **R1 MINOR-4 (precision):** unblock restores the out feed only —

--- a/docs/superpowers/specs/2026-07-10-block-teardown-design.md
+++ b/docs/superpowers/specs/2026-07-10-block-teardown-design.md
@@ -42,9 +42,12 @@ The missing pieces:
 
 ## 2. Non-goals
 
-- No change to room/group inbound (blocked members are already filtered at
-  send-time fan-out: rooms-store.js:62, tools/messaging.js:181; room
-  subscriptions are hub-and-spoke and out of scope).
+- No change to ROOM inbound (`room-inbound.js` hub-and-spoke path) — out of
+  scope. NOTE (R1 MAJOR-1 correction): the original rationale here ("blocked
+  members are filtered at send-time fan-out") was WRONG — a sender-side filter
+  (tools/messaging.js:181 filters *my* blocked members when *I* fan out) does
+  nothing about what a blocked contact sends *to me*. The legacy
+  `group_message` receive path is therefore IN scope now (D4c below).
 - No new unread-badge code: the badge bump WAS the stored row. The conversation
   list + `totalUnread` already filter `c.is_blocked = 0`
   (messages/data-queries.js:51), and the live `messages:changed` unread emit is
@@ -117,6 +120,22 @@ wiring path that forgets teardown:
   reuse and before the store. A blocked contact of ANY request_status (full,
   pending, accepted) is silently dropped on the catch-all path. This kills the
   S5.4 store path.
+- **(c) `group_message` handler** (boot.js:548-577, R1 MAJOR-1): the
+  `onSocialMessage` branch fires a notification UNCONDITIONALLY and stores a
+  `direction='received'` row with no `is_blocked` check — a blocked contact who
+  shares a group can still ping the notification tray via
+  `crow_send_group_message` (they didn't block us; their fan-out includes us).
+  Fix: extend the existing sender lookup to `SELECT id, is_blocked` and
+  early-return BEFORE the notification and the store when blocked.
+- **(d) blocked re-wire guard (R1 MINOR-2):** a blocked contact's
+  `invite_accepted` (or its ~60h retry re-send) currently flows
+  `handleInviteAccepted` → `upsertFullContact` → `wireFullContact`, recreating
+  the sub/feeds/DHT state this design tears down. Fix in two layers:
+  `handleInviteAccepted` early-returns (no upsert, no ack — silence toward the
+  blocked party; `recordProcessedEvent` hygiene untouched) when the resolved
+  sender contact is blocked, AND `wireFullContact` itself skips wiring when
+  `row.is_blocked` (belt: no upsert path — tool, accept, handshake — can wire a
+  blocked contact; the wiring returns on unblock via D2).
 
 ### D5 — Testability seam
 
@@ -146,12 +165,20 @@ unchanged.
    behavior green). **Mutation:** removing the guard reddens the blocked-accepted
    case on the message-count assertion.
 6. `onevent` guard: drive a real `NostrManager` instance with a stub relay that
-   captures the subscription's `onevent` (mirror the existing receive-path test
-   pattern — e.g. delivery-receipt-emit / boot-receive-decouple tests), deliver
-   a NIP-44-encrypted event for a contact flipped to `is_blocked=1` AFTER
-   subscribe → no messages row, no receipt attempt; flip back → stores.
-   **Mutation:** removing the fresh check reddens the blocked case.
-7. Full suite ≥ current baseline (1385/1 pre-existing/1 skip); gateway boots
+   captures the subscription's `onevent` — mirror `tests/nostr-receive-health-hooks.test.js`
+   / `tests/nostr-resubscribe.test.js` (`mgr.relays.set("wss://stub", relay)` +
+   captured `subscribeCalls[0].onevent` + `encryptToUs`; R1 MINOR-6 corrected the
+   earlier citation) — deliver a NIP-44-encrypted event for a contact flipped to
+   `is_blocked=1` AFTER subscribe → no messages row, no receipt attempt; flip
+   back → stores. **Mutation:** removing the fresh check reddens the blocked case.
+7. D4c group_message guard: blocked sender's group_message → no notification, no
+   stored row; unblocked sender's still notifies+stores. **Mutation:** removing
+   the guard reddens the blocked case on both assertions.
+8. D4d blocked re-wire: `handleInviteAccepted` from a blocked sender → no upsert
+   mutation, no ack, no wiring; `wireFullContact` with a blocked row → none of
+   initContact/joinContact/subscribeToContact called. **Mutation:** each layer's
+   removal reddens its own test.
+9. Full suite ≥ current baseline (1385/1 pre-existing/1 skip); gateway boots
    clean.
 
 ## 5. Verification beyond the suite
@@ -182,3 +209,22 @@ unchanged.
 - `unwireContact` also closes sync feeds; a blocked contact therefore stops
   message-mirroring too — same semantics the block handlers already had
   (closeContactFeeds was already inline).
+- **R1 MINOR-3 (accepted):** unblock over-wires a `req:` accepted stranger —
+  `wireFullContact` creates an out-feed + DHT topic where `accept_request` only
+  ever subscribed. Harmless waste (all guarded, stranger can't replicate);
+  documented asymmetry, not engineered around. Note `req:` rows have no synced
+  echo (they don't sync), so the "matches the sync-applied echo" argument
+  applies only to full contacts.
+- **R1 MINOR-4 (precision):** unblock restores the out feed only —
+  `initContact(row.id, null)` cannot restore a peer in-feed without a fresh
+  handshake (`theirFeedKey`). Identical to what a boot restart produces; DMs
+  (the finding's scope) are fully restored via the Nostr sub.
+- **R1 MINOR-5 (disclosure):** on a multi-own-instance fleet,
+  `_applyMessage` (instance-sync.js:1510) deliberately STORES a mirrored row
+  for a locally-blocked contact ("converged-block semantics") while suppressing
+  the badge + notification — so during the ~2s block-mirror window a peer's
+  store can still mirror in, invisibly. "Blocked inbound never stores" is
+  strictly true per-instance for relay inbound; fleet-wide invisibility is
+  row-suppression. §5's "no new messages row on crow" assertion is valid for
+  crow↔black-swan precisely because distinct identities have no instance-sync
+  mirror.

--- a/docs/superpowers/specs/2026-07-10-block-teardown-design.md
+++ b/docs/superpowers/specs/2026-07-10-block-teardown-design.md
@@ -1,0 +1,184 @@
+# Block actually blocks — Cluster C design (F-BLOCK-1 + addendum)
+
+Date: 2026-07-10 · Arc: Crow Messages usability overhaul, P4 walkthrough Cluster C
+Finding: F-BLOCK-1 [S5-MAJOR] — blocking a contact does not stop inbound messages
+until the next gateway restart; addendum: the blocked inbound lands `is_read=0`
+and bumps the unread badge. Independent of Clusters B/D.
+
+## 1. Problem
+
+`WHERE is_blocked = 0` is applied only when subscriptions are BUILT
+(`subscribeToIncoming` / boot-time contact iteration). Blocking an
+already-subscribed contact flips the row but never tears down its live
+per-contact Nostr relay subscription, so `subscribeToContact.onevent` keeps
+INSERTing inbound rows (with `is_read=0` → unread bump) until a restart rebuilds
+subscriptions with the filter. Verified live in the S5.4 walkthrough: a second DM
+from a blocked (accepted-stranger) contact was stored, `messages` count 1→2.
+
+What the block handlers DO already tear down (both the contacts panel and the
+messages panel have one): Hypercore feeds (`syncManager.closeContactFeeds`) and
+the DHT topic (`peerManager.leaveContact`) — inline, with a stale comment
+claiming "no lazy re-init path exists for contacts. A restart or re-invite is
+needed to reopen feeds after an unblock." That was true when written; since
+R4/#155 the lazy re-init exists (`wireFullContact` = `initContact` +
+`joinContact` + `subscribeToContact`, and `wireSyncedContact` wraps it with the
+blocked/local-bot/keyless guards).
+
+The missing pieces:
+1. Neither block handler tears down the **Nostr subscription** — the exact
+   channel the walkthrough proved still delivers.
+2. Neither unblock handler re-wires anything (and the sync-applied unblock DOES
+   re-wire via `onContactSynced` → `wireSyncedContact` — the local product
+   action is strictly worse than the synced echo of it).
+3. The sync-apply blocked branch (`wireSyncedContact`, contact-promote.js:101)
+   closes feeds + leaves the DHT but ALSO leaves the live Nostr sub — the same
+   gap on the cross-instance leg (blocks follow the user since Phase 3; S7 7.2
+   proved the `is_blocked` mirror lands in ~2s, but the mirrored instance keeps
+   receiving until restart too).
+4. `handleIncomingRequest` (boot.js) reuses an existing `pending`/`accepted`
+   request contact and stores the DM with **no `is_blocked` check** — the S5.4
+   store path for blocked request contacts, alive even after (1)-(3) tear down
+   per-contact subs, because the catch-all incoming subscription still fires.
+
+## 2. Non-goals
+
+- No change to room/group inbound (blocked members are already filtered at
+  send-time fan-out: rooms-store.js:62, tools/messaging.js:181; room
+  subscriptions are hub-and-spoke and out of scope).
+- No new unread-badge code: the badge bump WAS the stored row. The conversation
+  list + `totalUnread` already filter `c.is_blocked = 0`
+  (messages/data-queries.js:51), and the live `messages:changed` unread emit is
+  gated on `rowsAffected > 0`. Once blocked inbound never stores, nothing bumps.
+- No schema change — **SCHEMA_GENERATION stays 6** (verified: no DDL).
+- No sync-protocol change — block/unblock already emit `contact` updates
+  (Phase 3, live-proven in S7 7.2).
+- Receipts/acks FROM a blocked contact for messages we previously sent still
+  process (`handleDeliveryReceipt` is contact-bound and harmless); only their
+  inbound DMs are silenced.
+
+## 3. Design
+
+### D1 — Block tears down ALL live wiring (both panels)
+
+In both block handlers (contacts/api-handlers.js `action === "block"`,
+messages/api-handlers.js `action === "block"`): after the `is_blocked = 1`
+UPDATE, fetch the row once and replace the inline feeds+DHT teardown with
+`unwireContact(managers, row)` (contact-delete.js:94 — the #155 delete-path
+primitive: `nostrManager.unsubscribeFromContact(crow_id)` +
+`syncManager.closeContactFeeds(id)` + `peerManager.leaveContact(crow_id)`,
+each independently guarded, never throws). One teardown owner; the block
+handlers stop owning a hand-rolled subset. Then `emitContactChange("update",
+row)` as today. The stale "no lazy re-init path exists" comments are deleted
+(superseded by D2).
+
+`unsubscribeFromContact` keys handles as `${crowId}:${url}` and iterates
+`this.relays` — it works for `crow:`, `req:` and `manual:` ids alike (the S5.4
+contact was a `req:`-rooted accepted stranger; `accept_request` wires a
+per-contact sub at messages/api-handlers.js:319, so blocking one MUST unwire).
+
+### D2 — Unblock re-wires (both panels)
+
+In both unblock handlers: after the `is_blocked = 0` UPDATE, fetch the row and
+call `wireSyncedContact(managers, row)` (contact-promote.js:97). Its internal
+guards do the right thing for every contact class: now-unblocked keyed contact →
+`wireFullContact` (feeds + DHT + Nostr sub); `local-bot` → no-op; keyless
+`manual:` → no-op. Fully guarded, never throws — safe in a request handler.
+Unblock is now symmetric with block, no restart needed, and the local action
+matches what the sync-applied echo already did.
+
+### D3 — Sync-apply leg: the blocked branch uses the full teardown
+
+`wireSyncedContact`'s blocked branch (contact-promote.js:101-105) replaces its
+two inline calls (closeContactFeeds + leaveContact) with
+`unwireContact(managers, row)` — adding the missing `unsubscribeFromContact`.
+Import is clean: contact-promote.js already imports from contact-delete.js
+(readTombstone/clearTombstone), no new cycle. With this, a block placed on any
+of the user's instances tears down the live sub on ALL of them within the ~2s
+sync window, and a synced unblock re-wires via the same hook (already routed:
+`_applyContact` update → `onContactSynced` → `wireSyncedContact` →
+`wireFullContact` once `is_blocked=0` — the S7-proven path).
+
+### D4 — Receive-time guards (the race window + regression insurance)
+
+Teardown is the fix; these make the receive path *unable* to store blocked
+inbound even during the block→teardown race, an in-flight event, or a future
+wiring path that forgets teardown:
+
+- **(a) `subscribeToContact.onevent`** (nostr.js:~482, before the messages
+  INSERT): fresh single-row check `SELECT is_blocked FROM contacts WHERE id = ?`
+  — if blocked: return early. No store, no notification, no unread emit, no
+  instance-sync mirror emit, no delivery receipt, no `onMessage` callback.
+  Blocking is SILENT toward the blocked party (matching the delete path's
+  no-reconnect posture): we deliberately stop confirming receipt. One indexed
+  point-SELECT per inbound DM from that contact — negligible, and only until the
+  teardown lands (normally milliseconds later).
+- **(b) `handleIncomingRequest`** (boot.js:83-90): after `findContactByPubkey`,
+  `if (existing && Number(existing.is_blocked) === 1) return;` — before contact
+  reuse and before the store. A blocked contact of ANY request_status (full,
+  pending, accepted) is silently dropped on the catch-all path. This kills the
+  S5.4 store path.
+
+### D5 — Testability seam
+
+`handleContactAction` (contacts) gains `managers` in its options object
+(`{ sharingClientFactory, managers = getManagersOrNull() }`), mirroring the
+messages handler's existing `_managers` seam (api-handlers.js:56-57). Tests
+inject stub managers and assert the teardown/re-wire calls; production behavior
+unchanged.
+
+## 4. Tests (TDD; mutation-test every guard)
+
+1. Contacts-panel block: stub managers → `unsubscribeFromContact(crow_id)`,
+   `closeContactFeeds(id)`, `leaveContact(crow_id)` all called; row
+   `is_blocked=1`; `emitContactChange` still fires (existing S7 suite must stay
+   green). **Mutation:** reverting the handler to the old inline pair (dropping
+   unsubscribe) reddens exactly the Nostr-teardown assertion.
+2. Contacts-panel unblock: stub managers → `initContact` + `joinContact` +
+   `subscribeToContact` called (via `wireSyncedContact`); keyless `manual:`
+   contact → none called, no throw.
+3. Messages-panel block/unblock: same pair through `handlePostAction` with
+   `_managers`, keyed by `crow_id`, including a `req:` accepted-stranger row
+   (the S5.4 shape).
+4. `wireSyncedContact` blocked row → `unsubscribeFromContact` called (the D3
+   leg). **Mutation:** restoring the old inline pair reddens it.
+5. `handleIncomingRequest`: blocked pending / blocked accepted / blocked full →
+   NO message row, NO notification; unblocked pending still stores (existing
+   behavior green). **Mutation:** removing the guard reddens the blocked-accepted
+   case on the message-count assertion.
+6. `onevent` guard: drive a real `NostrManager` instance with a stub relay that
+   captures the subscription's `onevent` (mirror the existing receive-path test
+   pattern — e.g. delivery-receipt-emit / boot-receive-decouple tests), deliver
+   a NIP-44-encrypted event for a contact flipped to `is_blocked=1` AFTER
+   subscribe → no messages row, no receipt attempt; flip back → stores.
+   **Mutation:** removing the fresh check reddens the blocked case.
+7. Full suite ≥ current baseline (1385/1 pre-existing/1 skip); gateway boots
+   clean.
+
+## 5. Verification beyond the suite
+
+- **CDP scratch gateway:** click Block on a seeded contact in the real messages
+  UI → conversation disappears from the list, row `is_blocked=1`; Unblock →
+  reappears. (Subscription behavior needs a live peer — next bullet.)
+- **Post-deploy live E2E (crow ↔ black-swan, the kept test pairing):** block the
+  Black Swan contact on crow via the product UI; send a DM from black-swan →
+  assert NO new messages row on crow, unread badge unchanged, and (bonus) the
+  sender's message stays `relayed` (never `delivered` — receipts are silenced).
+  Unblock on crow; send again → arrives live. This reproduces the exact S5.4
+  walkthrough failure and proves it dead. Cross-instance leg: verify grackle/MPA
+  mirrored `is_blocked` AND their subscription maps no longer hold the contact's
+  keys (via a one-shot inspection or a second DM while blocked).
+
+## 6. Risks / review focus
+
+- `wireSyncedContact` on unblock re-runs `initContact` — verify re-init of an
+  already-torn-down feed pair is clean (it is the same call the sync-applied
+  unblock already makes today).
+- D4a adds a per-event DB read on the hot receive path — bounded (indexed PK
+  lookup), and only for per-contact subs.
+- Silencing delivery receipts to blocked senders is an intentional behavior
+  change (documented above).
+- The block→teardown ordering leaves a millisecond-scale race where an
+  in-flight event could store — closed by D4a's fresh check.
+- `unwireContact` also closes sync feeds; a blocked contact therefore stops
+  message-mirroring too — same semantics the block handlers already had
+  (closeContactFeeds was already inline).

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -283,7 +283,6 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
     // co-writes (design §D3). deleteContactLocal drops the old
     // contact_type='manual' restriction (so crow: rows are finally deletable)
     // and refuses origin='local-bot' rows, which this instance recreates at boot.
-    const managers = getManagersOrNull();
     const result = await deleteContactLocal(db, managers || {}, row);
     if (!result.ok) return { redirect: `/dashboard/contacts?view=contact&contact=${delId}` };
     return { redirect: "/dashboard/contacts" };

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -10,7 +10,8 @@ import { upsertSetting } from "../../settings/registry.js";
 import { getContacts } from "./data-queries.js";
 import { getManagersOrNull } from "../../../../sharing/managers.js";
 import { emitContactChange } from "../../../../sharing/contact-sync.js";
-import { deleteContactLocal } from "../../../../sharing/contact-delete.js";
+import { deleteContactLocal, unwireContact } from "../../../../sharing/contact-delete.js";
+import { wireSyncedContact } from "../../../../sharing/contact-promote.js";
 import { sanitizeDisplayName } from "../../../../sharing/display-name.js";
 import { emitGroupUpsert, emitGroupDelete } from "../../../../sharing/group-sync.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -35,8 +36,9 @@ async function makeSharingClient() {
  * Handle POST actions from the contacts panel.
  * @returns {{ redirect?: string, download?: string } | null}
  */
-export async function handleContactAction(req, db, { sharingClientFactory = makeSharingClient } = {}) {
+export async function handleContactAction(req, db, { sharingClientFactory = makeSharingClient, managers: injectedManagers = null } = {}) {
   const { action } = req.body;
+  const managers = injectedManagers || getManagersOrNull();
 
   // --- Block / Unblock ---
   if (action === "block" && req.body.contact_id) {
@@ -45,29 +47,18 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
       sql: "UPDATE contacts SET is_blocked = 1 WHERE id = ?",
       args: [contactId],
     });
-    // Close Hypercore feeds for the blocked contact to free FDs.
-    // NOTE: unblocking does NOT re-init feeds — no lazy re-init path exists for
-    // contacts. A restart or re-invite is needed to reopen feeds after an unblock.
-    const managers = getManagersOrNull();
-    if (managers) {
-      try {
-        // SyncManager keys by integer contactId; PeerManager keys by crow_id string.
-        if (managers.syncManager) {
-          await managers.syncManager.closeContactFeeds(contactId);
-        }
-        if (managers.peerManager) {
-          const { rows } = await db.execute({
-            sql: "SELECT crow_id FROM contacts WHERE id = ?",
-            args: [contactId],
-          });
-          if (rows[0]?.crow_id) {
-            await managers.peerManager.leaveContact(rows[0].crow_id);
-          }
-        }
-      } catch {}
-    }
+    // F-BLOCK-1 D1: tear down ALL live wiring — the Nostr relay sub (the leg
+    // the old inline pair missed; inbound kept storing until restart), the
+    // Hypercore feeds, and the DHT topic — via the delete-path primitive.
+    // unwireContact is the single teardown owner.
+    let row = null;
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
+      row = rows[0] || null;
+    } catch {}
+    if (managers && row) { try { await unwireContact(managers, row); } catch {} }
     // Phase 3: a block follows the user across their instances.
-    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
+    try { if (row) await emitContactChange("update", row); } catch {}
     return { redirect: "/dashboard/contacts" };
   }
 
@@ -77,7 +68,16 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
       sql: "UPDATE contacts SET is_blocked = 0 WHERE id = ?",
       args: [contactId],
     });
-    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
+    // F-BLOCK-1 D2: lazy re-wire (initContact + joinContact + subscribeToContact
+    // via wireSyncedContact's guards — keyless/local-bot rows stay inert). The
+    // old "no lazy re-init path exists" note predates R4/#155's wireFullContact.
+    let row = null;
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
+      row = rows[0] || null;
+    } catch {}
+    if (managers && row) { try { await wireSyncedContact(managers, row); } catch {} }
+    try { if (row) await emitContactChange("update", row); } catch {}
     return { redirect: "/dashboard/contacts" };
   }
 

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -10,6 +10,8 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
 import { getManagersOrNull } from "../../../../sharing/managers.js";
 import { emitContactChange } from "../../../../sharing/contact-sync.js";
+import { unwireContact } from "../../../../sharing/contact-delete.js";
+import { wireSyncedContact } from "../../../../sharing/contact-promote.js";
 import { markContactIsBot } from "../../shared/mark-contact-bot.js";
 import { createRoom, listRoomMembers } from "./rooms-store.js";
 import { buildRoomJoinEnvelope, fanOut } from "../../../../sharing/room-fanout.js";
@@ -91,28 +93,18 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
       sql: "UPDATE contacts SET is_blocked = 1 WHERE crow_id = ?",
       args: [req.body.crow_id],
     });
-    // Close Hypercore feeds for the blocked contact to free FDs.
-    // NOTE: unblocking does NOT re-init feeds — no lazy re-init path exists for
-    // contacts. A restart or re-invite is needed to reopen feeds after an unblock.
-    if (managers) {
-      try {
-        if (managers.syncManager) {
-          // SyncManager keys by integer contactId; look it up from crow_id.
-          const { rows } = await db.execute({
-            sql: "SELECT id FROM contacts WHERE crow_id = ?",
-            args: [req.body.crow_id],
-          });
-          if (rows[0]?.id != null) {
-            await managers.syncManager.closeContactFeeds(rows[0].id);
-          }
-        }
-        if (managers.peerManager) {
-          await managers.peerManager.leaveContact(req.body.crow_id);
-        }
-      } catch {}
-    }
+    // F-BLOCK-1 D1: tear down ALL live wiring — the Nostr relay sub (the leg
+    // the old inline pair missed; inbound kept storing until restart), the
+    // Hypercore feeds, and the DHT topic — via the delete-path primitive.
+    // unwireContact is the single teardown owner.
+    let row = null;
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [req.body.crow_id] });
+      row = rows[0] || null;
+    } catch {}
+    if (managers && row) { try { await unwireContact(managers, row); } catch {} }
     // Phase 3: a block follows the user across their instances.
-    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [req.body.crow_id] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
+    try { if (row) await emitContactChange("update", row); } catch {}
     return res.redirectAfterPost("/dashboard/messages");
   }
 
@@ -121,7 +113,16 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
       sql: "UPDATE contacts SET is_blocked = 0 WHERE crow_id = ?",
       args: [req.body.crow_id],
     });
-    try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [req.body.crow_id] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
+    // F-BLOCK-1 D2: lazy re-wire (initContact + joinContact + subscribeToContact
+    // via wireSyncedContact's guards — keyless/local-bot rows stay inert). The
+    // old "no lazy re-init path exists" note predates R4/#155's wireFullContact.
+    let row = null;
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [req.body.crow_id] });
+      row = rows[0] || null;
+    } catch {}
+    if (managers && row) { try { await wireSyncedContact(managers, row); } catch {} }
+    try { if (row) await emitContactChange("update", row); } catch {}
     return res.redirectAfterPost("/dashboard/messages");
   }
 

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -185,6 +185,18 @@ export async function handleInviteAccepted(db, managers, payload, senderPubkey, 
     // stranger could forge an invite_accepted to promote/hijack a gated contact.
     if (normalizePubkey(payload.secp256k1Pub) !== normalizePubkey(senderPubkey)) return;
 
+    // F-BLOCK-1 D4d: silence toward a blocked contact. Resolve BEFORE the
+    // replay-hygiene and short-code branches below — BOTH of those ack, and
+    // the common blocked case ("handshake processed, then blocked") re-sends
+    // the same event.id for ~60h, which would keep acking a blocked party.
+    // No upsert, no ack, no wiring. Skipping consumeShortInvite is safe: the
+    // invite was consumed on the pre-block accept, and an unconsumed row
+    // expires at the 72h ledger TTL.
+    try {
+      const senderContact = await findContactByPubkey(db, senderPubkey);
+      if (senderContact && Number(senderContact.is_blocked) === 1) return;
+    } catch { /* resolution failure must not break honest handshakes */ }
+
     // D4 (design §D4): clock-free replay hygiene. R5's retry loop re-publishes
     // the EXACT stored signed event for ~60h, so a stale retry arriving AFTER
     // the user deleted this contact carries the same event.id. Skip the upsert

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -81,6 +81,10 @@ export async function handleIncomingRequest(db, managers, { senderPubkey, conten
 
     const existing = await findContactByPubkey(db, senderPubkey);
     if (existing) {
+      // F-BLOCK-1 D4b: a blocked contact — ANY request_status (full, pending,
+      // accepted) — is silently dropped on the catch-all path: no store, no
+      // notification. This was the S5.4 live store path.
+      if (Number(existing.is_blocked) === 1) return;
       // A full contact (request_status NULL) is already handled by the
       // per-contact subscription — do nothing here to avoid a double-store.
       if (existing.request_status === null || existing.request_status === undefined) {
@@ -546,36 +550,7 @@ export async function wireNostrReceive(managers) {
         });
       } catch {}
     } else if (subtype === "group_message") {
-      const { group_name, sender_name, message: msgText } = payload;
-      if (!msgText) return;
-      try {
-        await createNotification(db, {
-          title: `[${group_name || "Group"}] ${sender_name || "Someone"}`,
-          body: msgText.length > 200 ? msgText.slice(0, 200) + "..." : msgText,
-          type: "peer",
-          source: "sharing:group_message",
-          priority: "high",
-        });
-      } catch (err) {
-        console.warn("[sharing] Failed to create group message notification:", err.message);
-      }
-      // Also store as a regular message with group context.
-      // Phase 3 PR-B: deliberately NOT emitted to instance-sync — synthetic
-      // grp_<ts> event id (not a real Nostr event); rooms have their own sync path.
-      try {
-        // Find the sender contact
-        const senderContact = await db.execute({
-          sql: "SELECT id FROM contacts WHERE crow_id = ?",
-          args: [payload.sender_crow_id || ""],
-        });
-        if (senderContact.rows.length > 0) {
-          await db.execute({
-            sql: `INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
-                  VALUES (?, ?, ?, 'received', 0, datetime('now'))`,
-            args: [senderContact.rows[0].id, `grp_${Date.now()}`, `[${group_name}] ${msgText}`],
-          });
-        }
-      } catch {}
+      await handleGroupMessageNotify(db, payload, managers);
     } else if (subtype === "bot_relay") {
       const localName = await resolveLocalInstanceName(db);
       if (payload.target_instance !== localName) return; // Not for us
@@ -628,6 +603,61 @@ export async function wireNostrReceive(managers) {
     }
   });
   console.log("[sharing] Subscribed to incoming Nostr messages");
+}
+
+/**
+ * F-BLOCK-1 D4c — the `group_message` fan-out notify+store logic, extracted
+ * from the inline `onSocialMessage` dispatcher below so it's unit-testable
+ * without live relays. Behavior is byte-identical to before EXCEPT the sender
+ * resolve now happens BEFORE the notification: a blocked group member's
+ * fan-out (which includes us) must neither notify nor store — send-side
+ * filters only cover members WE blocked when WE fan out. An UNKNOWN
+ * (non-contact) sender still notifies exactly as before — the guard is
+ * `found && is_blocked===1`, never `!found`.
+ *
+ * `managers.createNotification` may be injected (tests); otherwise the
+ * shared helper is used, matching `handleIncomingRequest`'s convention.
+ *
+ * @param {object} db
+ * @param {{group_name?:string, sender_name?:string, message?:string, sender_crow_id?:string}} payload
+ * @param {{createNotification?: Function}} [managers]
+ */
+export async function handleGroupMessageNotify(db, payload, managers = {}) {
+  const notify = (managers && managers.createNotification) || createNotification;
+  const { group_name, sender_name, message: msgText } = payload || {};
+  if (!msgText) return;
+  let senderRow = null;
+  try {
+    const senderContact = await db.execute({
+      sql: "SELECT id, is_blocked FROM contacts WHERE crow_id = ?",
+      args: [payload.sender_crow_id || ""],
+    });
+    senderRow = senderContact.rows[0] || null;
+  } catch { /* lookup failure degrades to today's behavior */ }
+  if (senderRow && Number(senderRow.is_blocked) === 1) return;
+  try {
+    await notify(db, {
+      title: `[${group_name || "Group"}] ${sender_name || "Someone"}`,
+      body: msgText.length > 200 ? msgText.slice(0, 200) + "..." : msgText,
+      type: "peer",
+      source: "sharing:group_message",
+      priority: "high",
+    });
+  } catch (err) {
+    console.warn("[sharing] Failed to create group message notification:", err.message);
+  }
+  // Also store as a regular message with group context.
+  // Phase 3 PR-B: deliberately NOT emitted to instance-sync — synthetic
+  // grp_<ts> event id (not a real Nostr event); rooms have their own sync path.
+  try {
+    if (senderRow) {
+      await db.execute({
+        sql: `INSERT INTO messages (contact_id, nostr_event_id, content, direction, is_read, created_at)
+              VALUES (?, ?, ?, 'received', 0, datetime('now'))`,
+        args: [senderRow.id, `grp_${Date.now()}`, `[${group_name}] ${msgText}`],
+      });
+    }
+  } catch {}
 }
 
 /**

--- a/servers/sharing/contact-promote.js
+++ b/servers/sharing/contact-promote.js
@@ -67,14 +67,17 @@ export async function persistIncomingCursor(db, createdAtSec) {
 
 import { normalizePubkey } from "./pubkey-util.js";
 import { emitContactChange, emitContactDelete } from "./contact-sync.js";
-import { readTombstone, clearTombstone } from "./contact-delete.js";
+import { readTombstone, clearTombstone, unwireContact } from "./contact-delete.js";
 
 const HEX_KEY = /^[0-9a-fA-F]{64}(?:[0-9a-fA-F]{2})?$/; // 64 x-only or 66 compressed
 
 /** Wire a full contact into sync feeds, the DHT topic, and the Nostr sub. Each
  * step is independently guarded — a partial-manager (tests) or a transient
  * failure must not abort the upsert (the row is already correct). */
-async function wireFullContact(managers, row) {
+export async function wireFullContact(managers, row) {
+  // F-BLOCK-1 D4d belt: no upsert path (tool, accept, invite_accepted) may
+  // wire a blocked contact. The wiring returns on unblock (wireSyncedContact).
+  if (row?.is_blocked) return;
   const { syncManager, peerManager, nostrManager } = managers || {};
   try { if (syncManager) await syncManager.initContact(row.id, null); } catch {}
   try { if (peerManager) await peerManager.joinContact({ crowId: row.crow_id, ed25519Pubkey: row.ed25519_pubkey }); } catch {}
@@ -97,10 +100,12 @@ async function wireFullContact(managers, row) {
 export async function wireSyncedContact(managers, row) {
   try {
     if (!managers || !row) return;
-    const { syncManager, peerManager } = managers;
     if (row.is_blocked) {
-      try { if (syncManager && row.id != null) await syncManager.closeContactFeeds(row.id); } catch {}
-      try { if (peerManager && row.crow_id) await peerManager.leaveContact(row.crow_id); } catch {}
+      // F-BLOCK-1 D3: FULL teardown. The old inline pair closed feeds + left
+      // the DHT but LEFT THE LIVE NOSTR SUB — the cross-instance leg of the
+      // finding (a synced block must silence this instance too).
+      // unwireContact is the single teardown owner (delete + block paths).
+      await unwireContact(managers, row);
       return;
     }
     if (row.origin === "local-bot") return;

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -479,6 +479,21 @@ export class NostrManager {
               }
             }
 
+            // F-BLOCK-1 D4a: fresh block check. The sub is torn down on block,
+            // but an in-flight event — or a future wiring path that forgets
+            // teardown — must not store, notify, bump unread, mirror, receipt,
+            // or surface a blocked contact's DM. Silent drop (no receipt: we
+            // deliberately stop confirming receipt to a blocked party).
+            if (contactId && this.db) {
+              try {
+                const { rows: blockRows } = await this.db.execute({
+                  sql: "SELECT is_blocked FROM contacts WHERE id = ?",
+                  args: [contactId],
+                });
+                if (Number(blockRows?.[0]?.is_blocked ?? 0) === 1) return;
+              } catch { /* an unreadable check must not break delivery */ }
+            }
+
             if (contactId && this.db) {
               try {
                 const result = await this.db.execute({

--- a/servers/sharing/sync.js
+++ b/servers/sharing/sync.js
@@ -187,9 +187,9 @@ export class SyncManager {
    * concurrent initContact call for the same contactId. Hypercore close is safe
    * and the on-disk storage persists; the next initContact call will reopen.
    *
-   * NOTE: UNBLOCKING a contact does NOT re-init feeds — no lazy re-init path
-   * exists for contacts. A restart or re-invite is needed to reopen feeds after
-   * an unblock. This is intentional; do NOT add re-init here.
+   * NOTE: unblock re-inits lazily via wireSyncedContact → wireFullContact →
+   * initContact (F-BLOCK-1 D2) — both panel unblock handlers and the synced
+   * onContactSynced hook route through it. Keep re-init OUT of this method.
    */
   async closeContactFeeds(contactId) {
     const prior = this._initLocks.get(contactId) || Promise.resolve();

--- a/tests/block-handler-teardown.test.js
+++ b/tests/block-handler-teardown.test.js
@@ -1,0 +1,98 @@
+/**
+ * Cluster C D1/D2 — the block actions tear down ALL live wiring (Nostr unsub +
+ * feeds + DHT) via unwireContact; the unblock actions lazily re-wire via
+ * wireSyncedContact. Both panels; includes the S5.4 req:-accepted shape.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
+
+const SECP = "02" + "a".repeat(64);
+
+function freshDb(tag) {
+  const dir = mkdtempSync(join(tmpdir(), `block-handlers-${tag}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function stubManagers() {
+  const calls = [];
+  return {
+    calls,
+    nostrManager: {
+      unsubscribeFromContact: (crowId) => calls.push(["unsub", crowId]),
+      subscribeToContact: async (c) => calls.push(["sub", c.crow_id || c.crowId]),
+    },
+    syncManager: {
+      closeContactFeeds: async (id) => calls.push(["closeFeeds", id]),
+      initContact: async (id) => calls.push(["initContact", id]),
+    },
+    peerManager: {
+      leaveContact: async (crowId) => calls.push(["leave", crowId]),
+      joinContact: async (c) => calls.push(["join", c.crowId]),
+    },
+  };
+}
+
+test("contacts panel: block → full teardown; unblock → re-wire; keyless manual stays inert", async () => {
+  const { db, cleanup } = freshDb("contacts");
+  try {
+    const ins = await db.execute({
+      sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES ('crow:t1', 'ed', ?, 'T1')",
+      args: [SECP],
+    });
+    const id = Number(ins.lastInsertRowid);
+
+    const m1 = stubManagers();
+    const out1 = await handleContactAction({ body: { action: "block", contact_id: String(id) } }, db, { managers: m1 });
+    assert.ok(out1?.redirect, "block redirects");
+    const k1 = m1.calls.map((c) => c[0]);
+    assert.ok(k1.includes("unsub"), "block tears down the Nostr sub (the F-BLOCK-1 leg)");
+    assert.ok(k1.includes("closeFeeds") && k1.includes("leave"), "feeds + DHT teardown preserved");
+    const b = await db.execute({ sql: "SELECT is_blocked FROM contacts WHERE id = ?", args: [id] });
+    assert.equal(Number(b.rows[0].is_blocked), 1);
+
+    const m2 = stubManagers();
+    await handleContactAction({ body: { action: "unblock", contact_id: String(id) } }, db, { managers: m2 });
+    const k2 = m2.calls.map((c) => c[0]);
+    assert.ok(k2.includes("initContact") && k2.includes("join") && k2.includes("sub"), "unblock re-wires (no restart needed)");
+
+    // Keyless manual contact: block+unblock never touch wiring, never throw.
+    const insM = await db.execute("INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, contact_type) VALUES ('manual:x', '', '', 'M', 'manual')");
+    const mid = Number(insM.lastInsertRowid);
+    const m3 = stubManagers();
+    await handleContactAction({ body: { action: "block", contact_id: String(mid) } }, db, { managers: m3 });
+    await handleContactAction({ body: { action: "unblock", contact_id: String(mid) } }, db, { managers: m3 });
+    assert.ok(!m3.calls.some((c) => c[0] === "sub" || c[0] === "join" || c[0] === "initContact"), "keyless manual is never wired");
+  } finally { cleanup(); }
+});
+
+test("messages panel: block/unblock by crow_id incl. the req:-accepted stranger shape", async () => {
+  const { db, cleanup } = freshDb("messages");
+  try {
+    const reqSecp = "f".repeat(64);
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, request_status) VALUES (?, ?, '', 'accepted')",
+      args: [`req:${reqSecp}`, reqSecp],
+    });
+    const res = { redirected: null, redirectAfterPost(u) { this.redirected = u; return u; } };
+
+    const m1 = stubManagers();
+    await handlePostAction({ body: { action: "block", crow_id: `req:${reqSecp}` } }, res, { db, _managers: m1 });
+    assert.ok(m1.calls.some((c) => c[0] === "unsub" && c[1] === `req:${reqSecp}`), "req: accepted stranger's live sub torn down (S5.4)");
+
+    const m2 = stubManagers();
+    await handlePostAction({ body: { action: "unblock", crow_id: `req:${reqSecp}` } }, res, { db, _managers: m2 });
+    assert.ok(m2.calls.some((c) => c[0] === "sub"), "unblock re-subscribes");
+  } finally { cleanup(); }
+});

--- a/tests/block-onevent-guard.test.js
+++ b/tests/block-onevent-guard.test.js
@@ -1,0 +1,102 @@
+/**
+ * Cluster C D4a — a per-contact subscription that is still live when the
+ * contact is blocked (block→teardown race, or a future wiring path that
+ * forgets teardown) must NOT store, receipt, or surface the inbound DM.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { getPublicKey, nip44 } from "nostr-tools";
+import { NostrManager } from "../servers/sharing/nostr.js";
+
+function stubRelay() {
+  const r = {
+    connected: true, subscribeCalls: [], closed: false,
+    subscribe(filters, { onevent, onclose }) {
+      r.subscribeCalls.push({ filters, onevent, onclose });
+      const s = { onevent, onclose, closed: false, close() { this.closed = true; } };
+      return s;
+    },
+    async connect() { r.connected = true; },
+    close() { r.closed = true; },
+  };
+  return r;
+}
+
+const ourPriv = new Uint8Array(32).fill(1);
+const theirPriv = new Uint8Array(32).fill(2);
+const ourPub = getPublicKey(ourPriv);
+const theirPub = getPublicKey(theirPriv);
+const identity = { secp256k1Pubkey: ourPub, secp256k1Priv: ourPriv };
+const encryptToUs = (pt) => nip44.v2.encrypt(pt, nip44.v2.utils.getConversationKey(theirPriv, ourPub));
+
+// The real onevent handler is invoked by resilient-subscribe.js's `wrapped()`
+// without being awaited (deliberate: a relay callback must never block on our
+// DB work). So `await onevent(event)` in this test resolves before onevent's
+// own internal await chain (block-check -> INSERT -> notify -> unread SELECT
+// -> receipt) settles. Poll for the eventually-consistent outcome instead of
+// asserting immediately.
+async function waitFor(predicate, { timeoutMs = 2000, intervalMs = 10 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "block-onevent-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("onevent: blocked contact's DM is silently dropped (no row, no receipt); unblocked stores", async () => {
+  const { db, cleanup } = freshDb();
+  try {
+    const ins = await db.execute({
+      sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name) VALUES ('crow:blockee', 'ed', ?, 'Blockee')",
+      args: [theirPub],
+    });
+    const contactId = Number(ins.lastInsertRowid);
+
+    const mgr = new NostrManager(identity, db);
+    let receipts = 0;
+    mgr._sendDeliveryReceipt = async () => { receipts++; };
+    const relay = stubRelay();
+    mgr.relays.set("wss://stub", relay);
+    await mgr.subscribeToContact({ id: contactId, crow_id: "crow:blockee", secp256k1_pubkey: theirPub, display_name: "Blockee" });
+    const onevent = relay.subscribeCalls[0].onevent;
+
+    const countRows = async () => {
+      const n = await db.execute({ sql: "SELECT COUNT(*) AS c FROM messages WHERE contact_id = ?", args: [contactId] });
+      return Number(n.rows[0].c);
+    };
+
+    // Block AFTER subscribe — the sub is live (the F-BLOCK-1 shape).
+    await db.execute({ sql: "UPDATE contacts SET is_blocked = 1 WHERE id = ?", args: [contactId] });
+    await onevent({ id: "evt-blocked", pubkey: theirPub, created_at: 1_700_000_000, content: encryptToUs("while blocked") });
+    // Settle window: give a wrongly-implemented guard a real chance to store
+    // or receipt before asserting the negative.
+    await new Promise((r) => setTimeout(r, 200));
+    assert.equal(await countRows(), 0, "blocked inbound must NOT store");
+    assert.equal(receipts, 0, "blocked inbound must NOT be receipted (silence)");
+
+    // Unblock — the same live sub stores again (fresh check each event).
+    await db.execute({ sql: "UPDATE contacts SET is_blocked = 0 WHERE id = ?", args: [contactId] });
+    await onevent({ id: "evt-unblocked", pubkey: theirPub, created_at: 1_700_000_001, content: encryptToUs("after unblock") });
+    const stored = await waitFor(async () => (await countRows()) === 1);
+    assert.ok(stored, "unblocked inbound stores");
+    const receipted = await waitFor(() => receipts === 1);
+    assert.ok(receipted, "unblocked inbound is receipted");
+    await mgr.destroy();
+  } finally { cleanup(); }
+});

--- a/tests/block-receive-guards.test.js
+++ b/tests/block-receive-guards.test.js
@@ -1,0 +1,106 @@
+/**
+ * Cluster C D4b + D4c — the catch-all receive paths drop a blocked contact's
+ * inbound: message-requests (any request_status) and group_message fan-outs
+ * (no notification, no store). An UNKNOWN group sender still notifies.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { handleIncomingRequest, handleGroupMessageNotify } from "../servers/sharing/boot.js";
+
+function freshDb(tag) {
+  const dir = mkdtempSync(join(tmpdir(), `block-guards-${tag}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+test("D4b: blocked request contact (pending/accepted/full) → no store, no notification", async () => {
+  const { db, cleanup } = freshDb("d4b");
+  try {
+    const cases = [
+      { secp: "a".repeat(64), status: "pending" },
+      { secp: "c".repeat(64), status: "accepted" },
+      { secp: "d".repeat(64), status: null },
+    ];
+    let notifications = 0;
+    const managers = { createNotification: async () => { notifications++; } };
+    for (const c of cases) {
+      await db.execute({
+        sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, request_status, is_blocked) VALUES (?, ?, '', ?, 1)",
+        args: [`req:${c.secp}`, c.secp, c.status],
+      });
+      await handleIncomingRequest(db, managers, { senderPubkey: c.secp, content: "hi", eventId: `e-${c.secp.slice(0, 4)}` });
+      const { rows } = await db.execute("SELECT COUNT(*) AS c FROM messages");
+      assert.equal(Number(rows[0].c), 0, `blocked ${c.status ?? "full"} contact must not store`);
+    }
+    assert.equal(notifications, 0, "no notifications for blocked senders");
+
+    // Control: an UNblocked pending request still stores (existing behavior).
+    const okSecp = "e".repeat(64);
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, request_status, is_blocked) VALUES (?, ?, '', 'pending', 0)",
+      args: [`req:${okSecp}`, okSecp],
+    });
+    await handleIncomingRequest(db, managers, { senderPubkey: okSecp, content: "hello", eventId: "e-ok" });
+    const { rows } = await db.execute("SELECT COUNT(*) AS c FROM messages");
+    assert.equal(Number(rows[0].c), 1, "unblocked pending request still stores");
+  } finally { cleanup(); }
+});
+
+test("D4c: group_message — blocked sender drops silently, unblocked stores+notifies, unknown sender still notifies", async () => {
+  const { db, cleanup } = freshDb("d4c");
+  try {
+    let notifications = 0;
+    const managers = { createNotification: async () => { notifications++; } };
+
+    // Blocked contact.
+    const blockedIns = await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, is_blocked) VALUES ('crow:blocked-member', ?, '', 1)",
+      args: ["f".repeat(64)],
+    });
+    await handleGroupMessageNotify(db, {
+      group_name: "Test Group",
+      sender_name: "Blocked Person",
+      message: "hello from blocked",
+      sender_crow_id: "crow:blocked-member",
+    }, managers);
+    assert.equal(notifications, 0, "blocked group sender must not notify");
+    let rows = (await db.execute("SELECT COUNT(*) AS c FROM messages WHERE contact_id = ?", [Number(blockedIns.lastInsertRowid)])).rows;
+    assert.equal(Number(rows[0].c), 0, "blocked group sender must not store");
+
+    // Unblocked contact — existing behavior preserved.
+    const okIns = await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, is_blocked) VALUES ('crow:ok-member', ?, '', 0)",
+      args: ["9".repeat(64)],
+    });
+    await handleGroupMessageNotify(db, {
+      group_name: "Test Group",
+      sender_name: "OK Person",
+      message: "hello from ok",
+      sender_crow_id: "crow:ok-member",
+    }, managers);
+    assert.equal(notifications, 1, "unblocked group sender notifies");
+    rows = (await db.execute("SELECT COUNT(*) AS c FROM messages WHERE contact_id = ?", [Number(okIns.lastInsertRowid)])).rows;
+    assert.equal(Number(rows[0].c), 1, "unblocked group sender stores");
+
+    // Unknown sender (no matching contact) — must still notify (pins the
+    // reorder against a `!found` mistake), but has nowhere to store.
+    await handleGroupMessageNotify(db, {
+      group_name: "Test Group",
+      sender_name: "Ghost",
+      message: "hello from nowhere",
+      sender_crow_id: "crow:no-such-contact",
+    }, managers);
+    assert.equal(notifications, 2, "unknown group sender still notifies");
+    const total = (await db.execute("SELECT COUNT(*) AS c FROM messages")).rows;
+    assert.equal(Number(total[0].c), 1, "unknown group sender has no row to store into (count unchanged)");
+  } finally { cleanup(); }
+});

--- a/tests/block-rewire-guards.test.js
+++ b/tests/block-rewire-guards.test.js
@@ -1,0 +1,92 @@
+/**
+ * Cluster C D3 + D4d — the sync-apply blocked branch performs the FULL
+ * teardown (incl. the Nostr unsub the old inline pair missed); a blocked
+ * contact's invite_accepted is silenced (no upsert, no ack — even on the
+ * ~60h replay of an already-processed event); wireFullContact refuses to
+ * wire a blocked row.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import { getPublicKey } from "nostr-tools";
+import { wireSyncedContact, wireFullContact } from "../servers/sharing/contact-promote.js";
+import { handleInviteAccepted } from "../servers/sharing/boot.js";
+import { recordProcessedEvent } from "../servers/sharing/processed-events.js";
+
+const theirPriv = new Uint8Array(32).fill(7);
+const theirPub = getPublicKey(theirPriv);
+
+function freshDb(tag) {
+  const dir = mkdtempSync(join(tmpdir(), `block-rewire-${tag}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return { db, cleanup() { try { db.close(); } catch {} rmSync(dir, { recursive: true, force: true }); } };
+}
+
+function stubManagers() {
+  const calls = [];
+  return {
+    calls,
+    nostrManager: {
+      unsubscribeFromContact: (crowId) => calls.push(["unsub", crowId]),
+      subscribeToContact: async (c) => calls.push(["sub", c.crow_id || c.crowId]),
+      sendControl: async () => calls.push(["ack"]),
+      relays: new Map([["wss://stub", {}]]),
+      connectRelays: async () => {},
+      sendInviteAccepted: async () => {},
+    },
+    syncManager: {
+      closeContactFeeds: async (id) => calls.push(["closeFeeds", id]),
+      initContact: async (id) => calls.push(["initContact", id]),
+    },
+    peerManager: {
+      leaveContact: async (crowId) => calls.push(["leave", crowId]),
+      joinContact: async (c) => calls.push(["join", c.crowId]),
+    },
+  };
+}
+
+test("D3: wireSyncedContact on a blocked row performs the FULL teardown (incl. Nostr unsub)", async () => {
+  const m = stubManagers();
+  await wireSyncedContact(m, { id: 7, crow_id: "crow:blocked1", is_blocked: 1, secp256k1_pubkey: theirPub, ed25519_pubkey: "ed" });
+  const kinds = m.calls.map((c) => c[0]);
+  assert.ok(kinds.includes("unsub"), "Nostr unsubscribe — the leg the old inline pair missed");
+  assert.ok(kinds.includes("closeFeeds"), "feeds closed");
+  assert.ok(kinds.includes("leave"), "DHT topic left");
+  assert.ok(!kinds.includes("sub"), "never subscribes a blocked row");
+});
+
+test("D4d belt: wireFullContact refuses a blocked row", async () => {
+  const m = stubManagers();
+  await wireFullContact(m, { id: 8, crow_id: "crow:blocked2", is_blocked: 1, secp256k1_pubkey: theirPub, ed25519_pubkey: "ed" });
+  assert.equal(m.calls.length, 0, "no initContact/joinContact/subscribeToContact for a blocked row");
+});
+
+test("D4d: blocked sender's invite_accepted → no upsert, no ack — even for an already-processed event.id", async () => {
+  const { db, cleanup } = freshDb("d4d");
+  try {
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, ed25519_pubkey, display_name, is_blocked) VALUES ('crow:blocked3', ?, 'ed', 'Blocked3', 1)",
+      args: [theirPub],
+    });
+    // The common blocked shape: the handshake WAS processed once, THEN the
+    // user blocked. The sender's ~60h retry re-sends the same event.id.
+    await recordProcessedEvent(db, "evt-replayed", "invite_accepted");
+
+    const m = stubManagers();
+    const payload = { type: "invite_accepted", crowId: "crow:blocked3", ed25519Pub: "ed", secp256k1Pub: theirPub, displayName: "Evil Rename" };
+    await handleInviteAccepted(db, m, payload, theirPub, { id: "evt-replayed" });
+
+    assert.ok(!m.calls.some((c) => c[0] === "ack"), "NO handshake ack to a blocked sender (placement before the replay branch)");
+    const { rows } = await db.execute("SELECT display_name FROM contacts WHERE crow_id = 'crow:blocked3'");
+    assert.equal(rows[0].display_name, "Blocked3", "no upsert mutation");
+    assert.ok(!m.calls.some((c) => c[0] === "sub" || c[0] === "initContact"), "no re-wire");
+  } finally { cleanup(); }
+});


### PR DESCRIPTION
## Cluster C — "Block actually blocks" (P4 walkthrough finding F-BLOCK-1 [MAJOR] + unread addendum)

Live-verified in the S5.4 walkthrough: blocking a contact flipped `is_blocked=1` but the live per-contact relay subscription kept storing inbound (with `is_read=0`, bumping the unread badge) until a gateway restart — the `WHERE is_blocked = 0` filter only ever applied at subscription BUILD time.

### What this ships
- **D1 — block tears down all live wiring, both panels:** the block handlers replace their inline feeds+DHT pair with the #155 delete-path primitive `unwireContact` (Nostr `unsubscribeFromContact` — the missing leg — + `closeContactFeeds` + `leaveContact`). One teardown owner, works for `crow:`/`req:`/`manual:` ids (incl. the S5.4 accepted-stranger shape wired by `accept_request`).
- **D2 — unblock re-wires, no restart:** both unblock handlers call `wireSyncedContact` (→ `wireFullContact`: initContact + joinContact + subscribeToContact). The stale "no lazy re-init path exists" comments (predating R4/#155) are gone, including the `sync.js` docstring twin.
- **D3 — cross-instance leg:** blocks follow the user (Phase 3); the sync-apply blocked branch now performs the FULL teardown too, so blocking on any instance silences all of them within the ~2s sync window.
- **D4 — four receive-time guards** (belt + the block→teardown race): fresh `is_blocked` check in `subscribeToContact.onevent` (no store/notification/unread/mirror/receipt/onMessage); `handleIncomingRequest` early-return (the S5.4 store path); `group_message` reorder — the sender is resolved BEFORE the previously-unconditional notification (an unknown sender still notifies exactly as before); `handleInviteAccepted` early-return placed BEFORE both ack branches (a blocked contact's ~60h retry no longer receives handshake acks) + exported `wireFullContact` refuses blocked rows.
- Blocking is **silent** toward the blocked party — no store, no receipt, no ack; indistinguishable from being offline.
- Unread addendum: the badge bump WAS the stored row; the conversation list already filters `is_blocked=0`. Nothing stores → nothing bumps.

### Rigor
- Spec `docs/superpowers/specs/2026-07-10-block-teardown-design.md`, 2-round adversarial review. R1 caught a MAJOR the original draft got factually wrong: the group_message receive path was unguarded (my non-goal rationale was a sender/receiver confusion — send-time fan-out filters only cover members *we* blocked). R2 caught that the handshake-silence guard's placement is load-bearing (both ack branches precede the natural insertion point).
- TDD per task with per-task reviews (reviewers independently red-verified guards by live reversion); **8/8 mutation tests** RED-then-reverted, including the exact wrong-placement mutation for the ack guard and the `!found` mistake for the group guard.
- Suite **1383 pass / 1 pre-existing fail (foreign `bundle-contract` registry drift, unchanged on main) / 1 skip**.
- **Real-browser CDP**: block via the actual Block button → conversation disappears from the rendered messages page; unblock button → it returns; DB flips both ways. 5/5.
- Final whole-branch review: **READY TO MERGE, 0 Critical / 0 Important** — end-to-end seams traced both directions incl. the peer sync leg; no block-status leak; **zero merge conflicts with #159 in either order** (verified via `git merge-tree`).

### Post-merge verification plan
Deploy crow+MPA+grackle(+black-swan), then live E2E on the kept crow↔black-swan pairing: block Black Swan on crow via UI → DM from black-swan → no new row on crow, unread unchanged, sender stays `relayed` → unblock → next DM arrives live.

No schema bump — `SCHEMA_GENERATION` stays 6.

### Follow-ups (logged, not here)
Harden the onevent test's negative assertion (happens-after instead of a 200ms sleep); `findContactByPubkey` no-ORDER-BY (pre-existing); room-inbound path is a declared non-goal.