### PR TITLE
Extensions follow-ups: a config prompt that survives, same-tab onboarding cards, a deterministic install-set barrier

### DIFF
--- a/docs/superpowers/specs/2026-07-11-extensions-followups-design.md
+++ b/docs/superpowers/specs/2026-07-11-extensions-followups-design.md
@@ -1,0 +1,484 @@
+# Extensions follow-up pool — design v3 (2026-07-11)
+
+Item 1 of `docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md`. Three accepted
+follow-ups from the extensions overhaul (PR #173). One branch, one PR:
+`fix/extensions-follow-up-pool`.
+
+**v3 folds TWO adversarial Opus review rounds (R1 REVISE: 4C/5I/8m; R2 REVISE: 5C/7I/5m).
+Every finding was re-verified against the code and the live host before folding.** The
+naive design would have badged Kevin's *working* bundles as unconfigured on day one. See
+§Review record.
+
+No schema change ⇒ the §3 auto-update **migration rail does not apply**; a plain merge +
+deploy is correct.
+
+## The central design fact (measured, not argued)
+
+A missing `bundles/<id>/.env` does **not** mean "unconfigured" on a real host — it usually
+means the bundle isn't gateway-managed-with-config at all. Measured against crow's actual
+10 installed bundles:
+
+| rule | would badge |
+|---|---|
+| naive (`.env` only, badge whenever a required key is empty) | **frigate (1 key), capstone-tracker (12 keys)** — both FALSE |
+| **v3** (managed-evidence gate + effective env) | **zero** — every installed bundle is either genuinely configured or not managed-with-config |
+
+`capstone-tracker`'s installed dir contains **only `manifest.json`** (an operator WIP stub);
+`frigate`/`motioneye` have no `.env` at all. So `existsSync(bundleDir)` is the **wrong**
+gate — it passes for all of them.
+
+**The rule (fail closed — never nag about something we cannot verify):** badge a bundle
+only when there is positive evidence the gateway manages its config —
+`bundles/<id>/.env` exists **OR** the bundle has an `mcp-addons.json` entry — and a
+required key is still empty in its *effective* env. This does not weaken the feature: every
+install path that has required keys **writes** a `.env` (user values, or `.env.example`
+copied at `bundles.js:1264`), so a genuinely unconfigured install still badges.
+
+---
+
+## 1a — Config state that survives, and finally exists at all
+
+### The problem
+
+After a **collection** install the client shows a NEEDS_CONFIG checklist modal. It is
+one-shot: `renderPendingChecklist` (`panels/extensions/client.js:1341`) reads
+`sessionStorage["crow_ext_needs_config"]` and `removeItem`s it *before* parsing
+(`:1345-1347`). Close the modal without configuring → the checklist is gone until you
+reinstall.
+
+And the deeper gap: `NEEDS_CONFIG` is emitted **only** by the `/install-set` job runner
+(`routes/bundles.js:1961-1966`). A bundle installed through the single `/install` path
+(`:1849`) that requires config gets **no prompt, ever**. For the most common install
+path, this affordance is not a fallback — it is the only surface that will ever tell the
+user their bundle is unconfigured.
+
+### D1 — Extract to one source of truth (do NOT duplicate)
+
+New module **`servers/gateway/bundles-config.js`** owns: `CROW_HOME`/`BUNDLES_DIR`,
+`APP_BUNDLES`, `getManifest`, `resolveEffectiveEnv` (new, see D3), `needsConfigKeys`, and
+the **`_setAppBundlesForTest` setter**. `routes/bundles.js` imports these and
+**re-exports `needsConfigKeys` and `_setAppBundlesForTest`** (delegating, not
+re-declaring).
+
+**This is load-bearing, not stylistic.** `APP_BUNDLES` is a mutable `let`
+(`bundles.js:126-129`) precisely so `_setAppBundlesForTest` can repoint it at a scratch
+tree — the guard that keeps the E2E suite from installing real bundles on Kevin's host
+(`tests/install-set-e2e.test.js:36-39`: *"a prior run of a test in this family actually
+installed uptime-kuma on the operator's live host"*). If the new module declares its own
+`APP_BUNDLES`, the setter repoints only one of the two roots, the isolation guard is
+half-broken, and **no assertion in the suite detects it**. There must be exactly one
+`APP_BUNDLES` binding in the codebase.
+
+Existing importers that must keep working unchanged: `tests/bundles-install-set.test.js:3`
+(imports `needsConfigKeys` from `routes/bundles.js`), `tests/install-set-e2e.test.js:107,144`
+(imports `_setAppBundlesForTest`). Circular-import risk is nil if `bundles-config.js`
+imports only node builtins.
+
+### D2 — Manifest source: installed-first, but ONLY for this feature
+
+`getManifest` reads only `APP_BUNDLES` (the repo checkout, `bundles.js:590-597`), while
+`resolveManifestHost` (`:191-197`) already prefers the **installed** copy, then the repo.
+For config-completeness the installed copy is the right truth (a bundle installed from a
+version no longer in the repo would otherwise yield `getManifest → null →
+needsConfigKeys → []`, silently hiding the affordance on exactly the stale installs that
+need it).
+
+**⚠️ Do NOT change `getManifest` itself.** It has ~18 callers, feeding `validateInstall`
+(`:1105`), the hardware gate (`:1139`), `/consent-challenge` (`:1811`), compose
+validation, `findDependents` (`:962`), `planInstallSet` (`:1712`). And the reverse
+divergence is real on this host **right now**: `~/.crow/bundles/` contains `dozzle`,
+`minio`, `romm`, `google-workspace`, `knowledge-base-mcp`, `fed-gov-data`,
+`texas-gov-data` — none of them in `installed.json`. Making `getManifest`
+installed-first would run consent/hardware/compose validation for a future install of any
+of those against a **stale installed manifest** instead of the repo's.
+
+Add a **separate** `getInstalledFirstManifest(id)` (installed → repo fallback), used
+**only** by `resolveEffectiveEnv` / `needsConfigKeys`. Leave `getManifest` untouched.
+
+Ordering is fine at the existing call site: `needsConfigKeys(member.id)`
+(`bundles.js:1961`) runs **after** `runInstallJob` has `cpSync`'d the source dir
+(`:1226-1228`), so the installed manifest exists by then.
+
+Accepted consequence: if an auto-update ships a manifest that adds a new `required` key,
+existing installs light up "Needs setup". That is **correct** — the container genuinely
+lacks a now-required value — and it is exactly the signal the product cannot show today.
+
+### D3 — Effective env: three sources, plus the managed-evidence gate
+
+`needsConfigKeys` today consults **only** `bundles/<id>/.env`. That is right for the
+moment it was written for (immediately post-install, where the runner just wrote the file)
+and wrong as a durable signal. Config that actually makes a bundle work lives in up to
+three places:
+
+1. **`bundles/<id>/.env`** — docker bundles (compose reads it).
+2. **`~/.crow/mcp-addons.json[<id>].env`** — MCP add-ons. `applyEnvToMcpAddons`
+   (`bundles.js:672-686`) writes it and its docstring (`:664-670`) is explicit: *"MCP
+   children are spawned with { ...process.env, ...(config.env||{}) } from mcp-addons.json
+   (proxy.js) — they never read bundles/<id>/.env."*
+3. **Ambient `process.env`** — `proxy.js:145` spawns MCP children with `{ ...process.env,
+   ...config.env }`, and `applyEnvToMcpAddons` skips blanks precisely so it won't *shadow*
+   "a working ambient value". A key supplied via the gateway's own env / systemd
+   `Environment=` is effective config that appears in neither file.
+
+`resolveEffectiveEnv(bundleId, manifest, { envOverride } = {})` merges, in precedence
+order: `.env` > `mcp-addons.json[<id>].env` > `process.env` (the last two only for bundles
+that register an MCP server). A required key is **configured** if its effective value is
+non-empty after `trim()`.
+
+**Managed-evidence gate (see "The central design fact"):** compute an affordance at all
+only when `.env` exists **or** the bundle has an `mcp-addons.json` entry. Otherwise return
+`[]` — we cannot distinguish "unconfigured" from "not managed this way", and a false nag
+is worse than a missing one. This is what keeps `capstone-tracker` (manifest-only stub) and
+`frigate`/`motioneye` (no `.env`) quiet, and it is what makes the prod badge count zero
+today.
+
+**Preserve the `envOverride` seam.** The current signature is
+`needsConfigKeys(bundleId, envOverride = null)` and `tests/bundles-install-set.test.js:40,45`
+depends on it to inject a parsed env. Keep it, and make it **short-circuit** the
+mcp-addons/ambient lookups entirely (an injected env is the whole truth) — otherwise that
+unit test's result would depend on whether the *host* happens to have the bundle in
+`mcp-addons.json`.
+
+Preserve the existing docstring rule: a key that already has a value — **including an
+`.env.example` default** (DB passwords, secret keys) — counts as configured and is never
+surfaced; those are consumed at first container boot and changing them later breaks the app
+or strands its data. Corollary, accepted and documented: manifest `default`s are copied into
+`mcp-addons.json` at install (`bundles.js:1355-1358`, `:1421-1424`), so an MCP bundle whose
+required key has a placeholder default will never badge. Do not "fix" this — it is the same
+rule.
+
+### D4 — Server-rendered affordance, computed in the panel handler
+
+Compute in **`panels/extensions.js:31`**, which already has `installed` in hand and is
+`async`: add `fetchNeedsConfig(installed)` to the panel's `data-queries.js` and pass the
+result into `buildExtensionsHTML({ ..., needsConfig = {} })` as a **defaulted** param
+(`html.js:148-156` destructures a fixed set; a *required* param would break
+`extensions-page-render.test.js`).
+
+**`html.js` stays pure and must never call `needsConfigKeys` itself.**
+`tests/extensions-client-contract.test.js:16-17` declares the contract — *"Nothing here
+imports routes/bundles.js or data-queries.js, so ~/.crow is never read or written"* —
+and computing inside `html.js` would make that unit test read Kevin's real
+`~/.crow/bundles/*/.env`.
+
+Render on any card whose list is non-empty (`html.js:303-338`): a **"Needs setup"** badge
+(reuse `badge()` from `shared/components.js`, as the status badges do at `html.js:308-310`
+— do not invent a class + CSS) plus a Configure button, all attributes `escapeHtml`'d like
+their neighbours:
+
+```
+<button class="btn btn-sm btn-primary bundle-configure"
+        data-id="${escapeHtml(id)}" data-keys="${escapeHtml(keys.join(","))}">
+```
+
+The gate is the **managed-evidence** rule of D3, *not* `existsSync(bundleDir)` — that
+predicate passes for `capstone-tracker` (manifest-only stub) and would render a permanent
+badge wired to a Configure button whose POST writes a `.env` into a directory nothing
+reads. (`POST /bundles/api/env` 404s only when the dir is entirely absent,
+`bundles.js:2302-2305`.)
+
+**Import discipline (`data-queries.js`):** import `needsConfigKeys` **only** from
+`bundles-config.js` — never from `routes/bundles.js`, which would drag express `Router`,
+`db.js`, `peer-forward`, `cross-host-auth`, `providers-db` and the settings registry into
+the panel data path and knot the import graph (`routes/bundles.js` already imports
+`panels/extensions/collections.js` at `:40`).
+
+**`APP_ROOT` depth:** `bundles.js:117` computes `resolve(__dirname, "../../..")` from
+`servers/gateway/routes/`. At `servers/gateway/bundles-config.js` the correct expression is
+`"../.."` (cf. `servers/gateway/env-manager.js:7`). A literal copy yields
+`APP_BUNDLES = /home/kh0pp/bundles` — every install 404s and `planInstallSet` skips every
+member. State it in the task brief.
+
+Rejected: a `needs_config` field on `GET /bundles/api/status` (`:1766`). It costs a client
+round-trip, and — decisively — `xhostVerify` is mounted **router-wide** (`:1755-1764`), so
+that route is a **cross-host peer surface**. Config-completeness of Kevin's bundles has no
+business being exposed to peers.
+
+### D5 — 🔒 Key NAMES only, never values
+
+Key names are already public (they're in the manifest's `env_vars`). Values are secrets
+(API keys, DB passwords). **No `.env` or `mcp-addons.json` value may reach the browser** —
+not in HTML, not in a data attribute, not in a JSON island. The compute layer returns
+`string[]` of names; the render layer never sees a value. This is the hard boundary, and
+the test for it must exercise the **compute→render seam end to end** (see AC-7) — a
+sentinel test that only renders would pass trivially and guard nothing.
+
+### D6 — Reuse the Configure modal, and make the badge actually clear
+
+The button opens the same env-only modal the checklist uses:
+`showInstallModal(id, name, envVars, 0, 0, false, /* configureOnly */ true, onSaved)`
+(`client.js:88`). `configureOnly` skips the consent fetch (`:113`), the resource warning
+(`:250`), and the community banner (`:231`), and routes submit through
+`/bundles/api/env` (`:332-380`). Env metadata comes from `ADDON_DATA[id]`, with a
+`{ name: key, required: true }` fallback (`:1294-1297`) — so an installed-but-unregistered
+bundle degrades gracefully. #173's blank-save guard (`6ba59036`) and the router-wide
+`xhostVerify` continue to apply unchanged; no new write path.
+
+**The existing configure flow does NOT reload** — an earlier draft claimed it did, and that
+was wrong. The checklist's `onSaved` (`client.js:1305-1318`) only splices the in-memory
+list, rewrites sessionStorage, and hides the modal; the `location.reload()` at `:579`
+belongs to `pollJob` (the install flow). So on success, **both** entry points must update
+the badge themselves.
+
+**The client must not decide whether the bundle is now configured — the server must tell
+it.** `submitConfigureOnly` (`client.js:322-341`) guards only the *all-blank* case, and
+`if (inp && inp.value)` even accepts whitespace (which `needsConfigKeys` trims away). So
+filling 1 of 12 keys returns 200, and a client that clears the badge on any 200 would hide
+a still-unconfigured bundle until the next navigation — a silent false "done".
+
+Therefore: **`POST /bundles/api/env` returns the bundle's remaining `needs_config: string[]`**
+(re-derived server-side after the write, via the same `needsConfigKeys`). `onSaved(resp)`
+then drives the DOM from that response — remove the badge only when `needs_config` is
+empty, otherwise update `data-keys` in place. This is server-derived truth, adds no new
+read surface, and fixes both entry points at once (including the cross-surface staleness
+where a save via the *checklist* would otherwise leave the card's badge stale).
+
+DOM plumbing (record it so nobody reinvents it): the installed card carries
+`data-addon-id` (`html.js:302`), reachable as `[data-addon-id="…"]` — **null-safe**, the
+card may not exist (e.g. saving from the checklist right after a restart). The card's own
+click handler already ignores `.btn` targets (`client.js:1038-1041`), so a `btn`-classed
+`.bundle-configure` needs no `stopPropagation`.
+
+No reload — that preserves the checklist's careful restart-safe semantics.
+
+**Known limitation, stated not fixed:** for MCP bundles `/bundles/api/env` returns
+`needs_restart: true` (`bundles.js:2331-2336`) and the child keeps its old env until a
+gateway restart. Clearing the badge means "configured", not "already live". The existing
+restart affordance covers the rest.
+
+### D7 — Leave the sessionStorage checklist's one-shot semantics alone
+
+It still fires post-collection-install as the *proactive* prompt. The card affordance is
+the durable, re-derivable surface. Do not change the one-shot consumption — that risks the
+reopen-loop #173 closed.
+
+### D8 — i18n
+
+New key (`extensions.needsSetup`) as a flat `{en, es}` entry in `shared/i18n.js`
+(cf. `:641`); `extensions.configure` already exists (`client.js:93`). Note the real
+fallback behavior: `t()` falls back to `entry.en` before the raw key (`i18n.js:1469-1471`),
+so a missing Spanish *value* ships English (not the literal key) — still wrong, still add
+both, but don't cite the wrong failure mode in the PR.
+
+### Acceptance criteria (1a)
+
+1. A bundle with an unmet required key shows the affordance on a fresh load with
+   **sessionStorage cleared**.
+2. It shows for a bundle installed via **single `/install`** (which never emitted a
+   checklist) — the regression this really closes.
+3. **A functioning MCP add-on configured via `mcp-addons.json` only (no `.env`) shows NO
+   affordance** (D3 — the day-one prod bug).
+4. **An MCP add-on whose required key is supplied only by ambient `process.env` shows NO
+   affordance** (D3 source 3).
+5. A bundle with **no managed evidence** (no `.env`, no mcp-addons entry — e.g. a
+   manifest-only stub like `capstone-tracker`, or `frigate`) shows **no** affordance, even
+   though required keys are "empty". This is the measured prod case.
+6. A bundle whose required keys all have values shows no affordance; a bundle with no
+   required keys shows no affordance.
+7. Clicking Configure opens the env-only modal scoped to exactly the missing keys.
+   **Partial save:** filling some-but-not-all keys → the badge REMAINS, with `data-keys`
+   narrowed to what's still missing (driven by the route's returned `needs_config`).
+   **Full save:** badge removed, no reinstall, no reload. Saving via the *checklist* also
+   updates/clears the card's badge.
+8. **Security (must actually be able to fail):** in a scratch `CROW_HOME`, fixture a bundle
+   with **two** required keys — one holding sentinel `SECRET_SENTINEL_VALUE_9f3a` (in
+   `.env` **and** in `mcp-addons.json`), one left **empty**. Drive
+   `fetchNeedsConfig → buildExtensionsHTML` and assert **both**: (a) the badge/Configure
+   button **is present** for that bundle (proving the render path is live — otherwise the
+   sentinel check is vacuous, since a fully-configured bundle renders nothing at all), and
+   (b) the sentinel appears **zero** times in the HTML.
+9. Honors `CROW_HOME` (a scratch-`CROW_HOME` gateway reports its OWN bundles — the
+   `1b28d38a` invariant).
+10. Exactly one **binding** of `APP_BUNDLES` exists (assert on the declaration/assignment
+    pattern — `^let APP_BUNDLES` / assignment sites — not a bare `grep -c`, since
+    `bundles.js` still *references* it in ~6 places), and both pre-existing importers
+    (`bundles-install-set.test.js`, `install-set-e2e.test.js`) pass **unchanged**.
+
+Test placement: AC-8 (and the other compute-layer criteria) go in a **new** test file that
+sets `CROW_HOME` **before a dynamic import** — both `bundles-config.js` and
+`data-queries.js:18` capture `CROW_HOME` at module load (the `install-set-e2e.test.js:105-111`
+pattern). Do **not** add them to `extensions-page-render.test.js` or
+`extensions-client-contract.test.js`: those declare "nothing here imports routes/bundles.js
+or data-queries.js, so ~/.crow is never read" (`:5-7`, `:16-17`), and breaking that makes
+them environment-dependent.
+
+**Pre-merge live sanity check (read-only, on prod) — re-run it, don't trust this doc:**
+compute what the badge *would* show for crow's real installed bundles. The v3 rule measured
+**zero** badges on 2026-07-11 (naive rule: frigate 1, capstone-tracker 12 — both false). Any
+bundle Kevin actually uses that reports "needs setup" is a bug, not a finding — stop and fix.
+
+---
+
+## 1b — Onboarding action-card targets (done-step cards ONLY)
+
+### Correctly scoped
+
+- **`deepLink()` (`onboarding.js:33`; callers `:155,:157,:160`) KEEPS `target="_blank"`.**
+  These are **mid-tour** steps, and the docstring (`:31-32`) states why: it opens the
+  surface in a new tab *so the tour stays open behind it*. Same-tab would navigate the user
+  out of the wizard mid-tour. **Out of scope — do not touch.**
+- **`renderActionCards()` (`onboarding.js:42`)** renders on the **done** step, after
+  `onboarding_completed_at` is persisted (`:213-218`). No tour remains; a new tab for an
+  internal dashboard link is just odd UX. **This is the only site in scope.**
+
+All four done-step cards are internal today (`:48,:54,:60,:66` — `/dashboard/memory`,
+`/dashboard/bot-builder`, `/dashboard/connect`, `/dashboard/extensions#collections`).
+
+### Design
+
+Extract a **pure classifier** (`isInternalHref(href)` → leading `/`) and use it in
+`renderActionCards`: internal hrefs render with no `target`/`rel`; external hrefs
+(absolute `http(s)://`) keep `target="_blank" rel="noopener"`. Classify by href so a card
+added later by Item 4d gets the right behavior automatically. The external branch is dead
+code on day one — unit-test the classifier directly with an external href, since the
+renderer cannot exercise it.
+
+### Acceptance criteria (1b)
+
+1. **Behavioral regression guard on the tour** (not a byte-diff): execute the renderer for
+   the `integrations` / `bot` / `connect` steps and assert each anchor still carries
+   `target="_blank" rel="noopener"`.
+2. Execute `renderActionCards` and assert per-card `target` by href class (executed
+   renderer — a source regex is not evidence).
+3. Every remaining `_blank` still carries `rel="noopener"`.
+4. `isInternalHref` unit-tested with both classes, including an external href.
+5. CDP: click an internal done-step card → navigates **in the same tab** and lands on the
+   surface. This **inverts** assertion 9b in `~/.crow/p4/ext-overhaul/runner-c.mjs` (which
+   asserted in the opened tab) — update that recipe in this PR.
+
+---
+
+## 1c — T12 timer pacing → barrier promise
+
+### Design
+
+Replace `_setInstallSetStepDelayForTest` (`bundles.js:156`, consumed at `:1940`) with a
+**barrier**: a module-private `let _installSetBarrier = null` + setter; the runner awaits
+it **at the top of each member iteration, including the first** — matching the current
+seam's placement (`:1940`). ("Between members" would let the first member's install race
+the three busy-gate fetches at `install-set-e2e.test.js:181-209`.)
+
+Production default is a **true no-op**: `null` barrier ⇒ the `if (barrier) await barrier`
+branch is never entered — no await, no timer. Prove the no-op **by mechanism** (default
+asserted via a read-only getter / unentered branch), not by a comment.
+
+The router is mounted **in-process** in the test (`install-set-e2e.test.js:160-163`), so
+there is no HTTP boundary to install the barrier across; and `beginInstallSet()` runs
+before `res.json()` (`bundles.js:1926-1934`), so `isInstallSetRunning()` is already true
+when the first response lands. The determinism is real.
+
+**Resolve placement — getting this wrong hangs the happy path.** The test must resolve the
+barrier **immediately after the busy-gate assertions** (`install-set-e2e.test.js:181-209`),
+so the runner proceeds and the poll loop (`:213-218`) sees completion. Resolving *only* in
+`t.after()` would park the runner while the poll burns its 100×50ms — a 100%-reproducible
+failure. Then **also** resolve idempotently in `t.after()` (alongside the existing
+`_setRestartHookForTest(null)` teardown, `:153-158`) as the failure story: if an assertion
+throws first, `endInstallSet()` in the runner's `finally` (`:1975`) would otherwise never
+run and leak the busy flag into the next test.
+
+Confirm `_setInstallSetStepDelayForTest` has no consumer besides `install-set-e2e.test.js`
+before deleting it (it does not).
+
+### Acceptance criteria (1c)
+
+1. Zero wall-clock sleeps in the busy-gate section (grep `setTimeout`/`sleep` → zero hits
+   in that block).
+2. The 409 assertion provably happens mid-flight, not "probably within 450ms".
+3. Production path proven to take no barrier by default.
+4. Mutation check: break the barrier ordering → a **named** assertion goes red; restore.
+5. Barrier resolved unconditionally in `t.after()`.
+6. Full suite green (scratch env).
+
+---
+
+## Risk / blast radius
+
+No schema change (no migration rail). No new write path (1a reuses `/bundles/api/env`).
+The security boundary is D5, tested end-to-end at the compute→render seam. The one real
+regression risk is 1b touching onboarding — bounded by the behavioral tour guard. The one
+real *product* risk is D3 (false badges on working add-ons) — bounded by AC-3 plus the
+read-only prod sanity check before merge.
+
+Gates: full suite on scratch env; `check-port-allocation.js` error block is exactly the one
+known `Port 8090 (capstone-tracker)` line; `build-registry.mjs --check` clean; CDP evidence
+in `~/.crow/p4/ext-followups/`.
+
+---
+
+## Review record
+
+**R2 — second adversarial Opus round, verdict REVISE (5 critical, 7 important).** It caught
+that three of R1's four "critical" folds were themselves wrong or incomplete — and proved it
+by computing the rule against the live host. All folded into v3:
+
+- **R2-C1 — the fold's own pre-merge gate already failed on prod.** The v2 rule would badge
+  `capstone-tracker` (12 keys) and `frigate` (1) — both false. `existsSync(bundleDir)` was
+  the wrong gate: `capstone-tracker`'s installed dir holds *only* `manifest.json`, so it
+  passes, and its Configure button would POST a `.env` into a stub directory nothing reads.
+  → Replaced with the **managed-evidence gate**; independently re-measured: **zero** badges
+  across crow's 10 installed bundles, while a real unconfigured install still badges.
+- **R2-C2 — AC-7 was STILL vacuous.** If the sentinel is the value of the only required key,
+  the bundle is configured → no badge renders → "zero occurrences" passes trivially, on an
+  implementation that leaks values for every *other* bundle. → AC-8 now fixtures two keys
+  (one sentinel-valued, one empty) and asserts the badge **is** present *and* the sentinel
+  is absent.
+- **R2-C3 — D3 silently dropped the `envOverride` seam** that D1 promised keeps working,
+  which would have turned `bundles-install-set.test.js:40` red (it would read the operator's
+  real `~/.crow`). → Signature pinned; `envOverride` short-circuits the other sources.
+- **R2-C4 — D2's "installed manifest first" leaked into the shared `getManifest`** (~18
+  callers: consent, hardware gate, compose validation, `planInstallSet`). And the reverse
+  divergence is live — `~/.crow/bundles/` holds 7 bundles absent from `installed.json`, so a
+  future install of any of them would have validated against a stale manifest. → Separate
+  `getInstalledFirstManifest`, used only by this feature.
+- **R2-C5 — D6 would false-clear on a partial save** (fill 1 of 12 keys → 200 → badge
+  removed → still-unconfigured bundle looks done). → `/bundles/api/env` now returns the
+  re-derived `needs_config`; the client renders server truth instead of guessing.
+- **Importants folded:** `APP_ROOT` depth differs at the new module's path (a literal copy
+  would point `APP_BUNDLES` at `/home/kh0pp/bundles` and 404 every install); ambient
+  `process.env` is a third effective-config source for MCP children (`proxy.js:145`);
+  `data-queries.js` must import from `bundles-config.js` only, never `routes/bundles.js`;
+  AC-8 needs its own scratch-`CROW_HOME` file (the two existing extension tests *declare*
+  they never read `~/.crow`); the 1c barrier must resolve right after the assertions or the
+  happy path hangs 100% of the time; manifest defaults copied into `mcp-addons.json` mean
+  some MCP bundles can never badge (accepted, documented).
+- **Minors:** `t()` falls back to English, not the raw key (my stated failure mode was
+  wrong); AC-10's grep must pin the *binding*, not references; reuse `badge()` from
+  `shared/components.js`; card DOM lookup must be null-safe.
+
+R2 also confirmed what R1 got right: the single-`APP_BUNDLES` requirement is workable via
+ESM live bindings + delegating re-exports; `panels/extensions.js:31` is the correct compute
+hook (`installed` is an **object** — iterate `Object.keys`); the install-set ordering is
+safe (the installed manifest exists by `:1961`); and the barrier-at-top-of-iteration
+placement is right.
+
+**R1 — first adversarial Opus round, verdict REVISE (4 critical, 5 important).** Verified
+and folded (several later corrected by R2, above):
+
+- **C1 (critical)** — the extraction would have split `APP_BUNDLES`, half-breaking the test
+  isolation guard that exists because a prior test *actually installed a bundle on Kevin's
+  live host*. → D1 now mandates a single binding + delegating re-exports.
+- **C2 (critical)** — "compute in the panel's data path" was ambiguous; computing inside
+  `html.js` would make a pure unit test read the real `~/.crow`. → D4 names
+  `panels/extensions.js:31` as the only correct hook, with a defaulted param.
+- **C3 (critical)** — the sentinel security test was vacuous: once the layering is right,
+  `html.js` structurally cannot emit a value, so a render-only test guards nothing. → AC-7
+  now drives compute→render.
+- **C4 (critical)** — an `installed.json` entry whose dir is gone would show a permanent
+  badge wired to a Configure button that always 404s. → D4 gates on `existsSync`.
+- **I1 (important)** — v1 wrongly claimed the configure flow reloads. It does not; the badge
+  would never clear. → D6 removes the badge from the DOM on save, from **both** entry points
+  (which also fixes cross-surface staleness, I2).
+- **I3 (important)** — **the day-one prod bug:** MCP add-ons keep their real env in
+  `mcp-addons.json`, never in `bundles/<id>/.env`, so working add-ons would have been badged
+  "Needs setup" across Kevin's fleet. → D3 resolves *effective* env; AC-3 + a read-only prod
+  check guard it.
+- **I4 (important)** — manifest source was unspecified (repo vs installed). → D2 picks the
+  installed copy, per the `resolveManifestHost` precedent.
+- **I5 (important)** — barrier placement ("between members" would have raced the busy-gate
+  assertions) and a missing failure story. → 1c fixed: top of each iteration incl. the first;
+  unconditional resolve in `t.after()`.
+- **Minors** folded: `renderActionCards` is at `:42` not `:74`; the external-href branch is
+  dead on day one so the classifier is extracted and unit-tested; the byte-unchanged
+  assertion replaced with a behavioral tour guard; i18n en+es (a missing key ships the raw
+  key as UI text); `escapeHtml` on the new attributes; the `xhostVerify` peer-surface reason
+  for rejecting the status-route option is now recorded.

