### PR TITLE
Board–plan unification 1: stage lifecycle, plan_ref, Execute/Plan dispatch

### DIFF
--- a/scripts/migrate-board-stages.mjs
+++ b/scripts/migrate-board-stages.mjs
@@ -1,0 +1,34 @@
+// scripts/migrate-board-stages.mjs
+// Board–plan unification Plan 1 Task 1: guarded ALTERs (init-pi-bots.mjs
+// pattern — PRAGMA presence check, additive, idempotent, absent-table
+// tolerant). Run on deploy, both instances. SQLite ADD COLUMN never rebuilds
+// the table, so existing CHECK constraints are unaffected.
+import Database from "better-sqlite3";
+import { tasksDbPath, botsDbPath } from "./pi-bots/instance-paths.mjs";
+
+function addColumnIfMissing(db, table, column, ddl) {
+  const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
+  if (!t) return "skip (" + table + " absent)";
+  const have = db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
+  if (have.includes(column)) return "no-op";
+  db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`).run();
+  return "added";
+}
+
+function open(p) { const d = new Database(p); d.pragma("busy_timeout = 10000"); return d; }
+
+const out = [];
+{
+  const tdb = open(tasksDbPath());
+  out.push(["tasks_items.stage", addColumnIfMissing(tdb, "tasks_items", "stage", "TEXT")]);
+  out.push(["tasks_items.assigned_bot", addColumnIfMissing(tdb, "tasks_items", "assigned_bot", "TEXT")]);
+  out.push(["tasks_items.plan_ref", addColumnIfMissing(tdb, "tasks_items", "plan_ref", "TEXT")]);
+  tdb.close();
+}
+{
+  const cdb = open(botsDbPath());
+  out.push(["project_spaces.repo_path", addColumnIfMissing(cdb, "project_spaces", "repo_path", "TEXT")]);
+  out.push(["bot_sessions.kind", addColumnIfMissing(cdb, "bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'")]);
+  cdb.close();
+}
+for (const [what, r] of out) console.log("  " + what + ": " + r);

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -38,6 +38,7 @@ import { remoteServersForBot, parseRemoteInvocationFlag } from "./remote-blocks.
 import { warmModel } from "./warm.mjs";
 import { meterBotTurn } from "./metering.mjs";
 import { getOrCreateLocalInstanceId } from "../../servers/gateway/instance-registry.js";
+import { statusToStage } from "../../servers/gateway/routes/board-stages.js";
 
 const HOME = "/home/kh0pp";
 const NODE = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
@@ -570,6 +571,22 @@ export async function handleInbound(opts) {
     const calls = pi.toolCalls();
     postTurn = { user: cleanMsg, assistant: text, toolNames: calls.map((c) => c.tool) };
     const newCardStatus = cardId != null ? cardStatus(cardId, tasksDbPath) : null;
+    // Board–plan unification: fold the bot-written status back onto the
+    // canonical stage column (single reconciliation point). Guarded on the
+    // column existing so pre-migration instances are untouched.
+    if (cardId != null && newCardStatus != null) {
+      try {
+        const t = db(tasksDbPath);
+        try {
+          const have = t.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+          if (have.includes("stage")) {
+            const cur = t.prepare("SELECT stage FROM tasks_items WHERE id=?").get(cardId);
+            t.prepare("UPDATE tasks_items SET stage=? WHERE id=?")
+              .run(statusToStage(newCardStatus, cur && cur.stage), cardId);
+          }
+        } finally { t.close(); }
+      } catch (e) { log("stage reconcile skipped (non-fatal): " + (e && e.message || e)); }
+    }
     const status = newCardStatus === "done" ? "done" : "waiting-user";
     session.pi_session_id = piSessionId;
     session.status = status; session.control = "run";

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -706,18 +706,24 @@ export async function planCard(opts) {
     pi_session_dir: repoRoot + "/.pi/board-planning", status: "active", control: "run",
     model: resolved.key, escalated: 0, kind: "planning",
   });
-  mkdirSync(repoRoot + "/.pi/board-planning", { recursive: true });
+  let pi;
+  try {
+    mkdirSync(repoRoot + "/.pi/board-planning", { recursive: true });
 
-  // Confinement belt: write_paths limited to plans+docs, bash denied. The
-  // stored def's policy is NOT used — planning is stricter than the bot.
-  const planningDef = Object.assign({}, def, {
-    permission_policy: { bash: "deny", write_paths: [repoRoot + "/.pi/plans", repoRoot + "/docs"] },
-    spawn_env: def.spawn_env || {},
-    tools: def.tools,
-  });
-  await warmModel(resolved.provider, log);
-  const pi = new PiRpc({ def: planningDef, sessionDir: repoRoot + "/.pi/board-planning",
-    resolved, piSessionId: null, appendSystemPromptFile: sysFile });
+    // Confinement belt: write_paths limited to plans+docs, bash denied. The
+    // stored def's policy is NOT used — planning is stricter than the bot.
+    const planningDef = Object.assign({}, def, {
+      permission_policy: { bash: "deny", write_paths: [repoRoot + "/.pi/plans", repoRoot + "/docs"] },
+      spawn_env: def.spawn_env || {},
+      tools: def.tools,
+    });
+    await warmModel(resolved.provider, log);
+    pi = new PiRpc({ def: planningDef, sessionDir: repoRoot + "/.pi/board-planning",
+      resolved, piSessionId: null, appendSystemPromptFile: sysFile });
+  } catch (e) {
+    session.status = "error"; upsertSession(session);
+    return { action: "error", error: e.message };
+  }
   try {
     await pi.prompt(buildPlanPrompt(card, ".pi/plans"), TURN_TIMEOUT_MS);
     const text = pi.assistantText();

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -39,6 +39,7 @@ import { warmModel } from "./warm.mjs";
 import { meterBotTurn } from "./metering.mjs";
 import { getOrCreateLocalInstanceId } from "../../servers/gateway/instance-registry.js";
 import { statusToStage } from "../../servers/gateway/routes/board-stages.js";
+import { parsePlanRef, containedRealPath } from "../../servers/gateway/routes/plan-ref.js";
 import { extractPlanFileLine, buildPlanPrompt } from "./plan_dispatch.mjs";
 
 const HOME = "/home/kh0pp";
@@ -303,6 +304,42 @@ function planFor(def, cardId) {
   const p = def.session_dir + "/plans/" + cardId + ".md";
   return { path: p, exists: existsSync(p), text: existsSync(p) ? readFileSync(p, "utf8") : "" };
 }
+// plan_ref-aware plan resolution for the execute path (final-review C1).
+// kind:"repo" resolves under the project's repo_path with the same fail-closed
+// containment as the board API; anything else (null ref, workspace ref,
+// pre-migration DBs, missing repo_path) falls back to the legacy workspace
+// path. Sync (better-sqlite3), never throws — a broken ref degrades to legacy.
+function planForCard(def, cardId, tasksDbPathArg) {
+  try {
+    const t = db(tasksDbPathArg);
+    let row = null;
+    try {
+      const have = t.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+      if (have.includes("plan_ref")) {
+        row = t.prepare("SELECT plan_ref, project_id FROM tasks_items WHERE id=?").get(Number(cardId));
+      }
+    } finally { t.close(); }
+    const ref = row ? parsePlanRef(row.plan_ref) : null;
+    if (ref && ref.kind === "repo" && row.project_id != null) {
+      const c = db(CROW_DB);
+      let repoRoot = null;
+      try {
+        const have = c.prepare("PRAGMA table_info(project_spaces)").all().map((col) => col.name);
+        if (have.includes("repo_path")) {
+          const p = c.prepare("SELECT repo_path FROM project_spaces WHERE id=?").get(Number(row.project_id));
+          repoRoot = p && p.repo_path ? String(p.repo_path) : null;
+        }
+      } finally { c.close(); }
+      if (repoRoot) {
+        const path = repoRoot.replace(/\/+$/, "") + "/" + ref.path;
+        if (containedRealPath(path, repoRoot) && existsSync(path)) {
+          return { path, exists: true, text: readFileSync(path, "utf8") };
+        }
+      }
+    }
+  } catch { /* fall through to legacy */ }
+  return planFor(def, cardId);
+}
 function getSession(botId, threadId) {
   const c = db(CROW_DB);
   const r = c.prepare("SELECT * FROM bot_sessions WHERE bot_id=? AND gateway_thread_id=? ORDER BY id DESC LIMIT 1").get(botId, threadId);
@@ -479,7 +516,7 @@ export async function handleInbound(opts) {
   // existing plan files live). Project-native bots that get a project_space
   // workspace will accumulate plans under <workspace>/bots/<bot_id>/plans/
   // once any are written; for the transition we look in both locations.
-  const plan = cardId != null ? planFor(def, cardId) : { path: null, exists: false, text: "" };
+  const plan = cardId != null ? planForCard(def, cardId, tasksDbPath) : { path: null, exists: false, text: "" };
 
   // M3b: structured project header replaces the bare "Project #N" string.
   // Falls back to a one-liner for legacy bots with no project_spaces row.
@@ -582,8 +619,15 @@ export async function handleInbound(opts) {
           const have = t.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
           if (have.includes("stage")) {
             const cur = t.prepare("SELECT stage FROM tasks_items WHERE id=?").get(cardId);
-            t.prepare("UPDATE tasks_items SET stage=? WHERE id=?")
-              .run(statusToStage(newCardStatus, cur && cur.stage), cardId);
+            // I2: null-stage cards behave exactly as today — a legacy card
+            // with no stage yet must not be stamped onto the stage model just
+            // because its bot-written status round-tripped as "pending".
+            // Only write when the card already carries a stage, or the new
+            // status unambiguously implies a real transition.
+            if ((cur && cur.stage != null) || ["done", "cancelled", "in_progress"].includes(String(newCardStatus))) {
+              t.prepare("UPDATE tasks_items SET stage=?, updated_at=datetime('now') WHERE id=?")
+                .run(statusToStage(newCardStatus, cur && cur.stage), cardId);
+            }
           }
         } finally { t.close(); }
       } catch (e) { log("stage reconcile skipped (non-fatal): " + (e && e.message || e)); }
@@ -664,6 +708,24 @@ export async function handleInbound(opts) {
   return result;
 }
 
+// I3b: the route (bot-board-api.js POST .../plan-dispatch) already flips the
+// card to stage='planning' BEFORE spawning this process. An early refusal in
+// planCard below (card not found / no repo_path / pi-capacity deferred /
+// non-local provider) must not strand the card in Planning with nothing
+// actually running — reset it back to Backlog/pending. Best-effort against
+// the SAME tasks db used to read the card; never throws. Do NOT call this
+// after a pi session has actually been started — the post-session error
+// paths carry the signal via the session row + status='error' instead.
+function resetStrandedCardBestEffort(cardsDb, cardId) {
+  try {
+    const c = db(cardsDb);
+    try {
+      c.prepare("UPDATE tasks_items SET stage='backlog', status='pending', updated_at=datetime('now') WHERE id=?")
+        .run(cardId);
+    } finally { c.close(); }
+  } catch { /* best-effort */ }
+}
+
 // Board plan dispatch (Plan 1 Task 7): spawn a CONFINED local-model planning
 // run against the card's project repo. Structural guarantees (spec §Safety):
 // resolved provider MUST be crow-local (no config knob reaches a paid model);
@@ -682,17 +744,22 @@ export async function planCard(opts) {
   const t = db(cardsDb);
   const card = t.prepare("SELECT id, title, description, project_id FROM tasks_items WHERE id=?").get(cardId);
   t.close();
-  if (!card) return { action: "error", error: "card not found" };
+  if (!card) { resetStrandedCardBestEffort(cardsDb, cardId); return { action: "error", error: "card not found" }; }
 
   const repoRoot = projectSpace && projectSpace.repo_path ? String(projectSpace.repo_path) : null;
   if (!repoRoot || !existsSync(repoRoot)) {
+    resetStrandedCardBestEffort(cardsDb, cardId);
     return { action: "error", error: "project has no repo_path (workspace plan dispatch is not in v1 — edit the plan in the drawer)" };
   }
 
-  if (countLivePi() >= LIFECYCLE_DEFAULTS.maxPi) return { action: "deferred", reason: "pi-capacity" };
+  if (countLivePi() >= LIFECYCLE_DEFAULTS.maxPi) {
+    resetStrandedCardBestEffort(cardsDb, cardId);
+    return { action: "deferred", reason: "pi-capacity" };
+  }
 
   const resolved = await resolveModel(def, { escalate: false });
   if (String(resolved.provider) !== "crow-local") {
+    resetStrandedCardBestEffort(cardsDb, cardId);
     return { action: "error", error: "plan dispatch is local-only; bot resolves to " + resolved.provider + "/" + resolved.model };
   }
 
@@ -713,7 +780,14 @@ export async function planCard(opts) {
     // Confinement belt: write_paths limited to plans+docs, bash denied. The
     // stored def's policy is NOT used — planning is stricter than the bot.
     const planningDef = Object.assign({}, def, {
-      permission_policy: { bash: "deny", write_paths: [repoRoot + "/.pi/plans", repoRoot + "/docs"] },
+      // I1: MERGE onto the bot's own policy (keeps external_send/confirm
+      // belts) rather than replacing it wholesale — bash/write/multi_agent
+      // are still forced down for the planning run.
+      permission_policy: Object.assign({}, def.permission_policy || {}, {
+        bash: "deny",
+        write_paths: [repoRoot + "/.pi/plans", repoRoot + "/docs"],
+        multi_agent: false,
+      }),
       spawn_env: def.spawn_env || {},
       tools: def.tools,
     });

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -39,6 +39,7 @@ import { warmModel } from "./warm.mjs";
 import { meterBotTurn } from "./metering.mjs";
 import { getOrCreateLocalInstanceId } from "../../servers/gateway/instance-registry.js";
 import { statusToStage } from "../../servers/gateway/routes/board-stages.js";
+import { extractPlanFileLine, buildPlanPrompt } from "./plan_dispatch.mjs";
 
 const HOME = "/home/kh0pp";
 const NODE = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
@@ -310,11 +311,11 @@ function getSession(botId, threadId) {
 function upsertSession(s) {
   const c = db(CROW_DB);
   if (s.id) {
-    c.prepare("UPDATE bot_sessions SET pi_session_id=?, pi_session_dir=?, project_id=?, card_id=?, plan_path=?, status=?, control=?, model=?, escalated=?, updated_at=datetime('now') WHERE id=?")
-      .run(s.pi_session_id == null ? null : s.pi_session_id, s.pi_session_dir == null ? null : s.pi_session_dir, s.project_id == null ? null : s.project_id, s.card_id == null ? null : s.card_id, s.plan_path == null ? null : s.plan_path, s.status, s.control, s.model == null ? null : s.model, s.escalated == null ? 0 : (s.escalated ? 1 : 0), s.id);
+    c.prepare("UPDATE bot_sessions SET pi_session_id=?, pi_session_dir=?, project_id=?, card_id=?, plan_path=?, status=?, control=?, model=?, escalated=?, kind=?, updated_at=datetime('now') WHERE id=?")
+      .run(s.pi_session_id == null ? null : s.pi_session_id, s.pi_session_dir == null ? null : s.pi_session_dir, s.project_id == null ? null : s.project_id, s.card_id == null ? null : s.card_id, s.plan_path == null ? null : s.plan_path, s.status, s.control, s.model == null ? null : s.model, s.escalated == null ? 0 : (s.escalated ? 1 : 0), s.kind == null ? "chat" : s.kind, s.id);
   } else {
-    const info = c.prepare("INSERT INTO bot_sessions (bot_id,pi_session_id,pi_session_dir,gateway_type,gateway_thread_id,project_id,card_id,plan_path,status,control,model,escalated) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)")
-      .run(s.bot_id, s.pi_session_id == null ? null : s.pi_session_id, s.pi_session_dir == null ? null : s.pi_session_dir, s.gateway_type || "gmail", s.gateway_thread_id, s.project_id == null ? null : s.project_id, s.card_id == null ? null : s.card_id, s.plan_path == null ? null : s.plan_path, s.status, s.control || "run", s.model == null ? null : s.model, s.escalated == null ? 0 : (s.escalated ? 1 : 0));
+    const info = c.prepare("INSERT INTO bot_sessions (bot_id,pi_session_id,pi_session_dir,gateway_type,gateway_thread_id,project_id,card_id,plan_path,status,control,model,escalated,kind) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")
+      .run(s.bot_id, s.pi_session_id == null ? null : s.pi_session_id, s.pi_session_dir == null ? null : s.pi_session_dir, s.gateway_type || "gmail", s.gateway_thread_id, s.project_id == null ? null : s.project_id, s.card_id == null ? null : s.card_id, s.plan_path == null ? null : s.plan_path, s.status, s.control || "run", s.model == null ? null : s.model, s.escalated == null ? 0 : (s.escalated ? 1 : 0), s.kind == null ? "chat" : s.kind);
     s.id = info.lastInsertRowid;
   }
   c.close(); return s;
@@ -663,6 +664,87 @@ export async function handleInbound(opts) {
   return result;
 }
 
+// Board plan dispatch (Plan 1 Task 7): spawn a CONFINED local-model planning
+// run against the card's project repo. Structural guarantees (spec §Safety):
+// resolved provider MUST be crow-local (no config knob reaches a paid model);
+// write_paths = [<repo>/.pi/plans, <repo>/docs] + bash deny; bot_sessions row
+// kind='planning' takes the same single-writer lock as execution.
+export async function planCard(opts) {
+  const cardId = Number(opts.cardId), botId = String(opts.botId);
+  const log = opts.log || function () {};
+  const bot = loadBot(botId);
+  const def = bot.def;
+  const projectId = bot.project_id == null ? null : Number(bot.project_id);
+  const projectSpace = loadProjectSpace(projectId);
+
+  // Same tasks-db resolution as handleInbound (project override wins).
+  const cardsDb = (projectSpace && projectSpace.tasks_db_uri) || TASKS_DB;
+  const t = db(cardsDb);
+  const card = t.prepare("SELECT id, title, description, project_id FROM tasks_items WHERE id=?").get(cardId);
+  t.close();
+  if (!card) return { action: "error", error: "card not found" };
+
+  const repoRoot = projectSpace && projectSpace.repo_path ? String(projectSpace.repo_path) : null;
+  if (!repoRoot || !existsSync(repoRoot)) {
+    return { action: "error", error: "project has no repo_path (workspace plan dispatch is not in v1 — edit the plan in the drawer)" };
+  }
+
+  if (countLivePi() >= LIFECYCLE_DEFAULTS.maxPi) return { action: "deferred", reason: "pi-capacity" };
+
+  const resolved = await resolveModel(def, { escalate: false });
+  if (String(resolved.provider) !== "crow-local") {
+    return { action: "error", error: "plan dispatch is local-only; bot resolves to " + resolved.provider + "/" + resolved.model };
+  }
+
+  const sysFile = join(mkdtempSync(join(tmpdir(), "pibot-plan-")), "sys.md");
+  writeFileSync(sysFile, "You are a careful software planner. You explore code read-only and write ONE plan file.", { mode: 0o600 });
+
+  // Planning session takes the card lock: kind='planning', status active.
+  let session = upsertSession({
+    bot_id: botId, gateway_thread_id: "board-plan-" + cardId, gateway_type: "board",
+    project_id: projectId, card_id: cardId, plan_path: null,
+    pi_session_dir: repoRoot + "/.pi/board-planning", status: "active", control: "run",
+    model: resolved.key, escalated: 0, kind: "planning",
+  });
+  mkdirSync(repoRoot + "/.pi/board-planning", { recursive: true });
+
+  // Confinement belt: write_paths limited to plans+docs, bash denied. The
+  // stored def's policy is NOT used — planning is stricter than the bot.
+  const planningDef = Object.assign({}, def, {
+    permission_policy: { bash: "deny", write_paths: [repoRoot + "/.pi/plans", repoRoot + "/docs"] },
+    spawn_env: def.spawn_env || {},
+    tools: def.tools,
+  });
+  await warmModel(resolved.provider, log);
+  const pi = new PiRpc({ def: planningDef, sessionDir: repoRoot + "/.pi/board-planning",
+    resolved, piSessionId: null, appendSystemPromptFile: sysFile });
+  try {
+    await pi.prompt(buildPlanPrompt(card, ".pi/plans"), TURN_TIMEOUT_MS);
+    const text = pi.assistantText();
+    const rel = extractPlanFileLine(text);
+    if (!rel || !existsSync(repoRoot + "/" + rel)) {
+      session.status = "error"; upsertSession(session);
+      return { action: "error", error: "planning run produced no verifiable PLAN_FILE (reply tail: " + text.slice(-200) + ")" };
+    }
+    const planRef = { kind: "repo", path: rel };
+    const t2 = db(cardsDb);
+    t2.prepare("UPDATE tasks_items SET plan_ref=?, stage='ready', status='pending', updated_at=datetime('now') WHERE id=?")
+      .run(JSON.stringify(planRef), cardId);
+    t2.close();
+    session.status = "done"; upsertSession(session);
+    appendAuditBridge(projectId, {
+      actor_type: "bot", actor_id: botId, action: "bot.plan",
+      target: "card:" + cardId, payload: { plan_ref: planRef, model: resolved.key },
+    });
+    return { action: "planned", planRef };
+  } catch (e) {
+    session.status = "error"; upsertSession(session);
+    return { action: "error", error: e.message };
+  } finally {
+    await pi.close();
+  }
+}
+
 export function stopSession(botId, threadId) {
   const s = getSession(botId, threadId);
   if (!s) return { ok: false, reason: "no session" };
@@ -676,12 +758,19 @@ if (import.meta.url === "file://" + process.argv[1]) {
     const bot = a[a.indexOf("--bot") + 1], thread = a[a.indexOf("--thread") + 1];
     console.log(JSON.stringify(stopSession(bot, thread))); process.exit(0);
   }
-  const inj = a[a.indexOf("--inject") + 1];
-  if (!inj) { console.error("usage: bridge.mjs --inject '<json>' | --stop --bot B --thread T"); process.exit(2); }
-  const payload = JSON.parse(inj);
-  handleInbound(Object.assign({}, payload, {
-    log: (m) => console.error("[bridge] " + m),
-    sendReply: async (t) => console.log("REPLY>>>\n" + t + "\n<<<REPLY"),
-  })).then((r) => { console.log("RESULT " + JSON.stringify(r)); process.exit(r.action === "error" ? 1 : 0); })
-    .catch((e) => { console.error("BRIDGE CRASH " + e.stack); process.exit(2); });
+  if (a.includes("--plan-card")) {
+    const payload = JSON.parse(a[a.indexOf("--plan-card") + 1]);
+    planCard(Object.assign({}, payload, { log: (m) => console.error("[plan] " + m) }))
+      .then((r) => { console.log("RESULT " + JSON.stringify(r)); process.exit(r.action === "error" ? 1 : 0); })
+      .catch((e) => { console.error("PLAN CRASH " + e.stack); process.exit(2); });
+  } else {
+    const inj = a[a.indexOf("--inject") + 1];
+    if (!inj) { console.error("usage: bridge.mjs --inject '<json>' | --stop --bot B --thread T | --plan-card '<json>'"); process.exit(2); }
+    const payload = JSON.parse(inj);
+    handleInbound(Object.assign({}, payload, {
+      log: (m) => console.error("[bridge] " + m),
+      sendReply: async (t) => console.log("REPLY>>>\n" + t + "\n<<<REPLY"),
+    })).then((r) => { console.log("RESULT " + JSON.stringify(r)); process.exit(r.action === "error" ? 1 : 0); })
+      .catch((e) => { console.error("BRIDGE CRASH " + e.stack); process.exit(2); });
+  }
 }

--- a/scripts/pi-bots/gateways/index.mjs
+++ b/scripts/pi-bots/gateways/index.mjs
@@ -48,6 +48,11 @@ export function gatewayHint(type, threadId) {
     return "\nGATEWAY THREAD: gmail thread_id=" + threadId
       + " — pass this verbatim as thread_id when drafting your reply via gmail_create_draft.";
   }
+  if (type === "board") {
+    return "\nGATEWAY: board (card ref: " + threadId + ") — this run was dispatched from the "
+      + "kanban board. Do NOT use gmail/discord tools to reply; write your durable result under "
+      + "the plan file's \"## Result\" section and keep your final reply to a short summary.";
+  }
   const a = HOST_BY_TYPE[type];
   if (a && typeof a.gatewayHint === "function") return a.gatewayHint(threadId);
   return "\nGATEWAY: " + type + " (thread ref: " + threadId

--- a/scripts/pi-bots/plan_dispatch.mjs
+++ b/scripts/pi-bots/plan_dispatch.mjs
@@ -1,0 +1,26 @@
+// scripts/pi-bots/plan_dispatch.mjs
+// Pure helpers for board plan dispatch (Plan 1 Task 7). The planning model
+// ends its reply with exactly one `PLAN_FILE: <relative path>` line; we take
+// the LAST well-formed occurrence and refuse absolute/traversal paths (the
+// same rules parsePlanRef enforces when the ref is stored).
+export function extractPlanFileLine(text) {
+  const matches = [...String(text || "").matchAll(/^PLAN_FILE:\s*(.+?)\s*$/gm)];
+  if (!matches.length) return null;
+  const p = matches[matches.length - 1][1];
+  if (!p || p.startsWith("/") || p.split("/").includes("..")) return null;
+  return p;
+}
+
+export function buildPlanPrompt(card, plansDir) {
+  return (
+    "You are the PLANNING model for a kanban card. Explore this repository " +
+    "READ-ONLY and produce an implementation plan.\n\n" +
+    "CARD #" + card.id + ": " + (card.title || "(untitled)") + "\n" +
+    (card.description ? "DESCRIPTION:\n" + card.description + "\n" : "") + "\n" +
+    "Write the plan as a markdown file under " + plansDir + "/ named " +
+    "<YYYY-MM-DD>-card-" + card.id + "-<short-slug>.md (create the directory if needed). " +
+    "The plan must contain numbered steps with exact file paths, code-level detail, and a " +
+    "testing section. Do NOT modify any file outside " + plansDir + "/ and docs/.\n\n" +
+    "End your reply with exactly one line:\nPLAN_FILE: <path relative to the repository root>"
+  );
+}

--- a/scripts/pi-bots/plan_dispatch.mjs
+++ b/scripts/pi-bots/plan_dispatch.mjs
@@ -6,7 +6,7 @@
 export function extractPlanFileLine(text) {
   const matches = [...String(text || "").matchAll(/^PLAN_FILE:\s*(.+?)\s*$/gm)];
   if (!matches.length) return null;
-  const p = matches[matches.length - 1][1];
+  const p = matches[matches.length - 1][1].trim();
   if (!p || p.startsWith("/") || p.split("/").includes("..")) return null;
   return p;
 }

--- a/servers/gateway/routes/board-stages.js
+++ b/servers/gateway/routes/board-stages.js
@@ -1,0 +1,40 @@
+// servers/gateway/routes/board-stages.js
+// Board–plan unification: the stage model. `stage` is the CANONICAL board
+// column; legacy `status` is a projection (stageToStatus) written in the same
+// statement by every stage writer. The bridge is the single reconciler for
+// bot-written status flips (statusToStage). Pure module — no I/O.
+export const STAGES = ["backlog", "planning", "ready", "executing", "done", "cancelled"];
+export const TERMINAL_STAGES = new Set(["done", "cancelled"]);
+
+const STAGE_TO_STATUS = {
+  backlog: "pending", planning: "pending", ready: "pending",
+  executing: "in_progress", done: "done", cancelled: "cancelled",
+};
+
+export function isStage(v) { return STAGES.includes(String(v)); }
+
+export function stageToStatus(stage) { return STAGE_TO_STATUS[String(stage)] || "pending"; }
+
+// Null/invalid stage (pre-migration cards) derives a stage from the legacy
+// status: terminal maps 1:1, in_progress → executing, pending → Ready when a
+// plan file exists else Backlog (spec "stage regression guard").
+export function effectiveStage(card, planExists) {
+  if (card && card.stage != null && isStage(card.stage)) return String(card.stage);
+  const s = String((card && card.status) || "pending");
+  if (s === "done") return "done";
+  if (s === "cancelled") return "cancelled";
+  if (s === "in_progress") return "executing";
+  return planExists ? "ready" : "backlog";
+}
+
+// Post-turn reconciliation: a bot flipped tasks_items.status via tasks_* mid
+// run; fold that back onto stage. Pre-execution refinements survive a bounce
+// back to pending; a pending after executing means the work stopped → Ready.
+export function statusToStage(status, prevStage) {
+  const s = String(status || "pending");
+  if (s === "done") return "done";
+  if (s === "cancelled") return "cancelled";
+  if (s === "in_progress") return "executing";
+  if (prevStage && ["backlog", "planning", "ready"].includes(String(prevStage))) return String(prevStage);
+  return "ready";
+}

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -54,6 +54,7 @@ import { proposalsDir, normalizeSkillName, listProposals } from "../../../script
 import { promoteSkill } from "../../../scripts/pi-bots/skill_promote.mjs";
 import { listBotSkillEvents } from "../../../scripts/pi-bots/skill_provenance.mjs";
 import { createProjectSpace, updateProjectSpaceMeta } from "../../shared/project-spaces.js";
+import { parsePlanRef, resolvePlanFile, containedRealPath } from "./plan-ref.js";
 
 // Slice C: operator-approved promotion target (the PRIMARY skills dir both the
 // pi bridge and the glasses voice path search via skill_resolver).
@@ -115,26 +116,6 @@ async function derivePlanPath(cdb, card) {
   return null;
 }
 
-// Realpath containment — the resolved file must live under sessionDir. For a
-// not-yet-existing plan file, resolve+contain the parent dir instead.
-function containedRealPath(path, sessionDir) {
-  try {
-    const rootReal = realpathSync(sessionDir);
-    let real;
-    if (existsSync(path)) {
-      real = realpathSync(path);
-    } else {
-      const slash = path.lastIndexOf("/");
-      const dir = path.slice(0, slash);
-      if (!existsSync(dir)) return null;
-      real = realpathSync(dir) + path.slice(slash);
-    }
-    if (real === rootReal || real.startsWith(rootReal + "/")) return real;
-    return null;
-  } catch {
-    return null;
-  }
-}
 
 // Fail-closed pi-liveness (Step-1 pinned pattern, recorded in the plan's
 // Verified Claims): a process is "the live pi holding bot_sessions row R"

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -582,6 +582,9 @@ export default function botBoardApiRouter(dashboardAuth) {
         });
         const child = spawn(NODE_BIN, [BRIDGE, "--inject", payload],
           { cwd: HOME, stdio: ["ignore", "ignore", "ignore"], detached: true });
+        // I3a: a spawn failure (e.g. a stale NODE_BIN path) must not crash the
+        // gateway as an uncaughtException — this dispatch is fire-and-forget.
+        child.on("error", () => {});
         child.unref();
       }
       return res.json({ ok: true, dispatched: bot });
@@ -629,6 +632,9 @@ export default function botBoardApiRouter(dashboardAuth) {
         const payload = JSON.stringify({ cardId: id, botId: bot });
         const child = spawn(NODE_BIN, [BRIDGE, "--plan-card", payload],
           { cwd: HOME, stdio: ["ignore", "ignore", "ignore"], detached: true });
+        // I3a: a spawn failure (e.g. a stale NODE_BIN path) must not crash the
+        // gateway as an uncaughtException — this dispatch is fire-and-forget.
+        child.on("error", () => {});
         child.unref();
       }
       return res.json({ ok: true, dispatched: bot });

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -55,6 +55,7 @@ import { promoteSkill } from "../../../scripts/pi-bots/skill_promote.mjs";
 import { listBotSkillEvents } from "../../../scripts/pi-bots/skill_provenance.mjs";
 import { createProjectSpace, updateProjectSpaceMeta } from "../../shared/project-spaces.js";
 import { parsePlanRef, resolvePlanFile, containedRealPath } from "./plan-ref.js";
+import { isStage, stageToStatus, effectiveStage } from "./board-stages.js";
 
 // Slice C: operator-approved promotion target (the PRIMARY skills dir both the
 // pi bridge and the glasses voice path search via skill_resolver).
@@ -176,6 +177,7 @@ export default function botBoardApiRouter(dashboardAuth) {
       const card = (await tdb.execute({
         sql:
           "SELECT id,title,description,status,priority,due_date,owner,tags,parent_id,project_id," +
+          "stage,assigned_bot,plan_ref," +
           "datetime(updated_at) AS updated_at, completed_at FROM tasks_items WHERE id=?",
         args: [id],
       })).rows[0];
@@ -183,10 +185,18 @@ export default function botBoardApiRouter(dashboardAuth) {
       cdb = createDbClient();
       let projects = [];
       try {
-        projects = (await cdb.execute({ sql: "SELECT id, name, slug FROM project_spaces WHERE archived_at IS NULL ORDER BY id", args: [] })).rows || [];
+        projects = (await cdb.execute({ sql: "SELECT id, name, slug, repo_path FROM project_spaces WHERE archived_at IS NULL ORDER BY id", args: [] })).rows || [];
       } catch { projects = []; }
       const { locked } = await lockState(cdb, id);
-      return res.json({ card, projects, locked });
+      // effectiveStage needs plan existence only for legacy null-stage cards.
+      let planExists = false;
+      if (card.stage == null) {
+        try {
+          const info = await derivePlanPath(cdb, card);
+          planExists = !!(info && existsSync(info.path));
+        } catch { planExists = false; }
+      }
+      return res.json({ card, projects, locked, effectiveStage: effectiveStage(card, planExists) });
     } catch (e) {
       return jsonError(res, 500, String(e.message || e));
     } finally {
@@ -241,11 +251,22 @@ export default function botBoardApiRouter(dashboardAuth) {
       if (!Number.isInteger(prio) || prio < 1 || prio > 5) return jsonError(res, 400, "priority must be 1-5");
       prioSet = true;
     }
+    let botSet = false, botVal = null;
+    if (b.assigned_bot !== undefined) {
+      botSet = true;
+      botVal = b.assigned_bot == null || b.assigned_bot === "" ? null : String(b.assigned_bot);
+    }
     let tdb, cdb;
     try {
       cdb = createDbClient();
       const { locked } = await lockState(cdb, id);
       if (locked) return res.status(409).json({ reason: "bot is working this card" });
+      if (botSet && botVal != null) {
+        const botRow = (await cdb.execute({
+          sql: "SELECT bot_id FROM pi_bot_defs WHERE bot_id=? AND enabled=1", args: [botVal],
+        })).rows[0];
+        if (!botRow) return jsonError(res, 400, "assigned_bot not found or disabled");
+      }
       tdb = createDbClient(TASKS_DB);
       const cur = (await tdb.execute({ sql: "SELECT status FROM tasks_items WHERE id=?", args: [id] })).rows[0];
       if (!cur) return jsonError(res, 404, "card not found");
@@ -258,6 +279,7 @@ export default function botBoardApiRouter(dashboardAuth) {
         b.tags == null || b.tags === "" ? null : String(b.tags),
       ];
       if (prioSet) { sets.push("priority=?"); args.push(prio); }
+      if (botSet) { sets.push("assigned_bot=?"); args.push(botVal); }
       if (b.status != null) {
         const ns = String(b.status);
         sets.push("status=?"); args.push(ns);
@@ -280,20 +302,34 @@ export default function botBoardApiRouter(dashboardAuth) {
   router.post(P + "/card/:id/move", async (req, res) => {
     const id = Number(req.params.id);
     if (!Number.isInteger(id)) return jsonError(res, 400, "bad id");
-    const status = String((req.body || {}).status || "");
-    if (!CARD_STATUSES.has(status)) return jsonError(res, 400, "invalid status"); // BEFORE SQL
+    const b = req.body || {};
+    const stageReq = b.stage != null ? String(b.stage) : null;
+    const status = String(b.status || "");
+    if (stageReq != null) {
+      if (!isStage(stageReq)) return jsonError(res, 400, "invalid stage"); // BEFORE SQL
+    } else if (!CARD_STATUSES.has(status)) {
+      return jsonError(res, 400, "invalid status"); // BEFORE SQL (legacy path unchanged)
+    }
     let tdb, cdb;
     try {
       cdb = createDbClient();
       const { locked } = await lockState(cdb, id);
       if (locked) return res.status(409).json({ reason: "bot is working this card" });
       tdb = createDbClient(TASKS_DB);
-      const cur = (await tdb.execute({ sql: "SELECT status FROM tasks_items WHERE id=?", args: [id] })).rows[0];
+      const cur = (await tdb.execute({ sql: "SELECT status, stage FROM tasks_items WHERE id=?", args: [id] })).rows[0];
       if (!cur) return jsonError(res, 404, "card not found");
-      const sets = ["status=?", "updated_at=datetime('now')"];
-      if (TERMINAL.has(status) && !TERMINAL.has(String(cur.status))) sets.push("completed_at=datetime('now')");
-      else if (!TERMINAL.has(status) && TERMINAL.has(String(cur.status))) sets.push("completed_at=NULL");
-      await tdb.execute({ sql: `UPDATE tasks_items SET ${sets.join(", ")} WHERE id=?`, args: [status, id] });
+      if (stageReq != null) {
+        const proj = stageToStatus(stageReq);
+        const sets = ["stage=?", "status=?", "updated_at=datetime('now')"];
+        if (TERMINAL.has(proj) && !TERMINAL.has(String(cur.status))) sets.push("completed_at=datetime('now')");
+        else if (!TERMINAL.has(proj) && TERMINAL.has(String(cur.status))) sets.push("completed_at=NULL");
+        await tdb.execute({ sql: `UPDATE tasks_items SET ${sets.join(", ")} WHERE id=?`, args: [stageReq, proj, id] });
+      } else {
+        const sets = ["status=?", "updated_at=datetime('now')"];
+        if (TERMINAL.has(status) && !TERMINAL.has(String(cur.status))) sets.push("completed_at=datetime('now')");
+        else if (!TERMINAL.has(status) && TERMINAL.has(String(cur.status))) sets.push("completed_at=NULL");
+        await tdb.execute({ sql: `UPDATE tasks_items SET ${sets.join(", ")} WHERE id=?`, args: [status, id] });
+      }
       return res.json({ ok: true });
     } catch (e) {
       return jsonError(res, 500, String(e.message || e));

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -537,6 +537,62 @@ export default function botBoardApiRouter(dashboardAuth) {
     }
   });
 
+  // ---- execute from board (spec: dispatch is explicit; drags never dispatch) ----
+  // Reuses the /session/send detached bridge --inject seam. Board turns get
+  // gateway_type "board" + thread "board-card-<id>"; the bot's durable output
+  // is the plan file ## Result + the audit log + the session transcript.
+  router.post(P + "/card/:id/execute", async (req, res) => {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id)) return jsonError(res, 400, "bad id");
+    let tdb, cdb;
+    try {
+      cdb = createDbClient();
+      const { locked } = await lockState(cdb, id);
+      if (locked) return res.status(409).json({ reason: "bot is working this card" });
+      tdb = createDbClient(TASKS_DB);
+      const card = (await tdb.execute({
+        sql: "SELECT id, status, stage, assigned_bot, plan_ref, project_id FROM tasks_items WHERE id=?",
+        args: [id],
+      })).rows[0];
+      if (!card) return jsonError(res, 404, "card not found");
+      const bot = card.assigned_bot ? String(card.assigned_bot) : "";
+      if (!bot) return jsonError(res, 400, "card has no assigned_bot");
+      const botRow = (await cdb.execute({
+        sql: "SELECT bot_id FROM pi_bot_defs WHERE bot_id=? AND enabled=1", args: [bot],
+      })).rows[0];
+      if (!botRow) return jsonError(res, 400, "assigned_bot not found or disabled");
+      let planExists = false;
+      try {
+        const info = await resolveCardPlan(cdb, card);
+        planExists = !info.error && existsSync(info.path);
+      } catch { planExists = false; }
+      const eff = effectiveStage(card, planExists);
+      if (eff !== "ready") return res.status(409).json({ reason: "card is not Ready (stage: " + eff + ")" });
+      await tdb.execute({
+        sql: "UPDATE tasks_items SET stage='executing', status='in_progress', updated_at=datetime('now') WHERE id=?",
+        args: [id],
+      });
+      if (!process.env.CROW_BOARD_DISPATCH_DRYRUN) {
+        const { spawn } = await import("node:child_process");
+        const NODE_BIN = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
+        const BRIDGE = HOME + "/crow/scripts/pi-bots/bridge.mjs";
+        const payload = JSON.stringify({
+          bot_id: bot, gateway_type: "board", gateway_thread_id: "board-card-" + id,
+          user_message: "execute #" + id,
+        });
+        const child = spawn(NODE_BIN, [BRIDGE, "--inject", payload],
+          { cwd: HOME, stdio: ["ignore", "ignore", "ignore"], detached: true });
+        child.unref();
+      }
+      return res.json({ ok: true, dispatched: bot });
+    } catch (e) {
+      return jsonError(res, 500, String(e.message || e));
+    } finally {
+      if (tdb) { try { tdb.close(); } catch {} }
+      if (cdb) { try { cdb.close(); } catch {} }
+    }
+  });
+
   // ---- create project ----
   router.post(P + "/project", async (req, res) => {
     const b = req.body || {};

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -117,6 +117,31 @@ async function derivePlanPath(cdb, card) {
   return null;
 }
 
+// plan_ref-aware resolution: repo refs resolve under the project's repo_path
+// (400-style null when unset — NEVER fall back to the workspace for a repo
+// ref); null/workspace refs keep the legacy derived path. Returns
+// { path, root, kind } or { error } for the endpoints to translate.
+async function resolveCardPlan(cdb, card) {
+  const ref = parsePlanRef(card.plan_ref);
+  if (ref && ref.kind === "repo") {
+    let repoRoot = null;
+    if (card.project_id != null) {
+      try {
+        const p = (await cdb.execute({
+          sql: "SELECT repo_path FROM project_spaces WHERE id=?", args: [Number(card.project_id)],
+        })).rows[0];
+        repoRoot = p && p.repo_path ? String(p.repo_path) : null;
+      } catch { repoRoot = null; }
+    }
+    const r = resolvePlanFile(ref, { repoRoot, workspaceInfo: null });
+    if (!r) return { error: "repo plan_ref set but project has no repo_path" };
+    return r;
+  }
+  const info = await derivePlanPath(cdb, card);
+  const r = resolvePlanFile(ref, { repoRoot: null, workspaceInfo: info });
+  if (!r) return { error: "no bot is linked to this project" };
+  return r;
+}
 
 // Fail-closed pi-liveness (Step-1 pinned pattern, recorded in the plan's
 // Verified Claims): a process is "the live pi holding bot_sessions row R"
@@ -371,16 +396,20 @@ export default function botBoardApiRouter(dashboardAuth) {
     let tdb, cdb;
     try {
       tdb = createDbClient(TASKS_DB);
-      const card = (await tdb.execute({ sql: "SELECT id, project_id FROM tasks_items WHERE id=?", args: [id] })).rows[0];
+      const card = (await tdb.execute({ sql: "SELECT id, project_id, plan_ref FROM tasks_items WHERE id=?", args: [id] })).rows[0];
       if (!card) return jsonError(res, 404, "card not found");
       cdb = createDbClient();
-      const info = await derivePlanPath(cdb, card);
-      if (!info) return res.json({ exists: false, markdown: "", mtime: null, reason: "no bot is linked to this project" });
-      const real = containedRealPath(info.path, info.sessionDir);
-      if (!real) return jsonError(res, 400, "plan path escapes the bot workspace");
-      if (!existsSync(info.path)) return res.json({ exists: false, markdown: "", mtime: null });
+      const info = await resolveCardPlan(cdb, card);
+      if (info.error) {
+        return info.error.startsWith("no bot")
+          ? res.json({ exists: false, markdown: "", mtime: null, reason: info.error })
+          : jsonError(res, 400, info.error);
+      }
+      const real = containedRealPath(info.path, info.root);
+      if (!real) return jsonError(res, 400, "plan path escapes its root");
+      if (!existsSync(info.path)) return res.json({ exists: false, markdown: "", mtime: null, kind: info.kind });
       const mtime = String(statSync(info.path).mtimeMs);
-      return res.json({ exists: true, markdown: readFileSync(info.path, "utf8"), mtime });
+      return res.json({ exists: true, markdown: readFileSync(info.path, "utf8"), mtime, kind: info.kind });
     } catch (e) {
       return jsonError(res, 500, String(e.message || e));
     } finally {
@@ -401,12 +430,14 @@ export default function botBoardApiRouter(dashboardAuth) {
       const { locked } = await lockState(cdb, id);
       if (locked) return res.status(409).json({ reason: "bot is working this card" });
       tdb = createDbClient(TASKS_DB);
-      const card = (await tdb.execute({ sql: "SELECT id, project_id FROM tasks_items WHERE id=?", args: [id] })).rows[0];
+      const card = (await tdb.execute({ sql: "SELECT id, project_id, plan_ref FROM tasks_items WHERE id=?", args: [id] })).rows[0];
       if (!card) return jsonError(res, 404, "card not found");
-      const info = await derivePlanPath(cdb, card);
-      if (!info) return jsonError(res, 400, "no bot is linked to this project — no plan path");
-      const real = containedRealPath(info.path, info.sessionDir);
-      if (!real) return jsonError(res, 400, "plan path escapes the bot workspace");
+      const info = await resolveCardPlan(cdb, card);
+      if (info.error) return jsonError(res, 400, info.error);
+      const real = containedRealPath(info.path, info.root);
+      if (!real) return jsonError(res, 400, "plan path escapes its root");
+      // repo plans may live in a not-yet-created .pi/plans/ — create it (contained).
+      mkdirSync(info.path.slice(0, info.path.lastIndexOf("/")), { recursive: true });
       const exists = existsSync(info.path);
       if (exists) {
         // Optimistic concurrency: the client's mtime (from its GET) must

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -593,6 +593,53 @@ export default function botBoardApiRouter(dashboardAuth) {
     }
   });
 
+  // ---- plan dispatch: local-model planning run (spec: hybrid dispatch A) ----
+  router.post(P + "/card/:id/plan-dispatch", async (req, res) => {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id)) return jsonError(res, 400, "bad id");
+    let tdb, cdb;
+    try {
+      cdb = createDbClient();
+      const { locked } = await lockState(cdb, id);
+      if (locked) return res.status(409).json({ reason: "bot is working this card" });
+      tdb = createDbClient(TASKS_DB);
+      const card = (await tdb.execute({
+        sql: "SELECT id, status, stage, assigned_bot, plan_ref, project_id FROM tasks_items WHERE id=?",
+        args: [id],
+      })).rows[0];
+      if (!card) return jsonError(res, 404, "card not found");
+      const bot = card.assigned_bot ? String(card.assigned_bot) : "";
+      if (!bot) return jsonError(res, 400, "card has no assigned_bot");
+      const botRow = (await cdb.execute({
+        sql: "SELECT bot_id FROM pi_bot_defs WHERE bot_id=? AND enabled=1", args: [bot],
+      })).rows[0];
+      if (!botRow) return jsonError(res, 400, "assigned_bot not found or disabled");
+      const eff = effectiveStage(card, false);
+      if (eff !== "backlog" && eff !== "planning") {
+        return res.status(409).json({ reason: "plan dispatch is only legal from Backlog (stage: " + eff + ")" });
+      }
+      await tdb.execute({
+        sql: "UPDATE tasks_items SET stage='planning', status='pending', updated_at=datetime('now') WHERE id=?",
+        args: [id],
+      });
+      if (!process.env.CROW_BOARD_DISPATCH_DRYRUN) {
+        const { spawn } = await import("node:child_process");
+        const NODE_BIN = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
+        const BRIDGE = HOME + "/crow/scripts/pi-bots/bridge.mjs";
+        const payload = JSON.stringify({ cardId: id, botId: bot });
+        const child = spawn(NODE_BIN, [BRIDGE, "--plan-card", payload],
+          { cwd: HOME, stdio: ["ignore", "ignore", "ignore"], detached: true });
+        child.unref();
+      }
+      return res.json({ ok: true, dispatched: bot });
+    } catch (e) {
+      return jsonError(res, 500, String(e.message || e));
+    } finally {
+      if (tdb) { try { tdb.close(); } catch {} }
+      if (cdb) { try { cdb.close(); } catch {} }
+    }
+  });
+
   // ---- create project ----
   router.post(P + "/project", async (req, res) => {
     const b = req.body || {};

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -434,10 +434,21 @@ export default function botBoardApiRouter(dashboardAuth) {
       if (!card) return jsonError(res, 404, "card not found");
       const info = await resolveCardPlan(cdb, card);
       if (info.error) return jsonError(res, 400, info.error);
+      // Containment BEFORE creation, on the deepest EXISTING ancestor — so a
+      // symlinked ancestor pointing outside the root is caught before mkdir
+      // can create anything through it. Then create the parent and re-verify
+      // the full path (still fail-closed).
+      const parentDir = info.path.slice(0, info.path.lastIndexOf("/"));
+      let probe = parentDir;
+      while (!existsSync(probe)) {
+        const i = probe.lastIndexOf("/");
+        if (i <= 0) break;
+        probe = probe.slice(0, i);
+      }
+      if (!containedRealPath(probe, info.root)) return jsonError(res, 400, "plan path escapes its root");
+      mkdirSync(parentDir, { recursive: true });
       const real = containedRealPath(info.path, info.root);
       if (!real) return jsonError(res, 400, "plan path escapes its root");
-      // repo plans may live in a not-yet-created .pi/plans/ — create it (contained).
-      mkdirSync(info.path.slice(0, info.path.lastIndexOf("/")), { recursive: true });
       const exists = existsSync(info.path);
       if (exists) {
         // Optimistic concurrency: the client's mtime (from its GET) must

--- a/servers/gateway/routes/plan-ref.js
+++ b/servers/gateway/routes/plan-ref.js
@@ -1,0 +1,56 @@
+// plan_ref: the card's pointer to its plan file. kind "repo" = markdown in
+// the project's git repo (canonical, spec decision #1), resolved under
+// project_spaces.repo_path; kind "workspace" = the legacy derived path
+// <bot session_dir>/plans/<cardId>.md. Fail-closed everywhere: a ref that
+// doesn't parse is null; a path that escapes its root is null.
+import { existsSync, realpathSync } from "node:fs";
+
+export function parsePlanRef(text) {
+  if (text == null || text === "") return null;
+  let o;
+  try { o = JSON.parse(String(text)); } catch { return null; }
+  if (!o || typeof o !== "object") return null;
+  if (o.kind === "workspace") return { kind: "workspace" };
+  if (o.kind === "repo") {
+    const p = typeof o.path === "string" ? o.path : "";
+    if (!p || p.startsWith("/") || p.split("/").includes("..")) return null;
+    return { kind: "repo", path: p };
+  }
+  return null;
+}
+
+// Moved VERBATIM from bot-board-api.js (Task 3): resolved file must live
+// under root; for a not-yet-existing file, resolve+contain the parent dir.
+export function containedRealPath(path, root) {
+  try {
+    const rootReal = realpathSync(root);
+    let real;
+    if (existsSync(path)) {
+      real = realpathSync(path);
+    } else {
+      const slash = path.lastIndexOf("/");
+      const dir = path.slice(0, slash);
+      if (!existsSync(dir)) return null;
+      real = realpathSync(dir) + path.slice(slash);
+    }
+    if (real === rootReal || real.startsWith(rootReal + "/")) return real;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// planRef + context → { path, root, kind } or null. repoRoot comes from
+// project_spaces.repo_path; workspaceInfo is the legacy derivePlanPath()
+// result ({ path, sessionDir }). Null planRef = legacy card → workspace.
+export function resolvePlanFile(planRef, { repoRoot, workspaceInfo }) {
+  if (planRef && planRef.kind === "repo") {
+    if (!repoRoot) return null;
+    const root = String(repoRoot).replace(/\/+$/, "");
+    return { path: root + "/" + planRef.path, root, kind: "repo" };
+  }
+  if (workspaceInfo && workspaceInfo.path && workspaceInfo.sessionDir) {
+    return { path: workspaceInfo.path, root: workspaceInfo.sessionDir, kind: "workspace" };
+  }
+  return null;
+}

--- a/tests/board-plan-dispatch.test.js
+++ b/tests/board-plan-dispatch.test.js
@@ -1,0 +1,23 @@
+// tests/board-plan-dispatch.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractPlanFileLine, buildPlanPrompt } from "../scripts/pi-bots/plan_dispatch.mjs";
+
+test("extractPlanFileLine finds the last well-formed marker, rejects escapes", () => {
+  assert.equal(extractPlanFileLine("done\nPLAN_FILE: .pi/plans/2026-07-12-card-9-auth.md\n"),
+    ".pi/plans/2026-07-12-card-9-auth.md");
+  assert.equal(extractPlanFileLine("PLAN_FILE: .pi/plans/a.md\nPLAN_FILE: .pi/plans/b.md"),
+    ".pi/plans/b.md");
+  assert.equal(extractPlanFileLine("PLAN_FILE: /etc/passwd"), null);
+  assert.equal(extractPlanFileLine("PLAN_FILE: ../escape.md"), null);
+  assert.equal(extractPlanFileLine("no marker here"), null);
+});
+
+test("buildPlanPrompt embeds card fields and the marker contract", () => {
+  const p = buildPlanPrompt({ id: 9, title: "Add auth", description: "JWT please" }, ".pi/plans");
+  assert.ok(p.includes("CARD #9"));
+  assert.ok(p.includes("Add auth"));
+  assert.ok(p.includes("JWT please"));
+  assert.ok(p.includes("PLAN_FILE:"));
+  assert.ok(p.includes(".pi/plans"));
+});

--- a/tests/board-plan-dispatch.test.js
+++ b/tests/board-plan-dispatch.test.js
@@ -11,6 +11,8 @@ test("extractPlanFileLine finds the last well-formed marker, rejects escapes", (
   assert.equal(extractPlanFileLine("PLAN_FILE: /etc/passwd"), null);
   assert.equal(extractPlanFileLine("PLAN_FILE: ../escape.md"), null);
   assert.equal(extractPlanFileLine("no marker here"), null);
+  assert.equal(extractPlanFileLine("PLAN_FILE:    \r\n"), null);
+  assert.equal(extractPlanFileLine("PLAN_FILE:\n"), null);
 });
 
 test("buildPlanPrompt embeds card fields and the marker contract", () => {

--- a/tests/board-plan-ref.test.js
+++ b/tests/board-plan-ref.test.js
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parsePlanRef, resolvePlanFile, containedRealPath }
+  from "../servers/gateway/routes/plan-ref.js";
+
+test("parsePlanRef accepts only well-formed refs", () => {
+  assert.equal(parsePlanRef(null), null);
+  assert.equal(parsePlanRef(""), null);
+  assert.equal(parsePlanRef("not json"), null);
+  assert.deepEqual(parsePlanRef('{"kind":"workspace"}'), { kind: "workspace" });
+  assert.deepEqual(parsePlanRef('{"kind":"repo","path":".pi/plans/2026-07-12-x.md"}'),
+    { kind: "repo", path: ".pi/plans/2026-07-12-x.md" });
+  assert.equal(parsePlanRef('{"kind":"repo","path":"/etc/passwd"}'), null);      // absolute
+  assert.equal(parsePlanRef('{"kind":"repo","path":"../../secrets.md"}'), null); // traversal
+  assert.equal(parsePlanRef('{"kind":"repo"}'), null);                           // missing path
+  assert.equal(parsePlanRef('{"kind":"other","path":"x.md"}'), null);            // unknown kind
+});
+
+test("resolvePlanFile: repo refs join under repoRoot; workspace falls through", () => {
+  const r = resolvePlanFile({ kind: "repo", path: ".pi/plans/a.md" }, { repoRoot: "/repo", workspaceInfo: null });
+  assert.deepEqual(r, { path: "/repo/.pi/plans/a.md", root: "/repo", kind: "repo" });
+  assert.equal(resolvePlanFile({ kind: "repo", path: "a.md" }, { repoRoot: null, workspaceInfo: null }), null);
+  const w = resolvePlanFile({ kind: "workspace" },
+    { repoRoot: null, workspaceInfo: { path: "/ws/plans/7.md", sessionDir: "/ws" } });
+  assert.deepEqual(w, { path: "/ws/plans/7.md", root: "/ws", kind: "workspace" });
+  assert.equal(resolvePlanFile(null, { repoRoot: "/repo", workspaceInfo: null }), null);
+});
+
+test("containedRealPath refuses symlink escapes, allows real children", () => {
+  const root = mkdtempSync(join(tmpdir(), "pr-root-"));
+  const outside = mkdtempSync(join(tmpdir(), "pr-out-"));
+  mkdirSync(join(root, "plans"));
+  writeFileSync(join(root, "plans", "ok.md"), "x");
+  assert.ok(containedRealPath(join(root, "plans", "ok.md"), root));
+  assert.ok(containedRealPath(join(root, "plans", "new.md"), root)); // not-yet-existing file, real parent
+  writeFileSync(join(outside, "evil.md"), "x");
+  symlinkSync(join(outside, "evil.md"), join(root, "plans", "link.md"));
+  assert.equal(containedRealPath(join(root, "plans", "link.md"), root), null);
+});

--- a/tests/board-stage-api.test.js
+++ b/tests/board-stage-api.test.js
@@ -1,0 +1,106 @@
+// tests/board-stage-api.test.js
+// Harness: scratch tasks.db + crow.db via env, ephemeral express server,
+// plain fetch. dashboardAuth stub = pass-through (auth is not under test).
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+
+const dir = mkdtempSync(join(tmpdir(), "board-api-"));
+process.env.CROW_TASKS_DB_PATH = join(dir, "tasks.db");
+process.env.CROW_DB_PATH = join(dir, "crow.db");
+
+// Seed BEFORE importing the router (module reads env at import time).
+{
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  t.exec(`CREATE TABLE tasks_items (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL,
+    description TEXT, status TEXT NOT NULL DEFAULT 'pending', priority INTEGER DEFAULT 3,
+    due_date TEXT, owner TEXT, tags TEXT, parent_id INTEGER, project_id INTEGER,
+    stage TEXT, assigned_bot TEXT, plan_ref TEXT,
+    created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now')), completed_at TEXT)`);
+  t.prepare("INSERT INTO tasks_items (title, project_id) VALUES ('card one', 1)").run();
+  t.close();
+  const c = new Database(process.env.CROW_DB_PATH);
+  c.exec(`CREATE TABLE project_spaces (id INTEGER PRIMARY KEY, name TEXT, slug TEXT,
+      workspace_dir TEXT, tasks_db_uri TEXT, archived_at TEXT, repo_path TEXT);
+    CREATE TABLE pi_bot_defs (bot_id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+      definition TEXT, enabled INTEGER NOT NULL DEFAULT 1, project_id INTEGER);
+    CREATE TABLE bot_sessions (id INTEGER PRIMARY KEY AUTOINCREMENT, bot_id TEXT NOT NULL,
+      card_id INTEGER, status TEXT NOT NULL DEFAULT 'active', control TEXT NOT NULL DEFAULT 'run',
+      pi_session_dir TEXT, kind TEXT NOT NULL DEFAULT 'chat', updated_at TEXT DEFAULT (datetime('now')))`);
+  c.prepare("INSERT INTO project_spaces (id, name, slug, repo_path) VALUES (1, 'proj', 'proj', NULL)").run();
+  c.prepare("INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled, project_id) VALUES ('scout', 'Scout', '{}', 1, 1)").run();
+  c.close();
+}
+
+let server, base;
+before(async () => {
+  const { default: express } = await import("express");
+  const { default: botBoardApiRouter } = await import("../servers/gateway/routes/bot-board-api.js");
+  const app = express();
+  app.use(express.json());
+  app.use(botBoardApiRouter((req, res, next) => next())); // auth stub
+  await new Promise((r) => { server = app.listen(0, r); });
+  base = "http://127.0.0.1:" + server.address().port + "/dashboard/bot-board-api";
+});
+after(() => server && server.close());
+
+test("GET card returns stage columns + effectiveStage (legacy null stage, no plan → backlog)", async () => {
+  const r = await (await fetch(base + "/card/1")).json();
+  assert.equal(r.card.stage, null);
+  assert.equal(r.effectiveStage, "backlog");
+  assert.ok(Object.hasOwn(r.card, "assigned_bot") && Object.hasOwn(r.card, "plan_ref"));
+  assert.ok(Object.hasOwn(r.projects[0], "repo_path"));
+});
+
+test("move by stage writes stage AND projected status atomically", async () => {
+  const r = await fetch(base + "/card/1/move", { method: "POST",
+    headers: { "content-type": "application/json" }, body: JSON.stringify({ stage: "executing" }) });
+  assert.equal(r.status, 200);
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  const row = t.prepare("SELECT stage, status, completed_at FROM tasks_items WHERE id=1").get();
+  t.close();
+  assert.equal(row.stage, "executing");
+  assert.equal(row.status, "in_progress");
+  assert.equal(row.completed_at, null);
+});
+
+test("move to done sets completed_at; back out clears it; bad stage 400s", async () => {
+  await fetch(base + "/card/1/move", { method: "POST",
+    headers: { "content-type": "application/json" }, body: JSON.stringify({ stage: "done" }) });
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  assert.ok(t.prepare("SELECT completed_at FROM tasks_items WHERE id=1").get().completed_at);
+  t.close();
+  await fetch(base + "/card/1/move", { method: "POST",
+    headers: { "content-type": "application/json" }, body: JSON.stringify({ stage: "ready" }) });
+  const t2 = new Database(process.env.CROW_TASKS_DB_PATH);
+  const row = t2.prepare("SELECT stage, status, completed_at FROM tasks_items WHERE id=1").get();
+  t2.close();
+  assert.deepEqual([row.stage, row.status, row.completed_at], ["ready", "pending", null]);
+  const bad = await fetch(base + "/card/1/move", { method: "POST",
+    headers: { "content-type": "application/json" }, body: JSON.stringify({ stage: "bogus" }) });
+  assert.equal(bad.status, 400);
+});
+
+test("legacy move by status still works unchanged", async () => {
+  const r = await fetch(base + "/card/1/move", { method: "POST",
+    headers: { "content-type": "application/json" }, body: JSON.stringify({ status: "in_progress" }) });
+  assert.equal(r.status, 200);
+});
+
+test("assigned_bot: set to known bot OK, unknown 400, clear OK", async () => {
+  const ok = await fetch(base + "/card/1", { method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ title: "card one", assigned_bot: "scout" }) });
+  assert.equal(ok.status, 200);
+  const bad = await fetch(base + "/card/1", { method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ title: "card one", assigned_bot: "nope" }) });
+  assert.equal(bad.status, 400);
+  const clear = await fetch(base + "/card/1", { method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ title: "card one", assigned_bot: "" }) });
+  assert.equal(clear.status, 200);
+});

