### PR TITLE
fix(auto-update): branch guard, no-stash tolerant pull, cross-process lock, --no-auth default OFF (F-UPDATE-1)

### DIFF
--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -8,12 +8,18 @@
  */
 
 import { execFile } from "node:child_process";
-import { dirname } from "node:path";
+import { readFileSync, writeFileSync, readdirSync, statSync, unlinkSync, renameSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isSupervised } from "../shared/supervisor.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const APP_ROOT = dirname(dirname(__dirname));
+let APP_ROOT = dirname(dirname(__dirname));
+
+/** Test-only: retarget git/npm/lock operations at a fixture repo. */
+export function _setAppRootForTest(dir) {
+  APP_ROOT = dir;
+}
 
 const DEFAULT_INTERVAL_HOURS = 6;
 const MIN_INTERVAL_HOURS = 1;
@@ -106,112 +112,106 @@ function run(cmd, args, options = {}) {
   });
 }
 
+const LOCK_STALE_MS = 30 * 60 * 1000;
+
+async function lockPath() {
+  const r = await run("git", ["rev-parse", "--absolute-git-dir"]);
+  if (r.code !== 0 || !r.stdout) return null; // not a git checkout → no lock possible
+  return join(r.stdout, "crow-auto-update.lock");
+}
+
+function readLock(path) {
+  try {
+    const [pidLine, tsLine] = readFileSync(path, "utf8").split("\n");
+    return { pid: parseInt(pidLine, 10), ts: Date.parse(tsLine || "") };
+  } catch { return null; }
+}
+
+function lockIsStale(info) {
+  if (!info || !Number.isFinite(info.pid)) return true;
+  let alive = true;
+  try { process.kill(info.pid, 0); } catch { alive = false; }
+  const old = !Number.isFinite(info.ts) || Date.now() - info.ts > LOCK_STALE_MS;
+  return !alive || old; // reclaim on (dead PID) OR (age>30min) — a wedged live updater must not block forever
+}
+
+/** Returns the lock file path on success, null when another updater holds it. */
+function acquireLock(path) {
+  // Sweep crash-orphaned quarantine files older than the staleness window.
+  try {
+    const dir = dirname(path);
+    for (const f of readdirSync(dir)) {
+      if (!f.startsWith(basename(path) + ".stale.")) continue;
+      const full = join(dir, f);
+      try { if (Date.now() - statSync(full).mtimeMs > LOCK_STALE_MS) unlinkSync(full); } catch {}
+    }
+  } catch {}
+  const body = `${process.pid}\n${new Date().toISOString()}\n`;
+  try {
+    writeFileSync(path, body, { flag: "wx" });
+    return path;
+  } catch (err) {
+    if (err.code !== "EEXIST") return null;
+  }
+  const info = readLock(path);
+  if (!lockIsStale(info)) return null; // live young holder → skip
+  // Atomic reclaim: rename-quarantine — exactly one winner among reclaimers
+  // racing the SAME stale inode (rename is NOT compare-and-swap; the lapping
+  // residual is accepted in the spec with named backstops).
+  const quarantine = `${path}.stale.${process.pid}`;
+  try { renameSync(path, quarantine); } catch { return null; } // ENOENT = lost the race
+  try { unlinkSync(quarantine); } catch {}
+  try {
+    writeFileSync(path, body, { flag: "wx" });
+    return path;
+  } catch { return null; } // a third party acquired meanwhile
+}
+
+/** Owner-checked release: never unlink a lock we no longer own. */
+function releaseLock(path) {
+  try {
+    const info = readLock(path);
+    if (info && info.pid === process.pid) unlinkSync(path);
+  } catch {}
+}
+
+/** Test-only: the lock primitives, unit-tested directly (they are not
+ *  exported for production use — checkForUpdates()/runLockedUpdate() are the
+ *  real callers). */
+export const _lockPrimitivesForTest = { acquireLock, releaseLock, lockIsStale };
+
 /**
  * Check for and apply updates
- * Returns { updated, from, to, error }
+ * Returns { updated, from, to, error, skipped?, message?, branch? }
  */
 export async function checkForUpdates() {
   const log = (msg) => console.log(`[auto-update] ${msg}`);
-
   try {
-    // Get current version
-    const currentRef = await run("git", ["rev-parse", "--short", "HEAD"]);
-    const currentVersion = currentRef.stdout;
-
-    // Fetch latest from remote
-    log("Checking for updates...");
-    const fetchResult = await run("git", ["fetch", "--quiet", "origin", "main"]);
-    if (fetchResult.code !== 0) {
-      const msg = `Fetch failed: ${fetchResult.stderr}`;
+    const branch = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (branch.code !== 0 || branch.stdout !== "main") {
+      const msg = branch.code !== 0
+        ? `Skipped: cannot determine branch (${branch.stderr || "not a git checkout"})`
+        : `Skipped: not on main (on '${branch.stdout}')`;
       log(msg);
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
-      return { updated: false, error: msg };
+      return { updated: false, skipped: "not-on-main", branch: branch.stdout, message: msg };
     }
-
-    // Check if there are new commits
-    const behind = await run("git", ["rev-list", "--count", "HEAD..origin/main"]);
-    const behindCount = parseInt(behind.stdout, 10) || 0;
-
-    await saveSetting("auto_update_current_version", currentVersion);
-
-    if (behindCount === 0) {
-      log("Already up to date.");
-      await saveSetting("auto_update_last_check", new Date().toISOString());
-      await saveSetting("auto_update_last_result", "Up to date");
-      await saveSetting("auto_update_latest_version", currentVersion);
-      return { updated: false };
-    }
-
-    log(`${behindCount} new commit(s) available. Updating...`);
-
-    // Stash any local changes before pulling
-    const stashResult = await run("git", ["stash", "--include-untracked"]);
-    const didStash = !stashResult.stdout.includes("No local changes");
-
-    // Pull
-    const pullResult = await run("git", ["pull", "--ff-only", "origin", "main"]);
-    if (pullResult.code !== 0) {
-      const msg = `Pull failed: ${pullResult.stderr}`;
+    const lock = await lockPath();
+    const held = lock ? acquireLock(lock) : null;
+    if (lock && !held) {
+      const info = readLock(lock);
+      const msg = `Skipped: another updater is running (pid ${info?.pid ?? "unknown"})`;
       log(msg);
-      if (didStash) {
-        await run("git", ["stash", "pop"]);
-      }
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
-      return { updated: false, error: msg };
+      return { updated: false, skipped: "locked", message: msg };
     }
-
-    // Install deps (only if package-lock changed)
-    const changedFiles = await run("git", ["diff", "--name-only", `${currentVersion}..HEAD`]);
-    if (changedFiles.stdout.includes("package-lock.json") || changedFiles.stdout.includes("package.json")) {
-      log("Dependencies changed — running npm install...");
-      const npmResult = await run("npm", ["install", "--omit=dev"], { timeout: 300000 });
-      if (npmResult.code !== 0) {
-        log(`npm install warning: ${npmResult.stderr}`);
-      }
+    try {
+      return await runLockedUpdate(log);
+    } finally {
+      if (held) releaseLock(held);
     }
-
-    // Run init-db for any schema changes
-    log("Running database migrations...");
-    await run("node", ["scripts/init-db.js"]);
-
-    // Restore stashed local changes
-    if (didStash) {
-      const popResult = await run("git", ["stash", "pop"]);
-      if (popResult.code !== 0) {
-        // Conflict: restore clean post-pull state, keep changes in stash
-        await run("git", ["checkout", "--", "."]);
-        log("Warning: local changes could not be auto-merged after update. They are saved in 'git stash list' and can be recovered with 'git stash pop'.");
-      } else {
-        log("Local changes stashed and restored successfully.");
-      }
-    }
-
-    const newRef = await run("git", ["rev-parse", "--short", "HEAD"]);
-    const newVersion = newRef.stdout;
-
-    await saveSetting("auto_update_last_check", new Date().toISOString());
-    await saveSetting("auto_update_last_result", `Updated ${currentVersion} → ${newVersion}`);
-    await saveSetting("auto_update_current_version", newVersion);
-    await saveSetting("auto_update_latest_version", newVersion);
-
-    log(`Updated: ${currentVersion} → ${newVersion}`);
-
-    // Restart to load the new code when supervised (systemd, launchd
-    // KeepAlive, Docker, etc.). Without a supervisor the pulled code only
-    // takes effect on the next manual restart.
-    if (isSupervised()) {
-      log("Restarting gateway to apply update...");
-      // Close the HTTP server first to release the port, then exit
-      // so the supervisor's restart doesn't hit EADDRINUSE
-      setTimeout(() => {
-        process.emit("crow:shutdown");
-        setTimeout(() => process.exit(1), 1000);
-      }, 1500);
-    }
-
-    return { updated: true, from: currentVersion, to: newVersion };
   } catch (err) {
     const msg = `Update error: ${err.message}`;
     console.error(`[auto-update] ${msg}`);
@@ -219,6 +219,106 @@ export async function checkForUpdates() {
     await saveSetting("auto_update_last_result", msg);
     return { updated: false, error: msg };
   }
+}
+
+/** The mutating sequence; exported ONLY as the test seam for the under-lock
+ *  branch re-check (spec D3b — the outer guard would abort a branch fixture
+ *  before the lock). */
+export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${m}`)) {
+  // Get current version
+  const currentRef = await run("git", ["rev-parse", "--short", "HEAD"]);
+  const currentVersion = currentRef.stdout;
+
+  // Fetch latest from remote
+  log("Checking for updates...");
+  const fetchResult = await run("git", ["fetch", "--quiet", "origin", "main"]);
+  if (fetchResult.code !== 0) {
+    const msg = `Fetch failed: ${fetchResult.stderr}`;
+    log(msg);
+    await saveSetting("auto_update_last_check", new Date().toISOString());
+    await saveSetting("auto_update_last_result", msg);
+    return { updated: false, error: msg };
+  }
+
+  // Check if there are new commits
+  const behind = await run("git", ["rev-list", "--count", "HEAD..origin/main"]);
+  const behindCount = parseInt(behind.stdout, 10) || 0;
+
+  await saveSetting("auto_update_current_version", currentVersion);
+
+  if (behindCount === 0) {
+    log("Already up to date.");
+    await saveSetting("auto_update_last_check", new Date().toISOString());
+    await saveSetting("auto_update_last_result", "Up to date");
+    await saveSetting("auto_update_latest_version", currentVersion);
+    return { updated: false };
+  }
+
+  log(`${behindCount} new commit(s) available. Updating...`);
+
+  // D3b: re-check the branch UNDER the lock, immediately before the pull —
+  // a parallel session's raw `git checkout` races the outer guard across the
+  // fetch window, and `pull --ff-only origin main` on an ancestor feature
+  // branch FAST-FORWARDS that ref (R1 empirically proved it).
+  const recheck = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (recheck.stdout !== "main") {
+    const msg = `Skipped: branch changed mid-update (now '${recheck.stdout}')`;
+    log(msg);
+    await saveSetting("auto_update_last_check", new Date().toISOString());
+    await saveSetting("auto_update_last_result", msg);
+    return { updated: false, skipped: "not-on-main", branch: recheck.stdout, message: msg };
+  }
+
+  // D2: pull directly — NO stash. `git pull --ff-only` refuses only when the
+  // incoming diff overlaps a locally-modified file; disjoint local WIP
+  // survives untouched.
+  const pullResult = await run("git", ["pull", "--ff-only", "origin", "main"]);
+  if (pullResult.code !== 0) {
+    const msg = `Pull failed (local changes may conflict with the update — resolve manually): ${pullResult.stderr}`;
+    log(msg);
+    await saveSetting("auto_update_last_check", new Date().toISOString());
+    await saveSetting("auto_update_last_result", msg);
+    return { updated: false, error: msg };
+  }
+
+  // Install deps (only if package-lock changed)
+  const changedFiles = await run("git", ["diff", "--name-only", `${currentVersion}..HEAD`]);
+  if (changedFiles.stdout.includes("package-lock.json") || changedFiles.stdout.includes("package.json")) {
+    log("Dependencies changed — running npm install...");
+    const npmResult = await run("npm", ["install", "--omit=dev"], { timeout: 300000 });
+    if (npmResult.code !== 0) {
+      log(`npm install warning: ${npmResult.stderr}`);
+    }
+  }
+
+  // Run init-db for any schema changes
+  log("Running database migrations...");
+  await run("node", ["scripts/init-db.js"]);
+
+  const newRef = await run("git", ["rev-parse", "--short", "HEAD"]);
+  const newVersion = newRef.stdout;
+
+  await saveSetting("auto_update_last_check", new Date().toISOString());
+  await saveSetting("auto_update_last_result", `Updated ${currentVersion} → ${newVersion}`);
+  await saveSetting("auto_update_current_version", newVersion);
+  await saveSetting("auto_update_latest_version", newVersion);
+
+  log(`Updated: ${currentVersion} → ${newVersion}`);
+
+  // Restart to load the new code when supervised (systemd, launchd
+  // KeepAlive, Docker, etc.). Without a supervisor the pulled code only
+  // takes effect on the next manual restart.
+  if (isSupervised()) {
+    log("Restarting gateway to apply update...");
+    // Close the HTTP server first to release the port, then exit
+    // so the supervisor's restart doesn't hit EADDRINUSE
+    setTimeout(() => {
+      process.emit("crow:shutdown");
+      setTimeout(() => process.exit(1), 1000);
+    }, 1500);
+  }
+
+  return { updated: true, from: currentVersion, to: newVersion };
 }
 
 /**

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -322,14 +322,30 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
 }
 
 /**
+ * D4: whether auto-update should even attempt to start. The
+ * CROW_AUTO_UPDATE=0|false kill switch always wins. Otherwise, a --no-auth
+ * gateway (an unauthenticated scratch/dev surface) defaults OFF and requires
+ * an explicit CROW_AUTO_UPDATE=1|true opt-in; every other gateway defaults
+ * ON (existing behavior preserved).
+ */
+export function shouldStartAutoUpdate({ env = {}, noAuth = false } = {}) {
+  if (env.CROW_AUTO_UPDATE === "0" || env.CROW_AUTO_UPDATE === "false") return false;
+  if (noAuth) return env.CROW_AUTO_UPDATE === "1" || env.CROW_AUTO_UPDATE === "true";
+  return true;
+}
+
+/**
  * Start the auto-update timer
  */
-export async function startAutoUpdate(database) {
+export async function startAutoUpdate(database, { noAuth = false } = {}) {
   db = database;
 
-  // Respect CROW_AUTO_UPDATE env var (overrides DB setting)
-  if (process.env.CROW_AUTO_UPDATE === "0" || process.env.CROW_AUTO_UPDATE === "false") {
-    console.log("[auto-update] Disabled via CROW_AUTO_UPDATE env var");
+  if (!shouldStartAutoUpdate({ env: process.env, noAuth })) {
+    console.log(
+      noAuth
+        ? "[auto-update] Disabled: --no-auth gateway defaults auto-update OFF (set CROW_AUTO_UPDATE=1 to opt in)"
+        : "[auto-update] Disabled via CROW_AUTO_UPDATE env var",
+    );
     return;
   }
 

--- a/servers/gateway/boot/post-listen.js
+++ b/servers/gateway/boot/post-listen.js
@@ -183,7 +183,7 @@ export async function runPostListenSetup(server, app, deps) {
   setInterval(runRemoteProbe, 60_000).unref();
 
   // Start auto-update checker
-  startAutoUpdate(createDbClient()).catch((err) => {
+  startAutoUpdate(createDbClient(), { noAuth }).catch((err) => {
     console.error("[auto-update] Failed to start:", err.message);
   });
 

--- a/servers/gateway/dashboard/settings/sections/updates.js
+++ b/servers/gateway/dashboard/settings/sections/updates.js
@@ -129,6 +129,10 @@ export default {
           } else if (data.error) {
             msg.style.color = 'var(--crow-error)';
             msg.textContent = data.error;
+          } else if (data.skipped) {
+            msg.style.display = 'block';
+            msg.style.color = 'var(--crow-text-muted)';
+            msg.textContent = data.message || data.skipped;
           } else {
             msg.style.color = 'var(--crow-text-muted)';
             msg.textContent = '${tJs("settings.alreadyUpToDate", lang)}';

--- a/tests/auto-update-hardening.test.js
+++ b/tests/auto-update-hardening.test.js
@@ -26,6 +26,9 @@ import assert from "node:assert/strict";
 import {
   checkForUpdates,
   runLockedUpdate,
+  startAutoUpdate,
+  stopAutoUpdate,
+  shouldStartAutoUpdate,
   _setAppRootForTest,
   _setDbForTest,
   _lockPrimitivesForTest,
@@ -311,4 +314,98 @@ test("lock primitives: lockIsStale — dead pid OR age>30min is stale, live+youn
   } finally {
     restoreRoot();
   }
+});
+
+// ---------------------------------------------------------------------------
+// D4: shouldStartAutoUpdate predicate — --no-auth defaults OFF, requires
+// explicit opt-in via CROW_AUTO_UPDATE=1|true; the kill-switch ("0"/"false")
+// semantics are preserved for every noAuth value.
+// ---------------------------------------------------------------------------
+
+test("D4 predicate: truth table over noAuth x CROW_AUTO_UPDATE", () => {
+  const cases = [
+    // [noAuth, envValue, expected]
+    [false, undefined, true],
+    [false, "0", false],
+    [false, "false", false],
+    [false, "1", true],
+    [false, "true", true],
+    [true, undefined, false],
+    [true, "0", false],
+    [true, "false", false],
+    [true, "1", true],
+    [true, "true", true],
+  ];
+  for (const [noAuth, envValue, expected] of cases) {
+    const env = envValue === undefined ? {} : { CROW_AUTO_UPDATE: envValue };
+    const got = shouldStartAutoUpdate({ env, noAuth });
+    assert.equal(
+      got,
+      expected,
+      `noAuth=${noAuth} CROW_AUTO_UPDATE=${envValue} expected ${expected} got ${got}`,
+    );
+  }
+});
+
+test("D4 predicate: defaults to { env: {}, noAuth: false } → true when called with no args", () => {
+  assert.equal(shouldStartAutoUpdate(), true);
+  assert.equal(shouldStartAutoUpdate({}), true);
+});
+
+// ---------------------------------------------------------------------------
+// D4: startAutoUpdate call-site wiring
+// ---------------------------------------------------------------------------
+
+test("startAutoUpdate: noAuth:true + CROW_AUTO_UPDATE unset → returns without arming (no 'Enabled' log, no DB writes)", async () => {
+  const fx = fixture();
+  const originalEnv = process.env.CROW_AUTO_UPDATE;
+  delete process.env.CROW_AUTO_UPDATE;
+  let dbCalls = 0;
+  const trackingDb = { execute: async () => { dbCalls++; return { rows: [] }; } };
+  const originalLog = console.log;
+  const logs = [];
+  console.log = (...args) => { logs.push(args.join(" ")); };
+  try {
+    _setAppRootForTest(fx.work);
+    await startAutoUpdate(trackingDb, { noAuth: true });
+  } finally {
+    console.log = originalLog;
+    if (originalEnv === undefined) delete process.env.CROW_AUTO_UPDATE;
+    else process.env.CROW_AUTO_UPDATE = originalEnv;
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+    stopAutoUpdate(); // safety net — must be a no-op if the predicate worked
+  }
+  assert.ok(
+    !logs.some((l) => l.includes("Enabled")),
+    `must not log "Enabled" when skipped via noAuth predicate; got: ${JSON.stringify(logs)}`,
+  );
+  assert.equal(dbCalls, 0, "must return before ever touching the db (no settings read, no version save)");
+});
+
+test("startAutoUpdate: noAuth:true + CROW_AUTO_UPDATE=1 → arms (logs 'Enabled'); torn down via stopAutoUpdate", async () => {
+  const fx = fixture();
+  const originalEnv = process.env.CROW_AUTO_UPDATE;
+  process.env.CROW_AUTO_UPDATE = "1";
+  const stub = { execute: async () => ({ rows: [] }) };
+  const originalLog = console.log;
+  const logs = [];
+  console.log = (...args) => { logs.push(args.join(" ")); };
+  try {
+    _setAppRootForTest(fx.work);
+    await startAutoUpdate(stub, { noAuth: true });
+  } finally {
+    console.log = originalLog;
+    stopAutoUpdate(); // clear the armed setTimeout before it can fire
+    if (originalEnv === undefined) delete process.env.CROW_AUTO_UPDATE;
+    else process.env.CROW_AUTO_UPDATE = originalEnv;
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+  assert.ok(
+    logs.some((l) => l.includes("Enabled")),
+    `expected an "Enabled" log when CROW_AUTO_UPDATE=1 opts a noAuth gateway in; got: ${JSON.stringify(logs)}`,
+  );
 });

--- a/tests/auto-update-hardening.test.js
+++ b/tests/auto-update-hardening.test.js
@@ -1,0 +1,314 @@
+/**
+ * F-UPDATE-1 auto-update hardening (Task 1): branch guard (D1), tolerant
+ * ff-only pull with no stash (D2), atomic-reclaim cross-process lock (D3),
+ * and the under-lock branch re-check (D3b).
+ *
+ * Fixtures are real temp git repos (a bare `origin` + a `work` clone) so the
+ * module's actual `run()` seam (`_setAppRootForTest`) exercises real git
+ * semantics — no mocking of git behavior itself. Every test retargets
+ * `_setAppRootForTest` at a fresh fixture and restores it to the REAL repo
+ * root before finishing (even on failure), so the real APP_ROOT never sees a
+ * mutating command from this file.
+ */
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  checkForUpdates,
+  runLockedUpdate,
+  _setAppRootForTest,
+  _setDbForTest,
+  _lockPrimitivesForTest,
+} from "../servers/gateway/auto-update.js";
+
+const REAL_APP_ROOT = join(import.meta.dirname, "..");
+const restoreRoot = () => _setAppRootForTest(REAL_APP_ROOT);
+const LOCK_STALE_MS = 30 * 60 * 1000;
+
+const g = (cwd, ...args) => execFileSync("git", args, { cwd, stdio: "pipe" }).toString().trim();
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "au-hard-"));
+  const origin = join(root, "origin.git");
+  const work = join(root, "work");
+  execFileSync("git", ["init", "--bare", "-b", "main", origin], { stdio: "pipe" });
+  execFileSync("git", ["clone", origin, work], { stdio: "pipe" });
+  g(work, "config", "user.email", "t@t");
+  g(work, "config", "user.name", "t");
+  writeFileSync(join(work, "a.txt"), "one\n");
+  g(work, "add", "a.txt");
+  g(work, "commit", "-m", "c1");
+  g(work, "push", "origin", "main");
+  return { root, origin, work, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+/** Push a commit to origin/main from a THIRD clone, so `work`'s tree is
+ *  untouched (the caller then makes work "behind"). */
+function originCommit(fx, file, content) {
+  const pusher = mkdtempSync(join(fx.root, "pusher-"));
+  execFileSync("git", ["clone", fx.origin, pusher], { stdio: "pipe" });
+  g(pusher, "config", "user.email", "t@t");
+  g(pusher, "config", "user.name", "t");
+  writeFileSync(join(pusher, file), content);
+  g(pusher, "add", file);
+  g(pusher, "commit", "-m", "up");
+  g(pusher, "push", "origin", "main");
+}
+
+const stubDb = () => ({ execute: async () => ({ rows: [] }) });
+
+// ---------------------------------------------------------------------------
+// D1: branch guard
+// ---------------------------------------------------------------------------
+
+test("D1 branch guard: on a feature branch, checkForUpdates skips WITHOUT fetching", async () => {
+  const fx = fixture();
+  try {
+    g(fx.work, "checkout", "-b", "feature/x");
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await checkForUpdates();
+    assert.equal(result.updated, false);
+    assert.equal(result.skipped, "not-on-main");
+    assert.equal(result.branch, "feature/x");
+    assert.ok(result.message && result.message.length > 0, "skip must carry a human message");
+    assert.equal(
+      existsSync(join(fx.work, ".git", "FETCH_HEAD")),
+      false,
+      "branch guard must abort BEFORE any fetch",
+    );
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+test("D1 branch guard: detached HEAD also skips as not-on-main", async () => {
+  const fx = fixture();
+  try {
+    const sha = g(fx.work, "rev-parse", "HEAD");
+    g(fx.work, "checkout", sha);
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await checkForUpdates();
+    assert.equal(result.skipped, "not-on-main");
+    assert.equal(result.branch, "HEAD");
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D2: tolerant ff-only pull, no stash
+// ---------------------------------------------------------------------------
+
+test("D2 tolerant pull: disjoint local dirty file survives byte-identical, no stash entry", async () => {
+  const fx = fixture();
+  try {
+    // A tracked file the incoming update will NOT touch.
+    writeFileSync(join(fx.work, "c.txt"), "orig\n");
+    g(fx.work, "add", "c.txt");
+    g(fx.work, "commit", "-m", "add c");
+    g(fx.work, "push", "origin", "main");
+
+    originCommit(fx, "a.txt", "two\n");
+
+    writeFileSync(join(fx.work, "c.txt"), "dirty-local\n");
+
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await checkForUpdates();
+    assert.equal(result.updated, true, JSON.stringify(result));
+    assert.equal(readFileSync(join(fx.work, "c.txt"), "utf8"), "dirty-local\n");
+    assert.equal(g(fx.work, "stash", "list"), "", "no stash entry must ever be created");
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+test("D2 tolerant pull: overlapping local dirty file refuses honestly, tree untouched, no stash", async () => {
+  const fx = fixture();
+  try {
+    originCommit(fx, "a.txt", "two\n");
+    writeFileSync(join(fx.work, "a.txt"), "local-dirty\n");
+
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await checkForUpdates();
+    assert.equal(result.updated, false);
+    assert.ok(result.error, "overlap must produce an honest error, not silent data loss");
+    assert.match(result.error, /conflict|would be overwritten|Pull failed/i);
+    assert.equal(readFileSync(join(fx.work, "a.txt"), "utf8"), "local-dirty\n");
+    assert.equal(g(fx.work, "stash", "list"), "", "no stash entry must ever be created");
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D3: cross-process lock
+// ---------------------------------------------------------------------------
+
+test("D3 lock: a live young lock skips with a message, and is left in place", async () => {
+  const fx = fixture();
+  try {
+    const lockFile = join(fx.work, ".git", "crow-auto-update.lock");
+    writeFileSync(lockFile, `${process.pid}\n${new Date().toISOString()}\n`);
+
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await checkForUpdates();
+    assert.equal(result.skipped, "locked");
+    assert.ok(result.message && result.message.includes(String(process.pid)));
+    assert.equal(existsSync(lockFile), true, "a live lock must not be disturbed by a skipped tick");
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+test("D3 lock: a stale lock (dead pid) is reclaimed and the update proceeds; lock removed after", async () => {
+  const fx = fixture();
+  try {
+    originCommit(fx, "a.txt", "two\n");
+
+    const lockFile = join(fx.work, ".git", "crow-auto-update.lock");
+    const oldTs = new Date(Date.now() - LOCK_STALE_MS - 60_000).toISOString();
+    writeFileSync(lockFile, `999999999\n${oldTs}\n`);
+
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await checkForUpdates();
+    assert.equal(result.updated, true, JSON.stringify(result));
+    assert.equal(existsSync(lockFile), false, "lock must be released after a successful run");
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D3b: branch re-check under the lock (TOCTOU)
+// ---------------------------------------------------------------------------
+
+test("D3b: runLockedUpdate re-checks branch under the lock and aborts without pulling", async () => {
+  const fx = fixture();
+  try {
+    originCommit(fx, "a.txt", "two\n");
+    // Simulate a parallel session's raw checkout landing AFTER the outer D1
+    // guard passed but before the lock's pull — exercised directly via the
+    // runLockedUpdate seam (checkForUpdates's own D1 guard would otherwise
+    // abort this fixture before we ever reach the lock).
+    g(fx.work, "checkout", "-b", "feat/y");
+    const before = g(fx.work, "rev-parse", "feat/y");
+
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const result = await runLockedUpdate();
+    assert.equal(result.updated, false);
+    assert.equal(result.skipped, "not-on-main");
+    assert.equal(result.branch, "feat/y");
+
+    const after = g(fx.work, "rev-parse", "feat/y");
+    assert.equal(after, before, "feat/y must not have been fast-forwarded by an aborted pull");
+  } finally {
+    _setDbForTest(null);
+    restoreRoot();
+    fx.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Lock primitives (unit-level, via _lockPrimitivesForTest)
+// ---------------------------------------------------------------------------
+
+test("lock primitives: acquire sweeps stale quarantine leftovers older than the staleness window", () => {
+  const dir = mkdtempSync(join(tmpdir(), "au-lockprim-"));
+  try {
+    const lockFile = join(dir, "crow-auto-update.lock");
+    const staleQuarantine = `${lockFile}.stale.424242`;
+    writeFileSync(staleQuarantine, "leftover");
+    const oldTime = new Date(Date.now() - LOCK_STALE_MS - 60_000);
+    utimesSync(staleQuarantine, oldTime, oldTime);
+
+    const held = _lockPrimitivesForTest.acquireLock(lockFile);
+    assert.equal(held, lockFile);
+    assert.equal(existsSync(staleQuarantine), false, "old quarantine file must be swept on acquire");
+  } finally {
+    restoreRoot();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lock primitives: stale reclaim leaves OUR pid in the lock", () => {
+  const dir = mkdtempSync(join(tmpdir(), "au-lockprim-"));
+  try {
+    const lockFile = join(dir, "crow-auto-update.lock");
+    const oldTs = new Date(Date.now() - LOCK_STALE_MS - 60_000).toISOString();
+    writeFileSync(lockFile, `999999999\n${oldTs}\n`);
+
+    const held = _lockPrimitivesForTest.acquireLock(lockFile);
+    assert.equal(held, lockFile);
+    const [pidLine] = readFileSync(lockFile, "utf8").split("\n");
+    assert.equal(parseInt(pidLine, 10), process.pid);
+  } finally {
+    restoreRoot();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lock primitives: releaseLock never unlinks a lock owned by a different pid", () => {
+  const dir = mkdtempSync(join(tmpdir(), "au-lockprim-"));
+  try {
+    const lockFile = join(dir, "crow-auto-update.lock");
+    writeFileSync(lockFile, `424242\n${new Date().toISOString()}\n`);
+
+    _lockPrimitivesForTest.releaseLock(lockFile);
+    assert.equal(existsSync(lockFile), true, "release must never touch a lock this process doesn't own");
+  } finally {
+    restoreRoot();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("lock primitives: lockIsStale — dead pid OR age>30min is stale, live+young is not", () => {
+  try {
+    assert.equal(_lockPrimitivesForTest.lockIsStale(null), true, "missing/unparsable info is stale");
+    assert.equal(
+      _lockPrimitivesForTest.lockIsStale({ pid: process.pid, ts: Date.now() }),
+      false,
+      "live pid, fresh timestamp must NOT be stale",
+    );
+    assert.equal(
+      _lockPrimitivesForTest.lockIsStale({ pid: 999999999, ts: Date.now() }),
+      true,
+      "dead pid is stale even if fresh",
+    );
+    assert.equal(
+      _lockPrimitivesForTest.lockIsStale({ pid: process.pid, ts: Date.now() - LOCK_STALE_MS - 60_000 }),
+      true,
+      "live pid but age>30min is stale",
+    );
+  } finally {
+    restoreRoot();
+  }
+});


### PR DESCRIPTION
Hardens the gateway self-updater (`servers/gateway/auto-update.js`) against the June-stash incident class. Spec: `docs/superpowers/specs/2026-07-11-auto-update-hardening-design.md` (2-round adversarial review; R1 empirically reproduced the ancestor-branch fast-forward TOCTOU and the fake-success manual skip). Plan: `docs/superpowers/plans/2026-07-11-auto-update-hardening.md`.

## What changed

- **D1 — branch guard**: `checkForUpdates()` no-ops unless HEAD is on `main`, returning an honest `{updated:false, skipped:"not-on-main", branch, message}`. Protects both the 6-hour timer and the manual "Check now" button.
- **D2 — stash/pop deleted**: the June incident's root cause. `git pull --ff-only` now runs directly against the tree. Disjoint local WIP survives untouched; overlapping WIP fails the pull honestly with the tree left alone and `git stash list` staying empty.
- **D3 — cross-process lock**: `<gitDir>/crow-auto-update.lock` (O_EXCL create) serializes crow-gateway/crow-mpa-gateway/scratch gateways sharing one tree. Stale locks (dead pid OR >30 min) are reclaimed via atomic rename-quarantine; release is owner-checked. Loser returns `{skipped:"locked", message}`.
- **D3b — under-lock re-check**: the mutating sequence (extracted to `runLockedUpdate()`) re-checks the branch immediately before the pull, closing the TOCTOU where a parallel `git checkout` between guard and pull would let `pull --ff-only origin main` fast-forward an ancestor feature ref.
- **D4 — `--no-auth` defaults auto-update OFF**: `shouldStartAutoUpdate({env, noAuth})` — scratch/dev gateways no longer self-update unless explicitly opted in with `CROW_AUTO_UPDATE=1`; the existing `CROW_AUTO_UPDATE=0` kill switch takes precedence in every mode. Wired at `boot/post-listen.js`.
- **Honest manual UI (R1 MAJOR-1)**: the Updates section's "Check now" handler renders skip results as a muted message (`data.message`) instead of falling through to a fake "Already up to date".

Also merges current `main` (registry regen from #167 had drifted past the branch base).

## Verification

- Full suite **1476 pass / 0 fail / 1 skip** post-merge; `tests/auto-update-tick-gate.test.js` (#163) untouched and green.
- 15 new tests in `tests/auto-update-hardening.test.js` on real temp-git fixtures (bare origin + work clone via `_setAppRootForTest`) — never touches the real repo.
- All 7 planned mutations verified red-then-restored (branch guard, stash reintroduction, EEXIST-skip, staleness reclaim, blind-unlink release, D3b re-check, noAuth branch).
- **Live CDP** on a scratch throwaway clone checked out on a branch: real "Check for updates now" click renders muted `Skipped: not on main (on 'scratch/cdp-branch')` — not "Already up to date"; repo HEAD/branch untouched, stash empty (7/7 checks; evidence `~/.crow/p4/f-update-1-evidence/`).
- Concurrent-updaters run on one fixture: exactly one `{updated:true}`, the other `{skipped:"locked"}`, HEAD converged.
- D4 observed live: `--no-auth` boot logs `[auto-update] Disabled: --no-auth gateway defaults auto-update OFF`.
- Final whole-branch review: READY TO MERGE, 0 critical / 0 important; three accepted minors documented in the review (D3b `recheck.code` cosmetic message, spec-accepted releaseLock lapping residual, redundant `display='block'`).

## Post-merge deploy checks

- `git stash list` on crow/MPA gains no entries across an update cycle.
- grackle companion bridge logs no auto-update start.
- A scratch `--no-auth` gateway boots with auto-update disabled by default.