--- a/servers/gateway/bundles-config.js
+++ b/servers/gateway/bundles-config.js
@@ -109,8 +109,16 @@ const isSet = (v) => typeof v === "string" && v.trim() !== "";
  *   3. ambient process.env            — same spawn: a key supplied via the gateway's
  *                                       own env / systemd Environment= is real config
  *                                       that appears in neither file.
- * (2) and (3) apply ONLY to bundles that register an MCP server — the gateway's
- * environment is not a Docker container's.
+ * (2) and (3) apply ONLY to bundles that register an MCP server. NOT because a docker
+ * bundle can't see the gateway's environment — it can: run() execFiles `docker compose`
+ * with no `env` option, so the child inherits process.env, and Compose interpolation
+ * prefers the shell env over the .env file. But a var consumed via `env_file:` (the
+ * common shape) genuinely does NOT see it, and we cannot tell the two apart from here.
+ * So for docker we trust only the .env — the conservative read. The cost is a possible
+ * false positive: a docker bundle whose required key is set solely in the gateway's
+ * systemd Environment= and left blank in .env would work yet still be badged. Zero
+ * instances of that across the fleet today. Do not "simplify" this by extending ambient
+ * lookup to docker bundles without handling env_file:.
  *
  * Precedence is resolved over *non-empty* values: a blank line in a copied
  * .env.example cannot mask a live mcp-addons value, because an MCP child never reads