--- a/tests/board-stage-api.test.js
+++ b/tests/board-stage-api.test.js
@@ -185,3 +185,21 @@ test("execute: refuses without assigned_bot, refuses when not Ready, dispatches 
   t4.close();
   assert.deepEqual([row.stage, row.status], ["executing", "in_progress"]);
 });
+
+test("plan-dispatch: only legal from backlog/planning; moves stage to planning", async () => {
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  t.prepare("UPDATE tasks_items SET stage='ready', assigned_bot='scout' WHERE id=1").run();
+  t.close();
+  const notBacklog = await fetch(base + "/card/1/plan-dispatch", { method: "POST" });
+  assert.equal(notBacklog.status, 409);
+  const t2 = new Database(process.env.CROW_TASKS_DB_PATH);
+  t2.prepare("UPDATE tasks_items SET stage='backlog', status='pending' WHERE id=1").run();
+  t2.close();
+  process.env.CROW_BOARD_DISPATCH_DRYRUN = "1";
+  const ok = await (await fetch(base + "/card/1/plan-dispatch", { method: "POST" })).json();
+  delete process.env.CROW_BOARD_DISPATCH_DRYRUN;
+  assert.equal(ok.ok, true);
+  const t3 = new Database(process.env.CROW_TASKS_DB_PATH);
+  assert.equal(t3.prepare("SELECT stage FROM tasks_items WHERE id=1").get().stage, "planning");
+  t3.close();
+});

