### PR TITLE
fix: follow-up pool minors — discovery pubkeys, honest conflict counts, glasses 404 poll stop, offline Nostr kill-switch

### DIFF
--- a/docs/developers/configuration.md
+++ b/docs/developers/configuration.md
@@ -43,6 +43,7 @@ A brand-new operator usually only ever touches these: `CROW_GATEWAY_URL` (remote
 |---|---|---|
 | `CROW_ORCHESTRATOR_PROVIDER` / `CROW_ORCHESTRATOR_MODEL` | *(DB `providers` table first)* | Default provider/model for the orchestrator. Prefer configuring providers in Settings → AI. |
 | `CROW_PROVIDERS_RECONCILE_MS` | `3600000` | Interval for the models.json → providers-DB reconcile (owner-asserted rows only; skipped entirely on `--no-auth` companions). |
+| `CROW_DISABLE_NOSTR` | *(unset)* | `1` disables all Nostr relay dialing (messaging transport). For scratch/test gateways: set together with `CROW_DISABLE_INSTANCE_SYNC=1` for a fully-offline boot. |
 | `COMPANION_FAST_MODEL` | `crow-voice/qwen3.5-4b` | Fast voice-turn model for the AI Companion. |
 | `COMPANION_ESCALATION_MODEL` | `crow-chat/qwen3.6-35b-a3b` | Escalation model (`!escalate` / tool turns). |
 | `COMPANION_FAST_DISABLE_THINKING` | `1` | Disable chain-of-thought on voice turns. |

--- a/servers/gateway/boot/peer-public-api.js
+++ b/servers/gateway/boot/peer-public-api.js
@@ -58,8 +58,11 @@ export async function mountPeerPublicApi(app, deps) {
         crow_discovery: true,
         crow_id: identity.crowId,
         display_name: nameSetting.rows[0]?.value || null,
-        ed25519_pubkey: identity.ed25519Public,
-        secp256k1_pubkey: identity.secp256k1Public,
+        // Identity fields are ed25519Pubkey/secp256k1Pubkey (identity.js) —
+        // the *Public spellings shipped undefined pubkeys for months (twin of
+        // the #165 identity-fields fix).
+        ed25519_pubkey: identity.ed25519Pubkey,
+        secp256k1_pubkey: identity.secp256k1Pubkey,
       });
     } catch (err) {
       res.status(500).json({ error: "Discovery unavailable" });

--- a/servers/gateway/dashboard/settings/migrations/llm-settings-migration.js
+++ b/servers/gateway/dashboard/settings/migrations/llm-settings-migration.js
@@ -123,8 +123,10 @@ async function migrateProfiles(db, profiles) {
 }
 
 /**
- * Step 2: fold .env AI_* vars into `cloud-env-default` + record its id in
- * `dashboard_settings.llm_chat_default_provider_id` (local-only key).
+ * Step 2: fold .env AI_* vars into the `cloud-env-default` provider row.
+ * (It used to also record `llm_chat_default_provider_id` in
+ * dashboard_settings; that vestigial write was removed in #163 D4 — the
+ * providers table is the sole output now.)
  */
 async function migrateEnvDefault(db) {
   let envVars;

--- a/servers/gateway/dashboard/settings/sections/sync-conflicts.js
+++ b/servers/gateway/dashboard/settings/sections/sync-conflicts.js
@@ -198,6 +198,7 @@ export default {
     let unresolvedRows = [];
     let resolvedRows = [];
     let unresolvedTotal = 0;
+    let resolvedTotal = 0;
     let dbError = null;
     try {
       const { rows: unresolved } = await db.execute({
@@ -212,9 +213,14 @@ export default {
         sql: `SELECT * FROM sync_conflicts WHERE resolved = 1 ORDER BY resolved_at DESC LIMIT 25`,
         args: [],
       });
+      const { rows: resolvedCount } = await db.execute({
+        sql: `SELECT COUNT(*) AS n FROM sync_conflicts WHERE resolved = 1`,
+        args: [],
+      });
       unresolvedRows = unresolved;
       unresolvedTotal = Number(unresolvedCount[0]?.n || 0);
       resolvedRows = resolved;
+      resolvedTotal = Number(resolvedCount[0]?.n || 0);
     } catch (err) {
       dbError = err.message || "Unknown error";
     }
@@ -303,7 +309,7 @@ export default {
 
     <h3 style="font-size:0.95rem;margin:0 0 0.5rem;font-weight:600">
       ${escapeHtml(t("syncConflicts.unresolvedHeading", lang))}
-      ${unresolvedRows.length > 0 ? `<span style="font-size:0.78rem;color:#e53935;margin-left:0.4rem">(${unresolvedRows.length})</span>` : ""}
+      ${unresolvedTotal > 0 ? `<span style="font-size:0.78rem;color:#e53935;margin-left:0.4rem">(${unresolvedTotal})</span>` : ""}
     </h3>
 
     ${overLimitNotice}
@@ -321,7 +327,7 @@ export default {
     <details style="margin-top:1.5rem">
       <summary style="cursor:pointer;font-size:0.85rem;color:var(--crow-text-muted);padding:0.4rem 0">
         ${escapeHtml(t("syncConflicts.resolvedHeading", lang))}
-        ${resolvedRows.length > 0 ? `(${resolvedRows.length})` : ""}
+        ${resolvedTotal > 0 ? `(${resolvedTotal})` : ""}
       </summary>
       <div style="overflow-x:auto;margin-top:0.5rem">
         <table class="sc-table">

--- a/servers/gateway/dashboard/settings/sync-allowlist.js
+++ b/servers/gateway/dashboard/settings/sync-allowlist.js
@@ -103,9 +103,12 @@ export function checkSyncKeyDrift(sections) {
 export const PROFILE_SYNC_KEYS = ["profile_display_name", "profile_avatar_url", "profile_bio"];
 
 /**
- * Instance-scope keys — per-install settings whose readers query the global
- * dashboard_settings table directly (auto-update timer, notification delivery
- * gate, peer-discovery API, public blog, media bundle, setup pages). Each
+ * Instance-scope keys — per-install settings whose load-bearing readers
+ * resolve from the global dashboard_settings table (most query it directly —
+ * auto-update timer, notification delivery gate, peer-discovery API, public
+ * blog, media bundle, setup pages; a few, like the language chrome and the
+ * onboarding guard, go through readSetting, which is equivalent post-heal
+ * because no instance-scope override rows remain). Each
  * instance's DB is its own world for these: replication is gated by
  * isSyncable at BOTH emit (instance-sync.js shouldSyncRow) and apply (the
  * inbound-entry dispatch), so a global row for a key listed here NEVER leaves

--- a/servers/gateway/dashboard/shared/notifications.js
+++ b/servers/gateway/dashboard/shared/notifications.js
@@ -594,16 +594,39 @@ export function headerIconsJs(lang) {
     if (!btn) return;
     try {
       var res = await fetch('/api/meta-glasses/devices', { credentials: 'same-origin' });
+      if (res.status === 404) {
+        // Bundle not installed — 404 is permanent for this page's lifetime.
+        // Cache the verdict (same key player.js uses) and stop the 15s poll
+        // instead of hammering a dead route forever (BH-6).
+        btn.style.display = 'none';
+        try { sessionStorage.setItem('crow-glasses-bundle', 'false'); } catch (e) {}
+        if (window.__crowPttVisibilityInterval) {
+          clearInterval(window.__crowPttVisibilityInterval);
+          window.__crowPttVisibilityInterval = null;
+        }
+        return;
+      }
       if (!res.ok) { btn.style.display = 'none'; return; }
+      try { sessionStorage.setItem('crow-glasses-bundle', 'true'); } catch (e) {}
       var data = await res.json();
       btn.style.display = (data.connected_count > 0) ? '' : 'none';
-    } catch {
+    } catch (e) {
       btn.style.display = 'none';
     }
   }
-  _refreshCrowPttVisibility();
-  if (!window.__crowPttVisibilityInterval) {
-    window.__crowPttVisibilityInterval = setInterval(_refreshCrowPttVisibility, 15000);
+  var _pttBundleCached = null;
+  try { _pttBundleCached = sessionStorage.getItem('crow-glasses-bundle'); } catch (e) {}
+  if (_pttBundleCached === 'false') {
+    // Known-absent this tab session (player.js probe or an earlier 404 here) —
+    // hide and never start the poll. Installing the bundle restarts the
+    // gateway; a fresh tab re-probes.
+    var _pttBtn = document.getElementById('crow-ptt-btn');
+    if (_pttBtn) _pttBtn.style.display = 'none';
+  } else {
+    _refreshCrowPttVisibility();
+    if (!window.__crowPttVisibilityInterval) {
+      window.__crowPttVisibilityInterval = setInterval(_refreshCrowPttVisibility, 15000);
+    }
   }
 
   async function toggleCrowPtt(e) {
@@ -941,16 +964,39 @@ export function tamagotchiJs(lang) {
     if (!btn) return;
     try {
       var res = await fetch('/api/meta-glasses/devices', { credentials: 'same-origin' });
+      if (res.status === 404) {
+        // Bundle not installed — 404 is permanent for this page's lifetime.
+        // Cache the verdict (same key player.js uses) and stop the 15s poll
+        // instead of hammering a dead route forever (BH-6).
+        btn.style.display = 'none';
+        try { sessionStorage.setItem('crow-glasses-bundle', 'false'); } catch (e) {}
+        if (window.__crowPttVisibilityInterval) {
+          clearInterval(window.__crowPttVisibilityInterval);
+          window.__crowPttVisibilityInterval = null;
+        }
+        return;
+      }
       if (!res.ok) { btn.style.display = 'none'; return; }
+      try { sessionStorage.setItem('crow-glasses-bundle', 'true'); } catch (e) {}
       var data = await res.json();
       btn.style.display = (data.connected_count > 0) ? '' : 'none';
-    } catch {
+    } catch (e) {
       btn.style.display = 'none';
     }
   }
-  _refreshCrowPttVisibility();
-  if (!window.__crowPttVisibilityInterval) {
-    window.__crowPttVisibilityInterval = setInterval(_refreshCrowPttVisibility, 15000);
+  var _pttBundleCached = null;
+  try { _pttBundleCached = sessionStorage.getItem('crow-glasses-bundle'); } catch (e) {}
+  if (_pttBundleCached === 'false') {
+    // Known-absent this tab session (player.js probe or an earlier 404 here) —
+    // hide and never start the poll. Installing the bundle restarts the
+    // gateway; a fresh tab re-probes.
+    var _pttBtn = document.getElementById('crow-ptt-btn');
+    if (_pttBtn) _pttBtn.style.display = 'none';
+  } else {
+    _refreshCrowPttVisibility();
+    if (!window.__crowPttVisibilityInterval) {
+      window.__crowPttVisibilityInterval = setInterval(_refreshCrowPttVisibility, 15000);
+    }
   }
 
   async function toggleCrowPtt(e) {

--- a/servers/gateway/dashboard/shared/player.js
+++ b/servers/gateway/dashboard/shared/player.js
@@ -682,6 +682,13 @@ export function playerBarJs(lang) {
   if (!bundleProbed) {
     fetch('/api/meta-glasses/devices', { credentials: 'same-origin' })
       .then(function(r) {
+        // Cache 'false' ONLY on an explicit 404 (bundle not installed) — a
+        // transient error (network blip, 401, 500) must not poison the
+        // tab-session cache, which the notifications PTT poll also honors.
+        if (r.status === 404) {
+          try { sessionStorage.setItem('crow-glasses-bundle', 'false'); } catch(e) {}
+          throw new Error();
+        }
         if (!r.ok) throw new Error();
         try { sessionStorage.setItem('crow-glasses-bundle', 'true'); } catch(e) {}
         return r.json();
@@ -695,7 +702,6 @@ export function playerBarJs(lang) {
         }
       })
       .catch(function() {
-        try { sessionStorage.setItem('crow-glasses-bundle', 'false'); } catch(e) {}
         glassesBundleAvailable = false;
       });
   }

--- a/servers/sharing/nostr.js
+++ b/servers/sharing/nostr.js
@@ -56,6 +56,15 @@ export const DEFAULT_RELAYS = [
   "wss://nostr.crow.maestro.press",
 ];
 
+/**
+ * Offline kill-switch for all Nostr relay dialing (scratch/test gateways
+ * must be able to boot without touching the public DEFAULT_RELAYS).
+ * Pure + injectable for tests.
+ */
+export function nostrDisabled(env = process.env) {
+  return env.CROW_DISABLE_NOSTR === "1";
+}
+
 export class NostrManager {
   constructor(identity, db) {
     this.identity = identity;
@@ -76,8 +85,22 @@ export class NostrManager {
 
   /**
    * Connect to configured relays.
+   *
+   * CROW_DISABLE_NOSTR=1 is the offline kill-switch: every dial funnels
+   * through here, so gating this one method keeps a scratch/test gateway
+   * from ever touching the baked-in public DEFAULT_RELAYS. (Hyperswarm is
+   * separately gated by CROW_DISABLE_INSTANCE_SYNC via shouldInitInstanceSync
+   * — set BOTH for a fully-offline boot.) Subscribe/publish paths degrade
+   * gracefully against the empty relay map.
    */
   async connectRelays(customRelays) {
+    if (nostrDisabled()) {
+      if (!this._disabledLogged) {
+        this._disabledLogged = true;
+        console.log("[nostr] Disabled via CROW_DISABLE_NOSTR — no relay connections will be made");
+      }
+      return [];
+    }
     // Prevent concurrent connection attempts
     if (this._connectingPromise) return this._connectingPromise;
 

--- a/servers/sharing/relay.js
+++ b/servers/sharing/relay.js
@@ -24,9 +24,11 @@ const TTL_DAYS = 30;
  * @param {object} db - libsql database client
  */
 export function createRelayHandlers(db) {
-  // Schedule periodic cleanup every hour
+  // Schedule periodic cleanup every hour. unref() so the housekeeping timer
+  // never keeps an embedding process (tests, one-shot scripts) alive — the
+  // long-running gateway is unaffected.
   if (db) {
-    setInterval(() => cleanupExpiredBlobs(db), 60 * 60 * 1000);
+    setInterval(() => cleanupExpiredBlobs(db), 60 * 60 * 1000).unref();
   }
 
   return {

--- a/tests/discover-profile.test.js
+++ b/tests/discover-profile.test.js
@@ -1,0 +1,95 @@
+/**
+ * /discover/profile field-name regression (follow-up pool, twin of the #165
+ * identity-fields fix): the identity object's fields are ed25519Pubkey /
+ * secp256k1Pubkey (identity.js), but the endpoint read identity.ed25519Public
+ * / identity.secp256k1Public — shipping `undefined` pubkeys in the public
+ * discovery profile, which breaks any client trying to add the discovered
+ * contact by key.
+ *
+ * CROW_DATA_DIR is pointed at a scratch dir BEFORE any import that touches
+ * identity.js (its DATA_DIR binds at module load) — a fresh throwaway
+ * identity is generated there; the real ~/.crow is never read or written.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const dir = mkdtempSync(join(tmpdir(), "discover-profile-"));
+const PREV = process.env.CROW_DATA_DIR;
+process.env.CROW_DATA_DIR = dir;
+
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: dir },
+  stdio: "pipe",
+  cwd: join(import.meta.dirname, ".."),
+});
+
+const { test, after } = await import("node:test");
+const assert = (await import("node:assert/strict")).default;
+const { createClient } = await import("@libsql/client");
+const { mountPeerPublicApi } = await import("../servers/gateway/boot/peer-public-api.js");
+const { loadOrCreateIdentity } = await import("../servers/sharing/identity.js");
+const express = (await import("express")).default;
+
+const db = createClient({ url: "file:" + join(dir, "crow.db") });
+
+after(() => {
+  try { db.close(); } catch {}
+  if (PREV === undefined) delete process.env.CROW_DATA_DIR;
+  else process.env.CROW_DATA_DIR = PREV;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("/discover/profile ships REAL hex pubkeys (not undefined) when discovery is enabled", async () => {
+  await db.execute("INSERT INTO dashboard_settings (key, value) VALUES ('discovery_enabled', 'true')");
+  await db.execute("INSERT INTO dashboard_settings (key, value) VALUES ('discovery_name', 'Test Crow')");
+
+  const app = express();
+  await mountPeerPublicApi(app, {
+    authMiddleware: null,
+    relayDb: db,
+    loadDynamicBackends: async () => {},
+  });
+
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+  try {
+    const res = await fetch(`http://127.0.0.1:${server.address().port}/discover/profile`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+
+    const identity = loadOrCreateIdentity();
+    assert.equal(body.crow_discovery, true);
+    assert.equal(body.crow_id, identity.crowId);
+    assert.equal(body.display_name, "Test Crow");
+    // The regression: these two were undefined (identity.ed25519Public /
+    // identity.secp256k1Public do not exist) and vanished from the JSON.
+    assert.match(String(body.ed25519_pubkey), /^[0-9a-f]{64}$/, "ed25519_pubkey must be 32-byte hex");
+    assert.equal(body.ed25519_pubkey, identity.ed25519Pubkey);
+    assert.match(String(body.secp256k1_pubkey), /^[0-9a-f]{66}$/, "secp256k1_pubkey must be 33-byte compressed hex");
+    assert.equal(body.secp256k1_pubkey, identity.secp256k1Pubkey);
+  } finally {
+    if (typeof server.closeAllConnections === "function") server.closeAllConnections();
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("/discover/profile stays 404 when discovery is disabled", async () => {
+  await db.execute("UPDATE dashboard_settings SET value = 'false' WHERE key = 'discovery_enabled'");
+  const app = express();
+  await mountPeerPublicApi(app, {
+    authMiddleware: null,
+    relayDb: db,
+    loadDynamicBackends: async () => {},
+  });
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise((r) => server.once("listening", r));
+  try {
+    const res = await fetch(`http://127.0.0.1:${server.address().port}/discover/profile`);
+    assert.equal(res.status, 404);
+  } finally {
+    if (typeof server.closeAllConnections === "function") server.closeAllConnections();
+    await new Promise((r) => server.close(r));
+  }
+});

--- a/tests/instance-scope-heal.test.js
+++ b/tests/instance-scope-heal.test.js
@@ -156,3 +156,32 @@ test("heal: (h) one key's failure does not abort the others AND leaves the flag 
     } finally { cleanup(); }
   });
 });
+
+test("heal: (k) EMPTY-STRING updated_at precedence — '' behaves like NULL on both sides", async () => {
+  // overrideWins() explicitly treats '' the same as NULL (String(ts).trim()
+  // === ''). Previously untested branch (#163 accepted minor).
+  const { dir, db, cleanup } = fresh();
+  await withDataDir(dir, async () => {
+    try {
+      const localId = getOrCreateLocalInstanceId();
+      // global ts '' → override wins (empty global timestamp = no basis to keep it)
+      await seedOverride(db, localId, "language", "es", "2026-07-01 10:00:00");
+      await seedGlobal(db, "language", "en", "");
+      // override ts '', global ts present → global wins, override deleted
+      await seedOverride(db, localId, "tts_voice", "af_bella", "");
+      await seedGlobal(db, "tts_voice", "en-US-BrianNeural", "2026-07-01 10:00:00");
+      // BOTH '' → override wins (globalTs '' short-circuits first)
+      await seedOverride(db, localId, "discovery_name", "Crow of Kevin", "");
+      await seedGlobal(db, "discovery_name", "old-name", "");
+
+      const n = await healInstanceScopeOverridesOnce(db);
+      assert.equal(n, 2, "language + discovery_name promoted");
+      assert.equal(await globalValue(db, "language"), "es", "global-ts-'' → override wins");
+      assert.equal(await globalValue(db, "tts_voice"), "en-US-BrianNeural", "override-ts-'' → global wins");
+      assert.equal(await globalValue(db, "discovery_name"), "Crow of Kevin", "both-'' → override wins");
+      assert.equal(await overrideCount(db, "tts_voice"), 0, "losing override deleted");
+      assert.equal(await overrideCount(db, "language"), 0);
+      assert.equal(await overrideCount(db, "discovery_name"), 0);
+    } finally { cleanup(); }
+  });
+});

--- a/tests/nostr-disable.test.js
+++ b/tests/nostr-disable.test.js
@@ -1,0 +1,39 @@
+/**
+ * CROW_DISABLE_NOSTR kill-switch (follow-up pool): every relay dial funnels
+ * through NostrManager.connectRelays, and scratch/test gateways were dialing
+ * the baked-in public DEFAULT_RELAYS on every boot. With the flag set,
+ * connectRelays returns [] without touching the network — combined with
+ * CROW_DISABLE_INSTANCE_SYNC (hyperswarm/feeds), a test gateway boots fully
+ * offline.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { NostrManager, nostrDisabled, DEFAULT_RELAYS } from "../servers/sharing/nostr.js";
+
+test("nostrDisabled: pure predicate on CROW_DISABLE_NOSTR", () => {
+  assert.equal(nostrDisabled({ CROW_DISABLE_NOSTR: "1" }), true);
+  assert.equal(nostrDisabled({ CROW_DISABLE_NOSTR: "0" }), false);
+  assert.equal(nostrDisabled({}), false);
+  assert.equal(nostrDisabled({ CROW_DISABLE_NOSTR: "true" }), false, "only the literal '1' disables");
+});
+
+test("connectRelays with CROW_DISABLE_NOSTR=1 returns [] and never populates the relay map", async () => {
+  const prev = process.env.CROW_DISABLE_NOSTR;
+  process.env.CROW_DISABLE_NOSTR = "1";
+  try {
+    const mgr = new NostrManager({ secp256k1Pubkey: "ab".repeat(33) }, null);
+    // db=null would otherwise fall back to DEFAULT_RELAYS and DIAL them —
+    // the gate must short-circuit first (and fast: no 10s connect timeouts).
+    const t0 = Date.now();
+    const urls = await mgr.connectRelays();
+    assert.deepEqual(urls, []);
+    assert.equal(mgr.relays.size, 0, "no relay connections were made");
+    assert.ok(Date.now() - t0 < 2000, "returned immediately — no dial attempts");
+    assert.ok(DEFAULT_RELAYS.length > 0, "sanity: the default relay floor exists and was skipped");
+    // Second call stays gated and quiet.
+    assert.deepEqual(await mgr.connectRelays(), []);
+  } finally {
+    if (prev === undefined) delete process.env.CROW_DISABLE_NOSTR;
+    else process.env.CROW_DISABLE_NOSTR = prev;
+  }
+});


### PR DESCRIPTION
Batch of small pre-approved follow-up-pool fixes (post-arc queue item 2):

1. **`/discover/profile` shipped `undefined` pubkeys** (`peer-public-api.js`) — the identity object's fields are `ed25519Pubkey`/`secp256k1Pubkey`; the endpoint read the nonexistent `*Public` spellings, so the public discovery profile omitted both keys (twin of the #165 identity-fields fix). New end-to-end test boots the mounted endpoint against a scratch identity and asserts real hex keys (mutation-checked: reverting the fix fails the test).
2. **Sync-conflicts headings now show TRUE totals** (`sync-conflicts.js`) — the unresolved heading rendered the LIMIT-200 page length (crow showed "(200)" with 219 unresolved) even though `COUNT(*)` was already fetched; the resolved summary gets its own `COUNT(*)` (was capped at the LIMIT-25 page).
3. **BH-6: the 15s glasses 404 poll stops when the bundle is absent** (`notifications.js`, both duplicated header variants + `player.js`) — the PTT visibility poll now caches the bundle-absent verdict in the same sessionStorage key player.js uses and clears its interval on an explicit 404 instead of hammering a dead route forever. Player's first-probe now caches `'false'` only on an explicit 404 so a transient error can't poison the tab-session cache (review nit). 401/500/network errors keep polling and self-heal.
4. **`CROW_DISABLE_NOSTR=1` kill-switch** (`nostr.js`) — every relay dial funnels through `connectRelays`; scratch/test gateways were dialing the baked-in public `DEFAULT_RELAYS` on every boot. With the flag (plus the existing `CROW_DISABLE_INSTANCE_SYNC=1` hyperswarm/feed gate) a test gateway boots fully offline. Documented in the env table.
5. **`relay.js` hourly cleanup interval is `unref()`d** — housekeeping must not keep an embedding process (tests, one-shot scripts) alive.
6. **#163 accepted minors** — stale JSDoc in `llm-settings-migration.js` (claimed the `llm_chat_default_provider_id` write that #163 D4 deleted); `INSTANCE_SCOPE_KEYS` docblock no longer overclaims global-direct readers; `overrideWins()`'s empty-string-timestamp branch now has tests (`''` behaves like NULL on both sides).

**Deferred out of this batch** (design-shaped, own PRs): `pruneStaleAdvertisedContacts` resurrection (the obvious `shouldSyncRow` fix is documented-inert; the real fix moves where `origin` is set) and the messages-arc sync-internal leftovers (key-rotation, lamport-preserving re-emit, #144 P2P dialer minors).

## Verification
- Full suite: **1519 tests, 1518 pass, 0 fail, 1 standing skip**.
- Adversarial whole-branch review: READY-TO-MERGE; both nits addressed or accepted (resolved-summary "showing first 25" notice left as-is — still strictly more honest than before).
- Review confirmed: 404 on the glasses route provably means bundle-absent (panel API routes mount only when installed; a down gateway makes fetch throw, not 404), and the two notifications.js copies live in mutually-exclusive header render modes.
- Post-deploy: CDP check that crow's sync-conflicts heading shows the true total (219) and the glasses poll behavior on a bundle-less dashboard.