--- a/servers/gateway/bundles-config.js
+++ b/servers/gateway/bundles-config.js
@@ -1,0 +1,182 @@
+/**
+ * Bundle config resolution — the SINGLE source of truth.
+ *
+ * Owns the paths every bundle code path resolves against (CROW_HOME/BUNDLES_DIR,
+ * APP_ROOT/APP_BUNDLES), manifest lookup, and the "is this bundle actually
+ * configured?" computation. `routes/bundles.js` imports these (and re-exports
+ * `needsConfigKeys` + `_setAppBundlesForTest` for its pre-existing importers);
+ * the extensions panel's data path imports `needsConfigKeys` from HERE and never
+ * from `routes/bundles.js`, which would drag express, db.js, peer-forward,
+ * cross-host-auth and the settings registry into the panel render path.
+ *
+ * Imports node builtins ONLY — no circular-import risk with routes/bundles.js.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Respect the instance's CROW_HOME (matches proxy.js resolveCrowHome). Without
+// this, an alternate instance (CROW_HOME=~/.crow-mpa, ~/.crow-finance) reads and
+// writes the MAIN ~/.crow, re-coupling the instances (commit 1b28d38a).
+export const CROW_HOME = process.env.CROW_HOME || join(homedir(), ".crow");
+export const BUNDLES_DIR = join(CROW_HOME, "bundles");
+export const MCP_ADDONS_PATH = join(CROW_HOME, "mcp-addons.json");
+
+// NOTE the depth: this file lives at servers/gateway/, so the repo root is two
+// levels up ("../.."), NOT the three that routes/bundles.js used from
+// servers/gateway/routes/ (cf. servers/gateway/env-manager.js:7). A literal copy
+// of the old expression points APP_BUNDLES at <home>/bundles and 404s every install.
+export const APP_ROOT = resolve(__dirname, "../..");
+
+// `let` (not `const`): _setAppBundlesForTest below repoints this at a scratch
+// source tree so install-set E2E tests never install real bundles onto the
+// operator's host (see tests/install-set-e2e.test.js — a prior run actually did).
+// This must remain the codebase's ONLY binding of APP_BUNDLES: routes/bundles.js
+// imports it (ESM live binding) so the setter repoints both readers at once.
+export let APP_BUNDLES = join(APP_ROOT, "bundles");
+
+/** Test-only: repoint the repo bundle-source root (normally APP_ROOT/bundles). */
+export function _setAppBundlesForTest(path) { APP_BUNDLES = path; }
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read manifest.json for a bundle from app source (the repo checkout).
+ *
+ * Deliberately repo-only. ~18 callers depend on this: validateInstall, the hardware
+ * gate, /consent-challenge, compose validation, findDependents, planInstallSet. The
+ * installed tree can hold bundles that are stale or absent from installed.json, and
+ * validating a *future* install against a stale installed manifest would be wrong.
+ * Config-completeness wants the other precedence — that is getInstalledFirstManifest.
+ */
+export function getManifest(bundleId) {
+  return readJson(join(APP_BUNDLES, bundleId, "manifest.json"));
+}
+
+/**
+ * Installed copy first, repo as fallback — the right truth for config-completeness
+ * ONLY (cf. resolveManifestHost, which uses the same precedence). A bundle installed
+ * from a version no longer in the repo would otherwise yield getManifest → null →
+ * needsConfigKeys → [], silently hiding the affordance on exactly the stale installs
+ * that need it. Do not widen this to getManifest's callers.
+ */
+export function getInstalledFirstManifest(bundleId) {
+  return (
+    readJson(join(BUNDLES_DIR, bundleId, "manifest.json")) ??
+    readJson(join(APP_BUNDLES, bundleId, "manifest.json"))
+  );
+}
+
+/** Parse a KEY=value .env file into a plain object (same grammar as the installer writes). */
+function parseEnvFile(path) {
+  const env = {};
+  try {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+      if (m) env[m[1]] = m[2];
+    }
+  } catch { /* unreadable → treat as empty */ }
+  return env;
+}
+
+/** The bundle's ~/.crow/mcp-addons.json entry, or null if it registers no MCP server. */
+function readMcpAddonEntry(bundleId) {
+  const all = readJson(MCP_ADDONS_PATH);
+  if (!all || typeof all !== "object") return null;
+  return all[bundleId] || null;
+}
+
+const isSet = (v) => typeof v === "string" && v.trim() !== "";
+
+/**
+ * Resolve a bundle's EFFECTIVE config env — what the thing actually runs with.
+ *
+ * Three sources, highest precedence first:
+ *   1. bundles/<id>/.env              — docker bundles (compose reads it).
+ *   2. mcp-addons.json[<id>].env      — MCP add-ons. proxy.js spawns children with
+ *                                       { ...process.env, ...config.env }; they never
+ *                                       read bundles/<id>/.env.
+ *   3. ambient process.env            — same spawn: a key supplied via the gateway's
+ *                                       own env / systemd Environment= is real config
+ *                                       that appears in neither file.
+ * (2) and (3) apply ONLY to bundles that register an MCP server — the gateway's
+ * environment is not a Docker container's.
+ *
+ * Precedence is resolved over *non-empty* values: a blank line in a copied
+ * .env.example cannot mask a live mcp-addons value, because an MCP child never reads
+ * that file — the value is genuinely in effect.
+ *
+ * `managed` is the managed-evidence gate: false when there is no positive evidence the
+ * gateway manages this bundle's config (no .env AND no mcp-addons entry). On a real
+ * host a missing .env usually means "not gateway-managed-with-config", not
+ * "unconfigured" — capstone-tracker's installed dir holds only manifest.json;
+ * frigate/motioneye have no .env. Callers must fail closed on managed === false.
+ *
+ * @param {string} bundleId
+ * @param {object|null} manifest         installed-first manifest (for env_vars names)
+ * @param {{envOverride?: object|null}} [opts]  envOverride = the whole truth (test seam)
+ * @returns {{managed: boolean, env: Record<string,string>}}
+ */
+export function resolveEffectiveEnv(bundleId, manifest, { envOverride = null } = {}) {
+  // An injected env is the WHOLE truth: it must not be topped up from mcp-addons or
+  // process.env, or a unit test's result would depend on what the host happens to have
+  // installed (tests/bundles-install-set.test.js:40,45).
+  if (envOverride) return { managed: true, env: { ...envOverride } };
+
+  const dotEnvPath = join(BUNDLES_DIR, bundleId, ".env");
+  const hasDotEnv = existsSync(dotEnvPath);
+  const mcpEntry = readMcpAddonEntry(bundleId);
+  if (!hasDotEnv && !mcpEntry) return { managed: false, env: {} };
+
+  const env = {};
+  if (mcpEntry) {
+    // Lowest precedence first: ambient, then the add-on's own env.
+    for (const v of manifest?.env_vars || []) {
+      if (isSet(process.env[v.name])) env[v.name] = process.env[v.name];
+    }
+    for (const [k, v] of Object.entries(mcpEntry.env || {})) {
+      if (isSet(v)) env[k] = v;
+    }
+  }
+  if (hasDotEnv) {
+    for (const [k, v] of Object.entries(parseEnvFile(dotEnvPath))) {
+      if (isSet(v)) env[k] = v;
+    }
+  }
+  return { managed: true, env };
+}
+
+/**
+ * Manifest-required env keys that are still EMPTY in the bundle's EFFECTIVE env.
+ *
+ * Keys with a value (including .env.example defaults — DB passwords, secret keys)
+ * count as configured and are NEVER surfaced: those are consumed at first container
+ * boot, and changing them afterwards breaks the app or strands its data. Corollary:
+ * manifest `default`s are copied into mcp-addons.json at install, so an MCP bundle
+ * whose required key has a placeholder default will never be reported. Same rule.
+ *
+ * Fails closed when the gateway has no evidence it manages this bundle's config
+ * (see resolveEffectiveEnv's `managed`) — a false nag is worse than a missing one.
+ *
+ * @param {string} bundleId
+ * @param {object} [envOverride] test seam — the parsed .env; short-circuits everything else
+ * @returns {string[]} key NAMES only. Never values: those are secrets (see D5).
+ */
+export function needsConfigKeys(bundleId, envOverride = null) {
+  const man = getInstalledFirstManifest(bundleId);
+  const required = (man?.env_vars || []).filter((v) => v.required).map((v) => v.name);
+  if (required.length === 0) return [];
+  const { managed, env } = resolveEffectiveEnv(bundleId, man, { envOverride });
+  if (!managed) return [];
+  return required.filter((k) => !isSet(env[k]));
+}

--- a/servers/gateway/dashboard/panels/extensions.js
+++ b/servers/gateway/dashboard/panels/extensions.js
@@ -8,7 +8,7 @@
 
 import { t } from "../shared/i18n.js";
 import { extensionStyles } from "./extensions/css.js";
-import { fetchRegistryData, fetchBundleStatus } from "./extensions/data-queries.js";
+import { fetchRegistryData, fetchBundleStatus, fetchNeedsConfig } from "./extensions/data-queries.js";
 import { extensionsClientJS } from "./extensions/client.js";
 import { handleExtensionsPost } from "./extensions/api-handlers.js";
 import { buildExtensionsHTML } from "./extensions/html.js";