--- a/tests/board-stage-api.test.js
+++ b/tests/board-stage-api.test.js
@@ -158,3 +158,30 @@ test("first plan save into a repo with NO .pi/plans tree creates it (contained)"
   t2.prepare("UPDATE tasks_items SET plan_ref=NULL WHERE id=1").run();
   t2.close();
 });
+
+test("execute: refuses without assigned_bot, refuses when not Ready, dispatches when Ready", async () => {
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  t.prepare("UPDATE tasks_items SET stage='ready', status='pending', assigned_bot=NULL WHERE id=1").run();
+  t.close();
+  const noBot = await fetch(base + "/card/1/execute", { method: "POST" });
+  assert.equal(noBot.status, 400);
+
+  const t2 = new Database(process.env.CROW_TASKS_DB_PATH);
+  t2.prepare("UPDATE tasks_items SET assigned_bot='scout', stage='backlog', status='pending' WHERE id=1").run();
+  t2.close();
+  const notReady = await fetch(base + "/card/1/execute", { method: "POST" });
+  assert.equal(notReady.status, 409);
+
+  const t3 = new Database(process.env.CROW_TASKS_DB_PATH);
+  t3.prepare("UPDATE tasks_items SET stage='ready' WHERE id=1").run();
+  t3.close();
+  process.env.CROW_BOARD_DISPATCH_DRYRUN = "1"; // test seam: skip the real spawn
+  const ok = await (await fetch(base + "/card/1/execute", { method: "POST" })).json();
+  delete process.env.CROW_BOARD_DISPATCH_DRYRUN;
+  assert.equal(ok.ok, true);
+  assert.equal(ok.dispatched, "scout");
+  const t4 = new Database(process.env.CROW_TASKS_DB_PATH);
+  const row = t4.prepare("SELECT stage, status FROM tasks_items WHERE id=1").get();
+  t4.close();
+  assert.deepEqual([row.stage, row.status], ["executing", "in_progress"]);
+});

