### PR TITLE
fix(tailnet-sync): #144 dial-transport minors — fallback ladder, IPv6, per-cycle backoff, live peer refresh, TLS verification on

### DIFF
--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -66,9 +66,14 @@ function verifyHandshakePayload(payload, expectedPubkeyHex) {
  * public Funnel, which only proxies the curated public path-list and
  * /api/instance-sync/stream is deliberately not on it.
  *
- * Fallback: ws://<tailscale_ip>:<fallbackPort> — a direct plain-WS dial of
- * the standard backend gateway port for Serve-less peers. fallbackPort is a
- * BACKEND port (the gateway listens plain HTTP), never a Serve HTTPS port.
+ * Fallback: ws://<tailscale_ip>:<port> direct plain-WS dials of the COMMON
+ * backend gateway ports for Serve-less peers. The peer's real backend port
+ * isn't advertised in its crow_instances row (gateway_url carries the Serve
+ * HTTPS port, not the backend), so the ladder tries the caller's own port
+ * plus the fleet-standard 3001/3002 (#144 minor: a single hardcoded 3002
+ * was wrong for any non-3002 peer). All fallback ports are BACKEND ports
+ * (the gateway listens plain HTTP), never Serve HTTPS ports. Bare IPv6
+ * addresses are bracketed for the URL (#144 minor).
  */
 export function peerToWsUrlCandidates(peer, fallbackPort = 3002) {
   const candidates = [];
@@ -80,13 +85,18 @@ export function peerToWsUrlCandidates(peer, fallbackPort = 3002) {
       const isHttp = u.protocol === "http:";
       const port = u.port ? parseInt(u.port, 10) : (isHttp ? 80 : 443);
       if (port !== 443) {
+        // u.hostname keeps IPv6 brackets — safe to re-embed verbatim.
         candidates.push(`${isHttp ? "ws" : "wss"}://${u.hostname}:${port}${WS_PATH}`);
       }
     }
   }
   if (peer?.tailscale_ip) {
-    const direct = `ws://${peer.tailscale_ip}:${fallbackPort}${WS_PATH}`;
-    if (!candidates.includes(direct)) candidates.push(direct);
+    const ip = String(peer.tailscale_ip);
+    const host = ip.includes(":") && !ip.startsWith("[") ? `[${ip}]` : ip;
+    for (const port of new Set([fallbackPort, 3001, 3002])) {
+      const direct = `ws://${host}:${port}${WS_PATH}`;
+      if (!candidates.includes(direct)) candidates.push(direct);
+    }
   }
   return candidates;
 }
