### PR TITLE
docs(2a): advertised-contact prune design (v4, 3 adversarial rounds) + harden the schema migration rail

### DIFF
--- a/docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md
+++ b/docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md
@@ -232,15 +232,34 @@ migration window is **authorized**, and **re-enabling it is mandatory** — the 
 "done" until auto-update is back ON and confirmed on all three boxes. If a session ends
 with it off, that is an incident, not a pending task.
 
+**⚠️ THE RAIL AS ORIGINALLY WRITTEN WAS INSUFFICIENT — corrected 2026-07-12 (Item 2a R3/MAJOR-4).**
+A `SCHEMA_GENERATION` bump does NOT run "just the new migration": `needsSchemaInit`
+(`servers/shared/schema-version.js:21-25`) → `gateway/index.js:134` runs **the ENTIRE
+`scripts/init-db.js`**, which contains **8 `DROP TABLE` statements** — `shared_items`
+(`:493`), `crow_context` (`:1275`), `dashboard_settings` (`:1834`), `research_projects`
+(`:2696`), a generic `DROP TABLE ${tableName}` (`:926`) — plus `DELETE FROM schedules`
+(`:2726`) and `DELETE FROM project_spaces` (`:1023`). These are *guarded rebuild-migrations*,
+but **they have not run since gen 6 was stamped**, and a bump re-arms every one of them
+against **FOUR** live DBs (crow, **MPA (`~/.crow-mpa` — easy to forget)**, grackle,
+black-swan — all verified at `user_version = 6` on 2026-07-12).
+**And the old rail could not detect the damage:** `PRAGMA integrity_check` reports *page-level*
+integrity — it returns `ok` for a table that was rebuilt having silently lost rows — and
+`user_version = 7` proves only that the script reached its last line.
+
 **Rail — for any PR that bumps `SCHEMA_GENERATION` or adds a boot heal:**
-1. Disable auto-update on all three boxes FIRST (Settings → Updates, or set
+1. Disable auto-update on all boxes FIRST (Settings → Updates, or set
    `auto_update_enabled=false`); confirm each box reports it disabled.
-2. Back up all three DBs (`crow.db.pre-<slug>-<ts>`), verify each backup file exists
-   and is non-zero.
-3. Merge.
-4. Deploy manually, in the §3 runbook order, one box at a time; verify health +
-   `PRAGMA integrity_check` + the migration's own acceptance check before moving on.
-5. Re-enable auto-update on all three; confirm.
+2. Back up **all four** DBs (`crow.db.pre-<slug>-<ts>`), verify each exists and is non-zero.
+3. **DRY-RUN GATE (new, mandatory):** run `node scripts/init-db.js` against a **COPY** of each
+   of the four prod DBs and **diff `sqlite_master` + per-table `COUNT(*)` pre/post**. Zero
+   unexplained deltas is a merge gate; ship the diff as evidence. (Stop the gateway before any
+   real run — init-db does heavy DDL against a DB the gateway holds open, and
+   `"database is locked"` is a documented recurring failure on this fleet.)
+4. Merge.
+5. Deploy manually, in the §3 runbook order, one box at a time; verify health +
+   `PRAGMA integrity_check` + **the per-table row-count diff** + the migration's own acceptance
+   check before moving on.
+6. Re-enable auto-update on all boxes; confirm.
 
 **Executor note on the lock:** crow runs TWO gateways off the same tree, and the
 **crow-mpa-gateway** is typically the one that wins the atomic update lock — the primary
@@ -409,21 +428,47 @@ lamport ties, offline-peer resurrection). All four live in `servers/sharing/`
 (`contact-sync.js`, `group-sync.js`, `tailnet-sync.js`, `instance-sync.js`) +
 `servers/gateway/dashboard/panels/messages/data-queries.js`.
 