--- a/tests/board-stage-api.test.js
+++ b/tests/board-stage-api.test.js
@@ -104,3 +104,36 @@ test("assigned_bot: set to known bot OK, unknown 400, clear OK", async () => {
     body: JSON.stringify({ title: "card one", assigned_bot: "" }) });
   assert.equal(clear.status, 200);
 });
+
+test("plan GET/POST honors a repo plan_ref, contained under repo_path", async () => {
+  const { mkdtempSync: mkd, mkdirSync: mkdir, writeFileSync: wf } = await import("node:fs");
+  const repo = mkd(join(tmpdir(), "board-repo-"));
+  mkdir(join(repo, ".pi", "plans"), { recursive: true });
+  wf(join(repo, ".pi", "plans", "card-1.md"), "# the plan\n");
+  const c = new Database(process.env.CROW_DB_PATH);
+  c.prepare("UPDATE project_spaces SET repo_path=? WHERE id=1").run(repo);
+  c.close();
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  t.prepare("UPDATE tasks_items SET plan_ref=? WHERE id=1")
+    .run(JSON.stringify({ kind: "repo", path: ".pi/plans/card-1.md" }));
+  t.close();
+  const g = await (await fetch(base + "/card/1/plan")).json();
+  assert.equal(g.exists, true);
+  assert.equal(g.kind, "repo");
+  assert.equal(g.markdown, "# the plan\n");
+  const p = await fetch(base + "/card/1/plan", { method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ markdown: "# edited\n", mtime: g.mtime }) });
+  assert.equal(p.status, 200);
+});
+
+test("repo plan_ref with no repo_path on the project → 400, never a fallback", async () => {
+  const c = new Database(process.env.CROW_DB_PATH);
+  c.prepare("UPDATE project_spaces SET repo_path=NULL WHERE id=1").run();
+  c.close();
+  const g = await fetch(base + "/card/1/plan");
+  assert.equal(g.status, 400);
+  const t = new Database(process.env.CROW_TASKS_DB_PATH); // restore for later tests
+  t.prepare("UPDATE tasks_items SET plan_ref=NULL WHERE id=1").run();
+  t.close();
+});

