### PR TITLE
fix(providers-sync): owner-asserts reconciler — end the 211-conflict providers/crow-local sync war

### DIFF
--- a/docs/developers/configuration.md
+++ b/docs/developers/configuration.md
@@ -42,6 +42,7 @@ A brand-new operator usually only ever touches these: `CROW_GATEWAY_URL` (remote
 | Variable | Default | Purpose |
 |---|---|---|
 | `CROW_ORCHESTRATOR_PROVIDER` / `CROW_ORCHESTRATOR_MODEL` | *(DB `providers` table first)* | Default provider/model for the orchestrator. Prefer configuring providers in Settings → AI. |
+| `CROW_PROVIDERS_RECONCILE_MS` | `3600000` | Interval for the models.json → providers-DB reconcile (owner-asserted rows only; skipped entirely on `--no-auth` companions). |
 | `COMPANION_FAST_MODEL` | `crow-voice/qwen3.5-4b` | Fast voice-turn model for the AI Companion. |
 | `COMPANION_ESCALATION_MODEL` | `crow-chat/qwen3.6-35b-a3b` | Escalation model (`!escalate` / tool turns). |
 | `COMPANION_FAST_DISABLE_THINKING` | `1` | Disable chain-of-thought on voice turns. |

--- a/servers/gateway/boot/admin-api.js
+++ b/servers/gateway/boot/admin-api.js
@@ -2,15 +2,24 @@
  * boot/admin-api.js — protected API endpoints (behind dashboard auth).
  *
  * /api/health (system stats), provider health matrix, LLM settings migration,
- * provider DB seed, provider DB reconciler, storage client wiring.
+ * provider DB seed, provider DB reconciler (boot + hourly), storage client wiring.
  * Non-route init blocks stay sequential inside.
- * deps: { dashboardAuth }
+ * deps: { dashboardAuth, noAuth }
  */
 
 import { createDbClient } from "../../db.js";
 
+// D5: hourly reconcile closes the boot-time tailscale race (own tailnet IP
+// absent at boot → own rows look unowned → heals within the hour, because
+// syncProvidersFromModelsJson recomputes getOwnAddresses() per run) and the
+// owner-never-restarts staleness window. Exported for the env-override test.
+export function reconcileIntervalMs(env = process.env) {
+  const n = Number(env.CROW_PROVIDERS_RECONCILE_MS);
+  return Number.isFinite(n) && n > 0 ? n : 3600_000;
+}
+
 export async function mountAdminApi(app, deps) {
-  const { dashboardAuth } = deps;
+  const { dashboardAuth, noAuth } = deps;
 
   // --- Protected API endpoints (behind dashboard auth) ---
   app.get("/api/health", dashboardAuth, async (req, res) => {
@@ -58,30 +67,56 @@ export async function mountAdminApi(app, deps) {
     console.warn("[llm-migration] skipped:", err.message);
   }
 
-  // --- Provider DB seed (Phase 5-full: first-boot migration from models.json) ---
-  try {
-    const { seedProvidersFromModelsJson } = await import("../../shared/providers-db.js");
-    const seed = await seedProvidersFromModelsJson(createDbClient());
-    if (seed.seeded > 0) {
-      console.log(`[providers] Seeded ${seed.seeded} providers from ${seed.source}`);
+  // --- Provider DB seed + reconciler (owner-asserts, spec D1/D5/R2-C1) ---
+  // R2-C1 gate: a --no-auth gateway (the crow-mcp-bridge companion) shares
+  // the primary's crow.db with feedsDisabled — its upsert writes land but
+  // never emit. Under D2 no-op suppression it can win the race to make
+  // DB==file, and the PRIMARY then suppresses its own emit → a models.json
+  // edit silently never reaches peers. So seed, boot reconcile, AND the
+  // hourly interval are all skipped on --no-auth. Precedent: mcp-mounts.js
+  // gates healProfileOverridesOnce on !feedsDisabled for the same
+  // shared-DB reason. Scratch/CROW_DISABLE_INSTANCE_SYNC gateways with
+  // their OWN DB still reconcile (no peers, no hazard).
+  if (noAuth) {
+    console.log("[providers] Seed/reconcile skipped: --no-auth companion shares the primary's DB and must not write synced provider rows");
+  } else {
+    // --- Provider DB seed (Phase 5-full: first-boot migration from models.json) ---
+    try {
+      const { seedProvidersFromModelsJson } = await import("../../shared/providers-db.js");
+      const seed = await seedProvidersFromModelsJson(createDbClient());
+      if (seed.seeded > 0) {
+        console.log(`[providers] Seeded ${seed.seeded} providers from ${seed.source}`);
+      }
+    } catch (err) {
+      console.warn("[providers] First-boot seed skipped:", err.message);
     }
-  } catch (err) {
-    console.warn("[providers] First-boot seed skipped:", err.message);
-  }
 
-  // --- Provider DB reconciler (LLM-consolidation: continuous sync from models.json) ---
-  // Picks up post-boot edits to models.json and upserts them. Skips rows marked
-  // disabled=1 by unregisterProvidersByBundle so uninstalled bundles don't
-  // silently re-enable on the next restart. The "Sync bundle providers" button
-  // in the LLM settings page passes force=true to explicitly re-enable.
-  try {
-    const { syncProvidersFromModelsJson } = await import("../../shared/providers-db.js");
-    const res = await syncProvidersFromModelsJson(createDbClient());
-    if (res.upserted > 0 || res.skipped_disabled > 0) {
-      console.log(`[providers] Reconciled models.json → DB: upserted=${res.upserted} skipped_disabled=${res.skipped_disabled}`);
-    }
-  } catch (err) {
-    console.warn("[providers] Reconciler skipped:", err.message);
+    // --- Provider DB reconciler (owner-asserts sync from models.json) ---
+    // Picks up post-boot edits to models.json — but only asserts entries this
+    // instance OWNS (baseUrl points at one of its own addresses) or that are
+    // absent from the DB; unowned present rows are sync-authoritative (D1).
+    // Skips rows marked disabled=1 by unregisterProvidersByBundle so
+    // uninstalled bundles don't silently re-enable on the next restart. The
+    // "Sync bundle providers" button passes force=true to explicitly re-enable.
+    // Never throws out of the timer; quiet when converged.
+    const reconcile = async () => {
+      try {
+        const { syncProvidersFromModelsJson } = await import("../../shared/providers-db.js");
+        const res = await syncProvidersFromModelsJson(createDbClient());
+        if (res.upserted > 0 || res.reenabled > 0) {
+          console.log(`[providers] Reconciled models.json → DB: upserted=${res.upserted} reenabled=${res.reenabled} unchanged=${res.unchanged} skipped_disabled=${res.skipped_disabled} skipped_unowned=${res.skipped_unowned}`);
+        }
+      } catch (err) {
+        console.warn("[providers] Reconciler skipped:", err.message);
+      }
+    };
+    await reconcile();
+    // D5: hourly re-run (fresh getOwnAddresses each time) — heals the
+    // boot-time tailscale race and owner-never-restarts staleness. D2 makes
+    // converged runs free (zero writes, zero emits). unref() so the timer
+    // never holds the process open.
+    const t = setInterval(reconcile, reconcileIntervalMs());
+    t.unref();
   }
 
   // --- Wire storage client to DB + identity (DB-first precedence over env) ---

--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -136,6 +136,18 @@ export async function mountMcpServers(app, deps) {
     console.warn(`[instance-sync] backfillGroupsOnce failed: ${err.message}`);
   }
 
+  // D7: one-shot providers backfill per NEW peer — per-peer outgoing Hypercores
+  // are born empty (no history replay), and D2's no-op suppression removed the
+  // accidental per-boot re-emit that used to deliver provider rows to fresh
+  // pairings. Guarded by per-peer flag rows; idempotent on later boots.
+  try {
+    if (syncManager?.backfillProvidersForNewPeers) {
+      await syncManager.backfillProvidersForNewPeers();
+    }
+  } catch (err) {
+    console.warn(`[instance-sync] backfillProvidersForNewPeers failed: ${err.message}`);
+  }
+
   // Bundle asset repair: when a bundle is marked installed but its ~/.crow/bundles/<id>/
   // directory is missing user-visible files (settings-section.js, panel/, manifest.json),
   // re-copy them from the app repo. Prevents the Companion migration gap from recurring.

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -42,8 +42,8 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname, resolve } from "node:path";
-import { networkInterfaces } from "node:os";
 import { loadProviders as loadCachedProviders } from "../shared/providers.js";
+import { getOwnAddresses, isLocallyOrchestratable } from "../shared/locality.js";
 import {
   setResidencyInitialized, recordResidency, releaseResidency,
   pruneResidency, getProviderHealth,
@@ -56,46 +56,10 @@ function loadProviders() {
   return loadCachedProviders();
 }
 
-/**
- * F-INSTALL-10 — physical locality gate.
- *
- * The orchestrator's job is `docker compose up/stop` on THIS machine, so the
- * only trustworthy signal is whether the provider's baseUrl points AT this
- * machine (loopback or one of our own interface addresses). The providers
- * `host` column cannot be used: it syncs fleet-wide with the seeding
- * instance's perspective baked in (live fleet: grackle's own embed row says
- * host='grackle-5fc01ac74463b6f4', crow's bundles say 'local' everywhere),
- * so a host-string gate either breaks a peer keeping its own bundle resident
- * or lets a fresh install start the maintainer-lab's bundles.
- */
-// Bridge/virtual interfaces carry SHARED-SUBNET gateway IPs (every docker
-// host has 172.17.0.1; libvirt ships 192.168.122.1) — never machine identity
-// (R2-M1). Skip them so a peer's hypothetical bridge-IP baseUrl can't
-// false-match here.
-const VIRTUAL_IF_RE = /^(docker|br-|veth|virbr|vmnet|lxc|cni)/;
-
-export function getOwnAddresses() {
-  const own = new Set(["localhost", "127.0.0.1", "::1"]);
-  try {
-    for (const [ifname, addrs] of Object.entries(networkInterfaces())) {
-      if (VIRTUAL_IF_RE.test(ifname)) continue;
-      for (const a of addrs || []) own.add(a.address);
-    }
-  } catch {}
-  return own;
-}
-
-export function isLocallyOrchestratable(p, ownAddrs = getOwnAddresses()) {
-  if (!p?.baseUrl) return false;
-  try {
-    // WHATWG URL keeps brackets on IPv6 hostnames ("[::1]"); interface
-    // addresses don't have them.
-    const h = new URL(p.baseUrl).hostname.replace(/^\[|\]$/g, "");
-    return ownAddrs.has(h);
-  } catch {
-    return false;
-  }
-}
+// F-INSTALL-10 physical locality gate — implementation lives in
+// servers/shared/locality.js (shared with the providers reconciler's
+// owner-asserts gate). Re-exported here for existing importers/tests.
+export { getOwnAddresses, isLocallyOrchestratable };
 
 const READINESS_TIMEOUT_MS = 240_000;  // vLLM VL warm takes 2.5-3.5 min on 16 GB
 const READINESS_POLL_MS = 2_000;

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -499,7 +499,9 @@ const { peerExposureGate } = await mountMcpServers(app, { authMiddleware, noAuth
 await mountFeatureRoutes(app, { authMiddleware, dashboardAuth, peerExposureGate, sessionManager, instructions, PORT });
 
 // boot/admin-api.js — /api/health, provider health, LLM migration, provider seed/reconciler, storage wiring
-await mountAdminApi(app, { dashboardAuth });
+// noAuth gates the provider seed/reconcile/interval (R2-C1: a --no-auth
+// companion shares the primary's DB and must not write synced provider rows).
+await mountAdminApi(app, { dashboardAuth, noAuth });
 
 // --- Mount Crow's Nest (conditional) ---
 try {

--- a/servers/shared/locality.js
+++ b/servers/shared/locality.js
@@ -1,0 +1,50 @@
+/**
+ * Physical locality predicate — shared by the GPU orchestrator (F-INSTALL-10)
+ * and the providers reconciler (owner-asserts sync design).
+ *
+ * The only trustworthy signal for "does this provider endpoint live on THIS
+ * machine" is whether its baseUrl points at loopback or one of our own
+ * interface addresses. The providers `host` column cannot be used: it syncs
+ * fleet-wide with the seeding instance's perspective baked in (live fleet:
+ * grackle's own embed row says host='grackle-5fc01ac74463b6f4', crow's
+ * bundles say 'local' everywhere), so a host-string gate either breaks a
+ * peer keeping its own bundle resident or lets a fresh install start the
+ * maintainer-lab's bundles.
+ *
+ * Caveat for sync-ownership callers: loopback addresses are in every
+ * instance's own-address set, so a loopback baseUrl is "local" EVERYWHERE —
+ * this predicate is a locality test, not a fleet-wide ownership partition.
+ * Loopback provider rows are kept off the sync wire entirely (see
+ * shouldSyncRow('providers') in servers/sharing/instance-sync.js).
+ */
+
+import { networkInterfaces } from "node:os";
+
+// Bridge/virtual interfaces carry SHARED-SUBNET gateway IPs (every docker
+// host has 172.17.0.1; libvirt ships 192.168.122.1) — never machine identity
+// (R2-M1). Skip them so a peer's hypothetical bridge-IP baseUrl can't
+// false-match here.
+const VIRTUAL_IF_RE = /^(docker|br-|veth|virbr|vmnet|lxc|cni)/;
+
+export function getOwnAddresses() {
+  const own = new Set(["localhost", "127.0.0.1", "::1"]);
+  try {
+    for (const [ifname, addrs] of Object.entries(networkInterfaces())) {
+      if (VIRTUAL_IF_RE.test(ifname)) continue;
+      for (const a of addrs || []) own.add(a.address);
+    }
+  } catch {}
+  return own;
+}
+
+export function isLocallyOrchestratable(p, ownAddrs = getOwnAddresses()) {
+  if (!p?.baseUrl) return false;
+  try {
+    // WHATWG URL keeps brackets on IPv6 hostnames ("[::1]"); interface
+    // addresses don't have them.
+    const h = new URL(p.baseUrl).hostname.replace(/^\[|\]$/g, "");
+    return ownAddrs.has(h);
+  } catch {
+    return false;
+  }
+}

--- a/servers/shared/providers-db.js
+++ b/servers/shared/providers-db.js
@@ -163,22 +163,101 @@ async function emitSync(op, row) {
 }
 
 /**
+ * Canonical deep-equal for parsed-JSON values: recursive, object-key-order
+ * insensitive, array-order sensitive. Used by the upsert no-op comparator so
+ * `models` / `gpu_policy` compare on structure, never on string form (a
+ * key-order shuffle in models.json must not count as a change).
+ */
+function canonicalJsonEqual(a, b) {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+  const aArr = Array.isArray(a);
+  if (aArr !== Array.isArray(b)) return false;
+  if (aArr) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => canonicalJsonEqual(v, b[i]));
+  }
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((k) => Object.prototype.hasOwnProperty.call(b, k) && canonicalJsonEqual(a[k], b[k]));
+}
+
+/**
+ * D2 no-op comparator: does the write-image match the stored row on every
+ * content column? Normalization rules (spec R1-F6):
+ *   - base_url/host/bundle_id/description/provider_type: (x ?? null), String
+ *     coercion on non-null (libsql may return non-string cell types).
+ *   - disabled: both sides → Number(x) ? 1 : 0 (libsql can return BigInt).
+ *   - api_key: null ≡ "" (both mean "no key"), otherwise strict.
+ *   - models: canonical deep-equal of JSON.parse(dbRow.models) vs the incoming
+ *     array. DB-side parse failure → CHANGED (R2-m3 FAIL-OPEN: the good
+ *     incoming content overwrites the corruption; fail-closed would make a
+ *     corrupt row permanently unhealable).
+ *   - gpu_policy: incoming null/undefined → UNCHANGED by definition (the SQL
+ *     uses COALESCE(excluded.gpu_policy, providers.gpu_policy), so a null
+ *     write keeps the stored value). Non-null → deep-equal of parsed values;
+ *     any parse failure → CHANGED (same fail-open rule).
+ */
+function upsertIsNoop(existing, w) {
+  const s = (x) => (x == null ? null : String(x));
+  if (s(existing.base_url) !== s(w.baseUrl)) return false;
+  if (s(existing.host) !== s(w.host)) return false;
+  if (s(existing.bundle_id) !== s(w.bundleId)) return false;
+  if (s(existing.description) !== s(w.description)) return false;
+  if (s(existing.provider_type) !== s(w.providerType)) return false;
+  if ((Number(existing.disabled) ? 1 : 0) !== (Number(w.disabled) ? 1 : 0)) return false;
+  const keyNorm = (x) => (x == null ? "" : String(x));
+  if (keyNorm(existing.api_key) !== keyNorm(w.apiKey)) return false;
+  let dbModels;
+  try { dbModels = JSON.parse(existing.models); } catch { return false; } // fail-open
+  if (!canonicalJsonEqual(dbModels, w.models)) return false;
+  if (w.gpuPolicy != null) {
+    let dbPolicy, incomingPolicy;
+    try { dbPolicy = existing.gpu_policy == null ? null : JSON.parse(existing.gpu_policy); } catch { return false; } // fail-open
+    try { incomingPolicy = JSON.parse(w.gpuPolicy); } catch { return false; } // fail-open
+    if (!canonicalJsonEqual(dbPolicy, incomingPolicy)) return false;
+  }
+  return true;
+}
+
+/**
  * Upsert a single provider. Bumps lamport_ts and sets instance_id so
  * instance-sync can propagate. Emits a sync change to peers when a
  * syncManager has been attached via setProviderSyncManager.
+ *
+ * No-op suppression (D2): when the row exists and every content column
+ * matches the write-image (per upsertIsNoop's normalization), returns
+ * `{ id, lamport_ts: <current>, unchanged: true }` WITHOUT writing, bumping
+ * lamport, or emitting to peers — unchanged content must never manufacture
+ * sync churn (the 211-conflict restart war).
  */
 export async function upsertProvider(db, provider) {
   if (!provider || !provider.id) throw new Error("provider.id required");
   const instanceId = getOrCreateLocalInstanceId();
   const { rows } = await db.execute({
-    sql: "SELECT lamport_ts FROM providers WHERE id = ?",
+    sql: "SELECT * FROM providers WHERE id = ?",
     args: [provider.id],
   });
   const currentTs = rows[0]?.lamport_ts ?? 0;
   const existed = rows.length > 0;
-  const newTs = Math.max(Number(currentTs), Number(provider.lamport_ts || 0)) + 1;
   const providerType = provider.providerType ?? provider.provider_type ?? null;
   const gpuPolicy = provider.gpuPolicy != null ? JSON.stringify(provider.gpuPolicy) : (provider.gpu_policy ?? null);
+
+  if (existed && upsertIsNoop(rows[0], {
+    baseUrl: provider.baseUrl || provider.base_url || "",
+    apiKey: provider.apiKey ?? provider.api_key ?? null,
+    host: provider.host || "local",
+    bundleId: provider.bundleId ?? provider.bundle_id ?? null,
+    description: provider.description ?? null,
+    models: provider.models || [],
+    disabled: provider.disabled ? 1 : 0,
+    providerType,
+    gpuPolicy,
+  })) {
+    return { id: provider.id, lamport_ts: Number(currentTs), unchanged: true };
+  }
+
+  const newTs = Math.max(Number(currentTs), Number(provider.lamport_ts || 0)) + 1;
 
   await db.execute({
     sql: `INSERT INTO providers

--- a/servers/shared/providers-db.js
+++ b/servers/shared/providers-db.js
@@ -29,6 +29,7 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { createDbClient } from "../db.js";
 import { getOrCreateLocalInstanceId } from "../gateway/instance-registry.js";
+import { getOwnAddresses, isLocallyOrchestratable } from "./locality.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HOME = process.env.HOME || "/home/kh0pp";
@@ -403,43 +404,122 @@ export async function unregisterProvidersByBundle(db, bundleId) {
 }
 
 /**
- * Continuous reconciler: upsert every provider declared in models.json so
- * post-boot edits to models.json propagate into the DB. Complements
- * seedProvidersFromModelsJson (which runs once on an empty table).
+ * D1 decision table for the owner-asserts reconciler. Pure — exported for
+ * exhaustive unit-testing of the matrix (tests/providers-reconcile-gate.test.js).
  *
- * Key safety rule: rows currently `disabled=1` are skipped unless
- * `force=true`. This is required because `unregisterProvidersByBundle`
- * uses the disabled flag to mark bundle-uninstall, and a naive reconciler
- * would silently re-enable those rows on the next gateway startup because
- * the bundle's entry still lives in models.json. The `force=true` path is
- * for the explicit "Sync bundle providers" operator action in the LLM
- * settings page — that action's semantics are "I know, re-enable."
+ *   seed          → row absent from DB: insert it (any instance may seed).
+ *   assert        → owned + enabled (or owned + disabled + force): full
+ *                   re-assert from models.json (D2 makes converged runs no-ops).
+ *   skip_unowned  → present + NOT owned + enabled: the DB/sync copy is
+ *                   authoritative; this instance's file must not assert.
+ *                   Force does NOT override this (spec R-Q1: force never
+ *                   asserts file content over an enabled unowned row).
+ *   skip_disabled → disabled without force: today's bundle-uninstall guard.
+ *   reenable      → present + NOT owned + disabled + force: flip disabled→0
+ *                   preserving DB content (never assert this file's copy).
+ */
+export function reconcileDecision({ owned, present, disabled, force }) {
+  if (!present) return "seed";
+  if (owned) {
+    if (!disabled) return "assert";
+    return force ? "assert" : "skip_disabled";
+  }
+  if (!disabled) return "skip_unowned";
+  return force ? "reenable" : "skip_disabled";
+}
+
+/**
+ * Re-enable a provider row WITHOUT asserting models.json content over it —
+ * the force path for unowned+disabled rows (spec R1-F5 / R2-M2).
+ *
+ * CRITICAL (R2-M2): this must round-trip through the PARSED listProvidersAll
+ * shape (models as an array, gpuPolicy as an object). Spreading a raw
+ * `SELECT *` row into upsertProvider would double-encode its string `models`
+ * through the unconditional JSON.stringify in the upsert write path.
+ * In-tree precedent: the llm_provider_enable action (providers-tab.js).
+ *
+ * Returns the upsertProvider result, or null when the id doesn't exist.
+ */
+export async function reenableProviderPreservingContent(db, id) {
+  const all = await listProvidersAll(db);
+  const row = all.find((p) => p.id === id);
+  if (!row) return null;
+  return upsertProvider(db, { ...row, disabled: false });
+}
+
+/**
+ * Continuous reconciler: assert models.json entries into the DB — but only
+ * the entries this instance OWNS (single-writer by endpoint ownership).
+ *
+ * Why the ownership gate (the 211-conflict war, spec D1): models.json is
+ * per-machine (repo file + git-untracked ~/.pi/agent/models.json overlay),
+ * so copies drift across the fleet. The old reconciler had every instance
+ * unconditionally assert its own file into fleet-synced rows on every boot —
+ * two drifted files ⇒ an infinite sync ping-pong (181 recurring
+ * providers/crow-local conflict rows) with peers' stale metadata overwriting
+ * the owner's truth. The volatile truth "what does the server at this
+ * endpoint serve" has exactly one natural owner: the instance whose address
+ * the baseUrl points at. Only that owner asserts; sync propagates the
+ * owner's copy to everyone else. Rows absent from the DB are still seeded by
+ * any instance (cloud rows have no owner and are seed-once, then
+ * dashboard/force-edited).
+ *
+ * Loopback baseUrls are co-owned by design (every instance's own-address set
+ * contains loopback) — harmless, because shouldSyncRow('providers') keeps
+ * loopback rows off the sync wire entirely (D9): each instance asserts its
+ * own file's loopback rows into its own DB only.
+ *
+ * Disabled-row safety rule (unchanged): rows `disabled=1` are skipped unless
+ * `force=true`, because `unregisterProvidersByBundle` uses the flag to mark
+ * bundle-uninstall. Force ("Sync bundle providers" button) means "I know,
+ * re-enable": owned rows get today's full re-assert; UNOWNED rows are only
+ * flipped back to enabled with their DB content preserved (see
+ * reenableProviderPreservingContent).
+ *
+ * `ownAddrs` is recomputed on EVERY call (never module-cached) so the hourly
+ * reconcile sees tailscale coming up after boot and tailnet/DHCP IP changes.
+ * Injectable for tests.
  *
  * @param {object} db
- * @param {{ force?: boolean }} opts
- * @returns {Promise<{ upserted: number, skipped_disabled: number, source: string|null }>}
+ * @param {{ force?: boolean, ownAddrs?: Set<string> }} opts
+ * @returns {Promise<{ upserted: number, unchanged: number, skipped_disabled: number,
+ *                     skipped_unowned: number, reenabled: number, source: string|null }>}
+ *   `upserted` counts actual writes; `unchanged` counts owned entries whose
+ *   content already converged (D2 no-op suppression).
  */
-export async function syncProvidersFromModelsJson(db, { force = false } = {}) {
+export async function syncProvidersFromModelsJson(db, { force = false, ownAddrs } = {}) {
   const dbClient = db || createDbClient();
+  const addrs = ownAddrs || getOwnAddresses(); // fresh every run — see doc comment
   const { path, config } = readModelsJson();
-  if (!config?.providers) return { upserted: 0, skipped_disabled: 0, source: path };
+  const counters = { upserted: 0, unchanged: 0, skipped_disabled: 0, skipped_unowned: 0, reenabled: 0 };
+  if (!config?.providers) return { ...counters, source: path };
 
   const entries = Object.entries(config.providers).filter(([id]) => !id.startsWith("$"));
-  if (entries.length === 0) return { upserted: 0, skipped_disabled: 0, source: path };
+  if (entries.length === 0) return { ...counters, source: path };
 
-  const { rows: disabledRows } = await dbClient.execute(
-    "SELECT id FROM providers WHERE disabled = 1",
-  );
-  const disabledIds = new Set(disabledRows.map((r) => r.id));
+  const { rows: existingRows } = await dbClient.execute("SELECT id, disabled FROM providers");
+  const existing = new Map(existingRows.map((r) => [r.id, r]));
 
-  let upserted = 0;
-  let skippedDisabled = 0;
   for (const [id, p] of entries) {
-    if (!force && disabledIds.has(id)) { skippedDisabled++; continue; }
+    const cur = existing.get(id);
+    const decision = reconcileDecision({
+      owned: isLocallyOrchestratable({ baseUrl: p.baseUrl }, addrs),
+      present: cur !== undefined,
+      disabled: cur !== undefined && !!Number(cur.disabled),
+      force,
+    });
+    if (decision === "skip_disabled") { counters.skipped_disabled++; continue; }
+    if (decision === "skip_unowned") { counters.skipped_unowned++; continue; }
+    if (decision === "reenable") {
+      const res = await reenableProviderPreservingContent(dbClient, id);
+      if (res) counters.reenabled++;
+      continue;
+    }
+    // "seed" | "assert" — full assert from the file entry.
     const gpuPolicy = (p.mutexGroup || p.alwaysResident || p.defaultMember)
       ? { mutexGroup: p.mutexGroup ?? null, alwaysResident: !!p.alwaysResident, defaultMember: !!p.defaultMember }
       : null;
-    await upsertProvider(dbClient, {
+    const res = await upsertProvider(dbClient, {
       id,
       baseUrl: p.baseUrl || "",
       apiKey: p.apiKey ?? null,
@@ -451,7 +531,8 @@ export async function syncProvidersFromModelsJson(db, { force = false } = {}) {
       providerType: inferProviderType(p.api) || p.providerType || null,
       gpuPolicy,
     });
-    upserted++;
+    if (res.unchanged) counters.unchanged++;
+    else counters.upserted++;
   }
-  return { upserted, skipped_disabled: skippedDisabled, source: path };
+  return { ...counters, source: path };
 }

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -85,7 +85,12 @@ export const EXCLUDED_COLUMNS = {
   crow_instances: ["auth_token_hash"],
   // apiKey can be sensitive for some deployments; keep in sync by default for
   // local-lab scenarios but flag here as the place to exclude if paranoid.
-  providers: [],
+  // created_at/updated_at are per-instance bookkeeping that ride the wire
+  // TODAY via disableProvider's SELECT * spread and manufacture the same
+  // spurious conflicts as contacts.created_at below. lamport_ts is sync
+  // metadata carried in the entry envelope, not the row (prior art:
+  // messages/contact_groups).
+  providers: ["created_at", "updated_at", "lamport_ts"],
   // Phase 3 (contacts follow the user): `verified` is a per-device attestation
   // ("I compared the safety number on THIS device") — never assert it on a
   // device that didn't check. `last_seen` is bumped on every inbound DM
@@ -115,6 +120,19 @@ export const EXCLUDED_COLUMNS = {
 // as project-less (null project_id).
 const OUTBOUND_TRANSFORMS = {
   research_notes: (row) => ({ ...row, project_id: null }),
+  // providers: a null gpu_policy must not ride the wire — _applyUpdate writes
+  // wire nulls verbatim and would null a peer's locally-set policy, while the
+  // local write path already treats null as "keep" (COALESCE,
+  // providers-db.js:198). Drop the key when null; pass through otherwise.
+  // NOTE: transforms are applied in emitChange AND to the local row in
+  // _checkConflict — must be pure (never mutate the input).
+  providers: (row) => {
+    if (row.gpu_policy == null) {
+      const { gpu_policy, ...rest } = row;
+      return rest;
+    }
+    return { ...row };
+  },
 };
 
 /**
@@ -203,6 +221,26 @@ function shouldSyncRow(table, row) {
     // `!= null` catches both null and undefined (a delete row omits room_uid).
     if (row.room_uid != null) return false;
     return Boolean(row.group_uid);
+  }
+  if (table === "providers") {
+    // Loopback endpoints are per-instance by construction: a peer dialing
+    // 127.0.0.1 reaches ITSELF, never the origin's service. They're also
+    // co-owned by every instance's locality predicate (loopback matches
+    // everywhere), so the reconciler ownership gate cannot partition them —
+    // keeping them off the wire entirely (this function gates BOTH emit and
+    // apply) is the only clean single-writer story. Missing/malformed
+    // base_url → defensive false: a providers row without a parseable
+    // endpoint shouldn't sync either.
+    if (!row || !row.base_url) return false;
+    let hostname;
+    try {
+      hostname = new URL(row.base_url).hostname;
+    } catch {
+      return false;
+    }
+    const host = hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+    if (host === "localhost" || host === "::1" || /^127\./.test(host)) return false;
+    return true;
   }
   if (table !== "dashboard_settings") return true;
   if (!row || !row.key) return false;
@@ -807,6 +845,16 @@ export class InstanceSyncManager {
     if (!SYNCED_TABLES.includes(table)) return null;
     if (!shouldSyncRow(table, row)) return null; // local-only row; don't broadcast
 
+    // Envelope counter floor: after a sync_state reset (e.g. DB recovery) the
+    // local counter can sit BELOW lamports already stamped on rows; an emit
+    // would then look stale to peers (they order on the envelope) and the
+    // divergence is silent and permanent. Floor the counter at the outgoing
+    // row's own lamport first — _advanceCounter is an atomic
+    // MAX(counter, ts+1), so the _nextLamport below strictly exceeds it.
+    const rowTs = Number(row?.lamport_ts);
+    if (Number.isFinite(rowTs) && rowTs > 0) {
+      await this._advanceCounter(rowTs);
+    }
     const lamportTs = await this._nextLamport();
 
     // Strip excluded columns

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -672,6 +672,116 @@ export class InstanceSyncManager {
   }
 
   /**
+   * D7 — one-shot providers backfill PER PEER GENERATION (the new-pairing
+   * counterpart to D2's no-op suppression). Outgoing sync feeds are per-peer
+   * Hypercores created EMPTY at first pairing (_initInstanceInner — no history
+   * replay); before D2, the boot reconciler's unconditional per-boot re-emit
+   * was accidentally how a newly-paired peer ever received this instance's
+   * provider rows. D2 kills that boot churn, so this backfill is the
+   * deliberate delivery channel.
+   *
+   * Unlike the GLOBAL contacts flag, the flag here is PER PEER
+   * (`__providers_backfill_v1:<peerId>` in dashboard_settings) so every FUTURE
+   * pairing also gets a backfill — not just the deploy transition. Only a
+   * "done:*" value is terminal; a stale non-done value is overwritten by the
+   * UPSERT done-mark. Zero armed peers → return WITHOUT writing any flag
+   * (feeds may not have opened yet this boot — retry next boot; contacts
+   * lesson, observed live on grackle 2026-07-06). Inbound backlog is drained
+   * first (I-B1) so a peer's already-delivered newer provider edit is applied
+   * before we re-emit with a fresh lamport.
+   *
+   * emitChange broadcasts to ALL peers: already-current peers converge the
+   * re-emit as re-delivery noise (rowsEquivalent → silent skip in
+   * _checkConflict, or a plain newer-lamport UPDATE with identical values) —
+   * accepted cost, same as the contacts backfill. shouldSyncRow('providers')
+   * inside emitChange drops loopback rows automatically, and
+   * EXCLUDED_COLUMNS/OUTBOUND_TRANSFORMS strip bookkeeping + null gpu_policy —
+   * no pre-filtering here. Disabled rows ARE included: disabled=1 is a synced
+   * fact the peer must learn (see disableProvider's emit).
+   *
+   * Documented limitation (parity with the contacts backfill): a pairing
+   * formed mid-run without a subsequent reboot waits for the next boot —
+   * acceptable, pairing flows involve restarts in practice.
+   * Never throws out of the loop. Returns the count of rows actually emitted.
+   */
+  async backfillProvidersForNewPeers() {
+    const FLAG_PREFIX = "__providers_backfill_v1:";
+    if (this.outFeeds.size === 0) {
+      // No peer feeds armed (yet) — deliberately write NO flags: feeds may
+      // simply not have opened yet this boot. A later boot retries; a
+      // genuinely peer-less instance just re-runs a cheap check per boot.
+      return 0;
+    }
+
+    // Which armed peers still need a backfill? Only "done:*" is terminal.
+    const newPeers = [];
+    for (const peerId of this.outFeeds.keys()) {
+      let done = false;
+      try {
+        const { rows } = await this.db.execute({
+          sql: "SELECT value FROM dashboard_settings WHERE key = ?",
+          args: [FLAG_PREFIX + peerId],
+        });
+        done = typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:");
+      } catch {}
+      if (!done) newPeers.push(peerId);
+    }
+    if (newPeers.length === 0) return 0; // every armed peer already covered
+
+    // I-B1 ordering guard: drain the locally-replicated inbound backlog FIRST,
+    // so a peer's already-delivered newer provider edit is applied before we
+    // re-emit with a fresh lamport and fabricate recency over it.
+    try {
+      for (const [peerId, inFeed] of this.inFeeds) {
+        await this._processNewEntries(peerId, inFeed);
+      }
+    } catch (err) {
+      console.warn(`[instance-sync] providers backfill drain failed: ${err.message}`);
+    }
+
+    let rows = [];
+    try {
+      // ALL rows, including disabled ones — disabled=1 is a synced fact.
+      // No pre-filtering: shouldSyncRow inside emitChange drops loopback rows,
+      // EXCLUDED_COLUMNS/OUTBOUND_TRANSFORMS handle wire hygiene.
+      const r = await this.db.execute({ sql: "SELECT * FROM providers" });
+      rows = r.rows || [];
+    } catch (err) {
+      console.warn(`[instance-sync] providers backfill read failed: ${err.message}`);
+      return 0;
+    }
+
+    let emitted = 0;
+    for (const row of rows) {
+      try {
+        // emitChange returns null when the row was gated off the wire
+        // (loopback / feedsDisabled) — only count rows that actually rode.
+        const ts = await this.emitChange("providers", "update", row);
+        if (ts != null) emitted++;
+      } catch (err) {
+        console.warn(`[instance-sync] providers backfill emit failed for ${row.id}: ${err.message}`);
+      }
+    }
+
+    for (const peerId of newPeers) {
+      try {
+        // UPSERT: a stale non-done value must be overwritten or the done-mark
+        // silently no-ops (per-boot re-emit thrash). Already-done peers are
+        // never rewritten — only the previously-unflagged ones.
+        await this.db.execute({
+          sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+          args: [FLAG_PREFIX + peerId, `done:${emitted}`],
+        });
+      } catch {}
+    }
+
+    if (emitted > 0) {
+      console.log(`[instance-sync] providers backfill: ${emitted} provider row(s) re-emitted for ${newPeers.length} new peer(s)`);
+    }
+    return emitted;
+  }
+
+  /**
    * C1: assign a DETERMINISTIC, FROZEN group_uid to every pre-existing PLAIN group
    * the migration left NULL, so the SAME logical group on two instances (same shared
    * identity) converges on ONE uid instead of duplicating. uid = first-32-hex of

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -690,9 +690,9 @@ export class InstanceSyncManager {
    * first (I-B1) so a peer's already-delivered newer provider edit is applied
    * before we re-emit with a fresh lamport.
    *
-   * emitChange broadcasts to ALL peers: already-current peers converge the
-   * re-emit as re-delivery noise (rowsEquivalent → silent skip in
-   * _checkConflict, or a plain newer-lamport UPDATE with identical values) —
+   * emitChange broadcasts to ALL peers as op="insert": fresh peers land the
+   * row via _applyInsert's INSERT OR IGNORE; already-current peers IGNORE and
+   * converge it as re-delivery noise (rowsEquivalent → no conflict logged) —
    * accepted cost, same as the contacts backfill. shouldSyncRow('providers')
    * inside emitChange drops loopback rows automatically, and
    * EXCLUDED_COLUMNS/OUTBOUND_TRANSFORMS strip bookkeeping + null gpu_policy —
@@ -754,9 +754,16 @@ export class InstanceSyncManager {
     let emitted = 0;
     for (const row of rows) {
       try {
+        // op MUST be "insert", not "update": providers has no natural-key
+        // apply handler, so an update falls through to the generic
+        // _applyUpdate (`UPDATE … WHERE id=?`) which matches ZERO rows on the
+        // freshly-paired peer this backfill exists for — the row would be
+        // silently never delivered. "insert" lands via _applyInsert's
+        // INSERT OR IGNORE: delivers to fresh peers, no-ops benignly on
+        // peers that already hold an equivalent row (final-review B1).
         // emitChange returns null when the row was gated off the wire
         // (loopback / feedsDisabled) — only count rows that actually rode.
-        const ts = await this.emitChange("providers", "update", row);
+        const ts = await this.emitChange("providers", "insert", row);
         if (ts != null) emitted++;
       } catch (err) {
         console.warn(`[instance-sync] providers backfill emit failed for ${row.id}: ${err.message}`);

--- a/tests/providers-backfill.test.js
+++ b/tests/providers-backfill.test.js
@@ -56,6 +56,8 @@ test("backfillProvidersForNewPeers: fresh peer → syncable (tailnet) row append
   assert.equal(n, 1, "only the tailnet row counts as emitted (loopback dropped inside emitChange)");
   assert.equal(feed.entries.length, 1, "exactly one entry appended to the peer feed");
   assert.equal(feed.entries[0].table, "providers");
+  assert.equal(feed.entries[0].op, "insert",
+    "backfill MUST emit op=insert — an update falls through to the generic UPDATE-by-id, matches zero rows on a fresh peer, and the row is silently never delivered (final-review B1)");
   assert.equal(feed.entries[0].row.id, "prov-tailnet");
   assert.ok(!feed.entries.some((e) => e.row.id === "prov-loop"), "loopback row never rides the wire");
   // Wire hygiene rides along (D3): bookkeeping columns stripped by emitChange.
@@ -129,4 +131,40 @@ test("backfillProvidersForNewPeers: disabled provider rows ARE emitted — disab
   assert.equal(feed.entries.length, 1);
   assert.equal(feed.entries[0].row.id, "prov-off");
   assert.equal(Number(feed.entries[0].row.disabled), 1, "disabled state rides the wire");
+});
+
+test("backfillProvidersForNewPeers: END-TO-END DELIVERY — a fresh peer that applies the backfill feed actually HOLDS the provider row (final-review B1)", async () => {
+  const origin = freshMgr("e2e-origin", "origin-1");
+  const peer = freshMgr("e2e-peer", "peer-fresh");
+  const feed = captureFeed();
+  origin.outFeeds.set("peer-fresh", feed);
+  await origin.db.execute({
+    sql: "INSERT INTO providers (id, base_url, models, lamport_ts) VALUES ('prov-e2e', 'http://100.118.41.122:8003/v1', ?, 7)",
+    args: [JSON.stringify([{ id: "m", contextWindow: 262144 }])],
+  });
+
+  assert.equal(await origin.backfillProvidersForNewPeers(), 1);
+
+  // The peer's providers table starts EMPTY (per-peer feeds are born empty —
+  // this is the exact case D7 exists for). Apply the captured wire.
+  const consumerFeed = {
+    get length() { return feed.entries.length; },
+    async get(seq) { return feed.entries[seq]; },
+  };
+  await peer._processNewEntries("origin-1", consumerFeed);
+
+  const { rows } = await peer.db.execute({
+    sql: "SELECT * FROM providers WHERE id = 'prov-e2e'",
+  });
+  assert.equal(rows.length, 1,
+    "the backfilled provider row must actually LAND on a fresh peer (op=insert via INSERT OR IGNORE; an op=update would UPDATE zero rows and vanish)");
+  assert.deepEqual(JSON.parse(rows[0].models), [{ id: "m", contextWindow: 262144 }]);
+  const { rows: conflicts } = await peer.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" });
+  assert.equal(Number(conflicts[0].n), 0, "delivery is conflict-free");
+
+  // Idempotence: re-applying the same feed is benign (INSERT OR IGNORE +
+  // equivalence — no duplicate, no conflict).
+  await peer._processNewEntries("origin-1", consumerFeed);
+  const { rows: again } = await peer.db.execute({ sql: "SELECT COUNT(*) AS n FROM providers WHERE id = 'prov-e2e'" });
+  assert.equal(Number(again[0].n), 1);
 });

--- a/tests/providers-backfill.test.js
+++ b/tests/providers-backfill.test.js
@@ -1,0 +1,132 @@
+// D7 — one-shot providers backfill per peer generation (new-pairing counterpart
+// to D2's no-op suppression). Outgoing sync feeds are per-peer Hypercores born
+// EMPTY at first pairing (no history replay); before this branch the boot
+// reconciler's unconditional re-emit was accidentally how a new peer ever
+// learned this instance's provider rows. D2 killed that — this backfill is the
+// deliberate delivery channel, flagged PER PEER so every future pairing (not
+// just the deploy transition) gets one.
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const TEST_PRIV = Buffer.alloc(32, 0xAB);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+// Capturing out-feed stub: emitChange broadcasts the SIGNED entry to every
+// armed peer feed via feed.append(entry) — the appended entries ARE the wire.
+function captureFeed() {
+  const entries = [];
+  return { entries, append: async (e) => entries.push(e) };
+}
+
+function freshMgr(label, id) {
+  const d = mkdtempSync(join(tmpdir(), `crow-prov-backfill-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: d }, stdio: "pipe" });
+  after(() => rmSync(d, { recursive: true, force: true }));
+  const m = new InstanceSyncManager(IDENTITY, createDbClient(join(d, "crow.db")), id);
+  m.feedsDisabled = false;
+  return m;
+}
+
+const FLAG = (peerId) => `__providers_backfill_v1:${peerId}`;
+
+async function flagValue(db, peerId) {
+  const { rows } = await db.execute({
+    sql: "SELECT value FROM dashboard_settings WHERE key = ?",
+    args: [FLAG(peerId)],
+  });
+  return rows[0]?.value ?? null;
+}
+
+test("backfillProvidersForNewPeers: fresh peer → syncable (tailnet) row appended, loopback dropped by shouldSyncRow, flag done:*; second run is a no-op", async () => {
+  const m = freshMgr("fresh", "local-1");
+  const feed = captureFeed();
+  m.outFeeds.set("peer-1", feed);
+  await m.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-tailnet', 'http://100.118.41.122:8003/v1', '[\"m1\"]')" });
+  await m.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-loop', 'http://127.0.0.1:9999/v1', '[\"m2\"]')" });
+
+  const n = await m.backfillProvidersForNewPeers();
+  assert.equal(n, 1, "only the tailnet row counts as emitted (loopback dropped inside emitChange)");
+  assert.equal(feed.entries.length, 1, "exactly one entry appended to the peer feed");
+  assert.equal(feed.entries[0].table, "providers");
+  assert.equal(feed.entries[0].row.id, "prov-tailnet");
+  assert.ok(!feed.entries.some((e) => e.row.id === "prov-loop"), "loopback row never rides the wire");
+  // Wire hygiene rides along (D3): bookkeeping columns stripped by emitChange.
+  assert.equal(feed.entries[0].row.created_at, undefined, "EXCLUDED_COLUMNS strip applies to the backfill emit too");
+  assert.match(await flagValue(m.db, "peer-1"), /^done:1$/, "per-peer flag written as done:<emitted>");
+
+  // (b) Second call: flag is terminal → 0 emitted, feed length unchanged.
+  assert.equal(await m.backfillProvidersForNewPeers(), 0, "flag-guarded second run is a no-op");
+  assert.equal(feed.entries.length, 1, "no re-append on the guarded second run");
+});
+
+test("backfillProvidersForNewPeers: no armed peers → returns 0, NO flag written (retryable); backfills once feeds arm", async () => {
+  const m = freshMgr("nopeers", "local-2");
+  await m.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-a', 'http://100.118.41.122:8003/v1', '[]')" });
+  assert.equal(await m.backfillProvidersForNewPeers(), 0);
+  const { rows } = await m.db.execute({ sql: "SELECT key FROM dashboard_settings WHERE key LIKE '__providers_backfill_v1:%'" });
+  assert.equal(rows.length, 0, "peerless run writes NO flags — boot can race feed-init (contacts lesson)");
+  // Feeds arm later (e.g. next boot) → the backfill runs then.
+  const feed = captureFeed();
+  m.outFeeds.set("peer-1", feed);
+  assert.equal(await m.backfillProvidersForNewPeers(), 1, "retry with armed feeds must backfill");
+  assert.equal(feed.entries.length, 1);
+  assert.match(await flagValue(m.db, "peer-1"), /^done:1$/);
+});
+
+test("backfillProvidersForNewPeers: flag semantics — only 'done:*' is terminal; a stale non-done value is overwritten (UPSERT)", async () => {
+  const m = freshMgr("staleflag", "local-3");
+  const feed = captureFeed();
+  m.outFeeds.set("peer-1", feed);
+  await m.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-a', 'http://100.118.41.122:8003/v1', '[]')" });
+  // A stale non-done flag (pre-fix code class of bug) must NOT be terminal.
+  await m.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, 'no-peers', datetime('now'))",
+    args: [FLAG("peer-1")],
+  });
+  assert.equal(await m.backfillProvidersForNewPeers(), 1, "stale non-done flag is not terminal — backfill runs");
+  assert.match(await flagValue(m.db, "peer-1"), /^done:1$/, "done-mark UPSERTs over the stale row");
+  assert.equal(await m.backfillProvidersForNewPeers(), 0, "terminal after the real run");
+  assert.equal(feed.entries.length, 1);
+});
+
+test("backfillProvidersForNewPeers: two peers, one already done → runs for the new peer; broadcast reaches BOTH feeds (accepted re-delivery cost); done peer's flag untouched", async () => {
+  const m = freshMgr("twopeers", "local-4");
+  const oldFeed = captureFeed();
+  const newFeed = captureFeed();
+  m.outFeeds.set("peer-old", oldFeed);
+  m.outFeeds.set("peer-new", newFeed);
+  await m.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-a', 'http://100.118.41.122:8003/v1', '[]')" });
+  await m.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, 'done:5', datetime('now'))",
+    args: [FLAG("peer-old")],
+  });
+
+  assert.equal(await m.backfillProvidersForNewPeers(), 1, "one unflagged peer arms the backfill");
+  assert.equal(newFeed.entries.length, 1, "new peer receives the backfill");
+  // emitChange broadcasts to ALL peers — the already-done peer receives the
+  // re-emit too. That is the ACCEPTED cost (same as the contacts backfill):
+  // an already-current peer converges it as re-delivery noise (rowsEquivalent
+  // → silent skip, or a plain newer-lamport UPDATE with identical values).
+  assert.equal(oldFeed.entries.length, 1, "broadcast also appends to the already-done peer's feed (documented accepted cost)");
+  assert.match(await flagValue(m.db, "peer-new"), /^done:1$/, "new peer's flag written");
+  assert.equal(await flagValue(m.db, "peer-old"), "done:5", "already-done peer's flag left untouched");
+});
+
+test("backfillProvidersForNewPeers: disabled provider rows ARE emitted — disabled=1 is a synced fact (disableProvider emits it)", async () => {
+  const m = freshMgr("disabled", "local-5");
+  const feed = captureFeed();
+  m.outFeeds.set("peer-1", feed);
+  await m.db.execute({ sql: "INSERT INTO providers (id, base_url, models, disabled) VALUES ('prov-off', 'http://100.121.254.89:8004/v1', '[]', 1)" });
+  assert.equal(await m.backfillProvidersForNewPeers(), 1, "disabled row still emitted — the peer must learn the disabled state");
+  assert.equal(feed.entries.length, 1);
+  assert.equal(feed.entries[0].row.id, "prov-off");
+  assert.equal(Number(feed.entries[0].row.disabled), 1, "disabled state rides the wire");
+});

