### PR TITLE
fix(dashboard): bug-hunt squash round 1 — Identity section, missing i18n labels, sync-conflicts cap

### DIFF
--- a/servers/gateway/dashboard/settings/sections/identity.js
+++ b/servers/gateway/dashboard/settings/sections/identity.js
@@ -14,8 +14,8 @@ export default {
 
   async getPreview() {
     try {
-      const { getOrCreateIdentity } = await import("../../../../sharing/identity.js");
-      const identity = await getOrCreateIdentity();
+      const { loadOrCreateIdentity } = await import("../../../../sharing/identity.js");
+      const identity = await loadOrCreateIdentity();
       return identity.crowId?.slice(0, 12) + "..." || "";
     } catch {
       return "";
@@ -24,11 +24,11 @@ export default {
 
   async render({ lang }) {
     try {
-      const { getOrCreateIdentity } = await import("../../../../sharing/identity.js");
-      const identity = await getOrCreateIdentity();
+      const { loadOrCreateIdentity } = await import("../../../../sharing/identity.js");
+      const identity = await loadOrCreateIdentity();
       return `<div style="font-family:'JetBrains Mono',monospace;font-size:0.85rem">
         <div style="margin-bottom:0.5rem"><span style="color:var(--crow-text-muted)">${t("settings.crowId", lang)}</span> ${escapeHtml(identity.crowId)}</div>
-        <div><span style="color:var(--crow-text-muted)">${t("settings.ed25519", lang)}</span> ${escapeHtml(identity.ed25519Public?.slice(0, 16))}...</div>
+        <div><span style="color:var(--crow-text-muted)">${t("settings.ed25519", lang)}</span> ${escapeHtml(identity.ed25519Pubkey?.slice(0, 16))}...</div>
       </div>`;
     } catch {
       return `<p style="color:var(--crow-text-muted)">${t("settings.identityNotAvailable", lang)}</p>`;

--- a/servers/gateway/dashboard/settings/sections/sync-conflicts.js
+++ b/servers/gateway/dashboard/settings/sections/sync-conflicts.js
@@ -197,10 +197,15 @@ export default {
 
     let unresolvedRows = [];
     let resolvedRows = [];
+    let unresolvedTotal = 0;
     let dbError = null;
     try {
       const { rows: unresolved } = await db.execute({
-        sql: `SELECT * FROM sync_conflicts WHERE resolved = 0 ORDER BY created_at DESC`,
+        sql: `SELECT * FROM sync_conflicts WHERE resolved = 0 ORDER BY created_at DESC LIMIT 200`,
+        args: [],
+      });
+      const { rows: unresolvedCount } = await db.execute({
+        sql: `SELECT COUNT(*) AS n FROM sync_conflicts WHERE resolved = 0`,
         args: [],
       });
       const { rows: resolved } = await db.execute({
@@ -208,6 +213,7 @@ export default {
         args: [],
       });
       unresolvedRows = unresolved;
+      unresolvedTotal = Number(unresolvedCount[0]?.n || 0);
       resolvedRows = resolved;
     } catch (err) {
       dbError = err.message || "Unknown error";
@@ -264,6 +270,12 @@ export default {
            ${escapeHtml(t("syncConflicts.noneResolved", lang))}
          </td></tr>`;
 
+    const overLimitNotice = unresolvedTotal > 200
+      ? `<div style="margin-bottom:0.75rem;padding:0.6rem 0.75rem;background:var(--crow-bg-deep);border-left:3px solid #ff9800;border-radius:4px;font-size:0.82rem;color:var(--crow-text-muted)">
+           ${escapeHtml(t("syncConflicts.showingFirst", lang).replace("{n}", String(unresolvedTotal)))}
+         </div>`
+      : "";
+
     const bulkResolveBtn = unresolvedRows.length > 0
       ? `<form method="POST" action="/dashboard/settings"
               style="margin-top:0.75rem"
@@ -293,6 +305,8 @@ export default {
       ${escapeHtml(t("syncConflicts.unresolvedHeading", lang))}
       ${unresolvedRows.length > 0 ? `<span style="font-size:0.78rem;color:#e53935;margin-left:0.4rem">(${unresolvedRows.length})</span>` : ""}
     </h3>
+
+    ${overLimitNotice}
 
     <div style="overflow-x:auto">
       <table class="sc-table">

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1094,6 +1094,8 @@ export const translations = {
   "settings.group.account": { en: "Account", es: "Cuenta" },
 
   // ─── Settings Section Labels ───
+  "settings.section.unifiedDashboard": { en: "Unified Dashboard", es: "Panel unificado" },
+  "settings.section.sharedStorage": { en: "Shared Storage", es: "Almacenamiento compartido" },
   "settings.section.theme": { en: "Theme", es: "Tema" },
   "settings.section.language": { en: "Language", es: "Idioma" },
   "settings.section.notifications": { en: "Notifications", es: "Notificaciones" },

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1184,6 +1184,7 @@ export const translations = {
     es: "¿Marcar todos los conflictos sin resolver como resueltos? Se mantendrá la versión actual (ganadora) de cada elemento.",
   },
   "syncConflicts.loadError": { en: "Failed to load conflicts", es: "Error al cargar conflictos" },
+  "syncConflicts.showingFirst": { en: "Showing first 200 of {n}", es: "Mostrando los primeros 200 de {n}" },
   "syncConflicts.msgApplied": { en: "The other version was restored.", es: "La otra versión fue restaurada." },
   "syncConflicts.msgStale": { en: "This item has changed since the conflict was recorded — please review the current version and confirm again.", es: "Este elemento ha cambiado desde que se registró el conflicto — revisa la versión actual y confirma de nuevo." },
   "syncConflicts.msgRefused": { en: "This version can't be restored automatically; its data remains visible below.", es: "Esta versión no se puede restaurar automáticamente; sus datos siguen visibles abajo." },

--- a/tests/settings-i18n-section-labels.test.js
+++ b/tests/settings-i18n-section-labels.test.js
@@ -1,0 +1,23 @@
+/**
+ * F2 (BH-1/2) — `settings.section.unifiedDashboard` (unified-dashboard.js:18)
+ * and `settings.section.sharedStorage` (shared-storage.js:62) were absent
+ * from shared/i18n.js, so t() fell through to its raw-key fallback and the
+ * menu label / page heading / breadcrumb rendered the literal key.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { t } from "../servers/gateway/dashboard/shared/i18n.js";
+
+test("settings.section.unifiedDashboard and .sharedStorage resolve in en + es", () => {
+  const cases = [
+    ["settings.section.unifiedDashboard", "en", "Unified Dashboard"],
+    ["settings.section.unifiedDashboard", "es", "Panel unificado"],
+    ["settings.section.sharedStorage", "en", "Shared Storage"],
+    ["settings.section.sharedStorage", "es", "Almacenamiento compartido"],
+  ];
+  for (const [key, lang, expected] of cases) {
+    const value = t(key, lang);
+    assert.notEqual(value, key, `t(${key}, ${lang}) must not fall back to the raw key`);
+    assert.equal(value, expected);
+  }
+});

--- a/tests/settings-identity-section.test.js
+++ b/tests/settings-identity-section.test.js
@@ -1,0 +1,57 @@
+/**
+ * F1 (BH-3) — Settings > Identity was permanently "Identity not available"
+ * because the section imported the non-existent `getOrCreateIdentity` (the
+ * real export is `loadOrCreateIdentity`) and, once that import is fixed,
+ * read the non-existent `ed25519Public` field (the real field is
+ * `ed25519Pubkey`).
+ *
+ * sharing/identity.js resolves DATA_DIR/IDENTITY_PATH as module-level consts
+ * at import time, so CROW_DATA_DIR must be set BEFORE the module is ever
+ * imported in a process — this test renders the section in a fresh child
+ * process (a throwaway script file) rather than mutating env after import.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dirname, "..");
+const SECTION_PATH = join(REPO_ROOT, "servers/gateway/dashboard/settings/sections/identity.js");
+
+function renderIdentitySection(dataDir) {
+  const script = `
+    import section from ${JSON.stringify(SECTION_PATH)};
+    const html = await section.render({ lang: "en" });
+    process.stdout.write(html);
+  `;
+  const scriptPath = join(dataDir, "_render.mjs");
+  writeFileSync(scriptPath, script);
+  return execFileSync(process.execPath, [scriptPath], {
+    env: { ...process.env, CROW_DATA_DIR: dataDir },
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+}
+
+test("identity section renders a real crow: id and non-empty ed25519 hex, not the placeholder", () => {
+  const dir = mkdtempSync(join(tmpdir(), "settings-identity-"));
+  try {
+    const html = renderIdentitySection(dir);
+
+    assert.ok(
+      !/Identity not available/.test(html),
+      "must NOT show the identityNotAvailable placeholder (broken import throws, caught, placeholder rendered)",
+    );
+
+    const crowIdMatch = html.match(/crow:[0-9a-z]+/);
+    assert.ok(crowIdMatch, "must render a real crow: id");
+
+    const ed25519Match = html.match(/Ed25519:<\/span>\s*([0-9a-f]*)\.\.\./);
+    assert.ok(ed25519Match, "must render the Ed25519 line with a hex value");
+    assert.ok(ed25519Match[1].length > 0, "ed25519 value must be NON-EMPTY (not escapeHtml(undefined) -> '')");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/settings-sync-conflicts-limit.test.js
+++ b/tests/settings-sync-conflicts-limit.test.js
@@ -1,0 +1,78 @@
+/**
+ * F3 (BH-5a) — the unresolved sync_conflicts SELECT had no LIMIT (the
+ * resolved SELECT already has LIMIT 25). With the live fleet count growing
+ * daily (BH-5b, out of scope here) the page grows unboundedly. Fix: cap the
+ * unresolved query at 200 rows and, when the true unresolved count exceeds
+ * 200, show an honest "showing first 200 of N" notice above the list —
+ * never a silent truncation.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import section from "../servers/gateway/dashboard/settings/sections/sync-conflicts.js";
+
+const dirs = [];
+after(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+function fresh() {
+  const dir = mkdtempSync(join(tmpdir(), "sync-conflicts-limit-"));
+  dirs.push(dir);
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  return createClient({ url: "file:" + join(dir, "crow.db") });
+}
+
+async function seedUnresolved(db, count) {
+  for (let i = 0; i < count; i++) {
+    await db.execute({
+      sql: `INSERT INTO sync_conflicts
+              (table_name, row_id, winning_instance_id, losing_instance_id,
+               winning_lamport_ts, losing_lamport_ts, winning_data, losing_data, resolved, op)
+            VALUES (?, ?, 'inst-a', 'inst-b', ?, ?, '{}', '{}', 0, 'update')`,
+      args: ["test_table", `row-${i}`, i + 1, i],
+    });
+  }
+}
+
+function fakeReq() {
+  return { csrfToken: "test-csrf", query: {} };
+}
+
+test("205 unresolved rows: render caps at 200 rows and shows the honest 'showing first 200 of 205' notice", async () => {
+  const db = fresh();
+  try {
+    await seedUnresolved(db, 205);
+    const html = await section.render({ req: fakeReq(), db, lang: "en" });
+
+    const rowMatches = html.match(/row-\d+/g) || [];
+    assert.equal(rowMatches.length, 200, "unresolved table must be capped at 200 rendered rows");
+
+    assert.match(html, /Showing first 200 of 205/, "must show the honest over-limit notice naming the true total");
+  } finally {
+    await db.close();
+  }
+});
+
+test("5 unresolved rows: no over-limit notice", async () => {
+  const db = fresh();
+  try {
+    await seedUnresolved(db, 5);
+    const html = await section.render({ req: fakeReq(), db, lang: "en" });
+
+    const rowMatches = html.match(/row-\d+/g) || [];
+    assert.equal(rowMatches.length, 5, "all 5 rows render");
+
+    assert.ok(!/Showing first/.test(html), "no notice when under the limit");
+  } finally {
+    await db.close();
+  }
+});


### PR DESCRIPTION
## What

Three fixes from the 2026-07-11 drive-as-user CDP bug-hunt round (standing QA directive; 122 checks against the live dashboard, evidence at `~/.crow/p4/bughunt-20260711/`). Spec (2-round adversarial Opus review, R1 APPROVE / R2 folds): `docs/superpowers/specs/2026-07-11-bughunt-squash-design.md`.

- **F1 (BH-3, MAJOR)** Settings → Identity has shown "Identity not available" on every request since the section was written: it imports `getOrCreateIdentity`, which doesn't exist (`servers/sharing/identity.js` exports `loadOrCreateIdentity`). R2 found the swap alone would un-mask a second bug — the render reads `identity.ed25519Public`, also nonexistent (`ed25519Pubkey` is real) — so both are fixed and the test asserts a non-empty Ed25519 value, not just the crow id.
- **F2 (BH-1/2, MINOR)** `settings.section.unifiedDashboard` / `settings.section.sharedStorage` were missing from i18n → raw keys rendered in menu, heading, and breadcrumb. Full sweep confirmed these are the only two missing labels (all 25 others + all 7 group keys present).
- **F3 (BH-5a, MAJOR-UI-half)** The unresolved sync-conflicts query had no LIMIT (211 live rows and climbing daily from the providers sync loop) → `LIMIT 200` + independent `COUNT(*)` + an honest "Showing first 200 of {n}" notice (call-site `.replace()` per codebase convention; `t()` doesn't interpolate). `resolve_all` remains unscoped by the display cap; the nest banner's count is COUNT(*)-driven and unaffected.

**Deliberately excluded (pooled as their own work items):** BH-4 CRIT — the maker-lab *bundle* 500s on the dropped `research_projects` table (bundle migration + learner-data archaeology; `project_spaces` shows Bluebird×5 dupes); BH-5b root cause — per-instance-volatile `models` field in the fleet-synced `providers/crow-local` row (same modeling wart family as F-10's `host`); BH-6 — meta-glasses 15s 404 poll; the latent `/discover/profile` wrong-field-name twin of F1 (`boot/peer-public-api.js:61-62`).

## Verification

- TDD: each fix red→green; mutations red-then-restored (F1 import + field name; F3 LIMIT + notice), final reviewer independently re-red-verified the F1 field-name mutation.
- Suite: 1401 pass / 1 fail / 1 skip — the 1 fail is the pre-existing rookery registry drift.
- Final whole-branch Opus review: **READY TO MERGE, 0 Critical / 0 Important** (capped-badge-vs-notice adjudicated honest-as-shipped; follow-up only).
- **CDP browser proof 4/4** on a scratch gateway running this branch: Identity renders the real `crow:` id + non-empty Ed25519; both section labels human-readable; 205 seeded conflicts render 200 rows + "Showing first 200 of 205" (screenshots `sq-01…04` in the evidence dir).

No schema change. Deploy is a plain fleet pull+restart; post-deploy check is the three-page CDP re-run on prod.