### PR TITLE
docs: CROW_DISABLE_INSTANCE_SYNC env entry + companion sync troubleshooting note

### DIFF
--- a/docs/architecture/companion.md
+++ b/docs/architecture/companion.md
@@ -86,6 +86,7 @@ The privacy rationale is the same in both cases: a shared kiosk's default charac
 - **"error calling the chat endpoint…"** — the generated `conf.yaml` is pointing OLVV at an endpoint that rejects the request. Check `docker logs crow-companion` for the upstream error. Common causes: a cloud profile rejecting an empty `tools: []` array (use a local model, which tolerates it), or the MCP bridge failing so no tools load. The bridge targets the gateway's MCP mounts (`/router`, `/storage`, `/wm`) on `CROW_MCP_BRIDGE_PORT` (default `3001`); `/router`, `/storage`, and `/wm` all require a local MCP token (generate it in the dashboard's Connect panel; `generate-config.py` reads it from the `CROW_LOCAL_MCP_TOKEN` env var and embeds it in `mcp_servers.json` — unset, the bridges get 401s).
 - **Avatar speaks its reasoning** — ensure the fast route disables thinking (`COMPANION_FAST_DISABLE_THINKING=1`, the default).
 - **Window/media commands do nothing** — the `crow_wm` MCP bridge isn't connected; verify `ToolManager initialized with N OpenAI tools` (N>0) in the container logs.
+- **Companion edits don't appear on paired instances** — expected: the companion container does not drive cross-instance sync. Its writes land through the gateway's MCP mounts, and only the primary gateway process (never a `--no-auth` companion/bridge gateway) opens the instance-sync feeds and emits changes. If gateway-side edits aren't syncing either, check `CROW_DISABLE_INSTANCE_SYNC` and the sync-conflicts page.
 
 ## Files
 

--- a/docs/developers/configuration.md
+++ b/docs/developers/configuration.md
@@ -81,6 +81,7 @@ A brand-new operator usually only ever touches these: `CROW_GATEWAY_URL` (remote
 | Variable | Default | Purpose |
 |---|---|---|
 | `CROW_UNIFIED_DASHBOARD` | enabled | Federated dashboard across paired instances (`0` disables). |
+| `CROW_DISABLE_INSTANCE_SYNC` | *(unset)* | `1` disables cross-instance sync entirely (Hypercore feeds, Hyperswarm DHT, tailnet-sync dialers). `--no-auth` gateways are always sync-disabled regardless. Pair with `CROW_DISABLE_NOSTR=1` for a fully-offline scratch/test boot. |
 | `CROW_PEER_TOKENS_PATH` | per-`CROW_HOME` | Peer credential file override (multi-gateway hosts). |
 | `CROW_CALLS_ENABLED` | `0` | WebRTC calls feature. |
 | `CROW_CALLS_MAX_PEERS` | `4` | Max peers per call room. |


### PR DESCRIPTION
The two remaining messages-arc doc-note leftovers (post-arc queue item 2):

- `CROW_DISABLE_INSTANCE_SYNC` documented in the Sharing/P2P env table (it gates Hypercore feeds, Hyperswarm, and the tailnet-sync dialers; `--no-auth` gateways are always sync-disabled; pairs with the new `CROW_DISABLE_NOSTR=1` for fully-offline scratch boots).
- Companion architecture doc: troubleshooting note that the companion container does not drive cross-instance sync (writes land via gateway MCP mounts; only the primary gateway emits sync changes).

Docs-only; no runtime surface.