-**2a. pruneStaleAdvertisedContacts resurrection.** The prune
-(`messages/data-queries.js:284`, called from `:275`) DELETEs contact rows where
-`origin = 'advertised'` and the contact has zero messages and its pubkey is no longer
-in the live set. The delete is local-only, so a peer re-advertises the row and it
-resurrects. **This item is the least-specified in the queue and sits in the layer that
-has bitten us most — do NOT skip the spec.** Two things the spec must nail down before
-any code: (i) *where `origin` is actually set* on a contact row (grep `origin` across
-`servers/sharing/` + `panels/messages|contacts` and enumerate every writer — the fix
-belongs there, at the point the row is classified, not at the prune); (ii) why the
-`shouldSyncRow` approach is a dead end — it was proven **documented-inert** in #155's R2
-review (MAJOR-2). Do not retry `shouldSyncRow`; read that review first
-(`docs/superpowers/specs/` + the #155 PR body).
-*Acceptance:* two-instance test — a pruned advertised contact stays gone on BOTH sides
-across a full sync cycle AND a restart of each side; a still-live advertised contact
-continues to sync normally (negative control); `sync_conflicts` does not grow.
+**2a. pruneStaleAdvertisedContacts resurrection — ✅ DESIGN COMPLETE (spec v4, 3 adversarial
+rounds), ⏳ BUILD NOT STARTED (deliberate stop).**
+Spec: `docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md`.
+Branch `fix/advertised-contact-prune` (spec + this doc only; **no code**).
+
+**Read the spec before touching code — three designs died in review, and the reasons are
+not obvious.** v1 (prune broadcasts a delete-wins tombstone) → R1 REVISE; v2 (local-only
+tombstone) → R2 REJECT; v3 → R3 REJECT; **v4's architecture was attacked directly by R3 and
+held.** The surviving insight: **`origin` is a *judgment* ("I may GC this") — view-relative,
+must NOT sync. "Instance X advertised this bot" is a *FACT* — it syncs safely, and lets every
+instance re-derive prunability from its OWN view.** That converges with no broadcast, no host
+authority, and protects the bot's host for free.
+
+**⚠️ TWO SCOPE CHANGES vs this plan's original assumptions:**
+- **2a now carries a SCHEMA BUMP (6→7)** — a new `contacts.advertised_by_instance_id` column.
+  So 2a, not just 2b, needs the §3 migration rail. (Every schema-free design was proven unsound.)
+- **The §3 rail itself was insufficient and has been corrected** (see the ⚠️ block there). This
+  gates **2b** too. **Recommendation: fix the rail as its own small PR FIRST.**
+
+Three real bugs found on the way, filed as follow-ups (details in spec §6/§7):
+- **[REAL, shipped code]** `emitChange` returns a valid lamport when `outFeeds.size === 0`
+  (`instance-sync.js:1027-1036`), so **#155's user-initiated contact delete**, in the boot
+  window, tombstones locally, broadcasts to **nobody**, and then silently drops the peer's
+  updates ⇒ permanent divergence, no error. `backfillContactsOnce:612` already guards that exact
+  window (its comment records it *observed live on grackle*). **→ fold into 2c.**
+- **[LATENT]** Every `origin='local-bot'` guard is weaker than it reads — a bot's host usually
+  has **no contacts row for its own bot** (only 1 such row exists fleet-wide, on MPA), so
+  `shouldSyncRow:204` / `deleteContactLocal:143` / `wireSyncedContact:111` are near-inert.
+- **[TODAY]** `getBotDirectory` **prunes as a side effect of a read** (`data-queries.js:275`) —
+  so the add path would durably delete contacts.
+
+*Acceptance (unchanged, and v4 delivers it):* a pruned advertised contact stays gone on BOTH
+sides across a full sync cycle AND a restart of each side; a still-live advertised contact
+continues to sync normally (negative control); `sync_conflicts` does not grow. **Plus:** the
+mutual-prune-then-re-add lamport-tie test (spec §5.6) — v3 shipped a permanent-divergence bug
+that every other test passed.
+
+**Live-state note that shapes the build:** *nothing on the fleet is advertised*
+(`allow_paired_instances` is false on all 3 bot defs), so **the prune has never fired** and the
+defect is doubly latent. There is **no urgency** — the bar is `fix-the-product` (correct on a
+fresh install). The live proof must CREATE a throwaway advertised bot on grackle.
 
 **2b. contact_groups offline-peer tombstones.** Group delete PROPAGATES live
 (`emitGroupDelete` exists and is wired at `panels/contacts/api-handlers.js:323`), so

--- a/docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md
+++ b/docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md
@@ -1,0 +1,418 @@
+# Item 2a — `pruneStaleAdvertisedContacts` resurrection: design
+
+**Status:** spec **v4** — design COMPLETE, implementation NOT started (deliberate stop, §8).
+**History:** v1 → R1 **REVISE** (4 CRIT) → v2 → R2 **REJECT** (4 CRIT) → v3 → R3 **REJECT**
+(2 CRIT, *spine confirmed*) → **v4** (folds R3; architecture unchanged).
+**Branch:** `fix/advertised-contact-prune`. **Plan:** `2026-07-11-opus-autonomous-arc.md` §4 Item 2a.
+**Constrains this:** `2026-07-09-contact-deletion-and-handshake-name-design.md` (PR #155) §2.6 + R2/MAJOR-2.
+
+> **⚠️ Two scope changes vs the plan, both forced by review:**
+> 1. **2a carries a SCHEMA BUMP** (`SCHEMA_GENERATION` 6→7). The plan assumed it was
+>    schema-free; three rounds proved every schema-free design unsound (§2).
+> 2. **The plan's migration rail is INSUFFICIENT — and this affects 2b, not just 2a.**
+>    See §7. Fix the rail before *any* schema-bumping PR ships.
+
+---
+
+## 0. Live-fleet measurement (corrected — R3 caught §0 measuring the wrong DB, again)
+
+Every previous round caught the *previous* §0 measuring the wrong thing: v2 never read
+`crow_instances`; v3 never read **MPA's `contacts`** — a CROW_HOME that §0 itself names as a
+trusted peer. All four production DBs are measured here (2026-07-12).
+
+| host | DB | contacts | `origin='advertised'` | `origin='local-bot'` | tombstones | `user_version` | lamport |
+|---|---|---|---|---|---|---|---|
+| crow | `~/.crow` | 4 | 0 | 0 | 4 | 6 | 4385 |
+| **MPA** | `~/.crow-mpa` | **5** | 0 | **1** | 4 | 6 | **4384** |
+| grackle | `~/.crow` | 3 | 0 | 0 | 4 | 6 | 4385 |
+| black-swan | `~/.crow` | 1 | 0 | 0 | 0 | 6 | — |
+
+**`crow_instances` (crow):** Grackle + **MPA**, both `trusted=1, active`. black-swan not paired.
+**Instance ids are PORTABLE** (R3 verified against all three registries: one id per instance,
+persisted in `$CROW_DATA_DIR/instance-id`, propagated verbatim by pairing) — this is the
+load-bearing assumption of F2 and it holds.
+
+**`pi_bot_defs` — what is actually advertised** (`listAdvertisedBots` = `enabled=1` AND a
+`crow-messages` gateway with `allow_paired_instances=true`, `bot-builder/crow-messages-admin.js:139`):
+crow `crow-home`; grackle `grackle-home`, `crow-glasses`. **`allow_paired_instances` is set on
+NONE of them.**
+
+**Six facts that shape everything:**
+
+1. **Not one bot on the fleet is advertised** ⇒ the directory is empty ⇒ `live.size === 0` ⇒
+   **the prune has never fired.** The defect is doubly latent. **There is no urgency**; the bar
+   is `fix-the-product` (correct on a fresh install), not incident response.
+2. **`origin='local-bot'` exists on exactly one row fleet-wide (MPA).** A bot's host usually has
+   **no contacts row for its own bot at all** (`ensureLocalBotContact`'s only caller is
+   `routes/peer-messages.js:373`, room hosting). Guards keyed on that column are near-inert —
+   which is what killed v1.
+3. Every contact is `origin=NULL`, `advertised_by` will start NULL everywhere ⇒ the new column
+   is a no-op on real data.
+4. **The fleet's lamport counters sit at 4385 / 4385 / 4384** — inside the ±1 tie regime that
+   produced R3's CRITICAL-1. Not hypothetical.
+5. **All four DBs are `user_version = 6`**, and a bump re-runs the *entire* `init-db.js` — which
+   contains **8 `DROP TABLE`** rebuild-migrations (§7).
+6. The live proof must **create** a throwaway advertised bot on grackle (fact 1). Kevin's three
+   existing bot definitions are not touched.
+
+---
+
+## 1. The defect chain
+
+**D1 — `origin` is classified AFTER the row is on the wire.** `crow_accept_bot_invite`
+(`tools/contacts.js:385`) inserts with no `origin`, then emits `insert` (`:406`). The *caller*
+stamps it afterwards: `contacts/api-handlers.js:432` (UPDATE → `markContactIsBot` → a **second**
+emit at `:437`) and `messages/api-handlers.js:264` (same UPDATE, **no emit** — asymmetric). Peers
+get `origin=NULL`, and whether they learn otherwise depends on *which panel the user clicked*.
+This is why #155's `shouldSyncRow` carve-out was **inert** (its R2/MAJOR-2).
+
+**D2 — `origin` rides the wire; apply writes the sender's value verbatim.**
+`EXCLUDED_COLUMNS.contacts` (`instance-sync.js:101`) omits it; `_applyContact` writes it on INSERT
+(`:1590`) and LWW UPDATE (`:1612`). `origin` is a **judgment** ("I may GC this"), true only
+relative to the holder. Replicating it is dangerous both ways: *toward the host* (a peer's emit
+creates/relabels the host's own bot row `'advertised'`; a host's own bots are never in its own
+`live` set, `data-queries.js:243` ⇒ **the host prunes its own bot**), and *toward a peer that
+cannot see the advertisement* (it inherits `'advertised'` for a bot it never sees advertised ⇒
+**it prunes a live bot on its next render**).
+
+**D3 — the prune deletes locally, with no emit and no tombstone (the reported bug).**
+`pruneStaleAdvertisedContacts` (`messages/data-queries.js:284-301`) issues a bare `DELETE`
+(`:297`). The row survives on every peer, so any later emit — **all of which are `op="update"`**
+(block/unblock `contacts/api-handlers.js:61,80`; profile edit `:257`; accept-request
+`messages/api-handlers.js:317`; `backfillContactsOnce:651`) — arrives with no local row and no
+tombstone → `_applyContact` takes `!localRow` (`:1543`) → **re-INSERT**. Resurrection.
+
+**D4 — the trigger is unsound, two independent ways.**
+(1) *Absent ≠ unavailable*: a peer that errors or exceeds the **2 s** timeout yields
+`{status:"unavailable"}` (`advertised-bots-cache.js:11,51`), cached **60 s**; the loop skips it
+silently (`data-queries.js:251`); the prune fires if **any single** peer answered
+(`live.size > 0`, `:275`).
+(2) *A peer answers **200 with a bot missing***: `buildAdvertisementPayload` `catch`es **per bot**
+and `continue`s (`bot-builder/crow-messages-admin.js:194-197`); the route still 200s
+(`federation.js:272`). A **"database is locked"** on `getOrCreatePairedRosterInvite`'s INSERT (a
+*documented recurring* failure here), an unreadable `identity.json` (⇒ **every** bot skipped,
+`{bots:[]}`, 200), or a bot merely **disabled** all produce a healthy-looking, incomplete list.
+
+**D4 is why D3 cannot be fixed alone.** Today the resurrection *is* the self-heal for a mis-fire.
+
+---
+
+## 2. Three designs died here (do not resurrect them)
+
+**v1 — the prune broadcasts a delete-wins tombstone.** R1, all re-verified: `emitChange` appends
+inside `for (…of this.outFeeds)` and **returns `lamportTs` unconditionally**
+(`instance-sync.js:1027-1036`) — with zero feeds it broadcasts to nobody and reports success
+(`backfillContactsOnce:612` guards exactly this window; its comment records it **observed live on
+grackle**); the `origin='local-bot'` host guards are **inert** (§0 fact 2) so the delete
+cascade-destroys the host's own bot's `messages` via FK; and delete-vs-update LWW is **asymmetric**
+(`:1506-1525` conflict-logs a losing delete, while `:1537` drops updates unconditionally) ⇒
+permanent divergence **and** `sync_conflicts` growth in a non-complete pairing graph.
+
+**v2 — strip `origin`, local-only tombstone, accept divergence.** R2, all re-verified: `deferEmit`
+**cannot cross the MCP boundary** (panels call `client.callTool`; zod `z.object()` strips unknown
+keys); v2's helper read `row.crow_id`/`row.lamport_ts` from a SELECT that fetches **neither**
+(`data-queries.js:286-292`) while `writeTombstone` **no-ops on a falsy crowId and swallows errors**
+(`contact-delete.js:29,37`) ⇒ the headline fix would have shipped as a **silent no-op**; and a
+durable tombstone on D4's trigger is a **net regression** vs today's self-healing bug.
+
+**v3 — as below, but with a `_nextLamport()` tombstone and a *negative* `partial` flag.** R3, both
+re-verified: the tombstone lamport produced a **permanent, unrecoverable divergence on a lamport
+tie** (the fleet sits at 4385/4385/4384 — §0 fact 4), and `partial` being a *negative* signal meant
+an old, drifted, or unlucky peer's `200 {bots:[]}` read as **complete** — reintroducing the exact
+regression that killed v2.
+
+### The insight that survived all three rounds
+
+> `origin` is a **judgment** — view-relative; it must not sync.
+> *"Instance X advertised this bot"* is a **FACT** — true everywhere; it syncs safely.
+
+Sync the fact; let every instance re-derive the judgment **from its own view**. Convergence then
+needs **no broadcast, no delete on the wire, and no host authority** — so v1's failure modes cannot
+arise and `sync_conflicts` cannot grow. R3 attacked this spine directly and **could not break it**:
+instance ids are portable, rule 1 does protect the host, and the per-advertiser trigger is strictly
+better than any denominator tweak.
+
+---
+
+## 3. The design (v4)
+
+### F1 — completeness is a POSITIVE assertion, checked on BOTH sides (fixes D4.2)
+
+*(R3/CRITICAL-2: v3's `partial:true` was a negative signal — absence of the key meant "trust me",
+so an old peer mid-rolling-deploy, a receiver-side validation drop, or a malformed body all read as
+complete.)*
+
+- **Sender:** `buildAdvertisementPayload` returns `complete: true` **only when zero bots were
+  skipped** (i.e. the `catch` at `:194` never fired).
+- **Receiver:** `doFetch` (`advertised-bots-cache.js:48-56`) downgrades to `complete: false` when
+  `raw.length !== bots.length` (a `validateBot` drop, `:54`), and returns
+  **`status:"unavailable"`** — not `ok` with an empty list — when the body is not `{bots:[…]}`.
+- **The prune requires `status === "ok" && complete === true`.** An old peer sends no key ⇒
+  `complete` is falsy ⇒ **never prunes**. Fail-safe by construction, across the whole rolling
+  deploy window.
+
+An **intentionally** un-advertised bot (deleted, disabled, `allow_paired_instances` off) is simply
+absent and *is* prunable — that is the product semantic, and it is documented: *disabling or
+un-advertising a bot removes it from paired instances' directories and prunes the zero-message
+contacts auto-added from it.* F1 draws the line at **error vs intent**, which is the distinction the
+code currently loses. (A6 in §4 is the precise long-term fix.)
+
+### F2 — `contacts.advertised_by_instance_id` (the FACT) — ⚠️ **SCHEMA BUMP 6 → 7**
+
+`init-db.js`: `addColumnIfMissing("contacts", "advertised_by_instance_id", "TEXT")`.
+`servers/shared/schema-version.js:13`: `SCHEMA_GENERATION = 7`.
+
+- **Set at INSERT only** (F5) = the instance_id of the peer whose directory the bot was added from.
+- **Synced** (deliberately *not* in `EXCLUDED_COLUMNS`) — a portable fact (§0).
+- **`NULL` ⇒ never prunable.** Manual and pasted-invite contacts are structurally safe, which
+  *dissolves* #155 §2.6's objection instead of arguing around it.
+- Every existing row is NULL (§0 fact 3) ⇒ no data migration.
+
+### F3 — `origin` is a judgment: strip it from the wire (fixes D2)
+
+Add `"origin"` to `EXCLUDED_COLUMNS.contacts` (`instance-sync.js:101`) **and** `ALWAYS_DROP`
+(`:1453`). R3 verified this is safe: **`shouldSyncRow` runs on the raw row at `:962`, *before* the
+strip at `:979`**, so the `origin='local-bot'` sync gate is unaffected. `origin` remains a local
+marker (it still drives the `is_bot` backfill at `init-db.js:2748`), but **the prune no longer keys
+on it** — it keys on F2's fact.
+
+### F4 — the prune, rewritten (fixes D3 + D4)
+
+**Call-site split (R3/MAJOR-6 — this is a real bug today):** `getBotDirectory` currently *calls the
+prune as a side effect* (`data-queries.js:275`). F5's handler needs the directory to resolve the
+advertiser, which would make **clicking "Add" durably delete other contacts**. So `getBotDirectory`
+gains `{ prune: false }` (default for every non-render caller) and **returns the per-instance map**;
+only the Messages/Contacts **render** invokes the prune.
+
+`perInstance: Map<instanceId, { ok, complete, pubkeys: Set }>`.
+
+```sql
+SELECT c.id, c.crow_id, c.lamport_ts, c.secp256k1_pubkey, c.advertised_by_instance_id
+FROM contacts c LEFT JOIN messages m ON m.contact_id = c.id
+WHERE c.advertised_by_instance_id IS NOT NULL
+GROUP BY c.id HAVING COUNT(m.id) = 0
+```
+*(`crow_id` and `lamport_ts` are called out because v2's helper read them from a SELECT that
+fetched neither — R2/C4. A missing `crow_id` must **warn and skip**, never rely on
+`writeTombstone`'s silent no-op.)*
+
+Prune row R **iff all** hold:
+1. `R.advertised_by_instance_id !== localInstanceId` — **the host never prunes its own bot** (a
+   fact, replacing the near-inert `origin='local-bot'` guard);
+2. that instance is a **trusted peer queried this cycle**;
+3. it answered **`ok` AND `complete`** (F1);
+4. R's x-only pubkey is absent from **that instance's** advertised set **and** from every other
+   `ok`+`complete` peer's set *(the second clause closes R3/MINOR-7: `getBotDirectory:250` dedups
+   on first-seen pubkey, so a bot advertised by two instances could otherwise be pruned while still
+   live)*;
+5. R has **zero messages** — the prune never destroys history.
+
+Then, via a new `servers/sharing/contact-prune.js`: `unwireContact` (`contact-delete.js:94` — also
+fixes a pre-existing Nostr-subscription leak) → `DELETE FROM contacts WHERE id = ?` →
+**`writeTombstone(db, R.crow_id, R.lamport_ts)` — LOCAL, no emit.**
+
+> **Tombstone lamport = `R.lamport_ts` (the pruned row's own), NOT a fresh counter value.**
+> This is R3/CRITICAL-1's fix, and it is the whole of it. v3 wrote `_nextLamport()`, which burns a
+> **local** counter invisible to the fleet (the prune emits nothing) — so two instances pruning
+> independently landed on tombstones the *re-adder's* insert could tie with, and the gate drops
+> ties (`:1538` `lamportTs <= tomb.lamport_ts`). At 4385/4385/4384 (§0 fact 4) that is a coin flip
+> ending in **permanent, unrecoverable divergence**. Using the row's own lamport makes the gate
+> exactly right with **no new column and no manager access**: a replay of an already-seen `insert`
+> is `<= R.lamport_ts` ⇒ dropped; a genuine re-add is emitted at the re-adder's next lamport, which
+> is necessarily `> R.lamport_ts` (its counter advanced past that row when it applied it) ⇒
+> **applies and clears the tombstone.** The existing gate needs no `kind` column: `op="update"` is
+> dropped unconditionally (`:1537`), and **every** D3 resurrection vector is an `update`.
+
+**Why this converges with no broadcast:** every instance paired with X evaluates the same rule
+against its own view of X and prunes independently ⇒ **"gone on both sides", the plan's acceptance
+criterion.** An instance *not* paired with X fails rule 2, keeps its copy (fail-safe), and its
+updates are dropped by the pruner's tombstone — so the pruner stays clean either way.
+
+### F5 — one shared `acceptBotInvite()`; classification never crosses the MCP surface
+
+Extract `acceptBotInvite(db, managers, { inviteCode, displayName, advertisedByInstanceId })` into
+`servers/sharing/accept-bot-invite.js`. **Both** the MCP tool (`tools/contacts.js:358`, **schema
+unchanged**) and the two panel handlers call it **directly** — the panels already import from
+`servers/sharing/`, so no MCP round-trip. This kills v2's unbuildable `deferEmit` *and* R1/M3 (a
+model must never be able to stamp a contact prunable).
+
+On the create branch, in one place: INSERT carrying `origin='advertised'`, `is_bot=1`,
+`advertised_by_instance_id=X` when the caller supplies X (panels) — or plain `origin=NULL,
+is_bot=0, advertised_by=NULL` when not (MCP paste: **byte-identical to today**) → `clearTombstone`
+→ **exactly one** `emitContactChange("insert", row)`. `insert` is load-bearing: it is the only op
+that passes a peer's tombstone gate (`:1538-1539`), so a re-add after a prune actually lands.
+`markContactIsBot` is retained on the already-a-contact branch (unchanged).
+
+**Where the panel gets X:** from a **prune-free** `getBotDirectory({prune:false})` read — parse the
+invite → x-only pubkey → the instance advertising it. Authoritative and unspoofable (never from the
+form).
+
+### ~~F6~~ — **DROPPED** (R3/MAJOR-3)
+
+v3 proposed guarding the same-secp rebind (`:1562-1582`) against a standing tombstone. R3 proved
+that clause is **unreachable**: the tombstone gate (`:1536-1541`) already returns for `op="update"`
+and for `insert <= tomb.lamport_ts`, so by the time control reaches the rebind, "tombstone lamport ≥
+entry's" is **false by construction**. It would have shipped as dead code with a green test.
+
+The *other* half — the rebind promoting a `req:` pending row to a full contact because
+`request_status` is not in `EXCLUDED_COLUMNS` — is on inspection **arguably correct** Phase-3
+behaviour (only the operator's own instances can emit, so the `insert` means *the user accepted this
+bot on another instance*, and contacts follow the user). **Not fixed here; filed for investigation
+(§6.4)** rather than "hardened" on a hunch. F4's durability does not depend on it.
+
+---
+
+## 4. Rejected alternatives
+
+| # | Alternative | Why rejected |
+|---|---|---|
+| A1 | Exclude `origin='advertised'` from `shouldSyncRow` | **Inert** (D1); loses pasted-invite bots (#155 R2/MAJOR-2). Forbidden by the plan. |
+| A2 | Prune broadcasts a delete-wins tombstone (**v1**) | §2 — zero-feed silent no-broadcast; inert host guards ⇒ cascades the host's own bot's DM history; LWW asymmetry ⇒ divergence + conflict growth. |
+| A3 | Local-only tombstone, accept divergence (**v2**) | §2 — unbuildable `deferEmit`; silent-no-op helper; durable tombstone on an unsound trigger = net regression. |
+| A4 | Delete the prune entirely | Honest; abandons a shipped feature and lets dead contacts accumulate. Fallback only if F4 fails review again. |
+| A5 | Derive `origin='advertised'` per-render from the live set | Also stamps **manually-added** invite-code bots that happen to be advertised ⇒ prunable ⇒ re-introduces the §2.6 loss. |
+| A6 | Host-authoritative bot-deletion propagation | Sound and strictly more precise (distinguishes *deleted* from *disabled*), but a **new mechanism** (bot-delete hook + wire delete + a DM-history-cascade decision) that needs F1/F2 anyway. **Filed (§6.1).** F2+F4 deliver the plan's acceptance without it. |
+
+---
+
+## 5. Test plan (TDD — RED first; every rule gets a mutation check)
+
+Scratch env: `CROW_HOME`+`CROW_DATA_DIR` (mkdtemp), `CROW_DISABLE_NOSTR=1`,
+`CROW_DISABLE_INSTANCE_SYNC=1`. Gate = the 3 known pre-existing scratch failures, zero others.
+
+1. **F1.** Sender: a bot whose identity throws ⇒ **no** `complete` key (and still 200); a clean
+   payload ⇒ `complete:true`. Receiver: a `validateBot` drop (`raw.length !== bots.length`) ⇒
+   `complete:false`; a non-`{bots:[…]}` body ⇒ `status:"unavailable"`. **An old peer (no key) ⇒
+   never prunes** — the rolling-deploy guard. *Mutation: make `complete` default-true ⇒ named test red.*
+2. **F5 / D1.** Panel add ⇒ **exactly one** emit, `op="insert"`, payload carries `is_bot=1` **and**
+   `advertised_by_instance_id=X`; row has `origin='advertised'`. MCP-tool path ⇒ still emits its own
+   `insert`; row is `origin=NULL, is_bot=0, advertised_by=NULL` (**emit-coverage regression guard**).
+   *Mutation: drop the panel emit ⇒ red.*
+3. **F3 / D2.** An emitted payload has **no `origin` key**. An inbound entry carrying
+   `origin:'advertised'` never writes `origin` locally — in **both** shapes: local row is
+   `'local-bot'` (unchanged) and **local row absent** (inserts with `origin` NULL — the real fleet
+   shape). *Mutation: remove `origin` from `EXCLUDED_COLUMNS` ⇒ all red.*
+4. **F4 — the trigger matrix.** Advertiser `ok`+`complete`, bot absent ⇒ pruned. Advertiser
+   `unavailable` ⇒ **not**. Advertiser `ok` but **not `complete`** ⇒ **not** *(the R3/CRITICAL-2
+   case)*. Bot absent from a *different* peer's list but present in its advertiser's ⇒ **not**. Bot
+   advertised by a **second** peer ⇒ **not** *(R3/MINOR-7)*. `advertised_by == me` ⇒ **not**
+   *(host protection)*. `advertised_by IS NULL` ⇒ **not** *(manual contact)*. Row **with messages**
+   ⇒ **not**. *Mutation: each of the seven conditions individually ⇒ a named test red.*
+5. **F4 — the headline (D3).** Two in-process instances on a shared feed. A prunes ⇒ row gone,
+   tombstone at **`row.lamport_ts`**; B emits `update` ⇒ **A does not resurrect**; restart A ⇒ still
+   gone. Negative control: a still-advertised contact syncs normally throughout.
+   *Mutation: bare DELETE ⇒ the resurrection assertion goes red.*
+6. **F4 — the lamport-tie regression (R3/CRITICAL-1). MANDATORY — v3's §5 was structurally
+   incapable of catching this.** **BOTH** instances prune (mutual GC, the case v3's plan omitted),
+   *then* the one with the **lower** counter re-adds and emits `insert`. The other **must** apply it
+   and clear its tombstone. Assert with counters deliberately set to a **tie** and to
+   **re-adder < peer**. *Mutation: write the tombstone at a fresh `_nextLamport()` instead of
+   `row.lamport_ts` ⇒ this test goes red (and every other test stays green — which is precisely why
+   v3 shipped the bug).*
+7. **F4 — convergence (the plan's acceptance).** Two instances **both** paired with advertiser X,
+   both holding the contact (one added it; the other got it by sync **with `advertised_by=X` on the
+   wire**). X un-advertises ⇒ **both** prune independently, **no delete on the wire**, `sync_conflicts`
+   unchanged on both.
+8. **R3/MAJOR-6.** `getBotDirectory({prune:false})` performs **zero** deletes (the add path must
+   never GC). *Mutation: default `prune` to true ⇒ red.*
+9. **`sync_conflicts` byte-identical** before/after every scenario (baselines: crow 219 / MPA ? /
+   grackle 162 / black-swan 0 — re-measure MPA).
+10. **Documented, not fixed (R1/M4).** After a prune, a DM from the still-running bot creates a
+    `req:<secp>` message-request row. Asserted so the behaviour is *chosen*, not discovered.
+
+**Live (crow ↔ grackle ↔ MPA).** Per §0 fact 1 nothing is advertised: create a **throwaway** bot on
+grackle with `allow_paired_instances=true` (Kevin's three defs untouched) → add it on crow from the
+directory → confirm the contact **and its `advertised_by_instance_id`** reach MPA over the wire →
+un-advertise on grackle → force a render → confirm it is pruned on crow **and independently on
+MPA**, with **no delete on the wire** → confirm crow does not resurrect on a grackle update →
+restart both → still gone → `sync_conflicts` unchanged on all four → delete the throwaway bot.
+**Before starting: `fuser ~/.crow/data/crow.db` and kill stale stdio MCP children** — `_contactCols`
+is memoized for the SyncManager's lifetime (`instance-sync.js:1440-1446`), so a process started
+before the migration silently drops the new column from every entry it applies (R3/MINOR-8).
+Evidence → `~/.crow/p4/2a-prune/`.
+
+---
+
+## 6. Follow-ups filed (append to the plan queue)
+
+1. **A6 — host-authoritative bot-deletion propagation.** The only mechanism that distinguishes
+   *deleted* from *disabled*.
+2. **[REAL BUG in shipped code — R1/C1] `emitChange` returns a valid lamport with
+   `outFeeds.size === 0`** (`instance-sync.js:1027-1036`). So **#155's user-initiated contact
+   delete**, if it lands in the boot window, writes a tombstone, broadcasts to **nobody**, and
+   thereafter silently drops the peer's updates (`:1537`) ⇒ permanent divergence, no error.
+   `backfillContactsOnce:612` already guards that window — comment records it **observed live on
+   grackle**. **→ Item 2c.**
+3. **[LATENT — R1/C2] Every `origin='local-bot'` guard is weaker than it reads**
+   (`shouldSyncRow:204`, `deleteContactLocal:143`, `wireSyncedContact:111`), because a host usually
+   has no row for its own bot (§0 fact 2). F2's fact protects the *prune* path; the others remain
+   exposed — e.g. #155's user delete can cascade-delete a host's own bot contact. Fix = recognise
+   own bots **by key** (`deriveBotIdentity`), or materialise the `local-bot` row at boot.
+4. **[INVESTIGATE — R2/M3, R3/MAJOR-3] The same-secp rebind promotes a `req:` pending row** to a
+   full contact (`request_status` is not in `EXCLUDED_COLUMNS`). Probably correct (contacts follow
+   the user), but undecided — decide it deliberately rather than by omission.
+
+**Residual, accepted:** *disable ≠ delete* (an intentionally disabled bot prunes zero-message
+contacts on paired instances — no history is ever destroyed, and re-advertising makes it re-addable);
+a peer not paired with the advertiser keeps its copy (fail-safe); a pruned-but-running bot's DM
+appears as a *message request*, not a resurrection.
+
+---
+
+## 7. ⚠️ The migration rail is INSUFFICIENT — and this blocks **2b**, not just 2a (R3/MAJOR-4)
+
+**Verified:** `needsSchemaInit` (`schema-version.js:21-25`) → `userVersion < SCHEMA_GENERATION` →
+`gateway/index.js:134` runs **the entire `scripts/init-db.js`**, not just the new column. That file
+contains **8 `DROP TABLE`** statements — `shared_items` (`:493`), `crow_context` (`:1275`),
+`dashboard_settings` (`:1834`), `research_projects` (`:2696`), a generic `DROP TABLE ${tableName}`
+(`:926`), plus `DELETE FROM schedules` (`:2726`) and `DELETE FROM project_spaces` (`:1023`).
+
+These are *guarded rebuild-migrations*, but **they have not run since gen 6 was stamped**, and a bump
+re-arms every one of them against **four** live production DBs (crow, MPA, grackle, black-swan — all
+at `user_version = 6`).
+
+**The plan's rail cannot detect the damage it exists to prevent.** `PRAGMA integrity_check` reports
+*page-level* integrity — it returns `ok` for a table that was rebuilt having silently lost rows.
+`user_version = 7` proves only that the script reached its last line.
+
+**Required rail addition, before ANY schema-bumping PR (2a or 2b) merges:**
+> Run `node scripts/init-db.js` against a **COPY** of each of the four prod DBs and **diff
+> `sqlite_master` + per-table `COUNT(*)` pre/post**. Zero unexplained deltas is a merge gate. Ship
+> the diff as evidence. (Also: init-db does heavy DDL against a DB the gateway holds open —
+> `"database is locked"` is a documented recurring failure on this fleet. Stop the gateway first.)
+
+---
+
+## 8. Status: design complete, implementation deliberately NOT started
+
+Three adversarial rounds killed three designs; **v4's architecture was attacked directly by R3 and
+held.** What remains is a build with a genuinely dangerous tail: a `SCHEMA_GENERATION` bump against
+four production databases whose migration rail I have just proven insufficient (§7).
+
+Starting that build at the end of a long session — with the rail unfixed, the dry-run diff not yet
+run, and a live proof that requires creating and then removing a throwaway advertised bot on
+grackle — is exactly the unattended risk the plan's own rules exist to prevent. **The honest
+deliverable of this session is the vetted design plus three production bugs found on the way** (§6.2,
+§6.3, §7). The build is a clean, well-specified fresh-session job.
+
+**Sequencing recommendation:** fix the rail (§7) **first**, as its own small PR — it gates 2b as
+much as 2a.
+
+---
+
+## 9. Review record
+
+- **R1 (Opus) — REVISE, 4 CRIT.** Killed v1. Its structural advice ("take A4, the fact-column") was
+  right, though not for its stated reason (a sounder *trigger*): the fact-column is right because it
+  moves the *judgment* to the only instance entitled to make it.
+- **R2 (Opus) — REJECT, 4 CRIT + 3 MAJOR.** Killed v2 and proposed the fact/judgment split.
+- **R3 (Opus) — REJECT, 2 CRIT + 4 MAJOR.** Killed v3's *mechanisms* while **confirming its spine**
+  under direct attack (portable instance ids; host protection; per-advertiser trigger; the schema
+  bump is load-bearing, not theater). Found the lamport-tie divergence, the negative-`partial`
+  regression, the unreachable F6 clause, the **init-db rail hazard (§7)**, the un-measured MPA DB,
+  and that `getBotDirectory` prunes as a side effect of an *add*.
+
+Every CRITICAL from every round was **independently re-verified by the authoring session against the
+code and the live DBs before folding** — the reviewers are not trusted either. Three separate times a
+reviewer caught §0 measuring the wrong table; that is the Item-1 lesson (*compute host-state rules
+against the real host*) refusing to be learned cheaply.


### PR DESCRIPTION
**Docs only — no code.** Item 2a of the autonomous arc turned out to be design-shaped in a way the plan did not anticipate. Three adversarial review rounds killed three designs; the fourth held. This PR ships the vetted design, three production bugs found on the way, and a correction to the migration rail that **gates Item 2b as much as 2a**.

## Why no code

The design that survives requires a **`SCHEMA_GENERATION` bump (6→7)** — and while proving that out I found the plan's migration rail cannot detect the damage it exists to prevent (below). Starting a four-database migration at the tail of a long session, on an unfixed rail, is exactly the unattended risk the plan's own rules forbid. The prune is also **doubly latent** — `allow_paired_instances` is false on all three bot definitions fleet-wide, so nothing is advertised and *the prune has never fired*. There is no urgency, only a correctness bar.

## The design (spec §3)

Three designs died before this one:

- **v1** — the prune broadcasts a delete-wins tombstone. `emitChange` returns a valid lamport when `outFeeds.size === 0`, so the broadcast can go nowhere and still report success; the `origin='local-bot'` host guards are inert (exactly **one** such row exists fleet-wide); and delete-vs-update LWW is asymmetric, diverging a non-complete pairing graph while growing `sync_conflicts`.
- **v2** — local-only tombstone. `deferEmit` cannot cross the MCP boundary (zod strips unknown keys); the helper read `crow_id` from a `SELECT` that never fetched it, and `writeTombstone` silently no-ops on a falsy id — the headline fix would have shipped as a **no-op**; and a durable tombstone on an unsound trigger is a **net regression**, since a peer answers **200 with a bot missing** when it is merely *disabled* or hits a locked DB.
- **v3** — writing the tombstone at a fresh lamport produced **permanent, unrecoverable divergence on a tie**. The fleet's counters are sitting at 4385 / 4385 / 4384 right now.

**v4's surviving insight:** `origin` is a **judgment** ("I may garbage-collect this") — view-relative, and it must not sync. *"Instance X advertised this bot"* is a **fact** — true everywhere, so it syncs safely and lets every instance re-derive prunability **from its own view**. That converges with **no broadcast, no delete on the wire, and no host authority**, and it protects the bot's host for free (`advertised_by == me` ⇒ never prune) with a fact instead of the near-inert `origin='local-bot'` column. R3 attacked that spine directly and could not break it.

## ⚠️ The migration rail was unsafe — this blocks 2b too

A `SCHEMA_GENERATION` bump does **not** run "just the new migration". `needsSchemaInit` → `gateway/index.js:134` runs **the entire `scripts/init-db.js`**, which carries **8 `DROP TABLE`** rebuild-migrations (`shared_items`, `crow_context`, `dashboard_settings`, `research_projects`, a generic `DROP TABLE ${tableName}`) plus `DELETE FROM schedules` / `project_spaces`. They are guarded, but **they have not run since gen 6 was stamped**, and a bump re-arms every one of them against **four** live DBs (crow, **MPA — easy to forget**, grackle, black-swan; all verified at `user_version = 6`).

And the old rail could not see the damage: `PRAGMA integrity_check` reports *page-level* integrity and returns `ok` for a table rebuilt having silently lost rows, while `user_version = 7` proves only that the script reached its last line.

The rail now requires a **dry-run gate**: run `init-db` against a **copy** of each of the four prod DBs and diff `sqlite_master` + per-table `COUNT(*)` pre/post, with zero unexplained deltas as a merge gate. **Recommendation: land the rail fix as its own small PR before any schema-bumping work.**

## Bugs found on the way (filed, not fixed here)

1. **[real, in shipped code]** `emitChange` returns a lamport with zero feeds — so **#155's user-initiated contact delete**, if it lands in the boot window, tombstones locally, broadcasts to **nobody**, and thereafter silently drops the peer's updates ⇒ permanent divergence, no error. `backfillContactsOnce:612` already guards that exact window; its comment records it *observed live on grackle*. → fold into **2c**.
2. **[latent]** Every `origin='local-bot'` guard is weaker than it reads, because a bot's host usually has **no contacts row for its own bot** at all.
3. **[today]** `getBotDirectory` **prunes as a side effect of a read**, so the add path would durably delete contacts.

## Verification

Docs-only; no runtime surface. Every CRITICAL from all three rounds was independently re-verified by the authoring session against the code and the live DBs before folding — three separate times a reviewer caught the spec's own §0 measuring the wrong table, which is the Item-1 lesson (*compute host-state rules against the real host*) refusing to be learned cheaply.