--- a/tests/board-stage-api.test.js
+++ b/tests/board-stage-api.test.js
@@ -137,3 +137,24 @@ test("repo plan_ref with no repo_path on the project → 400, never a fallback",
   t.prepare("UPDATE tasks_items SET plan_ref=NULL WHERE id=1").run();
   t.close();
 });
+
+test("first plan save into a repo with NO .pi/plans tree creates it (contained)", async () => {
+  const { mkdtempSync: mkd } = await import("node:fs");
+  const repo = mkd(join(tmpdir(), "board-repo-bare-"));
+  const c = new Database(process.env.CROW_DB_PATH);
+  c.prepare("UPDATE project_spaces SET repo_path=? WHERE id=1").run(repo);
+  c.close();
+  const t = new Database(process.env.CROW_TASKS_DB_PATH);
+  t.prepare("UPDATE tasks_items SET plan_ref=? WHERE id=1")
+    .run(JSON.stringify({ kind: "repo", path: ".pi/plans/first.md" }));
+  t.close();
+  const p = await fetch(base + "/card/1/plan", { method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ markdown: "# first plan\n" }) });
+  assert.equal(p.status, 200);
+  const g = await (await fetch(base + "/card/1/plan")).json();
+  assert.equal(g.markdown, "# first plan\n");
+  const t2 = new Database(process.env.CROW_TASKS_DB_PATH); // restore for any later tests
+  t2.prepare("UPDATE tasks_items SET plan_ref=NULL WHERE id=1").run();
+  t2.close();
+});