@@ -30,9 +30,12 @@ export default {
 
     const { installed, available, collections, registrySource, communityStores } = await fetchRegistryData();
     const { bundleStatus } = fetchBundleStatus(installed);
+    // Config completeness is computed HERE, never in html.js (which stays pure and
+    // is unit-tested without ~/.crow).
+    const needsConfig = fetchNeedsConfig(installed);
 
     const { viewsHtml, addonRegistryScript, collectionsScript } = buildExtensionsHTML({
-      installed, available, collections, registrySource, communityStores, bundleStatus, lang,
+      installed, available, collections, registrySource, communityStores, bundleStatus, needsConfig, lang,
     });
 
     // ─── Modal + client-side JavaScript ───

--- a/servers/gateway/dashboard/panels/extensions/client.js
+++ b/servers/gateway/dashboard/panels/extensions/client.js
@@ -362,7 +362,10 @@ export function extensionsClientJS(lang) {
                     ? '${tJs("extensions.configureNeedsRestart", lang)}'
                     : '${tJs("extensions.configureSaved", lang)}';
                   setTimeout(function() {
-                    if (typeof onSaved === "function") onSaved();
+                    // Hand the WHOLE response to onSaved: needs_config is the server's
+                    // re-derived truth about what is still missing, and the only thing
+                    // allowed to decide whether the "Needs setup" badge may come off.
+                    if (typeof onSaved === "function") onSaved(res.data);
                   }, 1200);
                 } else {
                   statusDiv.style.color = "var(--crow-error, #e74c3c)";
@@ -445,6 +448,67 @@ export function extensionsClientJS(lang) {
               parseInt(this.dataset.minram || "0", 10),
               parseInt(this.dataset.mindisk || "0", 10),
               this.dataset.community === "true");
+          });
+        });
+
+        // --- "Needs setup" → Configure (installed card) ---
+        // The durable affordance: unlike the post-collection-install checklist (one-shot
+        // sessionStorage), this is re-derived server-side on every render, and it is the
+        // ONLY prompt a bundle installed through the single /install path ever gets.
+
+        /** The installed card for a bundle id, or null (it may not be on this page). */
+        function findInstalledCard(id) {
+          var items = document.querySelectorAll(".ext-installed__item");
+          for (var i = 0; i < items.length; i++) {
+            if (items[i].dataset.addonId === id) return items[i];
+          }
+          return null;
+        }
+
+        /**
+         * Repaint a card's config state from the SERVER's re-derived needs_config.
+         * Empty => the bundle is configured: drop the badge and the button.
+         * Non-empty => still unconfigured: keep both, re-scope the button.
+         * Not an array (old server / no field) => leave the DOM alone: we have no truth,
+         * and a false "done" is worse than a stale badge.
+         */
+        function applyNeedsConfig(id, keys) {
+          if (!Array.isArray(keys)) return;
+          var item = findInstalledCard(id);
+          if (!item) return;                       // e.g. saved from the checklist after a restart
+          var btn = item.querySelector(".bundle-configure");
+          var badgeEl = item.querySelector(".ext-installed__needsconfig");
+          if (keys.length > 0) {
+            if (btn) btn.setAttribute("data-keys", keys.join(","));
+          } else {
+            if (btn) btn.remove();
+            if (badgeEl) badgeEl.remove();
+          }
+        }
+
+        document.querySelectorAll(".bundle-configure").forEach(function(btn) {
+          btn.addEventListener("click", function() {
+            var id = this.dataset.id;
+            var keys = (this.dataset.keys || "").split(",").filter(function(k) { return k; });
+            var addon = ADDON_DATA[id] || {};
+            // Scope the form to exactly the missing keys, with the registry's metadata
+            // where we have it — an installed-but-unregistered bundle degrades to a
+            // plain required text field rather than showing nothing.
+            var metaByName = {};
+            (addon.env_vars || []).forEach(function(ev) { metaByName[ev.name] = ev; });
+            var scopedEnvVars = keys.map(function(key) {
+              return metaByName[key] || { name: key, required: true };
+            });
+
+            showInstallModal(
+              id, addon.name || id, scopedEnvVars,
+              0, 0, false,
+              true, // configureOnly → writes through /bundles/api/env, never /install
+              function onSaved(resp) {
+                applyNeedsConfig(id, resp && resp.needs_config);
+                hideModal();
+              },
+            );
           });
         });
 