@@ -313,7 +323,9 @@ export function setupTailnetSyncServer(server, ctx) {
 /**
  * Outbound dialer state per peer.
  */
-class PeerDialer {
+// Exported for tests (backoff-cycle behavior); production callers construct
+// it only via startTailnetSyncClients' refresh loop.
+export class PeerDialer {
   constructor(peerRow, ctx) {
     this.peer = peerRow;
     this.ctx = ctx;
@@ -346,13 +358,21 @@ class PeerDialer {
   scheduleRetry() {
     if (this.stopped) return;
     this.timer = setTimeout(() => this.connect(), this.retryMs);
-    this.retryMs = Math.min(this.retryMs * 2, RETRY_MAX_MS);
+    // #144 minor: grow the backoff only after a FULL ladder cycle, so a
+    // healthy candidate later in the ladder gets its first try at the base
+    // delay instead of inheriting the exponential penalty earned by the
+    // candidates before it. _candCount is stamped by connect().
+    const cycle = Math.max(1, this._candCount || 1);
+    if (this.attempt % cycle === 0) {
+      this.retryMs = Math.min(this.retryMs * 2, RETRY_MAX_MS);
+    }
   }
 
   async connect() {
     if (this.stopped) return;
     const { identity, instanceSyncManager, db } = this.ctx;
     const candidates = peerToWsUrlCandidates(this.peer, this.ctx.gatewayPort);
+    this._candCount = candidates.length; // backoff grows once per full ladder cycle
     if (candidates.length === 0) {
       // No tailnet endpoint to dial; leave for Hyperswarm.
       return;
@@ -372,7 +392,14 @@ class PeerDialer {
     }
 
     let ws;
-    try { ws = new WebSocket(wsUrl, { handshakeTimeout: HANDSHAKE_TIMEOUT_MS, rejectUnauthorized: false }); }
+    // TLS verification is ON for wss candidates (#144 follow-up): every wss
+    // candidate is hostname-based (the ladder never emits raw-IP wss), and
+    // the fleet's Serve endpoints carry real LE certs — SNI + verification
+    // both work. ws:// candidates are unaffected. A deployment fronting its
+    // gateway with a self-signed cert should use an http/ws gateway_url or a
+    // real cert; silently accepting any cert on an authenticated sync
+    // transport was the worse default.
+    try { ws = new WebSocket(wsUrl, { handshakeTimeout: HANDSHAKE_TIMEOUT_MS }); }
     catch (err) {
       console.warn(`[tailnet-sync] dial failed for ${wsUrl}: ${err.message}`);
       return this.scheduleRetry();
@@ -489,7 +516,14 @@ export async function startTailnetSyncClients(ctx) {
     for (const peer of rows) {
       seenIds.add(peer.id);
       if (!peer.gateway_url) continue;
-      if (dialers.has(peer.id)) continue;
+      if (dialers.has(peer.id)) {
+        // #144 minor: keep the dialer's row snapshot fresh — a changed
+        // gateway_url/tailscale_ip previously kept dialing the OLD address
+        // until a gateway restart. connect() re-derives candidates from
+        // this.peer on every attempt, so updating the reference suffices.
+        dialers.get(peer.id).peer = peer;
+        continue;
+      }
       const dialer = new PeerDialer(peer, ctx);
       dialers.set(peer.id, dialer);
       dialer.start();

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -393,7 +393,7 @@ export class PeerDialer {
 
     let ws;
     // TLS verification is ON for wss candidates (#144 follow-up): every wss
-    // candidate is hostname-based (the ladder never emits raw-IP wss), and
+    // candidate is hostname-based (the fleet's wss candidates are all ts.net hostnames; a raw-IP https gateway_url would emit raw-IP wss, whose cert won't verify — the ws:// tailnet fallback recovers when tailscale_ip is set), and
     // the fleet's Serve endpoints carry real LE certs — SNI + verification
     // both work. ws:// candidates are unaffected. A deployment fronting its
     // gateway with a self-signed cert should use an http/ws gateway_url or a

--- a/tests/tailnet-sync-dial.test.js
+++ b/tests/tailnet-sync-dial.test.js
@@ -48,6 +48,7 @@ test("tailnet-IP fallback candidate uses the backend fallbackPort, not the Serve
   assert.deepEqual(urls, [
     `wss://grackle.dachshund-chromatic.ts.net:8444${WS_PATH}`,
     `ws://100.121.254.89:3002${WS_PATH}`,
+    `ws://100.121.254.89:3001${WS_PATH}`,
   ]);
 });
 
@@ -61,12 +62,20 @@ test("port 443 (public Funnel) is never dialed — falls back to tailnet IP", ()
     { gateway_url: "https://grackle.dachshund-chromatic.ts.net", tailscale_ip: "100.121.254.89" },
     3002
   );
-  assert.deepEqual(urls, [`ws://100.121.254.89:3002${WS_PATH}`]);
+  assert.deepEqual(urls, [
+    `ws://100.121.254.89:3002${WS_PATH}`,
+    `ws://100.121.254.89:3001${WS_PATH}`,
+  ]);
 });
 
 test("no gateway_url → tailnet IP + fallbackPort only", () => {
   const urls = peerToWsUrlCandidates({ tailscale_ip: "100.118.41.122" }, 3001);
-  assert.deepEqual(urls, [`ws://100.118.41.122:3001${WS_PATH}`]);
+  // #144 minor: the peer's backend port isn't advertised, so the ladder
+  // tries the caller's own port plus the fleet-standard 3001/3002.
+  assert.deepEqual(urls, [
+    `ws://100.118.41.122:3001${WS_PATH}`,
+    `ws://100.118.41.122:3002${WS_PATH}`,
+  ]);
 });
 
 test("neither gateway_url nor tailscale_ip → no candidates", () => {
@@ -79,7 +88,10 @@ test("malformed gateway_url falls back to the tailnet IP candidate", () => {
     { gateway_url: "not a url ::", tailscale_ip: "100.121.254.89" },
     3002
   );
-  assert.deepEqual(urls, [`ws://100.121.254.89:3002${WS_PATH}`]);
+  assert.deepEqual(urls, [
+    `ws://100.121.254.89:3002${WS_PATH}`,
+    `ws://100.121.254.89:3001${WS_PATH}`,
+  ]);
 });
 
 test("candidates are deduped when gateway_url already IS the tailnet-IP dial", () => {
@@ -87,7 +99,27 @@ test("candidates are deduped when gateway_url already IS the tailnet-IP dial", (
     { gateway_url: "http://100.121.254.89:3002", tailscale_ip: "100.121.254.89" },
     3002
   );
-  assert.deepEqual(urls, [`ws://100.121.254.89:3002${WS_PATH}`]);
+  assert.deepEqual(urls, [
+    `ws://100.121.254.89:3002${WS_PATH}`,
+    `ws://100.121.254.89:3001${WS_PATH}`,
+  ]);
+});
+
+test("non-standard caller port leads the fallback ladder, then the fleet-standard ports", () => {
+  const urls = peerToWsUrlCandidates({ tailscale_ip: "100.118.41.122" }, 3006);
+  assert.deepEqual(urls, [
+    `ws://100.118.41.122:3006${WS_PATH}`,
+    `ws://100.118.41.122:3001${WS_PATH}`,
+    `ws://100.118.41.122:3002${WS_PATH}`,
+  ]);
+});
+
+test("bare IPv6 tailscale_ip is bracketed in the direct candidates (#144 minor)", () => {
+  const urls = peerToWsUrlCandidates({ tailscale_ip: "fd7a:115c:a1e0::1" }, 3001);
+  assert.deepEqual(urls, [
+    `ws://[fd7a:115c:a1e0::1]:3001${WS_PATH}`,
+    `ws://[fd7a:115c:a1e0::1]:3002${WS_PATH}`,
+  ]);
 });
 
 test("upgrade handler destroys Funnel-tagged sockets before any handshake", () => {
@@ -120,4 +152,31 @@ test("upgrade handler ignores non-matching paths (leaves socket alone)", () => {
   const socket = { destroy: () => { destroyed = true; } };
   server.emit("upgrade", { url: "/other/ws", headers: {}, socket: {} }, socket, Buffer.alloc(0));
   assert.equal(destroyed, false);
+});
+
+test("backoff grows once per FULL ladder cycle, not per candidate (#144 minor)", async () => {
+  const { PeerDialer } = await import("../servers/sharing/tailnet-sync.js");
+  const d = new PeerDialer({ id: "peer-x" }, {});
+  d._candCount = 3; // three candidates in the ladder
+  const base = d.retryMs;
+
+  // Attempts 1 and 2 (mid-cycle): retry delay stays at base for the untried
+  // candidates — no exponential penalty inherited from earlier failures.
+  d.attempt = 1; d.scheduleRetry(); assert.equal(d.retryMs, base, "mid-cycle attempt 1: no growth");
+  d.attempt = 2; d.scheduleRetry(); assert.equal(d.retryMs, base, "mid-cycle attempt 2: no growth");
+  // Attempt 3 completes the cycle → double.
+  d.attempt = 3; d.scheduleRetry(); assert.equal(d.retryMs, base * 2, "full cycle → doubled");
+  // Next full cycle doubles again; cap respected eventually.
+  d.attempt = 6; d.scheduleRetry(); assert.equal(d.retryMs, base * 4, "second full cycle → doubled again");
+
+  // Single-candidate ladder degenerates to the old per-attempt behavior.
+  const d1 = new PeerDialer({ id: "peer-y" }, {});
+  d1._candCount = 1;
+  d1.attempt = 1; d1.scheduleRetry(); assert.equal(d1.retryMs, base * 2, "single candidate: doubles every retry");
+
+  // Unset _candCount (retry before any connect) must not throw or divide by zero.
+  const d2 = new PeerDialer({ id: "peer-z" }, {});
+  d2.attempt = 0; d2.scheduleRetry(); assert.equal(d2.retryMs, base * 2);
+
+  d.stop(); d1.stop(); d2.stop(); // clear pending timers so the test process exits
 });


### PR DESCRIPTION
The #144 review's logged minors for the tailnet WebSocket sync transport (post-arc queue item 2, messages-arc leftovers):

- **Fallback port ladder**: the direct `ws://<tailscale_ip>` fallback tried a single hardcoded port (wrong for any non-3002 Serve-less peer). The peer's backend port isn't advertised in its `crow_instances` row, so the ladder now tries the caller's own port plus the fleet-standard 3001/3002, deduped. Bare IPv6 `tailscale_ip`s are bracketed.
- **Per-cycle backoff**: exponential growth now applies once per FULL ladder cycle, so a healthy candidate later in the ladder gets its first try at the base delay instead of inheriting the penalty earned by dead candidates before it. Steady-state dial rate at the 60s cap is unchanged.
- **Live peer-row refresh**: `startTailnetSyncClients`' 60s rescan now updates existing dialers' peer snapshot — a changed `gateway_url`/`tailscale_ip` previously kept dialing the old address until a gateway restart.
- **TLS verification ON** (`rejectUnauthorized: false` removed): every wss candidate the ladder emits for this fleet is a ts.net hostname with a real LE cert (verified live: `grackle…:8444` and `crow…:8447` both `Verify return code: 0`); ws auto-derives SNI from the URL hostname. Silently accepting any certificate on an authenticated sync transport was the worse default. A deployment fronting its gateway with a self-signed cert should use an http/ws `gateway_url` or a real cert (the ws:// tailnet fallback recovers when `tailscale_ip` is set).
- **Ladder/backoff unit tests** (the #144 review's missing-test item): candidate matrix incl. IPv6 + non-standard ports, and the per-cycle growth behavior. `PeerDialer` exported for tests.

## Verification
- Full suite: **1522 tests, 1521 pass, 0 fail, 1 standing skip** (tailnet dial tests 17/17).
- Adversarial review: READY-WITH-NITS — TLS change traced against every wss candidate the fleet actually generates (no raw-IP https `gateway_url` exists anywhere; black-swan's portless row defaults to 443 → Funnel-guard skips it → ws:// only); pin math self-healing on ladder changes; backoff flattens to the old rate at cap. Comment nit folded; two edge-case nits accepted (cleared-gateway_url stale snapshot — no worse than before; backoff test drives fields directly).
- Post-deploy: watch `[tailnet-sync] replicating with peer` on crow after restart — live proof the verified-TLS dials still connect.