### PR TITLE
feat(scripts): schema-bump dry-run gate — prove init-db preserves every row before merging

### DIFF
--- a/docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md
+++ b/docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md
@@ -250,11 +250,25 @@ integrity — it returns `ok` for a table that was rebuilt having silently lost 
 1. Disable auto-update on all boxes FIRST (Settings → Updates, or set
    `auto_update_enabled=false`); confirm each box reports it disabled.
 2. Back up **all four** DBs (`crow.db.pre-<slug>-<ts>`), verify each exists and is non-zero.
-3. **DRY-RUN GATE (new, mandatory):** run `node scripts/init-db.js` against a **COPY** of each
-   of the four prod DBs and **diff `sqlite_master` + per-table `COUNT(*)` pre/post**. Zero
-   unexplained deltas is a merge gate; ship the diff as evidence. (Stop the gateway before any
-   real run — init-db does heavy DDL against a DB the gateway holds open, and
-   `"database is locked"` is a documented recurring failure on this fleet.)
+3. **DRY-RUN GATE (new, mandatory) — `scripts/schema-migration-dryrun.sh`.** It copies each DB,
+   runs `init-db` against the copy, and diffs `sqlite_master` + per-table `COUNT(*)` pre/post.
+   Zero unexplained deltas is the merge gate; ship the output as evidence. **Run it from the
+   bump-bearing branch** (that is the point — it must exercise YOUR migration):
+   ```
+   grackle "cp ~/.crow/data/crow.db /tmp/g.db"; scp kh0pp@100.121.254.89:/tmp/g.db /tmp/grackle.db
+   ssh black-swan "cp ~/.crow/data/crow.db /tmp/b.db"; scp black-swan:/tmp/b.db /tmp/bswan.db
+   scripts/schema-migration-dryrun.sh crow ~/.crow/data/crow.db mpa ~/.crow-mpa/data/crow.db \
+     grackle /tmp/grackle.db bswan /tmp/bswan.db
+   ```
+   For a well-behaved additive migration the ONLY deltas are your new column/table and
+   `user_version`; every row count is unchanged. Any unexplained row-count delta or lost table
+   is a STOP.
+   **Baseline established 2026-07-12 (gen 6, unmodified main): the gate PASSES on all four prod
+   DBs — zero schema deltas, zero row-count deltas, nothing lost.** So the 8 `DROP TABLE`
+   rebuild-migrations are empirically **inert on this fleet's real data**, and a bump is
+   de-risked — *provided you re-run the gate on your branch and it still passes.*
+   (Stop the gateway before any REAL migration run — init-db does heavy DDL against a DB the
+   gateway holds open, and `"database is locked"` is a documented recurring failure here.)
 4. Merge.
 5. Deploy manually, in the §3 runbook order, one box at a time; verify health +
    `PRAGMA integrity_check` + **the per-table row-count diff** + the migration's own acceptance

