### PR TITLE
fix(maker-lab): location-independent imports via CROW_APP_ROOT — completes the BH-4 migration

### DIFF
--- a/bundles/maker-lab/manifest.json
+++ b/bundles/maker-lab/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "maker-lab",
   "name": "Maker Lab",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
   "type": "mcp-server",
   "author": "Crow",

--- a/bundles/maker-lab/manifest.json
+++ b/bundles/maker-lab/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "maker-lab",
   "name": "Maker Lab",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
   "type": "mcp-server",
   "author": "Crow",

--- a/bundles/maker-lab/manifest.json
+++ b/bundles/maker-lab/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "maker-lab",
   "name": "Maker Lab",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
   "type": "mcp-server",
   "author": "Crow",

--- a/bundles/maker-lab/panel/maker-lab.js
+++ b/bundles/maker-lab/panel/maker-lab.js
@@ -23,9 +23,24 @@ import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import QRCode from "qrcode";
-import { createProjectSpace, updateProjectSpaceMeta } from "../../../servers/shared/project-spaces.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Inlined app-root resolver (BH-4 phase 2): this panel is copied ALONE into
+// ~/.crow/panels/ on install/refresh, so it cannot import a sibling
+// server/app-root.js — the logic is duplicated here, self-contained, using
+// the node:url/node:path/node:fs imports already above. Resolve the Crow
+// app repo root from an INSTALLED copy or an in-repo run; the gateway
+// exports CROW_APP_ROOT for itself and its spawned addon children, the
+// relative guess covers direct in-repo runs.
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const __appRootGuess = resolve(__dirname, "..", "..", "..");
+const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(__appRootGuess) ? __appRootGuess
+  : (process.env.CROW_APP_ROOT || __appRootGuess);
+const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);
+
+const { createProjectSpace, updateProjectSpaceMeta } = await appImport("servers/shared/project-spaces.js");
 
 // Sibling surfaces surfaced in the "Add more surfaces" card. Each entry
 // mirrors the bundle id in registry/add-ons.json; the install flow goes

--- a/bundles/maker-lab/panel/maker-lab.js
+++ b/bundles/maker-lab/panel/maker-lab.js
@@ -39,6 +39,10 @@ const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_
   : looksLikeAppRoot(__appRootGuess) ? __appRootGuess
   : (process.env.CROW_APP_ROOT || __appRootGuess);
 const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);
+// This panel's own lazy imports below target the BUNDLE's server/ dir (not
+// the app root's shared servers/ tree) — resolve through APP_ROOT +
+// bundles/maker-lab/server/, mirroring panel/routes.js's bundleImport().
+const bundleImport = (rel) => import(pathToFileURL(join(APP_ROOT, "bundles", "maker-lab", "server", rel)).href);
 
 const { createProjectSpace, updateProjectSpaceMeta } = await appImport("servers/shared/project-spaces.js");
 
@@ -90,7 +94,7 @@ function readInstalledBundleIds() {
 }
 
 async function loadDeviceBinding() {
-  return import(pathToFileURL(resolve(__dirname, "../server/device-binding.js")).href);
+  return bundleImport("device-binding.js");
 }
 
 export default {
@@ -105,7 +109,7 @@ export default {
     const componentsPath = join(appRoot, "servers/gateway/dashboard/shared/components.js");
     const { escapeHtml } = await import(pathToFileURL(componentsPath).href);
 
-    const sessionsMod = await import(pathToFileURL(resolve(__dirname, "../server/sessions.js")).href);
+    const sessionsMod = await bundleImport("sessions.js");
     const { mintSessionForLearner, mintGuestSession, mintBatchSessions } = sessionsMod;
 
     // ─── Helpers ─────────────────────────────────────────────────────────
@@ -347,7 +351,7 @@ export default {
             content: renderLessonImportResult({ errors: [`JSON parse error: ${err.message}`], raw, escapeHtml }),
           });
         }
