### PR TITLE
feat(bundles): version-aware refresh for installed first-party bundles — revives Maker Lab (BH-4)

### DIFF
--- a/bundles/maker-lab/manifest.json
+++ b/bundles/maker-lab/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "maker-lab",
   "name": "Maker Lab",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
   "type": "mcp-server",
   "author": "Crow",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -2741,7 +2741,7 @@
     {
       "id": "maker-lab",
       "name": "Maker Lab",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
       "type": "mcp-server",
       "author": "Crow",
@@ -4853,6 +4853,91 @@
       "official": true
     },
     {
+      "id": "rookery",
+      "name": "Rookery Reviewer",
+      "version": "0.1.0",
+      "description": "Self-hosted OpenScience reviewer + experiment-audit workspace assembler — audit a report's numeric claims against its registered evidence, on your own local model",
+      "type": "bundle",
+      "author": "kh0pper",
+      "category": "ai",
+      "tags": [
+        "research",
+        "audit",
+        "provenance",
+        "openscience",
+        "self-hosted"
+      ],
+      "icon": "search",
+      "docker": {
+        "composefile": "docker-compose.yml"
+      },
+      "server": {
+        "command": "./run.sh",
+        "args": [],
+        "envKeys": [
+          "ROOKERY_WORKSPACES_DIR",
+          "ROOKERY_REVIEWER_URL",
+          "UV_NO_CACHE"
+        ]
+      },
+      "panel": "panel/rookery.js",
+      "panelRoutes": "panel/routes.js",
+      "requires": {
+        "env": [
+          "ROOKERY_MODEL_BASE_URL"
+        ],
+        "min_ram_mb": 512,
+        "min_disk_mb": 1600
+      },
+      "env_vars": [
+        {
+          "name": "ROOKERY_MODEL_BASE_URL",
+          "description": "OpenAI-compatible endpoint for the reviewer model (e.g. a local llama.cpp/vLLM server; find your configured endpoint in Crow's AI settings). For a server on the Docker host use http://host.docker.internal:<port>/v1",
+          "required": true
+        },
+        {
+          "name": "ROOKERY_MODEL_ID",
+          "description": "Model id as reported by the endpoint's /v1/models",
+          "default": "local-model",
+          "required": true
+        },
+        {
+          "name": "ROOKERY_MODEL_API_KEY",
+          "description": "API key if the endpoint needs one (local servers usually ignore it)",
+          "default": "local",
+          "required": false,
+          "secret": true
+        },
+        {
+          "name": "ROOKERY_WORKSPACES_DIR",
+          "description": "Host directory where audit workspaces are assembled (shared by the reviewer and the assemble tool)",
+          "default": "~/.crow/data/rookery/workspaces",
+          "required": false
+        },
+        {
+          "name": "ROOKERY_CORS_ORIGINS",
+          "description": "Space-separated browser origins for the app's own CORS/CSRF whitelist. RECOMMENDED: set to your serving origin when the reviewer is served beyond localhost. Empty = shim strips Origin (fine for tunnel/localhost use; disables the app's origin check)",
+          "required": false
+        },
+        {
+          "name": "ROOKERY_REVIEWER_URL",
+          "description": "Where the reviewer UI is reachable on your deployment (serve 127.0.0.1:3061 at a ROOT origin: Tailscale Serve HTTPS port, reverse proxy, or ssh -L tunnel). Shown by the panel and the assemble tool",
+          "required": false
+        },
+        {
+          "name": "UV_NO_CACHE",
+          "description": "Disable uv's download cache for the host MCP process (prevents multi-GB cache growth)",
+          "default": "1",
+          "required": false
+        }
+      ],
+      "ports": [
+        3061
+      ],
+      "notes": "Self-hosted only — never configure the vendor's Atlas/cloud layer. The reviewer runs entirely on the endpoint you provide. Assembled workspaces contain COPIES of your report + evidence; originals are never modified. NO webUI block on purpose: the app cannot live behind the gateway's /proxy/<id>/ subpath (root-absolute asset paths baked in its binary) — serve 127.0.0.1:3061 at a root origin and set ROOKERY_REVIEWER_URL (see README).",
+      "official": true
+    },
+    {
       "id": "scratch-offline",
       "name": "Offline Block Coding (Scratch-compatible)",
       "version": "1.0.0",
@@ -6089,91 +6174,6 @@
       "webUI": null,
       "notes": "No host port publish. Expose via Caddy after install: caddy_add_federation_site { domain: WF_HOST, upstream: 'writefreely:8080', profile: 'activitypub' }. On first-run the admin account is created via the web UI; there is no CLI bootstrap.",
       "official": true
-    },
-    {
-      "id": "rookery",
-      "name": "Rookery Reviewer",
-      "version": "0.1.0",
-      "description": "Self-hosted OpenScience reviewer + experiment-audit workspace assembler — audit a report's numeric claims against its registered evidence, on your own local model",
-      "type": "bundle",
-      "author": "kh0pper",
-      "category": "ai",
-      "tags": [
-        "research",
-        "audit",
-        "provenance",
-        "openscience",
-        "self-hosted"
-      ],
-      "icon": "search",
-      "docker": {
-        "composefile": "docker-compose.yml"
-      },
-      "server": {
-        "command": "./run.sh",
-        "args": [],
-        "envKeys": [
-          "ROOKERY_WORKSPACES_DIR",
-          "ROOKERY_REVIEWER_URL",
-          "UV_NO_CACHE"
-        ]
-      },
-      "panel": "panel/rookery.js",
-      "panelRoutes": "panel/routes.js",
-      "requires": {
-        "env": [
-          "ROOKERY_MODEL_BASE_URL"
-        ],
-        "min_ram_mb": 512,
-        "min_disk_mb": 1600
-      },
-      "env_vars": [
-        {
-          "name": "ROOKERY_MODEL_BASE_URL",
-          "description": "OpenAI-compatible endpoint for the reviewer model (e.g. a local llama.cpp/vLLM server; find your configured endpoint in Crow's AI settings). For a server on the Docker host use http://host.docker.internal:<port>/v1",
-          "required": true
-        },
-        {
-          "name": "ROOKERY_MODEL_ID",
-          "description": "Model id as reported by the endpoint's /v1/models",
-          "default": "local-model",
-          "required": true
-        },
-        {
-          "name": "ROOKERY_MODEL_API_KEY",
-          "description": "API key if the endpoint needs one (local servers usually ignore it)",
-          "default": "local",
-          "required": false,
-          "secret": true
-        },
-        {
-          "name": "ROOKERY_WORKSPACES_DIR",
-          "description": "Host directory where audit workspaces are assembled (shared by the reviewer and the assemble tool)",
-          "default": "~/.crow/data/rookery/workspaces",
-          "required": false
-        },
-        {
-          "name": "ROOKERY_CORS_ORIGINS",
-          "description": "Space-separated browser origins for the app's own CORS/CSRF whitelist. RECOMMENDED: set to your serving origin when the reviewer is served beyond localhost. Empty = shim strips Origin (fine for tunnel/localhost use; disables the app's origin check)",
-          "required": false
-        },
-        {
-          "name": "ROOKERY_REVIEWER_URL",
-          "description": "Where the reviewer UI is reachable on your deployment (serve 127.0.0.1:3061 at a ROOT origin: Tailscale Serve HTTPS port, reverse proxy, or ssh -L tunnel). Shown by the panel and the assemble tool",
-          "required": false
-        },
-        {
-          "name": "UV_NO_CACHE",
-          "description": "Disable uv's download cache for the host MCP process (prevents multi-GB cache growth)",
-          "default": "1",
-          "required": false
-        }
-      ],
-      "ports": [
-        3061
-      ],
-      "notes": "Self-hosted only — never configure the vendor's Atlas/cloud layer. The reviewer runs entirely on the endpoint you provide. Assembled workspaces contain COPIES of your report + evidence; originals are never modified. NO webUI block on purpose: the app cannot live behind the gateway's /proxy/<id>/ subpath (root-absolute asset paths baked in its binary) — serve 127.0.0.1:3061 at a root origin and set ROOKERY_REVIEWER_URL (see README).",
-      "official": false
     }
   ]
 }