--- a/tests/providers-reconcile-gate.test.js
+++ b/tests/providers-reconcile-gate.test.js
@@ -1,0 +1,295 @@
+/**
+ * providers-reconcile-gate — D1/D5/R2-C1 of the providers-sync volatile-models
+ * spec (.superpowers/sdd/providers-volatile-spec.md).
+ *
+ * D1: syncProvidersFromModelsJson is single-writer by endpoint ownership —
+ * only the instance whose addresses match an entry's baseUrl asserts that
+ * entry over an existing DB row; absent rows are seeded by anyone; unowned
+ * present rows are sync-authoritative and skipped (counted skipped_unowned).
+ * Force flips unowned+disabled rows back to enabled WITHOUT asserting file
+ * content (reenableProviderPreservingContent — parsed shape round-trip, no
+ * models double-encode, R2-M2).
+ *
+ * Coverage strategy (models.json is read from module-level fixed search
+ * paths, including $HOME/.pi/agent/models.json, so the file content cannot
+ * be redirected per-test):
+ *   1. reconcileDecision — exported pure decision table, exhaustive matrix.
+ *   2. reenableProviderPreservingContent — direct row insert + round-trip
+ *      double-encode proof.
+ *   3. syncProvidersFromModelsJson with injectable ownAddrs against the REAL
+ *      merged models.json — expectations computed dynamically from the same
+ *      files (never hardcoded entries).
+ *   4. reconcileIntervalMs env-override parsing (D5).
+ *
+ * Harness: freshLibsql() pattern from providers-upsert-noop.test.js —
+ * CROW_DATA_DIR is pointed at a per-test tmp dir BEFORE any upsert so
+ * getOrCreateLocalInstanceId() never touches the real ~/.crow.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  reconcileDecision,
+  reenableProviderPreservingContent,
+  syncProvidersFromModelsJson,
+  setProviderSyncManager,
+} from "../servers/shared/providers-db.js";
+import { reconcileIntervalMs } from "../servers/gateway/boot/admin-api.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "providers-reconcile-gate-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return {
+    dir, db,
+    cleanup() {
+      setProviderSyncManager(null);
+      if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+      else process.env.CROW_DATA_DIR = prevDataDir;
+      try { db.close(); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function spySyncManager() {
+  const calls = [];
+  setProviderSyncManager({ emitChange: async (...a) => { calls.push(a); } });
+  return calls;
+}
+
+// Replicate readModelsJson's merge (providers-db.js MODELS_JSON_SEARCH_PATHS)
+// so expectations track the REAL files this host carries — repo models.json,
+// repo config/models.json, $HOME/.pi/agent/models.json, later files override.
+const REPO = resolve(import.meta.dirname, "..");
+const HOME = process.env.HOME || "/home/kh0pp";
+function mergedModelsJsonEntries() {
+  const providers = {};
+  for (const p of [
+    resolve(REPO, "models.json"),
+    resolve(REPO, "config/models.json"),
+    resolve(HOME, ".pi/agent/models.json"),
+  ]) {
+    try {
+      const j = JSON.parse(readFileSync(p, "utf-8"));
+      if (j && j.providers) Object.assign(providers, j.providers);
+    } catch {}
+  }
+  return Object.entries(providers).filter(([id]) => !id.startsWith("$"));
+}
+
+const LOOPBACK = ["localhost", "127.0.0.1", "::1"];
+function hostnameOf(baseUrl) {
+  try { return new URL(baseUrl).hostname.replace(/^\[|\]$/g, ""); } catch { return null; }
+}
+
+// --- 1. reconcileDecision: exhaustive matrix ---------------------------------
+
+const MATRIX = [
+  // [owned, present, disabled, force] → expected
+  // Absent rows always seed (any instance may insert; cloud rows seed-once).
+  [false, false, false, false, "seed"],
+  [false, false, false, true,  "seed"],
+  [false, false, true,  false, "seed"], // disabled is meaningless when absent
+  [false, false, true,  true,  "seed"],
+  [true,  false, false, false, "seed"],
+  [true,  false, false, true,  "seed"],
+  [true,  false, true,  false, "seed"],
+  [true,  false, true,  true,  "seed"],
+  // Owned + enabled → assert regardless of force (D2 makes converged a no-op).
+  [true,  true,  false, false, "assert"],
+  [true,  true,  false, true,  "assert"],
+  // Owned + disabled → today's semantics: skip unless force (full re-assert).
+  [true,  true,  true,  false, "skip_disabled"],
+  [true,  true,  true,  true,  "assert"],
+  // Unowned + enabled → DB/sync authoritative. Force does NOT override (R-Q1).
+  [false, true,  false, false, "skip_unowned"],
+  [false, true,  false, true,  "skip_unowned"],
+  // Unowned + disabled → skip; force flips enabled WITHOUT asserting content.
+  [false, true,  true,  false, "skip_disabled"],
+  [false, true,  true,  true,  "reenable"],
+];
+
+test("reconcileDecision: exhaustive owned×present×disabled×force matrix", () => {
+  for (const [owned, present, disabled, force, expected] of MATRIX) {
+    assert.equal(
+      reconcileDecision({ owned, present, disabled, force }),
+      expected,
+      `owned=${owned} present=${present} disabled=${disabled} force=${force}`,
+    );
+  }
+  // Sanity: the matrix really is the full 2^4 space.
+  assert.equal(MATRIX.length, 16);
+});
+
+// --- 2. reenableProviderPreservingContent: no double-encode (R2-M2) ----------
+
+const REENABLE_ID = "reenable-gate-test";
+const REENABLE_MODELS = [
+  {
+    id: "m1",
+    name: "Model One",
+    contextWindow: 262144,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0 },
+  },
+  { id: "m2", name: "Model Two", contextWindow: 8192 },
+];
+
+async function insertDisabledUnownedRow(db) {
+  await db.execute({
+    sql: `INSERT INTO providers
+          (id, base_url, api_key, host, bundle_id, description, models, disabled, lamport_ts, instance_id, provider_type, gpu_policy)
+          VALUES (?, ?, ?, ?, ?, ?, ?, 1, 5, 'peer-instance', ?, ?)`,
+    args: [
+      REENABLE_ID,
+      "http://203.0.113.9:9999/v1", // TEST-NET-3: owned by nobody
+      null, "local", "some-bundle", "unowned disabled row",
+      JSON.stringify(REENABLE_MODELS),
+      "openai-compat",
+      JSON.stringify({ mutexGroup: "peer-vram", alwaysResident: false, defaultMember: true }),
+    ],
+  });
+}
+
+test("reenableProviderPreservingContent: flips disabled→0, models survives as an ARRAY (no double-encode), content preserved, re-enable emits", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    await insertDisabledUnownedRow(db);
+
+    const res = await reenableProviderPreservingContent(db, REENABLE_ID);
+    assert.ok(res, "returns the upsert result");
+    assert.notEqual(res.unchanged, true, "disabled flip is a real change");
+    assert.equal(calls.length, 1, "re-enable propagates to peers (one emit)");
+
+    const { rows } = await db.execute({
+      sql: "SELECT * FROM providers WHERE id = ?", args: [REENABLE_ID],
+    });
+    const row = rows[0];
+    assert.equal(Number(row.disabled), 0, "row re-enabled");
+
+    // R2-M2 double-encode proof: one JSON.parse must yield the original
+    // ARRAY. A raw SELECT* spread would have stored a JSON string OF a
+    // string — the first parse would yield a string and a second parse
+    // would succeed. Here the second parse must THROW.
+    const parsed = JSON.parse(row.models);
+    assert.ok(Array.isArray(parsed), "models parses to an array on the FIRST parse");
+    assert.deepEqual(parsed, REENABLE_MODELS, "DB content preserved exactly (not asserted from file)");
+    assert.throws(() => JSON.parse(parsed), "second parse throws — proves models was not double-encoded");
+
+    // Other content preserved (never asserted from models.json).
+    assert.equal(row.base_url, "http://203.0.113.9:9999/v1");
+    assert.equal(row.description, "unowned disabled row");
+    assert.deepEqual(JSON.parse(row.gpu_policy), { mutexGroup: "peer-vram", alwaysResident: false, defaultMember: true });
+  } finally { cleanup(); }
+});
+
+test("reenableProviderPreservingContent: unknown id returns null, no write, no emit", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    const res = await reenableProviderPreservingContent(db, "does-not-exist");
+    assert.equal(res, null);
+    assert.equal(calls.length, 0);
+  } finally { cleanup(); }
+});
+
+// --- 3. syncProvidersFromModelsJson: injectable ownAddrs against real files --
+
+test("ownership gate end-to-end: seed-all → loopback-only skips unowned → adding a tailnet IP claims its entries", async () => {
+  const entries = mergedModelsJsonEntries();
+  assert.ok(entries.length > 0, "this host must carry at least one models.json entry");
+
+  const loopbackOnly = new Set(LOOPBACK);
+  const loopbackIds = entries.filter(([, p]) => loopbackOnly.has(hostnameOf(p.baseUrl))).map(([id]) => id);
+  const nonLoopback = entries.filter(([, p]) => {
+    const h = hostnameOf(p.baseUrl);
+    return h !== null && !loopbackOnly.has(h);
+  });
+  assert.ok(nonLoopback.length > 0, "repo models.json carries tailnet-addressed entries (crow-voice etc.)");
+
+  const { db, cleanup } = freshLibsql();
+  try {
+    setProviderSyncManager(null);
+
+    // Call 1: fresh DB, loopback-only ownAddrs → every entry is ABSENT →
+    // seed path regardless of ownership.
+    const first = await syncProvidersFromModelsJson(db, { ownAddrs: new Set(LOOPBACK) });
+    assert.equal(first.upserted, entries.length, "all entries seed on an empty DB");
+    assert.equal(first.skipped_unowned, 0, "absence beats ownership");
+    assert.equal(first.unchanged, 0);
+    assert.equal(first.reenabled, 0);
+    assert.equal(first.skipped_disabled, 0);
+
+    // Snapshot an unowned row's lamport so we can prove call 2 didn't touch it.
+    const probeId = nonLoopback[0][0];
+    const lamportOf = async (id) => Number(
+      (await db.execute({ sql: "SELECT lamport_ts FROM providers WHERE id = ?", args: [id] })).rows[0].lamport_ts,
+    );
+    const probeTsAfterSeed = await lamportOf(probeId);
+
+    // Call 2: same loopback-only ownAddrs, rows now PRESENT → non-loopback
+    // entries are unowned and skipped; loopback entries are co-owned →
+    // evaluated as assert, converged content → D2 unchanged.
+    const second = await syncProvidersFromModelsJson(db, { ownAddrs: new Set(LOOPBACK) });
+    assert.equal(second.skipped_unowned, entries.length - loopbackIds.length,
+      "every non-loopback entry counted skipped_unowned");
+    assert.equal(second.unchanged, loopbackIds.length,
+      "loopback entries evaluated as owned, converged → unchanged");
+    assert.equal(second.upserted, 0, "converged run writes nothing");
+    assert.equal(await lamportOf(probeId), probeTsAfterSeed, "unowned row untouched (no lamport bump)");
+
+    // Call 3: claim one tailnet IP. Its entries flip from skipped_unowned to
+    // owned+unchanged — observable ONLY via the counters (content identical,
+    // D2 suppresses writes), which is exactly what makes the counter
+    // semantics testable.
+    const claimedIp = hostnameOf(nonLoopback[0][1].baseUrl);
+    const claimedCount = nonLoopback.filter(([, p]) => hostnameOf(p.baseUrl) === claimedIp).length;
+    const third = await syncProvidersFromModelsJson(db, {
+      ownAddrs: new Set([...LOOPBACK, claimedIp]),
+    });
+    assert.equal(third.skipped_unowned, entries.length - loopbackIds.length - claimedCount,
+      `claiming ${claimedIp} removes its ${claimedCount} entries from skipped_unowned`);
+    assert.equal(third.unchanged, loopbackIds.length + claimedCount,
+      "claimed entries evaluated as owned (unchanged, content converged)");
+    assert.equal(third.upserted, 0);
+  } finally { cleanup(); }
+});
+
+test("force + unowned + disabled: real reconciler run re-enables without asserting file content is required only when ids collide with models.json — direct-insert ids never assert", async () => {
+  // An id NOT in models.json is never visited by the reconciler at all —
+  // prove the gate leaves foreign rows completely alone under force.
+  const { db, cleanup } = freshLibsql();
+  try {
+    setProviderSyncManager(null);
+    await insertDisabledUnownedRow(db); // id not present in any models.json
+    const res = await syncProvidersFromModelsJson(db, { force: true, ownAddrs: new Set(LOOPBACK) });
+    assert.equal(res.reenabled, 0, "rows absent from models.json are never touched");
+    const { rows } = await db.execute({
+      sql: "SELECT disabled FROM providers WHERE id = ?", args: [REENABLE_ID],
+    });
+    assert.equal(Number(rows[0].disabled), 1, "foreign disabled row stays disabled");
+  } finally { cleanup(); }
+});
+
+// --- 4. D5: RECONCILE interval env override ----------------------------------
+
+test("reconcileIntervalMs: default 1h, env override parses, garbage/zero/negative fall back", () => {
+  assert.equal(reconcileIntervalMs({}), 3600_000);
+  assert.equal(reconcileIntervalMs({ CROW_PROVIDERS_RECONCILE_MS: "60000" }), 60000);
+  assert.equal(reconcileIntervalMs({ CROW_PROVIDERS_RECONCILE_MS: "banana" }), 3600_000);
+  assert.equal(reconcileIntervalMs({ CROW_PROVIDERS_RECONCILE_MS: "0" }), 3600_000);
+  assert.equal(reconcileIntervalMs({ CROW_PROVIDERS_RECONCILE_MS: "-5" }), 3600_000);
+});

--- a/tests/providers-sync-wire.test.js
+++ b/tests/providers-sync-wire.test.js
@@ -1,0 +1,196 @@
+/**
+ * providers-sync wire hygiene — design items D3/D4/D8/D9 of
+ * .superpowers/sdd/providers-volatile-spec.md.
+ *
+ *   D3: EXCLUDED_COLUMNS.providers strips created_at/updated_at/lamport_ts.
+ *   D4: OUTBOUND_TRANSFORMS.providers drops a null gpu_policy from the wire
+ *       (tested behaviorally through emitChange — the transform itself is
+ *       module-private, matching shouldSyncRow).
+ *   D8: emitChange floors the lamport counter at the outgoing row's own
+ *       lamport_ts, so the envelope always exceeds it even after a
+ *       sync_state counter reset (DB recovery).
+ *   D9: shouldSyncRow('providers') rejects loopback base_urls in both
+ *       directions (emit and apply).
+ *
+ * Harness follows tests/instance-sync.test.js: real init-db.js schema in a
+ * tmp dir, fixed ed25519 identity, stub outbound feeds (no Hypercore).
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import {
+  InstanceSyncManager,
+  EXCLUDED_COLUMNS,
+  shouldSyncRowForTest,
+} from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+// ── Shared setup ─────────────────────────────────────────────────────────────
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-provsync-test-"));
+
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir },
+  stdio: "pipe",
+  cwd: join(import.meta.dirname, ".."),
+});
+
+const DB_PATH = join(tmpDir, "crow.db");
+
+after(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const TEST_PRIV = Buffer.alloc(32, 0xcd);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+let managerSeq = 0;
+
+/**
+ * Manager with a stub outbound feed capturing appended entries, and the
+ * sync_state counter pre-set to `counter`. feedsDisabled forced off so the
+ * test outcome doesn't depend on the runner's argv/env.
+ */
+async function makeManager({ counter = 0 } = {}) {
+  const db = createDbClient(DB_PATH);
+  const instanceId = `prov-test-${++managerSeq}`;
+  const mgr = new InstanceSyncManager(IDENTITY, db, instanceId);
+  mgr.feedsDisabled = false;
+  await db.execute({
+    sql: "INSERT OR REPLACE INTO sync_state (instance_id, local_counter) VALUES (?, ?)",
+    args: [instanceId, counter],
+  });
+  const entries = [];
+  mgr.outFeeds = new Map([["peer-1", { append: async (e) => { entries.push(e); } }]]);
+  return { mgr, db, entries };
+}
+
+// A syncable (non-loopback) providers row skeleton.
+function providerRow(overrides = {}) {
+  return {
+    id: "crow-local",
+    name: "crow llama.cpp",
+    base_url: "http://100.118.41.122:8003/v1",
+    models: '[{"id":"m1"}]',
+    ...overrides,
+  };
+}
+
+// ── D9: loopback emit/apply gate via shouldSyncRowForTest ────────────────────
+
+test("D9: loopback base_urls never sync; tailnet/LAN/cloud do; malformed/missing are defensive-false", () => {
+  const cases = [
+    ["http://localhost:3001/llm/v1", false],
+    ["http://127.0.0.1:8011/v1", false],
+    ["http://[::1]:8080/v1", false],
+    ["http://100.118.41.122:8003/v1", true],
+    ["http://10.0.0.21:9005/v1", true],
+    ["https://api.example.com/v1", true],
+  ];
+  for (const [base_url, expected] of cases) {
+    assert.equal(
+      shouldSyncRowForTest("providers", providerRow({ base_url })),
+      expected,
+      `base_url=${base_url} should be ${expected}`,
+    );
+  }
+  // Missing / malformed base_url → defensive false.
+  const noUrl = providerRow();
+  delete noUrl.base_url;
+  assert.equal(shouldSyncRowForTest("providers", noUrl), false, "missing base_url");
+  assert.equal(shouldSyncRowForTest("providers", providerRow({ base_url: "not a url" })), false, "malformed base_url");
+  assert.equal(shouldSyncRowForTest("providers", null), false, "null row");
+});
+
+// ── D3: excluded bookkeeping columns ─────────────────────────────────────────
+
+test("D3: EXCLUDED_COLUMNS.providers is exactly created_at/updated_at/lamport_ts", () => {
+  assert.deepEqual(
+    [...EXCLUDED_COLUMNS.providers].sort(),
+    ["created_at", "lamport_ts", "updated_at"],
+  );
+});
+
+// ── D4: null gpu_policy dropped from the wire (via emitChange) ───────────────
+
+test("D4: null gpu_policy key is ABSENT from the emitted entry row", async () => {
+  const { mgr, entries } = await makeManager();
+  const row = providerRow({ gpu_policy: null });
+  const snapshot = structuredClone(row);
+
+  const ts = await mgr.emitChange("providers", "update", row);
+  assert.ok(ts !== null, "emitChange should emit for a non-loopback providers row");
+  assert.equal(entries.length, 1);
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(entries[0].row, "gpu_policy"),
+    false,
+    "null gpu_policy must not ride the wire",
+  );
+  // Transform must be pure — the caller's row object is untouched.
+  assert.deepEqual(row, snapshot, "input row must not be mutated");
+});
+
+test("D4: non-null gpu_policy rides the wire unchanged", async () => {
+  const { mgr, entries } = await makeManager();
+  const row = providerRow({ gpu_policy: '{"mutexGroup":"x"}' });
+  const snapshot = structuredClone(row);
+
+  await mgr.emitChange("providers", "update", row);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].row.gpu_policy, '{"mutexGroup":"x"}');
+  assert.deepEqual(row, snapshot, "input row must not be mutated");
+});
+
+// ── D8: envelope counter floor ───────────────────────────────────────────────
+
+test("D8: counter behind row.lamport_ts (post-reset) → envelope exceeds the row's lamport", async () => {
+  const { mgr, entries } = await makeManager({ counter: 5 });
+  const row = providerRow({ lamport_ts: 4000 });
+
+  const ts = await mgr.emitChange("providers", "update", row);
+  assert.ok(ts > 4000, `envelope lamport ${ts} must exceed row.lamport_ts 4000`);
+  assert.equal(entries.length, 1);
+  assert.ok(entries[0].lamport_ts > 4000);
+});
+
+test("D8: counter already ahead of row.lamport_ts → floor never lowers it", async () => {
+  const { mgr, entries } = await makeManager({ counter: 9000 });
+  const row = providerRow({ lamport_ts: 4000 });
+
+  const ts = await mgr.emitChange("providers", "update", row);
+  assert.ok(ts > 9000, `envelope lamport ${ts} must exceed prior counter 9000`);
+  assert.equal(entries.length, 1);
+  assert.ok(entries[0].lamport_ts > 9000);
+});
+
+// ── D3+D4 integration through emitChange ─────────────────────────────────────
+
+test("D3+D4 integration: bookkeeping columns and null gpu_policy all stripped; content intact", async () => {
+  const { mgr, entries } = await makeManager();
+  const row = providerRow({
+    created_at: "2026-07-01 00:00:00",
+    updated_at: "2026-07-11 12:00:00",
+    lamport_ts: 42,
+    gpu_policy: null,
+  });
+
+  await mgr.emitChange("providers", "update", row);
+  assert.equal(entries.length, 1);
+  const wireRow = entries[0].row;
+  for (const key of ["created_at", "updated_at", "lamport_ts", "gpu_policy"]) {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(wireRow, key),
+      false,
+      `${key} must not ride the wire`,
+    );
+  }
+  assert.equal(wireRow.base_url, "http://100.118.41.122:8003/v1");
+  assert.equal(wireRow.models, '[{"id":"m1"}]');
+  assert.equal(wireRow.id, "crow-local");
+});