--- a/tests/board-stages-migration.test.js
+++ b/tests/board-stages-migration.test.js
@@ -1,0 +1,64 @@
+// tests/board-stages-migration.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { execFileSync } from "node:child_process";
+
+const NODE = process.execPath;
+
+function scratchDbs() {
+  const dir = mkdtempSync(join(tmpdir(), "board-mig-"));
+  const tasksDb = join(dir, "tasks.db");
+  const crowDb = join(dir, "crow.db");
+  const t = new Database(tasksDb);
+  t.exec(`CREATE TABLE tasks_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL,
+    description TEXT, status TEXT NOT NULL DEFAULT 'pending',
+    priority INTEGER DEFAULT 3, due_date TEXT, owner TEXT, tags TEXT,
+    parent_id INTEGER, project_id INTEGER, phase TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')), completed_at TEXT)`);
+  t.close();
+  const c = new Database(crowDb);
+  c.exec(`CREATE TABLE project_spaces (id INTEGER PRIMARY KEY, name TEXT, slug TEXT,
+    workspace_dir TEXT, tasks_db_uri TEXT, archived_at TEXT);
+    CREATE TABLE bot_sessions (id INTEGER PRIMARY KEY AUTOINCREMENT, bot_id TEXT NOT NULL,
+    card_id INTEGER, status TEXT NOT NULL DEFAULT 'active', control TEXT NOT NULL DEFAULT 'run',
+    updated_at TEXT DEFAULT (datetime('now')))`);
+  c.close();
+  return { tasksDb, crowDb };
+}
+
+function cols(dbPath, table) {
+  const d = new Database(dbPath);
+  const names = d.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
+  d.close();
+  return names;
+}
+
+function runMigration(env) {
+  execFileSync(NODE, ["scripts/migrate-board-stages.mjs"], {
+    env: { ...process.env, ...env }, encoding: "utf8",
+  });
+}
+
+test("adds stage/assigned_bot/plan_ref + repo_path + kind, idempotently", () => {
+  const { tasksDb, crowDb } = scratchDbs();
+  const env = { CROW_TASKS_DB_PATH: tasksDb, CROW_DB_PATH: crowDb };
+  runMigration(env);
+  for (const c of ["stage", "assigned_bot", "plan_ref"]) assert.ok(cols(tasksDb, "tasks_items").includes(c), c);
+  assert.ok(cols(crowDb, "project_spaces").includes("repo_path"));
+  assert.ok(cols(crowDb, "bot_sessions").includes("kind"));
+  runMigration(env); // second run must be a clean no-op
+  assert.equal(cols(tasksDb, "tasks_items").filter((c) => c === "stage").length, 1);
+});
+
+test("tolerates absent tables (primary gateway)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "board-mig-empty-"));
+  const tasksDb = join(dir, "tasks.db"); const crowDb = join(dir, "crow.db");
+  new Database(tasksDb).close(); new Database(crowDb).close();
+  runMigration({ CROW_TASKS_DB_PATH: tasksDb, CROW_DB_PATH: crowDb }); // must not throw
+});