@@ -1302,7 +1366,11 @@ export function extensionsClientJS(lang) {
                 scopedEnvVars,
                 0, 0, false,
                 true, // configureOnly
-                function onSaved() {
+                function onSaved(resp) {
+                  // The card behind this modal shows the same state — repaint it from
+                  // the server's needs_config, or a save made here leaves a stale
+                  // "Needs setup" badge on the Installed view.
+                  applyNeedsConfig(entry.id, resp && resp.needs_config);
                   // Clear this entry — from the in-memory checklist AND from
                   // sessionStorage, so a later reload (e.g. the restart this very
                   // save may have triggered) doesn't resurrect an already-done item.

--- a/servers/gateway/dashboard/panels/extensions/data-queries.js
+++ b/servers/gateway/dashboard/panels/extensions/data-queries.js
@@ -11,6 +11,10 @@ import { join, dirname } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
 import { loadCollections } from "./collections.js";
+// bundles-config.js ONLY — never routes/bundles.js, which would drag express
+// Router, db.js, peer-forward, cross-host-auth and the settings registry into the
+// panel's render path (it already imports ./collections.js, so that knot is real).
+import { needsConfigKeys } from "../../../bundles-config.js";
 
 export const REGISTRY_URL = "https://raw.githubusercontent.com/kh0pper/crow-addons/main/registry.json";
 // Respect the instance's CROW_HOME (matches bundles.js / proxy.js resolveCrowHome).
@@ -138,6 +142,27 @@ export async function fetchRegistryData() {
   available.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
 
   return { installed, available, collections: loadCollections(), registrySource, communityStores };
+}
+
+/**
+ * Which installed bundles still have an unmet required config key.
+ *
+ * Returns key NAMES only — a value from .env / mcp-addons.json must never reach the
+ * browser (D5). Bundles with nothing missing are omitted entirely, so the render
+ * layer can just test `needsConfig[id]`.
+ *
+ * `installed` is the OBJECT getInstalled() returns (keyed by id), not an array.
+ *
+ * @param {Record<string, object>} installed
+ * @returns {Record<string, string[]>}
+ */
+export function fetchNeedsConfig(installed) {
+  const out = {};
+  for (const id of Object.keys(installed || {})) {
+    const keys = needsConfigKeys(id);
+    if (keys.length > 0) out[id] = keys;
+  }
+  return out;
 }
 
 /**

--- a/servers/gateway/dashboard/panels/extensions/html.js
+++ b/servers/gateway/dashboard/panels/extensions/html.js
@@ -143,6 +143,12 @@ export function renderIcon(addon, size) {
  * Everything wraps; nothing scrolls sideways (the old 19-tab nowrap row is what
  * inflated the whole dashboard to 2555px).
  *
+ * PURE: plain data in, strings out. It must never call needsConfigKeys itself —
+ * `needsConfig` is computed in panels/extensions.js and handed in (defaulted, so the
+ * render unit tests keep passing). Computing it here would make those tests read the
+ * operator's real ~/.crow.
+ *
+ * @param {Record<string,string[]>} [needsConfig] id → still-missing required key NAMES
  * @returns {{viewsHtml:string, addonRegistryScript:string, collectionsScript:string}}
  */
 export function buildExtensionsHTML({
@@ -152,6 +158,7 @@ export function buildExtensionsHTML({
   registrySource,
   communityStores,
   bundleStatus,
+  needsConfig = {},
   lang,
 }) {
   const installedCount = Object.keys(installed).length;
@@ -312,6 +319,14 @@ export function buildExtensionsHTML({
         ? (isRunning ? badge(t("extensions.runningBadge", lang), "published") : badge(t("extensions.stoppedBadge", lang), "draft"))
         : badge(t("extensions.mcpServer", lang), "connected");
 
+      // Required keys still empty in this bundle's EFFECTIVE env (server-computed).
+      // The wrapper span is a DOM hook, not a style: the client removes it (and the
+      // Configure button) when a save comes back with an empty needs_config.
+      const missingKeys = needsConfig[id] || [];
+      const needsSetupBadge = missingKeys.length > 0
+        ? `<span class="ext-installed__needsconfig">${badge(t("extensions.needsSetup", lang), "draft")}</span>`
+        : "";
+
       let actions = "";
       if (isDocker) {
         if (isRunning) {
@@ -322,6 +337,9 @@ export function buildExtensionsHTML({
           actions = `<button class="btn btn-sm btn-primary bundle-action" data-action="start" data-id="${escapeHtml(id)}">${t("extensions.start", lang)}</button>`;
         }
       }
+      if (missingKeys.length > 0) {
+        actions += `<button class="btn btn-sm btn-primary bundle-configure" data-id="${escapeHtml(id)}" data-keys="${escapeHtml(missingKeys.join(","))}">${t("extensions.configure", lang)}</button>`;
+      }
       actions += `<button class="btn btn-sm btn-secondary bundle-uninstall" data-id="${escapeHtml(id)}" data-name="${escapeHtml(name)}" data-docker="${isDocker}">${t("extensions.remove", lang)}</button>`;
 
       return `<div class="ext-installed__item" data-addon-id="${escapeHtml(id)}" style="animation:fadeInUp 0.4s ease-out ${Math.min(i * 30, 300)}ms both">
@@ -329,6 +347,7 @@ export function buildExtensionsHTML({
           <div class="ext-installed__info">
             <span class="ext-installed__name">${escapeHtml(name)}</span>
             ${statusBadge}
+            ${needsSetupBadge}
             <span class="ext-installed__meta">v${escapeHtml(info.version || registryEntry?.version || "?")} · ${t("extensions.installedDate", lang)} ${formatDate(info.installed_at || info.installedAt)}</span>
           </div>
           <div class="ext-installed__actions">${actions}</div>

--- a/servers/gateway/dashboard/panels/onboarding.js
+++ b/servers/gateway/dashboard/panels/onboarding.js
@@ -35,6 +35,31 @@ function deepLink(label, href) {
 }
 
 /**
+ * Is this href a same-origin dashboard path? Deliberately conservative: only a
+ * leading "/" counts, and a protocol-relative "//host" does not (it is a
+ * cross-origin URL wearing a slash). Anything else — absolute http(s), mailto:,
+ * javascript:, a bare relative path — is treated as external.
+ * @param {string} href
+ * @returns {boolean}
+ */
+export function isInternalHref(href) {
+  return typeof href === "string" && href.startsWith("/") && !href.startsWith("//");
+}
+
+/**
+ * The target/rel attributes an action card's CTA should carry, decided by href.
+ * Internal links navigate in the same tab (the tour is over by the time the done
+ * step renders, so a new tab is just noise); external links keep opening a new tab,
+ * with rel="noopener" so the opened page cannot reach back through window.opener.
+ * Classifying by href means a card added later gets the right behavior for free.
+ * @param {string} href
+ * @returns {string} attribute string for button({ attrs })  ("" for internal)
+ */
+export function cardLinkAttrs(href) {
+  return isInternalHref(href) ? "" : 'target="_blank" rel="noopener"';
+}
+
+/**
  * "What to try first" action cards shown on the done step (W3-3; extensions
  * overhaul added the fourth, starter-collections, card). Each card is a link,
  * description, and CTA button.
@@ -71,7 +96,7 @@ function renderActionCards(lang) {
     <div class="onboarding-action-card">
       <div class="onboarding-action-card-title">${t(c.titleKey, lang)}</div>
       <div class="onboarding-action-card-body">${t(c.bodyKey, lang)}</div>
-      ${button(t(c.actionKey, lang), { variant: "secondary", size: "sm", href: c.href, attrs: 'target="_blank" rel="noopener"' })}
+      ${button(t(c.actionKey, lang), { variant: "secondary", size: "sm", href: c.href, attrs: cardLinkAttrs(c.href) })}
     </div>`).join("");
 
   return `<div class="onboarding-action-cards">${cardHtml}</div>`;

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -638,6 +638,7 @@ export const translations = {
   "extensions.collectionDone": { en: "Collection installed", es: "Colección instalada" },
   "extensions.collectionConfigure": { en: "Finish setup", es: "Completar configuración" },
   "extensions.collectionConfigureDesc": { en: "These extensions are installed but need a value before they can do anything:", es: "Estas extensiones están instaladas pero necesitan un valor para funcionar:" },
+  "extensions.needsSetup": { en: "Needs setup", es: "Requiere configuración" },
   "extensions.configure": { en: "Configure", es: "Configurar" },
   "extensions.configureDesc": { en: "This add-on is already installed. Fill in the value below and save.", es: "Este complemento ya está instalado. Completa el valor a continuación y guarda." },
   "extensions.configureEmpty": { en: "Fill in at least one value before saving.", es: "Completa al menos un valor antes de guardar." },

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -23,9 +23,7 @@ import { isSupervised } from "../../shared/supervisor.js";
 import { createDbClient } from "../../db.js";
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, rmSync, copyFileSync, unlinkSync, symlinkSync, statSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
-import { homedir } from "node:os";
-import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
 import { randomBytes, createHash } from "node:crypto";
 import { checkInstall as checkHardwareGate } from "../hardware-gate.js";
 import { checkGpuArchCompatible } from "../gpu-arch.js";
@@ -40,6 +38,16 @@ import { invalidateProvidersCache } from "../../shared/providers.js";
 import { writeSetting } from "../dashboard/settings/registry.js";
 import { getCollection } from "../dashboard/panels/extensions/collections.js";
 import { beginInstallSet, endInstallSet, isInstallSetRunning } from "../install-lock.js";
+import {
+  CROW_HOME,
+  BUNDLES_DIR,
+  MCP_ADDONS_PATH,
+  APP_ROOT,
+  APP_BUNDLES,
+  getManifest,
+  needsConfigKeys,
+  _setAppBundlesForTest,
+} from "../bundles-config.js";
 
 /**
  * Seed an STT/TTS profile from a bundle manifest's {stt,tts}ProfileSeed into the
@@ -110,27 +118,18 @@ async function unseedProfile(db, kind, seed, log) {
 const CONSENT_TOKEN_TTL_SECONDS = 15 * 60; // 15 min — covers slow image pulls
 const CONSENT_TOKEN_SCHEMA_VERSION = 1;
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-// Respect the instance's CROW_HOME (matches proxy.js resolveCrowHome). Without
-// this, installs on an alternate instance (CROW_HOME=~/.crow-mpa, ~/.crow-finance)
-// wrote bundle files + mcp-addons.json into the MAIN ~/.crow, re-coupling the
-// instances. Falls back to ~/.crow when unset (the main instance).
-const CROW_HOME = process.env.CROW_HOME || join(homedir(), ".crow");
-const BUNDLES_DIR = join(CROW_HOME, "bundles");
+// CROW_HOME / BUNDLES_DIR / APP_ROOT / APP_BUNDLES / getManifest / needsConfigKeys and
+// the _setAppBundlesForTest seam all live in ../bundles-config.js — the single source of
+// truth (imported here as ESM live bindings, so _setAppBundlesForTest repoints the one
+// and only APP_BUNDLES binding for every reader). Re-exported below for pre-existing
+// importers (tests/bundles-install-set.test.js, tests/install-set-e2e.test.js).
 const SKILLS_DIR = join(CROW_HOME, "skills");
 const PANELS_DIR = join(CROW_HOME, "panels");
-const MCP_ADDONS_PATH = join(CROW_HOME, "mcp-addons.json");
 const PANELS_CONFIG_PATH = join(CROW_HOME, "panels.json");
 const INSTALLED_PATH = join(CROW_HOME, "installed.json");
-const APP_ROOT = resolve(__dirname, "../../..");
-// `let` (not `const`): _setAppBundlesForTest below repoints this at a scratch
-// source tree so install-set E2E tests never install real bundles onto the
-// operator's host (see tests/install-set-e2e.test.js).
-let APP_BUNDLES = join(APP_ROOT, "bundles");
 const APP_ENV_PATH = join(APP_ROOT, ".env");
 
-/** Test-only: repoint the repo bundle-source root (normally APP_ROOT/bundles). */
-export function _setAppBundlesForTest(path) { APP_BUNDLES = path; }
+export { needsConfigKeys, _setAppBundlesForTest };
 
 // Test-only: override the collections.json path read by POST /install-set
 // (getCollection() defaults to the real registry/collections.json, which has
@@ -585,16 +584,6 @@ function getInstalled() {
 function saveInstalled(arr) {
   mkdirSync(dirname(INSTALLED_PATH), { recursive: true });
   writeFileSync(INSTALLED_PATH, JSON.stringify(arr, null, 2));
-}
-
-/** Read manifest.json for a bundle from app source */
-function getManifest(bundleId) {
-  const manifestPath = join(APP_BUNDLES, bundleId, "manifest.json");
-  try {
-    return JSON.parse(readFileSync(manifestPath, "utf8"));
-  } catch {
-    return null;
-  }
 }
 
 /** Run a shell command safely with execFile */
@@ -1713,31 +1702,6 @@ export function planInstallSet(collection) {
     if (!gpu.ok) return { id: m.id, action: "skip", reason: gpu.reason || "incompatible with this host's GPU" };
     return { id: m.id, action: "install" };
   });
-}
-
-/**
- * Manifest-required env keys that are still EMPTY in the bundle's written .env.
- * Keys with a value (including .env.example defaults — DB passwords, secret keys)
- * count as configured and are NEVER surfaced: those are consumed at first container
- * boot, and changing them afterwards breaks the app or strands its data.
- * @param {object} [envOverride] test seam — the parsed .env
- */
-export function needsConfigKeys(bundleId, envOverride = null) {
-  const man = getManifest(bundleId);
-  const required = (man?.env_vars || []).filter((v) => v.required).map((v) => v.name);
-  if (required.length === 0) return [];
-  let env = envOverride;
-  if (!env) {
-    env = {};
-    const envPath = join(BUNDLES_DIR, bundleId, ".env");
-    if (existsSync(envPath)) {
-      for (const line of readFileSync(envPath, "utf8").split("\n")) {
-        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
-        if (m) env[m[1]] = m[2];
-      }
-    }
-  }
-  return required.filter((k) => !env[k] || env[k].trim() === "");
 }
 
 /**

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -2292,12 +2292,19 @@ export default function bundlesRouter() {
     // Also configure the MCP child, which reads mcp-addons.json — not this .env.
     const mcpUpdated = applyEnvToMcpAddons(bundle_id, env_vars);
 
+    // RE-DERIVE config state from the files we just wrote and hand it back: the
+    // client must not decide "configured" itself. submitConfigureOnly guards only
+    // the all-blank case and its `if (inp && inp.value)` accepts whitespace (which
+    // needsConfigKeys trims away), so filling 1 of 12 keys still 200s — a client
+    // that cleared its badge on any 200 would hide a still-unconfigured bundle.
+    // Key NAMES only; never values (D5).
     res.json({
       ok: true,
       message: mcpUpdated
         ? "Environment variables saved — restart the gateway to apply them to the MCP server"
         : "Environment variables saved",
       needs_restart: mcpUpdated,
+      needs_config: needsConfigKeys(bundle_id),
     });
   });
 

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -144,15 +144,22 @@ export function _setCollectionsPathForTest(path) { _collectionsPathOverride = pa
 let _restartHookForTest = null;
 export function _setRestartHookForTest(fn) { _restartHookForTest = fn; }
 
-// Test-only: pace the install-set loop with a real setTimeout between members.
-// Default 0 = no delay (identical to production behavior). Without this, every
-// fixture install in the E2E suite is pure synchronous file I/O with no real
-// async wait, so the whole set finishes inside the microtask queue before a
-// concurrent HTTP request's socket data can even be read — the busy-gate
-// (second POST while the set runs → 409) would then be untestable over real
-// HTTP: there is no run happening for the second call to observe.
-let _installSetStepDelayMs = 0;
-export function _setInstallSetStepDelayForTest(ms) { _installSetStepDelayMs = ms; }
+// Test-only: a barrier the install-set runner awaits at the TOP of every member
+// iteration, including the first. Without it, every fixture install in the E2E
+// suite is pure synchronous file I/O with no real async wait, so the whole set
+// finishes before a concurrent HTTP request's socket data can even be read —
+// the busy-gate (second POST while the set runs → 409) would be untestable over
+// real HTTP: there is no run happening for the second call to observe. A test
+// installs a pending promise to park the runner mid-set deterministically, then
+// resolves it; this replaces an earlier wall-clock step-delay seam.
+//
+// Production default is null, which makes `if (_installSetBarrier)` in the
+// runner false — the branch is never entered, so production takes no await and
+// arms no timer. `_getInstallSetBarrierForTest` exists so a test can prove that
+// default by mechanism rather than trusting this comment.
+let _installSetBarrier = null;
+export function _setInstallSetBarrierForTest(promiseOrNull) { _installSetBarrier = promiseOrNull || null; }
+export function _getInstallSetBarrierForTest() { return _installSetBarrier; }
 
 // -----------------------------------------------------------------------
 // Cross-host manifest support (Phase 5-MVP)
@@ -1900,8 +1907,9 @@ export default function bundlesRouter() {
         appendLog(job, `Installing collection '${collection.name}' (${plan.filter((p) => p.action === "install").length} to install, ${plan.filter((p) => p.action === "skip").length} skipped)`);
 
         for (const member of collection.members) {
-          // Test-only pacing (see _setInstallSetStepDelayForTest) — 0 in production.
-          if (_installSetStepDelayMs > 0) await new Promise((r) => setTimeout(r, _installSetStepDelayMs));
+          // Test-only barrier (see _setInstallSetBarrierForTest) — null in
+          // production, so this branch is never entered: no await, no timer.
+          if (_installSetBarrier) await _installSetBarrier;
           // Live gate re-check: getInstalled() has grown as earlier members landed,
           // so cumulative RAM commitments and intra-set dependencies are enforced for
           // real — not against a stale pre-set snapshot.

--- a/tests/bundles-config.test.js
+++ b/tests/bundles-config.test.js
@@ -1,0 +1,223 @@
+// tests/bundles-config.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Unit tests for servers/gateway/bundles-config.js — the single source of truth
+ * for bundle config resolution (CROW_HOME/BUNDLES_DIR, APP_BUNDLES, getManifest,
+ * getInstalledFirstManifest, resolveEffectiveEnv, needsConfigKeys).
+ *
+ * Isolation rules (non-negotiable — see tests/install-set-e2e.test.js:35-39, where a
+ * prior run of a test in this family actually installed a bundle on the operator's
+ * live host): CROW_HOME/CROW_DATA_DIR point at a scratch dir set BEFORE a dynamic
+ * import (the module captures CROW_HOME at load, so ESM import hoisting would read
+ * the real ~/.crow), and APP_BUNDLES is repointed at a scratch fixture source tree
+ * via _setAppBundlesForTest. The real ~/.crow is never read or written.
+ */
+
+const home = mkdtempSync(join(tmpdir(), "crowhome-cfg-"));
+mkdirSync(join(home, "bundles"), { recursive: true });
+mkdirSync(join(home, "data"), { recursive: true });
+process.env.CROW_HOME = home;
+process.env.CROW_DATA_DIR = join(home, "data");
+
+const appBundles = mkdtempSync(join(tmpdir(), "crow-fixture-bundles-cfg-"));
+
+// Import AFTER the env is set.
+const {
+  needsConfigKeys,
+  resolveEffectiveEnv,
+  getManifest,
+  getInstalledFirstManifest,
+  _setAppBundlesForTest,
+} = await import("../servers/gateway/bundles-config.js");
+_setAppBundlesForTest(appBundles);
+
+process.on("exit", () => {
+  try { rmSync(home, { recursive: true, force: true }); } catch {}
+  try { rmSync(appBundles, { recursive: true, force: true }); } catch {}
+});
+
+/** Write a manifest into the fixture REPO tree (APP_BUNDLES). */
+function repoBundle(id, envVars, extra = {}) {
+  const dir = join(appBundles, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+    id, name: id, type: "bundle", version: "1.0.0", env_vars: envVars, ...extra,
+  }, null, 2));
+}
+
+/** Write a manifest into the INSTALLED tree (CROW_HOME/bundles). */
+function installedBundle(id, envVars, extra = {}) {
+  const dir = join(home, "bundles", id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+    id, name: id, type: "bundle", version: "1.0.0", env_vars: envVars, ...extra,
+  }, null, 2));
+  return dir;
+}
+
+/** Write CROW_HOME/bundles/<id>/.env */
+function writeDotEnv(id, kv) {
+  const dir = join(home, "bundles", id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".env"), Object.entries(kv).map(([k, v]) => `${k}=${v}`).join("\n") + "\n");
+}
+
+/** Rewrite CROW_HOME/mcp-addons.json with the given map. */
+function writeMcpAddons(map) {
+  writeFileSync(join(home, "mcp-addons.json"), JSON.stringify(map, null, 2));
+}
+
+const REQ = (...names) => names.map((n) => ({ name: n, required: true }));
+
+test("managed-evidence gate: no .env and no mcp-addons entry => nothing reported (fail closed)", () => {
+  // The measured prod case: capstone-tracker's installed dir holds ONLY manifest.json;
+  // frigate has no .env. existsSync(bundleDir) passes for both, so it is the wrong gate.
+  // Without positive evidence the gateway manages this bundle's config we cannot tell
+  // "unconfigured" from "not managed this way" — and a false nag is worse than none.
+  repoBundle("fx-stub", REQ("FX_A", "FX_B"));
+  installedBundle("fx-stub", REQ("FX_A", "FX_B")); // manifest only — no .env
+  writeMcpAddons({});
+  assert.deepEqual(needsConfigKeys("fx-stub"), []);
+});
+
+test("a .env with every required key filled reports nothing", () => {
+  repoBundle("fx-docker-ok", REQ("FX_URL", "FX_KEY"));
+  installedBundle("fx-docker-ok", REQ("FX_URL", "FX_KEY"));
+  writeDotEnv("fx-docker-ok", { FX_URL: "http://localhost:1", FX_KEY: "abc" });
+  writeMcpAddons({});
+  assert.deepEqual(needsConfigKeys("fx-docker-ok"), []);
+});
+
+test("a .env with an empty required key reports exactly that key", () => {
+  repoBundle("fx-docker-partial", REQ("FX_URL", "FX_KEY"));
+  installedBundle("fx-docker-partial", REQ("FX_URL", "FX_KEY"));
+  writeDotEnv("fx-docker-partial", { FX_URL: "http://localhost:2", FX_KEY: "   " }); // whitespace = empty
+  writeMcpAddons({});
+  assert.deepEqual(needsConfigKeys("fx-docker-partial"), ["FX_KEY"]);
+});
+
+test("an MCP add-on configured via mcp-addons.json only (no .env) reports nothing", () => {
+  // The day-one prod bug: MCP children are spawned with { ...process.env, ...config.env }
+  // from mcp-addons.json (proxy.js:145) — they never read bundles/<id>/.env. A working
+  // add-on has no .env at all and must not be badged.
+  repoBundle("fx-mcp", REQ("FX_TOKEN"), { server: { command: "node", args: [] } });
+  installedBundle("fx-mcp", REQ("FX_TOKEN"), { server: { command: "node", args: [] } });
+  writeMcpAddons({ "fx-mcp": { command: "node", args: [], env: { FX_TOKEN: "live-token" } } });
+  assert.deepEqual(needsConfigKeys("fx-mcp"), []);
+});
+
+test("an MCP add-on whose required key comes only from ambient process.env reports nothing", () => {
+  repoBundle("fx-mcp-ambient", REQ("FX_AMBIENT_TOKEN"), { server: { command: "node", args: [] } });
+  installedBundle("fx-mcp-ambient", REQ("FX_AMBIENT_TOKEN"), { server: { command: "node", args: [] } });
+  // Registered as an MCP add-on but with no env of its own — the value is supplied by the
+  // gateway's own environment (systemd Environment=), which proxy.js passes to the child.
+  writeMcpAddons({ "fx-mcp-ambient": { command: "node", args: [] } });
+  process.env.FX_AMBIENT_TOKEN = "from-systemd";
+  try {
+    assert.deepEqual(needsConfigKeys("fx-mcp-ambient"), []);
+  } finally {
+    delete process.env.FX_AMBIENT_TOKEN;
+  }
+});
+
+test("an MCP add-on with no value anywhere reports its required key", () => {
+  repoBundle("fx-mcp-empty", REQ("FX_MISSING"), { server: { command: "node", args: [] } });
+  installedBundle("fx-mcp-empty", REQ("FX_MISSING"), { server: { command: "node", args: [] } });
+  writeMcpAddons({ "fx-mcp-empty": { command: "node", args: [], env: {} } });
+  assert.deepEqual(needsConfigKeys("fx-mcp-empty"), ["FX_MISSING"]);
+});
+
+test("envOverride short-circuits mcp-addons and process.env — it is the whole truth", () => {
+  // tests/bundles-install-set.test.js:40,45 inject a parsed env. If the other sources
+  // were still consulted, that unit test's result would depend on whether the HOST
+  // happens to carry the bundle in ~/.crow/mcp-addons.json.
+  repoBundle("fx-override", REQ("FX_OKEY"), { server: { command: "node", args: [] } });
+  installedBundle("fx-override", REQ("FX_OKEY"), { server: { command: "node", args: [] } });
+  writeMcpAddons({ "fx-override": { command: "node", args: [], env: { FX_OKEY: "would-satisfy" } } });
+  process.env.FX_OKEY = "ambient-would-satisfy";
+  try {
+    assert.deepEqual(needsConfigKeys("fx-override", { FX_OKEY: "" }), ["FX_OKEY"]);
+    assert.deepEqual(needsConfigKeys("fx-override", { FX_OKEY: "given" }), []);
+  } finally {
+    delete process.env.FX_OKEY;
+  }
+});
+
+test("a bundle with no required keys reports nothing", () => {
+  repoBundle("fx-noreq", [{ name: "FX_OPT", required: false }]);
+  installedBundle("fx-noreq", [{ name: "FX_OPT", required: false }]);
+  writeDotEnv("fx-noreq", { FX_OPT: "" });
+  writeMcpAddons({});
+  assert.deepEqual(needsConfigKeys("fx-noreq"), []);
+});
+
+test("required keys come from the INSTALLED manifest, not the repo copy", () => {
+  // A bundle installed from a version whose manifest no longer matches the repo must
+  // still surface the keys the INSTALLED copy actually needs.
+  repoBundle("fx-drift", REQ("FX_OLD"));
+  installedBundle("fx-drift", REQ("FX_NEW"));
+  writeDotEnv("fx-drift", { FX_OLD: "set-in-old" }); // FX_NEW absent
+  writeMcpAddons({});
+  assert.deepEqual(needsConfigKeys("fx-drift"), ["FX_NEW"]);
+  assert.equal(getInstalledFirstManifest("fx-drift").env_vars[0].name, "FX_NEW");
+  // getManifest's semantics are UNCHANGED — it still reads the repo only (~18 callers:
+  // consent, hardware gate, compose validation, planInstallSet).
+  assert.equal(getManifest("fx-drift").env_vars[0].name, "FX_OLD");
+});
+
+test("getInstalledFirstManifest falls back to the repo copy when not installed", () => {
+  repoBundle("fx-repo-only", REQ("FX_R"));
+  assert.equal(getInstalledFirstManifest("fx-repo-only").env_vars[0].name, "FX_R");
+  assert.equal(getInstalledFirstManifest("fx-nonexistent-xyz"), null);
+});
+
+test("resolveEffectiveEnv: .env wins over mcp-addons, which wins over ambient process.env", () => {
+  repoBundle("fx-prec", REQ("FX_P1", "FX_P2", "FX_P3"), { server: { command: "node", args: [] } });
+  const man = installedBundle("fx-prec", REQ("FX_P1", "FX_P2", "FX_P3"), { server: { command: "node", args: [] } }) && getInstalledFirstManifest("fx-prec");
+  writeDotEnv("fx-prec", { FX_P1: "from-dotenv" });
+  writeMcpAddons({ "fx-prec": { command: "node", args: [], env: { FX_P1: "from-mcp", FX_P2: "from-mcp" } } });
+  process.env.FX_P1 = "from-ambient";
+  process.env.FX_P2 = "from-ambient";
+  process.env.FX_P3 = "from-ambient";
+  try {
+    const { managed, env } = resolveEffectiveEnv("fx-prec", man);
+    assert.equal(managed, true);
+    assert.equal(env.FX_P1, "from-dotenv");
+    assert.equal(env.FX_P2, "from-mcp");
+    assert.equal(env.FX_P3, "from-ambient");
+    assert.deepEqual(needsConfigKeys("fx-prec"), []);
+  } finally {
+    delete process.env.FX_P1;
+    delete process.env.FX_P2;
+    delete process.env.FX_P3;
+  }
+});
+
+test("a docker bundle (no mcp-addons entry) never inherits ambient process.env", () => {
+  // Compose reads bundles/<id>/.env; the gateway's own environment is NOT the container's.
+  repoBundle("fx-docker-ambient", REQ("FX_D_KEY"));
+  installedBundle("fx-docker-ambient", REQ("FX_D_KEY"));
+  writeDotEnv("fx-docker-ambient", { FX_D_KEY: "" });
+  writeMcpAddons({});
+  process.env.FX_D_KEY = "ambient-must-not-count";
+  try {
+    assert.deepEqual(needsConfigKeys("fx-docker-ambient"), ["FX_D_KEY"]);
+  } finally {
+    delete process.env.FX_D_KEY;
+  }
+});
+
+test("CROW_HOME is honored: the installed tree read is the scratch one, not ~/.crow", () => {
+  // The 1b28d38a invariant. If the module hard-coded homedir()/.crow this fixture —
+  // which exists ONLY under the scratch home — would be invisible.
+  repoBundle("fx-crowhome", REQ("FX_H"));
+  installedBundle("fx-crowhome", REQ("FX_H"));
+  writeDotEnv("fx-crowhome", { FX_H: "" });
+  writeMcpAddons({});
+  assert.deepEqual(needsConfigKeys("fx-crowhome"), ["FX_H"]);
+});

--- a/tests/extensions-client-contract.test.js
+++ b/tests/extensions-client-contract.test.js
@@ -74,9 +74,9 @@ const MANY_MEDIA = Array.from({ length: 10 }, (_, i) => ({
  * @param {string}   opts.hash        initial location.hash
  * @returns the DOM plus the spies the tests assert against
  */
-function boot({ available = AVAILABLE, collections = COLLECTIONS, installed = {}, fetchImpl, session = {}, hash = "" } = {}) {
+function boot({ available = AVAILABLE, collections = COLLECTIONS, installed = {}, needsConfig = {}, fetchImpl, session = {}, hash = "" } = {}) {
   const { viewsHtml, addonRegistryScript, collectionsScript } = buildExtensionsHTML({
-    installed, available, collections,
+    installed, available, collections, needsConfig,
     registrySource: "local", communityStores: [], bundleStatus: {}, lang: "en",
   });
 
@@ -548,6 +548,119 @@ test("BEHAVIOR: an empty Configure save is refused — no fetch, onSaved never r
     /fill in|value/i,
     "the form tells the user why it didn't save",
   );
+});
+
+// ─── 6b. The durable card affordance: "Needs setup" → Configure → server truth ───
+
+/**
+ * The card's badge state is NOT the client's to decide. `submitConfigureOnly`
+ * guards only the all-blank case and its `if (inp && inp.value)` even accepts
+ * whitespace, so filling 1 of N keys returns 200 — a client that cleared the badge
+ * on any 200 would hide a still-unconfigured bundle. Every assertion below drives
+ * the DOM from the route's re-derived `needs_config`.
+ */
+const CARD_BOOT = {
+  installed: { jellyfin: { version: "1.0.0" } },
+  needsConfig: { jellyfin: ["JELLYFIN_API_KEY", "JELLYFIN_URL"] },
+};
+const card = (document) => document.querySelector('.ext-installed__item[data-addon-id="jellyfin"]');
+
+test("BEHAVIOR: an unconfigured installed card carries the Needs setup badge and a Configure button scoped to the missing keys", () => {
+  const { document } = boot({ ...CARD_BOOT, fetchImpl: envFetch() });
+
+  const item = card(document);
+  assert.ok(item.querySelector(".ext-installed__needsconfig"), "the Needs setup badge is on the card");
+  assert.match(item.textContent, /Needs setup/);
+  const btn = item.querySelector(".bundle-configure");
+  assert.ok(btn, "and a Configure button");
+  assert.equal(btn.getAttribute("data-keys"), "JELLYFIN_API_KEY,JELLYFIN_URL");
+});
+
+test("BEHAVIOR: a configured installed card carries neither badge nor Configure button", () => {
+  const { document } = boot({ installed: { jellyfin: { version: "1.0.0" } }, needsConfig: {}, fetchImpl: envFetch() });
+  const item = card(document);
+  assert.equal(item.querySelector(".ext-installed__needsconfig"), null);
+  assert.equal(item.querySelector(".bundle-configure"), null);
+});
+
+test("BEHAVIOR: the card's Configure button opens the env-only form for exactly the missing keys (registry metadata, with a fallback)", async () => {
+  const { document, click, settle, calls } = boot({ ...CARD_BOOT, fetchImpl: envFetch() });
+
+  click(card(document).querySelector(".bundle-configure"));
+  await settle();
+
+  assert.match(document.getElementById("modal-content").textContent, /Configure.*Jellyfin/s);
+  assert.ok(document.getElementById("env_JELLYFIN_API_KEY"), "the registry-described key");
+  assert.ok(document.getElementById("env_JELLYFIN_URL"), "and the key with no registry metadata (name/required fallback)");
+  assert.ok(!calls.some((c) => c.url.includes("/consent-challenge/")), "configureOnly skips the consent gate");
+});
+
+test("BEHAVIOR: a FULL Configure save from the card clears the Needs setup badge and the Configure button", async () => {
+  const { document, click, settle, flushTimers, calls } = boot({
+    ...CARD_BOOT,
+    fetchImpl: envFetch({ body: { ok: true, needs_restart: false, needs_config: [] } }),
+  });
+
+  click(card(document).querySelector(".bundle-configure"));
+  await settle();
+  document.getElementById("env_JELLYFIN_API_KEY").value = "k";
+  document.getElementById("env_JELLYFIN_URL").value = "http://jf";
+  click(document.querySelector("#modal-content .ext-checklist__save"));
+  await settle();
+  flushTimers();   // the queued onSaved()
+
+  const envCall = calls.find((c) => c.url.includes("/bundles/api/env"));
+  assert.deepEqual(envCall.body, { bundle_id: "jellyfin", env_vars: { JELLYFIN_API_KEY: "k", JELLYFIN_URL: "http://jf" } });
+
+  const item = card(document);
+  assert.equal(item.querySelector(".ext-installed__needsconfig"), null, "the badge is gone — the server said nothing is missing");
+  assert.equal(item.querySelector(".bundle-configure"), null, "and so is the Configure button");
+});
+
+test("BEHAVIOR: a PARTIAL Configure save keeps the badge and narrows data-keys to the still-missing keys", async () => {
+  const { document, click, settle, flushTimers } = boot({
+    ...CARD_BOOT,
+    // 1 of 2 keys filled → the route re-derives and says JELLYFIN_URL is still missing.
+    fetchImpl: envFetch({ body: { ok: true, needs_restart: false, needs_config: ["JELLYFIN_URL"] } }),
+  });
+
+  click(card(document).querySelector(".bundle-configure"));
+  await settle();
+  document.getElementById("env_JELLYFIN_API_KEY").value = "k";
+  click(document.querySelector("#modal-content .ext-checklist__save"));
+  await settle();
+  flushTimers();
+
+  const item = card(document);
+  assert.ok(
+    item.querySelector(".ext-installed__needsconfig"),
+    "the bundle is STILL unconfigured — a 200 on a partial save must not clear the badge",
+  );
+  assert.equal(
+    item.querySelector(".bundle-configure").getAttribute("data-keys"),
+    "JELLYFIN_URL",
+    "and the Configure button is re-scoped to what the SERVER says is still missing",
+  );
+});
+
+test("BEHAVIOR: saving from the checklist also updates the card's badge (no cross-surface staleness)", async () => {
+  const { document, click, settle, flushTimers } = boot({
+    ...CARD_BOOT,
+    session: { crow_ext_needs_config: JSON.stringify([{ id: "jellyfin", keys: ["JELLYFIN_API_KEY", "JELLYFIN_URL"] }]) },
+    fetchImpl: envFetch({ body: { ok: true, needs_restart: false, needs_config: ["JELLYFIN_URL"] } }),
+  });
+
+  click(document.querySelector(".ext-checklist__configure"));
+  await settle();
+  document.getElementById("env_JELLYFIN_API_KEY").value = "k";
+  click(document.querySelector("#modal-content .ext-checklist__save"));
+  await settle();
+  flushTimers();
+
+  const item = card(document);
+  assert.ok(item.querySelector(".ext-installed__needsconfig"), "the card behind the checklist still shows Needs setup");
+  assert.equal(item.querySelector(".bundle-configure").getAttribute("data-keys"), "JELLYFIN_URL",
+    "a save made from the checklist re-scopes the card's Configure button too");
 });
 
 // ─── 7. Category badge i18n (the live gap: the detail modal rendered the raw slug) ───

--- a/tests/extensions-needs-config.test.js
+++ b/tests/extensions-needs-config.test.js
@@ -1,0 +1,209 @@
+/**
+ * "Needs setup" — the durable config-state affordance on the Installed cards.
+ *
+ * Compute layer (bundles-config.js → panels/extensions/data-queries.js), the
+ * compute→render seam (html.js), and the server truth the client renders
+ * (POST /bundles/api/env returns the RE-DERIVED needs_config).
+ *
+ * Isolation (non-negotiable): CROW_HOME/CROW_DATA_DIR point at a scratch dir and
+ * every module under test is imported DYNAMICALLY afterwards — both
+ * bundles-config.js and data-queries.js capture CROW_HOME at module load, so a
+ * static import would read (and the route test would WRITE) the operator's real
+ * ~/.crow. Never add these tests to extensions-page-render.test.js or
+ * extensions-client-contract.test.js: those two declare they never touch ~/.crow.
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const HOME = mkdtempSync(join(tmpdir(), "crowhome-needsconfig-"));
+mkdirSync(join(HOME, "bundles"), { recursive: true });
+mkdirSync(join(HOME, "data"), { recursive: true });
+
+process.env.CROW_HOME = HOME;
+process.env.CROW_DATA_DIR = join(HOME, "data");
+process.env.CROW_AUTO_UPDATE = "0";
+process.env.CROW_DISABLE_HEALTH_MONITOR = "1";
+process.env.CROW_DISABLE_INSTANCE_SYNC = "1";
+process.env.CROW_DISABLE_NOSTR = "1";
+
+/** The sentinel that must never reach the browser (AC-8). */
+const SENTINEL = "SECRET_SENTINEL_VALUE_9f3a";
+
+/** Write an INSTALLED bundle: manifest (+ optional .env) under CROW_HOME/bundles/<id>. */
+function installedBundle(id, envVars, dotEnv /* object|null */) {
+  const dir = join(HOME, "bundles", id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+    id, name: id, type: "bundle", version: "1.0.0", env_vars: envVars,
+  }, null, 2));
+  if (dotEnv) {
+    writeFileSync(
+      join(dir, ".env"),
+      Object.entries(dotEnv).map(([k, v]) => `${k}=${v}`).join("\n") + "\n",
+    );
+  }
+}
+
+function writeMcpAddons(entries) {
+  writeFileSync(join(HOME, "mcp-addons.json"), JSON.stringify(entries, null, 2));
+}
+
+const REQUIRED = (...names) => names.map((n) => ({ name: n, description: `${n} desc`, required: true }));
+
+// ─── Fixtures (one scratch CROW_HOME shared by the whole file) ───
+
+// docker-style: .env present, one required key still blank → the affordance
+installedBundle("fx-docker", REQUIRED("DOCKER_KEY"), { DOCKER_KEY: "" });
+
+// MCP add-on configured ONLY through mcp-addons.json (no .env) → AC-3, no affordance
+installedBundle("fx-mcp", REQUIRED("MCP_KEY"), null);
+
+// MCP add-on whose required key only exists in the gateway's ambient env → AC-4
+installedBundle("fx-ambient", REQUIRED("AMBIENT_KEY"), null);
+process.env.AMBIENT_KEY = "from-systemd";
+
+// manifest-only stub (capstone-tracker's real shape): no .env, no mcp entry → AC-5
+installedBundle("fx-stub", REQUIRED("STUB_KEY"), null);
+
+// every required key has a value → AC-6
+installedBundle("fx-done", REQUIRED("DONE_KEY"), { DONE_KEY: "set" });
+// no required keys at all → AC-6
+installedBundle("fx-norequire", [{ name: "OPTIONAL_KEY", required: false }], { OPTIONAL_KEY: "" });
+
+// AC-8: TWO required keys — one holds the sentinel (in .env AND mcp-addons.json),
+// one is empty. The empty one is what makes the card render an affordance at all;
+// without it this test would be vacuous (a configured bundle renders nothing).
+installedBundle("fx-secret", REQUIRED("SENTINEL_KEY", "EMPTY_KEY"), {
+  SENTINEL_KEY: SENTINEL,
+  EMPTY_KEY: "",
+});
+
+// the route test's target: two required keys, both blank
+installedBundle("fx-route", REQUIRED("KEY_A", "KEY_B"), { KEY_A: "", KEY_B: "" });
+
+writeMcpAddons({
+  "fx-mcp": { command: "node", args: ["x.js"], env: { MCP_KEY: "live-value" } },
+  "fx-ambient": { command: "node", args: ["x.js"], env: {} },
+  "fx-secret": { command: "node", args: ["x.js"], env: { SENTINEL_KEY: SENTINEL } },
+});
+
+writeFileSync(join(HOME, "installed.json"), JSON.stringify(
+  ["fx-docker", "fx-mcp", "fx-ambient", "fx-stub", "fx-done", "fx-norequire", "fx-secret", "fx-route"]
+    .map((id) => ({ id, version: "1.0.0", installed_at: "2026-07-11T00:00:00Z" })),
+));
+
+// Import AFTER the env is set (CROW_HOME is captured at module load).
+const { fetchNeedsConfig, getInstalled } = await import(
+  "../servers/gateway/dashboard/panels/extensions/data-queries.js"
+);
+const { buildExtensionsHTML } = await import(
+  "../servers/gateway/dashboard/panels/extensions/html.js"
+);
+const { default: bundlesRouter } = await import("../servers/gateway/routes/bundles.js");
+
+after(() => {
+  try { rmSync(HOME, { recursive: true, force: true }); } catch {}
+});
+
+// ─── Compute layer ───
+
+test("fetchNeedsConfig: a managed bundle with an empty required key reports that key by NAME", () => {
+  const map = fetchNeedsConfig(getInstalled());
+  assert.deepEqual(map["fx-docker"], ["DOCKER_KEY"]);
+});
+
+test("fetchNeedsConfig: an MCP add-on configured only via mcp-addons.json reports nothing (AC-3)", () => {
+  const map = fetchNeedsConfig(getInstalled());
+  assert.ok(!map["fx-mcp"] || map["fx-mcp"].length === 0,
+    "a WORKING add-on whose env lives in mcp-addons.json must never be badged");
+});
+
+test("fetchNeedsConfig: a required key supplied only by ambient process.env reports nothing (AC-4)", () => {
+  const map = fetchNeedsConfig(getInstalled());
+  assert.ok(!map["fx-ambient"] || map["fx-ambient"].length === 0,
+    "proxy.js spawns MCP children with { ...process.env, ...config.env } — the ambient value is real config");
+});
+
+test("fetchNeedsConfig: a bundle with no managed evidence reports nothing (AC-5)", () => {
+  const map = fetchNeedsConfig(getInstalled());
+  assert.ok(!map["fx-stub"], "no .env and no mcp-addons entry → we cannot tell unconfigured from unmanaged: fail closed");
+});
+
+test("fetchNeedsConfig: a configured bundle and a bundle with no required keys report nothing (AC-6)", () => {
+  const map = fetchNeedsConfig(getInstalled());
+  assert.ok(!map["fx-done"]);
+  assert.ok(!map["fx-norequire"]);
+});
+
+test("fetchNeedsConfig: the map is keyed by bundle id over the installed OBJECT", () => {
+  const map = fetchNeedsConfig(getInstalled());
+  assert.deepEqual(Object.keys(map).sort(), ["fx-docker", "fx-route", "fx-secret"]);
+  assert.deepEqual(map["fx-route"], ["KEY_A", "KEY_B"]);
+});
+
+// ─── AC-8: the compute→render seam leaks key NAMES only, never VALUES ───
+
+test("SECURITY: the compute→render seam emits the Configure affordance but never a config VALUE (AC-8)", () => {
+  const installed = getInstalled();
+  const needsConfig = fetchNeedsConfig(installed);
+
+  assert.deepEqual(needsConfig["fx-secret"], ["EMPTY_KEY"],
+    "only the EMPTY key is missing — the sentinel-valued one is configured");
+
+  const { viewsHtml, addonRegistryScript, collectionsScript } = buildExtensionsHTML({
+    installed,
+    available: [{ id: "fx-secret", name: "Fixture Secret", description: "d", type: "bundle", category: "other", version: "1.0.0", author: "x", tags: [], env_vars: REQUIRED("SENTINEL_KEY", "EMPTY_KEY") }],
+    collections: [],
+    registrySource: "local",
+    communityStores: [],
+    bundleStatus: {},
+    needsConfig,
+    lang: "en",
+  });
+  const html = viewsHtml + addonRegistryScript + collectionsScript;
+
+  // (a) the affordance IS rendered — otherwise (b) would be vacuous
+  assert.match(html, /class="btn btn-sm btn-primary bundle-configure"[^>]*data-id="fx-secret"/,
+    "the Configure button must be on the fx-secret card");
+  assert.match(html, /data-keys="EMPTY_KEY"/, "scoped to the still-missing key");
+  assert.match(html, /Needs setup/, "and the badge is rendered");
+
+  // (b) and the secret is nowhere in what we hand the browser
+  assert.equal(html.split(SENTINEL).length - 1, 0,
+    "a config VALUE must never reach the browser — key names are public, values are secrets (D5)");
+});
+
+// ─── Server truth: POST /bundles/api/env returns the RE-DERIVED needs_config ───
+
+test("POST /bundles/api/env: a PARTIAL save returns the keys that are STILL missing", async (t) => {
+  const app = express();
+  app.use(express.json());
+  app.use(bundlesRouter());
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  t.after(() => server.close());
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  const post = (body) => fetch(base + "/bundles/api/env", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }).then((r) => r.json());
+
+  // 1 of 2 keys — and a whitespace-only value for the other, which the client's
+  // `if (inp && inp.value)` guard happily accepts but needsConfigKeys trims away.
+  const partial = await post({ bundle_id: "fx-route", env_vars: { KEY_A: "value-a", KEY_B: "   " } });
+  assert.equal(partial.ok, true);
+  assert.deepEqual(partial.needs_config, ["KEY_B"],
+    "the route must RE-DERIVE config state after the write — a 200 does not mean 'configured'");
+
+  const full = await post({ bundle_id: "fx-route", env_vars: { KEY_B: "value-b" } });
+  assert.equal(full.ok, true);
+  assert.deepEqual(full.needs_config, [], "every required key now has a value");
+  assert.equal(typeof full.needs_restart, "boolean", "the pre-existing response fields survive");
+});

--- a/tests/install-set-e2e.test.js
+++ b/tests/install-set-e2e.test.js
@@ -92,6 +92,34 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * A barrier the install-set runner parks on at the TOP of every member
+ * iteration. It is a thenable, not a bare promise, so the test can observe the
+ * runner's interaction with it as a mechanism rather than infer it from timing:
+ *   - `awaited` counts every `await barrier` the runner performs (one per member),
+ *   - `reached` resolves the instant the runner first parks on it, which is what
+ *     lets the busy-gate assertions below run provably mid-flight with zero
+ *     wall-clock sleeping,
+ *   - `release()` unparks the runner and is idempotent.
+ */
+function makeBarrier() {
+  let release;
+  let notifyReached;
+  const gate = new Promise((r) => { release = r; });
+  const reached = new Promise((r) => { notifyReached = r; });
+  const barrier = {
+    awaited: 0,
+    reached,
+    release,
+    then(onFulfilled, onRejected) {
+      barrier.awaited++;
+      notifyReached();
+      return gate.then(onFulfilled, onRejected);
+    },
+  };
+  return barrier;
+}
+
 test("install-set: sequential, continue-on-error, exactly one deferred restart, live gates", async (t) => {
   const home = scratchHome();
   process.env.CROW_HOME = home;
@@ -107,9 +135,21 @@ test("install-set: sequential, continue-on-error, exactly one deferred restart, 
     _setAppBundlesForTest,
     _setCollectionsPathForTest,
     _setRestartHookForTest,
-    _setInstallSetStepDelayForTest,
+    _setInstallSetBarrierForTest,
+    _getInstallSetBarrierForTest,
   } = await import("../servers/gateway/routes/bundles.js");
   const { loadCollections } = await import("../servers/gateway/dashboard/panels/extensions/collections.js");
+
+  // Production no-op, proven by mechanism (not by a comment): on a fresh import,
+  // before anything installs a barrier, the module-private barrier is null. The
+  // runner's only interaction with it is `if (_installSetBarrier) await
+  // _installSetBarrier` — and the thenable spy below proves that branch is live
+  // and gated on the barrier's truthiness. null is falsy ⇒ in production the
+  // branch is never entered: no await, no timer.
+  assert.equal(
+    _getInstallSetBarrierForTest(), null,
+    "production default: the install-set barrier must be null on a fresh import, so the runner's `if (barrier) await barrier` branch is never entered",
+  );
 
   // Fixture bundle source tree (this repoints APP_BUNDLES — the app's real
   // bundles/ tree is never touched or read).
@@ -143,16 +183,22 @@ test("install-set: sequential, continue-on-error, exactly one deferred restart, 
 
   _setAppBundlesForTest(fixtureBundlesDir);
   _setCollectionsPathForTest(fixtureCollectionsPath);
-  // Real (small) macrotask pacing between members — see the seam's doc
-  // comment in bundles.js for why this is required to make the busy-gate
-  // assertion below observable at all over real HTTP, rather than flaky.
-  _setInstallSetStepDelayForTest(150);
+  // Park the set runner at the top of every member iteration. This replaces the
+  // old wall-clock step-delay seam: the busy-gate assertions below no longer
+  // race a ~450ms timer, they run while the runner is provably parked.
+  const barrier = makeBarrier();
+  _setInstallSetBarrierForTest(barrier);
   const restartCalls = [];
   _setRestartHookForTest((delayMs) => restartCalls.push(delayMs));
 
   t.after(() => {
     _setRestartHookForTest(null);
-    _setInstallSetStepDelayForTest(0);
+    // Idempotent release (the happy path already released it after the busy-gate
+    // assertions). This is the failure story: if an assertion throws while the
+    // runner is parked, the runner never reaches the `finally` that calls
+    // endInstallSet() and the busy flag leaks into the next test.
+    barrier.release();
+    _setInstallSetBarrierForTest(null);
     try { rmSync(fixtureBundlesDir, { recursive: true, force: true }); } catch {}
     try { rmSync(home, { recursive: true, force: true }); } catch {}
   });
@@ -176,8 +222,24 @@ test("install-set: sequential, continue-on-error, exactly one deferred restart, 
     assert.equal(plan.length, 3);
     assert.ok(plan.every((p) => p.action === "install"), `expected all 3 members to plan as "install": ${JSON.stringify(plan)}`);
 
+    // Wait until the runner has actually parked on the barrier. From here the
+    // busy-gate assertions are provably mid-flight — not "probably within 450ms".
+    await barrier.reached;
+
+    // The barrier gates the TOP of each iteration, INCLUDING the first: the
+    // runner must park BEFORE installing member 1, otherwise the first member's
+    // install races these busy-gate fetches.
+    assert.equal(barrier.awaited, 1, "the runner must await the barrier once, at the top of the first member's iteration");
+    assert.equal(
+      existsSync(join(home, "bundles", "fx-panel")), false,
+      "the barrier must gate the TOP of the first iteration — fx-panel was already installed by the time the runner reached the barrier",
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(home, "installed.json"), "utf8")), [],
+      "no member may be installed while the runner is parked on the barrier",
+    );
+
     // Busy gate: a second POST while the first set is still running must 409.
-    // The step-delay seam above keeps the job alive for ~450ms so this isn't a race.
     const res2 = await fetch(base + "/bundles/api/install-set", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -207,6 +269,11 @@ test("install-set: sequential, continue-on-error, exactly one deferred restart, 
     assert.equal(res4.status, 409, `a single /uninstall while a set is running must 409: ${JSON.stringify(body4)}`);
     assert.match(body4.error, /collection install is in progress/i);
     assert.equal(body4.job_id, undefined, "a rejected /uninstall must not create a job");
+
+    // Busy-gate assertions are done — unpark the runner so the set can finish.
+    // This MUST happen here, not only in t.after(): a runner left parked would
+    // make the poll loop below burn all 100 iterations and fail every time.
+    barrier.release();
 
     // Poll the shared job until it finishes.
     let job;
@@ -241,6 +308,11 @@ test("install-set: sequential, continue-on-error, exactly one deferred restart, 
     assert.ok(ids.includes("fx-panel"), `installed.json missing fx-panel: ${JSON.stringify(ids)}`);
     assert.ok(ids.includes("fx-skill"), `installed.json missing fx-skill: ${JSON.stringify(ids)}`);
     assert.ok(!ids.includes("fx-broken"), `installed.json must NOT include the failed fx-broken: ${JSON.stringify(ids)}`);
+
+    // One await per member — the barrier gates the top of EVERY iteration, so a
+    // future member added to the set cannot slip past it.
+    assert.equal(barrier.awaited, 3, "the runner must await the barrier once per member (3 members)");
+    assert.equal(_getInstallSetBarrierForTest(), barrier, "the barrier setter is the only thing that mutates the module-private barrier");
   } finally {
     server.close();
   }

--- a/tests/onboarding-links.test.js
+++ b/tests/onboarding-links.test.js
@@ -1,0 +1,118 @@
+// tests/onboarding-links.test.js
+//
+// Item 1b — done-step action cards target the SAME tab; mid-tour deep links do NOT.
+//
+// Every assertion here runs the real renderer and inspects the produced HTML — a
+// source regex would not be evidence that the emitted anchors changed. The one
+// exception is the classifier, which is unit-tested directly because its external
+// branch is dead code on day one (all four done-step cards are internal).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import onboardingPanel, {
+  isInternalHref,
+  cardLinkAttrs,
+} from "../servers/gateway/dashboard/panels/onboarding.js";
+
+// Same seam as tests/onboarding.test.js: drive the panel handler with a stub layout.
+// No db => the done step's onboarding_completed_at write is skipped.
+async function render(step) {
+  let captured = "";
+  const layout = ({ content }) => content;
+  const res = { send(h) { captured = h; }, setHeader() {} };
+  const req = { method: "GET", query: { step: String(step) }, headers: {} };
+  const out = await onboardingPanel.handler(req, res, { layout, lang: "en" });
+  return typeof out === "string" ? out : captured;
+}
+
+/** Every `<a ...>` open tag in an HTML string. */
+function anchors(html) {
+  return html.match(/<a\b[^>]*>/g) || [];
+}
+
+/** The anchor open-tag whose href is exactly `href` (asserts exactly one). */
+function anchorFor(html, href) {
+  const found = anchors(html).filter((a) => a.includes(`href="${href}"`));
+  assert.equal(found.length, 1, `expected exactly one anchor for ${href}, got ${found.length}`);
+  return found[0];
+}
+
+/** Just the done step's action-card grid, so nav/callout anchors don't pollute assertions. */
+function actionCardsSlice(html) {
+  const start = html.indexOf('<div class="onboarding-action-cards">');
+  assert.ok(start !== -1, "done step must render the action-cards grid");
+  return html.slice(start);
+}
+
+const CARD_HREFS = [
+  "/dashboard/memory",
+  "/dashboard/bot-builder",
+  "/dashboard/connect",
+  "/dashboard/extensions#collections",
+];
+
+// (a) THE REGRESSION GUARD. deepLink() is mid-tour: it must keep opening a new tab
+// so the wizard stays alive behind it. If 1b's change bleeds into deepLink, this
+// goes red.
+test("mid-tour deep links still open in a new tab (deepLink is out of scope)", async () => {
+  const midTour = [
+    [1, "/dashboard/settings?section=integrations"],
+    [2, "/dashboard/bot-builder"],
+    [3, "/dashboard/connect"],
+  ];
+  for (const [step, href] of midTour) {
+    const a = anchorFor(await render(step), href);
+    assert.match(a, /target="_blank"/, `mid-tour step ${step} (${href}) must keep target=_blank`);
+    assert.match(a, /rel="noopener"/, `mid-tour step ${step} (${href}) must keep rel=noopener`);
+  }
+});
+
+// (b) The done-step cards are all internal today => no target, no rel.
+test("done-step action cards navigate in the same tab (no target attribute)", async () => {
+  const cards = actionCardsSlice(await render(4));
+  for (const href of CARD_HREFS) {
+    const a = anchorFor(cards, href);
+    assert.doesNotMatch(a, /target=/, `internal card ${href} must not set target`);
+    assert.doesNotMatch(a, /rel=/, `internal card ${href} must not set rel (nothing to protect)`);
+  }
+  // And the grid as a whole carries no stray new-tab anchor.
+  assert.doesNotMatch(cards, /target="_blank"/, "no done-step card opens a new tab");
+});
+
+// (c) Whatever _blank survives anywhere in the tour must still be safe.
+test("every remaining target=_blank anchor carries rel=noopener", async () => {
+  for (const step of [0, 1, 2, 3, 4]) {
+    for (const a of anchors(await render(step))) {
+      if (a.includes('target="_blank"')) {
+        assert.match(a, /rel="noopener"/, `step ${step}: _blank anchor without rel=noopener: ${a}`);
+      }
+    }
+  }
+});
+
+// (d) The classifier, both ways. Conservative: only a leading "/" is internal.
+test("isInternalHref: only same-origin dashboard paths are internal", () => {
+  for (const href of ["/dashboard/memory", "/dashboard/extensions#collections", "/"]) {
+    assert.equal(isInternalHref(href), true, `${href} is internal`);
+  }
+  for (const href of [
+    "https://docs.crow.example/guide",
+    "http://example.com",
+    "//evil.example.com/x",     // protocol-relative: NOT internal
+    "javascript:alert(1)",      // eslint-disable-line no-script-url
+    "mailto:a@b.c",
+    "dashboard/memory",         // relative, no leading slash
+    "",
+    null,
+    undefined,
+  ]) {
+    assert.equal(isInternalHref(href), false, `${String(href)} is NOT internal`);
+  }
+});
+
+// (e) The external branch is dead code in the renderer today (Item 4d may add such a
+// card), so exercise it at the classifier/attrs layer instead.
+test("an external card href would still get target=_blank rel=noopener", () => {
+  assert.equal(cardLinkAttrs("https://crow.example/docs"), 'target="_blank" rel="noopener"');
+  assert.equal(cardLinkAttrs("//evil.example.com/x"), 'target="_blank" rel="noopener"');
+  assert.equal(cardLinkAttrs("/dashboard/memory"), "");
+});


### PR DESCRIPTION
Item 1 of the Opus-autonomous arc (`docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md`). The three accepted follow-ups from the extensions overhaul (#173).

## What ships

**1a — an unconfigured extension finally says so, durably.** Today the NEEDS_CONFIG checklist is one-shot: it's consumed from sessionStorage at load, so closing the modal loses it until you reinstall. And it only ever existed for *collection* installs — a bundle installed through the single `/install` path that needs config got no prompt, ever. Installed cards now carry a "Needs setup" badge + Configure button, derived live, so the prompt cannot be lost and finally exists for the common install path.

**1b — onboarding's done-step cards navigate in the same tab.** They opened new tabs, which is odd once the tour is over.

**1c — the install-set busy-gate E2E uses a barrier instead of timer pacing.** Deterministic, and ~440ms faster (measured 0.73s → 0.29s).

## The design decision worth reading

The naive rule — badge whenever a manifest-required key is empty in `bundles/<id>/.env` — would have lit up **working** bundles on this fleet on day one. Measured against the real host: it badges `frigate` (1 key) and `capstone-tracker` (12), because a missing `.env` usually means the bundle isn't gateway-managed-with-config, not that it's unconfigured. `capstone-tracker`'s installed dir holds only a `manifest.json`. MCP add-ons never read that file at all — their env lives in `mcp-addons.json`, or is ambient in the gateway's process env (`proxy.js` spawns children with `{...process.env, ...config.env}`).

So the rule fails closed: badge only with positive evidence the gateway manages the config (a written `.env`, or an `mcp-addons` entry), and resolve the effective env across all the places config actually lives. Re-measured with the new code: **zero badges across crow (10 bundles), crow-mpa, and grackle; black-swan has no installed.json at all and returns `{}` without crashing** — while a synthetic unconfigured install still badges.

A partial save can't false-clear the badge either: `POST /bundles/api/env` returns the re-derived `needs_config` and the client renders server truth. Fill 1 of 12 keys and the badge stays, narrowed.

## Structure

`needsConfigKeys` and friends move into a new `servers/gateway/bundles-config.js` so the panel can ask "is this configured?" without importing the router (which would drag express, the DB and peer-auth into the panel's data path) and without re-deriving `CROW_HOME` itself — that duplication is what made the store panel render *another instance's* installed list until `1b28d38a`. `APP_BUNDLES` stays a single mutable binding: that seam is what stops the E2E suite installing real bundles onto the operator's host, so splitting it would have quietly half-broken the isolation guard.

Key **names** reach the browser; **values** never do — asserted end-to-end with a sentinel that the test can actually fail on.

## Verification

- Suite **1633 pass / 3 fail / 1 skip** on a scratch `CROW_HOME`. The 3 failures are pre-existing on unmodified `main` under the same scratch env (they read prod state to pass, so they'd fail on a fresh clone) — queued as a separate minors fix, not introduced here.
- Two adversarial design rounds before any code (the second found that three of the first's four "critical" folds were themselves wrong, and proved it by computing the rule against the live host). Final whole-branch review: READY TO MERGE, 0 critical.
- Every guard mutation-checked (disable it → a *named* test goes red → restore).
- **CDP browser evidence, 10/10** on a scratch gateway (`~/.crow/p4/ext-followups/`): badge appears on a fresh load with sessionStorage cleared; only the *empty* key is listed; the manifest-only stub stays quiet; the secret never reaches the DOM while the affordance does; Configure opens scoped to the missing key; a real save clears the badge with **no reload** and writes the `.env`; done-step cards land in-tab; and the regression guard — mid-tour deep links still open a new tab, so the wizard survives.

## Follow-ups filed (not this PR)

- A docker bundle whose required key has **no default** never gets a `.env` written by the UI install path (`bundles.js:1252-1263` — the `.env.example` fallback is dead for UI installs), so it can never badge. `frigate` is the live instance. One-line fix, but it changes install behavior → its own PR.
- The unregistered-bundle env fallback drops `secret`, so such a key renders `type=text`.
- The 3 prod-dependent tests above.