-        const { validateLesson } = await import(pathToFileURL(resolve(__dirname, "../server/lesson-validator.js")).href);
+        const { validateLesson } = await bundleImport("lesson-validator.js");
         const { valid, errors } = validateLesson(parsed);
         if (!valid) {
           return layout({

--- a/bundles/maker-lab/panel/routes.js
+++ b/bundles/maker-lab/panel/routes.js
@@ -267,8 +267,8 @@ export default function makerLabKioskRouter(/* dashboardAuth */) {
       return noSessionResponse(res);
     }
 
-    const deviceBinding = await import(pathToFileURL(resolve(__dirname, "../server/device-binding.js")).href);
-    const sessionsMod = await import(pathToFileURL(resolve(__dirname, "../server/sessions.js")).href);
+    const deviceBinding = await bundleImport("device-binding.js");
+    const sessionsMod = await bundleImport("sessions.js");
 
     const fp = fingerprint(req);
     const loopback = deviceBinding.isLoopback(req);
@@ -571,7 +571,7 @@ export default function makerLabKioskRouter(/* dashboardAuth */) {
     });
 
     // Route through the shared hint pipeline (LLM + filter). Phase 2.
-    const { handleHintRequest } = await import(pathToFileURL(resolve(__dirname, "../server/hint-pipeline.js")).href);
+    const { handleHintRequest } = await bundleImport("hint-pipeline.js");
     try {
       const result = await handleHintRequest(db, {
         sessionToken: guard.sessionToken,
@@ -594,7 +594,7 @@ export default function makerLabKioskRouter(/* dashboardAuth */) {
   // backend Maker Lab is currently routing hints through. Read-only;
   // no secrets leaked.
   router.get("/maker-lab/api/engine", async (req, res) => {
-    const mod = await import(pathToFileURL(resolve(__dirname, "../server/resolve-llm-endpoint.js")).href);
+    const mod = await bundleImport("resolve-llm-endpoint.js");
     const resolved = await mod.resolveLlmEndpoint();
     res.json({
       engine: resolved.engine,
@@ -614,7 +614,7 @@ export default function makerLabKioskRouter(/* dashboardAuth */) {
   // AND thus shares the host's loopback) can reach it.
 
   router.post("/maker-lab/api/hint-internal", express_json(), async (req, res) => {
-    const deviceBinding = await import(pathToFileURL(resolve(__dirname, "../server/device-binding.js")).href);
+    const deviceBinding = await bundleImport("device-binding.js");
     if (!deviceBinding.isLoopback(req)) {
       return res.status(403).json({ error: "loopback_only" });
     }
@@ -631,7 +631,7 @@ export default function makerLabKioskRouter(/* dashboardAuth */) {
     if (!session) return res.status(401).json({ error: "session_invalid" });
     if (session.state === "revoked") return res.status(410).json({ error: "revoked" });
 
-    const { handleHintRequest } = await import(pathToFileURL(resolve(__dirname, "../server/hint-pipeline.js")).href);
+    const { handleHintRequest } = await bundleImport("hint-pipeline.js");
     try {
       const result = await handleHintRequest(db, {
         sessionToken: session_token,

--- a/bundles/maker-lab/panel/routes.js
+++ b/bundles/maker-lab/panel/routes.js
@@ -21,10 +21,29 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Inlined app-root resolver (BH-4 phase 2 follow-up): this file is copied
+// ALONE into ~/.crow/panels/maker-lab-routes.js on install/refresh — same
+// as panel/maker-lab.js — so none of its `../server/*` siblings exist
+// relative to __dirname on an installed copy. Every lazy import below must
+// resolve through the bundle's real on-disk location under CROW_APP_ROOT
+// instead. Logic duplicated (not imported) from
+// bundles/maker-lab/server/app-root.js / panel/maker-lab.js's own inline
+// copy, since this file travels alone too and can't rely on a sibling.
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const __appRootGuess = resolve(__dirname, "..", "..", "..");
+const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(__appRootGuess) ? __appRootGuess
+  : (process.env.CROW_APP_ROOT || __appRootGuess);
+// These lazy imports target the BUNDLE's own server/ dir (not the app root's
+// shared servers/ tree) — resolve through APP_ROOT + bundles/maker-lab/server/,
+// which is always present on an installed instance (CROW_APP_ROOT points at
+// the repo checkout).
+const bundleImport = (rel) => import(pathToFileURL(join(APP_ROOT, "bundles", "maker-lab", "server", rel)).href);
+
 // Lazy DB
 let createDbClient;
 try {
-  const dbMod = await import(pathToFileURL(resolve(__dirname, "../server/db.js")).href);
+  const dbMod = await bundleImport("db.js");
   createDbClient = dbMod.createDbClient;
 } catch {
   createDbClient = null;
@@ -162,7 +181,7 @@ function ageBandFromGuestBand(band) {
 // where the bundle's server/ modules aren't reachable.
 let startRetentionSweep;
 try {
-  const mod = await import(pathToFileURL(resolve(__dirname, "../server/retention-sweep.js")).href);
+  const mod = await bundleImport("retention-sweep.js");
   startRetentionSweep = mod.startRetentionSweep;
 } catch {
   startRetentionSweep = null;

--- a/bundles/maker-lab/server/app-root.js
+++ b/bundles/maker-lab/server/app-root.js
@@ -1,0 +1,16 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (~/.crow/bundles/…)
+ * or an in-repo run. The gateway exports CROW_APP_ROOT for itself and its
+ * spawned addon children; the relative guess covers direct in-repo runs.
+ * The W2-5 migration's static `../../../servers/...` imports only resolved
+ * in-repo — this resolver is what lets the installed copy run at all.
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/maker-lab/server/db.js
+++ b/bundles/maker-lab/server/db.js
@@ -1,7 +1,9 @@
 import { existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
-import { createDbClient as createSharedDbClient } from "../../../servers/db.js";
+import { appImport } from "./app-root.js";
+
+const { createDbClient: createSharedDbClient } = await appImport("servers/db.js");
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/bundles/maker-lab/server/device-binding.js
+++ b/bundles/maker-lab/server/device-binding.js
@@ -9,8 +9,10 @@
  * This module handles the server-side checks for both.
  */
 
-import { verifySession } from "../../../servers/gateway/dashboard/auth.js";
-import { createProjectSpace } from "../../../servers/shared/project-spaces.js";
+import { appImport } from "./app-root.js";
+
+const { verifySession } = await appImport("servers/gateway/dashboard/auth.js");
+const { createProjectSpace } = await appImport("servers/shared/project-spaces.js");
 
 /**
  * Is the request coming from loopback (same-host)?

--- a/bundles/maker-lab/server/server.js
+++ b/bundles/maker-lab/server/server.js
@@ -31,7 +31,9 @@ import {
   mintGuestSession,
   mintBatchSessions,
 } from "./sessions.js";
-import { createProjectSpace, updateProjectSpaceMeta } from "../../../servers/shared/project-spaces.js";
+import { appImport } from "./app-root.js";
+
+const { createProjectSpace, updateProjectSpaceMeta } = await appImport("servers/shared/project-spaces.js");
 
 const ENDING_FLUSH_SEC = 5;
 

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -2741,7 +2741,7 @@
     {
       "id": "maker-lab",
       "name": "Maker Lab",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
       "type": "mcp-server",
       "author": "Crow",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -2741,7 +2741,7 @@
     {
       "id": "maker-lab",
       "name": "Maker Lab",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
       "type": "mcp-server",
       "author": "Crow",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -2741,7 +2741,7 @@
     {
       "id": "maker-lab",
       "name": "Maker Lab",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Scaffolded AI learning companion paired with FOSS maker surfaces (Blockly first). Hint-ladder pedagogy, per-learner memory, age-banded personas, classroom-capable.",
       "type": "mcp-server",
       "author": "Crow",

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -37,6 +37,10 @@ import { fileURLToPath } from "node:url";
 
 const __gatewayDir = dirnamePath(fileURLToPath(import.meta.url));
 const __appRoot = resolvePath(__gatewayDir, "../..");
+// Export the repo root so spawned addon children (bundle MCP servers) can
+// resolve shared servers/ modules without a hardcoded repo-relative path —
+// see bundles/maker-lab/server/app-root.js (BH-4 phase 2).
+process.env.CROW_APP_ROOT ||= __appRoot;
 const envPath = resolvePath(__appRoot, ".env");
 if (existsSync(envPath)) {
   for (const line of readFileSync(envPath, "utf8").split("\n")) {

--- a/tests/maker-lab-location-independence.test.js
+++ b/tests/maker-lab-location-independence.test.js
@@ -257,33 +257,32 @@ describe("maker-lab location independence (BH-4 phase 2)", () => {
     );
   });
 
-  test("class-regression: the fixed `../server/{db,retention-sweep}.js` lazy dynamic-import pattern does not reappear anywhere under panel/*.js", () => {
-    // Narrower than the static-import net above (which only ever matched
-    // `from "../../../servers/..."`, i.e. the shared top-level servers/
-    // tree): this catches the DYNAMIC `import(pathToFileURL(resolve(__dirname,
-    // "../server/...")))` shape that caused this exact regression — a
-    // relative resolution assuming a sibling ../server/ dir that doesn't
-    // exist once a panel/*.js file is copied alone. Scoped to the two
-    // targets this follow-up fixed (db.js, retention-sweep.js) rather than
-    // every `../server/*` lazy import in panel/*.js: panel/routes.js and
-    // panel/maker-lab.js both have other pre-existing lazy imports of this
-    // same shape (device-binding.js, sessions.js, hint-pipeline.js,
-    // resolve-llm-endpoint.js, lesson-validator.js) that are a real but
-    // separate, tracked, out-of-scope gap — asserting a blanket "zero
-    // matches" here would either force fixing them as a drive-by (out of
-    // this follow-up's stated scope) or require a brittle allowlist that
-    // doesn't buy anything additional over a green earlier-run gate check.
+  test("class-regression: no import (static or dynamic) escaping the panel dir remains anywhere under panel/*.js", () => {
+    // Widened from a narrow db.js/retention-sweep.js-only net (this follow-up's
+    // first pass) to a blanket net now that ALL nine pre-existing lazy
+    // `../server/*` sites (routes.js: device-binding.js x2, sessions.js,
+    // hint-pipeline.js x2, resolve-llm-endpoint.js; maker-lab.js:
+    // device-binding.js, sessions.js, lesson-validator.js) have been converted
+    // through the file-local `bundleImport(rel)` helper (routes.js has its
+    // own; maker-lab.js gained an equivalent one alongside its existing
+    // `appImport`). Every panel/*.js file is copied ALONE into
+    // ~/.crow/panels/ on install/refresh, so ANY import escaping the panel
+    // dir via `../` (static `from "../..."` or dynamic
+    // `import("../...")` / `import(pathToFileURL(resolve(__dirname,
+    // "../...")))`) is location-dependent and will 500/crash once installed.
+    // Same-dir `./` imports and node builtins/package imports (bare
+    // specifiers, `node:fs`, etc.) are unaffected and allowed.
     const files = listJsFiles(join(MAKER_LAB_DIR, "panel"));
-    const lazyBrokenImport = /pathToFileURL\(resolve\(__dirname,\s*["'`]\.\.\/server\/(db|retention-sweep)\.js["'`]\)\)/;
+    const escapingImport = /from\s+["'`]\.\.\/|import\(\s*["'`]\.\.\/|import\(pathToFileURL\(resolve\(__dirname,\s*["'`]\.\.\//;
     const offenders = [];
     for (const f of files) {
       const src = readFileSync(f, "utf8");
-      if (lazyBrokenImport.test(src)) offenders.push(f);
+      if (escapingImport.test(src)) offenders.push(f);
     }
     assert.deepEqual(
       offenders,
       [],
-      `broken "../server/{db,retention-sweep}.js" lazy dynamic-import pattern reappeared in: ` +
+      `an import escaping the panel dir (via "../") reappeared in: ` +
         `${offenders.map((f) => f.replace(REPO_ROOT + "/", "")).join(", ")}`
     );
   });

--- a/tests/maker-lab-location-independence.test.js
+++ b/tests/maker-lab-location-independence.test.js
@@ -78,6 +78,58 @@ function runImport(absPath, env = {}) {
   return { status: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
 }
 
+/**
+ * Import routes.js's default export (the kiosk router factory) in a fresh
+ * node subprocess, then invoke the router's FIRST layer directly — the
+ * `router.use(["/kiosk", "/maker-lab"], ...)` gate middleware that every
+ * kiosk route passes through before its own handler runs. This is the
+ * non-vacuous check the panel/maker-lab.js-only `runImport` can't give us:
+ * routes.js's lazy db.js/retention-sweep.js imports are wrapped in
+ * try/catch, so a bare "the module imported without throwing" (exit 0)
+ * would pass whether or not the import inside the try actually succeeded —
+ * the catch swallows it either way. Driving the gate for real distinguishes
+ * "resolved" (calls next()) from "silently degraded" (500 db_unavailable).
+ *
+ * Calling `router.stack[0].handle` directly (rather than routing a request
+ * through the full Router matcher) is deliberate: it exercises exactly the
+ * gate closure we care about without also dispatching into a real route
+ * handler, which would need a fully-migrated schema in the scratch DB.
+ *
+ * Returns { status, stdout, stderr, observed } — `observed` is null on a
+ * non-zero exit (see stderr) or the parsed `{ nextCalled: true }` /
+ * `{ status: 500, body: { error: "db_unavailable" } }` result otherwise.
+ */
+function runKioskGateCheck(absPath, env = {}) {
+  const url = pathToFileURL(absPath).href;
+  const code = `
+    import(${JSON.stringify(url)}).then((mod) => {
+      const router = mod.default();
+      const gate = router.stack[0];
+      let observed = null;
+      const req = { method: "GET", url: "/kiosk/api/context", headers: {}, secure: false };
+      const res = {
+        statusCode: 200,
+        status(code) { this.statusCode = code; return this; },
+        json(body) { observed = { status: this.statusCode, body }; },
+      };
+      gate.handle(req, res, (err) => {
+        if (!observed) observed = { nextCalled: true, err: err ? String(err.message || err) : null };
+      });
+      process.stdout.write(JSON.stringify(observed));
+      process.exit(0);
+    }).catch((e) => { console.error(String((e && e.stack) || e)); process.exit(1); });
+  `;
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", code], {
+    cwd: dirname(absPath),
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  let observed = null;
+  try { observed = result.stdout ? JSON.parse(result.stdout.trim()) : null; } catch { observed = null; }
+  return { status: result.status, stdout: result.stdout || "", stderr: result.stderr || "", observed };
+}
+
 describe("maker-lab location independence (BH-4 phase 2)", () => {
   test("no static repo-relative `servers/` import remains under panel/ or server/", () => {
     const files = [
@@ -154,5 +206,85 @@ describe("maker-lab location independence (BH-4 phase 2)", () => {
     writeFileSync(dbPath, current);
     const green = runImport(dbPath, { CROW_APP_ROOT: REPO_ROOT });
     assert.equal(green.status, 0, `expected the current (fixed) content to import cleanly after restoring it:\n${green.stderr}`);
+  });
+
+  // ─── BH-4 phase 2 follow-up: panel/routes.js is ALSO copied alone ────────
+  //
+  // routes.js is copied to ~/.crow/panels/maker-lab-routes.js independently
+  // of panel/maker-lab.js (bundles.js resolves `manifest.panelRoutes`
+  // separately from `manifest.panel`). Its two try/catch-guarded lazy
+  // imports of ../server/db.js and ../server/retention-sweep.js used to
+  // resolve relative to __dirname, which on the installed copy is
+  // ~/.crow/panels — not the bundle dir — so the import silently failed,
+  // createDbClient/startRetentionSweep stayed null, and the gate middleware
+  // (`router.use(["/kiosk","/maker-lab"], ...)`, first thing every kiosk
+  // route hits) 500'd db_unavailable on every request. Fixed the same way
+  // as maker-lab.js: an inlined app-root resolver + bundle-absolute imports.
+
+  test("installed-location routes.js import succeeds with CROW_APP_ROOT set (copied alone, like ~/.crow/panels)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maker-lab-routes-import-"));
+    cpSync(join(MAKER_LAB_DIR, "panel", "routes.js"), join(tmp, "maker-lab-routes.js"));
+    symlinkSync(join(REPO_ROOT, "node_modules"), join(tmp, "node_modules"));
+
+    const withRoot = runImport(join(tmp, "maker-lab-routes.js"), { CROW_APP_ROOT: REPO_ROOT });
+    assert.equal(withRoot.status, 0, `expected import to succeed with CROW_APP_ROOT set:\n${withRoot.stderr}`);
+  });
+
+  test("installed-location routes.js: the db lazy-import actually resolves (non-vacuous — a bare successful import doesn't prove this, since the try/catch swallows a failed import into a null createDbClient)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maker-lab-routes-gate-"));
+    cpSync(join(MAKER_LAB_DIR, "panel", "routes.js"), join(tmp, "maker-lab-routes.js"));
+    symlinkSync(join(REPO_ROOT, "node_modules"), join(tmp, "node_modules"));
+
+    // Scratch DB path so createDbClient() (real better-sqlite3 client) never
+    // touches ~/.crow — CROW_DB_PATH takes priority over CROW_DATA_DIR/HOME
+    // resolution in servers/db.js's createDbClient().
+    const scratchDbPath = join(tmp, "scratch.db");
+    const result = runKioskGateCheck(join(tmp, "maker-lab-routes.js"), {
+      CROW_APP_ROOT: REPO_ROOT,
+      CROW_DB_PATH: scratchDbPath,
+    });
+    assert.equal(result.status, 0, `expected the gate-check subprocess to exit cleanly:\n${result.stderr}`);
+    assert.ok(result.observed, `expected a parsed observation from the gate-check subprocess, got stdout: ${result.stdout}`);
+    assert.equal(
+      result.observed.nextCalled,
+      true,
+      `expected the kiosk gate middleware to resolve the db and call next(); got: ${JSON.stringify(result.observed)}`
+    );
+    assert.equal(
+      result.observed.status,
+      undefined,
+      `gate middleware must not have set a db_unavailable response status; got: ${JSON.stringify(result.observed)}`
+    );
+  });
+
+  test("class-regression: the fixed `../server/{db,retention-sweep}.js` lazy dynamic-import pattern does not reappear anywhere under panel/*.js", () => {
+    // Narrower than the static-import net above (which only ever matched
+    // `from "../../../servers/..."`, i.e. the shared top-level servers/
+    // tree): this catches the DYNAMIC `import(pathToFileURL(resolve(__dirname,
+    // "../server/...")))` shape that caused this exact regression — a
+    // relative resolution assuming a sibling ../server/ dir that doesn't
+    // exist once a panel/*.js file is copied alone. Scoped to the two
+    // targets this follow-up fixed (db.js, retention-sweep.js) rather than
+    // every `../server/*` lazy import in panel/*.js: panel/routes.js and
+    // panel/maker-lab.js both have other pre-existing lazy imports of this
+    // same shape (device-binding.js, sessions.js, hint-pipeline.js,
+    // resolve-llm-endpoint.js, lesson-validator.js) that are a real but
+    // separate, tracked, out-of-scope gap — asserting a blanket "zero
+    // matches" here would either force fixing them as a drive-by (out of
+    // this follow-up's stated scope) or require a brittle allowlist that
+    // doesn't buy anything additional over a green earlier-run gate check.
+    const files = listJsFiles(join(MAKER_LAB_DIR, "panel"));
+    const lazyBrokenImport = /pathToFileURL\(resolve\(__dirname,\s*["'`]\.\.\/server\/(db|retention-sweep)\.js["'`]\)\)/;
+    const offenders = [];
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      if (lazyBrokenImport.test(src)) offenders.push(f);
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `broken "../server/{db,retention-sweep}.js" lazy dynamic-import pattern reappeared in: ` +
+        `${offenders.map((f) => f.replace(REPO_ROOT + "/", "")).join(", ")}`
+    );
   });
 });

--- a/tests/maker-lab-location-independence.test.js
+++ b/tests/maker-lab-location-independence.test.js
@@ -1,0 +1,158 @@
+/**
+ * Maker Lab location-independence (BH-4 phase 2) — tests/maker-lab-location-independence.test.js
+ *
+ * PR #166's version-refresh copies bundle code from the repo into
+ * `~/.crow/bundles/<id>/` and the served panel into `~/.crow/panels/<id>.js`.
+ * Deploy revealed maker-lab was REPO-LOCATION-DEPENDENT: five static
+ * relative imports of repo-shared `servers/` modules only resolved from the
+ * repo tree, so the installed panel failed
+ * (`Cannot find module '/home/servers/shared/project-spaces.js'`) and the
+ * MCP child crash-looped.
+ *
+ * Fix: a resolver (`bundles/maker-lab/server/app-root.js`, inlined in
+ * panel/maker-lab.js since that file is copied ALONE) that finds the repo
+ * root from `CROW_APP_ROOT` (set by the gateway for its spawned addon
+ * children) or an in-repo relative guess, then dynamic-imports through it.
+ *
+ * This file:
+ *  (a) is a class-regression net — no static repo-relative `servers/`
+ *      import may reappear anywhere under bundles/maker-lab/{panel,server}.
+ *  (b)/(c) prove the installed-location shape actually works: copy the
+ *      panel (alone) / the server tree to a scratch temp dir mimicking
+ *      ~/.crow/panels or ~/.crow/bundles/maker-lab, then import it in a
+ *      SUBPROCESS with CROW_APP_ROOT set — it must succeed.
+ *  (d) is a mutation check: a synthetic copy carrying the PRE-FIX static
+ *      import reproduces the crash (proving (a)/(c) are a real regression
+ *      net), then the current (fixed) content is proven green in the same
+ *      spot. Only a throwaway temp copy is ever mutated — the tracked repo
+ *      file under test is never touched.
+ *
+ * NEVER touches ~/.crow (prod). All subprocess imports run against scratch
+ * temp dirs + an explicit CROW_APP_ROOT env var.
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  cpSync,
+  symlinkSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const MAKER_LAB_DIR = join(REPO_ROOT, "bundles", "maker-lab");
+
+/** Recursively list every .js file under `dir`. */
+function listJsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listJsFiles(p));
+    else if (entry.isFile() && entry.name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Import `absPath` in a fresh node subprocess with `env` merged over the
+ * current process env. Returns { status, stdout, stderr }. Never throws on
+ * a non-zero exit — callers assert on `status` themselves.
+ */
+function runImport(absPath, env = {}) {
+  const url = pathToFileURL(absPath).href;
+  const code = `import(${JSON.stringify(url)}).then(() => process.exit(0)).catch((e) => { console.error(String((e && e.stack) || e)); process.exit(1); });`;
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", code], {
+    cwd: dirname(absPath),
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  return { status: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
+}
+
+describe("maker-lab location independence (BH-4 phase 2)", () => {
+  test("no static repo-relative `servers/` import remains under panel/ or server/", () => {
+    const files = [
+      ...listJsFiles(join(MAKER_LAB_DIR, "panel")),
+      ...listJsFiles(join(MAKER_LAB_DIR, "server")),
+    ];
+    assert.ok(files.length > 0, "expected to find .js files under bundles/maker-lab");
+    const staticServersImport = /from\s+["'](?:\.\.\/){2,3}servers\//;
+    const offenders = [];
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      if (staticServersImport.test(src)) offenders.push(f);
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `static repo-relative "servers/" import(s) found in: ${offenders.map((f) => f.replace(REPO_ROOT + "/", "")).join(", ")}`
+    );
+  });
+
+  test("installed-location panel import succeeds with CROW_APP_ROOT set (copied alone, like ~/.crow/panels)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maker-lab-panel-"));
+    cpSync(join(MAKER_LAB_DIR, "panel", "maker-lab.js"), join(tmp, "maker-lab.js"));
+    // Mirror the real PANELS_DIR/node_modules symlink bundles.js maintains
+    // for panel route resolution (bundles.js:407-411) — the panel's `import
+    // QRCode from "qrcode"` needs a resolvable node_modules alongside it.
+    symlinkSync(join(REPO_ROOT, "node_modules"), join(tmp, "node_modules"));
+
+    const withRoot = runImport(join(tmp, "maker-lab.js"), { CROW_APP_ROOT: REPO_ROOT });
+    assert.equal(withRoot.status, 0, `expected import to succeed with CROW_APP_ROOT set:\n${withRoot.stderr}`);
+
+    // Without CROW_APP_ROOT, from a location that doesn't look like the repo,
+    // the relative guess won't find servers/db.js either — it MAY fail. That
+    // failure mode isn't part of the contract (a bare in-repo run without the
+    // gateway's env line still works via the relative guess); only the
+    // success-with-CROW_APP_ROOT path above is asserted.
+  });
+
+  test("installed-location server db.js import succeeds with CROW_APP_ROOT set (whole server/ tree copied, like ~/.crow/bundles/maker-lab)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maker-lab-server-"));
+    cpSync(join(MAKER_LAB_DIR, "server"), join(tmp, "server"), { recursive: true });
+
+    const result = runImport(join(tmp, "server", "db.js"), { CROW_APP_ROOT: REPO_ROOT });
+    assert.equal(result.status, 0, `expected server/db.js to import cleanly from an installed-location copy:\n${result.stderr}`);
+  });
+
+  test("mutation: a synthetic pre-fix static import reproduces the crash, then the current content is proven green in the same spot", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "maker-lab-mutant-"));
+    cpSync(join(MAKER_LAB_DIR, "server"), join(tmp, "server"), { recursive: true });
+    const dbPath = join(tmp, "server", "db.js");
+    const current = readFileSync(dbPath, "utf8");
+
+    // Recreate the PRE-FIX static import this bundle shipped with when PR
+    // #166's version-refresh deploy crash-looped the MCP child: it only
+    // resolved from the repo tree, so an installed copy crashed with
+    // "Cannot find module '/home/servers/db.js'" (live gateway log evidence).
+    // This mutation is applied ONLY to the throwaway tmp copy above — the
+    // tracked repo file under test is never written to.
+    const mutated = current.replace(
+      `import { appImport } from "./app-root.js";\n\nconst { createDbClient: createSharedDbClient } = await appImport("servers/db.js");`,
+      `import { createDbClient as createSharedDbClient } from "../../../servers/db.js";`
+    );
+    assert.notEqual(mutated, current, "mutation pattern did not match current db.js content — update this test alongside db.js");
+
+    writeFileSync(dbPath, mutated);
+    const red = runImport(dbPath, { CROW_APP_ROOT: REPO_ROOT });
+    assert.notEqual(red.status, 0, "expected the pre-fix static import to fail from an installed-location copy");
+    assert.match(red.stderr, /Cannot find module|ERR_MODULE_NOT_FOUND/, `expected a module-resolution error, got:\n${red.stderr}`);
+
+    // Restore the tmp copy to the current (fixed) content and prove it's
+    // green in the exact same installed-location spot — the "red-then-
+    // restored" proof that the fix (not the test environment) is what
+    // makes this pass.
+    writeFileSync(dbPath, current);
+    const green = runImport(dbPath, { CROW_APP_ROOT: REPO_ROOT });
+    assert.equal(green.status, 0, `expected the current (fixed) content to import cleanly after restoring it:\n${green.stderr}`);
+  });
+});


### PR DESCRIPTION
Phase 2 of BH-4 (follows #166). Deploying #166 revealed the W2-5 maker-lab migration is repo-location-dependent: 5 static + 11 lazy `../server/`/`../../../servers/` imports resolve only in-repo, so the installed panel (`~/.crow/panels/`, copied alone) and bundle server (`~/.crow/bundles/`) fail — the page 404'd and the MCP child crash-looped; the old April symlinks were the accidental workaround.

Fix: gateway exports `CROW_APP_ROOT` at module load (index.js:43, `||=` honors overrides; in-process panel imports and spawned addon children both inherit); `bundles/maker-lab/server/app-root.js` resolver + inline resolvers in the two copied-alone panel files; all 16 sites converted (names + error semantics preserved); blanket class-regression grep net forbids any panel-dir-escaping import; manifest 0.1.1→0.1.4 + registry regens (each diff maker-lab-only) so #166's refresh delivers it at next boot.

Verification: 10 tests in `tests/maker-lab-location-independence.test.js` incl. non-vacuous copied-alone subprocess proofs (panel import, server tree, kiosk-gate middleware drives `next()` with no `db_unavailable`); mutation red-verified (final reviewer independently re-red one converted site); suite 1461/0/1; bundle-contract 25/25; final whole-branch Opus review READY TO MERGE 0C/0I (3 accepted minors: `.env`-set CROW_APP_ROOT inert by design; resolver triplication inherent to copied-alone files; componentsPath pre-existing). Post-merge: restart crow → refresh 0.1.2→0.1.4 → CDP `/dashboard/maker-lab` renders = BH-4 closed.