--- a/tests/board-stages.test.js
+++ b/tests/board-stages.test.js
@@ -1,0 +1,36 @@
+// tests/board-stages.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { STAGES, isStage, stageToStatus, effectiveStage, statusToStage, TERMINAL_STAGES }
+  from "../servers/gateway/routes/board-stages.js";
+
+test("stage vocabulary and projection", () => {
+  assert.deepEqual(STAGES, ["backlog", "planning", "ready", "executing", "done", "cancelled"]);
+  assert.equal(stageToStatus("backlog"), "pending");
+  assert.equal(stageToStatus("planning"), "pending");
+  assert.equal(stageToStatus("ready"), "pending");
+  assert.equal(stageToStatus("executing"), "in_progress");
+  assert.equal(stageToStatus("done"), "done");
+  assert.equal(stageToStatus("cancelled"), "cancelled");
+  assert.ok(TERMINAL_STAGES.has("done") && TERMINAL_STAGES.has("cancelled"));
+  assert.ok(isStage("ready") && !isStage("pending") && !isStage(""));
+});
+
+test("effectiveStage: explicit stage wins; legacy null-stage derives from status+plan", () => {
+  assert.equal(effectiveStage({ stage: "planning", status: "pending" }, true), "planning");
+  assert.equal(effectiveStage({ stage: null, status: "done" }, false), "done");
+  assert.equal(effectiveStage({ stage: null, status: "cancelled" }, true), "cancelled");
+  assert.equal(effectiveStage({ stage: null, status: "in_progress" }, false), "executing");
+  assert.equal(effectiveStage({ stage: null, status: "pending" }, true), "ready");   // spec: null stage + plan = Ready
+  assert.equal(effectiveStage({ stage: null, status: "pending" }, false), "backlog"); // spec: null stage, no plan = Backlog
+  assert.equal(effectiveStage({ stage: "bogus", status: "pending" }, false), "backlog"); // invalid stored stage falls back
+});
+
+test("statusToStage: bot-written status reconciles onto stage, preserving pre-exec refinement", () => {
+  assert.equal(statusToStage("done", "executing"), "done");
+  assert.equal(statusToStage("cancelled", "ready"), "cancelled");
+  assert.equal(statusToStage("in_progress", "ready"), "executing");
+  assert.equal(statusToStage("pending", "planning"), "planning"); // bot bounced it back: keep refinement
+  assert.equal(statusToStage("pending", "executing"), "ready");   // was executing, bot reset: Ready (plan exists by then)
+  assert.equal(statusToStage("pending", null), "ready");
+});