--- a/tests/providers-upsert-noop.test.js
+++ b/tests/providers-upsert-noop.test.js
@@ -1,0 +1,274 @@
+/**
+ * providers-upsert-noop — D2 of the providers-sync volatile-models spec
+ * (.superpowers/sdd/providers-volatile-spec.md).
+ *
+ * upsertProvider must suppress no-op writes: when the write-image (the exact
+ * values the INSERT would compute) matches the stored row on every content
+ * column, it returns { id, lamport_ts, unchanged: true } with NO DB write,
+ * NO lamport bump, and NO emitChange. Any real change (or an absent row)
+ * keeps today's write+bump+emit behavior exactly.
+ *
+ * Comparator normalization under test (R1-F6):
+ *   - disabled: 0/1-vs-bool equivalence both sides
+ *   - api_key: null ≡ "" (both mean "no key")
+ *   - models / gpu_policy: canonical deep-equal on parsed JSON
+ *     (key-order-insensitive, arrays order-sensitive)
+ *   - gpu_policy incoming null ≡ unchanged (mirrors the write path's COALESCE)
+ *   - corrupt DB-side JSON → CHANGED (R2-m3 fail-open: the good content heals
+ *     the row; fail-closed would make corruption permanent)
+ *
+ * Harness: freshLibsql() pattern from accept-idempotent.test.js. The test
+ * process sets CROW_DATA_DIR to the per-test tmp dir BEFORE any upsert so
+ * getOrCreateLocalInstanceId() (instance-registry.js:333) writes its
+ * instance-id file there — the real ~/.crow is never touched.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { upsertProvider, setProviderSyncManager } from "../servers/shared/providers-db.js";
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "providers-upsert-noop-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  // getOrCreateLocalInstanceId() keys on process.env.CROW_DATA_DIR — point it
+  // at the tmp dir so the instance-id file lands there, never in ~/.crow.
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return {
+    dir, db,
+    cleanup() {
+      setProviderSyncManager(null);
+      if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+      else process.env.CROW_DATA_DIR = prevDataDir;
+      try { db.close(); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+// Spy on the sync manager exactly the way emitSync consumes it
+// (providers-db.js: _syncManager.emitChange("providers", op, row)).
+function spySyncManager() {
+  const calls = [];
+  setProviderSyncManager({ emitChange: async (...a) => { calls.push(a); } });
+  return calls;
+}
+
+// A provider covering every content column, with nested models structure.
+function baseProvider() {
+  return {
+    id: "noop-test-prov",
+    baseUrl: "http://100.118.41.122:8003/v1",
+    apiKey: null,
+    host: "local",
+    bundleId: null,
+    description: "no-op suppression test provider",
+    models: [
+      {
+        id: "m1",
+        name: "Model One",
+        contextWindow: 262144,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0 },
+      },
+      { id: "m2", name: "Model Two", contextWindow: 8192 },
+    ],
+    disabled: false,
+    providerType: "openai-compat",
+    gpuPolicy: { mutexGroup: "vram", alwaysResident: false, defaultMember: true },
+  };
+}
+
+async function dbRow(db, id) {
+  const { rows } = await db.execute({ sql: "SELECT * FROM providers WHERE id = ?", args: [id] });
+  return rows[0];
+}
+
+// --- a. identical re-upsert → unchanged, lamport stable, ONE emit ---
+test("identical re-upsert is a no-op: unchanged:true, lamport stable, emitChange called exactly once", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    const first = await upsertProvider(db, baseProvider());
+    assert.equal(calls.length, 1, "insert emits once");
+    assert.notEqual(first.unchanged, true, "insert is not 'unchanged'");
+    const tsAfterInsert = Number((await dbRow(db, "noop-test-prov")).lamport_ts);
+
+    const second = await upsertProvider(db, baseProvider());
+    assert.equal(second.unchanged, true, "identical re-upsert reports unchanged");
+    assert.equal(calls.length, 1, "no second emit for unchanged content");
+    const tsAfterNoop = Number((await dbRow(db, "noop-test-prov")).lamport_ts);
+    assert.equal(tsAfterNoop, tsAfterInsert, "lamport_ts not bumped in DB");
+  } finally { cleanup(); }
+});
+
+// --- b. each content column changed one at a time → write + bump + second emit ---
+const columnMutations = {
+  base_url: (p) => { p.baseUrl = "http://100.121.254.89:9999/v1"; },
+  api_key: (p) => { p.apiKey = "sk-changed"; },
+  host: (p) => { p.host = "cloud"; },
+  bundle_id: (p) => { p.bundleId = "some-bundle"; },
+  description: (p) => { p.description = "changed description"; },
+  "models nested value": (p) => { p.models[0].name = "Model One Renamed"; },
+  disabled: (p) => { p.disabled = true; },
+  provider_type: (p) => { p.providerType = "anthropic"; },
+  "gpu_policy object": (p) => { p.gpuPolicy = { mutexGroup: "vram-b", alwaysResident: true, defaultMember: true }; },
+};
+
+for (const [column, mutate] of Object.entries(columnMutations)) {
+  test(`changed column '${column}' → write + lamport bump + second emit`, async () => {
+    const { db, cleanup } = freshLibsql();
+    try {
+      const calls = spySyncManager();
+      const first = await upsertProvider(db, baseProvider());
+      const changed = baseProvider();
+      mutate(changed);
+      const second = await upsertProvider(db, changed);
+      assert.notEqual(second.unchanged, true, `'${column}' change must not be suppressed`);
+      assert.equal(calls.length, 2, `'${column}' change emits a second time`);
+      assert.ok(Number(second.lamport_ts) > Number(first.lamport_ts), `'${column}' change bumps lamport`);
+      const row = await dbRow(db, "noop-test-prov");
+      assert.equal(Number(row.lamport_ts), Number(second.lamport_ts), "DB row carries the bumped lamport");
+    } finally { cleanup(); }
+  });
+}
+
+// --- c. disabled trap: false vs stored 0, and 0 vs false ---
+test("disabled trap: disabled:false re-upsert over DB-stored 0 is unchanged; 0-vs-false equivalent", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    await upsertProvider(db, baseProvider()); // stores disabled = 0
+    const again = baseProvider();
+    again.disabled = false;
+    const res = await upsertProvider(db, again);
+    assert.equal(res.unchanged, true, "false over stored 0 is unchanged");
+
+    const zero = baseProvider();
+    zero.disabled = 0;
+    const res2 = await upsertProvider(db, zero);
+    assert.equal(res2.unchanged, true, "disabled:0 ≡ disabled:false");
+    assert.equal(calls.length, 1, "only the original insert emitted");
+  } finally { cleanup(); }
+});
+
+// --- d. models key-order shuffle → unchanged ---
+test("models with shuffled object key order are unchanged (canonical deep-equal, not string compare)", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    await upsertProvider(db, baseProvider());
+    const shuffled = baseProvider();
+    shuffled.models = [
+      {
+        cost: { output: 0, input: 0 },
+        input: ["text"],
+        reasoning: true,
+        contextWindow: 262144,
+        name: "Model One",
+        id: "m1",
+      },
+      { contextWindow: 8192, id: "m2", name: "Model Two" },
+    ];
+    const res = await upsertProvider(db, shuffled);
+    assert.equal(res.unchanged, true, "key-order shuffle is not a change");
+    assert.equal(calls.length, 1, "no emit for key-order shuffle");
+  } finally { cleanup(); }
+});
+
+// --- e. nested contextWindow change inside models[0] → CHANGED ---
+test("nested contextWindow change inside models[0] is detected as CHANGED", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    await upsertProvider(db, baseProvider());
+    const changed = baseProvider();
+    changed.models[0].contextWindow = 1048576; // the exact live-drift value
+    const res = await upsertProvider(db, changed);
+    assert.notEqual(res.unchanged, true, "nested contextWindow change must write");
+    assert.equal(calls.length, 2, "nested change emits");
+  } finally { cleanup(); }
+});
+
+// --- f. api_key null vs "" → unchanged ---
+test("api_key null ≡ '' (both mean no key) → unchanged", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    const p = baseProvider();
+    p.apiKey = null;
+    await upsertProvider(db, p);
+    const empty = baseProvider();
+    empty.apiKey = "";
+    const res = await upsertProvider(db, empty);
+    assert.equal(res.unchanged, true, "'' over stored null is unchanged");
+    assert.equal(calls.length, 1, "no emit for null-vs-empty api_key");
+  } finally { cleanup(); }
+});
+
+// --- g. gpu_policy incoming null/undefined over a stored policy → unchanged (COALESCE) ---
+test("gpu_policy: stored policy + incoming gpuPolicy undefined/null → unchanged (COALESCE semantics)", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    await upsertProvider(db, baseProvider()); // stores a gpu_policy
+    const noPolicy = baseProvider();
+    delete noPolicy.gpuPolicy; // undefined
+    const res = await upsertProvider(db, noPolicy);
+    assert.equal(res.unchanged, true, "undefined gpuPolicy leaves the column untouched → unchanged");
+
+    const nullPolicy = baseProvider();
+    nullPolicy.gpuPolicy = null;
+    const res2 = await upsertProvider(db, nullPolicy);
+    assert.equal(res2.unchanged, true, "null gpuPolicy also unchanged");
+    assert.equal(calls.length, 1, "no emit for null-policy re-upserts");
+
+    const row = await dbRow(db, "noop-test-prov");
+    assert.ok(row.gpu_policy, "stored gpu_policy preserved");
+  } finally { cleanup(); }
+});
+
+// --- h. corrupt DB JSON → CHANGED (R2-m3 fail-open), row healed ---
+test("corrupt DB models JSON → CHANGED (fail-open): identical re-upsert writes, emits, and heals the row", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const calls = spySyncManager();
+    await upsertProvider(db, baseProvider());
+    await db.execute({
+      sql: "UPDATE providers SET models = ? WHERE id = ?",
+      args: ["{bad json", "noop-test-prov"],
+    });
+    const res = await upsertProvider(db, baseProvider());
+    assert.notEqual(res.unchanged, true, "corrupt DB JSON must be treated as CHANGED (fail-open)");
+    assert.equal(calls.length, 2, "healing write emits");
+    const row = await dbRow(db, "noop-test-prov");
+    assert.doesNotThrow(() => {
+      const parsed = JSON.parse(row.models);
+      assert.equal(parsed[0].id, "m1");
+    }, "row healed: models parses again");
+  } finally { cleanup(); }
+});
+
+// --- i. return shape on the unchanged path ---
+test("unchanged path returns { id, lamport_ts: <number>, unchanged: true }", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    spySyncManager();
+    const first = await upsertProvider(db, baseProvider());
+    const res = await upsertProvider(db, baseProvider());
+    assert.equal(res.id, "noop-test-prov");
+    assert.equal(res.unchanged, true);
+    assert.equal(typeof res.lamport_ts, "number", "lamport_ts is a plain Number (libsql may hand back BigInt)");
+    assert.equal(res.lamport_ts, Number(first.lamport_ts), "unchanged path reports the current row lamport");
+  } finally { cleanup(); }
+});

--- a/tests/providers-war-sim.test.js
+++ b/tests/providers-war-sim.test.js
@@ -1,0 +1,170 @@
+/**
+ * providers-war-sim — T6 integration test for the owner-asserts design
+ * (spec: .superpowers/sdd/providers-volatile-spec.md).
+ *
+ * Simulates the exact production failure the branch fixes: the fleet is in a
+ * post-war state where the owner's DB row carries a NON-OWNER's stale
+ * metadata at a HIGH lamport (grackle's 181-conflict assert war), and proves
+ * the D6 self-heal transition end-to-end across two real DBs:
+ *
+ *   1. Owner A re-asserts truth → the emitted envelope lamport strictly
+ *      exceeds the stale row's historical 4000 (upsert max+1 + D8 floor).
+ *   2. The wire entry carries no created_at/updated_at/lamport_ts (D3) and
+ *      no null gpu_policy key (D4).
+ *   3. Non-owner B applies the entry → converges to truth, ZERO conflict rows.
+ *   4. B's reconciler decision for the same row is skip_unowned (D1) — the
+ *      war's other writer is gone.
+ *   5. A re-asserting identical content is a no-op: no write, no new feed
+ *      entry (D2) — the boot-churn engine is off.
+ *   6. Re-delivering the same feed to B is silent re-delivery noise — still
+ *      zero conflicts.
+ *
+ * Harness: real init-db.js schema per instance (TWO tmp dirs = two DBs, like
+ * real paired instances), stub feed (no Hypercore), shared test identity so
+ * sign/verify pass (pattern: tests/instance-sync.test.js).
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import {
+  upsertProvider, setProviderSyncManager, reconcileDecision,
+} from "../servers/shared/providers-db.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const A_ID = "aaaaaaaa-0000-0000-0000-00000000000a"; // owner (crow)
+const B_ID = "bbbbbbbb-0000-0000-0000-00000000000b"; // non-owner (grackle)
+
+const dirA = mkdtempSync(join(tmpdir(), "war-sim-A-"));
+const dirB = mkdtempSync(join(tmpdir(), "war-sim-B-"));
+for (const dir of [dirA, dirB]) {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+}
+// getOrCreateLocalInstanceId (used by upsertProvider) keys on CROW_DATA_DIR.
+const PREV_DATA_DIR = process.env.CROW_DATA_DIR;
+process.env.CROW_DATA_DIR = dirA;
+
+const TEST_PRIV = Buffer.alloc(32, 0xCD);
+const IDENTITY = {
+  ed25519Priv: TEST_PRIV,
+  ed25519Pubkey: Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex"),
+};
+
+const dbA = createDbClient(join(dirA, "crow.db"));
+const dbB = createDbClient(join(dirB, "crow.db"));
+const mgrA = new InstanceSyncManager(IDENTITY, dbA, A_ID);
+const mgrB = new InstanceSyncManager(IDENTITY, dbB, B_ID);
+mgrA.feedsDisabled = false;
+mgrB.feedsDisabled = false;
+
+function makeStubFeed() {
+  const feed = {
+    entries: [],
+    get length() { return feed.entries.length; },
+    async get(seq) { return feed.entries[seq]; },
+    async append(entry) { feed.entries.push(entry); return feed.entries.length - 1; },
+  };
+  return feed;
+}
+const feedAtoB = makeStubFeed();
+mgrA.outFeeds.set(B_ID, feedAtoB);
+
+after(() => {
+  setProviderSyncManager(null);
+  if (PREV_DATA_DIR === undefined) delete process.env.CROW_DATA_DIR;
+  else process.env.CROW_DATA_DIR = PREV_DATA_DIR;
+  try { dbA.close(); } catch {}
+  try { dbB.close(); } catch {}
+  rmSync(dirA, { recursive: true, force: true });
+  rmSync(dirB, { recursive: true, force: true });
+});
+
+// The endpoint A owns; B does not (foreign address in both instances' terms —
+// ownership is asserted via reconcileDecision, not live interfaces, here).
+const BASE_URL = "http://100.64.77.1:8003/v1";
+const STALE_MODELS = JSON.stringify([{ id: "qwen", name: "STALE Q6_K 1M", contextWindow: 1048576 }]);
+const TRUTH_MODELS = [{ id: "qwen", name: "TRUTH Q5_K_XL 256K", contextWindow: 262144 }];
+
+async function conflictCount(db) {
+  const { rows } = await db.execute("SELECT COUNT(*) AS n FROM sync_conflicts");
+  return Number(rows[0].n);
+}
+
+async function providerRow(db) {
+  const { rows } = await db.execute({
+    sql: "SELECT * FROM providers WHERE id = ?", args: ["war-local"],
+  });
+  return rows[0];
+}
+
+test("war sim: owner heals a stale high-lamport fleet; non-owner is gated; converged fleet is silent", async () => {
+  // ── Post-war starting state: BOTH DBs hold the non-owner's stale copy at
+  //    lamport 4000 (what the 181-conflict war left behind on the live fleet).
+  for (const db of [dbA, dbB]) {
+    await db.execute({
+      sql: `INSERT INTO providers (id, base_url, host, models, disabled, lamport_ts, instance_id)
+            VALUES ('war-local', ?, 'local', ?, 0, 4000, ?)`,
+      args: [BASE_URL, STALE_MODELS, B_ID],
+    });
+  }
+
+  // ── Step 1: owner A re-asserts truth (what its post-deploy reconcile does
+  //    for an owned+differs entry).
+  setProviderSyncManager(mgrA);
+  const res1 = await upsertProvider(dbA, {
+    id: "war-local", baseUrl: BASE_URL, host: "local", models: TRUTH_MODELS,
+  });
+  assert.equal(res1.unchanged, undefined, "content differed — must be a real write");
+  assert.equal(feedAtoB.length, 1, "exactly one wire entry emitted");
+
+  const entry = feedAtoB.entries[0];
+  assert.equal(entry.table, "providers");
+  assert.ok(entry.lamport_ts > 4000,
+    `envelope lamport ${entry.lamport_ts} must exceed the stale row's 4000 (upsert max+1 / D8 floor)`);
+  // D3: bookkeeping columns never ride the wire.
+  assert.ok(!("created_at" in entry.row), "created_at stripped (D3)");
+  assert.ok(!("updated_at" in entry.row), "updated_at stripped (D3)");
+  assert.ok(!("lamport_ts" in entry.row), "row lamport_ts stripped (D3 — envelope carries it)");
+  // D4: null gpu_policy key dropped.
+  assert.ok(!("gpu_policy" in entry.row), "null gpu_policy dropped from the wire (D4)");
+
+  // ── Step 2: non-owner B applies the entry → converges to truth, no conflict.
+  await mgrB._processNewEntries(A_ID, feedAtoB);
+  const rowB = await providerRow(dbB);
+  const modelsB = JSON.parse(rowB.models);
+  assert.equal(modelsB[0].name, "TRUTH Q5_K_XL 256K", "B converged to the owner's truth");
+  assert.equal(modelsB[0].contextWindow, 262144);
+  assert.equal(Number(rowB.lamport_ts), Number(entry.lamport_ts), "B stamped the envelope lamport");
+  assert.equal(await conflictCount(dbB), 0, "convergence produced zero conflict rows on B");
+
+  // ── Step 3: B's reconciler is gated for this row (D1) — the other writer
+  //    of the war is gone. (Ownership decision is the pure seam the live
+  //    reconciler routes through; B does not own the endpoint.)
+  assert.equal(
+    reconcileDecision({ owned: false, present: true, disabled: false, force: false }),
+    "skip_unowned",
+    "non-owner must never assert its file copy over a present enabled row",
+  );
+
+  // ── Step 4: converged owner re-assert is a full no-op (D2) — the restart
+  //    churn engine is off.
+  const res2 = await upsertProvider(dbA, {
+    id: "war-local", baseUrl: BASE_URL, host: "local", models: TRUTH_MODELS,
+  });
+  assert.equal(res2.unchanged, true, "identical content → suppressed");
+  assert.equal(feedAtoB.length, 1, "no second wire entry (D2: no emit on no-op)");
+
+  // ── Step 5: re-delivering the same feed to B is silent re-delivery noise.
+  await mgrB._processNewEntries(A_ID, feedAtoB);
+  assert.equal(await conflictCount(dbB), 0, "re-delivery stays conflict-free");
+  assert.equal(await conflictCount(dbA), 0, "owner side clean throughout");
+});


### PR DESCRIPTION
## Problem

`sync_conflicts` held 219 rows — **181 of them the same row, `providers/crow-local`**, recurring since 2026-07-06 with lamport ties, plus an endless operator conflict bell. Worse than the noise: the war was overwriting the owner's truth — crow's live DB carried grackle's stale copy of its own model metadata (contextWindow 1048576 vs the real 262144, wrong display name), which is what `resolve-profile`, the providers tab, and bot-builder model lists read.

**Root cause**: `crow-local` is defined in `~/.pi/agent/models.json` — a per-machine, git-untracked file — and the boot reconciler (`syncProvidersFromModelsJson`) unconditionally upserted every entry of the local file into the fleet-synced `providers` table on every boot, bumping lamport and emitting each time even when nothing changed. Two machines with drifted files ⇒ a permanent assert ping-pong at restart cadence.

## Design: owner-asserts (spec + 2-round adversarial design review in `.superpowers/sdd/providers-volatile-*.md`)

The volatile truth "what does the server at this endpoint serve" has exactly one natural owner — the instance whose address the baseUrl points at. Only the owner asserts; sync propagates the owner's copy to everyone else.

- **D1 — reconciler ownership gate**: `syncProvidersFromModelsJson` asserts an entry only when this instance owns the endpoint (`isLocallyOrchestratable`, the existing F-INSTALL-10 predicate, extracted to `servers/shared/locality.js`) or the row is absent (seed). Unowned present rows are sync-authoritative. Force ("Sync bundle providers") re-enables unowned disabled rows via the parsed `listProvidersAll` shape (never a raw `SELECT *` spread — that double-encodes `models`).
- **D2 — no-op suppression in `upsertProvider`**: identical content (normalized per-column: int/bool `disabled`, canonical deep-equal `models`/`gpu_policy`, null≡"" `api_key`, fail-open on corrupt DB JSON) returns `{unchanged:true}` — no write, no lamport bump, no emit. The restart-churn engine is off.
- **D3 — wire hygiene**: `EXCLUDED_COLUMNS.providers = [created_at, updated_at, lamport_ts]` — the timestamps ride the wire TODAY via `disableProvider`'s `SELECT *` spread and manufacture spurious conflicts.
- **D4 — null `gpu_policy` dropped from the wire** (`OUTBOUND_TRANSFORMS`): the sync apply path writes wire nulls verbatim and would null a peer's locally-set VRAM policy.
- **D5 — hourly reconcile** (fresh `getOwnAddresses` per run): closes the boot-time tailscale race (own tailnet IP absent at boot) and owner-never-restarts staleness. **Gated off `--no-auth` companions** (with the boot seed/reconcile): a shared-DB non-emitting writer + D2 would otherwise silently strand models.json edits (same class as the `healProfileOverridesOnce` gate).
- **D7 — one-shot providers backfill per new peer**: per-peer Hypercore feeds are born empty; before this branch the boot churn was accidentally how a new pairing ever received provider rows. Emits `op=insert` (INSERT OR IGNORE — delivers to fresh peers, benign on current ones), per-peer `__providers_backfill_v1:<peerId>` flags.
- **D8 — envelope counter floor** in `emitChange`: the envelope lamport always exceeds the outgoing row's own historical value, so a sync_state counter reset (DB recovery) can't make the owner's re-assert look stale forever.
- **D9 — loopback emit-gate** in `shouldSyncRow('providers')`: loopback baseUrls are per-instance by construction (a peer dialing 127.0.0.1 reaches itself) and co-owned by every locality predicate — they never ride the wire, either direction.

**Self-heal, no migration (D6)**: on the first post-deploy boot, the owner re-asserts its truth with an envelope lamport strictly above the stale row's, peers apply it, and the non-owner's reconciler is gated thereafter. Fleet converges on its own.

## Rejected alternative (documented in the spec)

"Stop syncing `host='local'` rows" (R1's preferred simpler fix) was refuted with code evidence: consumers dial the absolute `base_url` from the synced row (`resolve-profile.js:46`) — grackle genuinely routes to crow's endpoints through its synced copy, and providers-sync is the healing channel that keeps that metadata correct. The scoped remnant both review rounds converged on (loopback-only gate) is D9.

## Verification

- Full suite: **1514 tests, 1513 pass, 0 fail, 1 standing skip**.
- Per-task TDD with mutation checks (inverted gate verdicts, dropped floors, fail-closed comparator, raw-SELECT* force branch — all killed by tests).
- Two-instance war simulation (`tests/providers-war-sim.test.js`): owner heals a stale lamport-4000 fleet end-to-end, non-owner gated, converged fleet emits nothing.
- End-to-end D7 delivery test: fresh peer applies the backfill feed → row lands, conflict-free, idempotent.
- Scratch-clone gateway boots (scratch HOME + scratch env): normal mode seeds 9 / reconciles `upserted=5 unchanged=1 skipped_unowned=3` (grackle's rows correctly unowned on crow); `--no-auth` mode logs only the skip line.
- Final whole-branch adversarial review: one blocking finding (D7 op=update never delivered to fresh peers) — fixed in `ded3023e` with the delivery test that proves it.

## Post-deploy plan

Deploy fleet-wide, then restart-storm (grackle → crow → grackle) and assert: `sync_conflicts` counts frozen on all four instances; crow's `crow-local` row healed to Q5_K_XL/262144 with owner instance_id; grackle's boot reconcile logs `skipped_unowned` for crow's rows. Overnight soak re-check.