### PR TITLE
fix(sharing): messages health signal mirrors live relay socket state (F-HEALTH-2, the R7 follow-up)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-cluster-d-relay-signal-honesty.md
+++ b/docs/superpowers/plans/2026-07-10-cluster-d-relay-signal-honesty.md
@@ -1,0 +1,204 @@
+# Cluster D — Relay-Signal Honesty Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The messages nest signal reflects LIVE relay socket state (F-HEALTH-2 / the R7 follow-up) — a post-boot relay outage drives it to `[warn] "0 relays"` within one health tick instead of staying green forever.
+
+**Architecture:** One private `NostrManager._refreshRelayHealth()` (count `relay.connected === true` → `setRelaysConnected`), called at the end of `_doConnectRelays` (replacing the map-size set — defensive only) and at the TOP of each existing `_startHealthLoop` tick, BEFORE the `ensureHealthy` sweep (ordering load-bearing). Spec (2-round adversarially reviewed): `docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md`.
+
+**Tech Stack:** Node ESM, nostr-tools 2.23.3, node:test.
+
+## Global Constraints
+
+- **No SCHEMA_GENERATION bump**; no new env knobs (reuses `CROW_NOSTR_HEALTH_MS`).
+- **NEVER `git commit --amend`.** Positional-path commits only (`git add <path>` for NEW files); `git show --stat HEAD` after every commit. Never `git add -A`.
+- Branch: `fix/messages-cluster-d-relay-signal-honesty`. Suite baseline: 1385-class pass / 1 pre-existing foreign fail (bundle-contract) / 1 skip.
+- HARD REQ: `_refreshRelayHealth`'s body wrapped in try/catch (first sync throw-surface in an unguarded interval callback).
+- HARD REQ: place the new method adjacent to `_startHealthLoop` (~line 385) — NOT in lines ~470-510 (Cluster C #160's onevent hunk; merges must stay clean in either order).
+- HARD REQ: the refresh call in the tick goes BEFORE the `ensureHealthy` for-loop (a same-tick reconnect must not re-hide the outage) with a comment pinning the ordering.
+- HARD REQ: `destroy()` additionally calls `setRelaysConnected(0)`.
+- Tests: `await mgr.destroy()` + restore `CROW_NOSTR_HEALTH_MS` in `finally`; bounded waitFor polling, no fixed sleeps.
+
+---
+
+### Task 1: `_refreshRelayHealth` + call sites + tests
+
+**Files:**
+- Modify: `servers/sharing/nostr.js` (line ~123 in `_doConnectRelays`; `_startHealthLoop` ~385-399; `destroy()` ~766-784; new method adjacent to `_startHealthLoop`)
+- Test: `tests/relay-signal-honesty.test.js` (new)
+
+**Interfaces:**
+- Consumes: `setRelaysConnected`, `getReceiveHealth`, `_resetReceiveHealth` from `servers/sharing/receive-health.js` (setRelaysConnected already imported in nostr.js).
+- Produces: `NostrManager._refreshRelayHealth()` (private; tests may call it).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/relay-signal-honesty.test.js`:
+
+```js
+/**
+ * Cluster D (F-HEALTH-2) — relaysConnected mirrors LIVE socket state:
+ * refreshed on every health tick (before the ensureHealthy sweep) and at
+ * connect; a throwing stub can't kill the interval; destroy zeroes the count.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getPublicKey } from "nostr-tools";
+import { NostrManager } from "../servers/sharing/nostr.js";
+import { getReceiveHealth, _resetReceiveHealth } from "../servers/sharing/receive-health.js";
+
+const ourPriv = new Uint8Array(32).fill(1);
+const identity = { secp256k1Pubkey: getPublicKey(ourPriv), secp256k1Priv: ourPriv };
+
+const waitFor = async (fn, ms = 3000, step = 25) => {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { if (fn()) return true; await new Promise((r) => setTimeout(r, step)); }
+  return fn();
+};
+
+test("_refreshRelayHealth counts only live sockets (not map size)", async () => {
+  _resetReceiveHealth();
+  const mgr = new NostrManager(identity, null);
+  mgr.relays.set("wss://a", { connected: true });
+  mgr.relays.set("wss://b", { connected: true });
+  mgr.relays.set("wss://c", { connected: false });
+  mgr.relays.set("wss://d", null);
+  mgr._refreshRelayHealth();
+  assert.equal(getReceiveHealth().relaysConnected, 2, "2 live of 4 entries");
+  await mgr.destroy();
+});
+
+test("_doConnectRelays end-state uses the live count (direct call — the connectRelays wrapper early-returns on a non-empty map)", async () => {
+  _resetReceiveHealth();
+  const mgr = new NostrManager(identity, null);
+  mgr.relays.set("wss://dead", { connected: false }); // survives the empty connect loop
+  await mgr._doConnectRelays([]);
+  assert.equal(getReceiveHealth().relaysConnected, 0, "size===1 but live===0 — the size-count mutation reddens here");
+  await mgr.destroy();
+});
+
+test("health-loop tick refreshes the count both ways; throwing getter never kills the loop; destroy zeroes", async () => {
+  _resetReceiveHealth();
+  const prev = process.env.CROW_NOSTR_HEALTH_MS;
+  process.env.CROW_NOSTR_HEALTH_MS = "50";
+  const mgr = new NostrManager(identity, null);
+  try {
+    const stub = { connected: true };
+    mgr.relays.set("wss://stub", stub);
+    // A hostile entry whose getter throws — the tick must survive it (HARD REQ).
+    mgr.relays.set("wss://evil", { get connected() { throw new Error("boom"); } });
+    // Start the loop DIRECTLY with no registered subscription — a registered
+    // resilient sub's ensureHealthy would call stub.connect() and resurrect it.
+    mgr._startHealthLoop();
+    assert.ok(await waitFor(() => getReceiveHealth().relaysConnected === 1), "tick counts the one live stub (evil getter swallowed)");
+    stub.connected = false;
+    assert.ok(await waitFor(() => getReceiveHealth().relaysConnected === 0), "tick notices the post-boot socket death (F-HEALTH-2)");
+    stub.connected = true;
+    assert.ok(await waitFor(() => getReceiveHealth().relaysConnected === 1), "tick recovers after reconnect");
+    await mgr.destroy();
+    assert.equal(getReceiveHealth().relaysConnected, 0, "destroy zeroes the count");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_NOSTR_HEALTH_MS; else process.env.CROW_NOSTR_HEALTH_MS = prev;
+    await mgr.destroy().catch(() => {});
+  }
+});
+```
+
+NOTE FOR THE IMPLEMENTER: if the throwing-getter entry makes the WHOLE tick abort under a naive implementation, that is exactly the RED the try/catch requirement exists for — the final implementation may catch per-iteration or whole-body (spec allows either) as long as the live stub is still counted OR the loop provably survives; if whole-body catch makes assertion 1 unreachable with the evil entry present, count entries defensively per-iteration (try around the getter access) so both hold. Choose the implementation that keeps all three assertions green.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/relay-signal-honesty.test.js`
+Expected: FAIL — `_refreshRelayHealth` is not a function.
+
+- [ ] **Step 3: Implement**
+
+In `servers/sharing/nostr.js`:
+
+1. New method directly ABOVE `_startHealthLoop` (~line 385; NOT in the 470-510 window — Cluster C's hunk):
+
+```js
+  /**
+   * F-HEALTH-2: mirror LIVE socket state into receive-health. relay.connected
+   * is the canonical liveness bit — enablePing flips it false on a silently-
+   * dead socket (the same signal ensureHealthy keys on), and ensureHealthy's
+   * relay.connect() flips it back true, so the count self-heals both ways.
+   * Fully guarded: this runs synchronously inside the interval callback, and
+   * an escaped throw there is an uncaughtException (per-entry try so one
+   * hostile/broken relay object can't hide the others).
+   */
+  _refreshRelayHealth() {
+    let live = 0;
+    for (const relay of this.relays.values()) {
+      try { if (relay && relay.connected === true) live++; } catch { /* count it dead */ }
+    }
+    try { setRelaysConnected(live); } catch { /* never escape the interval */ }
+  }
+```
+
+2. In `_startHealthLoop`, at the TOP of the interval callback (before the `for` over subscriptions):
+
+```js
+    this._healthTimer = setInterval(() => {
+      // F-HEALTH-2: refresh BEFORE the ensureHealthy sweep — the sweep
+      // reconnects this same tick, and refreshing after it would erase the
+      // degraded reading and re-hide the outage (the exact bug class this
+      // fixes). Ordering is load-bearing; do not move below the loop.
+      this._refreshRelayHealth();
+      for (const h of this.subscriptions.values()) {
+```
+
+3. In `_doConnectRelays`, replace `setRelaysConnected(this.relays.size);` with:
+
+```js
+    // F-HEALTH-2: live count, not map size (defensive — at connect time they
+    // match today because the wrapper only runs from an empty map, but a
+    // relay dropping between .set() and here reads honest).
+    this._refreshRelayHealth();
+```
+
+4. In `destroy()`, after the relays are closed/cleared, add:
+
+```js
+    setRelaysConnected(0); // a destroyed manager must not freeze a stale count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/relay-signal-honesty.test.js tests/nostr-receive-health-hooks.test.js tests/nostr-resubscribe.test.js tests/receive-health.test.js tests/messages-health-signal.test.js`
+Expected: ALL PASS (the four pre-existing suites pin the signal ladder + receive-path behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/relay-signal-honesty.test.js
+git commit tests/relay-signal-honesty.test.js servers/sharing/nostr.js -m "fix(sharing): messages signal mirrors LIVE relay socket state — refresh on every health tick, before the ensureHealthy sweep (F-HEALTH-2, the R7 follow-up)"
+git show --stat HEAD
+```
+
+---
+
+### Task 2: Full suite, boot check, mutation evidence
+
+**Files:** none (evidence to `.superpowers/sdd/progress.md` — git-IGNORED).
+
+- [ ] **Step 1: Full suite** — `node --test tests/*.test.js 2>&1 | tail -6`. Expected ≥ baseline (+3), the 1 pre-existing foreign fail only.
+- [ ] **Step 2: Boot check** — `CROW_GATEWAY_URL=http://localhost:3097 PORT=3097 timeout 25 node servers/gateway/index.js --no-auth 2>&1 | head -50` — clean, no new warnings.
+- [ ] **Step 3: Mutations** (apply → named test RED → revert → clean):
+
+| # | Mutation | Test that must go RED |
+|---|---|---|
+| M1 | `_refreshRelayHealth`: count `this.relays.size` instead of live | test 1 ("2 live of 4") AND test 2 |
+| M2 | remove the tick's `_refreshRelayHealth()` call | test 3 ("tick notices the post-boot socket death") |
+| M3 | move the refresh call BELOW the ensureHealthy for-loop | must stay GREEN in test 3 (no sub registered) — instead verify by INSPECTION + the code comment; record that this mutation is guarded by comment + final review, not a test (the test can't see sweep ordering without a registered sub, and registering one resurrects the stub — documented limitation) |
+| M4 | remove the per-entry try/catch (naive `relay.connected === true` without try) | test 3 (the evil-getter entry throws → loop dies or count wrong) |
+| M5 | remove `setRelaysConnected(0)` from destroy() | test 3 final assertion |
+
+- [ ] **Step 4: Append evidence to the progress ledger.**
+
+---
+
+## Post-implementation (controller)
+
+1. Final whole-branch Opus review → PR → Kevin gate.
+2. Post-merge deploy fleet; live E2E per spec §5: `ss -K` the relay sockets on black-swan, poll the nest signal at ≤10s cadence over ~2 minutes — expect ok → degraded/warn (latched exactly one ~45s tick) → ok.

--- a/docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md
+++ b/docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md
@@ -134,12 +134,27 @@ the degraded state latches for exactly one health tick (~45s) before
 (next tick) back to `[ok] "4 relays"`. This is the exact scenario that stayed
 green in the walkthrough.
 
-## 6. Risks / review focus
+## 6. Risks / implementation requirements (R2-hardened)
 
+- **HARD REQ (R2 #1):** `_refreshRelayHealth`'s body is wrapped in `try/catch`.
+  It is the FIRST synchronous throw-surface in an interval callback that has no
+  sync guard (the existing body is pure async-dispatch with per-promise
+  `.catch`); an escaped throw is an uncaughtException — the "gateway silently
+  dies" class this arc exists to kill. Tested with a throwing `.connected`
+  getter stub.
+- **HARD REQ (R2 #2):** place `_refreshRelayHealth` adjacent to
+  `_startHealthLoop` (~:385) or after `_doConnectRelays` (~:125) — NOT in the
+  ~:470-510 window, which is Cluster C (#160)'s onevent hunk; keeps the merge
+  conflict-free in either order (B #159 doesn't touch nostr.js at all).
+- **HARD REQ (R2 #3):** the health-loop test must `await mgr.destroy()` AND
+  restore `CROW_NOSTR_HEALTH_MS` in `finally` (same-file state bleed; the
+  50ms interval keeps writing the process-global count).
+- **(R2 #4, cleanliness):** `destroy()` additionally calls
+  `setRelaysConnected(0)` — not prod-reachable today (the manager is a
+  lifetime singleton; destroy is test-only), but a destroyed manager must not
+  freeze a stale count into the signal.
 - `relay.connected` getter semantics across nostr-tools versions (pinned
-  dependency; ensureHealthy already relies on it — no new coupling).
-- The refresh runs inside the interval callback — must never throw (wrap; a
-  throw in an interval is an uncaughtException).
+  2.23.3; ensureHealthy already relies on it — no new coupling).
 - Signal flap risk: a relay mid-reconnect at tick time shows a lower count for
   one tick — cosmetic, honest, and the warn threshold (0) makes flapping warns
   unlikely unless ALL relays are down (which deserves the warn).

--- a/docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md
+++ b/docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md
@@ -1,0 +1,125 @@
+# Relay-signal honesty — Cluster D design (F-HEALTH-2)
+
+Date: 2026-07-10 · Arc: Crow Messages usability overhaul, P4 walkthrough Cluster D
+Finding: F-HEALTH-2 [S8-MAJOR] — the messages nest signal is blind to post-boot
+relay socket loss. Live-verified: all of black-swan's relay sockets were killed
+(`ss -K`) and the signal stayed `[ok] "4 relays"`. This is the long-standing R7
+follow-up. Independent of Clusters B/C.
+
+## 1. Problem
+
+`setRelaysConnected(this.relays.size)` runs ONLY at the end of
+`connectRelays()` (servers/sharing/nostr.js:123). Two defects compound:
+
+1. **Never refreshed:** `this.relays` is a Map populated at connect and never
+   pruned; sockets die, `relay.connected` flips false (via `enablePing` — the
+   PR #115 mechanism that is already load-bearing for `ensureHealthy()`), but
+   `relaysConnected` keeps the boot-time value forever. The nest signal
+   (health-signals.js:611, `relaysConnected === 0 → warn`) can effectively
+   only fire for a boot-time all-relays-down.
+2. **Counts the map, not liveness:** even at connect time, `this.relays.size`
+   counts stale entries from earlier connects (entries are only ever added or
+   overwritten by URL, never removed), so the boot count itself can overcount.
+
+Meanwhile the receive path's own resilience (makeResilientSub + the 45s
+`_startHealthLoop`) reconnects within seconds — delivery self-heals while the
+signal lies. The operator-facing honesty is the missing half.
+
+## 2. Non-goals
+
+- No change to reconnect behavior (#115's `ensureHealthy` engine is untouched).
+- No per-relay detail in the signal (it renders a count; partial outages show
+  the honest lower count, warn stays keyed on 0 — unchanged threshold).
+- No schema change — **SCHEMA_GENERATION stays 6**. No new env knobs (reuses
+  `CROW_NOSTR_HEALTH_MS`).
+- pi-bots' adapter keeps its own loop (it doesn't feed the gateway signal).
+
+## 3. Design
+
+One private helper on `NostrManager`:
+
+```js
+  /** F-HEALTH-2: mirror LIVE socket state into receive-health. relay.connected
+   * is the canonical liveness bit — enablePing flips it false on a silently-
+   * dead socket (the same signal ensureHealthy keys on), and ensureHealthy's
+   * relay.connect() flips it back true, so the count self-heals both ways. */
+  _refreshRelayHealth() {
+    let live = 0;
+    for (const relay of this.relays.values()) {
+      if (relay && relay.connected === true) live++;
+    }
+    setRelaysConnected(live);
+  }
+```
+
+Called from exactly two places:
+1. **End of `connectRelays()`** — replacing `setRelaysConnected(this.relays.size)`
+   (fixes the stale-entry overcount at connect time too).
+2. **Top of every `_startHealthLoop` tick** (the existing 45s
+   `CROW_NOSTR_HEALTH_MS` interval) — before the `ensureHealthy` sweep, so the
+   signal reflects the pre-heal truth each tick and the next tick reports the
+   healed state.
+
+Honesty contract: the signal reflects live socket state within
+≤ ping-timeout + one health tick (~45-60s) of a socket death, and recovers on
+the tick after `ensureHealthy` reconnects. The S8 repro (kill all sockets)
+now drives the signal to `[warn] "0 relays"` instead of a permanent green.
+
+### Alternatives rejected
+
+- **Event-driven decrement (relay onclose/onerror):** the exact approach #115
+  disproved — close events do not fire on RST/half-open/idle-timeout paths;
+  `enablePing` + polling is the proven pattern, and nostr.js:101-104 already
+  documents `relay.connected` as "the ONLY signal ensureHealthy() has".
+- **Compute at signal read time:** the nest signal reads `receive-health.js`,
+  which is deliberately ZERO-imports (the pre-QW2 suite-hang trap); reaching
+  into the live NostrManager from the gateway signal would reintroduce exactly
+  the import-pulls-up-sharing-sockets hazard that module exists to prevent.
+- **Prune dead relays from the Map:** changes `this.relays` consumers'
+  semantics (send paths iterate it; `relays.size === 0` gates reconnects) for
+  no signal benefit; counting liveness is strictly smaller.
+
+### Loop-liveness precondition
+
+`_startHealthLoop` is started by `subscribeToIncoming` / `subscribeToContact`
+(nostr.js:552/717) — the receive boot always subscribes, so whenever the
+messages signal is meaningful the loop exists. If receive wiring failed
+entirely, `receiveWired=false` already warns with precedence over the relay
+count (R8 ladder — unchanged). A manager that never subscribed (pure-send
+usage) keeps the connect-time count, same as today.
+
+## 4. Tests (TDD; mutation-test the guard)
+
+1. `_refreshRelayHealth`: Map seeded with fake relays `{connected:true}` ×2 +
+   `{connected:false}` ×1 + a null entry → `getReceiveHealth().relaysConnected === 2`.
+   **Mutation:** reverting to `this.relays.size` must redden this.
+2. `connectRelays` end-state: pre-seed the map with a dead (`connected:false`)
+   stub, call `connectRelays([])` → count is 0, not 1 (pins the overcount fix;
+   the existing "mirrors relay count" test in nostr-receive-health-hooks stays
+   green).
+3. Health-loop tick refresh: `CROW_NOSTR_HEALTH_MS=50`, start the loop, flip a
+   stub relay's `connected` false → poll until `relaysConnected` drops (bounded
+   waitFor, no fixed sleep); flip back true → poll until it recovers.
+   **Mutation:** removing the tick's refresh call must redden this.
+4. Full suite ≥ current baseline (1385-class / 1 pre-existing foreign fail / 1
+   skip); gateway boots clean.
+
+## 5. Verification beyond the suite
+
+Post-deploy live E2E (repeat the S8 probe that proved the finding): on
+black-swan, kill all relay sockets (`ss -K`, deadman-armed per the unattended
+-window rule if the window is long — here it is seconds and self-healing) →
+the Messages nest signal must leave `[ok]` and show the degraded count/warn
+within ~1 minute → sockets self-heal via ensureHealthy → signal returns to
+`[ok] "4 relays"`. This is the exact scenario that stayed green in the
+walkthrough.
+
+## 6. Risks / review focus
+
+- `relay.connected` getter semantics across nostr-tools versions (pinned
+  dependency; ensureHealthy already relies on it — no new coupling).
+- The refresh runs inside the interval callback — must never throw (wrap; a
+  throw in an interval is an uncaughtException).
+- Signal flap risk: a relay mid-reconnect at tick time shows a lower count for
+  one tick — cosmetic, honest, and the warn threshold (0) makes flapping warns
+  unlikely unless ALL relays are down (which deserves the warn).

--- a/docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md
+++ b/docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md
@@ -17,9 +17,13 @@ follow-up. Independent of Clusters B/C.
    `relaysConnected` keeps the boot-time value forever. The nest signal
    (health-signals.js:611, `relaysConnected === 0 → warn`) can effectively
    only fire for a boot-time all-relays-down.
-2. **Counts the map, not liveness:** even at connect time, `this.relays.size`
-   counts stale entries from earlier connects (entries are only ever added or
-   overwritten by URL, never removed), so the boot count itself can overcount.
+2. **(Defensive only — R1 F2 correction):** the originally-claimed "stale
+   entries from earlier connects overcount at boot" state is UNREACHABLE —
+   `connectRelays` early-returns when the map is non-empty (nostr.js:84), so
+   `_doConnectRelays` only ever runs from an empty map and `size === live` at
+   line 123 today. Replacing the size-count with the live-count at connect is
+   kept as defensive correctness (a relay that drops between `.set()` and the
+   count reads honest), not as a bug fix. The REAL defect is #1 alone.
 
 Meanwhile the receive path's own resilience (makeResilientSub + the 45s
 `_startHealthLoop`) reconnects within seconds — delivery self-heals while the
@@ -56,14 +60,20 @@ Called from exactly two places:
 1. **End of `connectRelays()`** — replacing `setRelaysConnected(this.relays.size)`
    (fixes the stale-entry overcount at connect time too).
 2. **Top of every `_startHealthLoop` tick** (the existing 45s
-   `CROW_NOSTR_HEALTH_MS` interval) — before the `ensureHealthy` sweep, so the
-   signal reflects the pre-heal truth each tick and the next tick reports the
-   healed state.
+   `CROW_NOSTR_HEALTH_MS` interval) — **before** the `ensureHealthy` sweep.
+   **This ordering is LOAD-BEARING (R1 F5):** the same tick's `ensureHealthy`
+   reconnects the socket; refreshed *after* the sweep, the reconnect would
+   erase the degraded reading and re-hide the outage — the F-HEALTH-2 bug
+   class reintroduced. Refresh-first latches the degraded count for one full
+   tick. A code comment must pin this against future reordering.
 
-Honesty contract: the signal reflects live socket state within
-≤ ping-timeout + one health tick (~45-60s) of a socket death, and recovers on
-the tick after `ensureHealthy` reconnects. The S8 repro (kill all sockets)
-now drives the signal to `[warn] "0 relays"` instead of a permanent green.
+Honesty contract (R1 F3 — pinned nostr-tools 2.23.3 defaults: pingFrequency
+29s, pingTimeout 20s): the signal reflects a **hard close** (RST / `ss -K`)
+within ≤ one health tick (~45s), and a **silent half-open** (NAT idle-drop)
+within ≤ pingFrequency + pingTimeout + one tick (~95s). It recovers on the
+tick after `ensureHealthy` reconnects. The S8 repro (hard kill) now drives the
+signal to `[warn] "0 relays"` for at least one full tick instead of a
+permanent green.
 
 ### Alternatives rejected
 
@@ -93,13 +103,21 @@ usage) keeps the connect-time count, same as today.
 1. `_refreshRelayHealth`: Map seeded with fake relays `{connected:true}` ×2 +
    `{connected:false}` ×1 + a null entry → `getReceiveHealth().relaysConnected === 2`.
    **Mutation:** reverting to `this.relays.size` must redden this.
-2. `connectRelays` end-state: pre-seed the map with a dead (`connected:false`)
-   stub, call `connectRelays([])` → count is 0, not 1 (pins the overcount fix;
-   the existing "mirrors relay count" test in nostr-receive-health-hooks stays
-   green).
-3. Health-loop tick refresh: `CROW_NOSTR_HEALTH_MS=50`, start the loop, flip a
-   stub relay's `connected` false → poll until `relaysConnected` drops (bounded
-   waitFor, no fixed sleep); flip back true → poll until it recovers.
+2. Connect-path end-state (R1 F1 — the naive `connectRelays([])` version is
+   VACUOUS: the :84 non-empty-map early-return skips `_doConnectRelays`
+   entirely and the assertion passes off the reset state): pre-seed the map
+   with a dead (`connected:false`) stub and call **`_doConnectRelays([])`
+   directly** — the stub survives the empty connect loop, so `size===1` while
+   live===0. Assert `relaysConnected === 0`. **Mutation:** reverting line
+   ~123 to `this.relays.size` must redden THIS variant (a genuinely live
+   guard).
+3. Health-loop tick refresh (R1 F4 — start the loop via
+   **`mgr._startHealthLoop()` directly with NO registered subscription**, or
+   the same tick's `ensureHealthy` calls the stub's `connect()` which flips it
+   back to connected and races the poll): `CROW_NOSTR_HEALTH_MS=50`, seed a
+   connected stub in the map, start the loop, poll `relaysConnected===1`; flip
+   `stub.connected=false` → poll until it drops to 0 (bounded waitFor, no
+   fixed sleep); flip back true → poll until it recovers to 1.
    **Mutation:** removing the tick's refresh call must redden this.
 4. Full suite ≥ current baseline (1385-class / 1 pre-existing foreign fail / 1
    skip); gateway boots clean.
@@ -108,11 +126,13 @@ usage) keeps the connect-time count, same as today.
 
 Post-deploy live E2E (repeat the S8 probe that proved the finding): on
 black-swan, kill all relay sockets (`ss -K`, deadman-armed per the unattended
--window rule if the window is long — here it is seconds and self-healing) →
-the Messages nest signal must leave `[ok]` and show the degraded count/warn
-within ~1 minute → sockets self-heal via ensureHealthy → signal returns to
-`[ok] "4 relays"`. This is the exact scenario that stayed green in the
-walkthrough.
+-window rule if the window is long — here it is seconds and self-healing).
+**Poll the nest signal at ≤10s cadence across a ~2-minute window (R1 F5)** —
+the degraded state latches for exactly one health tick (~45s) before
+`ensureHealthy`'s reconnect clears it, so a single glance can miss it. Expect:
+`[ok] "4 relays"` → (≤1 tick) degraded count / `[warn] "0 relays"` →
+(next tick) back to `[ok] "4 relays"`. This is the exact scenario that stayed
+green in the walkthrough.
 
 ## 6. Risks / review focus
 

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -120,7 +120,10 @@ export class NostrManager {
       }
     }
 
-    setRelaysConnected(this.relays.size);
+    // F-HEALTH-2: live count, not map size (defensive — at connect time they
+    // match today because the wrapper only runs from an empty map, but a
+    // relay dropping between .set() and here reads honest).
+    this._refreshRelayHealth();
     return [...this.relays.keys()];
   }
 
@@ -378,6 +381,23 @@ export class NostrManager {
   }
 
   /**
+   * F-HEALTH-2: mirror LIVE socket state into receive-health. relay.connected
+   * is the canonical liveness bit — enablePing flips it false on a silently-
+   * dead socket (the same signal ensureHealthy keys on), and ensureHealthy's
+   * relay.connect() flips it back true, so the count self-heals both ways.
+   * Fully guarded: this runs synchronously inside the interval callback, and
+   * an escaped throw there is an uncaughtException (per-entry try so one
+   * hostile/broken relay object can't hide the others).
+   */
+  _refreshRelayHealth() {
+    let live = 0;
+    for (const relay of this.relays.values()) {
+      try { if (relay && relay.connected === true) live++; } catch { /* count it dead */ }
+    }
+    try { setRelaysConnected(live); } catch { /* never escape the interval */ }
+  }
+
+  /**
    * Start the single periodic health loop that re-establishes any resilient
    * subscription whose relay has dropped. Idempotent (created once). unref'd so
    * it never keeps the process alive on its own.
@@ -386,6 +406,11 @@ export class NostrManager {
     if (this._healthTimer) return;
     const ms = Number(process.env.CROW_NOSTR_HEALTH_MS) || 45000;
     this._healthTimer = setInterval(() => {
+      // F-HEALTH-2: refresh BEFORE the ensureHealthy sweep — the sweep
+      // reconnects this same tick, and refreshing after it would erase the
+      // degraded reading and re-hide the outage (the exact bug class this
+      // fixes). Ordering is load-bearing; do not move below the loop.
+      this._refreshRelayHealth();
       for (const h of this.subscriptions.values()) {
         // ensureHealthy is async — a sync try/catch would NOT catch a rejected
         // promise. Wrap so a stray rejection can never become an unhandledRejection
@@ -781,5 +806,6 @@ export class NostrManager {
       } catch {}
     }
     this.relays.clear();
+    setRelaysConnected(0); // a destroyed manager must not freeze a stale count
   }
 }

--- a/tests/relay-signal-honesty.test.js
+++ b/tests/relay-signal-honesty.test.js
@@ -1,0 +1,66 @@
+/**
+ * Cluster D (F-HEALTH-2) — relaysConnected mirrors LIVE socket state:
+ * refreshed on every health tick (before the ensureHealthy sweep) and at
+ * connect; a throwing stub can't kill the interval; destroy zeroes the count.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getPublicKey } from "nostr-tools";
+import { NostrManager } from "../servers/sharing/nostr.js";
+import { getReceiveHealth, _resetReceiveHealth } from "../servers/sharing/receive-health.js";
+
+const ourPriv = new Uint8Array(32).fill(1);
+const identity = { secp256k1Pubkey: getPublicKey(ourPriv), secp256k1Priv: ourPriv };
+
+const waitFor = async (fn, ms = 3000, step = 25) => {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { if (fn()) return true; await new Promise((r) => setTimeout(r, step)); }
+  return fn();
+};
+
+test("_refreshRelayHealth counts only live sockets (not map size)", async () => {
+  _resetReceiveHealth();
+  const mgr = new NostrManager(identity, null);
+  mgr.relays.set("wss://a", { connected: true });
+  mgr.relays.set("wss://b", { connected: true });
+  mgr.relays.set("wss://c", { connected: false });
+  mgr.relays.set("wss://d", null);
+  mgr._refreshRelayHealth();
+  assert.equal(getReceiveHealth().relaysConnected, 2, "2 live of 4 entries");
+  await mgr.destroy();
+});
+
+test("_doConnectRelays end-state uses the live count (direct call — the connectRelays wrapper early-returns on a non-empty map)", async () => {
+  _resetReceiveHealth();
+  const mgr = new NostrManager(identity, null);
+  mgr.relays.set("wss://dead", { connected: false }); // survives the empty connect loop
+  await mgr._doConnectRelays([]);
+  assert.equal(getReceiveHealth().relaysConnected, 0, "size===1 but live===0 — the size-count mutation reddens here");
+  await mgr.destroy();
+});
+
+test("health-loop tick refreshes the count both ways; throwing getter never kills the loop; destroy zeroes", async () => {
+  _resetReceiveHealth();
+  const prev = process.env.CROW_NOSTR_HEALTH_MS;
+  process.env.CROW_NOSTR_HEALTH_MS = "50";
+  const mgr = new NostrManager(identity, null);
+  try {
+    const stub = { connected: true };
+    mgr.relays.set("wss://stub", stub);
+    // A hostile entry whose getter throws — the tick must survive it (HARD REQ).
+    mgr.relays.set("wss://evil", { get connected() { throw new Error("boom"); } });
+    // Start the loop DIRECTLY with no registered subscription — a registered
+    // resilient sub's ensureHealthy would call stub.connect() and resurrect it.
+    mgr._startHealthLoop();
+    assert.ok(await waitFor(() => getReceiveHealth().relaysConnected === 1), "tick counts the one live stub (evil getter swallowed)");
+    stub.connected = false;
+    assert.ok(await waitFor(() => getReceiveHealth().relaysConnected === 0), "tick notices the post-boot socket death (F-HEALTH-2)");
+    stub.connected = true;
+    assert.ok(await waitFor(() => getReceiveHealth().relaysConnected === 1), "tick recovers after reconnect");
+    await mgr.destroy();
+    assert.equal(getReceiveHealth().relaysConnected, 0, "destroy zeroes the count");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_NOSTR_HEALTH_MS; else process.env.CROW_NOSTR_HEALTH_MS = prev;
+    await mgr.destroy().catch(() => {});
+  }
+});

--- a/tests/relay-signal-honesty.test.js
+++ b/tests/relay-signal-honesty.test.js
@@ -64,3 +64,47 @@ test("health-loop tick refreshes the count both ways; throwing getter never kill
     await mgr.destroy().catch(() => {});
   }
 });
+
+test("health-loop tick order: _refreshRelayHealth runs BEFORE the ensureHealthy sweep (M3 pin)", async () => {
+  _resetReceiveHealth();
+  const prev = process.env.CROW_NOSTR_HEALTH_MS;
+  process.env.CROW_NOSTR_HEALTH_MS = "50";
+  const mgr = new NostrManager(identity, null);
+  try {
+    const stub = { connected: true };
+    mgr.relays.set("wss://stub", stub);
+
+    // A FAKE subscription handle, not a real resilient sub — a real one's
+    // ensureHealthy calls relay.connect() and would resurrect the dying
+    // stub, hiding the very ordering bug this test exists to catch. This
+    // handle only observes: it records the receive-health value at the
+    // instant the sweep invokes it, and never touches mgr.relays.
+    const recordings = [];
+    mgr.subscriptions.set("fake:sub", {
+      ensureHealthy: () => { recordings.push(getReceiveHealth().relaysConnected); },
+    });
+
+    mgr._startHealthLoop();
+    assert.ok(await waitFor(() => recordings.length >= 1), "first tick reached the sweep");
+
+    // Kill the stub's socket, then wait for the NEXT tick to record a value.
+    // If _refreshRelayHealth runs first (current code), that tick's refresh
+    // sees the death and sets relaysConnected=0 before ensureHealthy is ever
+    // called, so the recording is 0. If ensureHealthy ran first (refresh
+    // moved after the loop — the M3 mutation), it would still observe the
+    // stale relaysConnected=1 from the previous tick's refresh.
+    stub.connected = false;
+    const countBeforeFlip = recordings.length;
+    assert.ok(await waitFor(() => recordings.length > countBeforeFlip), "a tick ran after the flip");
+    assert.equal(
+      recordings[countBeforeFlip],
+      0,
+      "first post-flip ensureHealthy call must observe relaysConnected===0 — proves refresh ran before the sweep this same tick; refresh-after would still read 1",
+    );
+
+    await mgr.destroy();
+  } finally {
+    if (prev === undefined) delete process.env.CROW_NOSTR_HEALTH_MS; else process.env.CROW_NOSTR_HEALTH_MS = prev;
+    await mgr.destroy().catch(() => {});
+  }
+});


### PR DESCRIPTION
## Cluster D — "Signal honesty" (P4 walkthrough finding F-HEALTH-2 [MAJOR])

Live-verified in the S8 walkthrough: killing ALL of black-swan's relay sockets left the Messages nest signal `[ok] "4 relays"` — `setRelaysConnected(this.relays.size)` ran only at `connectRelays`, the Map is never pruned, and the count was frozen at its boot value forever. The receive path itself self-heals within seconds (#115's `ensureHealthy`), so delivery recovered while the operator signal lied. This is the long-standing R7 follow-up.

### What this ships
One private helper, `NostrManager._refreshRelayHealth()` — counts relays where `relay.connected === true` (the same canonical liveness bit `enablePing` + `ensureHealthy` already key on) — called from:
- the **top of every `_startHealthLoop` tick** (existing 45s cadence), **before** the `ensureHealthy` sweep — the ordering is load-bearing (refresh-after would let the same-tick reconnect erase the degraded reading and re-hide the outage) and is pinned by a comment **and a dedicated recorder test** whose refresh-after mutation goes red;
- the end of `_doConnectRelays` (replacing the map-size count — defensive only; the review proved the "boot overcount" state unreachable);
- plus `setRelaysConnected(0)` in `destroy()`.

Per-entry `try/catch` inside the refresh — it is the first synchronous throw-surface in an interval callback with no other sync guard; an escaped throw would be an uncaughtException.

**Honesty contract** (nostr-tools 2.23.3: pingFrequency 29s, pingTimeout 20s): a hard close (RST) reaches the signal within ≤1 tick (~45s); a silent half-open within ~95s; recovery on the tick after `ensureHealthy` reconnects. Warn threshold unchanged (`0 relays`).

### Rigor
- Spec `docs/superpowers/specs/2026-07-10-relay-signal-honesty-design.md`, 2-round adversarial review. R1 killed two of my own claims: the "boot overcount" justification was unreachable, and the spec's connect-path test was **vacuous** (its mutation guard was dead code behind the `connectRelays` early-return) — fixed via a direct `_doConnectRelays([])` test. R2 confirmed the folds and disarmed the biggest structural fear (multiple NostrManagers fighting the process-global count — the manager is a first-call-wins singleton; the pi-bots adapter is out-of-process and never imports receive-health).
- TDD with per-task review; **all 5 mutations red-verified** including the exact wrong-ordering move (a fake-subscription recorder observes what count `ensureHealthy` sees at call time).
- Suite **1378 pass / 1 pre-existing foreign fail (bundle-contract registry drift) / 1 skip**; clean boot.
- Final whole-branch review: **READY TO MERGE, zero findings**; `git merge-tree` proves clean merges with **both #159 and #160 in any order** (three-way verified).

### Post-merge verification plan
Repeat the S8 probe on black-swan (`ss -K` all relay sockets), **polling the nest signal at ≤10s cadence over ~2 minutes** (the degraded state latches exactly one health tick before self-heal): expect `[ok] "4 relays"` → `[warn] "0 relays"` → `[ok] "4 relays"`.

No schema bump — `SCHEMA_GENERATION` stays 6. No new env knobs.