--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -141,7 +141,7 @@ export async function mountMcpServers(app, deps) {
   // re-copy them from the app repo. Prevents the Companion migration gap from recurring.
   try {
     const { repairInstalledBundleAssets } = await import("../routes/bundles.js");
-    const { repaired, errors } = repairInstalledBundleAssets();
+    const { repaired, errors } = await repairInstalledBundleAssets();
     if (repaired.length > 0) {
       console.log(`[bundles] Repaired assets: ${repaired.join("; ")}`);
     }

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -22,7 +22,7 @@ import bus from "../../shared/event-bus.js";
 import { isSupervised } from "../../shared/supervisor.js";
 import { createDbClient } from "../../db.js";
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync, copyFileSync, unlinkSync, symlinkSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync, copyFileSync, unlinkSync, symlinkSync, statSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -257,20 +257,207 @@ function emitJobChanged(job) {
 
 /** Read installed.json as array */
 /**
- * Repair missing bundle UI artifacts for already-installed bundles.
+ * First path segment of a manifest-declared path, or null for a falsy/non-string
+ * input. Used to derive extra refresh-eligible roots from manifest.server.args[0],
+ * .panel, .panelRoutes, .skills[] — see isValidPathSegment for the guard that
+ * keeps a hostile declared path (e.g. "../x") from ever being joined.
+ */
+function firstPathSegment(p) {
+  if (!p || typeof p !== "string") return null;
+  const seg = p.split("/")[0];
+  return seg || null;
+}
+
+/** A single, plain, non-traversal path segment (no "/", not "." or ".."). */
+function isValidPathSegment(seg) {
+  return typeof seg === "string" && seg.length > 0 && seg !== "." && seg !== ".." && !seg.includes("/") && !seg.includes("\\");
+}
+
+/**
+ * Copy one explicit-include item (a top-level file or a directory) from a
+ * bundle's repo source into its installed dest dir. No-op (returns false) if
+ * the item doesn't exist in the repo source. cpSync is additive: dest-only
+ * files not present in the source survive.
+ */
+function copyBundleRefreshItem(appSrc, destDir, item) {
+  const src = join(appSrc, item);
+  if (!existsSync(src)) return false;
+  const dst = join(destDir, item);
+  if (statSync(src).isDirectory()) {
+    cpSync(src, dst, { recursive: true });
+  } else {
+    mkdirSync(dirname(dst), { recursive: true });
+    copyFileSync(src, dst);
+  }
+  return true;
+}
+
+/**
+ * True iff the repo package.json declares a dependency NAME absent from the
+ * installed bundle's node_modules/ — the ONLY npm-install trigger (R1/R2:
+ * narrow, added-dep-only; a removed dep or a version-range-only bump must NOT
+ * fire a boot-time npm install). existsSync(join(nm, depName)) handles
+ * @scope/name naturally.
+ */
+function bundleNeedsNpmInstall(appSrc, destDir) {
+  const pkg = readJsonSafe(join(appSrc, "package.json"), null);
+  if (!pkg || !pkg.dependencies || typeof pkg.dependencies !== "object") return false;
+  const nodeModules = join(destDir, "node_modules");
+  return Object.keys(pkg.dependencies).some((depName) => !existsSync(join(nodeModules, depName)));
+}
+
+/**
+ * D1 (BH-4): version-keyed refresh of one installed first-party bundle.
+ *
+ * If the repo manifest and the installed manifest are both readable and their
+ * `version` strings differ (both-undefined counts as EQUAL — crow's no-version
+ * bundles like vllm/llama must never churn; otherwise a difference in either
+ * direction refreshes, since the repo is the source of truth and installed
+ * copies are snapshots, not forks), this:
+ *   1. Copies the explicit-include set of code artifacts from appSrc → destDir
+ *      (type-aware: docker-surface bundles get a narrower set, since existing
+ *      docker bundles bind-mount config/scripts/etc into LIVE containers and a
+ *      refresh must never mutate a running container's mounts).
+ *   2. Re-copies the served PANELS_DIR artifacts (<id>.js, <id>-routes.js),
+ *      rmSync-first for determinism, and ensures the PANELS_DIR node_modules
+ *      symlink exists (install-parity — an April-era install may predate it).
+ *   3. Runs `npm install --omit=dev` in destDir, via the injected runner,
+ *      ONLY when an added dependency name triggers it (warn-only; never
+ *      throws into the caller).
+ *
+ * Returns null (caller falls back to the existing missing-only repair) when
+ * either manifest is unreadable/missing or the versions are equal. Otherwise
+ * returns { oldVersion, newVersion, touched }.
+ */
+async function refreshVersionedBundle({ id, appSrc, destDir, runner }) {
+  const repoManifest = readJsonSafe(join(appSrc, "manifest.json"), null);
+  const installedManifest = readJsonSafe(join(destDir, "manifest.json"), null);
+  if (!repoManifest || !installedManifest) return null;
+
+  const oldVersion = installedManifest.version;
+  const newVersion = repoManifest.version;
+  const bothUndefined = oldVersion === undefined && newVersion === undefined;
+  if (bothUndefined || oldVersion === newVersion) return null;
+
+  const isDocker = !!repoManifest.docker;
+  const touched = [];
+
+  // Explicit-include set (R1 MAJOR-4: generalized to cover JS AND Python
+  // first-party bundles). R2 MAJOR-2: type-aware restriction — docker-surface
+  // bundles get ONLY manifest.json/settings-section.js/server//panel//skills/
+  // + validated manifest-declared roots, NEVER config/scripts/templates/src
+  // (existing bundles bind-mount exactly those into live containers).
+  const topFiles = isDocker
+    ? ["manifest.json", "settings-section.js"]
+    : ["manifest.json", "package.json", "package-lock.json", "pyproject.toml", "uv.lock", "settings-section.js", "main.py", "run.sh", "config.py"];
+  const dirs = isDocker
+    ? ["server", "panel", "skills"]
+    : ["server", "panel", "skills", "curriculum", "public", "scripts", "templates", "routes", "config", "src"];
+  // Never copied for ANY type: docker-compose.yml, Dockerfile, entrypoint.sh,
+  // .env*, node_modules/, data/ — simply absent from both lists above.
+
+  // Manifest-declared roots: the bundle contract is manifest-declaration-
+  // driven, so any path a manifest names is code by definition. Each is
+  // reduced to its first path segment and validated to a single plain segment
+  // before any join (R2 minor — same traversal class F-HEALTH-1 fixed for
+  // bundleId elsewhere in this file).
+  const declaredRoots = new Set();
+  const declare = (p) => {
+    const seg = firstPathSegment(p);
+    if (seg && isValidPathSegment(seg)) declaredRoots.add(seg);
+  };
+  if (repoManifest.server?.args?.[0]) declare(repoManifest.server.args[0]);
+  if (typeof repoManifest.panel === "string") declare(repoManifest.panel);
+  else if (repoManifest.panel && typeof repoManifest.panel === "object") declaredRoots.add("panel");
+  if (repoManifest.panelRoutes) declare(repoManifest.panelRoutes);
+  if (Array.isArray(repoManifest.skills)) {
+    for (const s of repoManifest.skills) declare(s);
+  }
+
+  for (const item of new Set([...topFiles, ...dirs, ...declaredRoots])) {
+    if (copyBundleRefreshItem(appSrc, destDir, item)) touched.push(item);
+  }
+
+  // Served panel artifacts — exactly as install does (bundles.js ~:1170-1184),
+  // rmSync-first (R1 minor: crow's live panel files are legacy symlinks into
+  // the bundle dir; cpSync-over-symlink is safe on Node 20, but rm-first is
+  // deterministic across Node versions, and post-refresh they're regular files).
+  mkdirSync(PANELS_DIR, { recursive: true });
+  const panelRelPath = resolvePanelPath(repoManifest, id);
+  if (panelRelPath) {
+    const panelSrc = join(destDir, panelRelPath);
+    if (existsSync(panelSrc)) {
+      const panelDst = join(PANELS_DIR, `${id}.js`);
+      rmSync(panelDst, { force: true });
+      cpSync(panelSrc, panelDst);
+      touched.push(`panels/${id}.js`);
+    }
+  }
+  if (repoManifest.panelRoutes) {
+    const routesSrc = join(destDir, repoManifest.panelRoutes);
+    if (existsSync(routesSrc)) {
+      const routesDst = join(PANELS_DIR, `${id}-routes.js`);
+      rmSync(routesDst, { force: true });
+      cpSync(routesSrc, routesDst);
+      touched.push(`panels/${id}-routes.js`);
+    }
+  }
+  // Install-parity: ensure the PANELS_DIR node_modules symlink exists (an
+  // April-era install may predate it — bundles.js:1186).
+  const nmLink = join(PANELS_DIR, "node_modules");
+  if (!existsSync(nmLink)) {
+    const gatewayNm = join(APP_ROOT, "node_modules");
+    if (existsSync(gatewayNm)) {
+      try { symlinkSync(gatewayNm, nmLink); } catch {}
+    }
+  }
+
+  // npm step: narrow, added-dep-name-only trigger; warn-only; via the
+  // injected runner so tests never shell out to a real npm.
+  if (bundleNeedsNpmInstall(appSrc, destDir)) {
+    try {
+      await runner("npm", ["install", "--omit=dev"], { cwd: destDir });
+      touched.push("npm install");
+    } catch (err) {
+      console.warn(`[bundles] npm install failed for ${id}: ${err.message}`);
+    }
+  }
+
+  console.log(`[bundles] refreshed ${id} ${oldVersion} -> ${newVersion}`);
+  return { oldVersion, newVersion, touched };
+}
+
+/**
+ * Repair missing bundle UI artifacts for already-installed bundles, and
+ * (D1, BH-4) refresh a bundle's installed copy when the repo manifest's
+ * version has moved past the installed manifest's version.
  *
  * Prior incident (2026-04-14): the Companion bundle's docker service was migrated
  * from grackle to crow, but ~/.crow/bundles/companion/settings-section.js was
  * absent on crow because only the docker volumes moved over. This meant the
  * Settings → Companion section disappeared until the file was manually copied.
  *
+ * Prior incident (2026-07-11, BH-4): W2-5 migrated bundles/maker-lab/ in-repo
+ * from research_projects to project_spaces, but the missing-only repair below
+ * never refreshes a file that's merely stale-but-present — the installed copy
+ * was an April snapshot, so /dashboard/maker-lab 500'd on `no such table:
+ * research_projects` for months. The version-keyed refresh phase (above,
+ * refreshVersionedBundle) is the fix: ANY version delta re-copies the
+ * bundle's code + served panel artifacts, since the repo is the source of
+ * truth. It runs BEFORE — and, when it fires, supersedes — the missing-only
+ * repair for that bundle.
+ *
  * This function idempotently re-copies settings-section.js and panel/ from the
- * app repo (APP_BUNDLES) into ~/.crow/bundles/<id>/ for every installed bundle.
+ * app repo (appBundles) into ~/.crow/bundles/<id>/ for every installed bundle.
  * It's safe to run on every gateway start — cpSync overwrites identical files.
  *
- * Returns { repaired: string[], errors: Array<{id, error}> }.
+ * @param {{appBundles?: string, run?: Function}} [opts]
+ *   appBundles: override the repo bundles root (test seam; defaults to APP_BUNDLES).
+ *   run: override the shell runner used for the npm-install step (test seam;
+ *        defaults to the module's `run`).
+ * @returns {Promise<{repaired: string[], errors: Array<{id, error}>}>}
  */
-export function repairInstalledBundleAssets() {
+export async function repairInstalledBundleAssets({ appBundles = APP_BUNDLES, run: runner = run } = {}) {
   const repaired = [];
   const errors = [];
 
@@ -288,13 +475,20 @@ export function repairInstalledBundleAssets() {
     const id = typeof entry === "string" ? entry : entry?.id;
     if (!id || !isValidBundleId(id)) continue;
 
-    const appSrc = join(APP_BUNDLES, id);
+    const appSrc = join(appBundles, id);
     if (!existsSync(appSrc)) continue; // not a first-party bundle — skip
 
     const destDir = join(BUNDLES_DIR, id);
     const touched = [];
     try {
       mkdirSync(destDir, { recursive: true });
+
+      // D1: version-keyed refresh phase, BEFORE the missing-only repair below.
+      const refreshed = await refreshVersionedBundle({ id, appSrc, destDir, runner });
+      if (refreshed) {
+        repaired.push(`${id}: refreshed ${refreshed.oldVersion} -> ${refreshed.newVersion} (${refreshed.touched.join(", ") || "no files changed"})`);
+        continue; // refresh fully supersedes the missing-only phase for this bundle
+      }
 
       // settings-section.js: single file — copy if missing or stale-size
       const settingsSrc = join(appSrc, "settings-section.js");

--- a/tests/bundle-version-refresh.test.js
+++ b/tests/bundle-version-refresh.test.js
@@ -1,0 +1,345 @@
+/**
+ * Bundle version-aware refresh (BH-4, D1) — tests/bundle-version-refresh.test.js
+ *
+ * `repairInstalledBundleAssets()` now runs a version-keyed refresh phase
+ * BEFORE its long-standing missing-only repair: for each installed first-party
+ * bundle whose repo manifest.version differs from the installed manifest's
+ * version (both-undefined counts as equal), it re-copies the bundle's
+ * explicit-include code artifacts + the served PANELS_DIR panel/routes files,
+ * and — only when a repo package.json declares a dependency name absent from
+ * the installed node_modules/ — runs a (test-injected) npm install.
+ *
+ * CROW_HOME is env-keyed (read once at module import) so the DEST side
+ * (~/.crow/bundles, ~/.crow/panels) is redirected to a scratch tmp dir set
+ * BEFORE the dynamic import below — this file never touches the real
+ * ~/.crow. The SOURCE side (the repo's bundles/ dir) is redirected per-call
+ * via the injectable `appBundles` param, so each test gets its own throwaway
+ * "repo". The npm runner is always the injected fake — no real npm ever runs.
+ */
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+/** Write `content` to `root/relPath`, creating parent dirs as needed. */
+function put(root, relPath, content) {
+  const p = join(root, relPath);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, content);
+}
+
+function readAt(root, relPath) {
+  return readFileSync(join(root, relPath), "utf8");
+}
+
+function freshRoot(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/** Fake npm runner: records calls, never shells out. */
+function fakeRunner() {
+  const calls = [];
+  const runner = async (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return { stdout: "", stderr: "" };
+  };
+  runner.calls = calls;
+  return runner;
+}
+
+let CROW_HOME;
+let repairInstalledBundleAssets;
+
+before(async () => {
+  CROW_HOME = freshRoot("crowhome-refresh-");
+  // Module-level const in bundles.js reads process.env.CROW_HOME once at
+  // import time — MUST be set before the dynamic import.
+  process.env.CROW_HOME = CROW_HOME;
+  ({ repairInstalledBundleAssets } = await import("../servers/gateway/routes/bundles.js"));
+});
+
+after(() => {
+  delete process.env.CROW_HOME;
+});
+
+/** Overwrite ~/.crow/installed.json (scratch CROW_HOME) with the given ids. */
+function setInstalled(ids) {
+  put(CROW_HOME, "installed.json", JSON.stringify(ids.map((id) => ({ id }))));
+}
+
+function destBundleDir(id) {
+  return join(CROW_HOME, "bundles", id);
+}
+function destPanelsDir() {
+  return join(CROW_HOME, "panels");
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 + 3: version differs → refresh runs; code + panel artifacts
+// overwritten; instance-local files (.env, data/, extra node_modules entry)
+// survive byte-identical.
+// ---------------------------------------------------------------------------
+describe("version differs → refresh (+ instance-local preservation)", () => {
+  const id = "widget-v";
+  let repoRoot;
+  let runner;
+  let result;
+
+  before(async () => {
+    repoRoot = freshRoot("crowrepo-widgetv-");
+    // --- repo (source) side: version 1.1.0 ---
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({
+      id, name: "Widget", version: "1.1.0", type: "mcp-server", category: "misc",
+      description: "d", server: { command: "node", args: ["server/index.js"] },
+      panel: `panel/${id}.js`, panelRoutes: "panel/routes.js", skills: [`skills/${id}.md`],
+    }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { leftpad: "^1.0.0" } }));
+    put(repoRoot, `${id}/server/index.js`, "console.log('v2 server');\n");
+    put(repoRoot, `${id}/panel/${id}.js`, "export default 'v2-panel';\n");
+    put(repoRoot, `${id}/panel/routes.js`, "export default 'v2-routes';\n");
+    put(repoRoot, `${id}/skills/${id}.md`, "# v2 skill\n");
+    put(repoRoot, `${id}/settings-section.js`, "export const settings = 'v2';\n");
+
+    // --- installed (dest) side: stale version 1.0.0 ---
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    put(CROW_HOME, `bundles/${id}/server/index.js`, "console.log('v1 STALE server');\n");
+    put(CROW_HOME, `bundles/${id}/.env`, "SECRET=abc123\n");
+    put(CROW_HOME, `bundles/${id}/data/marker.txt`, "learner-data\n");
+    // leftpad already present → the npm trigger for THIS bundle must stay silent.
+    put(CROW_HOME, `bundles/${id}/node_modules/leftpad/index.js`, "module.exports = () => {};\n");
+    put(CROW_HOME, `bundles/${id}/node_modules/extra-pkg/marker.js`, "extra file preserved\n");
+    put(CROW_HOME, `panels/${id}.js`, "OLD PANEL CONTENT\n");
+    put(CROW_HOME, `panels/${id}-routes.js`, "OLD ROUTES CONTENT\n");
+
+    setInstalled([id]);
+
+    // Single invocation — its outcome is asserted from multiple angles below
+    // (overwritten-vs-preserved). A second invocation would find manifest.json
+    // already equalized to 1.1.0 by the first run and correctly no-op, which
+    // would defeat a test that wants to observe the refresh itself.
+    runner = fakeRunner();
+    result = await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+  });
+
+  test("code files + panel artifacts are overwritten from the repo", () => {
+    assert.deepEqual(result.errors, []);
+    assert.ok(result.repaired.some((r) => r.includes(id)), "repaired list mentions the bundle");
+
+    assert.equal(readAt(destBundleDir(id), "server/index.js"), "console.log('v2 server');\n");
+    assert.equal(readAt(destBundleDir(id), "settings-section.js"), "export const settings = 'v2';\n");
+    assert.equal(readAt(destBundleDir(id), "skills/widget-v.md"), "# v2 skill\n");
+    assert.equal(JSON.parse(readAt(destBundleDir(id), "manifest.json")).version, "1.1.0");
+    assert.equal(readAt(destPanelsDir(), `${id}.js`), "export default 'v2-panel';\n");
+    assert.equal(readAt(destPanelsDir(), `${id}-routes.js`), "export default 'v2-routes';\n");
+
+    // leftpad already present in node_modules → no npm trigger for this bundle.
+    assert.equal(runner.calls.length, 0, "npm must not fire when no dep name is missing");
+  });
+
+  test("instance-local files survive the refresh byte-identical", () => {
+    assert.equal(readAt(destBundleDir(id), ".env"), "SECRET=abc123\n");
+    assert.equal(readAt(destBundleDir(id), "data/marker.txt"), "learner-data\n");
+    assert.equal(readAt(destBundleDir(id), "node_modules/extra-pkg/marker.js"), "extra file preserved\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: version equal → refresh phase is a no-op; existing missing-only
+// repair behavior is unchanged (a present-but-stale file is NOT touched; a
+// genuinely missing file still gets repaired).
+// ---------------------------------------------------------------------------
+describe("version equal → no refresh (missing-only behavior preserved)", () => {
+  const id = "widget-eq";
+  let repoRoot;
+
+  before(() => {
+    repoRoot = freshRoot("crowrepo-widgeteq-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "Widget Eq", version: "2.0.0", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/server/index.js`, "REPO CONTENT\n");
+    put(repoRoot, `${id}/settings-section.js`, "export const settings = 'repo';\n");
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "2.0.0", type: "mcp-server" }));
+    put(CROW_HOME, `bundles/${id}/server/index.js`, "DEST STALE CONTENT DIFFERENT\n");
+    // settings-section.js deliberately absent on the dest side — missing-only
+    // repair should still fill it in even though the refresh phase is a no-op.
+
+    setInstalled([id]);
+  });
+
+  test("a present-but-differing file is left untouched (no refresh fired)", async () => {
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(readAt(destBundleDir(id), "server/index.js"), "DEST STALE CONTENT DIFFERENT\n");
+    assert.equal(runner.calls.length, 0);
+  });
+
+  test("a genuinely missing file is still repaired by the existing missing-only phase", async () => {
+    assert.equal(readAt(destBundleDir(id), "settings-section.js"), "export const settings = 'repo';\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: npm trigger — added dep name fires; removed-dep-only and
+// version-range-only changes do NOT.
+// ---------------------------------------------------------------------------
+describe("npm trigger — added-dep-name-only", () => {
+  test("an added dependency name absent from installed node_modules fires npm", async () => {
+    const id = "widget-npm-added";
+    const repoRoot = freshRoot("crowrepo-npmadd-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { qrcode: "^1.5.0" } }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    // node_modules exists but has no qrcode/ dir — the ADDED dep.
+    put(CROW_HOME, `bundles/${id}/node_modules/.keep`, "");
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 1, "npm must fire for an added dep name");
+    assert.equal(runner.calls[0].cmd, "npm");
+    assert.deepEqual(runner.calls[0].args, ["install", "--omit=dev"]);
+    assert.equal(runner.calls[0].opts.cwd, destBundleDir(id));
+  });
+
+  test("a removed-dep-only change does NOT fire npm", async () => {
+    const id = "widget-npm-removed";
+    const repoRoot = freshRoot("crowrepo-npmrm-");
+    // Repo DROPS old-dep entirely; the only remaining dep (kept-dep) is
+    // already present on the installed side.
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "kept-dep": "^1.0.0" } }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    put(CROW_HOME, `bundles/${id}/node_modules/kept-dep/index.js`, "module.exports = {};\n");
+    put(CROW_HOME, `bundles/${id}/node_modules/old-dep/index.js`, "module.exports = {};\n"); // stale, no longer declared
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 0, "npm must NOT fire when nothing new was added");
+  });
+
+  test("a version-range-only change to an already-present dep does NOT fire npm", async () => {
+    const id = "widget-npm-range";
+    const repoRoot = freshRoot("crowrepo-npmrange-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "kept-dep": "^2.0.0" } })); // range bumped, name unchanged
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    put(CROW_HOME, `bundles/${id}/node_modules/kept-dep/index.js`, "module.exports = {};\n");
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 0, "npm must NOT fire on a version-range-only change");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4b: docker-type restriction (config/scripts NOT copied even if
+// present in the repo) + manifest-declared-root path-traversal rejection.
+// ---------------------------------------------------------------------------
+describe("4b — docker-type restriction + declared-root traversal rejection", () => {
+  test("docker-surface bundle: config/ and scripts/ are NOT copied even when present in repo", async () => {
+    const id = "widget-docker";
+    const repoRoot = freshRoot("crowrepo-docker-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({
+      id, name: "D", version: "2.0.0", type: "bundle", category: "misc", description: "d",
+      docker: { composefile: "docker-compose.yml" },
+    }));
+    put(repoRoot, `${id}/docker-compose.yml`, "services: {}\n");
+    put(repoRoot, `${id}/config/settings.yml`, "repo config\n");
+    put(repoRoot, `${id}/scripts/bootstrap.sh`, "#!/bin/sh\necho repo script\n");
+    put(repoRoot, `${id}/server/index.js`, "docker server v2\n"); // still allowed for docker type
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "bundle" }));
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+
+    assert.ok(!existsSync(join(destBundleDir(id), "config")), "config/ must not be copied for a docker-surface bundle");
+    assert.ok(!existsSync(join(destBundleDir(id), "scripts")), "scripts/ must not be copied for a docker-surface bundle");
+    assert.equal(readAt(destBundleDir(id), "server/index.js"), "docker server v2\n", "server/ is still copied for docker-surface bundles");
+  });
+
+  test("non-docker (mcp-server) bundle: config/ and scripts/ ARE copied", async () => {
+    const id = "widget-nondocker";
+    const repoRoot = freshRoot("crowrepo-nondocker-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "M", version: "2.0.0", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/config/settings.yml`, "repo config\n");
+    put(repoRoot, `${id}/scripts/bootstrap.sh`, "#!/bin/sh\necho repo script\n");
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    setInstalled([id]);
+
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: fakeRunner() });
+
+    assert.equal(readAt(destBundleDir(id), "config/settings.yml"), "repo config\n");
+    assert.equal(readAt(destBundleDir(id), "scripts/bootstrap.sh"), "#!/bin/sh\necho repo script\n");
+  });
+
+  test("a manifest-declared root of \"../x\" is rejected — no copy outside the bundle dir", async () => {
+    const id = "widget-traversal";
+    const repoRoot = freshRoot("crowrepo-traversal-");
+    // A hostile/malformed manifest declares a server entrypoint that walks up
+    // out of the bundle dir. Also plant the "escape" file just outside the
+    // bundle dir in the same repo root to prove it's never touched.
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({
+      id, name: "T", version: "2.0.0", type: "mcp-server", category: "misc", description: "d",
+      server: { command: "node", args: ["../x/evil.js"] },
+    }));
+    put(repoRoot, "x/evil.js", "should never be reachable via the bundle dir\n");
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    setInstalled([id]);
+
+    const { errors } = await repairInstalledBundleAssets({ appBundles: repoRoot, run: fakeRunner() });
+    assert.deepEqual(errors, []);
+    // The only valid first segment of "../x/evil.js" is "..", which must be
+    // rejected outright — no "../x" (or anything else escaping the bundle
+    // dir) may appear inside the installed bundle's directory.
+    assert.ok(!existsSync(join(destBundleDir(id), "..", "x")), "declared root must never escape the bundle dir");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: unreadable/missing installed manifest → falls back to missing-only
+// repair, no throw.
+// ---------------------------------------------------------------------------
+describe("unreadable/missing installed manifest → missing-only fallback, no throw", () => {
+  test("installed bundle with no manifest.json at all falls back cleanly", async () => {
+    const id = "widget-nomanifest";
+    const repoRoot = freshRoot("crowrepo-nomanifest-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "NM", version: "1.0.0", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/settings-section.js`, "export const settings = 'repo';\n");
+
+    // Dest dir exists but has never had a manifest.json copied to it.
+    mkdirSync(destBundleDir(id), { recursive: true });
+    setInstalled([id]);
+
+    const { repaired, errors } = await repairInstalledBundleAssets({ appBundles: repoRoot, run: fakeRunner() });
+    assert.deepEqual(errors, []);
+    // Missing-only phase still ran: settings-section.js + manifest.json get
+    // filled in because they were absent.
+    assert.equal(readAt(destBundleDir(id), "settings-section.js"), "export const settings = 'repo';\n");
+    assert.ok(JSON.parse(readAt(destBundleDir(id), "manifest.json")).id === id);
+    assert.ok(repaired.some((r) => r.includes(id)));
+  });
+
+  test("installed manifest.json that fails to parse falls back cleanly (no throw)", async () => {
+    const id = "widget-badjson";
+    const repoRoot = freshRoot("crowrepo-badjson-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "BJ", version: "1.0.0", type: "mcp-server", category: "misc", description: "d" }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, "{ not valid json !!");
+    setInstalled([id]);
+
+    await assert.doesNotReject(async () => {
+      const { errors } = await repairInstalledBundleAssets({ appBundles: repoRoot, run: fakeRunner() });
+      assert.deepEqual(errors, []);
+    });
+  });
+});

--- a/tests/gateway-shutdown.test.js
+++ b/tests/gateway-shutdown.test.js
@@ -89,8 +89,11 @@ function openSse(port, path) {
 /** Spawn a fresh gateway process; return { child, port, dataDir }. */
 async function spawnGateway() {
   const dataDir = mkdtempSync(join(tmpdir(), "gw-shutdown-"));
+  // Scratch CROW_HOME so the gateway's boot-time bundle/panel repair never
+  // touches the operator's real ~/.crow (see repairInstalledBundleAssets).
+  const crowHome = join(dataDir, "crow-home");
   execFileSync(process.execPath, ["scripts/init-db.js"], {
-    env: { ...process.env, CROW_DATA_DIR: dataDir },
+    env: { ...process.env, CROW_DATA_DIR: dataDir, CROW_HOME: crowHome },
     stdio: "pipe",
     cwd: join(import.meta.dirname, ".."),
   });
@@ -105,6 +108,7 @@ async function spawnGateway() {
       env: {
         ...process.env,
         CROW_DATA_DIR: dataDir,
+        CROW_HOME: crowHome,
         CROW_GATEWAY_URL: `http://127.0.0.1:${port}`,
         PORT: String(port),
         CROW_SHUTDOWN_DRAIN_MS: "500",

--- a/tests/wm-auth.test.js
+++ b/tests/wm-auth.test.js
@@ -115,9 +115,12 @@ let token = null;
 before(async () => {
   dataDir = mkdtempSync(join(tmpdir(), "wm-auth-"));
   const dbPath = join(dataDir, "crow.db");
+  // Scratch CROW_HOME so the gateway's boot-time bundle/panel repair never
+  // touches the operator's real ~/.crow (see repairInstalledBundleAssets).
+  const crowHome = join(dataDir, "crow-home");
 
   execFileSync(process.execPath, ["scripts/init-db.js"], {
-    env: { ...process.env, CROW_DATA_DIR: dataDir, CROW_DB_PATH: dbPath },
+    env: { ...process.env, CROW_DATA_DIR: dataDir, CROW_DB_PATH: dbPath, CROW_HOME: crowHome },
     stdio: "pipe",
     cwd: repoRoot,
   });
@@ -135,7 +138,7 @@ before(async () => {
     db.close();
   `;
   token = execFileSync(process.execPath, ["--input-type=module", "-e", mintScript], {
-    env: { ...process.env, CROW_DATA_DIR: dataDir, CROW_DB_PATH: dbPath },
+    env: { ...process.env, CROW_DATA_DIR: dataDir, CROW_DB_PATH: dbPath, CROW_HOME: crowHome },
     cwd: repoRoot,
     encoding: "utf8",
   }).trim();
@@ -148,6 +151,7 @@ before(async () => {
       ...process.env,
       CROW_DATA_DIR: dataDir,
       CROW_DB_PATH: dbPath,
+      CROW_HOME: crowHome,
       CROW_GATEWAY_URL: `http://127.0.0.1:${port}`,
       PORT: String(port),
     },


### PR DESCRIPTION
## What

`/dashboard/maker-lab` has been a hard 500 (`no such table: research_projects`) since June's W2-5 table drop — but the bundle *source* was already migrated to `project_spaces` back then. The real product bug: **installed first-party bundles never receive repo updates.** `repairInstalledBundleAssets()` only copies missing files, and W2-5 shipped without a bundle version bump, so crow's installed maker-lab (and its served panel at `~/.crow/panels/`) stayed an April snapshot forever.

Spec (2-round adversarial Opus review, both REVISE→folded): `docs/superpowers/specs/2026-07-11-bundle-version-refresh-design.md`. Operator directive: migrate the bundle; no learner-data recovery from backups.

- **D1** (`abe02d42`): version-keyed refresh phase in `repairInstalledBundleAssets` (now async + awaited at its only call site, injectable `{appBundles, run}` seams). Explicit-include copy generalized for JS+Python bundles; **type-aware**: docker-surface bundles refresh only `server//panel//skills/`+manifest (never `config//scripts/` — lemmy/maker-lab-advanced bind-mount those into live containers); single-segment validation on manifest-declared roots (F-HEALTH-1 traversal-class defense); rmSync-before-cpSync on served panels (crow's were legacy symlinks); PANELS_DIR `node_modules` link ensured (install-parity); npm only on an **added** dep name absent from `node_modules` (warn-only, bounded 300s). Instance files (`.env`, `data/`, dest-only content) structurally untouched.
- **D2** (`c52502b0`): maker-lab 0.1.0 → 0.1.1 + the **mandatory full registry regen** — which also absorbs the pre-existing rookery drift, flipping the long-red `bundle-contract` test green (regen diff verified: only maker-lab + rookery entries).
- **Leak fix** (`2615a269`): gateway-boot tests (`gateway-shutdown`, `wm-auth`) now scratch `CROW_HOME` — see incident below.

## Incident disclosure (benign outcome, real defect, fixed here)

During a full-suite run on crow, the two gateway-boot tests inherited the real `CROW_HOME` and the new refresh fired against prod's installed maker-lab (files at 07:23 CDT). The outcome was byte-for-byte the intended deploy end-state (verified: manifest 0.1.1, migrated code, panels identical-to-repo, nmLink created; the running gateway still serves the cached April module, so the page 500s until restart). The defect — "running the suite mutates the operator's `~/.crow`" — is fixed in `2615a269` with an empty-`find` proof (suite run leaves zero new mtimes under `~/.crow/bundles` + `~/.crow/panels`). Side effect: prod crow is already "pre-refreshed"; deploy just needs the restart.

## Verification

- 12 new tests (version trigger both directions, both-undefined-equal, docker-type gate, traversal rejection, instance-file preservation, npm added-dep-only trigger via recorded runner, missing-manifest fallback); **six mutations red-then-restored**, final reviewer independently re-red-verified two.
- `bundle-contract`: 24/25 → **25/25**. Full suite: **1434 pass / 0 fail / 1 skip** — first fully-green suite since the rookery drift began.
- Final whole-branch Opus review: **READY TO MERGE, 0 findings**; the "npm not type-gated" concern adjudicated correct (docker bundles' `server/` is a host-side node child that needs deps — `actual-budget` proof).
- Real-world refresh E2E: prod itself (via the incident) — April snapshot → 0.1.1 correctly, nmLink created.
- Post-merge deploy check: restart crow → CDP `/dashboard/maker-lab` renders (the BH-4 repro is the red case) + `PRAGMA integrity_check` after the bundle server's first spawn (its init-tables does a guarded FK-rebuild DDL pass on the shared crow.db).

No schema change (SCHEMA_GENERATION untouched).