--- a/scripts/schema-migration-dryrun.sh
+++ b/scripts/schema-migration-dryrun.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Schema-bump dry-run gate.
+#
+# WHY: bumping SCHEMA_GENERATION does NOT run "just your new migration".
+# needsSchemaInit (servers/shared/schema-version.js) -> servers/gateway/index.js
+# runs the ENTIRE scripts/init-db.js, which contains 8 DROP TABLE
+# rebuild-migrations (shared_items, crow_context, dashboard_settings,
+# research_projects, a generic DROP TABLE ${tableName}) plus DELETE FROM
+# schedules / project_spaces. They are guarded, but they have not executed since
+# the current generation was stamped, and a bump re-arms every one of them
+# against every live DB in the fleet.
+#
+# And PRAGMA integrity_check CANNOT detect the damage: it reports page-level
+# integrity and returns "ok" for a table that was rebuilt having silently lost
+# rows. user_version = <new> only proves the script reached its last line.
+#
+# So: before ANY schema-bumping PR merges, run init-db against a COPY of each
+# prod DB and diff sqlite_master + per-table COUNT(*) pre/post. Zero unexplained
+# deltas is the merge gate. Never point this at a live DB — it always copies.
+#
+# USAGE:
+#   scripts/schema-migration-dryrun.sh <label> <path-to-db> [<label> <db> ...]
+#
+# The whole fleet (run from crow; pull the remote DBs to local copies first):
+#   scripts/schema-migration-dryrun.sh \
+#     crow    ~/.crow/data/crow.db \
+#     mpa     ~/.crow-mpa/data/crow.db \
+#     grackle /tmp/grackle.db \
+#     bswan   /tmp/bswan.db
+#
+# EXPECTED OUTPUT for a well-behaved additive migration: the only schema delta is
+# your new column/table, user_version advances, and every row count is unchanged.
+# ANY unexplained row-count delta or lost table is a STOP.
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILED=0
+
+snapshot() { # $1=db  $2=out-prefix
+  sqlite3 "$1" \
+    "SELECT type||' '||name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY 1;" \
+    > "$2.schema" 2>/dev/null
+  : > "$2.counts"
+  local t n
+  for t in $(sqlite3 "$1" "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;" 2>/dev/null); do
+    n=$(sqlite3 "$1" "SELECT COUNT(*) FROM \"$t\";" 2>/dev/null || echo ERR)
+    printf '%s\t%s\n' "$t" "$n" >> "$2.counts"
+  done
+}
+
+dryrun_one() { # $1=label  $2=src-db
+  local label="$1" src="$2"
+  local work cp rc pre_uv post_uv integ
+  if [ ! -f "$src" ]; then
+    echo "════════ $label ════════"
+    echo "  SKIP — no such DB: $src"
+    return 0
+  fi
+  work="$(mktemp -d)"; cp="$work/crow.db"
+  cp "$src" "$cp" || { echo "[$label] COPY FAILED"; FAILED=1; return 1; }
+
+  snapshot "$cp" "$work/pre"
+  pre_uv=$(sqlite3 "$cp" "PRAGMA user_version;")
+
+  ( cd "$REPO_ROOT" && CROW_DB_PATH="$cp" node scripts/init-db.js ) > "$work/init.log" 2>&1
+  rc=$?
+
+  snapshot "$cp" "$work/post"
+  post_uv=$(sqlite3 "$cp" "PRAGMA user_version;")
+  integ=$(sqlite3 "$cp" "PRAGMA integrity_check;" | head -1)
+
+  echo "════════ $label ════════"
+  echo "  init-db exit=$rc   user_version: $pre_uv -> $post_uv   integrity: $integ"
+  [ "$rc" -ne 0 ] && FAILED=1
+  [ "$integ" != "ok" ] && FAILED=1
+
+  echo "  ── schema objects added/removed ──"
+  if diff "$work/pre.schema" "$work/post.schema" | grep -qE '^[<>]'; then
+    diff "$work/pre.schema" "$work/post.schema" | grep -E '^[<>]' | sed 's/^/    /'
+  else
+    echo "    (none)"
+  fi
+
+  echo "  ── ROW-COUNT DELTAS (what integrity_check cannot see) ──"
+  if join -t$'\t' "$work/pre.counts" "$work/post.counts" 2>/dev/null \
+       | awk -F'\t' '$2!=$3 {print "    " $1 ": " $2 " -> " $3}' | grep -q .; then
+    join -t$'\t' "$work/pre.counts" "$work/post.counts" \
+      | awk -F'\t' '$2!=$3 {print "    " $1 ": " $2 " -> " $3}'
+    echo "    ^^^ STOP — unexplained row loss"
+    FAILED=1
+  else
+    echo "    (none — all preserved tables identical)"
+  fi
+
+  echo "  ── tables that DISAPPEARED ──"
+  if comm -23 <(cut -f1 "$work/pre.counts" | sort) <(cut -f1 "$work/post.counts" | sort) | grep -q .; then
+    comm -23 <(cut -f1 "$work/pre.counts" | sort) <(cut -f1 "$work/post.counts" | sort) | sed 's/^/    LOST: /'
+    FAILED=1
+  else
+    echo "    (none)"
+  fi
+
+  [ "$rc" -ne 0 ] && { echo "  ── init-db errors ──"; tail -5 "$work/init.log" | sed 's/^/    /'; }
+  rm -rf "$work"
+}
+
+[ $# -lt 2 ] && { grep '^# ' "$0" | sed 's/^# \?//' | head -32; exit 2; }
+while [ $# -ge 2 ]; do dryrun_one "$1" "$2"; shift 2; echo; done
+
+if [ "$FAILED" -eq 0 ]; then
+  echo "✅ DRY-RUN GATE PASSED — no unexplained schema or row-count deltas."
+  exit 0
+fi
+echo "❌ DRY-RUN GATE FAILED — do NOT merge the schema bump."
+exit 1


### PR DESCRIPTION
Makes the migration rail's new dry-run requirement (PR #175) an executable gate instead of prose. **Prerequisite for the pending Item 2a and 2b schema bumps.**

## The problem

Bumping `SCHEMA_GENERATION` does **not** run "just your new migration". `needsSchemaInit` → `servers/gateway/index.js:134` runs **the entire `scripts/init-db.js`**, which carries **8 `DROP TABLE`** rebuild-migrations (`shared_items`, `crow_context`, `dashboard_settings`, `research_projects`, a generic `DROP TABLE ${tableName}`) plus `DELETE FROM schedules` / `project_spaces`. They're guarded — but **they have not executed since gen 6 was stamped**, so a bump re-arms every one of them against every live DB in the fleet. There are **four** here, all at `user_version = 6`: crow, **MPA (`~/.crow-mpa` — the easy one to forget)**, grackle, black-swan.

And the existing rail could not detect the damage. `PRAGMA integrity_check` reports *page-level* integrity — it returns `ok` for a table that was rebuilt having silently lost rows — and `user_version = <new>` only proves the script reached its last line.

## The gate

`scripts/schema-migration-dryrun.sh <label> <db> [<label> <db> …]` copies each DB, runs `init-db` against the **copy**, and diffs `sqlite_master` + per-table `COUNT(*)` pre/post. Any unexplained row-count delta or lost table fails the run (exit 1). It never touches a live DB.

Run it **from the bump-bearing branch** — the point is to exercise *your* migration. For a well-behaved additive migration the only deltas are your new column and `user_version`; every row count is unchanged.

## Result on unmodified main (gen 6) — the reason this is good news

```
════════ crow ════════      init-db exit=0   user_version: 6 -> 6   integrity: ok
════════ mpa ════════       init-db exit=0   user_version: 6 -> 6   integrity: ok
════════ grackle ════════   init-db exit=0   user_version: 6 -> 6   integrity: ok
════════ bswan ════════     init-db exit=0   user_version: 6 -> 6   integrity: ok
  schema objects added/removed: (none)
  ROW-COUNT DELTAS:             (none — all preserved tables identical)
  tables that DISAPPEARED:      (none)
✅ DRY-RUN GATE PASSED
```

**All four production DBs are clean** — `init-db` is idempotent on every one of them. So the 8 `DROP TABLE` migrations are **empirically inert on this fleet's real data**. The hazard is real in mechanism but does not fire here, which materially **de-risks the pending 2a/2b bumps** — provided the gate is re-run on the bump-bearing branch and still passes.

## Verification

- Gate script: `bash -n` clean; executed against copies of all four prod DBs (output above); exit 0.
- `node scripts/build-registry.mjs --check` → OK.
- `node scripts/check-port-allocation.js` → the single known error, `Port 8090 (capstone-tracker)` (untracked local WIP, invisible to CI). The `Port 8080` line is a pre-existing **WARN**, allowlisted in `known-port-conflicts.json`.
- Full suite on a scratch `CROW_HOME`/`CROW_DATA_DIR`.
- No runtime surface: a new shell script plus the plan doc.