### PR DESCRIPTION
Implements Plan 1 of the board–plan unification design (pi-lab docs/specs/2026-07-10-board-plan-unification-design.md):

- **Canonical `stage` column** (backlog → planning → ready → executing → done/cancelled) with the legacy 4-value `status` as a projection written in the same statement; the bridge's post-turn reconcile is the only other stage writer (null-stage legacy cards are never stamped — they behave exactly as today).
- **Card-level `assigned_bot`** (validated against enabled `pi_bot_defs`), replacing the implicit first-bot-in-project rule for dispatch.
- **`plan_ref` pointers**: repo plans live in the project repo (`.pi/plans/…`, resolved under a new `project_spaces.repo_path` with fail-closed realpath containment); workspace plans keep the legacy derived path byte-for-byte.
- **Execute-from-board**: `POST /card/:id/execute` (Ready-only, lock-checked) dispatches the assigned bot through the existing `bridge --inject` seam with `gateway_type:"board"`; the execute prompt resolves the plan via `plan_ref`.
- **Local-only plan dispatch**: `POST /card/:id/plan-dispatch` spawns a confined planning run (`bash: deny`, `write_paths` limited to `.pi/plans` + `docs`, policy MERGED onto the bot's own so external-send/confirm belts survive, `multi_agent` forced off); refuses any resolved provider other than `crow-local` — paid models structurally cannot launch unattended. Planning sessions take the single-writer card lock (`bot_sessions.kind='planning'`).

Migration is guarded-ALTER, additive, absent-table tolerant (`scripts/migrate-board-stages.mjs`). Zero new npm deps. 41/41 board tests pass; full suite clean except the pre-existing registry-drift failure (present at base 5ced7c1a, untouched by this branch).

## ⚠️ Deploy gate (do this BEFORE restarting gateway or bridge, both instances)

Run `node scripts/migrate-board-stages.mjs` against the live DBs first. Two independent traps on a pre-migration DB:
- bridge: `upsertSession` now binds `kind` unconditionally — every bot session write throws (blast radius: all bots, not just board features);
- gateway: `GET /card/:id`, `/move`, and plan GET/POST now SELECT `stage`/`assigned_bot`/`plan_ref` — the existing drawer and legacy status moves 500.

## Remaining acceptance (operator)

End-to-end smoke on the MPA instance per the plan's Task 8 Step 2 (scratch chore card → assign → plan in drawer → Ready → execute → `## Result` + stage done; legacy card + chat pickup regression).

## Review trail

Subagent-driven: per-task spec+quality reviews, two review loops (first-repo-plan-save containment ordering; planCard setup-failure lock release), final whole-branch review (verdict: ready) with a fix wave (plan_ref-aware execute prompt; merged planning policy; null-stage reconcile guard; dispatch spawn hardening). Non-blocking follow-ons noted in the review: repo-ref-unresolvable should abort instead of degrading to the legacy path; unify GET card's planExists with resolveCardPlan when the pi-lab /card extension lands; per-card planning session dirs; route-level symlinked-ancestor test.