### PR TITLE
fix(sync): advertised-contact prune — durable, fail-safe, convergent (Item 2a, SCHEMA 6→7)

### DIFF
--- a/docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md
+++ b/docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md
@@ -299,18 +299,50 @@ that passes a peer's tombstone gate (`:1538-1539`), so a re-add after a prune ac
 invite → x-only pubkey → the instance advertising it. Authoritative and unspoofable (never from the
 form).
 
-### ~~F6~~ — **DROPPED** (R3/MAJOR-3)
+### F6 — dropped by R3, **RESTORED by R5/CRITICAL-2** (the premise had been deleted)
 
-v3 proposed guarding the same-secp rebind (`:1562-1582`) against a standing tombstone. R3 proved
-that clause is **unreachable**: the tombstone gate (`:1536-1541`) already returns for `op="update"`
-and for `insert <= tomb.lamport_ts`, so by the time control reaches the rebind, "tombstone lamport ≥
-entry's" is **false by construction**. It would have shipped as dead code with a green test.
+> #### 🔴 R5 — "F6 is unreachable" was true of v3 and FALSE of v5. Nobody re-derived it.
+> R3 dropped F6 (a guard on the same-secp rebind) as **unreachable**, and it was right *at the time*:
+> the tombstone gate returned for `op="update"` **and** for `insert <= tomb.lamport_ts`, so by the
+> time control reached the rebind, "a tombstone is standing" was **false by construction**.
+>
+> **`kind='prune'` deleted exactly that premise.** A prune tombstone deliberately does **not** gate an
+> `insert` on lamport (that is R4's whole fix) — so a standing GC tombstone now coexists with a
+> reachable rebind, and F6's clause went from dead code to a live hole in one commit. **The dropped
+> finding was never re-derived against the design that replaced it.**
+>
+> **The resurrection, on top of §5 test 10's own state:**
+> 1. the contact is pruned (GC tombstone standing, row gone);
+> 2. the bot is un-advertised, **not dead** — it DMs us, and §5.10 files that under a `req:<secp>`
+>    placeholder row **carrying the message**;
+> 3. a **replayed ORIGINAL `insert`** arrives (feed replay after a re-pair or a DB restore — this
+>    fleet has had both). It misses on `crow_id`, matches the placeholder on **secp**, and **REBINDS
+>    it**: the pruned bot is back, **carrying that DM**.
+> 4. And now it *has* a message ⇒ prune **rule 5** (`HAVING COUNT(m.id) = 0` — "the prune never
+>    destroys history") **blocks it from EVER being re-pruned.**
+>
+> So the claim that licenses letting replayed inserts through — *"worst case a redelivered ORIGINAL
+> insert re-creates the row and the next render simply RE-PRUNES it. Self-healing."* — was **FALSE**.
+> Defect **D3**, restored.
+>
+> **The fix (narrow, and verified against the schema):** `contacts` is `UNIQUE` on **`crow_id` only**
+> — there is no unique index on `secp256k1_pubkey` — so a `crow:<botid>` row and a `req:<secp>` row
+> may coexist. When a **`kind='prune'`** tombstone stands **and** the same-secp match is a **`req:`**
+> placeholder, skip the rebind and fall through to a plain INSERT. The re-add lands **fresh,
+> zero-message, and RE-PRUNABLE** (self-healing genuinely restored) and the DM stays on the message
+> request — which is exactly the semantic §5.10 documents. The rebind is **not** disabled generally:
+> it remains load-bearing for the ordinary `req:` → `crow:` handshake promotion.
+>
+> **The lesson:** a finding dropped as *unreachable* is only as good as the premise that made it so.
+> When a later change deletes that premise, the dropped finding is **live again** — and nothing in
+> the process re-opens it. Record the premise *with* the dismissal, and re-check it on every change
+> that touches the gate it depends on.
 
 The *other* half — the rebind promoting a `req:` pending row to a full contact because
-`request_status` is not in `EXCLUDED_COLUMNS` — is on inspection **arguably correct** Phase-3
-behaviour (only the operator's own instances can emit, so the `insert` means *the user accepted this
-bot on another instance*, and contacts follow the user). **Not fixed here; filed for investigation
-(§6.4)** rather than "hardened" on a hunch. F4's durability does not depend on it.
+`request_status` is not in `EXCLUDED_COLUMNS` — is, **for a live (un-pruned) contact**, still
+**arguably correct** Phase-3 behaviour (only the operator's own instances can emit, so the `insert`
+means *the user accepted this bot on another instance*, and contacts follow the user). That path is
+untouched. **Filed for investigation (§6.4)** rather than "hardened" on a hunch.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md
+++ b/docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md
@@ -1,9 +1,61 @@
 # Item 2a — `pruneStaleAdvertisedContacts` resurrection: design
 
-**Status:** spec **v4** — design COMPLETE, implementation NOT started (deliberate stop, §8).
+**Status:** spec **v5** — BUILT and shipped on `fix/advertised-contact-prune-impl`.
 **History:** v1 → R1 **REVISE** (4 CRIT) → v2 → R2 **REJECT** (4 CRIT) → v3 → R3 **REJECT**
-(2 CRIT, *spine confirmed*) → **v4** (folds R3; architecture unchanged).
-**Branch:** `fix/advertised-contact-prune`. **Plan:** `2026-07-11-opus-autonomous-arc.md` §4 Item 2a.
+(2 CRIT, *spine confirmed*) → v4 → **its convergence proof was found FALSE during the build**
+(R4, below) → **v5** (adds `contact_tombstones.kind`; architecture otherwise unchanged).
+**Branch:** `fix/advertised-contact-prune-impl`. **Plan:** `2026-07-11-opus-autonomous-arc.md` §4 Item 2a.
+
+> ### 🔴 R4 — v4's convergence proof was FALSE. Read this before touching the tombstone.
+> v4 (§3 F4) claimed: *"a genuine re-add is emitted at the re-adder's next lamport, which is
+> necessarily `> R.lamport_ts` (its counter advanced past that row when it applied it) ⇒
+> **applies and clears the tombstone.**"*
+>
+> **That clause is false, and it is a fourth permanent-divergence bug** — found by the
+> two-instance durability suite (§5.6's harness) *during the build*, not by any of the three
+> adversarial review rounds. The gate runs on the **PEER**, against the **PEER's** tombstone —
+> which sits at the **PEER's** row lamport. Two instances' row lamports are equal **only when
+> every emit has been applied on both sides.**
+>
+> | step | A | B |
+> |---|---|---|
+> | A adds the bot, emits `insert@1` | row 1, counter 1 | row 1 |
+> | B renames/blocks it → emits `update@3`. **A never receives it** (offline / feed lag) | counter still 1 | row **3** |
+> | advertiser un-advertises ⇒ **both prune** | tombstone **@1** | tombstone **@3** |
+> | user re-adds on A ⇒ `acceptBotInvite` emits `insert@2` | row back | — |
+> | B applies: `2 <= 3` ⇒ **DROPPED** (`instance-sync.js:1549`) | has the bot | **no row, tombstone stands** |
+>
+> **Permanent:** every later emit from A is `op="update"`, dropped *unconditionally* by the
+> tombstone. `sync_conflicts` stays 0. Nothing is logged. Only a manual re-add on B recovers it.
+>
+> Neither existing counter-floor saves it (both verified in code): `emitChange:980-983` floors
+> at the **outgoing row's** lamport — but a re-added row is a **fresh INSERT** (`lamport_ts` 0),
+> so there is nothing to floor against; `_applyEntry:1127` advances on receipt — but A never
+> *received* the update.
+>
+> **Root cause:** a prune tombstone's lamport is a **LOCAL row lamport**. Comparing a **global**
+> insert lamport against it compares **incommensurable things**. An authoritative user delete
+> (#155) is different: it was **BROADCAST**, so its lamport *is* a global emit lamport and the
+> stale-replay gate is correct there.
+>
+> **v5's fix — `contact_tombstones.kind`** (gen 7 covers it; no second bump):
+> - `NULL` = **authoritative** (a user delete) — keeps the `insert <= tomb.lamport_ts ⇒ drop` gate.
+> - `'prune'` = **garbage collection** — blocks `op="update"` (which is *all* of defect D3, since
+>   every resurrection vector is an update) but **never gates an `insert` on lamport.**
+> - `ON CONFLICT` resolves **authoritative-always-wins**, so a GC write can never weaken a real
+>   user delete into a permissive gate.
+>
+> Worst case under v5: a redelivered *original* insert re-creates the row, and the next render
+> simply **re-prunes it** — self-healing, no divergence. Safe because *every* `op="insert"`
+> emitter was enumerated: `accept-bot-invite.js:124` (a genuine re-add — **must** land);
+> `contact-promote.js:237` (an accepted message-request — should land); `contacts/api-handlers.js:124,414`
+> (manual/vCard — `advertised_by` NULL ⇒ never prunable ⇒ unreachable); `backfillContactsOnce`
+> (excludes `is_bot=1` **and** emits `op="update"` — doubly unreachable).
+>
+> **The lesson, again:** the unit test that *names* the property ("tombstone lamport === the row's
+> own") stayed **GREEN** under the fresh-counter mutation, because its harness passes a null
+> `managers` and has no SyncManager. Only a **two-instance mutual prune** can see this class of
+> bug. §5.6 was right to be mandatory — and it was still not enough on its own.
 **Constrains this:** `2026-07-09-contact-deletion-and-handshake-name-design.md` (PR #155) §2.6 + R2/MAJOR-2.
 
 > **⚠️ Two scope changes vs the plan, both forced by review:**
@@ -383,7 +435,23 @@ at `user_version = 6`).
 
 ---
 
-## 8. Status: design complete, implementation deliberately NOT started
+## 8. Status: BUILT (2026-07-12) — see the R4 block at the top
+
+The build shipped F1–F5 as five commits plus a sixth carrying the **R4 fix** (`contact_tombstones.kind`)
+and the two-instance durability suite that found it. F6 stayed dropped. The dry-run gate was re-run
+**from the bump-bearing branch** and passed on all four prod DBs (`~/.crow/p4/2a-prune/dryrun-branch-gen7.txt`):
+`user_version` 6→7, zero row-count deltas, nothing lost, and all four *existing* tombstones migrate to
+`kind = NULL` (**authoritative** — the safe direction; a `'prune'` default would have weakened Kevin's
+real user-deletes).
+
+**A blind spot in the gate itself, found here and filed:** `scripts/schema-migration-dryrun.sh` diffs
+`sqlite_master` **object names**, so `ALTER TABLE … ADD COLUMN` is **invisible** to it. It proves nothing
+was *lost*; it cannot prove your migration *happened*. Both new columns were therefore verified positively
+against a migrated copy by hand. **Fix: add a per-table `PRAGMA table_info` diff.**
+
+<details><summary>Original v4 stop-note (kept — its reasoning was right)</summary>
+
+### Design complete, implementation deliberately NOT started
 
 Three adversarial rounds killed three designs; **v4's architecture was attacked directly by R3 and
 held.** What remains is a build with a genuinely dangerous tail: a `SCHEMA_GENERATION` bump against
@@ -396,7 +464,9 @@ deliverable of this session is the vetted design plus three production bugs foun
 §6.3, §7). The build is a clean, well-specified fresh-session job.
 
 **Sequencing recommendation:** fix the rail (§7) **first**, as its own small PR — it gates 2b as
-much as 2a.
+much as 2a. *(Done — PR #176.)*
+
+</details>
 
 ---
 
@@ -412,7 +482,19 @@ much as 2a.
   regression, the unreachable F6 clause, the **init-db rail hazard (§7)**, the un-measured MPA DB,
   and that `getBotDirectory` prunes as a side effect of an *add*.
 
+- **R4 (the build's own two-instance durability suite) — v4's convergence proof FALSE, 1 CRIT.**
+  Killed v4's *tombstone semantics* (not its spine). **No review round caught this** — three
+  adversarial Opus rounds read the proof and accepted it. Only executable, two-instance,
+  *mutual-prune* code found it. See the 🔴 R4 block at the top of this document.
+
 Every CRITICAL from every round was **independently re-verified by the authoring session against the
 code and the live DBs before folding** — the reviewers are not trusted either. Three separate times a
 reviewer caught §0 measuring the wrong table; that is the Item-1 lesson (*compute host-state rules
 against the real host*) refusing to be learned cheaply.
+
+**And the R4 lesson, which is sharper:** three rounds of adversarial *prose* review signed off on a
+convergence proof that a *test* demolished in one run. Prose review is necessary here and it is not
+sufficient. For any distributed-state change, the acceptance gate must be **executable and
+multi-instance** — and it must exercise the *mutual* case, because the single-actor case is exactly
+where these bugs hide (the unit test that names the property stayed green under the mutation that
+breaks it).

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1889,6 +1889,26 @@ await initTable("contact_tombstones table", `
   );
 `);
 
+// --- 2a/F4: WHY a tombstone exists, which decides whether its lamport is a
+// meaningful bound on an incoming `insert`.
+//
+//   NULL     AUTHORITATIVE — a user delete (F-CONTACT-1). Its lamport is a GLOBAL
+//            emit lamport (emitContactDelete broadcast it), so it IS commensurable
+//            with an incoming insert's lamport. Keeps the original `insert <=
+//            tomb.lamport_ts ⇒ drop` gate: a stale replay of an already-seen insert
+//            must not undo the delete.
+//   'prune'  GARBAGE COLLECTION — the advertised-contact prune (F4). It emits NOTHING
+//            and stamps the tombstone with the PRUNED ROW'S OWN lamport, which is a
+//            LOCAL row lamport: two instances' row lamports agree only once every emit
+//            has been applied on both sides. Comparing a global insert lamport against
+//            it compares incommensurable things, so a `prune` tombstone must NOT gate
+//            inserts on lamport at all (see instance-sync.js `_applyContact`).
+//
+// Precedence on conflict is AUTHORITATIVE-WINS (the safe, more-restrictive direction):
+// a GC write must never weaken a real user delete into a permissive gate. Resolved in
+// writeTombstone's ON CONFLICT clause, not here.
+await addColumnIfMissing("contact_tombstones", "kind", "TEXT");
+
 // --- F-CONTACT-1 (design §D4): clock-free replay hygiene for authenticated
 // control events (invite_accepted). Record every successfully-handled event.id so
 // a stale ~60h retry cannot resurrect a deleted contact. Rows older than 30 days

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1906,7 +1906,7 @@ await initTable("contact_tombstones table", `
 //
 // Precedence on conflict is AUTHORITATIVE-WINS (the safe, more-restrictive direction):
 // a GC write must never weaken a real user delete into a permissive gate. Resolved in
-// writeTombstone's ON CONFLICT clause, not here.
+// contact-delete.js's `tombstoneStatement()` ON CONFLICT clause, not here.
 await addColumnIfMissing("contact_tombstones", "kind", "TEXT");
 
 // --- F-CONTACT-1 (design §D4): clock-free replay hygiene for authenticated

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -2747,6 +2747,11 @@ await addColumnIfMissing("bot_message_invites", "kind", "TEXT"); // NULL=normal,
 await addColumnIfMissing("contacts", "is_bot", "INTEGER DEFAULT 0");
 await db.execute({ sql: "UPDATE contacts SET is_bot = 1 WHERE origin = 'advertised' AND is_bot = 0" });
 
+// --- Advertised-contact provenance (advertised-contact prune, 2026-07-12) ---
+// contacts.advertised_by_instance_id records a fact: the instance_id of the peer
+// whose advertised-bot directory this contact was added from. Set at INSERT only.
+await addColumnIfMissing("contacts", "advertised_by_instance_id", "TEXT"); // NULL=manual/pasted-invite contact, NEVER prunable
+
 // Stamp the schema generation so the gateway boot gate can detect when an
 // out-of-band code update introduced migrations that a plain restart missed.
 // (PRAGMA values can't be bound params — interpolate the coerced Number.)

--- a/servers/gateway/dashboard/advertised-bots-cache.js
+++ b/servers/gateway/dashboard/advertised-bots-cache.js
@@ -3,6 +3,19 @@
  * + TTL cache. Sibling of overview-cache.js, same signed-fetch seam. A peer
  * that errors/times out yields an `unavailable` sentinel (never throws), so a
  * single offline Crow can't break the Messages render.
+ *
+ * COMPLETENESS CONTRACT. Every result carries a boolean `complete`, and it is
+ * true ONLY when both sides positively agree the list is whole:
+ *   - the sender asserted `complete: true` (it skipped no bot while building the
+ *     payload — see buildAdvertisementPayload), AND
+ *   - the receiver dropped no entry in validateBot (raw.length === bots.length).
+ * Anything else — an old peer that sends no `complete` key, a malformed body, a
+ * timeout, an unparseable bot — is `complete: false`. Absence of the assertion
+ * is never trust: a body that isn't `{bots: [...]}` is reported `unavailable`
+ * rather than `ok` with an empty list, because "this peer advertises nothing" is
+ * a claim a garbage collector would act on by DELETING contacts. Consumers that
+ * destroy data must require `status === "ok" && complete === true`; this is
+ * fail-safe by construction across a rolling deploy.
  */
 import { forwardSignedRequest } from "../../shared/peer-forward.js";
 import { getOrCreateLocalInstanceId } from "../instance-registry.js";
@@ -48,16 +61,24 @@ let _fetchImpl = defaultFetchImpl;
 async function doFetch(db, instanceId) {
   let result;
   try { result = await _fetchImpl(db, instanceId); }
-  catch (err) { return { instanceId, status: "unavailable", reason: "exception:" + (err?.message || "unknown"), bots: [] }; }
-  if (!result || !result.ok) return { instanceId, status: "unavailable", reason: result?.error || "fetch_failed", bots: [] };
-  const raw = result.body && Array.isArray(result.body.bots) ? result.body.bots : [];
+  catch (err) { return { instanceId, status: "unavailable", reason: "exception:" + (err?.message || "unknown"), bots: [], complete: false }; }
+  if (!result || !result.ok) return { instanceId, status: "unavailable", reason: result?.error || "fetch_failed", bots: [], complete: false };
+  // A body without a `bots` array is an outage, NOT "this peer advertises
+  // nothing" — the latter is a claim the prune would act on by deleting.
+  if (!result.body || !Array.isArray(result.body.bots)) {
+    return { instanceId, status: "unavailable", reason: "bad_body", bots: [], complete: false };
+  }
+  const raw = result.body.bots;
   const bots = raw.map((b) => validateBot(b, instanceId)).filter(Boolean);
-  return { instanceId, status: "ok", bots };
+  // Both sides must agree: the sender positively asserted it, and we parsed
+  // every entry it sent. An old peer sends no key ⇒ false.
+  const complete = result.body.complete === true && raw.length === bots.length;
+  return { instanceId, status: "ok", bots, complete };
 }
 
 /** Fetch (or return cached) advertised bots for one paired peer. Never throws. */
 export async function getPeerAdvertisedBots(db, instanceId) {
-  if (!instanceId) return { instanceId, status: "unavailable", reason: "no_id", bots: [] };
+  if (!instanceId) return { instanceId, status: "unavailable", reason: "no_id", bots: [], complete: false };
   const entry = _cache.get(instanceId);
   if (entry && entry.expiresAt > now()) {
     if (entry.inflight) return entry.inflight;
@@ -72,7 +93,7 @@ export async function getPeerAdvertisedBots(db, instanceId) {
       _cache.set(instanceId, { data, expiresAt: now() + TTL_MS });
       return data;
     } catch (err) {
-      const sentinel = { instanceId, status: "unavailable", reason: "exception:" + (err?.message || "unknown"), bots: [] };
+      const sentinel = { instanceId, status: "unavailable", reason: "exception:" + (err?.message || "unknown"), bots: [], complete: false };
       _cache.set(instanceId, { data: sentinel, expiresAt: now() + TTL_MS });
       return sentinel;
     }

--- a/servers/gateway/dashboard/panels/bot-builder/crow-messages-admin.js
+++ b/servers/gateway/dashboard/panels/bot-builder/crow-messages-admin.js
@@ -162,6 +162,14 @@ export async function listAdvertisedBots(db) {
  * name) plus the x-only messaging pubkey for receiver-side dedup. A bot whose
  * identity can't derive (no instance seed) is skipped, not fatal.
  *
+ * COMPLETENESS IS A POSITIVE ASSERTION. `complete: true` is set ONLY when zero
+ * bots were skipped; if any bot was skipped the key is OMITTED (never
+ * `complete: false`). The receiver treats a missing key as incomplete, so a
+ * peer that is old, drifted, or answering with a malformed body can never be
+ * read as authoritative — and the downstream contact prune, which DELETES, only
+ * ever acts on a positively-asserted complete list. A skip is still a 200: the
+ * bots that did resolve are returned.
+ *
  * NOTE: there is intentionally NO top-level `relay_url` (the relays are already
  * embedded in the signed invite_code via generateBotInviteCode, so a separate
  * field would be redundant).
@@ -173,6 +181,7 @@ export async function buildAdvertisementPayload(
   db, { instanceId, instanceLabel, _identityFor = botIdentityFor, _buildInviteCode = buildInviteCode } = {}
 ) {
   const bots = [];
+  let skipped = 0;
   for (const b of await listAdvertisedBots(db)) {
     try {
       const ident = _identityFor(b.botId); // throws if no identity.json beside crow.db
@@ -189,11 +198,15 @@ export async function buildAdvertisementPayload(
       if (b.description) entry.description = b.description;
       bots.push(entry);
     } catch (err) {
-      // Skip a bot whose identity can't derive (no instance seed). Log so a
-      // surprising DB/identity error leaves a trace rather than vanishing
-      // silently (cf. the 2026-06-14 crow.db silent-federation-blackout).
+      // Skip a bot whose identity can't derive (no instance seed), or whose
+      // invite INSERT hit "database is locked". Log so a surprising DB/identity
+      // error leaves a trace rather than vanishing silently (cf. the 2026-06-14
+      // crow.db silent-federation-blackout). One skip forfeits the completeness
+      // assertion for the whole payload.
+      skipped += 1;
       console.warn(`[crow-messages] advertise skip for bot ${b.botId}:`, err.message);
     }
   }
-  return { bots };
+  // Positive assertion only: omit the key entirely when anything was skipped.
+  return skipped === 0 ? { bots, complete: true } : { bots };
 }

--- a/servers/gateway/dashboard/panels/contacts.js
+++ b/servers/gateway/dashboard/panels/contacts.js
@@ -95,7 +95,9 @@ export default {
       const { getBotDirectory } = await import("./messages/data-queries.js");
       const { buildBotDirectory } = await import("../shared/bot-directory.js");
       const { csrfInput } = await import("../shared/csrf.js");
-      const dir = await getBotDirectory(db).catch(() => ({ groups: [], total: 0, notAddedCount: 0 }));
+      // A RENDER — one of only two call sites that opt into the stale-contact prune.
+      const dir = await getBotDirectory(db, { prune: true })
+        .catch(() => ({ groups: [], total: 0, notAddedCount: 0, perInstance: new Map() }));
       bodyHtml = buildBotDirectory({ groups: dir.groups, context: "contacts", csrf: csrfInput(req), lang });
     } else {
       // --- All Contacts (default) ---

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -18,6 +18,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
 import { markContactIsBot } from "../../shared/mark-contact-bot.js";
+import { resolveAdvertisedByInstanceId } from "../../shared/resolve-advertiser.js";
+import { acceptBotInvite } from "../../../../sharing/accept-bot-invite.js";
 import { extractInviteCode } from "../../../../sharing/invite-url.js";
 
 /**
@@ -36,7 +38,14 @@ async function makeSharingClient() {
  * Handle POST actions from the contacts panel.
  * @returns {{ redirect?: string, download?: string } | null}
  */
-export async function handleContactAction(req, db, { sharingClientFactory = makeSharingClient, managers: injectedManagers = null } = {}) {
+export async function handleContactAction(req, db, {
+  sharingClientFactory = makeSharingClient,
+  managers: injectedManagers = null,
+  // The directory path no longer uses the MCP client — it calls the shared accept
+  // directly. Injectable so tests can drive the routing without a real sharing runtime.
+  // (sharingClientFactory stays: OTHER actions in this handler still use it.)
+  acceptBotInviteFn = acceptBotInvite,
+} = {}) {
   const { action } = req.body;
   const managers = injectedManagers || getManagersOrNull();
 
@@ -415,6 +424,13 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
   }
 
   // --- Browse bots directory: add bot as contact ---
+  //
+  // F5/D1: calls the shared acceptBotInvite DIRECTLY — no MCP round-trip. The old
+  // path went tool → INSERT (unclassified) → emit "insert" → UPDATE origin →
+  // markContactIsBot → a SECOND emit ("update"). Peers saw an unclassified row first
+  // and a classified one only if they were reachable for both; the messages panel
+  // emitted nothing at all after its UPDATE. Now the classification rides the INSERT
+  // and exactly ONE "insert" is emitted, from inside acceptBotInvite.
   if (action === "dir_add_bot" && req.body.invite_code) {
     const code = req.body.invite_code.trim();
     let botCrowId = null;
@@ -425,18 +441,13 @@ export async function handleContactAction(req, db, { sharingClientFactory = make
     let wasNew = false;
     if (botCrowId) { try { const { rows } = await db.execute({ sql: "SELECT 1 FROM contacts WHERE crow_id = ?", args: [botCrowId] }); wasNew = rows.length === 0; } catch {} }
     try {
-      const client = await sharingClientFactory();
-      try {
-        const accepted = await client.callTool({ name: "crow_accept_bot_invite", arguments: { invite_code: code } });
-        if (!accepted?.isError && botCrowId) {
-          if (wasNew) await db.execute({ sql: "UPDATE contacts SET origin = 'advertised' WHERE crow_id = ?", args: [botCrowId] });
-          await markContactIsBot(db, botCrowId);
-          // Phase 3: propagate the final advertised-bot state (origin + is_bot)
-          // to the user's other instances. (The accept tool emits the base row;
-          // this update carries the advertised/is_bot flags set just above.)
-          try { const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [botCrowId] }); if (rows[0]) await emitContactChange("update", rows[0]); } catch {}
-        }
-      } finally { await client.close(); }
+      // Provenance is AUTHORITATIVE and UNSPOOFABLE: resolved server-side from the
+      // advertised directory, never from req.body. Unresolvable ⇒ null ⇒ the contact
+      // is never prunable (the fail-safe direction).
+      const advertisedByInstanceId = await resolveAdvertisedByInstanceId(db, code);
+      await acceptBotInviteFn(db, managers, { inviteCode: code, advertisedByInstanceId });
+      // Already-a-contact branch only: acceptBotInvite classifies rows IT creates.
+      if (botCrowId && !wasNew) await markContactIsBot(db, botCrowId);
     } catch (err) { console.error("[contacts] dir_add_bot failed:", err.message); }
     return { redirect: "/dashboard/contacts?view=bots" };
   }

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -445,7 +445,12 @@ export async function handleContactAction(req, db, {
       // advertised directory, never from req.body. Unresolvable ⇒ null ⇒ the contact
       // is never prunable (the fail-safe direction).
       const advertisedByInstanceId = await resolveAdvertisedByInstanceId(db, code);
-      await acceptBotInviteFn(db, managers, { inviteCode: code, advertisedByInstanceId });
+      // `isBot` is asserted INDEPENDENTLY of provenance: this action IS the bot directory,
+      // so whatever the user clicked is a bot even when the 60 s cache expired or a peer
+      // timed out and the advertiser came back null. Folding bot-ness into provenance
+      // (R5/MAJOR-3) would land is_bot=0 — unbadged, and re-emitted by backfillContactsOnce
+      // on every boot.
+      await acceptBotInviteFn(db, managers, { inviteCode: code, advertisedByInstanceId, isBot: true });
       // Already-a-contact branch only: acceptBotInvite classifies rows IT creates.
       if (botCrowId && !wasNew) await markContactIsBot(db, botCrowId);
     } catch (err) { console.error("[contacts] dir_add_bot failed:", err.message); }

--- a/servers/gateway/dashboard/panels/messages.js
+++ b/servers/gateway/dashboard/panels/messages.js
@@ -59,8 +59,9 @@ export default {
     const { items, totalUnread } = await getUnifiedConversationList(db);
 
     // Cross-instance bot directory (read-only browse; never throws).
-    let botDirectory = { groups: [], total: 0, notAddedCount: 0 };
-    try { botDirectory = await getBotDirectory(db); } catch {}
+    let botDirectory = { groups: [], total: 0, notAddedCount: 0, perInstance: new Map() };
+    // A RENDER — one of only two call sites that opt into the stale-contact prune.
+    try { botDirectory = await getBotDirectory(db, { prune: true }); } catch {}
 
     // Pending message requests (L6 "Requests (N)" inbox; never throws).
     let requests = [];

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -275,7 +275,12 @@ export async function handlePostAction(req, res, {
       // advertised directory, never from req.body. Unresolvable ⇒ null ⇒ the contact
       // is never prunable (the fail-safe direction).
       const advertisedByInstanceId = await resolveAdvertisedByInstanceId(db, code);
-      await acceptBotInviteFn(db, managers, { inviteCode: code, advertisedByInstanceId });
+      // `isBot` is asserted INDEPENDENTLY of provenance: this action IS the bot directory,
+      // so whatever the user clicked is a bot even when the 60 s cache expired or a peer
+      // timed out and the advertiser came back null. Folding bot-ness into provenance
+      // (R5/MAJOR-3) would land is_bot=0 — unbadged, and re-emitted by backfillContactsOnce
+      // on every boot.
+      await acceptBotInviteFn(db, managers, { inviteCode: code, advertisedByInstanceId, isBot: true });
       if (botCrowId) {
         if (!wasNew) await markContactIsBot(db, botCrowId);
         if (action === "dir_message_bot") {

--- a/servers/gateway/dashboard/panels/messages/api-handlers.js
+++ b/servers/gateway/dashboard/panels/messages/api-handlers.js
@@ -13,6 +13,8 @@ import { emitContactChange } from "../../../../sharing/contact-sync.js";
 import { unwireContact } from "../../../../sharing/contact-delete.js";
 import { wireSyncedContact } from "../../../../sharing/contact-promote.js";
 import { markContactIsBot } from "../../shared/mark-contact-bot.js";
+import { resolveAdvertisedByInstanceId } from "../../shared/resolve-advertiser.js";
+import { acceptBotInvite } from "../../../../sharing/accept-bot-invite.js";
 import { createRoom, listRoomMembers } from "./rooms-store.js";
 import { buildRoomJoinEnvelope, fanOut } from "../../../../sharing/room-fanout.js";
 import { extractInviteCode } from "../../../../sharing/invite-url.js";
@@ -55,7 +57,15 @@ async function getSharingClient() {
  * Handle POST actions from the messages panel.
  * Returns true if the action was handled (response sent), false otherwise.
  */
-export async function handlePostAction(req, res, { db, sharingClientFactory = getSharingClient, _managers = null }) {
+export async function handlePostAction(req, res, {
+  db,
+  sharingClientFactory = getSharingClient,
+  _managers = null,
+  // The directory path no longer uses the MCP client — it calls the shared accept
+  // directly. Injectable so tests can drive the routing without a real sharing runtime.
+  // (sharingClientFactory stays: the PASTE form and every other action still use it.)
+  acceptBotInviteFn = acceptBotInvite,
+}) {
   const managers = _managers || getManagersOrNull();
   const { action } = req.body;
 
@@ -238,17 +248,22 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
     return res.redirectAfterPost("/dashboard/messages");
   }
 
+  // F5/D1: the DIRECTORY path calls the shared acceptBotInvite DIRECTLY — no MCP
+  // round-trip. The old path emitted the unclassified row from inside the tool and
+  // then stamped origin/is_bot with a local UPDATE and NO emit at all — so peers
+  // learned this was a bot only if the user happened to use the CONTACTS panel
+  // instead (which emitted a second time). Now the classification rides the INSERT
+  // and acceptBotInvite emits exactly one "insert".
   if ((action === "dir_add_bot" || action === "dir_message_bot") && req.body.invite_code) {
     const code = req.body.invite_code.trim();
     let botCrowId = null;
     try {
       const { parseBotInviteCode } = await import("../../../../sharing/identity.js");
       botCrowId = parseBotInviteCode(code).botCrowId;
-    } catch { /* malformed — accept will report; bail to plain redirect */ }
+    } catch { /* malformed — the accept below reports; bail to plain redirect */ }
 
-    // Was this bot already a contact? Only tag origin on contacts WE create
-    // (mirrors the removed message_advertised_bot discipline), preserving the
-    // pruneStaleAdvertisedContacts lifecycle + the is_bot backfill grain.
+    // Was this bot already a contact? acceptBotInvite only classifies rows IT creates,
+    // so markContactIsBot is kept for the already-a-contact branch.
     let wasNew = false;
     if (botCrowId) {
       try { const { rows } = await db.execute({ sql: "SELECT 1 FROM contacts WHERE crow_id = ?", args: [botCrowId] }); wasNew = rows.length === 0; } catch {}
@@ -256,20 +271,17 @@ export async function handlePostAction(req, res, { db, sharingClientFactory = ge
 
     let redirectTo = "/dashboard/messages";
     try {
-      const client = await sharingClientFactory();
-      try {
-        const accepted = await client.callTool({ name: "crow_accept_bot_invite", arguments: { invite_code: code } });
-        if (accepted?.isError) return res.redirectAfterPost("/dashboard/messages");
-        if (botCrowId) {
-          if (wasNew) await db.execute({ sql: "UPDATE contacts SET origin = 'advertised' WHERE crow_id = ?", args: [botCrowId] });
-          await markContactIsBot(db, botCrowId);
-          if (action === "dir_message_bot") {
-            const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [botCrowId] });
-            if (rows[0]?.id != null) redirectTo = `/dashboard/messages?open=${rows[0].id}`;
-          }
+      // Provenance is AUTHORITATIVE and UNSPOOFABLE: resolved server-side from the
+      // advertised directory, never from req.body. Unresolvable ⇒ null ⇒ the contact
+      // is never prunable (the fail-safe direction).
+      const advertisedByInstanceId = await resolveAdvertisedByInstanceId(db, code);
+      await acceptBotInviteFn(db, managers, { inviteCode: code, advertisedByInstanceId });
+      if (botCrowId) {
+        if (!wasNew) await markContactIsBot(db, botCrowId);
+        if (action === "dir_message_bot") {
+          const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [botCrowId] });
+          if (rows[0]?.id != null) redirectTo = `/dashboard/messages?open=${rows[0].id}`;
         }
-      } finally {
-        await client.close();
       }
     } catch (err) {
       console.error("[messages] dir bot materialize failed:", err.message);

--- a/servers/gateway/dashboard/panels/messages/data-queries.js
+++ b/servers/gateway/dashboard/panels/messages/data-queries.js
@@ -225,8 +225,21 @@ export async function getMessageStatus(db) {
  * grouped by instance, each marked added/contactId via a pubkey match against
  * contacts (includes blocked — a blocked bot is still "known"). Shows ALL bots
  * (added ones are badged, not hidden). Never throws.
+ *
+ * `prune` DEFAULTS TO FALSE — garbage collection is opt-in, and only the Messages
+ * and Contacts RENDER opts in. This is a real bug fix: the prune used to run as a
+ * side effect of every call, so the "Add this bot" path — which reads this directory
+ * to resolve *which instance advertised* the bot — would durably DELETE other
+ * contacts as a side effect of a click (spec §3 F4 / R3-MAJOR-6). A new caller must
+ * ask for GC; it can never inherit it.
+ *
+ * Returns `{ groups, total, notAddedCount, perInstance }` where
+ *   perInstance: Map<instanceId, { ok:boolean, complete:boolean, pubkeys:Set<string> }>
+ * carries an entry for EVERY trusted peer queried this cycle — including ones that
+ * came back unavailable (`ok:false`), because the prune must distinguish "queried but
+ * unavailable" from "never queried". `pubkeys` are trailing-64 lowercase x-only keys.
  */
-export async function getBotDirectory(db) {
+export async function getBotDirectory(db, { prune = false } = {}) {
   const known = new Map(); // trailing-64 lowercased x-only pubkey -> contact id
   try {
     const { rows } = await db.execute("SELECT id, secp256k1_pubkey FROM contacts WHERE secp256k1_pubkey IS NOT NULL AND request_status IS NULL");
@@ -244,13 +257,25 @@ export async function getBotDirectory(db) {
 
   const settled = await Promise.allSettled(peerIds.map((id) => getPeerAdvertisedBots(db, id)));
   const seen = new Set();
-  const live = new Set();
+  const perInstance = new Map();
   const groupsByInst = new Map();
   let total = 0, notAddedCount = 0;
-  for (const s of settled) {
-    if (s.status !== "fulfilled" || !s.value || s.value.status !== "ok") continue;
-    for (const b of s.value.bots) {
-      live.add(b.messaging_pubkey);
+  // Index-match against peerIds: a REJECTED settled entry carries no instanceId, and
+  // an absent entry would read to the prune as "never queried" (⇒ fail-safe, but wrong).
+  for (let i = 0; i < settled.length; i++) {
+    const instanceId = peerIds[i];
+    const s = settled[i];
+    const v = s.status === "fulfilled" ? s.value : null;
+    const ok = !!(v && v.status === "ok" && Array.isArray(v.bots));
+    // `complete` is a POSITIVE assertion from both sides. An old peer sends no key ⇒
+    // falsy ⇒ this instance is never a licence to delete.
+    const complete = ok && v.complete === true;
+    const pubkeys = new Set();
+    if (ok) for (const b of v.bots) pubkeys.add(b.messaging_pubkey);
+    perInstance.set(instanceId, { ok, complete, pubkeys });
+
+    if (!ok) continue;
+    for (const b of v.bots) {
       if (seen.has(b.messaging_pubkey)) continue;
       seen.add(b.messaging_pubkey);
       const contactId = known.get(b.messaging_pubkey) ?? null;
@@ -272,30 +297,101 @@ export async function getBotDirectory(db) {
       groupsByInst.set(b.instance_id, g);
     }
   }
-  if (live.size > 0) { try { await pruneStaleAdvertisedContacts(db, live); } catch {} }
-  return { groups: Array.from(groupsByInst.values()), total, notAddedCount };
+
+  if (prune && perInstance.size > 0) {
+    try {
+      const { getManagersOrNull } = await import("../../../../sharing/managers.js");
+      await pruneStaleAdvertisedContacts(db, perInstance, localId, getManagersOrNull());
+    } catch {}
+  }
+  return { groups: Array.from(groupsByInst.values()), total, notAddedCount, perInstance };
 }
 
 /**
- * Delete origin='advertised' contacts that have no message history AND are no
- * longer advertised (not in `livePubkeys`, a Set of trailing-64 lowercased
- * x-only keys). Contacts with history are always kept. Never throws.
+ * Garbage-collect advertised contacts whose advertiser no longer advertises them.
+ *
+ * TRIGGER: `contacts.advertised_by_instance_id IS NOT NULL` — the FACT of who
+ * advertised the bot, not `origin` (a judgment: view-relative, classified after the
+ * row is already on the wire, and no longer trustworthy). NULL provenance — a manual
+ * or pasted-invite contact — is structurally never prunable.
+ *
+ * Prune row R iff ALL FIVE hold:
+ *   1. R's advertiser is NOT this instance — the host NEVER prunes its own bot;
+ *   2. that advertiser is in `perInstance` (a trusted peer queried this cycle);
+ *   3. it answered `ok === true` AND `complete === true` (both: an errored, timed-out,
+ *      or silently-truncated list is never a licence to delete);
+ *   4. R's x-only pubkey is absent from that advertiser's set AND from every other
+ *      ok+complete peer's set (the directory dedups on first-seen pubkey, so a bot
+ *      advertised by two instances would otherwise be pruned while still live);
+ *   5. R has zero messages (the SQL HAVING) — the prune NEVER destroys history.
+ *
+ * CONVERGENCE WITHOUT A BROADCAST: the delete is local and emits nothing — it writes
+ * only a local tombstone. Every instance paired with advertiser X evaluates this same
+ * rule against its own view of X and prunes independently ⇒ "gone on both sides" with
+ * no delete on the wire and no host authority. An instance NOT paired with X fails
+ * rule 2 and keeps its copy (fail-safe); its later `update` emits are dropped by the
+ * pruner's tombstone, so the pruner stays clean either way. Never throws (it runs
+ * inside a render).
+ *
+ * @param {object} db async db client
+ * @param {Map<string, {ok:boolean, complete:boolean, pubkeys:Set<string>}>} perInstance
+ * @param {string|null} localInstanceId
+ * @param {object|null} managers passed down (never resolved here) — null/partial is fine
  */
-export async function pruneStaleAdvertisedContacts(db, livePubkeys) {
+export async function pruneStaleAdvertisedContacts(db, perInstance, localInstanceId, managers) {
   try {
+    if (!perInstance || perInstance.size === 0) return;
+    // Rule 1 is unprovable without our own id: `advertiser === localInstanceId` can
+    // never match when localInstanceId is falsy, which would silently DISABLE host
+    // protection (getOrCreateLocalInstanceId is guarded at the call site and yields
+    // null if it throws). No id ⇒ no prune.
+    if (!localInstanceId) {
+      console.warn("[prune] local instance id unavailable — cannot prove rule 1 (host never prunes its own bot). Skipping the prune.");
+      return;
+    }
+    // crow_id + lamport_ts are LOAD-BEARING here: the tombstone is keyed on crow_id and
+    // written at the row's OWN lamport. writeTombstone no-ops on a falsy crowId and
+    // swallows errors, so selecting neither would ship the headline fix as a silent no-op.
     const { rows } = await db.execute(`
-      SELECT c.id, c.secp256k1_pubkey
+      SELECT c.id, c.crow_id, c.lamport_ts, c.secp256k1_pubkey, c.advertised_by_instance_id
       FROM contacts c
       LEFT JOIN messages m ON m.contact_id = c.id
-      WHERE c.origin = 'advertised'
+      WHERE c.advertised_by_instance_id IS NOT NULL
       GROUP BY c.id
       HAVING COUNT(m.id) = 0`);
+
     for (const r of rows) {
+      // 1. the host never prunes its own bot.
+      const advertiser = r.advertised_by_instance_id;
+      if (!advertiser || advertiser === localInstanceId) continue;
+      // 2. a trusted peer queried this cycle.
+      const entry = perInstance.get(advertiser);
+      if (!entry) continue;
+      // 3. it answered, and asserted a whole list.
+      if (!entry.ok || !entry.complete) continue;
+      // 4. absent from its advertiser's set AND from every other ok+complete peer's.
       const h = String(r.secp256k1_pubkey || "");
       const pk = h.length >= 64 ? h.slice(-64).toLowerCase() : "";
-      if (!livePubkeys.has(pk)) {
-        await db.execute({ sql: "DELETE FROM contacts WHERE id = ?", args: [r.id] });
+      if (!pk) continue; // unidentifiable key ⇒ undecidable ⇒ keep
+      if (entry.pubkeys.has(pk)) continue;
+      let liveElsewhere = false;
+      for (const [instId, e] of perInstance) {
+        if (instId === advertiser) continue;
+        if (e.ok && e.complete && e.pubkeys.has(pk)) { liveElsewhere = true; break; }
       }
+      if (liveElsewhere) continue;
+      // 5. zero messages — enforced by the HAVING clause above.
+
+      if (!r.crow_id) {
+        console.warn(`[prune] contact ${r.id} has no crow_id — cannot tombstone it, so a delete would be resurrectable. Skipping.`);
+        continue;
+      }
+      const { pruneAdvertisedContact } = await import("../../../../sharing/contact-prune.js");
+      await pruneAdvertisedContact(db, managers, {
+        id: Number(r.id),
+        crow_id: String(r.crow_id),
+        lamport_ts: Number(r.lamport_ts) || 0,
+      });
     }
   } catch {}
 }

--- a/servers/gateway/dashboard/panels/messages/data-queries.js
+++ b/servers/gateway/dashboard/panels/messages/data-queries.js
@@ -333,6 +333,17 @@ export async function getBotDirectory(db, { prune = false } = {}) {
  * pruner's tombstone, so the pruner stays clean either way. Never throws (it runs
  * inside a render).
  *
+ * ⚠️ SCOPE OF THAT CLAIM — it holds for a COMPLETE pairing graph, which is what this
+ * fleet has. Rule 4's "live elsewhere" clause scans THIS instance's own peer set, so two
+ * instances paired with DIFFERENT advertiser sets can legitimately disagree: if A is
+ * paired with both X and Y (both advertising bot Z) but C is paired with X only, then
+ * when X un-advertises Z, C prunes it and A keeps it (Y still advertises it). That is a
+ * divergent steady state — but a FAIL-SAFE one: nobody deletes a bot that some peer they
+ * can see still advertises, no history is destroyed (rule 5), and C's tombstone quietly
+ * drops A's later `update`s rather than fighting them. Do not read this function as
+ * promising convergence under an arbitrary topology; it promises that nobody GCs a
+ * contact its own advertiser still vouches for.
+ *
  * @param {object} db async db client
  * @param {Map<string, {ok:boolean, complete:boolean, pubkeys:Set<string>}>} perInstance
  * @param {string|null} localInstanceId

--- a/servers/gateway/dashboard/shared/resolve-advertiser.js
+++ b/servers/gateway/dashboard/shared/resolve-advertiser.js
@@ -1,0 +1,46 @@
+/**
+ * Resolve WHO advertised a bot — server-side, from the directory, never from the form
+ * (spec `2026-07-12-advertised-contact-prune-design.md` §3 F5).
+ *
+ * `contacts.advertised_by_instance_id` is the FACT the garbage collector acts on: when
+ * that instance stops advertising this bot, the zero-message contact is pruned. So the
+ * value must be authoritative and unspoofable. A caller that took it from the POST body
+ * would let anyone who can reach the form stamp an arbitrary contact prunable — or stamp
+ * a live one with a bogus advertiser and have it pruned on the next render.
+ *
+ * Unresolvable (peer unreachable, bot in nobody's list, malformed code) ⇒ `null` ⇒ NULL
+ * provenance ⇒ the contact is structurally NEVER prunable. That is the fail-safe
+ * direction, and it is the ONLY fallback — never a value from the request.
+ */
+
+import { getBotDirectory } from "../panels/messages/data-queries.js";
+import { parseBotInviteCode } from "../../../sharing/identity.js";
+
+/**
+ * @param {object} db async db client ({ execute })
+ * @param {string} inviteCode the bot invite code the user clicked "Add" on
+ * @returns {Promise<string|null>} the advertising instance's id, or null. Never throws.
+ */
+export async function resolveAdvertisedByInstanceId(db, inviteCode) {
+  try {
+    const bot = parseBotInviteCode(String(inviteCode || "").trim());
+    // getBotDirectory's `pubkeys` Sets hold trailing-64 lowercase x-only keys
+    // (validateBot strips the 02/03 compressed prefix). Match that shape exactly.
+    const x = String(bot.secp256k1Pubkey || "").slice(-64).toLowerCase();
+    if (x.length !== 64) return null;
+
+    // R3-MAJOR-6: `{ prune: false }` is MANDATORY here, and is passed explicitly even
+    // though it is already the default. getBotDirectory garbage-collects stale
+    // advertised contacts as a SIDE EFFECT of a read when asked to — so a pruning read
+    // on this path would make clicking "Add" durably DELETE other contacts.
+    const { perInstance } = await getBotDirectory(db, { prune: false });
+
+    // `ok` (the peer answered with a parseable list) is the right bar — `complete` is a
+    // licence to DELETE, not to attribute. A truncated list that still positively
+    // contains this bot is proof enough of who advertised it.
+    for (const [instanceId, info] of perInstance || []) {
+      if (info?.ok && info.pubkeys?.has(x)) return instanceId;
+    }
+  } catch { /* unresolvable ⇒ NULL provenance ⇒ never prunable */ }
+  return null;
+}

--- a/servers/shared/schema-version.js
+++ b/servers/shared/schema-version.js
@@ -10,7 +10,7 @@
 // by servers/gateway/index.js during boot; importing scripts/init-db.js here
 // (or anything that runs DB work at module top-level) would execute init-db
 // as an unwanted side effect.
-export const SCHEMA_GENERATION = 6;
+export const SCHEMA_GENERATION = 7;
 
 // Pure decision helper for the gateway boot gate. Returns true when the DB
 // needs init-db to run: either core tables are missing (fresh/incomplete

--- a/servers/sharing/accept-bot-invite.js
+++ b/servers/sharing/accept-bot-invite.js
@@ -60,13 +60,16 @@ export function buildBotAcceptPayload(token, identity, displayName) {
  * @param {string} [opts.displayName] overrides the name baked into the invite
  * @param {string} [opts.advertisedByInstanceId] the instance whose directory this bot
  *   came from — supplied ONLY by the panel directory handlers, resolved server-side.
- *   Absent ⇒ `origin=NULL, is_bot=0, advertised_by_instance_id=NULL` (the pasted-invite
- *   shape: byte-identical to the pre-F5 tool, and structurally never prunable).
+ *   Absent ⇒ `origin=NULL, advertised_by_instance_id=NULL` (structurally never prunable).
+ * @param {boolean} [opts.isBot] assert bot-ness INDEPENDENTLY of provenance. Supplied by
+ *   the panel directory handlers (a bot clicked in the bot directory IS a bot). Absent ⇒
+ *   `is_bot` follows provenance, which keeps the MCP/pasted-invite path byte-identical to
+ *   the pre-F5 tool (`is_bot=0` unless the caller marks it).
  * @returns {Promise<{ok:true, outcome:"created"|"existing", contactId:number, name:string,
  *                     botCrowId:string, notified:boolean, error?:string}>}
  * @throws on a malformed invite code or a failed INSERT — the callers render that.
  */
-export async function acceptBotInvite(db, managers, { inviteCode, displayName, advertisedByInstanceId } = {}) {
+export async function acceptBotInvite(db, managers, { inviteCode, displayName, advertisedByInstanceId, isBot } = {}) {
   const { syncManager, nostrManager, identity } = managers || {};
   const bot = parseBotInviteCode(String(inviteCode || "").trim());
   // Prefer an explicit name, else the friendly name the owner put in the invite,
@@ -88,9 +91,19 @@ export async function acceptBotInvite(db, managers, { inviteCode, displayName, a
     outcome = "created";
     // THE one place the classification is decided. An advertiser means: this bot
     // came out of that instance's directory (a FACT, portable and true everywhere)
-    // ⇒ it is a bot, it is advertised, and it is garbage-collectable when that
-    // instance stops advertising it. No advertiser means none of those things.
+    // ⇒ it is advertised, and it is garbage-collectable when that instance stops
+    // advertising it. No advertiser means none of those things.
     const advertisedBy = advertisedByInstanceId ? String(advertisedByInstanceId) : null;
+    // BOT-NESS AND PRUNABILITY ARE DIFFERENT FACTS (R5/MAJOR-3). Deriving `is_bot` from
+    // `advertisedBy` conflates them, and provenance resolution is genuinely fallible: the
+    // advertised-bots cache expires after 60 s and any peer can exceed the 2 s directory
+    // timeout, so a bot the user clicked in the BOT DIRECTORY can arrive here with a null
+    // advertiser. Deriving bot-ness from that would land `is_bot=0`: unbadged in the UI,
+    // AND swept into `backfillContactsOnce` (which filters `is_bot = 0`) to be re-emitted
+    // as an `update` on every boot. So the directory handlers assert `isBot` explicitly and
+    // an unresolvable advertiser costs only PRUNABILITY (advertised_by=NULL — the fail-safe
+    // direction). The MCP/pasted-invite path passes neither ⇒ `is_bot=0`, exactly as before.
+    const isBotFlag = isBot === true || advertisedBy ? 1 : 0;
     const result = await db.execute({
       sql: `INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey,
                                   origin, is_bot, advertised_by_instance_id)
@@ -98,7 +111,7 @@ export async function acceptBotInvite(db, managers, { inviteCode, displayName, a
       args: [
         bot.botCrowId, name, bot.ed25519Pubkey, bot.secp256k1Pubkey,
         advertisedBy ? "advertised" : null,
-        advertisedBy ? 1 : 0,
+        isBotFlag,
         advertisedBy,
       ],
     });

--- a/servers/sharing/accept-bot-invite.js
+++ b/servers/sharing/accept-bot-invite.js
@@ -1,0 +1,143 @@
+/**
+ * Accept a Crow Messages bot invite — the ONE place a bot contact is created
+ * (spec `2026-07-12-advertised-contact-prune-design.md` §3 F5, defect D1).
+ *
+ * D1 was a split-brain: `crow_accept_bot_invite` INSERTed an UNCLASSIFIED row and
+ * emitted it, and the *caller* stamped the classification afterwards — the contacts
+ * panel with a SECOND emit (`op="update"`), the messages panel with NO emit at all.
+ * Peers therefore received `origin=NULL`, and whether they ever learned otherwise
+ * depended on which panel the user happened to click. With F2's provenance column
+ * that is no longer merely untidy: a row that reaches a peer without
+ * `advertised_by_instance_id` is UN-prunable there, and one stamped wrongly is
+ * OVER-prunable. So the classification rides the INSERT, in one place, and exactly
+ * one `insert` is emitted from a re-SELECT of the row it produced.
+ *
+ * `insert` is load-bearing: it is the only op that passes a peer's tombstone gate
+ * (`instance-sync.js` drops `op="update"` unconditionally when a tombstone stands),
+ * so a re-add after a prune actually lands.
+ *
+ * PROVENANCE IS NEVER AN ARGUMENT A MODEL CONTROLS. `crow_accept_bot_invite`'s zod
+ * schema is deliberately unchanged — it has no advertiser parameter. Only the panel
+ * directory handlers supply `advertisedByInstanceId`, and they resolve it server-side
+ * from a prune-free directory read. No advertiser ⇒ NULL provenance ⇒ never prunable,
+ * which is the fail-safe direction.
+ *
+ * IMPORT DISCIPLINE: `managers` is passed IN, never imported — managers.js → nostr.js
+ * → contact-promote.js → contact-sync.js is a live import chain, and a static
+ * managers.js import here would close the cycle.
+ */
+
+import { parseBotInviteCode } from "./identity.js";
+import { emitContactChange } from "./contact-sync.js";
+import { clearTombstone } from "./contact-delete.js";
+
+/**
+ * Build the DM payload a recipient sends to a bot to accept its invite.
+ * The adapter authorizes future chats on the SIGNED event pubkey, so the keys
+ * here are labels the bot stores; the token is the bearer capability it checks.
+ */
+export function buildBotAcceptPayload(token, identity, displayName) {
+  return JSON.stringify({
+    type: "crow_social",
+    subtype: "bot_invite_accept",
+    token,
+    sender: {
+      crow_id: identity.crowId,
+      ed25519_pubkey: identity.ed25519Pubkey,
+      secp256k1_pubkey: identity.secp256k1Pubkey,
+      display_name: displayName || identity.crowId,
+    },
+  });
+}
+
+/**
+ * Add a bot as a contact and tell it we accepted. Idempotent on the bot's crow_id.
+ *
+ * @param {object} db async db client ({ execute })
+ * @param {object} managers { syncManager?, peerManager?, nostrManager?, identity? }
+ * @param {object} opts
+ * @param {string} opts.inviteCode the `crow:<id>.<payload>.<sig>` bot invite
+ * @param {string} [opts.displayName] overrides the name baked into the invite
+ * @param {string} [opts.advertisedByInstanceId] the instance whose directory this bot
+ *   came from — supplied ONLY by the panel directory handlers, resolved server-side.
+ *   Absent ⇒ `origin=NULL, is_bot=0, advertised_by_instance_id=NULL` (the pasted-invite
+ *   shape: byte-identical to the pre-F5 tool, and structurally never prunable).
+ * @returns {Promise<{ok:true, outcome:"created"|"existing", contactId:number, name:string,
+ *                     botCrowId:string, notified:boolean, error?:string}>}
+ * @throws on a malformed invite code or a failed INSERT — the callers render that.
+ */
+export async function acceptBotInvite(db, managers, { inviteCode, displayName, advertisedByInstanceId } = {}) {
+  const { syncManager, nostrManager, identity } = managers || {};
+  const bot = parseBotInviteCode(String(inviteCode || "").trim());
+  // Prefer an explicit name, else the friendly name the owner put in the invite,
+  // else the raw crow: id.
+  const name = displayName || bot.name || bot.botCrowId;
+
+  const existing = await db.execute({
+    sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [bot.botCrowId],
+  });
+
+  let contactId;
+  let outcome;
+  if (existing.rows.length > 0) {
+    // Already a contact: reuse the row, emit nothing. The callers keep their
+    // markContactIsBot on this branch.
+    contactId = Number(existing.rows[0].id);
+    outcome = "existing";
+  } else {
+    outcome = "created";
+    // THE one place the classification is decided. An advertiser means: this bot
+    // came out of that instance's directory (a FACT, portable and true everywhere)
+    // ⇒ it is a bot, it is advertised, and it is garbage-collectable when that
+    // instance stops advertising it. No advertiser means none of those things.
+    const advertisedBy = advertisedByInstanceId ? String(advertisedByInstanceId) : null;
+    const result = await db.execute({
+      sql: `INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey,
+                                  origin, is_bot, advertised_by_instance_id)
+            VALUES (?,?,?,?,?,?,?)`,
+      args: [
+        bot.botCrowId, name, bot.ed25519Pubkey, bot.secp256k1Pubkey,
+        advertisedBy ? "advertised" : null,
+        advertisedBy ? 1 : 0,
+        advertisedBy,
+      ],
+    });
+    contactId = Number(result.lastInsertRowid);
+
+    try { await syncManager.initContact(contactId, null); } catch { /* bot has no hypercore feed; non-fatal */ }
+    // Subscribe to the bot's replies over Nostr (new contact only — existing
+    // contacts already have a live subscription from their first accept or from
+    // restart, so re-subscribing would leak a handle per relay).
+    try {
+      await nostrManager.subscribeToContact({
+        id: contactId, crowId: bot.botCrowId, secp256k1_pubkey: bot.secp256k1Pubkey,
+      });
+    } catch { /* non-fatal — re-subscribed on next restart */ }
+
+    // Phase 3: an accepted remote bot is a real cross-instance contact — propagate
+    // it to the user's other instances, ALREADY CLASSIFIED. Exactly one emit.
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
+      if (rows[0]) {
+        // D3.2: a local re-add supersedes any tombstone for this bot's crowId.
+        await clearTombstone(db, bot.botCrowId);
+        await emitContactChange("insert", rows[0]);
+      }
+    } catch { /* never blocks the accept */ }
+  }
+
+  // Tell the bot we accepted (carries the token it validates). Failing to reach it
+  // is NOT a failure of the accept: the contact is added either way, and the bot
+  // authorizes us when it next comes online.
+  try {
+    if (nostrManager.relays.size === 0) await nostrManager.connectRelays();
+    await nostrManager.sendMessage(
+      { secp256k1_pubkey: bot.secp256k1Pubkey },
+      buildBotAcceptPayload(bot.token, identity, name),
+    );
+  } catch (err) {
+    return { ok: true, outcome, contactId, name, botCrowId: bot.botCrowId, notified: false, error: err.message };
+  }
+
+  return { ok: true, outcome, contactId, name, botCrowId: bot.botCrowId, notified: true };
+}

--- a/servers/sharing/contact-delete.js
+++ b/servers/sharing/contact-delete.js
@@ -21,32 +21,56 @@ function isReqId(id) {
 /**
  * UPSERT a tombstone keeping the MAX lamport_ts. deleted_at is set to now (unix
  * seconds) on first write and preserved on conflict. No-op for `req:` ids.
+ *
+ * `kind` says WHY the contact is gone, and that decides whether the tombstone's
+ * lamport is a meaningful bound on an incoming `insert` (see instance-sync.js
+ * `_applyContact`):
+ *   - `null`    AUTHORITATIVE — a user delete. Its lamport is a GLOBAL emit lamport
+ *               (emitContactDelete broadcast it) ⇒ comparable to an insert's ⇒ keeps
+ *               the `insert <= tomb.lamport_ts ⇒ drop` stale-replay gate.
+ *   - `'prune'` GARBAGE COLLECTION — the advertised-contact prune (2a/F4). It emits
+ *               nothing and stamps the tombstone with a LOCAL row lamport ⇒ NOT
+ *               comparable across instances ⇒ must not gate inserts on lamport.
+ *
+ * Precedence on conflict is AUTHORITATIVE-ALWAYS-WINS — the safe, more-restrictive
+ * direction. prune+prune ⇒ 'prune'; ANY authoritative delete on either side ⇒ NULL.
+ * A GC write must never weaken a real user delete into a permissive gate; the reverse
+ * (an authoritative delete strengthening a prune tombstone) is exactly what we want.
+ *
  * @param {object} db async db client ({ execute })
  * @param {string} crowId
  * @param {number} lamportTs the delete's Lamport clock
+ * @param {"prune"|null} [kind] null (default) = authoritative user delete
  */
-export async function writeTombstone(db, crowId, lamportTs) {
+export async function writeTombstone(db, crowId, lamportTs, kind = null) {
   if (!db || !crowId || isReqId(crowId)) return;
   try {
     await db.execute({
-      sql: `INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at)
-            VALUES (?, ?, ?)
-            ON CONFLICT(crow_id) DO UPDATE SET lamport_ts = MAX(lamport_ts, excluded.lamport_ts)`,
-      args: [crowId, Number(lamportTs) || 0, Math.floor(Date.now() / 1000)],
+      sql: `INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(crow_id) DO UPDATE SET
+              lamport_ts = MAX(lamport_ts, excluded.lamport_ts),
+              kind = CASE WHEN contact_tombstones.kind = 'prune' AND excluded.kind = 'prune'
+                          THEN 'prune' ELSE NULL END`,
+      args: [crowId, Number(lamportTs) || 0, Math.floor(Date.now() / 1000), kind === "prune" ? "prune" : null],
     });
   } catch { /* never throw into a receive path */ }
 }
 
 /**
+ * `kind` is SELECTed deliberately: the apply gate branches on it, and a gate cannot
+ * read a column the query never returned. (Omitting it is a SILENT no-op — the gate
+ * would see `undefined`, take the authoritative branch, and drop every genuine re-add
+ * with no error. This is the same trap that killed design v2.)
  * @param {object} db async db client
  * @param {string} crowId
- * @returns {Promise<{crow_id:string,lamport_ts:number,deleted_at:number}|null>}
+ * @returns {Promise<{crow_id:string,lamport_ts:number,deleted_at:number,kind:"prune"|null}|null>}
  */
 export async function readTombstone(db, crowId) {
   if (!db || !crowId || isReqId(crowId)) return null;
   try {
     const { rows } = await db.execute({
-      sql: `SELECT crow_id, lamport_ts, deleted_at FROM contact_tombstones WHERE crow_id = ?`,
+      sql: `SELECT crow_id, lamport_ts, deleted_at, kind FROM contact_tombstones WHERE crow_id = ?`,
       args: [crowId],
     });
     return rows[0] || null;

--- a/servers/sharing/contact-delete.js
+++ b/servers/sharing/contact-delete.js
@@ -60,24 +60,35 @@ function isReqId(id) {
  * @param {number} lamportTs the delete's Lamport clock
  * @param {"prune"|null} [kind] null (default) = authoritative user delete
  */
+/**
+ * The tombstone UPSERT as a STATEMENT, so a caller can commit it atomically with other
+ * writes via `db.batch()` (which wraps its statements in one transaction). The advertised-
+ * contact prune needs exactly that: its DELETE and its tombstone MUST land together, or
+ * not at all. See `contact-prune.js` for why neither ordering is safe on its own.
+ * Callers using this bypass writeTombstone's `req:` guard — check `isReqId` yourself.
+ */
+export function tombstoneStatement(crowId, lamportTs, kind = null) {
+  return {
+    sql: `INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(crow_id) DO UPDATE SET
+            lamport_ts = CASE
+              WHEN contact_tombstones.kind = 'prune' AND excluded.kind IS NULL
+                THEN excluded.lamport_ts               -- GC → authoritative: the DELETE's global lamport
+              WHEN contact_tombstones.kind IS NULL AND excluded.kind = 'prune'
+                THEN contact_tombstones.lamport_ts     -- authoritative → GC: the delete's lamport stands
+              ELSE MAX(contact_tombstones.lamport_ts, excluded.lamport_ts) -- same kind ⇒ comparable
+            END,
+            kind = CASE WHEN contact_tombstones.kind = 'prune' AND excluded.kind = 'prune'
+                        THEN 'prune' ELSE NULL END`,
+    args: [crowId, Number(lamportTs) || 0, Math.floor(Date.now() / 1000), kind === "prune" ? "prune" : null],
+  };
+}
+
 export async function writeTombstone(db, crowId, lamportTs, kind = null) {
   if (!db || !crowId || isReqId(crowId)) return;
   try {
-    await db.execute({
-      sql: `INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind)
-            VALUES (?, ?, ?, ?)
-            ON CONFLICT(crow_id) DO UPDATE SET
-              lamport_ts = CASE
-                WHEN contact_tombstones.kind = 'prune' AND excluded.kind IS NULL
-                  THEN excluded.lamport_ts               -- GC → authoritative: the DELETE's global lamport
-                WHEN contact_tombstones.kind IS NULL AND excluded.kind = 'prune'
-                  THEN contact_tombstones.lamport_ts     -- authoritative → GC: the delete's lamport stands
-                ELSE MAX(contact_tombstones.lamport_ts, excluded.lamport_ts) -- same kind ⇒ comparable
-              END,
-              kind = CASE WHEN contact_tombstones.kind = 'prune' AND excluded.kind = 'prune'
-                          THEN 'prune' ELSE NULL END`,
-      args: [crowId, Number(lamportTs) || 0, Math.floor(Date.now() / 1000), kind === "prune" ? "prune" : null],
-    });
+    await db.execute(tombstoneStatement(crowId, lamportTs, kind));
   } catch { /* never throw into a receive path */ }
 }
 

--- a/servers/sharing/contact-delete.js
+++ b/servers/sharing/contact-delete.js
@@ -37,6 +37,24 @@ function isReqId(id) {
  * A GC write must never weaken a real user delete into a permissive gate; the reverse
  * (an authoritative delete strengthening a prune tombstone) is exactly what we want.
  *
+ * ⚠️ LAMPORTS ARE COMMENSURABLE ONLY *WITHIN* A KIND — never MAX across them.
+ * The two kinds stamp `lamport_ts` from different clocks:
+ *   - authoritative → a GLOBAL emit lamport (emitContactDelete broadcast it);
+ *   - 'prune'       → the pruned row's LOCAL row lamport (nothing was emitted).
+ * `lamport_ts` has exactly ONE consumer — the `insert <= tomb.lamport_ts ⇒ drop`
+ * stale-replay gate — and that gate is only meaningful against a global lamport. A
+ * blanket `MAX(lamport_ts, excluded.lamport_ts)` on a kind TRANSITION launders the
+ * local number into the global field and arms the gate at a value no emitter can
+ * exceed: the genuine re-add is dropped, every later `op="update"` from the re-adder is
+ * then dropped unconditionally by the same tombstone ⇒ PERMANENT silent divergence,
+ * zero `sync_conflicts`. (This is why an authoritative delete emitted at a LOW lamport
+ * is not merely a curiosity: `emitContactDelete` sends `{crow_id}` alone — a row with
+ * no `lamport_ts` — so emitChange's counter floor never applies to deletes, and a
+ * lagging or post-DB-recovery instance really does delete at a low lamport.)
+ *
+ * So on a transition the SURVIVING kind's OWN lamport wins, and MAX applies only when
+ * both sides are the same kind.
+ *
  * @param {object} db async db client ({ execute })
  * @param {string} crowId
  * @param {number} lamportTs the delete's Lamport clock
@@ -49,7 +67,13 @@ export async function writeTombstone(db, crowId, lamportTs, kind = null) {
       sql: `INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind)
             VALUES (?, ?, ?, ?)
             ON CONFLICT(crow_id) DO UPDATE SET
-              lamport_ts = MAX(lamport_ts, excluded.lamport_ts),
+              lamport_ts = CASE
+                WHEN contact_tombstones.kind = 'prune' AND excluded.kind IS NULL
+                  THEN excluded.lamport_ts               -- GC → authoritative: the DELETE's global lamport
+                WHEN contact_tombstones.kind IS NULL AND excluded.kind = 'prune'
+                  THEN contact_tombstones.lamport_ts     -- authoritative → GC: the delete's lamport stands
+                ELSE MAX(contact_tombstones.lamport_ts, excluded.lamport_ts) -- same kind ⇒ comparable
+              END,
               kind = CASE WHEN contact_tombstones.kind = 'prune' AND excluded.kind = 'prune'
                           THEN 'prune' ELSE NULL END`,
       args: [crowId, Number(lamportTs) || 0, Math.floor(Date.now() / 1000), kind === "prune" ? "prune" : null],

--- a/servers/sharing/contact-delete.js
+++ b/servers/sharing/contact-delete.js
@@ -14,7 +14,7 @@
  */
 
 /** @param {string} id @returns {boolean} true for a per-instance `req:` row. */
-function isReqId(id) {
+export function isReqId(id) {
   return typeof id === "string" && id.startsWith("req:");
 }
 

--- a/servers/sharing/contact-prune.js
+++ b/servers/sharing/contact-prune.js
@@ -21,15 +21,19 @@ import { unwireContact, writeTombstone } from "./contact-delete.js";
  *      failed). This also fixes a pre-existing Nostr-subscription leak: the bare DELETE
  *      this replaces never unsubscribed.
  *   2. DELETE FROM contacts.
- *   3. writeTombstone at **`row.lamport_ts` — the pruned row's OWN lamport**, never a
- *      fresh counter value. The prune emits nothing, so a fresh counter burn is invisible
- *      to the fleet: two instances pruning independently would land on tombstones that a
- *      re-adder's `insert` can TIE with, and the apply gate drops ties
- *      (`instance-sync.js` `lamportTs <= tomb.lamport_ts`) ⇒ permanent, unrecoverable
- *      divergence. The row's own lamport makes the gate exactly right: a replay of an
- *      already-seen `insert` is `<= row.lamport_ts` ⇒ dropped; a genuine re-add is emitted
- *      at the re-adder's next lamport, necessarily `> row.lamport_ts` (its counter advanced
- *      past that row when it applied it) ⇒ applies and clears the tombstone.
+ *   3. writeTombstone at **`row.lamport_ts` — the pruned row's OWN lamport** — and marked
+ *      **`kind='prune'`**, i.e. GARBAGE COLLECTION rather than an authoritative delete.
+ *      The `kind` is what makes the lamport safe to carry: a prune emits nothing, so its
+ *      lamport is a LOCAL row lamport, and two instances' row lamports agree only once
+ *      every emit has been applied on both sides. One un-replicated `update` on a peer
+ *      (a rename, a block) lifts THAT peer's row lamport, so its tombstone outruns a
+ *      re-adder's `insert` — and a lamport gate would drop the re-add, then drop every
+ *      later `update` from the re-adder unconditionally: permanent divergence, zero
+ *      `sync_conflicts`, nothing logged. So the apply gate does NOT compare an `insert`
+ *      against a `kind='prune'` tombstone at all (`instance-sync.js` `_applyContact`).
+ *      A prune's ONLY job is to block resurrection-by-`update` (defect D3), and every D3
+ *      vector IS an `update`; those stay dropped. Worst case, a redelivered ORIGINAL
+ *      insert re-creates the row — and the next render simply re-prunes it. Self-healing.
  *
  * @param {object} db async db client ({ execute })
  * @param {object|null} managers { nostrManager?, syncManager?, peerManager? } — null/partial is fine
@@ -43,6 +47,6 @@ export async function pruneAdvertisedContact(db, managers, row) {
   if (!row.crow_id) return { ok: false, reason: "no-crow-id" };
   await unwireContact(managers, row);
   await db.execute({ sql: "DELETE FROM contacts WHERE id = ?", args: [row.id] });
-  await writeTombstone(db, row.crow_id, row.lamport_ts);
+  await writeTombstone(db, row.crow_id, row.lamport_ts, "prune");
   return { ok: true };
 }

--- a/servers/sharing/contact-prune.js
+++ b/servers/sharing/contact-prune.js
@@ -12,49 +12,58 @@
  * stay out of the managers.js → nostr.js import cycle (see its header). Do NOT import
  * managers.js here; the caller passes `managers` in.
  */
-import { unwireContact, writeTombstone, readTombstone } from "./contact-delete.js";
+import { unwireContact, readTombstone, tombstoneStatement } from "./contact-delete.js";
 
 /**
- * Delete one stale advertised contact. Order is LOAD-BEARING:
+ * Delete one stale advertised contact.
  *
- *   1. writeTombstone at **`row.lamport_ts` — the pruned row's OWN lamport** — and marked
- *      **`kind='prune'`**, i.e. GARBAGE COLLECTION rather than an authoritative delete.
- *      The `kind` is what makes the lamport safe to carry: a prune emits nothing, so its
- *      lamport is a LOCAL row lamport, and two instances' row lamports agree only once
- *      every emit has been applied on both sides. One un-replicated `update` on a peer
- *      (a rename, a block) lifts THAT peer's row lamport, so its tombstone outruns a
- *      re-adder's `insert` — and a lamport gate would drop the re-add, then drop every
- *      later `update` from the re-adder unconditionally: permanent divergence, zero
- *      `sync_conflicts`, nothing logged. So the apply gate does NOT compare an `insert`
- *      against a `kind='prune'` tombstone at all (`instance-sync.js` `_applyContact`).
- *      A prune's ONLY job is to block resurrection-by-`update` (defect D3), and every D3
- *      vector IS an `update`; those stay dropped. A redelivered ORIGINAL insert re-creates
- *      the row — and the next render simply re-prunes it, as a fresh zero-message row
- *      (`_applyContact` will not rebind a `req:` placeholder while a GC tombstone stands,
- *      precisely so this stays true). Self-healing.
+ * ── The tombstone is `kind='prune'`, at the row's OWN `lamport_ts` ──
+ * A prune emits nothing, so its lamport is a LOCAL row lamport, and two instances' row
+ * lamports agree only once every emit has been applied on both sides. One un-replicated
+ * `update` on a peer (a rename, a block) lifts THAT peer's row lamport, so its tombstone
+ * outruns a re-adder's `insert` — and a lamport gate would drop the re-add, then drop
+ * every later `update` from the re-adder unconditionally: permanent divergence, zero
+ * `sync_conflicts`, nothing logged. So the apply gate does NOT compare an `insert` against
+ * a `kind='prune'` tombstone at all (`instance-sync.js` `_applyContact`). A prune's ONLY
+ * job is to block resurrection-by-`update` (defect D3) — and every D3 vector IS an
+ * `update`; those stay dropped.
  *
- *   2. VERIFY the tombstone landed, and REFUSE the delete if it did not. `writeTombstone`
- *      swallows every error by design (it runs on a receive path and must never throw), so
- *      "delete, then best-effort tombstone" silently produces the one state this whole
- *      feature exists to prevent: the row GONE with nothing to block its resurrection by
- *      the next peer `update`. The failure is not exotic — `"database is locked"` is a
- *      DOCUMENTED recurring failure on this DB. This is the same distrust the `crow_id`
- *      guard below already encodes, extended from "a tombstone is possible" to "a
- *      tombstone actually LANDED".
+ * ── ⚠️ The DELETE and the tombstone MUST be ATOMIC. Neither ordering is safe alone. ──
+ *   - **tombstone → DELETE** leaves a tombstone beside a LIVE row, and `_applyContact`
+ *     rule (a) clears any tombstone whenever a local row exists. Nothing serializes the
+ *     receive path against the render that calls the prune, and `unwireContact` awaits real
+ *     network teardown — so a concurrent inbound entry for this `crow_id` (a peer's boot
+ *     backfill, a rename, a block — and peers are touching this contact right now, because
+ *     they all see the same directory change) STRIPS the tombstone inside that window. The
+ *     DELETE then lands untombstoned ⇒ resurrectable ⇒ defect D3, restored, silently.
+ *   - **DELETE → tombstone** leaves the row GONE with no tombstone if the tombstone write
+ *     fails — and `writeTombstone` swallows every error by design (it runs on a receive
+ *     path and must never throw), while `"database is locked"` is a DOCUMENTED recurring
+ *     failure on this DB.
+ * So both statements go in ONE `db.batch()` (which wraps them in a single transaction):
+ * either both land or neither does. A failed transaction leaves the contact fully intact
+ * and fully wired, and the next render simply re-attempts.
  *
- *   3. unwireContact — BEFORE the row is removed (an in-flight `subscribeToContact`
- *      onevent INSERT against a deleted contact_id would raise FOREIGN KEY constraint
- *      failed). This also fixes a pre-existing Nostr-subscription leak: the bare DELETE
- *      this replaces never unsubscribed. It runs only once the delete is COMMITTED to,
- *      so a refused prune leaves the contact fully wired.
+ * `unwireContact` still runs BEFORE the transaction — an in-flight `subscribeToContact`
+ * onevent INSERT against a deleted `contact_id` would otherwise raise FOREIGN KEY
+ * constraint failed. (It also fixes a pre-existing Nostr-subscription leak: the bare DELETE
+ * this replaces never unsubscribed.) If the transaction then fails we have unwired a
+ * surviving contact; that self-heals on the next restart's re-wire and is far cheaper than
+ * an untombstoned delete.
  *
- *   4. DELETE FROM contacts.
+ * ── Scope of "self-healing" (do NOT overclaim this — it is load-bearing) ──
+ * A redelivered ORIGINAL `insert` re-creates the row, and the next render re-prunes it as a
+ * fresh zero-message row (`_applyContact` will not rebind a `req:` placeholder while a GC
+ * tombstone stands, precisely so this stays true). **That holds only until the bot's next
+ * DM.** The re-created row is wired for Nostr, so if the still-running bot messages the user
+ * before that next render, the row acquires a message and prune rule 5 (zero messages —
+ * history is never destroyed) makes it PERMANENTLY un-prunable, alongside the `req:` row for
+ * the same key. That end state is not a defect — it is the design's fail-safe axis (keep,
+ * never delete; no history lost) and it is strictly better than resurrecting the contact by
+ * stealing the message request's DM. But it is NOT "self-healing", and this feature's entire
+ * failure history is an asserted invariant whose premise was later quietly removed.
  *
- * A tombstone briefly coexisting with a live row (between 1 and 4, or forever if we
- * refuse at 2) is BENIGN: `_applyContact` rule (a) clears any tombstone whenever a local
- * row exists. Tombstone-then-delete is the strictly safer order.
- *
- * @param {object} db async db client ({ execute })
+ * @param {object} db async db client ({ execute, batch })
  * @param {object|null} managers { nostrManager?, syncManager?, peerManager? } — null/partial is fine
  * @param {{id:number, crow_id:string, lamport_ts:number}} row
  * @returns {Promise<{ok:true}|{ok:false, reason:string}>}
@@ -65,17 +74,32 @@ export async function pruneAdvertisedContact(db, managers, row) {
   // id) ⇒ the delete would be resurrectable. Refuse rather than ship a silent no-op.
   if (!row.crow_id) return { ok: false, reason: "no-crow-id" };
 
-  await writeTombstone(db, row.crow_id, row.lamport_ts, "prune");
-  if (!(await readTombstone(db, row.crow_id))) {
+  await unwireContact(managers, row);
+
+  // ONE transaction: the DELETE and the tombstone land together or not at all (see above —
+  // both orderings are unsafe on their own, in opposite directions).
+  try {
+    await db.batch([
+      { sql: "DELETE FROM contacts WHERE id = ?", args: [row.id] },
+      tombstoneStatement(row.crow_id, row.lamport_ts, "prune"),
+    ]);
+  } catch (err) {
     console.warn(
-      `[prune] contact ${row.id} (${row.crow_id}): the tombstone did NOT land — refusing to delete. ` +
-      `Deleting without one leaves the contact resurrectable by the next peer 'update'. It will be ` +
-      `re-attempted on the next render.`,
+      `[prune] contact ${row.id} (${row.crow_id}): the delete+tombstone transaction FAILED ` +
+      `(${err?.message || "unknown"}) — the contact is intact and will be re-attempted on the ` +
+      `next render. Deleting without a tombstone would leave it resurrectable by the next peer 'update'.`,
     );
-    return { ok: false, reason: "tombstone-failed" };
+    return { ok: false, reason: "prune-txn-failed" };
   }
 
-  await unwireContact(managers, row);
-  await db.execute({ sql: "DELETE FROM contacts WHERE id = ?", args: [row.id] });
+  // Belt-and-braces: the transaction committed, so this must hold. If it somehow does not,
+  // the row is already gone and we cannot undo it — so make it LOUD rather than silent.
+  if (!(await readTombstone(db, row.crow_id))) {
+    console.error(
+      `[prune] contact ${row.id} (${row.crow_id}): the delete COMMITTED but no tombstone is ` +
+      `readable. The contact is now resurrectable by the next peer 'update'.`,
+    );
+    return { ok: false, reason: "tombstone-lost" };
+  }
   return { ok: true };
 }

--- a/servers/sharing/contact-prune.js
+++ b/servers/sharing/contact-prune.js
@@ -12,16 +12,12 @@
  * stay out of the managers.js → nostr.js import cycle (see its header). Do NOT import
  * managers.js here; the caller passes `managers` in.
  */
-import { unwireContact, writeTombstone } from "./contact-delete.js";
+import { unwireContact, writeTombstone, readTombstone } from "./contact-delete.js";
 
 /**
  * Delete one stale advertised contact. Order is LOAD-BEARING:
- *   1. unwireContact — BEFORE the row is removed (an in-flight `subscribeToContact`
- *      onevent INSERT against a deleted contact_id would raise FOREIGN KEY constraint
- *      failed). This also fixes a pre-existing Nostr-subscription leak: the bare DELETE
- *      this replaces never unsubscribed.
- *   2. DELETE FROM contacts.
- *   3. writeTombstone at **`row.lamport_ts` — the pruned row's OWN lamport** — and marked
+ *
+ *   1. writeTombstone at **`row.lamport_ts` — the pruned row's OWN lamport** — and marked
  *      **`kind='prune'`**, i.e. GARBAGE COLLECTION rather than an authoritative delete.
  *      The `kind` is what makes the lamport safe to carry: a prune emits nothing, so its
  *      lamport is a LOCAL row lamport, and two instances' row lamports agree only once
@@ -32,8 +28,31 @@ import { unwireContact, writeTombstone } from "./contact-delete.js";
  *      `sync_conflicts`, nothing logged. So the apply gate does NOT compare an `insert`
  *      against a `kind='prune'` tombstone at all (`instance-sync.js` `_applyContact`).
  *      A prune's ONLY job is to block resurrection-by-`update` (defect D3), and every D3
- *      vector IS an `update`; those stay dropped. Worst case, a redelivered ORIGINAL
- *      insert re-creates the row — and the next render simply re-prunes it. Self-healing.
+ *      vector IS an `update`; those stay dropped. A redelivered ORIGINAL insert re-creates
+ *      the row — and the next render simply re-prunes it, as a fresh zero-message row
+ *      (`_applyContact` will not rebind a `req:` placeholder while a GC tombstone stands,
+ *      precisely so this stays true). Self-healing.
+ *
+ *   2. VERIFY the tombstone landed, and REFUSE the delete if it did not. `writeTombstone`
+ *      swallows every error by design (it runs on a receive path and must never throw), so
+ *      "delete, then best-effort tombstone" silently produces the one state this whole
+ *      feature exists to prevent: the row GONE with nothing to block its resurrection by
+ *      the next peer `update`. The failure is not exotic — `"database is locked"` is a
+ *      DOCUMENTED recurring failure on this DB. This is the same distrust the `crow_id`
+ *      guard below already encodes, extended from "a tombstone is possible" to "a
+ *      tombstone actually LANDED".
+ *
+ *   3. unwireContact — BEFORE the row is removed (an in-flight `subscribeToContact`
+ *      onevent INSERT against a deleted contact_id would raise FOREIGN KEY constraint
+ *      failed). This also fixes a pre-existing Nostr-subscription leak: the bare DELETE
+ *      this replaces never unsubscribed. It runs only once the delete is COMMITTED to,
+ *      so a refused prune leaves the contact fully wired.
+ *
+ *   4. DELETE FROM contacts.
+ *
+ * A tombstone briefly coexisting with a live row (between 1 and 4, or forever if we
+ * refuse at 2) is BENIGN: `_applyContact` rule (a) clears any tombstone whenever a local
+ * row exists. Tombstone-then-delete is the strictly safer order.
  *
  * @param {object} db async db client ({ execute })
  * @param {object|null} managers { nostrManager?, syncManager?, peerManager? } — null/partial is fine
@@ -45,8 +64,18 @@ export async function pruneAdvertisedContact(db, managers, row) {
   // No crow_id ⇒ no tombstone is possible (writeTombstone silently no-ops on a falsy
   // id) ⇒ the delete would be resurrectable. Refuse rather than ship a silent no-op.
   if (!row.crow_id) return { ok: false, reason: "no-crow-id" };
+
+  await writeTombstone(db, row.crow_id, row.lamport_ts, "prune");
+  if (!(await readTombstone(db, row.crow_id))) {
+    console.warn(
+      `[prune] contact ${row.id} (${row.crow_id}): the tombstone did NOT land — refusing to delete. ` +
+      `Deleting without one leaves the contact resurrectable by the next peer 'update'. It will be ` +
+      `re-attempted on the next render.`,
+    );
+    return { ok: false, reason: "tombstone-failed" };
+  }
+
   await unwireContact(managers, row);
   await db.execute({ sql: "DELETE FROM contacts WHERE id = ?", args: [row.id] });
-  await writeTombstone(db, row.crow_id, row.lamport_ts, "prune");
   return { ok: true };
 }

--- a/servers/sharing/contact-prune.js
+++ b/servers/sharing/contact-prune.js
@@ -12,7 +12,7 @@
  * stay out of the managers.js → nostr.js import cycle (see its header). Do NOT import
  * managers.js here; the caller passes `managers` in.
  */
-import { unwireContact, readTombstone, tombstoneStatement } from "./contact-delete.js";
+import { unwireContact, readTombstone, tombstoneStatement, isReqId } from "./contact-delete.js";
 
 /**
  * Delete one stale advertised contact.
@@ -47,9 +47,12 @@ import { unwireContact, readTombstone, tombstoneStatement } from "./contact-dele
  * `unwireContact` still runs BEFORE the transaction — an in-flight `subscribeToContact`
  * onevent INSERT against a deleted `contact_id` would otherwise raise FOREIGN KEY
  * constraint failed. (It also fixes a pre-existing Nostr-subscription leak: the bare DELETE
- * this replaces never unsubscribed.) If the transaction then fails we have unwired a
- * surviving contact; that self-heals on the next restart's re-wire and is far cheaper than
- * an untombstoned delete.
+ * this replaces never unsubscribed.) But if the transaction then FAILS we have unwired a
+ * contact that SURVIVED — and that is NOT benign: `boot.js`'s global-inbox catch-all
+ * early-returns for a full contact (`request_status` NULL) on the grounds that its
+ * per-contact subscription is handling the DM, which we just closed. The bot's next message
+ * would be neither stored nor filed as a request — it would silently VANISH. So the failure
+ * path RE-WIRES the surviving contact (see the catch).
  *
  * ── Scope of "self-healing" (do NOT overclaim this — it is load-bearing) ──
  * A redelivered ORIGINAL `insert` re-creates the row, and the next render re-prunes it as a
@@ -73,6 +76,13 @@ export async function pruneAdvertisedContact(db, managers, row) {
   // No crow_id ⇒ no tombstone is possible (writeTombstone silently no-ops on a falsy
   // id) ⇒ the delete would be resurrectable. Refuse rather than ship a silent no-op.
   if (!row.crow_id) return { ok: false, reason: "no-crow-id" };
+  // `tombstoneStatement` deliberately bypasses writeTombstone's guards so it can join the
+  // batch — so the `req:` guard has to be re-asserted HERE, or we would DELETE the row and
+  // write a `req:`-keyed tombstone that readTombstone/clearTombstone can never see (both
+  // no-op on `req:`), violating the table's stated invariant and failing OPEN. No live path
+  // reaches this today (the prune's SELECT needs a non-NULL advertised_by, and `req:` rows
+  // never sync) — but "unreachable" premises have evaporated twice on this branch already.
+  if (isReqId(row.crow_id)) return { ok: false, reason: "req-id" };
 
   await unwireContact(managers, row);
 
@@ -89,6 +99,23 @@ export async function pruneAdvertisedContact(db, managers, row) {
       `(${err?.message || "unknown"}) — the contact is intact and will be re-attempted on the ` +
       `next render. Deleting without a tombstone would leave it resurrectable by the next peer 'update'.`,
     );
+    // RE-WIRE. We already unwired, and the row SURVIVED — an alive-but-torn-down contact is
+    // NOT benign, it SILENTLY LOSES THE BOT'S NEXT DM. boot.js's global-inbox catch-all
+    // early-returns for a full contact (`request_status` NULL) precisely because "the
+    // per-contact subscription is already handling it" — and we just closed that
+    // subscription. The DM would be neither stored on the contact nor filed as a message
+    // request: it would simply vanish. (An un-advertised bot is not a dead bot — that is the
+    // premise of the whole message-request semantic.) Nothing re-wires before the next
+    // gateway restart or inbound sync entry, so do it here.
+    try {
+      const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [row.id] });
+      if (rows[0]) {
+        // Lazy dynamic import: contact-promote sits on the managers → nostr chain, and this
+        // module must stay off it (see the header). Same pattern as contact-delete's loadSyncMod.
+        const { wireFullContact } = await import("./contact-promote.js");
+        await wireFullContact(managers, rows[0]);
+      }
+    } catch { /* best-effort; the next restart re-wires */ }
     return { ok: false, reason: "prune-txn-failed" };
   }
 

--- a/servers/sharing/contact-prune.js
+++ b/servers/sharing/contact-prune.js
@@ -8,9 +8,14 @@
  * conclusion from its own view. So the prune writes a LOCAL tombstone and emits
  * NOTHING: no delete on the wire, no host authority, and `sync_conflicts` cannot grow.
  *
- * Imports ONLY from ./contact-delete.js — which is deliberately dependency-free to
+ * STATICALLY imports only ./contact-delete.js — which is deliberately dependency-free to
  * stay out of the managers.js → nostr.js import cycle (see its header). Do NOT import
- * managers.js here; the caller passes `managers` in.
+ * managers.js here; the caller passes `managers` in. The one exception is a LAZY dynamic
+ * import of ./contact-promote.js on the prune's failure path (to re-wire a contact that
+ * survived a failed transaction — see `pruneAdvertisedContact`). That is acyclic: nothing on
+ * the managers → nostr → contact-promote chain imports THIS module (its only importer,
+ * panels/messages/data-queries.js, imports it dynamically), and it is verified to resolve in
+ * both module-init orders. Keep it lazy anyway.
  */
 import { unwireContact, readTombstone, tombstoneStatement, isReqId } from "./contact-delete.js";
 
@@ -113,18 +118,36 @@ export async function pruneAdvertisedContact(db, managers, row) {
         // Lazy dynamic import: contact-promote sits on the managers → nostr chain, and this
         // module must stay off it (see the header). Same pattern as contact-delete's loadSyncMod.
         const { wireFullContact } = await import("./contact-promote.js");
+        // rows[0], NOT `row`: `row` is the prune's 3-field skeleton (id/crow_id/lamport_ts),
+        // so `is_blocked` would read undefined and defeat wireFullContact's blocked guard —
+        // re-subscribing a BLOCKED contact, with undefined pubkeys.
         await wireFullContact(managers, rows[0]);
       }
-    } catch { /* best-effort; the next restart re-wires */ }
+    } catch (reErr) {
+      // Do NOT swallow this. Landing here means the contact is alive and STILL UNWIRED —
+      // exactly the state the re-wire exists to prevent, and its symptom (the bot's next DM
+      // silently vanishing) is invisible. Every other failure on this path is loud; so is this.
+      console.warn(
+        `[prune] contact ${row.id} (${row.crow_id}): the prune failed AND re-wiring it failed ` +
+        `(${reErr?.message || "unknown"}) — the contact is alive but torn down, so the bot's next ` +
+        `DM will be dropped. It re-wires on the next gateway restart or inbound sync entry.`,
+      );
+    }
     return { ok: false, reason: "prune-txn-failed" };
   }
 
   // Belt-and-braces: the transaction committed, so this must hold. If it somehow does not,
   // the row is already gone and we cannot undo it — so make it LOUD rather than silent.
   if (!(await readTombstone(db, row.crow_id))) {
-    console.error(
-      `[prune] contact ${row.id} (${row.crow_id}): the delete COMMITTED but no tombstone is ` +
-      `readable. The contact is now resurrectable by the next peer 'update'.`,
+    // Not necessarily data loss: readTombstone returns null on ANY read error, and a peer's
+    // legitimate `insert` can re-create the row and clear this tombstone (clearTombAfterApply)
+    // in the window between the commit and this read. So report it as needing a look, not as a
+    // certainty — but never as silence: if it IS real, the contact is resurrectable and nothing
+    // else would ever say so.
+    console.warn(
+      `[prune] contact ${row.id} (${row.crow_id}): the delete COMMITTED but no tombstone reads ` +
+      `back. Either a transient read error, a peer's concurrent re-add (benign), or the contact ` +
+      `is now resurrectable by the next peer 'update'. Worth checking contact_tombstones.`,
     );
     return { ok: false, reason: "tombstone-lost" };
   }

--- a/servers/sharing/contact-prune.js
+++ b/servers/sharing/contact-prune.js
@@ -1,0 +1,48 @@
+/**
+ * Advertised-contact prune primitive (spec `2026-07-12-advertised-contact-prune-design.md` §3 F4).
+ *
+ * Distinct from contact-delete.js's `deleteContactLocal`: that is a USER-initiated
+ * delete and it BROADCASTS (`emitContactDelete`). This is garbage collection — the
+ * un-advertised bot is gone from this instance's view of its advertiser, and every
+ * other instance paired with that advertiser will independently reach the same
+ * conclusion from its own view. So the prune writes a LOCAL tombstone and emits
+ * NOTHING: no delete on the wire, no host authority, and `sync_conflicts` cannot grow.
+ *
+ * Imports ONLY from ./contact-delete.js — which is deliberately dependency-free to
+ * stay out of the managers.js → nostr.js import cycle (see its header). Do NOT import
+ * managers.js here; the caller passes `managers` in.
+ */
+import { unwireContact, writeTombstone } from "./contact-delete.js";
+
+/**
+ * Delete one stale advertised contact. Order is LOAD-BEARING:
+ *   1. unwireContact — BEFORE the row is removed (an in-flight `subscribeToContact`
+ *      onevent INSERT against a deleted contact_id would raise FOREIGN KEY constraint
+ *      failed). This also fixes a pre-existing Nostr-subscription leak: the bare DELETE
+ *      this replaces never unsubscribed.
+ *   2. DELETE FROM contacts.
+ *   3. writeTombstone at **`row.lamport_ts` — the pruned row's OWN lamport**, never a
+ *      fresh counter value. The prune emits nothing, so a fresh counter burn is invisible
+ *      to the fleet: two instances pruning independently would land on tombstones that a
+ *      re-adder's `insert` can TIE with, and the apply gate drops ties
+ *      (`instance-sync.js` `lamportTs <= tomb.lamport_ts`) ⇒ permanent, unrecoverable
+ *      divergence. The row's own lamport makes the gate exactly right: a replay of an
+ *      already-seen `insert` is `<= row.lamport_ts` ⇒ dropped; a genuine re-add is emitted
+ *      at the re-adder's next lamport, necessarily `> row.lamport_ts` (its counter advanced
+ *      past that row when it applied it) ⇒ applies and clears the tombstone.
+ *
+ * @param {object} db async db client ({ execute })
+ * @param {object|null} managers { nostrManager?, syncManager?, peerManager? } — null/partial is fine
+ * @param {{id:number, crow_id:string, lamport_ts:number}} row
+ * @returns {Promise<{ok:true}|{ok:false, reason:string}>}
+ */
+export async function pruneAdvertisedContact(db, managers, row) {
+  if (!db || !row || row.id == null) return { ok: false, reason: "no-row" };
+  // No crow_id ⇒ no tombstone is possible (writeTombstone silently no-ops on a falsy
+  // id) ⇒ the delete would be resurrectable. Refuse rather than ship a silent no-op.
+  if (!row.crow_id) return { ok: false, reason: "no-crow-id" };
+  await unwireContact(managers, row);
+  await db.execute({ sql: "DELETE FROM contacts WHERE id = ?", args: [row.id] });
+  await writeTombstone(db, row.crow_id, row.lamport_ts);
+  return { ok: true };
+}

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -97,8 +97,17 @@ export const EXCLUDED_COLUMNS = {
   // (boot.js) — syncing it would firehose the feed. `id` is the per-instance
   // AUTOINCREMENT key (never portable). `created_at` differs when two instances
   // independently form the same req: row, manufacturing spurious conflicts.
+  // `origin` (item 2a / F3) is a JUDGMENT — "this is an advertised bot I may
+  // garbage-collect" — true only relative to the instance holding the row, never
+  // a portable fact. Replicating it is dangerous both ways: toward the bot's HOST
+  // (a peer's emit could relabel the host's own bot row 'advertised', and a host
+  // never sees its OWN bots in its advertised directory ⇒ it would prune its own
+  // bot, FK-CASCADING the DM history away), and toward a peer that cannot see the
+  // advertisement (it inherits 'advertised' for a bot it never sees advertised ⇒
+  // prunes a live bot). Each instance re-derives its own judgment from its own
+  // view; the syncable FACT is which instance advertised the bot.
   // All stripped from the wire; the row still syncs (keyed on crow_id).
-  contacts: ["verified", "last_seen", "id", "created_at"],
+  contacts: ["verified", "last_seen", "id", "created_at", "origin"],
   // Phase 3 PR-B: messages sync keyed on nostr_event_id; the per-instance
   // id/contact_id are never portable (crow_id rides the wire instead). is_read
   // is per-device (each instance computes its own unread badge). lamport_ts is
@@ -1435,8 +1444,10 @@ export class InstanceSyncManager {
     }
 
     // PRAGMA-filter incoming keys to live columns; always drop id/lamport_ts/
-    // instance_id and the never-synced verified/last_seen/created_at (defense on
-    // apply — these are stripped on emit too).
+    // instance_id and the never-synced verified/last_seen/created_at/origin
+    // (defense on apply — these are stripped on emit too). `origin` is NOT
+    // belt-and-braces: an un-upgraded peer still runs the pre-F3 emit path and
+    // WILL keep sending it, so the receive side has to refuse it on its own.
     if (!this._contactCols) {
       try {
         const { rows: pragma } = await this.db.execute({ sql: "PRAGMA table_info(contacts)", args: [] });
@@ -1450,7 +1461,7 @@ export class InstanceSyncManager {
       console.warn("[instance-sync] _applyContact: contacts columns unavailable — skipping");
       return;
     }
-    const ALWAYS_DROP = new Set(["id", "lamport_ts", "instance_id", "verified", "last_seen", "created_at"]);
+    const ALWAYS_DROP = new Set(["id", "lamport_ts", "instance_id", "verified", "last_seen", "created_at", "origin"]);
     const filtered = {};
     for (const [k, v] of Object.entries(row)) {
       if (ALWAYS_DROP.has(k)) continue;

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1502,6 +1502,16 @@ export class InstanceSyncManager {
       tomb = null;
     }
 
+    // The lamport a STANDING tombstone may contribute to an AUTHORITATIVE one.
+    // Commensurable only within a kind (see writeTombstone's header): an authoritative
+    // tombstone's lamport is a GLOBAL emit lamport, a 'prune' tombstone's is the pruned
+    // row's LOCAL row lamport. `Math.max`-ing a prune's local number into the
+    // authoritative field launders it straight into the `insert <= tomb.lamport_ts ⇒
+    // drop` gate — that field's only consumer — arming it at a value the deleting
+    // instance's own re-add can never exceed ⇒ permanent, silent divergence. So a
+    // 'prune' tombstone contributes ZERO here.
+    const tombFloor = tomb && tomb.kind !== "prune" ? Number(tomb.lamport_ts) || 0 : 0;
+
     // ── delete ──────────────────────────────────────────────────────────────
     if (op === "delete") {
       // A tombstone is written only when the delete is AUTHORITATIVE. The ROW
@@ -1511,7 +1521,7 @@ export class InstanceSyncManager {
       // tombstone: the row won, so no tombstone is warranted.
       if (!localRow) {
         // delete-before-insert race: record the tombstone, apply nothing.
-        await writeTombstone(this.db, crowId, Math.max(tomb?.lamport_ts ?? 0, lamportTs));
+        await writeTombstone(this.db, crowId, Math.max(tombFloor, lamportTs));
         return;
       }
       if (lamportTs > localTs) {
@@ -1522,7 +1532,10 @@ export class InstanceSyncManager {
           try { await this.onContactDeleted(localRow); } catch { /* never throw into apply */ }
         }
         await this.db.execute({ sql: "DELETE FROM contacts WHERE crow_id = ?", args: [crowId] });
-        await writeTombstone(this.db, crowId, Math.max(tomb?.lamport_ts ?? 0, lamportTs));
+        // (Rule (a) above already cleared any tombstone coexisting with a local row, so
+        // `tombFloor` is 0 on this branch today. Kept in the same shape as the branch
+        // above so the two can never drift apart if rule (a) is ever relaxed.)
+        await writeTombstone(this.db, crowId, Math.max(tombFloor, lamportTs));
         return;
       }
       try {
@@ -1593,7 +1606,35 @@ export class InstanceSyncManager {
         sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ? ORDER BY id ASC LIMIT 1",
         args: [secpNorm],
       })).rows[0] || null : null;
-      if (secpRow) {
+
+      // F6 (re-derived, R5/CRITICAL-2). The design dropped F6 as "unreachable": the
+      // tombstone gate above returned for `op=update` and for `insert <= tomb.lamport_ts`,
+      // so a standing tombstone could never coexist with a rebind. `kind='prune'` REMOVED
+      // that premise — a prune deliberately does not gate an insert on lamport — and F6
+      // was never re-derived. It is reachable now:
+      //
+      //   prune ⇒ tombstone stands, row gone. The bot is un-advertised, not dead: it DMs
+      //   us, and the receive path files that under a `req:<secp>` placeholder WITH the
+      //   message (the documented §5.10 semantic). A REPLAYED ORIGINAL insert (feed replay
+      //   after a re-pair or a DB restore) then arrives, misses on crow_id, matches that
+      //   placeholder on secp — and REBINDS it. The pruned bot is back, CARRYING the DM.
+      //   Worse, it now has a message, so prune rule 5 (`HAVING COUNT(m.id) = 0` — the
+      //   prune never destroys history) can NEVER prune it again. Permanent resurrection:
+      //   exactly defect D3, and the "worst case, the next render re-prunes it —
+      //   self-healing" claim that justifies letting replayed inserts through is FALSE.
+      //
+      // So: when a GC tombstone stands, do not promote a `req:` placeholder — fall through
+      // to the plain INSERT below. Legal because `contacts` is UNIQUE on `crow_id` ONLY
+      // (no unique index on secp256k1_pubkey), so `crow:<botid>` and `req:<secp>` coexist.
+      // The re-add lands FRESH, zero-message, and RE-PRUNABLE (self-healing restored), and
+      // the DM stays on the message request, which is where §5.10 says it belongs.
+      //
+      // NARROW BY CONSTRUCTION — the rebind is load-bearing for the ordinary `req:` →
+      // `crow:` handshake promotion (contact-promote.js) and must not be disabled
+      // generally. Only a GC tombstone + a `req:` placeholder skips it.
+      const skipPruneRebind = tomb?.kind === "prune" && String(secpRow?.crow_id || "").startsWith("req:");
+
+      if (secpRow && !skipPruneRebind) {
         // Never relabel a real `crow:` id DOWN to a `req:` placeholder (a 3+-
         // instance cross-feed reorder could otherwise un-promote). One-directional.
         if (String(crowId).startsWith("req:") && !String(secpRow.crow_id).startsWith("req:")) return;
@@ -1625,7 +1666,19 @@ export class InstanceSyncManager {
     }
 
     if (lamportTs > localTs) {
-      const updateKeys = Object.keys(filtered).filter((k) => k !== "crow_id");
+      // `advertised_by_instance_id` is written when a crow_id is FIRST materialized
+      // here (INSERT / REBIND) and NEVER on a subsequent UPDATE (2a/F2 — "set at INSERT
+      // only", honoured on the apply side too). Without this, a peer that added the bot
+      // FROM A DIRECTORY would stamp provenance onto THIS instance's MANUALLY PASTED row
+      // for the same bot — silently making a hand-added contact garbage-collectable and
+      // breaking #155 §2.6 (pasted-invite bots must not be lost). Provenance is a fact
+      // about how a row was ACQUIRED HERE; it is not the sender's to assign after the
+      // fact. A peer that has never seen the contact still learns it on INSERT, so
+      // convergence (spec §5.7) is unaffected; an instance that already held the contact
+      // manually simply keeps it — the documented fail-safe direction.
+      const updateKeys = Object.keys(filtered).filter(
+        (k) => k !== "crow_id" && k !== "advertised_by_instance_id"
+      );
       // PR3 parity: a synced key rebind invalidates a local safety-number check.
       // `verified` is excluded from the wire (only ever set by a local device
       // comparison), so a secp/ed change MUST reset it to 0 — matching the local

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1538,16 +1538,34 @@ export class InstanceSyncManager {
 
     // (c) A tombstone is still standing and there is NO local row (rule (a)
     //     already cleared any tombstone that coexisted with a row). Delete wins
-    //     over a concurrent update; a stale insert replay is dropped; only a
-    //     fresher insert re-adds — and it must APPLY before it clears (ordering
-    //     is load-bearing: _processNewEntries locks per remote instance, so a
-    //     concurrent stale update from another feed must see either the tombstone
-    //     or the row, never neither — design §D3.1(c)).
+    //     over a concurrent update; an insert re-adds — and it must APPLY before it
+    //     clears (ordering is load-bearing: _processNewEntries locks per remote
+    //     instance, so a concurrent stale update from another feed must see either
+    //     the tombstone or the row, never neither — design §D3.1(c)).
+    //
+    //     The lamport gate applies to AUTHORITATIVE tombstones ONLY (`kind` NULL — a
+    //     user delete, F-CONTACT-1). Those were BROADCAST, so their lamport is a global
+    //     emit lamport and IS commensurable with an incoming insert's: `insert <=
+    //     tomb.lamport_ts` is a stale replay of an already-seen insert and must not undo
+    //     the user's delete.
+    //
+    //     A `kind='prune'` tombstone (2a/F4) is GARBAGE COLLECTION and is NOT comparable.
+    //     It emits nothing, and it is stamped with the pruned row's OWN lamport — a LOCAL
+    //     row lamport. Two instances' row lamports are equal only when every emit has been
+    //     applied on both sides, so a single un-replicated `update` on a peer (a rename, a
+    //     block) lifts THAT peer's row lamport and its tombstone then outruns the re-adder's
+    //     `insert`. Gating on it would drop a GENUINE re-add — and every subsequent `update`
+    //     from the re-adder is `op="update"`, dropped unconditionally by the line above ⇒ the
+    //     contact lives on one instance and is gone from the other FOREVER, with zero
+    //     sync_conflicts and nothing logged. GC is not authoritative, so we let the insert
+    //     land. Worst case a redelivered ORIGINAL insert re-creates the row and the next
+    //     render simply RE-PRUNES it — self-healing. `op="update"` still returns above, which
+    //     is the whole of defect D3 (every resurrection vector is an update).
     let clearTombAfterApply = false;
     if (tomb) {
-      if (op === "update") return;                    // drop — delete wins over a concurrent update
-      if (lamportTs <= tomb.lamport_ts) return;        // stale insert replay
-      clearTombAfterApply = true;                      // insert above the tombstone: apply, THEN clear
+      if (op === "update") return;                    // drop — delete wins over a concurrent update (D3)
+      if (tomb.kind !== "prune" && lamportTs <= tomb.lamport_ts) return; // stale insert replay (authoritative only)
+      clearTombAfterApply = true;                      // the insert stands: apply, THEN clear
     }
 
     // ── insert / update ────────────────────────────────────────────────────

--- a/servers/sharing/tools/contacts.js
+++ b/servers/sharing/tools/contacts.js
@@ -8,10 +8,9 @@
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { isKioskActive, kioskBlockedResponse } from "../../shared/kiosk-guard.js";
-import { generateInviteCode, parseInviteCode, parseBotInviteCode, computeSafetyNumber } from "../identity.js";
+import { generateInviteCode, parseInviteCode, computeSafetyNumber } from "../identity.js";
 import { upsertFullContact } from "../contact-promote.js";
-import { emitContactChange } from "../contact-sync.js";
-import { clearTombstone } from "../contact-delete.js";
+import { acceptBotInvite } from "../accept-bot-invite.js";
 import { sanitizeDisplayName } from "../display-name.js";
 import { buildInviteUrl, extractInviteCode } from "../invite-url.js";
 import {
@@ -111,24 +110,11 @@ async function acceptInviteCore({ invite_code, display_name }, { db, identity, s
   };
 }
 
-/**
- * Build the DM payload a recipient sends to a bot to accept its invite.
- * The adapter authorizes future chats on the SIGNED event pubkey, so the keys
- * here are labels the bot stores; the token is the bearer capability it checks.
- */
-export function buildBotAcceptPayload(token, identity, displayName) {
-  return JSON.stringify({
-    type: "crow_social",
-    subtype: "bot_invite_accept",
-    token,
-    sender: {
-      crow_id: identity.crowId,
-      ed25519_pubkey: identity.ed25519Pubkey,
-      secp256k1_pubkey: identity.secp256k1Pubkey,
-      display_name: displayName || identity.crowId,
-    },
-  });
-}
+// Re-export: buildBotAcceptPayload now lives beside the accept it belongs to. Kept
+// exported from here because it has always been part of this module's surface — and
+// it must NOT be imported back from tools/contacts.js into accept-bot-invite.js, which
+// would close an import cycle.
+export { buildBotAcceptPayload } from "../accept-bot-invite.js";
 
 export function registerContactsTools(server, ctx) {
   const { db, identity, peerManager, syncManager, nostrManager } = ctx;
@@ -364,65 +350,29 @@ export function registerContactsTools(server, ctx) {
       invite_code: z.string().max(2000).describe("The bot invite code (crow:<id>.<payload>.<sig>)"),
       display_name: z.string().max(100).optional().describe("Name to show for this bot"),
     },
+    // NOTE the schema above has NO advertiser / instance-id parameter, and must never
+    // gain one. `advertised_by_instance_id` is what makes a contact garbage-collectable;
+    // a model must never be able to stamp a contact prunable. Provenance is resolved
+    // SERVER-SIDE from the advertised directory (dashboard/shared/resolve-advertiser.js)
+    // and is supplied only by the panel directory handlers. This tool is the PASTE path:
+    // it has no advertiser, so it yields NULL provenance — correct, and never prunable.
     async ({ invite_code, display_name }) => {
       if (await isKioskActive(db)) return kioskBlockedResponse("crow_accept_bot_invite");
       try {
-        const bot = parseBotInviteCode(invite_code.trim());
-        // Prefer an explicit name, else the friendly name the owner put in the
-        // invite, else the raw crow: id.
-        const name = display_name || bot.name || bot.botCrowId;
-
-        // Add the bot as a contact so it appears in Messages and we subscribe
-        // for its replies. Idempotent on crow_id.
-        const existing = await db.execute({
-          sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [bot.botCrowId],
-        });
-        let contactId;
-        if (existing.rows.length > 0) {
-          contactId = Number(existing.rows[0].id);
-        } else {
-          const result = await db.execute({
-            sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
-            args: [bot.botCrowId, name, bot.ed25519Pubkey, bot.secp256k1Pubkey],
-          });
-          contactId = Number(result.lastInsertRowid);
-          try { await syncManager.initContact(contactId, null); } catch { /* bot has no hypercore feed; non-fatal */ }
-          // Subscribe to the bot's replies over Nostr (new contact only — existing
-          // contacts already have a live subscription from their first accept or
-          // from restart, so re-subscribing would leak a handle per relay).
-          try {
-            await nostrManager.subscribeToContact({
-              id: contactId, crowId: bot.botCrowId, secp256k1_pubkey: bot.secp256k1Pubkey,
-            });
-          } catch { /* non-fatal — re-subscribed on next restart */ }
-          // Phase 3: an accepted remote bot is a real cross-instance contact —
-          // propagate it to the user's other instances (advertised/remote bots
-          // sync per S-BOTS; a local-bot would be gated by shouldSyncRow).
-          try {
-            const { rows } = await db.execute({ sql: "SELECT * FROM contacts WHERE id = ?", args: [contactId] });
-            if (rows[0]) {
-              // D3.2: a local re-add supersedes any tombstone for this bot's crowId.
-              await clearTombstone(db, bot.botCrowId);
-              await emitContactChange("insert", rows[0]);
-            }
-          } catch { /* never blocks the accept */ }
-        }
-
-        // Tell the bot we accepted (carries the token it validates).
-        try {
-          if (nostrManager.relays.size === 0) await nostrManager.connectRelays();
-          await nostrManager.sendMessage(
-            { secp256k1_pubkey: bot.secp256k1Pubkey },
-            buildBotAcceptPayload(bot.token, identity, name)
-          );
-        } catch (err) {
+        const r = await acceptBotInvite(
+          db,
+          { syncManager, peerManager, nostrManager, identity },
+          { inviteCode: invite_code.trim(), displayName: display_name },
+        );
+        // Failing to reach the bot is NOT a failure of the accept — the contact is
+        // added either way and the bot authorizes us when it next comes online.
+        if (!r.notified) {
           return {
-            content: [{ type: "text", text: `Added ${name}, but could not reach the bot to confirm (it will authorize you when next online): ${err.message}` }],
+            content: [{ type: "text", text: `Added ${r.name}, but could not reach the bot to confirm (it will authorize you when next online): ${r.error}` }],
           };
         }
-
         return {
-          content: [{ type: "text", text: `Added ${name}! You can now message this bot from your Messages list.` }],
+          content: [{ type: "text", text: `Added ${r.name}! You can now message this bot from your Messages list.` }],
         };
       } catch (err) {
         return {

--- a/tests/advertised-by-column.test.js
+++ b/tests/advertised-by-column.test.js
@@ -1,0 +1,87 @@
+/**
+ * F2 (advertised-contact prune, design §3) — Task 1: the provenance column.
+ *
+ * contacts.advertised_by_instance_id records a FACT: the instance_id of the peer
+ * whose advertised-bot directory this contact was materialized from. It is set at
+ * INSERT only. NULL = manual/pasted-invite contact, which is NEVER prunable.
+ *
+ * Harness mirrors tests/contact-tombstones.test.js: real init-db into a tmpdir
+ * (never ~/.crow), then the async createDbClient handle.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { SCHEMA_GENERATION } from "../servers/shared/schema-version.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-advby-test-"));
+function initDb() {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: tmpDir },
+    stdio: "pipe",
+  });
+}
+initDb();
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const db = createDbClient(DB_PATH);
+
+test("contacts has an advertised_by_instance_id TEXT column after init-db", async () => {
+  const { rows } = await db.execute("PRAGMA table_info(contacts)");
+  const col = rows.find((r) => r.name === "advertised_by_instance_id");
+  assert.ok(col, "advertised_by_instance_id column present on contacts");
+  assert.equal(String(col.type).toUpperCase(), "TEXT");
+});
+
+test("the schema generation was bumped for this migration (>= 7) and is stamped on the DB", async () => {
+  assert.ok(
+    SCHEMA_GENERATION >= 7,
+    `SCHEMA_GENERATION must be >= 7 for the advertised_by_instance_id migration, got ${SCHEMA_GENERATION}`,
+  );
+  const { rows } = await db.execute("PRAGMA user_version");
+  assert.equal(Number(rows[0].user_version), SCHEMA_GENERATION);
+});
+
+test("advertised_by_instance_id defaults to NULL (manual contact = never prunable)", async () => {
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
+    args: ["crow:manual1", "Manual", "e".repeat(64), "s".repeat(66)],
+  });
+  const { rows } = await db.execute({
+    sql: "SELECT advertised_by_instance_id FROM contacts WHERE crow_id = ?",
+    args: ["crow:manual1"],
+  });
+  assert.equal(rows[0].advertised_by_instance_id, null);
+});
+
+test("the migration is additive — re-running init-db preserves existing contact rows", async () => {
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
+    args: ["crow:survivor", "Survivor", "a".repeat(64), "b".repeat(66)],
+  });
+  initDb(); // must not throw, must not drop/recreate contacts
+  const fresh = createDbClient(DB_PATH);
+  const { rows } = await fresh.execute({
+    sql: "SELECT display_name, advertised_by_instance_id FROM contacts WHERE crow_id = ?",
+    args: ["crow:survivor"],
+  });
+  assert.equal(rows.length, 1, "pre-existing contact row survived the re-init");
+  assert.equal(rows[0].display_name, "Survivor");
+  assert.equal(rows[0].advertised_by_instance_id, null, "new column is present and NULL on the migrated row");
+});
+
+test("advertised_by_instance_id round-trips the advertising peer's instance_id", async () => {
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey, origin, advertised_by_instance_id) VALUES (?,?,?,?,?,?)",
+    args: ["crow:advbot", "Bot", "c".repeat(64), "d".repeat(66), "advertised", "inst-grackle-1"],
+  });
+  const { rows } = await db.execute({
+    sql: "SELECT advertised_by_instance_id FROM contacts WHERE crow_id = ?",
+    args: ["crow:advbot"],
+  });
+  assert.equal(rows[0].advertised_by_instance_id, "inst-grackle-1");
+});

--- a/tests/advertised-prune-durability.test.js
+++ b/tests/advertised-prune-durability.test.js
@@ -1,0 +1,486 @@
+// tests/advertised-prune-durability.test.js
+//
+// F4 durability + convergence (spec `2026-07-12-advertised-contact-prune-design.md`
+// §5 tests 5, 6, 7, 9, 10). tests/roster-advertise-prune.test.js covers the trigger
+// matrix on ONE instance; this file covers what happens BETWEEN two instances — the
+// half where three previous designs died:
+//
+//   v1  broadcast a delete   ⇒ LWW asymmetry ⇒ divergence + sync_conflicts growth (test 9)
+//   v2  bare local delete    ⇒ any later `update` re-INSERTs the row              (test 5)
+//   v3  fresh-counter tomb   ⇒ a MUTUAL prune + re-add ties at the gate and is
+//                              dropped FOREVER — and v3's test plan never once
+//                              pruned on both sides, so every test passed         (test 6)
+//
+// HARNESS: two real instances (each its own mkdtemp CROW_DATA_DIR + real init-db +
+// real InstanceSyncManager) joined by a fake out-feed that captures every entry
+// emitChange() appends and hands it to the peer's _applyEntry(). Capturing the feed
+// (rather than running hypercore) is what lets us assert the design's central claim
+// NEGATIVELY: that the prune puts NOTHING on the wire.
+//
+// NEVER point this file at ~/.crow or ~/.crow-mpa — this code path DELETES contacts.
+import { test, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { acceptBotInvite } from "../servers/sharing/accept-bot-invite.js";
+import { pruneStaleAdvertisedContacts } from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+import { emitContactChange, __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
+import { readTombstone } from "../servers/sharing/contact-delete.js";
+import { deriveBotIdentity, generateBotInviteCode, parseBotInviteCode } from "../servers/sharing/identity.js";
+import { normalizePubkey } from "../servers/sharing/pubkey-util.js";
+import { handleIncomingRequest } from "../servers/sharing/boot.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+// ── identities ───────────────────────────────────────────────────────────────
+// One shared ed25519 identity: instance-sync verifies every entry against
+// `this.identity.ed25519Pubkey`, and a user's instances share one identity.
+const TEST_PRIV = Buffer.alloc(32, 0x5e);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+const A_ID = "inst-aaaa-0000-0000-0000-00000000000a";
+const B_ID = "inst-bbbb-0000-0000-0000-00000000000b";
+const ADV = "inst-advertiser-x"; // the peer whose directory the bot came from
+
+/** The bot that gets un-advertised and pruned. */
+const BOT = deriveBotIdentity(randomBytes(32), "prune-bot");
+const BOT_CODE = generateBotInviteCode(BOT, "tok-prune", [], "Prune Bot");
+const BOT_CROW_ID = parseBotInviteCode(BOT_CODE).botCrowId;
+const BOT_X = String(BOT.secp256k1Pubkey).slice(-64).toLowerCase();
+
+/** The negative control: a bot that stays advertised throughout. */
+const KEEP = deriveBotIdentity(randomBytes(32), "keep-bot");
+const KEEP_CODE = generateBotInviteCode(KEEP, "tok-keep", [], "Keep Bot");
+const KEEP_CROW_ID = parseBotInviteCode(KEEP_CODE).botCrowId;
+const KEEP_X = String(KEEP.secp256k1Pubkey).slice(-64).toLowerCase();
+
+// ── two real instances ───────────────────────────────────────────────────────
+function initInstance(label) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-prune-dur-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    stdio: "pipe",
+  });
+  return { dir, path: join(dir, "crow.db") };
+}
+const A_FILES = initInstance("a");
+const B_FILES = initInstance("b");
+after(() => {
+  __setEmitSinkForTest(null);
+  rmSync(A_FILES.dir, { recursive: true, force: true });
+  rmSync(B_FILES.dir, { recursive: true, force: true });
+});
+
+/**
+ * The shared feed. `wire` holds EVERY entry either instance appended — the object
+ * of assertion for "the prune broadcasts nothing" and "no delete on the wire".
+ * Entries are JSON round-tripped, exactly as a real hypercore would deliver them.
+ */
+function newFleet() {
+  const wire = [];
+  const A = { id: A_ID, db: createDbClient(A_FILES.path) };
+  const B = { id: B_ID, db: createDbClient(B_FILES.path) };
+  const attach = (inst) => {
+    inst.mgr = new InstanceSyncManager(IDENTITY, inst.db, inst.id);
+    inst.mgr.feedsDisabled = false;
+    inst.mgr.outFeeds = new Map([["peer", {
+      append: async (e) => { wire.push({ from: inst.id, entry: JSON.parse(JSON.stringify(e)) }); },
+    }]]);
+  };
+  attach(A);
+  attach(B);
+  let cursor = 0;
+  /** Replicate every un-delivered entry to the other side, in order. */
+  const deliver = async () => {
+    while (cursor < wire.length) {
+      const { from, entry } = wire[cursor++];
+      const dest = from === A.id ? B : A;
+      await dest.mgr._applyEntry(from, entry);
+    }
+  };
+  /** Restart an instance: brand-new db handle + manager over the SAME file. */
+  const restart = async (inst) => {
+    inst.db = createDbClient(inst.id === A_ID ? A_FILES.path : B_FILES.path);
+    attach(inst);
+  };
+  return { A, B, wire, deliver, restart };
+}
+
+/** Run `fn` with `inst` as the emit sink — an emit belongs to exactly one instance. */
+async function act(inst, fn) {
+  __setEmitSinkForTest(inst.mgr);
+  try { return await fn(); } finally { __setEmitSinkForTest(null); }
+}
+
+const row = async (inst, crowId) => (await inst.db.execute({
+  sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [crowId],
+})).rows[0] || null;
+
+const conflicts = async (inst) => Number((await inst.db.execute("SELECT COUNT(*) c FROM sync_conflicts")).rows[0].c);
+
+const counter = async (inst) => Number((await inst.db.execute({
+  sql: "SELECT local_counter FROM sync_state WHERE instance_id = ?", args: [inst.id],
+})).rows[0]?.local_counter ?? 0);
+
+const setCounter = async (inst, n) => {
+  await inst.mgr._ensureCounter();
+  await inst.db.execute({ sql: "UPDATE sync_state SET local_counter = ? WHERE instance_id = ?", args: [n, inst.id] });
+};
+
+/** perInstance as getBotDirectory builds it: ADV answered ok+complete with `live` keys. */
+const directory = (...liveXOnlyKeys) => new Map([
+  [ADV, { ok: true, complete: true, pubkeys: new Set(liveXOnlyKeys) }],
+]);
+
+/**
+ * The prune, called exactly as getBotDirectory({prune:true}) calls it — and run
+ * with `inst` INSTALLED AS THE LIVE EMIT SINK, as it is in production. This is
+ * load-bearing, not decoration: emitContactChange/emitContactDelete resolve their
+ * sink from the module-global (the real InstanceSyncManager at runtime). With a
+ * null sink, a prune that DID broadcast a delete would emit into the void and the
+ * wire assertions below would pass vacuously — v1's exact failure, invisible.
+ */
+const prune = (inst, perInstance) =>
+  act(inst, () => pruneStaleAdvertisedContacts(inst.db, perInstance, inst.id, { syncManager: inst.mgr }));
+
+/** A adds the bot from ADV's directory; B receives it by sync. Returns the shared lamport. */
+async function addFromDirectoryAndSync(fleet, code, crowId) {
+  await act(fleet.A, () => acceptBotInvite(fleet.A.db, {}, { inviteCode: code, advertisedByInstanceId: ADV }));
+  await fleet.deliver();
+  const a = await row(fleet.A, crowId);
+  const b = await row(fleet.B, crowId);
+  assert.ok(a && b, "setup: both instances hold the contact");
+  assert.equal(Number(a.lamport_ts), Number(b.lamport_ts), "setup: both rows converged on one lamport");
+  return Number(a.lamport_ts);
+}
+
+/** Every real resurrection vector is an `op="update"` (block, rename, accept, boot backfill). */
+async function emitUpdate(inst, crowId, patch = {}) {
+  const keys = Object.keys(patch);
+  if (keys.length) {
+    await inst.db.execute({
+      sql: `UPDATE contacts SET ${keys.map((k) => `${k} = ?`).join(", ")} WHERE crow_id = ?`,
+      args: [...keys.map((k) => patch[k]), crowId],
+    });
+  }
+  const r = await row(inst, crowId);
+  await act(inst, () => emitContactChange("update", r));
+}
+
+beforeEach(async () => {
+  const dbs = [createDbClient(A_FILES.path), createDbClient(B_FILES.path)];
+  for (const db of dbs) {
+    await db.execute("DELETE FROM messages");
+    await db.execute("DELETE FROM contacts");
+    await db.execute("DELETE FROM contact_tombstones");
+    await db.execute("DELETE FROM crow_instances");
+    await db.execute("DELETE FROM notifications");
+  }
+  __setEmitSinkForTest(null);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 5 — THE HEADLINE (defect D3: resurrection)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("5. A prunes ⇒ tombstone at the row's OWN lamport_ts; B's later `update` does NOT resurrect it; a restart of A does not either", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  // Both instances hold the same advertised contact (A added it, B got it by sync),
+  // plus a second one that stays advertised (the negative control).
+  const lamport = await addFromDirectoryAndSync(f, BOT_CODE, BOT_CROW_ID);
+  await addFromDirectoryAndSync(f, KEEP_CODE, KEEP_CROW_ID);
+  const wireBeforePrune = f.wire.length;
+
+  // ADV stops advertising the bot (KEEP is still in its list).
+  await prune(f.A, directory(KEEP_X));
+
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "the pruned row is gone on A");
+  const tomb = await readTombstone(f.A.db, BOT_CROW_ID);
+  assert.ok(tomb, "the prune wrote a tombstone (a bare DELETE is resurrectable)");
+  assert.equal(Number(tomb.lamport_ts), lamport,
+    "the tombstone sits at the PRUNED ROW'S OWN lamport_ts — not a fresh counter value (spec §3 F4)");
+  assert.equal(f.wire.length, wireBeforePrune, "the prune emitted NOTHING");
+
+  // THE resurrection vector. block/unblock, profile edit, accept-request and the
+  // boot backfill are ALL op="update" — B still holds the row and still emits.
+  await emitUpdate(f.B, BOT_CROW_ID, { is_blocked: 1 });
+  await f.deliver();
+  assert.equal(await row(f.A, BOT_CROW_ID), null,
+    "D3: a peer's `update` against a standing tombstone must NOT re-INSERT the contact");
+
+  // Durability across a process restart — the whole point of a row, not memory.
+  await f.restart(f.A);
+  assert.ok(await readTombstone(f.A.db, BOT_CROW_ID), "the tombstone survived the restart");
+  await emitUpdate(f.B, BOT_CROW_ID, { display_name: "Zombie" });
+  await f.deliver();
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "still gone after a restart of A");
+
+  // NEGATIVE CONTROL — ordinary contact sync is untouched by any of the above.
+  await emitUpdate(f.B, KEEP_CROW_ID, { display_name: "Keep Bot Renamed" });
+  await f.deliver();
+  const keep = await row(f.A, KEEP_CROW_ID);
+  assert.ok(keep, "the still-advertised contact was never pruned");
+  assert.equal(keep.display_name, "Keep Bot Renamed", "and it still syncs normally");
+  assert.equal(await readTombstone(f.A.db, KEEP_CROW_ID), null, "no tombstone for the live contact");
+
+  // §5 test 9
+  assert.equal(await conflicts(f.A), c0.a, "sync_conflicts unchanged on A");
+  assert.equal(await conflicts(f.B), c0.b, "sync_conflicts unchanged on B");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 6 — THE LAMPORT-TIE REGRESSION (R3/CRITICAL-1)
+//
+// v3's plan never pruned on BOTH sides, so it could not see this. A MUTUAL prune is
+// the NORMAL case: both instances are paired with ADV, both see the bot vanish from
+// its directory, both reach the same conclusion. The prune emits nothing, so a
+// counter burned by a tombstone is invisible to the fleet — and the re-adder's
+// `insert` can then land at or below the peer's tombstone and be dropped FOREVER.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mutual prune, then the LOWER-counter instance re-adds and emits `insert`.
+ * The peer MUST apply it and clear its tombstone. `arrange` sets the counters.
+ */
+async function mutualPruneThenReAdd(arrange) {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+  const lamport = await addFromDirectoryAndSync(f, BOT_CODE, BOT_CROW_ID);
+  await arrange(f, lamport);
+
+  // BOTH instances independently reach the same conclusion. This is the case v3
+  // omitted, and the only one in which the tombstone lamports can disagree.
+  await prune(f.A, directory());
+  await prune(f.B, directory());
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "pruned on A");
+  assert.equal(await row(f.B, BOT_CROW_ID), null, "pruned on B");
+
+  // The re-adder must be the one with the LOWER counter — the losing side of the tie.
+  const [reAdder, peer] = (await counter(f.A)) <= (await counter(f.B)) ? [f.A, f.B] : [f.B, f.A];
+
+  // ADV re-advertises; the user adds the bot again on the lower-counter instance.
+  await act(reAdder, () => acceptBotInvite(reAdder.db, {}, { inviteCode: BOT_CODE, advertisedByInstanceId: ADV }));
+  await f.deliver();
+
+  assert.ok(await row(reAdder, BOT_CROW_ID), "the re-add landed locally");
+  assert.equal(await readTombstone(reAdder.db, BOT_CROW_ID), null, "the re-adder cleared its own tombstone");
+  assert.ok(await row(peer, BOT_CROW_ID),
+    "THE ASSERTION: the peer MUST apply the re-add. A tombstone written at a fresh counter " +
+    "value ties with (or outruns) the re-adder's insert, the gate drops it, and the two " +
+    "instances diverge PERMANENTLY — with no error, on both sides, forever.");
+  assert.equal(await readTombstone(peer.db, BOT_CROW_ID), null, "and the peer cleared its tombstone");
+  assert.equal(await conflicts(f.A), c0.a, "sync_conflicts unchanged on A");
+  assert.equal(await conflicts(f.B), c0.b, "sync_conflicts unchanged on B");
+}
+
+test("6a. MUTUAL prune with the counters at an exact TIE, then the re-add ⇒ both sides converge", async () => {
+  // The live fleet sits at 4385 / 4385 / 4384 — this is the regime, not a hypothetical.
+  await mutualPruneThenReAdd(async (f) => {
+    await setCounter(f.A, 4385);
+    await setCounter(f.B, 4385);
+  });
+});
+
+test("6b. MUTUAL prune with the RE-ADDER's counter BELOW its peer's, then the re-add ⇒ both sides converge", async () => {
+  // The shape a two-instance sync produces on its own: the applier's counter is
+  // MAX(counter, ts+1), so the receiver always ends up AHEAD of the emitter.
+  await mutualPruneThenReAdd(async (f) => {
+    assert.ok((await counter(f.A)) < (await counter(f.B)),
+      "the natural post-sync state already puts the adder BELOW its peer");
+  });
+});
+
+test("6c. MUTUAL prune with the re-adder's counter FAR below its peer's ⇒ both sides converge", async () => {
+  await mutualPruneThenReAdd(async (f, lamport) => {
+    await setCounter(f.A, lamport);       // the adder, still where its own emit left it
+    await setCounter(f.B, lamport + 500); // the peer, run far ahead by unrelated local writes
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 6d — THE INCOMMENSURABLE-LAMPORT REGRESSION.
+//
+// v4's convergence proof claimed a genuine re-add "is emitted at the re-adder's next
+// lamport, which is necessarily > R.lamport_ts ⇒ applies and clears the tombstone".
+// FALSE. The gate runs on the PEER, against the PEER's tombstone, which sits at the
+// PEER's ROW lamport. Two instances' row lamports are equal only when every emit has
+// been applied on both sides. One un-replicated `update` on the peer (a rename, a
+// block — every one of them is an `op="update"`) and the peer's tombstone OUTRUNS the
+// re-adder's insert. The gate drops the insert; every later `update` from the re-adder
+// is then dropped unconditionally by the same tombstone. PERMANENT divergence, zero
+// sync_conflicts, no log line. A prune tombstone's lamport is a LOCAL row lamport —
+// comparing a global insert lamport against it compares incommensurable things.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("6d. a re-add CONVERGES even when the peer's tombstone outran it (the peer had an un-replicated update)", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  // A adds the bot from ADV's directory and emits insert@L; B applies it. Both rows @L.
+  const L = await addFromDirectoryAndSync(f, BOT_CODE, BOT_CROW_ID);
+
+  // B blocks the bot contact and emits update@L' (L' > L) — and A NEVER RECEIVES IT
+  // (offline, feed lag). B's ROW lamport now outruns A's, and A's counter never learns
+  // it (_applyEntry:_advanceCounter only runs on receipt — the premise is non-receipt).
+  const sent = f.wire.length;
+  await emitUpdate(f.B, BOT_CROW_ID, { is_blocked: 1 });
+  const lost = f.wire.splice(sent); // dropped on the floor: A never sees this entry
+  assert.equal(lost.length, 1, "setup: B emitted exactly one update, and it never reached A");
+
+  const aTs = Number((await row(f.A, BOT_CROW_ID)).lamport_ts);
+  const bTs = Number((await row(f.B, BOT_CROW_ID)).lamport_ts);
+  assert.equal(aTs, L, "setup: A's row still sits at the original insert's lamport");
+  assert.ok(bTs > aTs, "setup: B's ROW lamport outran A's — this is the divergence the gate cannot see");
+
+  // ADV un-advertises ⇒ BOTH instances prune independently. Each writes its tombstone at
+  // its OWN row lamport ⇒ the two tombstones DISAGREE, and nothing on the wire says so.
+  await prune(f.A, directory());
+  await prune(f.B, directory());
+  assert.equal(Number((await readTombstone(f.A.db, BOT_CROW_ID)).lamport_ts), aTs, "A's tombstone @ A's row lamport");
+  assert.equal(Number((await readTombstone(f.B.db, BOT_CROW_ID)).lamport_ts), bTs, "B's tombstone @ B's HIGHER row lamport");
+
+  // ADV re-advertises. The user re-adds the bot on A. The re-added row is a FRESH INSERT
+  // (lamport_ts 0), so emitChange's counter floor has nothing to floor against — the
+  // insert goes out at A's own next counter value, at or BELOW B's tombstone.
+  await act(f.A, () => acceptBotInvite(f.A.db, {}, { inviteCode: BOT_CODE, advertisedByInstanceId: ADV }));
+  const reAdd = f.wire.at(-1).entry;
+  assert.equal(reAdd.op, "insert", "the re-add goes out as an `insert`");
+  assert.ok(Number(reAdd.lamport_ts) <= bTs,
+    "the re-add's lamport is at or below B's tombstone — this is the trap the lamport gate walks into");
+  await f.deliver();
+
+  assert.ok(await row(f.A, BOT_CROW_ID), "the re-add landed on A");
+  assert.equal(await readTombstone(f.A.db, BOT_CROW_ID), null, "A cleared its own tombstone");
+
+  assert.ok(await row(f.B, BOT_CROW_ID),
+    "THE ASSERTION: B MUST apply the genuine re-add. A prune tombstone is GARBAGE COLLECTION, not an " +
+    "authoritative delete — it exists only to block resurrection-by-`update` (D3). Gating an `insert` on " +
+    "its lamport drops the re-add, and then every later `update` from A is dropped unconditionally by the " +
+    "same tombstone: the bot is on A and NOT on B, forever, with zero sync_conflicts and nothing logged.");
+  assert.equal(await readTombstone(f.B.db, BOT_CROW_ID), null, "and B cleared its tombstone once the row was back");
+
+  // A follow-up rename from A must now reach B — proof the gate is not still swallowing updates.
+  await emitUpdate(f.A, BOT_CROW_ID, { display_name: "Back Again" });
+  await f.deliver();
+  assert.equal((await row(f.B, BOT_CROW_ID)).display_name, "Back Again", "and normal contact sync resumed on B");
+
+  assert.equal(await conflicts(f.A), c0.a, "sync_conflicts unchanged on A");
+  assert.equal(await conflicts(f.B), c0.b, "sync_conflicts unchanged on B");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 7 — CONVERGENCE (the plan's acceptance criterion)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("7. both instances paired with ADV prune INDEPENDENTLY — provenance crossed the wire, no delete ever did", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+  for (const inst of [f.A, f.B]) {
+    await inst.db.execute({
+      sql: "INSERT INTO crow_instances (id, name, crow_id, trusted, status, is_home) VALUES (?,?,?,1,'active',0)",
+      args: [ADV, "Advertiser", "crow:adv0000001"],
+    });
+  }
+
+  // A ADDED it from ADV's directory. B receives it BY SYNC.
+  await act(f.A, () => acceptBotInvite(f.A.db, {}, { inviteCode: BOT_CODE, advertisedByInstanceId: ADV }));
+
+  // The provenance must actually cross the wire — if it does not, B can NEVER prune
+  // (rule: advertised_by_instance_id IS NOT NULL) and the whole design fails.
+  const inserts = f.wire.filter((w) => w.entry.table === "contacts" && w.entry.op === "insert");
+  assert.equal(inserts.length, 1, "exactly one insert on the wire");
+  assert.equal(inserts[0].entry.row.advertised_by_instance_id, ADV,
+    "the FACT of who advertised the bot rides the wire (it is NOT in EXCLUDED_COLUMNS)");
+  assert.equal("origin" in inserts[0].entry.row, false,
+    "…while `origin` — a judgment — does not (F3)");
+
+  await f.deliver();
+  const b = await row(f.B, BOT_CROW_ID);
+  assert.equal(b.advertised_by_instance_id, ADV, "B stored the provenance it received");
+  assert.equal(b.origin, null, "B did NOT inherit the sender's judgment");
+
+  // ADV un-advertises. Each instance reaches the same conclusion from its OWN view.
+  const wireBefore = f.wire.length;
+  await prune(f.A, directory());
+  await prune(f.B, directory());
+
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "gone on A");
+  assert.equal(await row(f.B, BOT_CROW_ID), null, "gone on B — it pruned independently, from its own view of ADV");
+  assert.equal(f.wire.length, wireBefore, "NOTHING was emitted by either prune");
+  assert.equal(f.wire.filter((w) => w.entry.op === "delete").length, 0,
+    "ZERO `op=delete` on the wire — convergence needs no broadcast and no host authority (v1 died here)");
+
+  // Deliver anything still queued; a delete-free wire must leave both sides settled.
+  await f.deliver();
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "still gone on A after replication");
+  assert.equal(await row(f.B, BOT_CROW_ID), null, "still gone on B after replication");
+
+  // §5 test 9
+  assert.equal(await conflicts(f.A), c0.a, "sync_conflicts unchanged on A");
+  assert.equal(await conflicts(f.B), c0.b, "sync_conflicts unchanged on B");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 9 — sync_conflicts must not grow. Growth is what killed v1.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("9. a FULL lifecycle (add → sync → mutual prune → resurrection attempt → re-add) grows sync_conflicts by ZERO on both instances", async () => {
+  const f = newFleet();
+  const before = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  await addFromDirectoryAndSync(f, BOT_CODE, BOT_CROW_ID);
+  await addFromDirectoryAndSync(f, KEEP_CODE, KEEP_CROW_ID);
+  await prune(f.A, directory(KEEP_X));
+  await prune(f.B, directory(KEEP_X));
+  await emitUpdate(f.B, KEEP_CROW_ID, { display_name: "Still Here" });
+  await act(f.A, () => acceptBotInvite(f.A.db, {}, { inviteCode: BOT_CODE, advertisedByInstanceId: ADV }));
+  // ONE drain at the end — the interleaving that exposes v1's LWW asymmetry: a
+  // broadcast delete would arrive at a peer that has ALREADY re-added the row at a
+  // higher lamport ⇒ the delete LOSES ⇒ `_insertConflictRow` ⇒ the log grows.
+  await f.deliver();
+
+  // The conflict log FIRST — it is this test's named mechanism, and under a
+  // broadcast-delete prune it is the assertion that must report.
+  assert.equal(await conflicts(f.A), before.a,
+    "sync_conflicts BYTE-IDENTICAL on A — a broadcast delete would collide with the re-added row and log one");
+  assert.equal(await conflicts(f.B), before.b, "sync_conflicts BYTE-IDENTICAL on B");
+  assert.ok(await row(f.B, BOT_CROW_ID), "and the lifecycle actually converged");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 10 — DOCUMENTED, NOT FIXED. An accepted trade-off, asserted so that it
+// is a CHOICE on the record rather than a surprise in production.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("10. ACCEPTED TRADE-OFF: a DM from a pruned-but-still-running bot arrives as a message REQUEST — it must not resurrect the contact", async () => {
+  const f = newFleet();
+  await addFromDirectoryAndSync(f, BOT_CODE, BOT_CROW_ID);
+  await prune(f.A, directory());
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "pruned");
+
+  // The bot is un-advertised, not dead. It DMs us. It is no longer a contact, so the
+  // receive path files it as a message request under `req:<secp>` — by design.
+  await handleIncomingRequest(f.A.db, { createNotification: async () => {} }, {
+    senderPubkey: BOT.secp256k1Pubkey, content: "still here", eventId: "evt-prune-10",
+  });
+
+  const reqId = "req:" + normalizePubkey(BOT.secp256k1Pubkey);
+  const req = await row(f.A, reqId);
+  assert.ok(req, "the DM landed as a `req:<secp>` message-request row");
+  assert.equal(req.request_status, "pending", "…in the pending-request state, awaiting the user");
+  const { rows: msgs } = await f.A.db.execute({
+    sql: "SELECT content FROM messages WHERE contact_id = ?", args: [req.id],
+  });
+  assert.deepEqual(msgs.map((m) => m.content), ["still here"], "the message itself is NOT lost");
+
+  // And the pruned contact stays pruned: a request is not a resurrection.
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "the pruned bot contact was NOT recreated");
+  assert.ok(await readTombstone(f.A.db, BOT_CROW_ID), "its tombstone still stands");
+});

--- a/tests/advertised-prune-durability.test.js
+++ b/tests/advertised-prune-durability.test.js
@@ -30,7 +30,7 @@ import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
 import { acceptBotInvite } from "../servers/sharing/accept-bot-invite.js";
 import { pruneStaleAdvertisedContacts } from "../servers/gateway/dashboard/panels/messages/data-queries.js";
 import { emitContactChange, __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
-import { readTombstone } from "../servers/sharing/contact-delete.js";
+import { readTombstone, deleteContactLocal } from "../servers/sharing/contact-delete.js";
 import { deriveBotIdentity, generateBotInviteCode, parseBotInviteCode } from "../servers/sharing/identity.js";
 import { normalizePubkey } from "../servers/sharing/pubkey-util.js";
 import { handleIncomingRequest } from "../servers/sharing/boot.js";
@@ -376,6 +376,94 @@ test("6d. a re-add CONVERGES even when the peer's tombstone outran it (the peer 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// §5 test 6e — R5/CRITICAL-1: the LAUNDERED LAMPORT.
+//
+// `writeTombstone`'s ON CONFLICT kept `MAX(lamport_ts, excluded.lamport_ts)` across a
+// KIND TRANSITION, and `_applyContact`'s delete branch passed `Math.max(tomb.lamport_ts,
+// lamportTs)` regardless of the standing tombstone's kind. Both launder a prune's LOCAL
+// row lamport into the AUTHORITATIVE tombstone — the one field whose only consumer is the
+// `insert <= tomb.lamport_ts ⇒ drop` gate, which is only meaningful for GLOBAL emit
+// lamports. The two numbers are not commensurable, so a prune that ran at a high local row
+// lamport arms the gate at a value the deleting instance's own re-add can never exceed.
+// `emitContactDelete` sends only `{crow_id}` — a row with no `lamport_ts` — so emitChange's
+// counter floor does not apply to deletes: a lagging or post-DB-recovery instance really
+// does emit its delete at a low lamport. Result: the genuine re-add is dropped, every later
+// `op="update"` from the re-adder is dropped unconditionally by the same tombstone, and the
+// two instances diverge PERMANENTLY with zero sync_conflicts.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("6e. a prune's LOCAL lamport must not be laundered into an authoritative tombstone — a user delete at a LOW lamport still lets the genuine re-add land", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  // A adds the bot; B receives it by sync. Both rows @L.
+  await addFromDirectoryAndSync(f, BOT_CODE, BOT_CROW_ID);
+
+  // A sees several updates B never does (offline / feed lag) ⇒ A's ROW lamport climbs
+  // far above anything B's counter knows about. Every one of these is an `op="update"`
+  // (rename, block, unblock…) — the ordinary traffic of a contact.
+  for (const name of ["A1", "A2", "A3", "A4", "A5"]) {
+    const sent = f.wire.length;
+    await emitUpdate(f.A, BOT_CROW_ID, { display_name: name });
+    f.wire.splice(sent); // never reaches B
+  }
+  const aRowTs = Number((await row(f.A, BOT_CROW_ID)).lamport_ts);
+
+  // B is a post-DB-recovery instance: `sync_state` was rebuilt and its counter sits low.
+  // (crow's own fleet has had exactly this — a DB recovery + a re-pair.)
+  await setCounter(f.B, 2);
+
+  // ADV un-advertises ⇒ A prunes. Its tombstone carries A's HIGH local row lamport.
+  await prune(f.A, directory());
+  const pruneTomb = await readTombstone(f.A.db, BOT_CROW_ID);
+  assert.equal(pruneTomb.kind, "prune", "setup: A's tombstone is garbage collection");
+  assert.equal(Number(pruneTomb.lamport_ts), aRowTs, "setup: …stamped with A's LOCAL row lamport");
+
+  // On B the user DELETES the bot for real — an AUTHORITATIVE delete. It is broadcast, and
+  // `emitContactDelete` passes only { crow_id } ⇒ no counter floor ⇒ it goes out at B's own
+  // low counter, BELOW A's prune lamport.
+  const bRow = await row(f.B, BOT_CROW_ID);
+  await act(f.B, () => deleteContactLocal(f.B.db, { syncManager: f.B.mgr }, bRow));
+  const del = f.wire.at(-1).entry;
+  assert.equal(del.op, "delete", "setup: the user delete IS broadcast");
+  assert.ok(Number(del.lamport_ts) < aRowTs,
+    "setup: the authoritative delete's GLOBAL lamport is below A's LOCAL prune lamport — the whole trap");
+  await f.deliver();
+
+  // A now holds an AUTHORITATIVE tombstone. Its lamport must be the DELETE's (a global emit
+  // lamport), never the prune's (a local row lamport).
+  const authTomb = await readTombstone(f.A.db, BOT_CROW_ID);
+  assert.equal(authTomb.kind, null, "A's tombstone was upgraded to authoritative by the user's delete");
+  assert.equal(Number(authTomb.lamport_ts), Number(del.lamport_ts),
+    "…AT THE DELETE'S LAMPORT. Carrying the prune's local lamport forward arms the stale-insert gate at a " +
+    "number B can never emit past.");
+
+  // The user changes their mind and re-adds the bot on B. A genuine re-add, `op=insert`.
+  await act(f.B, () => acceptBotInvite(f.B.db, {}, { inviteCode: BOT_CODE, advertisedByInstanceId: ADV }));
+  const reAdd = f.wire.at(-1).entry;
+  assert.equal(reAdd.op, "insert", "the re-add goes out as an `insert`");
+  assert.ok(Number(reAdd.lamport_ts) < aRowTs,
+    "…and it is BELOW A's laundered prune lamport — exactly what the un-fixed gate drops");
+  await f.deliver();
+
+  assert.ok(await row(f.B, BOT_CROW_ID), "the re-add landed on B");
+  assert.ok(await row(f.A, BOT_CROW_ID),
+    "THE ASSERTION: A MUST apply the genuine re-add. A prune's LOCAL row lamport is not comparable with an " +
+    "`insert`'s GLOBAL one; laundering it into the authoritative tombstone drops the re-add, and then every " +
+    "later `update` from B is dropped unconditionally by the same tombstone — the bot lives on B and is gone " +
+    "from A FOREVER, with zero sync_conflicts and nothing logged.");
+  assert.equal(await readTombstone(f.A.db, BOT_CROW_ID), null, "and A cleared its tombstone once the row was back");
+
+  // Ordinary sync must resume — proof the tombstone is not still swallowing B's updates.
+  await emitUpdate(f.B, BOT_CROW_ID, { display_name: "Back On Both" });
+  await f.deliver();
+  assert.equal((await row(f.A, BOT_CROW_ID)).display_name, "Back On Both", "normal contact sync resumed on A");
+
+  assert.equal(await conflicts(f.A), c0.a, "sync_conflicts unchanged on A");
+  assert.equal(await conflicts(f.B), c0.b, "sync_conflicts unchanged on B");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // §5 test 7 — CONVERGENCE (the plan's acceptance criterion)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -483,4 +571,88 @@ test("10. ACCEPTED TRADE-OFF: a DM from a pruned-but-still-running bot arrives a
   // And the pruned contact stays pruned: a request is not a resurrection.
   assert.equal(await row(f.A, BOT_CROW_ID), null, "the pruned bot contact was NOT recreated");
   assert.ok(await readTombstone(f.A.db, BOT_CROW_ID), "its tombstone still stands");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// §5 test 11 — R5/CRITICAL-2: the same-secp REBIND, on top of test 10's exact state.
+//
+// F6 (a guard on the rebind) was DROPPED from the design as "unreachable — the tombstone
+// gate already returns for op=update and for insert <= tomb.lamport_ts, so by the time
+// control reaches the rebind, `tombstone lamport >= entry's` is false by construction."
+// The `kind='prune'` change removed exactly that premise (a prune tombstone deliberately
+// does NOT gate an insert on lamport) and F6 was never re-derived. So with a prune
+// tombstone standing, a REPLAYED ORIGINAL insert (a feed replay after a re-pair or a DB
+// restore — crow's fleet has had both) now reaches the rebind, finds the `req:<secp>` row
+// that test 10 just created, and REBINDS it: the pruned bot comes back CARRYING that DM.
+// And because it now has a message, prune rule 5 (`HAVING COUNT(m.id) = 0` — the prune
+// never destroys history) blocks it from EVER being re-pruned. That kills the design's
+// self-healing claim ("the next render simply re-prunes it") and restores defect D3.
+//
+// The fix is narrow: a `crow:` row and a `req:` row may coexist (contacts is UNIQUE on
+// crow_id ONLY), so when a prune tombstone stands we do NOT promote the placeholder —
+// the re-add lands as a fresh, zero-message, RE-PRUNABLE row and the DM stays where the
+// documented §5.10 semantic puts it: on the message request.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("11. a REPLAYED original insert must not rebind the pruned bot's message-REQUEST row — it lands fresh, keeps zero messages, and is RE-PRUNABLE (self-healing)", async () => {
+  const f = newFleet();
+
+  // B added the bot from ADV's directory; A got it by sync. (The replayed entry has to
+  // come from the OTHER instance's feed — that is what a re-pair/restore replays.)
+  await act(f.B, () => acceptBotInvite(f.B.db, {}, { inviteCode: BOT_CODE, advertisedByInstanceId: ADV }));
+  const originalInsert = f.wire.at(-1).entry;
+  assert.equal(originalInsert.op, "insert", "setup: B's accept emitted the original insert");
+  await f.deliver();
+  assert.ok(await row(f.A, BOT_CROW_ID), "setup: A holds the bot");
+
+  // ADV un-advertises ⇒ A prunes. Prune tombstone standing, row gone.
+  await prune(f.A, directory());
+  assert.equal(await row(f.A, BOT_CROW_ID), null, "setup: pruned on A");
+  assert.equal((await readTombstone(f.A.db, BOT_CROW_ID)).kind, "prune", "setup: …a GC tombstone");
+
+  // §5 test 10's exact state: the bot is un-advertised, not dead. It DMs us, so the
+  // receive path files it as a message request under `req:<secp>` WITH the message.
+  await handleIncomingRequest(f.A.db, { createNotification: async () => {} }, {
+    senderPubkey: BOT.secp256k1Pubkey, content: "still here", eventId: "evt-prune-11",
+  });
+  const reqId = "req:" + normalizePubkey(BOT.secp256k1Pubkey);
+  const reqBefore = await row(f.A, reqId);
+  assert.ok(reqBefore, "setup: the DM landed as a `req:<secp>` row");
+
+  // THE PROBE: B's feed is replayed (re-pair / DB restore) and A re-applies the ORIGINAL
+  // insert. The prune tombstone does not gate it on lamport — by design — so it reaches
+  // the same-secp rebind.
+  await f.A.mgr._applyEntry(B_ID, originalInsert);
+
+  // 1. The placeholder must NOT have been promoted…
+  const reqAfter = await row(f.A, reqId);
+  assert.ok(reqAfter,
+    "THE ASSERTION: the `req:` message-request row must still be a `req:` row. Rebinding it promotes the " +
+    "pruned bot back to a full contact CARRYING the DM — and a contact with a message can never be pruned " +
+    "again (rule 5, `HAVING COUNT(m.id) = 0`), so the resurrection is PERMANENT. That is defect D3, restored.");
+  assert.equal(reqAfter.request_status, "pending", "…still a pending request, awaiting the user");
+  assert.equal(Number(reqAfter.id), Number(reqBefore.id), "…the same row, untouched");
+  const { rows: reqMsgs } = await f.A.db.execute({
+    sql: "SELECT content FROM messages WHERE contact_id = ?", args: [reqAfter.id],
+  });
+  assert.deepEqual(reqMsgs.map((m) => m.content), ["still here"], "…and the DM stayed on it (§5.10's semantic)");
+
+  // 2. …the re-add landed as a FRESH row instead (a `crow:` row and a `req:` row may
+  //    coexist — contacts is UNIQUE on crow_id only).
+  const fresh = await row(f.A, BOT_CROW_ID);
+  assert.ok(fresh, "the replayed insert re-created the contact as a fresh row");
+  assert.notEqual(Number(fresh.id), Number(reqAfter.id), "…a DIFFERENT row from the message request");
+  assert.equal(fresh.advertised_by_instance_id, ADV, "…carrying its provenance, so it is prunable again");
+  const { rows: freshMsgs } = await f.A.db.execute({
+    sql: "SELECT COUNT(*) AS n FROM messages WHERE contact_id = ?", args: [fresh.id],
+  });
+  assert.equal(Number(freshMsgs[0].n), 0, "…with ZERO messages");
+
+  // 3. SELF-HEALING — the whole justification for letting a replayed insert through.
+  await prune(f.A, directory());
+  assert.equal(await row(f.A, BOT_CROW_ID), null,
+    "THE PROOF: the next render RE-PRUNES it. This is the claim contact-prune.js makes in its header " +
+    "(\"the next render simply re-prunes it — self-healing\"), and a rebound row carrying a message could " +
+    "never satisfy rule 5, so the claim was FALSE until the rebind was guarded.");
+  assert.ok(await row(f.A, reqId), "and the message request — with its DM — survives the re-prune");
 });

--- a/tests/bot-directory-cache.test.js
+++ b/tests/bot-directory-cache.test.js
@@ -27,3 +27,75 @@ test("description is null when absent and capped when overlong", async () => {
   assert.equal(r.bots[1].description.length, 140, "capped at 140");
   _setFetchImpl(null);
 });
+
+// --- F1: completeness is a POSITIVE assertion, checked on the receiver too (spec §3 F1) ---
+
+const okBot = (id, pk = PK) => ({ bot_id: id, display_name: id, messaging_pubkey: "02" + pk, invite_code: "crow:a.b.c" });
+
+test("F1 receiver: a sender-asserted, fully-parsed payload is complete", async () => {
+  withBody({ bots: [okBot("b1")], complete: true });
+  const r = await getPeerAdvertisedBots({}, "c-inst-1");
+  assert.equal(r.status, "ok");
+  assert.equal(r.complete, true);
+  _setFetchImpl(null);
+});
+
+test("F1 receiver: a validateBot drop downgrades complete to false (status stays ok)", async () => {
+  withBody({ bots: [okBot("b1"), { bot_id: "bad", messaging_pubkey: "not-hex", invite_code: "crow:a.b.c" }], complete: true });
+  const r = await getPeerAdvertisedBots({}, "c-inst-2");
+  assert.equal(r.status, "ok", "a drop is not an outage");
+  assert.equal(r.bots.length, 1, "the malformed entry is dropped");
+  assert.equal(r.complete, false, "receiver could not parse a bot the sender sent → not complete");
+  _setFetchImpl(null);
+});
+
+test("F1 receiver: a body that is not {bots:[...]} is unavailable, not ok-with-empty-bots", async () => {
+  withBody({});
+  const r1 = await getPeerAdvertisedBots({}, "c-inst-3");
+  assert.equal(r1.status, "unavailable", "missing bots array is an outage, not 'advertises nothing'");
+  assert.deepEqual(r1.bots, []);
+  assert.equal(r1.complete, false);
+
+  withBody({ bots: "nope" });
+  const r2 = await getPeerAdvertisedBots({}, "c-inst-4");
+  assert.equal(r2.status, "unavailable", "non-array bots is an outage");
+  assert.equal(r2.complete, false);
+  _setFetchImpl(null);
+});
+
+test("F1 receiver: ROLLING-DEPLOY GUARD — an old peer sending no complete key yields complete:false", async () => {
+  withBody({ bots: [okBot("b1")] }); // old sender: 200, valid bots, NO complete key
+  const r = await getPeerAdvertisedBots({}, "c-inst-5");
+  assert.equal(r.status, "ok", "an old peer is still reachable");
+  assert.equal(r.bots.length, 1);
+  assert.equal(r.complete, false, "absence of a positive assertion must never read as complete");
+  _setFetchImpl(null);
+});
+
+test("F1 receiver: a legitimately empty advertised list from a healthy peer IS complete", async () => {
+  withBody({ bots: [], complete: true });
+  const r = await getPeerAdvertisedBots({}, "c-inst-6");
+  assert.equal(r.status, "ok");
+  assert.deepEqual(r.bots, []);
+  assert.equal(r.complete, true, "empty is not the same as broken");
+  _setFetchImpl(null);
+});
+
+test("F1 receiver: unavailable sentinels all carry complete:false", async () => {
+  _resetCache();
+  _setFetchImpl(async () => ({ ok: false, error: "timeout" }));
+  const fetchFailed = await getPeerAdvertisedBots({}, "c-inst-7");
+  assert.equal(fetchFailed.status, "unavailable");
+  assert.equal(fetchFailed.complete, false);
+
+  _resetCache();
+  _setFetchImpl(async () => { throw new Error("boom"); });
+  const threw = await getPeerAdvertisedBots({}, "c-inst-8");
+  assert.equal(threw.status, "unavailable");
+  assert.equal(threw.complete, false);
+
+  const noId = await getPeerAdvertisedBots({}, "");
+  assert.equal(noId.status, "unavailable");
+  assert.equal(noId.complete, false, "the no_id sentinel too");
+  _setFetchImpl(null);
+});

--- a/tests/bot-directory-contacts-surface.test.js
+++ b/tests/bot-directory-contacts-surface.test.js
@@ -1,25 +1,54 @@
 // tests/bot-directory-contacts-surface.test.js
+//
+// The contacts panel's directory action (dir_add_bot): routing + redirect. F5 moved the
+// materialize off the MCP client onto the shared `acceptBotInvite`, which also killed
+// this panel's SECOND emit (it used to fire "insert" from inside the tool and then
+// "update" after stamping origin/is_bot — D1). The classification + the exactly-one-emit
+// guarantee are asserted against a REAL schema in tests/crow-accept-bot-invite.test.js.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createClient } from "@libsql/client";
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { deriveBotIdentity, generateBotInviteCode, parseBotInviteCode } from "../servers/sharing/identity.js";
 import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+
+// The directory read resolves the local instance id from $CROW_DATA_DIR. Pin it to a
+// throwaway dir so this test can NEVER read or write ~/.crow.
+process.env.CROW_DATA_DIR = mkdtempSync(join(tmpdir(), "crow-dirsurf-test-"));
 
 const ident = deriveBotIdentity(randomBytes(32), "c-dir-bot");
 const CODE = generateBotInviteCode(ident, "tok", [], "Dir Bot");
 const CROW_ID = parseBotInviteCode(CODE).botCrowId;
 
-test("contacts dir_add_bot materializes + flags is_bot", async () => {
+test("contacts dir_add_bot materializes via the SHARED acceptBotInvite, not the MCP tool", async () => {
   const db = createClient({ url: ":memory:" });
   await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, secp256k1_pubkey TEXT, origin TEXT, is_bot INTEGER DEFAULT 0)`);
-  const calls = [];
-  const fakeClient = { async callTool(a){ calls.push(a.name); if (a.name==="crow_accept_bot_invite") await db.execute({ sql:"INSERT INTO contacts (crow_id, secp256k1_pubkey) VALUES (?,?)", args:[CROW_ID, ident.secp256k1Pubkey] }); return { content:[{type:"text",text:"ok"}] }; }, async close(){} };
-  const req = { body: { action: "dir_add_bot", invite_code: CODE } };
-  const result = await handleContactAction(req, db, { sharingClientFactory: async () => fakeClient });
+  const toolCalls = [];
+  const accepts = [];
+  const result = await handleContactAction(
+    { body: { action: "dir_add_bot", invite_code: CODE } },
+    db,
+    {
+      managers: {},
+      // Any callTool from the directory path is a regression — F5 removed that round-trip.
+      sharingClientFactory: async () => ({ async callTool(a){ toolCalls.push(a.name); return { content: [] }; }, async close(){} }),
+      acceptBotInviteFn: async (_db, _mgr, opts) => {
+        accepts.push(opts);
+        await db.execute({
+          sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, origin, is_bot) VALUES (?,?,?,?)",
+          args: [CROW_ID, ident.secp256k1Pubkey, opts.advertisedByInstanceId ? "advertised" : null, opts.advertisedByInstanceId ? 1 : 0],
+        });
+        return { ok: true, outcome: "created", botCrowId: CROW_ID, notified: true };
+      },
+    },
+  );
   assert.equal(result.redirect, "/dashboard/contacts?view=bots");
-  assert.deepEqual(calls, ["crow_accept_bot_invite"]);
-  const { rows } = await db.execute({ sql:"SELECT is_bot, origin FROM contacts WHERE crow_id=?", args:[CROW_ID] });
-  assert.equal(Number(rows[0].is_bot), 1);
-  assert.equal(rows[0].origin, "advertised", "new contact tagged origin=advertised");
+  assert.deepEqual(toolCalls, [], "no MCP round-trip on the directory path");
+  assert.equal(accepts.length, 1, "exactly one accept");
+  assert.equal(accepts[0].inviteCode, CODE);
+  const { rows } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM contacts WHERE crow_id=?", args: [CROW_ID] });
+  assert.equal(Number(rows[0].n), 1, "contact materialized");
 });

--- a/tests/bot-directory-materialize.test.js
+++ b/tests/bot-directory-materialize.test.js
@@ -80,6 +80,30 @@ test("dir_message_bot materializes and redirects to ?open=<id>", async () => {
   assert.equal(res._redir, `/dashboard/messages?open=${rows[0].id}`, "redirects to the new conversation");
 });
 
+// R5/MAJOR-3: bot-ness and prunability are DIFFERENT facts.
+//
+// Deriving `is_bot` from provenance conflates them. The advertised-bots cache expires
+// after 60 s and any peer can exceed the 2 s directory timeout, so
+// `resolveAdvertisedByInstanceId` legitimately returns null between the render and the
+// click — and the user who clicked a BOT in the BOT DIRECTORY then gets `is_bot=0`: not
+// badged as a bot, AND swept into `backfillContactsOnce` (which filters `is_bot = 0`) to
+// be re-emitted as an `update` every boot. A directory add is a bot whether or not we
+// could resolve WHO advertised it, so the handlers assert it EXPLICITLY. (Both actions:
+// they are the same code path, and both must carry it.)
+for (const action of ["dir_add_bot", "dir_message_bot"]) {
+  test(`${action} passes isBot:true EXPLICITLY — an unresolvable advertiser costs prunability, never bot-ness`, async () => {
+    const db = await db0(); const accepts = [];
+    const req = { body: { action, invite_code: CODE } };
+    await handlePostAction(req, fakeRes(), { db, _managers: {}, acceptBotInviteFn: spyAccept(db, accepts) });
+    assert.equal(accepts.length, 1, "exactly one accept");
+    assert.equal(accepts[0].advertisedByInstanceId ?? null, null,
+      "setup: the advertiser is unresolvable here (no directory) — the 60 s-cache / 2 s-timeout case");
+    assert.equal(accepts[0].isBot, true,
+      "…and the accept is STILL told this is a bot. Otherwise the row lands is_bot=0: unbadged in the UI " +
+      "and re-emitted as an `update` by backfillContactsOnce on every boot.");
+  });
+}
+
 test("dir_add_bot on a failed accept does not materialize anything", async () => {
   const db = await db0();
   const req = { body: { action: "dir_add_bot", invite_code: CODE } };

--- a/tests/bot-directory-materialize.test.js
+++ b/tests/bot-directory-materialize.test.js
@@ -1,10 +1,27 @@
 // tests/bot-directory-materialize.test.js
+//
+// The messages panel's DIRECTORY actions (dir_add_bot / dir_message_bot): routing and
+// redirects. F5 moved the materialize itself off the MCP client and onto the shared
+// `acceptBotInvite` — so what this file guards is that the handler calls the SHARED
+// accept (never the tool), and that dir_message_bot still lands inside the conversation.
+//
+// The classification the accept performs (origin/is_bot/advertised_by_instance_id, and
+// the single "insert" emit) is asserted end-to-end against a REAL schema in
+// tests/crow-accept-bot-invite.test.js — it cannot be expressed on the hand-rolled
+// contacts table here.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createClient } from "@libsql/client";
 import { randomBytes } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { deriveBotIdentity, generateBotInviteCode, parseBotInviteCode } from "../servers/sharing/identity.js";
 import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
+
+// The directory read resolves the local instance id from $CROW_DATA_DIR. Pin it to a
+// throwaway dir so this test can NEVER read or write ~/.crow.
+process.env.CROW_DATA_DIR = mkdtempSync(join(tmpdir(), "crow-dirmat-test-"));
 
 const SEED = randomBytes(32);
 const BOT_ID = "dir-bot-1";
@@ -18,39 +35,60 @@ async function db0() {
   await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, secp256k1_pubkey TEXT, origin TEXT, is_bot INTEGER DEFAULT 0)`);
   return db;
 }
-function fakeClientThatAccepts(db, calls) {
-  return { async callTool(a){ calls.push(a.name); if (a.name==="crow_accept_bot_invite") { await db.execute({ sql:"INSERT INTO contacts (crow_id, secp256k1_pubkey) VALUES (?,?)", args:[CROW_ID, ident.secp256k1Pubkey] }); } return { content:[{type:"text",text:"ok"}] }; }, async close(){} };
+
+/** Stand-in for the shared accept: records the call and materializes the row like the real one. */
+function spyAccept(db, calls) {
+  return async (_db, _managers, opts) => {
+    calls.push(opts);
+    await db.execute({
+      sql: "INSERT INTO contacts (crow_id, secp256k1_pubkey, origin, is_bot) VALUES (?,?,?,?)",
+      args: [CROW_ID, ident.secp256k1Pubkey, opts.advertisedByInstanceId ? "advertised" : null, opts.advertisedByInstanceId ? 1 : 0],
+    });
+    return { ok: true, outcome: "created", botCrowId: CROW_ID, notified: true };
+  };
 }
 
-test("dir_add_bot materializes the contact and flags is_bot=1", async () => {
-  const db = await db0(); const calls = [];
+/** Any MCP callTool from the directory path is a regression — F5 removed that round-trip. */
+function forbiddenClientFactory(toolCalls) {
+  return async () => ({ async callTool(a){ toolCalls.push(a.name); return { content: [] }; }, async close(){} });
+}
+
+test("dir_add_bot materializes via the SHARED acceptBotInvite, not the MCP tool", async () => {
+  const db = await db0(); const accepts = []; const toolCalls = [];
   const req = { body: { action: "dir_add_bot", invite_code: CODE } };
   const res = fakeRes();
-  await handlePostAction(req, res, { db, sharingClientFactory: async () => fakeClientThatAccepts(db, calls) });
+  await handlePostAction(req, res, {
+    db, _managers: {},
+    sharingClientFactory: forbiddenClientFactory(toolCalls),
+    acceptBotInviteFn: spyAccept(db, accepts),
+  });
   assert.equal(res.headersSent, true);
-  assert.deepEqual(calls, ["crow_accept_bot_invite"], "accept only, no send");
-  const { rows } = await db.execute({ sql: "SELECT is_bot, origin FROM contacts WHERE crow_id=?", args: [CROW_ID] });
-  assert.equal(Number(rows[0].is_bot), 1, "contact flagged is_bot");
-  assert.equal(rows[0].origin, "advertised", "new contact tagged origin=advertised (prune lifecycle)");
+  assert.deepEqual(toolCalls, [], "the directory path makes NO MCP round-trip (D1: that is where the double/absent emit came from)");
+  assert.equal(accepts.length, 1, "exactly one accept");
+  assert.equal(accepts[0].inviteCode, CODE);
+  const { rows } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM contacts WHERE crow_id=?", args: [CROW_ID] });
+  assert.equal(Number(rows[0].n), 1, "contact materialized");
 });
 
-test("dir_message_bot materializes, flags is_bot, and redirects to ?open=<id>", async () => {
-  const db = await db0(); const calls = [];
+test("dir_message_bot materializes and redirects to ?open=<id>", async () => {
+  const db = await db0(); const accepts = [];
   const req = { body: { action: "dir_message_bot", invite_code: CODE } };
   const res = fakeRes();
-  await handlePostAction(req, res, { db, sharingClientFactory: async () => fakeClientThatAccepts(db, calls) });
-  assert.deepEqual(calls, ["crow_accept_bot_invite"], "accept only; no forced message");
-  const { rows } = await db.execute({ sql: "SELECT id, is_bot FROM contacts WHERE crow_id=?", args: [CROW_ID] });
-  assert.equal(Number(rows[0].is_bot), 1);
+  await handlePostAction(req, res, { db, _managers: {}, acceptBotInviteFn: spyAccept(db, accepts) });
+  assert.equal(accepts.length, 1, "accept only; no forced message");
+  const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id=?", args: [CROW_ID] });
   assert.equal(res._redir, `/dashboard/messages?open=${rows[0].id}`, "redirects to the new conversation");
 });
 
-test("dir_add_bot on a failed accept does not flag anything", async () => {
-  const db = await db0(); const calls = [];
-  const fc = { async callTool(a){ calls.push(a.name); return { isError: true, content:[{type:"text",text:"bad"}] }; }, async close(){} };
+test("dir_add_bot on a failed accept does not materialize anything", async () => {
+  const db = await db0();
   const req = { body: { action: "dir_add_bot", invite_code: CODE } };
   const res = fakeRes();
-  await handlePostAction(req, res, { db, sharingClientFactory: async () => fc });
+  await handlePostAction(req, res, {
+    db, _managers: {},
+    acceptBotInviteFn: async () => { throw new Error("bad invite"); },
+  });
+  assert.equal(res.headersSent, true, "still redirects — a failed add must not 500 the panel");
   const { rows } = await db.execute("SELECT COUNT(*) AS n FROM contacts");
   assert.equal(Number(rows[0].n), 0, "nothing materialized");
 });

--- a/tests/bot-directory-payload.test.js
+++ b/tests/bot-directory-payload.test.js
@@ -28,3 +28,38 @@ test("advertisement omits description when the tagline is unset", async () => {
   assert.equal(bots.length, 1);
   assert.equal("description" in bots[0], false, "no description field when unset");
 });
+
+// --- F1: completeness is a POSITIVE assertion (spec §3 F1) ---
+
+const advertised = (botId) => ({
+  bot_id: botId, display_name: botId,
+  definition: JSON.stringify({ gateways: [{ type: "crow-messages", allow_paired_instances: true }] }),
+});
+
+test("F1 sender: a clean payload asserts complete:true", async () => {
+  const db = fakeDb([advertised("b1"), advertised("b2")]);
+  const payload = await buildAdvertisementPayload(db, seams);
+  assert.equal(payload.bots.length, 2);
+  assert.equal(payload.complete, true, "zero bots skipped → positive completeness assertion");
+});
+
+test("F1 sender: a bot whose identity throws omits the complete key entirely", async () => {
+  const db = fakeDb([advertised("good"), advertised("broken")]);
+  const payload = await buildAdvertisementPayload(db, {
+    ...seams,
+    _identityFor: (botId) => {
+      if (botId === "broken") throw new Error("database is locked");
+      return ident;
+    },
+  });
+  assert.ok(!("complete" in payload), "a skipped bot must NOT assert completeness (no negative flag either)");
+  assert.equal(payload.bots.length, 1, "the other bots are still returned (still a 200-shaped payload)");
+  assert.equal(payload.bots[0].bot_id, "good");
+});
+
+test("F1 sender: an empty advertised list is still a complete payload", async () => {
+  const db = fakeDb([]);
+  const payload = await buildAdvertisementPayload(db, seams);
+  assert.deepEqual(payload.bots, []);
+  assert.equal(payload.complete, true, "nothing advertised, nothing skipped → complete");
+});

--- a/tests/contact-tombstones.test.js
+++ b/tests/contact-tombstones.test.js
@@ -148,6 +148,28 @@ test("kind precedence: prune then an AUTHORITATIVE delete becomes authoritative 
   await clearTombstone(db, "crow:k-pd");
 });
 
+// ── R5/CRITICAL-1: lamports are commensurable only WITHIN a kind ─────────────
+//
+// A prune's lamport is the pruned row's LOCAL row lamport. An authoritative
+// tombstone's lamport is a GLOBAL emit lamport, and it is the sole input to the
+// `insert <= tomb.lamport_ts ⇒ drop` gate (instance-sync.js `_applyContact`). A
+// blanket `MAX(lamport_ts, excluded.lamport_ts)` on the kind TRANSITION launders the
+// local number into the global field — arming the gate at a value no emitter can
+// ever exceed. The test above (prune@10 → auth@30) could not see this: MAX happens
+// to give the right answer whenever the authoritative delete's lamport is the higher
+// of the two. Invert the magnitudes and the defect is plain.
+test("kind precedence: prune@500 then an AUTHORITATIVE delete@21 takes the DELETE's lamport (21) — a local row lamport must never become the global insert gate", async () => {
+  await writeTombstone(db, "crow:k-launder", 500, "prune"); // a LOCAL row lamport (this instance saw many updates)
+  await writeTombstone(db, "crow:k-launder", 21);           // the user's REAL delete, broadcast at a global lamport of 21
+  const t = await readTombstone(db, "crow:k-launder");
+  assert.equal(t.kind, null, "the user's delete upgrades the tombstone to authoritative");
+  assert.equal(Number(t.lamport_ts), 21,
+    "the SURVIVING kind's own lamport wins. MAX(500,21)=500 would arm the stale-insert gate at 500 — a number " +
+    "no genuine re-add from the deleting instance can exceed — so every re-add is dropped, and every later " +
+    "`update` from the re-adder is dropped unconditionally by the same tombstone: permanent silent divergence.");
+  await clearTombstone(db, "crow:k-launder");
+});
+
 test("kind precedence: an AUTHORITATIVE delete then a prune STAYS authoritative — GC must never weaken a user delete", async () => {
   await writeTombstone(db, "crow:k-dp", 30);          // user delete @30
   await writeTombstone(db, "crow:k-dp", 10, "prune"); // a later prune of the same crow_id

--- a/tests/contact-tombstones.test.js
+++ b/tests/contact-tombstones.test.js
@@ -56,10 +56,9 @@ test("processed_control_events has the expected columns", async () => {
   assert.deepEqual(rows.map((r) => r.name).sort(), ["event_id", "kind", "seen_at"]);
 });
 
-test("PRAGMA user_version === 6", async () => {
+test("init-db stamps PRAGMA user_version with the current SCHEMA_GENERATION", async () => {
   const { rows } = await db.execute("PRAGMA user_version");
-  assert.equal(rows[0].user_version, 6);
-  assert.equal(SCHEMA_GENERATION, 6);
+  assert.equal(Number(rows[0].user_version), SCHEMA_GENERATION);
 });
 
 test("init-db is idempotent — re-run preserves rows and does not throw", async () => {
@@ -69,7 +68,7 @@ test("init-db is idempotent — re-run preserves rows and does not throw", async
   const { rows } = await fresh.execute({ sql: "SELECT lamport_ts FROM contact_tombstones WHERE crow_id = ?", args: ["crow:idem"] });
   assert.equal(rows[0].lamport_ts, 7);
   const { rows: uv } = await fresh.execute("PRAGMA user_version");
-  assert.equal(uv[0].user_version, 6);
+  assert.equal(Number(uv[0].user_version), SCHEMA_GENERATION);
 });
 
 // ── Task 2: tombstone primitives ────────────────────────────────────────────

--- a/tests/contact-tombstones.test.js
+++ b/tests/contact-tombstones.test.js
@@ -46,9 +46,9 @@ test("contact_tombstones + processed_control_events tables exist after init-db",
   assert.deepEqual(rows.map((r) => r.name), ["contact_tombstones", "processed_control_events"]);
 });
 
-test("contact_tombstones has the expected columns", async () => {
+test("contact_tombstones has the expected columns (incl. `kind` — 2a/F4)", async () => {
   const { rows } = await db.execute("PRAGMA table_info(contact_tombstones)");
-  assert.deepEqual(rows.map((r) => r.name).sort(), ["crow_id", "deleted_at", "lamport_ts"]);
+  assert.deepEqual(rows.map((r) => r.name).sort(), ["crow_id", "deleted_at", "kind", "lamport_ts"]);
 });
 
 test("processed_control_events has the expected columns", async () => {
@@ -108,6 +108,62 @@ test("writeTombstone sets deleted_at on first write and preserves it on conflict
   await writeTombstone(db, "crow:da", 20);
   assert.equal((await readTombstone(db, "crow:da")).deleted_at, first);
   await clearTombstone(db, "crow:da");
+});
+
+// ── 2a/F4: tombstone `kind` — WHY the contact is gone ───────────────────────
+//
+// NULL = AUTHORITATIVE (a user delete; its lamport was BROADCAST ⇒ comparable to an
+// incoming insert's ⇒ keeps the stale-replay lamport gate).
+// 'prune' = GARBAGE COLLECTION (the advertised-contact prune; it emits nothing and
+// carries a LOCAL row lamport ⇒ NOT comparable ⇒ must not gate inserts).
+// Precedence is AUTHORITATIVE-ALWAYS-WINS: a GC write must never weaken a user delete.
+
+test("readTombstone RETURNS `kind` — the apply gate cannot branch on a column the SELECT omits", async () => {
+  await writeTombstone(db, "crow:k-read", 10, "prune");
+  const t = await readTombstone(db, "crow:k-read");
+  assert.ok("kind" in t, "`kind` is present in the returned row (omitting it is a SILENT no-op — the v2 trap)");
+  assert.equal(t.kind, "prune");
+  await clearTombstone(db, "crow:k-read");
+
+  await writeTombstone(db, "crow:k-read2", 10); // default = authoritative
+  assert.equal((await readTombstone(db, "crow:k-read2")).kind, null, "a user delete defaults to authoritative (NULL)");
+  await clearTombstone(db, "crow:k-read2");
+});
+
+test("kind precedence: prune then prune STAYS 'prune' (two instances GC'ing the same bot)", async () => {
+  await writeTombstone(db, "crow:k-pp", 10, "prune");
+  await writeTombstone(db, "crow:k-pp", 20, "prune");
+  const t = await readTombstone(db, "crow:k-pp");
+  assert.equal(t.kind, "prune", "still garbage collection — nobody deleted anything authoritatively");
+  assert.equal(t.lamport_ts, 20, "and MAX(lamport) still holds");
+  await clearTombstone(db, "crow:k-pp");
+});
+
+test("kind precedence: prune then an AUTHORITATIVE delete becomes authoritative (NULL) — and the lamport gate is armed again", async () => {
+  await writeTombstone(db, "crow:k-pd", 10, "prune");
+  await writeTombstone(db, "crow:k-pd", 30);   // the user really deleted it
+  const t = await readTombstone(db, "crow:k-pd");
+  assert.equal(t.kind, null, "the user's delete UPGRADES the tombstone to authoritative");
+  assert.equal(t.lamport_ts, 30);
+  await clearTombstone(db, "crow:k-pd");
+});
+
+test("kind precedence: an AUTHORITATIVE delete then a prune STAYS authoritative — GC must never weaken a user delete", async () => {
+  await writeTombstone(db, "crow:k-dp", 30);          // user delete @30
+  await writeTombstone(db, "crow:k-dp", 10, "prune"); // a later prune of the same crow_id
+  const t = await readTombstone(db, "crow:k-dp");
+  assert.equal(t.kind, null,
+    "STILL authoritative. Letting a prune overwrite it would flip a user delete onto the permissive " +
+    "insert path and a stale insert replay could resurrect the deleted contact.");
+  assert.equal(t.lamport_ts, 30, "and the lower prune lamport did not lower the gate");
+  await clearTombstone(db, "crow:k-dp");
+});
+
+test("kind precedence: delete then delete stays authoritative", async () => {
+  await writeTombstone(db, "crow:k-dd", 10);
+  await writeTombstone(db, "crow:k-dd", 20);
+  assert.equal((await readTombstone(db, "crow:k-dd")).kind, null);
+  await clearTombstone(db, "crow:k-dd");
 });
 
 // ── Task 2: emitContactDelete co-writes the local tombstone ─────────────────

--- a/tests/contacts-origin-wire.test.js
+++ b/tests/contacts-origin-wire.test.js
@@ -136,6 +136,50 @@ test("F3 apply (local row PRESENT as local-bot): an inbound `origin:advertised` 
     "a peer must NOT be able to relabel the host's own bot as prunable");
 });
 
+// ── F2: provenance is set at INSERT only, never by a later UPDATE ───────────
+
+test("F2 apply (local row PRESENT, manually pasted): an inbound UPDATE must NOT stamp advertised_by onto it", async () => {
+  // A peer that added this bot FROM A DIRECTORY carries advertised_by=X on the wire.
+  // If apply wrote that on a LWW UPDATE, it would silently make THIS instance's
+  // hand-pasted contact garbage-collectable — breaking #155 §2.6 (pasted-invite bots
+  // must not be lost). Provenance is a fact about how a row was ACQUIRED HERE; it is
+  // not the sender's to assign after the fact.
+  const { mgr, db } = makeManager();
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, is_bot, advertised_by_instance_id, lamport_ts) VALUES ('crow:f2paste','e',?,'Pasted Bot',1,NULL,10)",
+    args: [secp(404)],
+  });
+  await mgr._applyEntry(REMOTE_ID, signedEntry("contacts", "update", {
+    crow_id: "crow:f2paste",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(404),
+    display_name: "Pasted Bot (renamed on the peer)",
+    advertised_by_instance_id: "inst-advertiser-X",
+  }, 50));
+  const row = (await db.execute({ sql: "SELECT advertised_by_instance_id AS adv, display_name FROM contacts WHERE crow_id='crow:f2paste'" })).rows[0];
+  assert.equal(row.display_name, "Pasted Bot (renamed on the peer)", "the update itself applied (LWW)");
+  assert.equal(row.adv, null,
+    "a peer must NOT be able to make this instance's hand-pasted contact prunable");
+});
+
+test("F2 apply (local row ABSENT): an inbound INSERT DOES carry advertised_by — convergence depends on it", async () => {
+  // The negative above must not be over-applied: a peer learning the contact for the
+  // FIRST time has to receive the provenance, or it can never prune independently and
+  // spec §5.7's convergence fails.
+  const { mgr, db } = makeManager();
+  await mgr._applyEntry(REMOTE_ID, signedEntry("contacts", "insert", {
+    crow_id: "crow:f2sync",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(405),
+    display_name: "Synced Bot",
+    is_bot: 1,
+    advertised_by_instance_id: "inst-advertiser-X",
+  }, 60));
+  const row = (await db.execute({ sql: "SELECT advertised_by_instance_id AS adv FROM contacts WHERE crow_id='crow:f2sync'" })).rows[0];
+  assert.equal(row.adv, "inst-advertiser-X",
+    "provenance MUST cross the wire on INSERT — without it the receiver can never prune");
+});
+
 // ── F3 REGRESSION GUARD ─────────────────────────────────────────────────────
 // This is the test that proves the strip runs AFTER the gate. It passed BEFORE
 // the F3 change too — that is exactly its job: it must still pass AFTER.

--- a/tests/contacts-origin-wire.test.js
+++ b/tests/contacts-origin-wire.test.js
@@ -1,0 +1,171 @@
+/**
+ * Item 2a / F3 (spec §3 F3, defect D2) — `contacts.origin` is a JUDGMENT, not a fact.
+ *
+ * "This is an advertised bot I may garbage-collect" is true only relative to the
+ * instance holding the row. Replicating it is dangerous in BOTH directions:
+ *   - toward the bot's host: a peer's emit could relabel the host's own bot row
+ *     `origin='advertised'`; a host never sees its OWN bots in its advertised
+ *     directory ⇒ a later GC pass would prune the host's own bot (FK CASCADE
+ *     takes its DM history with it);
+ *   - toward a peer that cannot see the advertisement: it inherits 'advertised'
+ *     for a bot it never sees advertised ⇒ it prunes a live bot on next render.
+ *
+ * So `origin` is stripped on emit (EXCLUDED_COLUMNS.contacts) AND dropped on
+ * apply (_applyContact's ALWAYS_DROP — an un-upgraded peer still sends it).
+ *
+ * The load-bearing ordering: `shouldSyncRow` (which gates on origin === 'local-bot')
+ * runs on the RAW row at instance-sync.js:963, BEFORE the EXCLUDED_COLUMNS strip at
+ * :978-981. Excluding `origin` therefore does NOT disable that gate — the last test
+ * here is the regression guard that keeps it that way.
+ *
+ * Harness mirrors tests/contacts-sync.test.js + tests/providers-sync-wire.test.js:
+ * real init-db.js schema in a tmpdir, fixed ed25519 identity, stub outbound feed.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager, EXCLUDED_COLUMNS } from "../servers/sharing/instance-sync.js";
+import { sign } from "../servers/sharing/identity.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-origin-wire-test-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir },
+  stdio: "pipe",
+  cwd: join(import.meta.dirname, ".."),
+});
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const TEST_PRIV = Buffer.alloc(32, 0x3f);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+const REMOTE_ID = "bbbbbbbb-0000-0000-0000-00000000f300";
+
+let seq = 0;
+
+/** Manager with a stub outbound feed capturing appended entries. */
+function makeManager() {
+  const db = createDbClient(DB_PATH);
+  const mgr = new InstanceSyncManager(IDENTITY, db, `f3-test-${++seq}`);
+  mgr.feedsDisabled = false; // don't depend on the runner's argv/env
+  const entries = [];
+  mgr.outFeeds = new Map([["peer-1", { append: async (e) => { entries.push(e); } }]]);
+  return { mgr, db, entries };
+}
+
+function signedEntry(table, op, row, lamport_ts, instance_id = REMOTE_ID) {
+  const e = { table, op, row, lamport_ts, instance_id };
+  e.signature = sign(JSON.stringify(e), IDENTITY.ed25519Priv);
+  return e;
+}
+
+// Unique 64-hex secp per test (all tests share ONE db file — avoid secp-rebind collisions).
+const secp = (n) => String(n).padStart(64, "0");
+
+// ── F3, emit side ───────────────────────────────────────────────────────────
+
+test("F3 emit: `origin` is in EXCLUDED_COLUMNS.contacts", () => {
+  assert.ok(EXCLUDED_COLUMNS.contacts.includes("origin"),
+    "origin is a local judgment — it must never be advertised on the wire");
+});
+
+test("F3 emit: an emitted contacts entry carries NO `origin` key at all", async () => {
+  const { mgr, entries } = makeManager();
+  const row = {
+    crow_id: "crow:f3emit",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(301),
+    display_name: "Advertised Bot",
+    origin: "advertised",
+    is_bot: 1,
+  };
+  const ts = await mgr.emitChange("contacts", "update", row);
+  assert.ok(typeof ts === "number", "an advertised-bot contact still syncs (only `origin` is stripped)");
+  assert.equal(entries.length, 1, "exactly one entry on the wire");
+  const payload = entries[0].row;
+  assert.ok(!("origin" in payload),
+    `emitted payload must not carry an \`origin\` key; got ${JSON.stringify(payload)}`);
+  assert.equal(payload.is_bot, 1, "the FACT columns still ride the wire (only the judgment is stripped)");
+});
+
+// ── F3, apply side ──────────────────────────────────────────────────────────
+
+test("F3 apply (local row ABSENT): an inbound `origin:advertised` INSERTs with origin NULL", async () => {
+  // The real fleet shape: a host usually has NO contacts row for its own bot, so
+  // the peer's entry lands on the INSERT branch and would create the row already
+  // labelled prunable.
+  const { mgr, db } = makeManager();
+  await mgr._applyEntry(REMOTE_ID, signedEntry("contacts", "insert", {
+    crow_id: "crow:f3ins",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(302),
+    display_name: "Peer's Bot",
+    origin: "advertised",
+  }, 40));
+  const row = (await db.execute({ sql: "SELECT origin, display_name FROM contacts WHERE crow_id='crow:f3ins'" })).rows[0];
+  assert.ok(row, "the contact row was created (the row still syncs)");
+  assert.equal(row.display_name, "Peer's Bot", "the rest of the row applied normally");
+  assert.equal(row.origin, null,
+    "origin must be NULL: the judgment is re-derived locally, never inherited from the wire");
+});
+
+test("F3 apply (local row PRESENT as local-bot): an inbound `origin:advertised` leaves origin unchanged", async () => {
+  // Host protection: a peer must not be able to relabel the host's OWN bot as
+  // prunable — the host never sees its own bots advertised, so it would GC it
+  // (and FK CASCADE would destroy its DM history).
+  const { mgr, db } = makeManager();
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, origin, lamport_ts) VALUES ('crow:f3host','e',?,'My Bot','local-bot',10)",
+    args: [secp(303)],
+  });
+  await mgr._applyEntry(REMOTE_ID, signedEntry("contacts", "update", {
+    crow_id: "crow:f3host",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(303),
+    display_name: "My Bot (renamed on the peer)",
+    origin: "advertised",
+  }, 50));
+  const row = (await db.execute({ sql: "SELECT origin, display_name FROM contacts WHERE crow_id='crow:f3host'" })).rows[0];
+  assert.equal(row.display_name, "My Bot (renamed on the peer)", "the update itself applied (LWW)");
+  assert.equal(row.origin, "local-bot",
+    "a peer must NOT be able to relabel the host's own bot as prunable");
+});
+
+// ── F3 REGRESSION GUARD ─────────────────────────────────────────────────────
+// This is the test that proves the strip runs AFTER the gate. It passed BEFORE
+// the F3 change too — that is exactly its job: it must still pass AFTER.
+
+test("F3 REGRESSION GUARD: excluding `origin` did NOT disable the origin='local-bot' emit gate", async () => {
+  const { mgr, entries } = makeManager();
+
+  // shouldSyncRow (instance-sync.js:963) reads the RAW row, before the
+  // EXCLUDED_COLUMNS strip (:978-981). If a refactor ever reorders those, the
+  // strip would erase `origin` first and this gate would silently open —
+  // broadcasting a phantom contact for a bot that only exists on THIS instance.
+  const localBot = await mgr.emitChange("contacts", "update", {
+    crow_id: "crow:f3localbot",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(304),
+    origin: "local-bot",
+    is_bot: 1,
+  });
+  assert.equal(localBot, null, "a local-bot row must be refused by the emit gate");
+  assert.equal(entries.length, 0, "and NOTHING may reach the wire");
+
+  // Control: a normal contact on the same manager DOES emit — so the assertion
+  // above is the gate firing, not a dead harness.
+  const normal = await mgr.emitChange("contacts", "update", {
+    crow_id: "crow:f3normal",
+    ed25519_pubkey: "e",
+    secp256k1_pubkey: secp(305),
+    origin: "advertised",
+  });
+  assert.ok(typeof normal === "number", "a normal contact still emits");
+  assert.equal(entries.length, 1, "exactly the normal contact reached the wire");
+  assert.equal(entries[0].row.crow_id, "crow:f3normal");
+});

--- a/tests/contacts-sync.test.js
+++ b/tests/contacts-sync.test.js
@@ -258,6 +258,69 @@ test("Task6: a winning remote delete fires onContactDeleted then removes the row
   await m._applyEntry(REMOTE_ID, signedEntry("contacts", "delete", { crow_id: "crow:tnone" }, 5)); // no row → no throw
 });
 
+// ── 2a/F4: the gate reads `kind` — GC tombstones do NOT gate inserts on lamport ──
+//
+// A prune tombstone carries a LOCAL row lamport (the prune emits nothing), so it is
+// incommensurable with an incoming insert's GLOBAL emit lamport. A user-delete tombstone
+// carries a broadcast lamport and IS commensurable. The gate must tell them apart.
+
+// THE #155 REGRESSION GUARD — the one that matters most after this change. An
+// AUTHORITATIVE tombstone (a user delete, kind NULL) keeps its lamport gate: a stale
+// insert replay is still DROPPED. Weakening this would let a redelivered old insert
+// resurrect a contact the user deliberately deleted.
+test("2a/F4 guard: an AUTHORITATIVE (user-delete) tombstone STILL drops a stale insert replay — #155 unchanged", async () => {
+  const m = mgr(); const db = m.db;
+  await writeTombstone(db, "crow:k1", 100); // no kind ⇒ authoritative user delete
+  // below the tombstone
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert",
+    { crow_id: "crow:k1", ed25519_pubkey: "", secp256k1_pubkey: secp(111), display_name: "Zombie" }, 50));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:k1'" })).rows[0].c, 0,
+    "a stale insert BELOW an authoritative tombstone stays dropped");
+  // and at an exact TIE (the gate is `<=`)
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert",
+    { crow_id: "crow:k1", ed25519_pubkey: "", secp256k1_pubkey: secp(111), display_name: "Zombie" }, 100));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:k1'" })).rows[0].c, 0,
+    "…and an insert TYING with it stays dropped");
+  assert.ok(await readTombstone(db, "crow:k1"), "the user's tombstone still stands");
+});
+
+// The fix: a GC tombstone must not reject an insert on lamport, at ANY lamport. The
+// re-adder's insert can legitimately sit BELOW the peer's prune tombstone, because the
+// peer's tombstone sits at the peer's own (possibly un-replicated) ROW lamport.
+test("2a/F4 guard: a 'prune' (GC) tombstone lets a LOWER insert land and clears — a re-add must never be gated on a local row lamport", async () => {
+  const m = mgr(); const db = m.db;
+  await writeTombstone(db, "crow:k2", 100, "prune");
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert",
+    { crow_id: "crow:k2", ed25519_pubkey: "", secp256k1_pubkey: secp(112), display_name: "Re-added" }, 50));
+  assert.equal((await db.execute({ sql: "SELECT display_name FROM contacts WHERE crow_id='crow:k2'" })).rows[0]?.display_name, "Re-added",
+    "the genuine re-add lands even though its lamport is BELOW the prune tombstone");
+  assert.equal(await readTombstone(db, "crow:k2"), null, "and the GC tombstone is cleared once the row is back");
+});
+
+// …but D3 is untouched: every resurrection vector (rename, block, unblock, backfill) is
+// an `op=update`, and those are still dropped unconditionally by a standing tombstone.
+test("2a/F4 guard: a 'prune' (GC) tombstone STILL drops a resurrecting `update` — D3 intact", async () => {
+  const m = mgr(); const db = m.db;
+  await writeTombstone(db, "crow:k3", 100, "prune");
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "update",
+    { crow_id: "crow:k3", ed25519_pubkey: "", secp256k1_pubkey: secp(113), display_name: "Zombie" }, 150));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:k3'" })).rows[0].c, 0,
+    "an `update` against a GC tombstone must NOT resurrect the contact — the prune's entire job");
+  assert.ok(await readTombstone(db, "crow:k3"), "the GC tombstone still stands");
+});
+
+// Precedence, end to end at the gate: once the USER deletes a previously-pruned contact,
+// the tombstone is authoritative and the lamport gate is armed again.
+test("2a/F4 guard: prune + a later USER delete ⇒ authoritative ⇒ the stale insert replay is DROPPED again", async () => {
+  const m = mgr(); const db = m.db;
+  await writeTombstone(db, "crow:k4", 100, "prune");
+  await writeTombstone(db, "crow:k4", 100);      // the user then really deleted it
+  await m._applyEntry(REMOTE_ID, signedEntry("contacts", "insert",
+    { crow_id: "crow:k4", ed25519_pubkey: "", secp256k1_pubkey: secp(114), display_name: "Zombie" }, 50));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contacts WHERE crow_id='crow:k4'" })).rows[0].c, 0,
+    "the authoritative delete re-armed the lamport gate — a GC write must never leave it permissive");
+});
+
 // ── Task 9: sanitize the sync ingress (design §D5) ───────────────────────────
 // A peer entry's display_name is remote-controlled; sanitize it the moment
 // `filtered` is built, BEFORE the equivalence check — else every redelivery of a

--- a/tests/contacts-sync.test.js
+++ b/tests/contacts-sync.test.js
@@ -53,8 +53,10 @@ test("shouldSyncRow: contacts carve-outs", () => {
   assert.equal(ok({ crow_id: "crow:a", origin: "local-bot" }), false, "local-bot never syncs");
 });
 
-test("EXCLUDED_COLUMNS.contacts strips id + created_at + verified + last_seen", () => {
-  assert.deepEqual([...EXCLUDED_COLUMNS.contacts].sort(), ["created_at", "id", "last_seen", "verified"]);
+// `origin` joined the list in item 2a / F3 — it is a local judgment, not a
+// portable fact. Its own coverage lives in tests/contacts-origin-wire.test.js.
+test("EXCLUDED_COLUMNS.contacts strips id + created_at + verified + last_seen + origin", () => {
+  assert.deepEqual([...EXCLUDED_COLUMNS.contacts].sort(), ["created_at", "id", "last_seen", "origin", "verified"]);
 });
 
 // ── Task 2: _applyContact ──────────────────────────────────────────────────

--- a/tests/crow-accept-bot-invite.test.js
+++ b/tests/crow-accept-bot-invite.test.js
@@ -1,6 +1,34 @@
-import { test, mock } from "node:test";
+// tests/crow-accept-bot-invite.test.js
+//
+// F5 (spec `2026-07-12-advertised-contact-prune-design.md` §3 F5, §5 test 2):
+// ONE shared `acceptBotInvite()`; the classification (`origin`, `is_bot`,
+// `advertised_by_instance_id`) is carried by the INSERT itself, in one place,
+// and the row reaches the wire already classified. D1 was the opposite: the tool
+// inserted an unclassified row, emitted it, and the *caller* stamped the
+// classification afterwards — the contacts panel with a SECOND emit, the messages
+// panel with NO emit at all. Peers got `origin=NULL` and whether they ever learned
+// otherwise depended on which panel the user happened to click.
+//
+// A REAL schema is mandatory: the feature lives in columns
+// (`advertised_by_instance_id`, `lamport_ts`) a hand-rolled `contacts` cannot express.
+// NEVER point this file at ~/.crow — this code path INSERTs and DELETEs contacts.
+import { test, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { buildBotAcceptPayload } from "../servers/sharing/tools/contacts.js";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { createDbClient } from "../servers/db.js";
+import {
+  buildBotAcceptPayload,
+} from "../servers/sharing/tools/contacts.js";
+import { acceptBotInvite } from "../servers/sharing/accept-bot-invite.js";
+import { deriveBotIdentity, generateBotInviteCode, parseBotInviteCode } from "../servers/sharing/identity.js";
+import { __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
+import { _setFetchImpl, _resetCache } from "../servers/gateway/dashboard/advertised-bots-cache.js";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { handlePostAction } from "../servers/gateway/dashboard/panels/messages/api-handlers.js";
 
 test("buildBotAcceptPayload carries the token + the accepter's identity, typed crow_social/bot_invite_accept", () => {
   const identity = {
@@ -33,9 +61,7 @@ function makeStubSharingFactory() {
 }
 
 test("messages handlePostAction routes accept_bot_invite to the sharing tool and redirects", async () => {
-  const { handlePostAction } = await import("../servers/gateway/dashboard/panels/messages/api-handlers.js");
-  // Inject a stub factory so no real sharing runtime (relay sockets/Hyperswarm)
-  // starts — otherwise this test never lets the process exit.
+  // The PASTE form keeps its MCP round-trip (it has no advertiser ⇒ NULL provenance).
   const sharingClientFactory = makeStubSharingFactory();
   const calls = [];
   const req = { body: { action: "accept_bot_invite", invite_code: "crow:x.y.z" } };
@@ -46,7 +72,6 @@ test("messages handlePostAction routes accept_bot_invite to the sharing tool and
 });
 
 test("messages handlePostAction send_peer honors the injected sharingClientFactory (no real runtime)", async () => {
-  const { handlePostAction } = await import("../servers/gateway/dashboard/panels/messages/api-handlers.js");
   // Regression guard: the send_peer branch used to call getSharingClient()
   // directly, ignoring the injectable factory and starting the real sharing
   // runtime (live relay sockets). Prove the injected stub is the one used.
@@ -61,4 +86,259 @@ test("messages handlePostAction send_peer honors the injected sharingClientFacto
   assert.equal(sent?.name, "crow_send_message", "send_peer went through the injected factory");
   assert.equal(sent?.arguments?.contact, "Alice");
   assert.equal(sent?.arguments?.message, "hello there");
+});
+
+// ── F5: the shared accept + server-side provenance ───────────────────────────
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-acceptbot-test-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir },
+  stdio: "pipe",
+});
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const LOCAL_ID = "inst-local-f5";
+const ADV = "inst-advertiser-f5";
+
+// getOrCreateLocalInstanceId() reads $CROW_DATA_DIR/instance-id at call time.
+// Pin both so the directory read resolves LOCAL_ID and never touches ~/.crow.
+writeFileSync(join(tmpDir, "instance-id"), LOCAL_ID);
+process.env.CROW_DATA_DIR = tmpDir;
+
+const db = createDbClient(DB_PATH);
+
+const BOT = deriveBotIdentity(randomBytes(32), "f5-bot");
+const CODE = generateBotInviteCode(BOT, "tok-f5", [], "F5 Bot");
+const BOT_CROW_ID = parseBotInviteCode(CODE).botCrowId;
+/** trailing-64 lowercase x-only key — the shape getBotDirectory's `pubkeys` Sets hold. */
+const BOT_X = String(BOT.secp256k1Pubkey).slice(-64).toLowerCase();
+
+const STALE_PK = "f".repeat(64); // a prunable contact's key; never advertised
+
+/** Stand up a fake advertised directory: ADV serves `bots`, everyone else is unreachable. */
+function advertise(bots) {
+  _resetCache();
+  _setFetchImpl(async (_db, instanceId) =>
+    instanceId === ADV
+      ? { ok: true, body: { bots, complete: true } }
+      : { ok: false, error: "not_paired" });
+}
+
+const BOT_ENTRY = {
+  bot_id: "f5-bot",
+  display_name: "F5 Bot",
+  messaging_pubkey: BOT.secp256k1Pubkey, // 02/03-prefixed; the cache normalizes
+  invite_code: CODE,
+};
+
+async function seedAdvertiser() {
+  await db.execute({
+    sql: "INSERT INTO crow_instances (id, name, crow_id, trusted, status, is_home) VALUES (?,?,?,1,'active',0)",
+    args: [ADV, "Advertiser", "crow:adv0000001"],
+  });
+}
+
+/** A zero-message contact whose advertiser is ADV and whose key ADV does NOT advertise ⇒ prunable. */
+async function seedPrunableContact() {
+  await db.execute({
+    sql: `INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey,
+                                lamport_ts, origin, is_bot, advertised_by_instance_id)
+          VALUES ('crow:stalebot1', 'Stale Bot', 'ed01', ?, 100, 'advertised', 1, ?)`,
+    args: ["02" + STALE_PK, ADV],
+  });
+}
+
+function fakeRes() {
+  return { headersSent: false, _redir: null, redirectAfterPost(u) { this.headersSent = true; this._redir = u; return this; } };
+}
+
+async function contactRow(crowId) {
+  const { rows } = await db.execute({
+    sql: "SELECT origin, is_bot, advertised_by_instance_id FROM contacts WHERE crow_id = ?",
+    args: [crowId],
+  });
+  return rows[0] || null;
+}
+
+beforeEach(async () => {
+  await db.execute("DELETE FROM messages");
+  await db.execute("DELETE FROM contacts");
+  await db.execute("DELETE FROM contact_tombstones");
+  await db.execute("DELETE FROM crow_instances");
+  _resetCache();
+  _setFetchImpl(null);
+  __setEmitSinkForTest(null);
+});
+
+/** Capture every emitContactChange. The sink REPLACES the SyncManager, so it sees the RAW row. */
+function captureEmits() {
+  const emits = [];
+  __setEmitSinkForTest({ emitChange: async (table, op, row) => { emits.push({ table, op, row }); return 1; } });
+  return emits;
+}
+
+// ── §5 test 2, first half: the panel directory add ───────────────────────────
+
+test("F5: contacts-panel directory add emits EXACTLY ONE insert carrying is_bot + advertised_by_instance_id", async () => {
+  await seedAdvertiser();
+  advertise([BOT_ENTRY]);
+  const emits = captureEmits();
+  try {
+    const out = await handleContactAction(
+      { body: { action: "dir_add_bot", invite_code: CODE } },
+      db,
+      { managers: {} },
+    );
+    assert.equal(out.redirect, "/dashboard/contacts?view=bots");
+
+    // THE assertion. The old contacts panel fired TWO emits (insert, then update);
+    // the old messages panel fired one then nothing. Both are bugs this replaces.
+    assert.equal(emits.length, 1, "exactly one emit — not the old insert-then-update pair");
+    assert.equal(emits[0].table, "contacts");
+    assert.equal(emits[0].op, "insert", "insert is load-bearing: it is the only op that passes a peer's tombstone gate");
+    assert.equal(Number(emits[0].row.is_bot), 1, "the emitted payload is already classified as a bot");
+    assert.equal(emits[0].row.advertised_by_instance_id, ADV, "the FACT of who advertised it rides the wire");
+    // NOTE on `origin`: this sink stands in for the SyncManager, so it sees the RAW
+    // row — which does still carry origin. The wire strip happens INSIDE
+    // SyncManager.emitChange (EXCLUDED_COLUMNS.contacts, F3) and is locked down by
+    // tests/contacts-origin-wire.test.js. Asserting its absence HERE would be
+    // asserting a falsehood about this seam.
+
+    const row = await contactRow(BOT_CROW_ID);
+    assert.equal(row.origin, "advertised", "local row classified at INSERT, not by a follow-up UPDATE");
+    assert.equal(Number(row.is_bot), 1);
+    assert.equal(row.advertised_by_instance_id, ADV);
+  } finally { __setEmitSinkForTest(null); }
+});
+
+test("F5: messages-panel dir_message_bot emits exactly one classified insert and opens the conversation", async () => {
+  await seedAdvertiser();
+  advertise([BOT_ENTRY]);
+  const emits = captureEmits();
+  try {
+    const res = fakeRes();
+    await handlePostAction(
+      { body: { action: "dir_message_bot", invite_code: CODE } },
+      res,
+      { db, _managers: {} },
+    );
+    assert.equal(emits.length, 1, "exactly one emit — the messages panel used to emit NOTHING here");
+    assert.equal(emits[0].op, "insert");
+    assert.equal(emits[0].row.advertised_by_instance_id, ADV);
+    const { rows } = await db.execute({ sql: "SELECT id FROM contacts WHERE crow_id = ?", args: [BOT_CROW_ID] });
+    assert.equal(res._redir, `/dashboard/messages?open=${rows[0].id}`, "still lands inside the new conversation");
+  } finally { __setEmitSinkForTest(null); }
+});
+
+// ── §5 test 2, second half: the MCP / paste path is BYTE-IDENTICAL to today ──
+
+test("F5: the MCP/paste path (no advertiser) still emits its own insert, and the row is NULL-provenance", async () => {
+  const emits = captureEmits();
+  try {
+    // The tool is a thin wrapper over exactly this call — no advertisedByInstanceId.
+    const r = await acceptBotInvite(db, {}, { inviteCode: CODE });
+    assert.equal(r.outcome, "created");
+    assert.equal(r.botCrowId, BOT_CROW_ID);
+    assert.equal(r.notified, false, "no nostrManager ⇒ 'added, but could not reach the bot' — NOT a failed accept");
+    assert.equal(r.ok, true, "the contact is still added");
+
+    // Emit-coverage regression guard: the refactor must not lose the tool's emit.
+    assert.equal(emits.length, 1, "the tool path still emits");
+    assert.equal(emits[0].op, "insert");
+
+    const row = await contactRow(BOT_CROW_ID);
+    assert.equal(row.origin, null, "pasted invite ⇒ no judgment");
+    assert.equal(Number(row.is_bot), 0);
+    assert.equal(row.advertised_by_instance_id, null, "NULL provenance ⇒ structurally NEVER prunable");
+  } finally { __setEmitSinkForTest(null); }
+});
+
+// ── §5 test 3: provenance is resolved server-side, never taken from the form ──
+
+test("F5: a forged advertised_by in the POST body is IGNORED — provenance comes from the directory", async () => {
+  await seedAdvertiser();
+  advertise([BOT_ENTRY]);
+  await handleContactAction(
+    {
+      body: {
+        action: "dir_add_bot",
+        invite_code: CODE,
+        advertised_by: "inst-attacker",
+        advertised_by_instance_id: "inst-attacker",
+      },
+    },
+    db,
+    { managers: {} },
+  );
+  const row = await contactRow(BOT_CROW_ID);
+  assert.equal(row.advertised_by_instance_id, ADV, "the directory is authoritative; the form is not");
+});
+
+test("F5: with NO resolvable advertiser, a forged body field still cannot stamp the row prunable", async () => {
+  // No trusted peers at all ⇒ nothing to resolve against.
+  await handlePostAction(
+    { body: { action: "dir_add_bot", invite_code: CODE, advertised_by_instance_id: "inst-attacker" } },
+    fakeRes(),
+    { db, _managers: {} },
+  );
+  const row = await contactRow(BOT_CROW_ID);
+  assert.equal(row.advertised_by_instance_id, null, "unspoofable: NULL, never the attacker's value");
+});
+
+// ── §5 test 4 (R3-MAJOR-6): the ADD path performs ZERO deletes ────────────────
+
+test("F5/R3-MAJOR-6: adding a bot from the directory DELETES NOTHING — a prunable contact survives", async () => {
+  await seedAdvertiser();
+  await seedPrunableContact(); // advertised_by=ADV, zero messages, key NOT in ADV's list ⇒ prunable
+  advertise([BOT_ENTRY]);      // ADV answers ok+complete and does NOT advertise STALE_PK
+
+  await handleContactAction(
+    { body: { action: "dir_add_bot", invite_code: CODE } },
+    db,
+    { managers: {} },
+  );
+
+  const stale = await contactRow("crow:stalebot1");
+  assert.ok(stale, "clicking Add must never garbage-collect: getBotDirectory prunes as a SIDE EFFECT when asked to, so the add path MUST read it with {prune:false}");
+  const { rows: tombs } = await db.execute("SELECT COUNT(*) AS n FROM contact_tombstones");
+  assert.equal(Number(tombs[0].n), 0, "and it must not tombstone anything either");
+  assert.ok(await contactRow(BOT_CROW_ID), "the bot the user actually clicked IS added");
+});
+
+// ── §5 test 5: unresolvable advertiser ⇒ NULL provenance (fail-safe) ──────────
+
+test("F5: an unresolvable advertiser (peer unreachable) yields NULL provenance, and the contact is STILL added", async () => {
+  await seedAdvertiser();
+  _resetCache();
+  _setFetchImpl(async () => ({ ok: false, error: "timeout" })); // directory unreachable
+
+  const emits = captureEmits();
+  try {
+    await handleContactAction(
+      { body: { action: "dir_add_bot", invite_code: CODE } },
+      db,
+      { managers: {} },
+    );
+    const row = await contactRow(BOT_CROW_ID);
+    assert.ok(row, "the add succeeds — a directory outage must not block the user");
+    assert.equal(row.advertised_by_instance_id, null, "un-prunable is the FAIL-SAFE direction");
+    assert.equal(emits.length, 1, "still exactly one insert emit");
+  } finally { __setEmitSinkForTest(null); }
+});
+
+// ── The already-a-contact branch is unchanged: reuse the row, no second emit ──
+
+test("F5: re-adding an existing bot reuses the row and emits NOTHING", async () => {
+  await seedAdvertiser();
+  advertise([BOT_ENTRY]);
+  await handleContactAction({ body: { action: "dir_add_bot", invite_code: CODE } }, db, { managers: {} });
+
+  const emits = captureEmits();
+  try {
+    await handleContactAction({ body: { action: "dir_add_bot", invite_code: CODE } }, db, { managers: {} });
+    assert.equal(emits.length, 0, "no emit on the already-a-contact branch");
+    const { rows } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM contacts WHERE crow_id = ?", args: [BOT_CROW_ID] });
+    assert.equal(Number(rows[0].n), 1, "idempotent on crow_id");
+  } finally { __setEmitSinkForTest(null); }
 });

--- a/tests/crow-accept-bot-invite.test.js
+++ b/tests/crow-accept-bot-invite.test.js
@@ -323,6 +323,16 @@ test("F5: an unresolvable advertiser (peer unreachable) yields NULL provenance, 
     const row = await contactRow(BOT_CROW_ID);
     assert.ok(row, "the add succeeds — a directory outage must not block the user");
     assert.equal(row.advertised_by_instance_id, null, "un-prunable is the FAIL-SAFE direction");
+    // R5/MAJOR-3: BOT-NESS AND PRUNABILITY ARE DIFFERENT FACTS. Deriving is_bot from
+    // provenance conflates them: the 60 s advertised-bots cache can expire between the
+    // render and the click, and any peer can hit the 2 s timeout — either way the
+    // advertiser is unresolvable, and the user who clicked a BOT in the bot directory
+    // then gets is_bot=0. That row is not badged as a bot, AND it is swept into
+    // `backfillContactsOnce` (which filters `is_bot = 0`) and re-emitted as an `update`
+    // on every boot. The directory handlers therefore assert is_bot EXPLICITLY.
+    assert.equal(Number(row.is_bot), 1,
+      "a bot clicked in the BOT DIRECTORY is a bot even when we could not resolve WHO advertised it — " +
+      "the unresolvable advertiser costs prunability (advertised_by=NULL), never bot-ness");
     assert.equal(emits.length, 1, "still exactly one insert emit");
   } finally { __setEmitSinkForTest(null); }
 });

--- a/tests/groups-schema.test.js
+++ b/tests/groups-schema.test.js
@@ -17,9 +17,8 @@ const db = initDb();
 after(() => rmSync(tmpDir, { recursive: true, force: true }));
 
 test("SCHEMA_GENERATION is stamped on the db", async () => {
-  assert.equal(SCHEMA_GENERATION, 6);
   const { rows } = await db.execute("PRAGMA user_version");
-  assert.equal(Number(rows[0].user_version), 6);
+  assert.equal(Number(rows[0].user_version), SCHEMA_GENERATION);
 });
 
 test("contact_groups has group_uid + lamport_ts", async () => {

--- a/tests/roster-advertise-prune.test.js
+++ b/tests/roster-advertise-prune.test.js
@@ -236,6 +236,82 @@ test("a row with a falsy crow_id is WARNED and SKIPPED, never deleted", async ()
   assert.match(warnings[0], /crow_id/i);
 });
 
+// ── R5/MAJOR-4: the tombstone must LAND before the row is destroyed ──────────
+//
+// The prune DELETEd first and tombstoned after, and `writeTombstone` swallows every
+// error (`catch {}` — it runs on a receive path and must never throw). So a failing
+// tombstone INSERT left the contact GONE with NO tombstone: the exact resurrectable
+// state this whole feature exists to prevent, re-armed by an empty catch. And the
+// failure is not exotic — `"database is locked"` on this DB is a *documented recurring*
+// failure (spec §1 D4.2; crow has had two DB-lock incidents).
+//
+// The order is therefore: tombstone → VERIFY it landed → only then unwire + DELETE. A
+// tombstone coexisting with a live row is benign: `_applyContact` rule (a) clears any
+// tombstone whenever a local row exists.
+
+/** Wrap a db so the tombstone INSERT fails the way SQLite really fails: "database is locked". */
+function dbWithFailingTombstoneWrite(realDb) {
+  return {
+    execute: async (q) => {
+      const sql = typeof q === "string" ? q : q?.sql || "";
+      if (/INSERT\s+INTO\s+contact_tombstones/i.test(sql)) throw new Error("database is locked");
+      return realDb.execute(q);
+    },
+  };
+}
+
+test("the tombstone write FAILING (\"database is locked\") REFUSES the delete — the contact survives rather than becoming resurrectable", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+  const perInstance = new Map([[ADV, peer({ pubkeys: [PK_KEEP] })]]);
+
+  const warnings = [];
+  const origWarn = console.warn;
+  console.warn = (...a) => warnings.push(a.join(" "));
+  try {
+    await pruneStaleAdvertisedContacts(dbWithFailingTombstoneWrite(db), perInstance, LOCAL_ID, null);
+  } finally {
+    console.warn = origWarn;
+  }
+
+  assert.deepEqual(await contactIds(), [1],
+    "THE ASSERTION: no tombstone ⇒ NO DELETE. Deleting first and tombstoning best-effort leaves the row gone " +
+    "with nothing to block resurrection — the next `update` from any peer that still holds it re-INSERTs it. " +
+    "That is defect D3, restored by a `catch {}`.");
+  assert.equal(await tombstone("crow:gone"), null, "setup check: the tombstone genuinely did not land");
+  assert.ok(warnings.some((w) => /tombstone/i.test(w)), "the refusal is LOUD, not silent");
+});
+
+test("pruneAdvertisedContact reports {ok:false, reason:'tombstone-failed'} when the tombstone cannot be written", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+  const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
+
+  const origWarn = console.warn;
+  console.warn = () => {};
+  let res;
+  try {
+    res = await pruneAdvertisedContact(dbWithFailingTombstoneWrite(db), null, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+  } finally {
+    console.warn = origWarn;
+  }
+
+  assert.deepEqual(res, { ok: false, reason: "tombstone-failed" },
+    "the caller is TOLD. The existing guard already refuses a falsy crow_id for exactly this reason " +
+    "(a tombstone that cannot be written makes the delete resurrectable); the same distrust must extend " +
+    "to the write actually LANDING, not merely being attempted.");
+  assert.deepEqual(await contactIds(), [1], "and the row is still there");
+});
+
+test("the prune still succeeds normally — the tombstone lands BEFORE the row is destroyed", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+  const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
+
+  const res = await pruneAdvertisedContact(db, null, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+
+  assert.deepEqual(res, { ok: true });
+  assert.deepEqual(await contactIds(), [], "the row is gone");
+  assert.equal(Number((await tombstone("crow:gone")).lamport_ts), 4382, "…and the tombstone is there, at the row's own lamport");
+});
+
 // ── unwireContact runs BEFORE the delete (Nostr-subscription leak fix) ───────
 
 test("the prune unwires the contact before deleting it, and a partial managers object never throws", async () => {

--- a/tests/roster-advertise-prune.test.js
+++ b/tests/roster-advertise-prune.test.js
@@ -320,40 +320,103 @@ test("the prune still succeeds normally — the DELETE and the tombstone commit 
   assert.equal(Number((await tombstone("crow:gone")).lamport_ts), 4382, "…and the tombstone is there, at the row's own lamport");
 });
 
-test("a concurrent apply during unwire CANNOT strip the tombstone — the DELETE and the tombstone are ATOMIC", async () => {
-  // THE RACE (found re-reviewing the fix for the previous race — this is why atomicity, not
-  // ordering, is the answer): `_applyContact` rule (a) clears any tombstone whenever a LOCAL
-  // ROW EXISTS. So writing the tombstone BEFORE the delete leaves tombstone-beside-live-row —
-  // and `unwireContact` awaits real network teardown (hypercore close, DHT leave), a wide
-  // window. Nothing serializes the receive path against the render that calls the prune, and
-  // peers are touching this very contact right now (they all see the same directory change).
-  // An inbound entry landing in that window strips the tombstone; the DELETE then lands
-  // UNTOMBSTONED and the next peer `update` re-INSERTs the contact. Defect D3, restored.
+test("a concurrent apply CANNOT strip the tombstone — the DELETE and the tombstone are ATOMIC", async () => {
+  // THE RACE (found re-reviewing the fix for the previous race — this is why ATOMICITY, not
+  // ordering, is the answer). `_applyContact` rule (a) clears any tombstone whenever a LOCAL
+  // ROW EXISTS. Nothing serializes the receive path against the render that calls the prune,
+  // and peers are touching this very contact right now (they all see the same directory
+  // change). So ANY non-atomic prune has an `await` boundary between its tombstone write and
+  // its DELETE at which an inbound entry can land, fire rule (a), and strip the tombstone —
+  // and the DELETE then lands UNTOMBSTONED, so the next peer `update` re-INSERTs the contact.
+  // Defect D3, restored.
   //
-  // Simulate it faithfully: rule (a) fires (clearTombstone) from inside unwireContact.
+  // MODEL THE INTERLEAVE FAITHFULLY: wrap the db so that `execute()` of the DELETE fires a
+  // clearTombstone FIRST — i.e. a receive-path apply slips in at that await boundary. Under
+  // HEAD both statements go through `batch()` (one transaction) and NEVER through `execute()`,
+  // so nothing can interleave and the tombstone survives. Under any two-statement version the
+  // clear lands between them and the belt-and-braces readTombstone trips.
+  //
+  // (An earlier version of this test fired the clear from inside unwireContact. That was
+  // VACUOUS: unwire runs before the tombstone is written, so the clear hit an empty table and
+  // was a no-op. It passed for a reason unrelated to atomicity — the exact vacuity class this
+  // branch keeps producing.)
   const { clearTombstone } = await import("../servers/sharing/contact-delete.js");
   const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
   await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
 
+  const racingDb = {
+    execute: async (q) => {
+      const sql = typeof q === "string" ? q : q?.sql || "";
+      if (/DELETE\s+FROM\s+contacts/i.test(sql)) await clearTombstone(db, "crow:gone"); // ← the apply interleaves
+      return db.execute(q);
+    },
+    batch: (stmts) => db.batch(stmts),
+  };
+
+  const res = await pruneAdvertisedContact(racingDb, null, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+
+  assert.deepEqual(res, { ok: true }, "the prune succeeded — so a tombstone MUST have survived with it");
+  assert.deepEqual(await contactIds(), [], "the row is gone");
+  const t = await tombstone("crow:gone");
+  assert.ok(t, "THE ASSERTION: the row must NEVER be deleted without a surviving tombstone. The " +
+    "tombstone is committed in the SAME TRANSACTION as the DELETE, so a concurrent rule-(a) " +
+    "clear has no boundary to land in.");
+  assert.equal(Number(t.lamport_ts), 4382, "and it still carries the pruned row's own lamport");
+});
+
+test("an alive-but-unwired contact is never left behind — a FAILED prune transaction RE-WIRES it", async () => {
+  // unwireContact runs BEFORE the transaction (FK safety). If the transaction then fails, the
+  // contact SURVIVES but is torn down — and that silently loses the bot's next DM: boot.js's
+  // global-inbox catch-all early-returns for a full contact (request_status NULL) because
+  // "the per-contact subscription is handling it", and we just closed that subscription. The
+  // message would be neither stored nor filed as a request. An un-advertised bot is not a
+  // dead bot, so this is a live message-loss path, not a theoretical one.
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+  const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
+
+  const unsubbed = [];
+  const resubbed = [];
   const managers = {
     nostrManager: {
-      unsubscribeFromContact: async (crowId) => {
-        // ← an inbound contacts entry for this crow_id is applied here; the row is still
-        //   alive, so rule (a) wipes any tombstone standing beside it.
-        await clearTombstone(db, crowId);
-      },
+      unsubscribeFromContact: async (id) => unsubbed.push(id),
+      subscribeToContact: async (c) => resubbed.push(c.crowId),
     },
   };
 
-  const res = await pruneAdvertisedContact(db, managers, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+  const origWarn = console.warn;
+  console.warn = () => {};
+  let res;
+  try {
+    res = await pruneAdvertisedContact(dbWithFailingTombstoneWrite(db), managers, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+  } finally {
+    console.warn = origWarn;
+  }
 
-  assert.deepEqual(res, { ok: true });
-  assert.deepEqual(await contactIds(), [], "the row is gone");
-  const t = await tombstone("crow:gone");
-  assert.ok(t, "THE ASSERTION: the row must NEVER be deleted without a surviving tombstone. " +
-    "The tombstone is written INSIDE the same transaction as the DELETE, so a concurrent " +
-    "rule-(a) clear cannot land between them.");
-  assert.equal(Number(t.lamport_ts), 4382, "and it still carries the pruned row's own lamport");
+  assert.deepEqual(res, { ok: false, reason: "prune-txn-failed" });
+  assert.deepEqual(await contactIds(), [1], "the contact survived the failed transaction");
+  assert.deepEqual(unsubbed, ["crow:gone"], "setup check: it really was unwired first");
+  assert.deepEqual(resubbed, ["crow:gone"],
+    "THE ASSERTION: a surviving contact must be RE-WIRED. Left unwired, the bot's next DM is " +
+    "dropped on the floor — not stored, not filed as a message request.");
+});
+
+test("a `req:` crow_id is REFUSED — tombstoneStatement bypasses writeTombstone's req: guard", async () => {
+  // tombstoneStatement deliberately skips writeTombstone's guards so it can join the batch.
+  // So the req: guard must be re-asserted in the prune, or we would DELETE the row and write
+  // a req:-keyed tombstone that readTombstone/clearTombstone can never see (both no-op on
+  // req:) — violating contact_tombstones' stated invariant and failing OPEN. Unreachable
+  // today; "unreachable" premises have evaporated twice on this branch.
+  const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
+  await db.execute({
+    sql: `INSERT INTO contacts (id, crow_id, display_name, ed25519_pubkey, secp256k1_pubkey, lamport_ts, advertised_by_instance_id)
+          VALUES (9, 'req:' || ?, 'Pending', 'ed09', '02' || ?, 5, ?)`,
+    args: [PK_BOT, PK_BOT, ADV],
+  });
+
+  const res = await pruneAdvertisedContact(db, null, { id: 9, crow_id: "req:" + PK_BOT, lamport_ts: 5 });
+
+  assert.deepEqual(res, { ok: false, reason: "req-id" }, "refused, not deleted");
+  assert.deepEqual(await contactIds(), [9], "the row survives — failing SAFE, not open");
 });
 
 // ── unwireContact runs BEFORE the delete (Nostr-subscription leak fix) ───────

--- a/tests/roster-advertise-prune.test.js
+++ b/tests/roster-advertise-prune.test.js
@@ -400,6 +400,37 @@ test("an alive-but-unwired contact is never left behind — a FAILED prune trans
     "dropped on the floor — not stored, not filed as a message request.");
 });
 
+test("the failed-prune re-wire must NOT re-subscribe a BLOCKED survivor", async () => {
+  // The re-wire passes the RE-SELECTED row, not the prune's 3-field skeleton
+  // ({id, crow_id, lamport_ts}). With the skeleton, `is_blocked` reads undefined, defeating
+  // wireFullContact's blocked guard — a blocked contact would be re-subscribed to Nostr with
+  // undefined pubkeys. Nothing else in the suite pins this, so a refactor could silently
+  // reintroduce it.
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+  await db.execute("UPDATE contacts SET is_blocked = 1 WHERE id = 1");
+  const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
+
+  const resubbed = [];
+  const managers = {
+    nostrManager: {
+      unsubscribeFromContact: async () => {},
+      subscribeToContact: async (c) => resubbed.push(c.crowId),
+    },
+  };
+
+  const origWarn = console.warn;
+  console.warn = () => {};
+  try {
+    await pruneAdvertisedContact(dbWithFailingTombstoneWrite(db), managers, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+  } finally {
+    console.warn = origWarn;
+  }
+
+  assert.deepEqual(await contactIds(), [1], "the contact survived the failed transaction");
+  assert.deepEqual(resubbed, [], "a BLOCKED contact must never be re-subscribed — the re-wire " +
+    "has to read the real row, not the prune's skeleton");
+});
+
 test("a `req:` crow_id is REFUSED — tombstoneStatement bypasses writeTombstone's req: guard", async () => {
   // tombstoneStatement deliberately skips writeTombstone's guards so it can join the batch.
   // So the req: guard must be re-asserted in the prune, or we would DELETE the row and write

--- a/tests/roster-advertise-prune.test.js
+++ b/tests/roster-advertise-prune.test.js
@@ -1,27 +1,305 @@
 // tests/roster-advertise-prune.test.js
-import { test } from "node:test";
+//
+// F4 (spec `2026-07-12-advertised-contact-prune-design.md` §3 F4, §5 tests 4 & 8):
+// the advertised-contact prune. A REAL schema is mandatory here — the feature is
+// expressed in columns (`advertised_by_instance_id`, `lamport_ts`, `crow_id`) and
+// in a second table (`contact_tombstones`) that a hand-rolled 4-column `contacts`
+// cannot express. Running init-db into a mkdtemp CROW_DATA_DIR also proves the new
+// column really lands via the migration.
+//
+// NEVER point this file at ~/.crow — this code DELETES contacts.
+import { test, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { createClient } from "@libsql/client";
-import { pruneStaleAdvertisedContacts } from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import {
+  getBotDirectory,
+  pruneStaleAdvertisedContacts,
+} from "../servers/gateway/dashboard/panels/messages/data-queries.js";
+import { _setFetchImpl, _resetCache } from "../servers/gateway/dashboard/advertised-bots-cache.js";
 
-test("prunes advertised contacts with no history that are no longer advertised", async () => {
-  const db = createClient({ url: ":memory:" });
-  await db.execute(`CREATE TABLE contacts (id INTEGER PRIMARY KEY, crow_id TEXT, secp256k1_pubkey TEXT, origin TEXT)`);
-  await db.execute(`CREATE TABLE messages (id INTEGER PRIMARY KEY, contact_id INTEGER)`);
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-prune-test-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir },
+  stdio: "pipe",
+});
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
 
-  // 1) advertised, no history, NOT live  → pruned
-  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, secp256k1_pubkey, origin) VALUES (1,'a','02'||?,'advertised')", args: ["a".repeat(64)] });
-  // 2) advertised, no history, STILL live → kept
-  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, secp256k1_pubkey, origin) VALUES (2,'b','02'||?,'advertised')", args: ["b".repeat(64)] });
-  // 3) advertised, HAS history, not live → kept
-  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, secp256k1_pubkey, origin) VALUES (3,'c','02'||?,'advertised')", args: ["c".repeat(64)] });
-  await db.execute("INSERT INTO messages (contact_id) VALUES (3)");
-  // 4) manual contact, no history, not live → kept (origin NULL)
-  await db.execute({ sql: "INSERT INTO contacts (id, crow_id, secp256k1_pubkey, origin) VALUES (4,'d','02'||?,NULL)", args: ["d".repeat(64)] });
+const LOCAL_ID = "inst-local";
+const ADV = "inst-advertiser";
+const OTHER = "inst-other";
 
-  const live = new Set(["b".repeat(64)]);
-  await pruneStaleAdvertisedContacts(db, live);
+// getOrCreateLocalInstanceId() reads $CROW_DATA_DIR/instance-id at call time.
+// Pin both so getBotDirectory resolves LOCAL_ID and never touches ~/.crow.
+writeFileSync(join(tmpDir, "instance-id"), LOCAL_ID);
+process.env.CROW_DATA_DIR = tmpDir;
 
+const db = createDbClient(DB_PATH);
+
+const PK_BOT = "a".repeat(64); // the advertised bot's x-only key
+const PK_KEEP = "b".repeat(64);
+
+/** Insert a contacts row. `pk` is stored 02-prefixed to exercise trailing-64 normalization. */
+async function seedContact({ id, crowId, pk, advertisedBy = null, lamport = 100, messages = 0 }) {
+  await db.execute({
+    sql: `INSERT INTO contacts (id, crow_id, display_name, ed25519_pubkey, secp256k1_pubkey,
+                                lamport_ts, origin, is_bot, advertised_by_instance_id)
+          VALUES (?, ?, ?, ?, ?, ?, 'advertised', 1, ?)`,
+    args: [id, crowId, "Bot " + id, "ed" + String(id).padStart(2, "0"), "02" + pk, lamport, advertisedBy],
+  });
+  for (let i = 0; i < messages; i++) {
+    await db.execute({
+      sql: "INSERT INTO messages (contact_id, content, direction) VALUES (?, ?, 'received')",
+      args: [id, "hello " + i],
+    });
+  }
+}
+
+async function contactIds() {
   const { rows } = await db.execute("SELECT id FROM contacts ORDER BY id");
-  assert.deepEqual(rows.map((r) => r.id), [2, 3, 4], "only the stale advertised no-history contact is pruned");
+  return rows.map((r) => Number(r.id));
+}
+
+async function tombstone(crowId) {
+  const { rows } = await db.execute({
+    sql: "SELECT crow_id, lamport_ts FROM contact_tombstones WHERE crow_id = ?",
+    args: [crowId],
+  });
+  return rows[0] || null;
+}
+
+/** perInstance entry factory — `pubkeys` are x-only lowercase, as getBotDirectory builds them. */
+function peer({ ok = true, complete = true, pubkeys = [] } = {}) {
+  return { ok, complete, pubkeys: new Set(pubkeys) };
+}
+
+beforeEach(async () => {
+  await db.execute("DELETE FROM messages");
+  await db.execute("DELETE FROM contacts");
+  await db.execute("DELETE FROM contact_tombstones");
+  await db.execute("DELETE FROM crow_instances");
+  _resetCache();
+  _setFetchImpl(null);
+});
+
+// ── The trigger matrix (spec §5.4) ───────────────────────────────────────────
+
+test("1. advertiser ok+complete and the bot is ABSENT from its list ⇒ PRUNED, tombstone at the row's own lamport_ts", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+  const perInstance = new Map([[ADV, peer({ pubkeys: [PK_KEEP] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [], "the stale advertised contact is deleted");
+  const t = await tombstone("crow:gone");
+  assert.ok(t, "a tombstone is written so a peer's later `update` cannot resurrect the row");
+  // ANTI-DIVERGENCE: the tombstone MUST carry the pruned row's own lamport, never a
+  // fresh counter value (spec §3 F4 / R3-CRITICAL-1 — a fresh burn is invisible to the
+  // fleet and ties with a re-adder's insert, which the apply gate drops ⇒ permanent
+  // divergence at the live fleet's 4385/4385/4384).
+  assert.equal(Number(t.lamport_ts), 4382, "tombstone lamport === the pruned row's lamport_ts");
+});
+
+test("2. advertiser is unavailable (ok:false) ⇒ NOT pruned", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV });
+  const perInstance = new Map([[ADV, peer({ ok: false, complete: false, pubkeys: [] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "an offline/timed-out advertiser never authorises a delete");
+  assert.equal(await tombstone("crow:gone"), null);
+});
+
+test("2a. `ok` and `complete` are INDEPENDENTLY load-bearing — ok:false never prunes even if complete reads true", async () => {
+  // getBotDirectory only ever derives complete from ok, so this shape cannot arise
+  // from it today. The rule is `ok === true AND complete === true` (BOTH), and the
+  // prune DELETES: it must not silently start depending on that coupling holding, in
+  // this or any future caller.
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV });
+  const perInstance = new Map([[ADV, peer({ ok: false, complete: true, pubkeys: [] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "an unavailable peer's bot list is not evidence of anything");
+  assert.equal(await tombstone("crow:gone"), null);
+});
+
+test("2b. advertiser was NOT queried this cycle (unpaired / untrusted) ⇒ NOT pruned", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: "inst-never-queried" });
+  const perInstance = new Map([[ADV, peer({ pubkeys: [] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "'never queried' must not read as 'queried and it advertises nothing'");
+});
+
+test("3. advertiser answered ok but NOT complete ⇒ NOT pruned", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV });
+  const perInstance = new Map([[ADV, peer({ ok: true, complete: false, pubkeys: [PK_KEEP] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "a 200 with a silently-missing bot never authorises a delete");
+});
+
+test("4. bot absent from a DIFFERENT peer's list but PRESENT in its own advertiser's ⇒ NOT pruned", async () => {
+  await seedContact({ id: 1, crowId: "crow:live", pk: PK_BOT, advertisedBy: ADV });
+  const perInstance = new Map([
+    [ADV, peer({ pubkeys: [PK_BOT] })],
+    [OTHER, peer({ pubkeys: [] })],
+  ]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "only the advertiser's own view can retire its bot");
+});
+
+test("5. bot advertised by a SECOND ok+complete peer ⇒ NOT pruned", async () => {
+  await seedContact({ id: 1, crowId: "crow:dual", pk: PK_BOT, advertisedBy: ADV });
+  const perInstance = new Map([
+    [ADV, peer({ pubkeys: [] })],
+    [OTHER, peer({ pubkeys: [PK_BOT] })],
+  ]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "the directory dedups on first-seen pubkey — a bot advertised by two instances is still live");
+});
+
+test("6. advertised_by_instance_id === the local instance ⇒ NOT pruned (host protection)", async () => {
+  await seedContact({ id: 1, crowId: "crow:mine", pk: PK_BOT, advertisedBy: LOCAL_ID });
+  const perInstance = new Map([
+    [LOCAL_ID, peer({ pubkeys: [] })],
+    [ADV, peer({ pubkeys: [] })],
+  ]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "the host NEVER prunes its own bot");
+});
+
+test("6a. a falsy localInstanceId prunes NOTHING — rule 1 is unprovable, so host protection fails SAFE", async () => {
+  // getOrCreateLocalInstanceId is guarded at the call site and yields null if it
+  // throws. With localInstanceId null, `advertiser === localInstanceId` can never
+  // match, so rule 1 would silently disable and the host could prune its OWN bot.
+  await seedContact({ id: 1, crowId: "crow:mine", pk: PK_BOT, advertisedBy: LOCAL_ID });
+  await seedContact({ id: 2, crowId: "crow:theirs", pk: PK_KEEP, advertisedBy: ADV });
+  const perInstance = new Map([
+    [LOCAL_ID, peer({ pubkeys: [] })],
+    [ADV, peer({ pubkeys: [] })],
+  ]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, null, null);
+
+  assert.deepEqual(await contactIds(), [1, 2], "no local id ⇒ no prune at all, not a prune with rule 1 disabled");
+});
+
+test("7. advertised_by_instance_id IS NULL (manual / pasted-invite contact) ⇒ NOT pruned", async () => {
+  await seedContact({ id: 1, crowId: "crow:manual", pk: PK_BOT, advertisedBy: null });
+  const perInstance = new Map([[ADV, peer({ pubkeys: [] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "NULL provenance is structurally never prunable");
+});
+
+test("8. row HAS messages ⇒ NOT pruned (the prune never destroys history)", async () => {
+  await seedContact({ id: 1, crowId: "crow:chatty", pk: PK_BOT, advertisedBy: ADV, messages: 2 });
+  const perInstance = new Map([[ADV, peer({ pubkeys: [] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+
+  assert.deepEqual(await contactIds(), [1], "a contact with history is kept even when un-advertised");
+});
+
+// ── The silent-no-op trap (spec §3 F4: writeTombstone no-ops on a falsy crowId) ──
+
+test("a row with a falsy crow_id is WARNED and SKIPPED, never deleted", async () => {
+  await seedContact({ id: 1, crowId: "", pk: PK_BOT, advertisedBy: ADV });
+  const perInstance = new Map([[ADV, peer({ pubkeys: [] })]]);
+
+  const warnings = [];
+  const origWarn = console.warn;
+  console.warn = (...a) => warnings.push(a.join(" "));
+  try {
+    await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, null);
+  } finally {
+    console.warn = origWarn;
+  }
+
+  assert.deepEqual(await contactIds(), [1], "no crow_id ⇒ no tombstone is possible ⇒ never delete (writeTombstone would silently no-op)");
+  assert.equal(warnings.length, 1, "the skip is reported, not silent");
+  assert.match(warnings[0], /crow_id/i);
+});
+
+// ── unwireContact runs BEFORE the delete (Nostr-subscription leak fix) ───────
+
+test("the prune unwires the contact before deleting it, and a partial managers object never throws", async () => {
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 7 });
+  const unsubbed = [];
+  const managers = { nostrManager: { unsubscribeFromContact: async (id) => unsubbed.push(id) } };
+  const perInstance = new Map([[ADV, peer({ pubkeys: [] })]]);
+
+  await pruneStaleAdvertisedContacts(db, perInstance, LOCAL_ID, managers);
+
+  assert.deepEqual(unsubbed, ["crow:gone"], "unsubscribeFromContact ran (the old bare DELETE leaked the subscription)");
+  assert.deepEqual(await contactIds(), []);
+});
+
+// ── getBotDirectory: perInstance, and prune is OPT-IN (spec §5.8 / R3-MAJOR-6) ──
+
+async function seedInstances(ids) {
+  for (const id of ids) {
+    await db.execute({
+      sql: "INSERT INTO crow_instances (id, name, crow_id, trusted, status) VALUES (?, ?, ?, 1, 'active')",
+      args: [id, id, "crow:" + id],
+    });
+  }
+}
+
+test("getBotDirectory returns perInstance with an entry for EVERY queried peer, including unavailable ones", async () => {
+  await seedInstances([ADV, OTHER]);
+  _setFetchImpl(async (_db, instanceId) => {
+    if (instanceId === OTHER) throw new Error("offline");
+    return { ok: true, body: { complete: true, bots: [
+      { bot_id: "b1", display_name: "Helper", messaging_pubkey: "02" + PK_BOT, invite_code: "crow:a.b.c" },
+    ] } };
+  });
+
+  const dir = await getBotDirectory(db);
+
+  assert.ok(dir.perInstance instanceof Map, "perInstance is a Map");
+  assert.deepEqual([...dir.perInstance.keys()].sort(), [ADV, OTHER].sort());
+  const adv = dir.perInstance.get(ADV);
+  assert.equal(adv.ok, true);
+  assert.equal(adv.complete, true);
+  assert.deepEqual([...adv.pubkeys], [PK_BOT], "x-only lowercase, 02-prefix stripped");
+  const other = dir.perInstance.get(OTHER);
+  assert.equal(other.ok, false, "a queried-but-unavailable peer is present with ok:false, not absent");
+  assert.equal(other.complete, false);
+  assert.equal(other.pubkeys.size, 0);
+  // display shape unchanged
+  assert.equal(dir.groups.length, 1);
+  assert.equal(dir.total, 1);
+  assert.equal(dir.notAddedCount, 1);
+});
+
+test("getBotDirectory(db) with DEFAULT options performs ZERO deletes; only {prune:true} garbage-collects", async () => {
+  await seedInstances([ADV]);
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 55 });
+  // ADV is ok+complete and advertises nothing → row 1 is prunable.
+  _setFetchImpl(async () => ({ ok: true, body: { complete: true, bots: [] } }));
+
+  const dir = await getBotDirectory(db);
+  assert.deepEqual(await contactIds(), [1], "a read must never GC — the add path calls this and would otherwise delete contacts");
+  assert.equal(dir.total, 0);
+
+  _resetCache();
+  await getBotDirectory(db, { prune: true });
+  assert.deepEqual(await contactIds(), [], "the render opts in and the stale contact is collected");
+  assert.ok(await tombstone("crow:gone"), "and the tombstone is written");
 });

--- a/tests/roster-advertise-prune.test.js
+++ b/tests/roster-advertise-prune.test.js
@@ -251,11 +251,19 @@ test("a row with a falsy crow_id is WARNED and SKIPPED, never deleted", async ()
 
 /** Wrap a db so the tombstone INSERT fails the way SQLite really fails: "database is locked". */
 function dbWithFailingTombstoneWrite(realDb) {
+  const hasTombstoneWrite = (stmts) =>
+    (stmts || []).some((s) => /INSERT\s+INTO\s+contact_tombstones/i.test(typeof s === "string" ? s : s?.sql || ""));
   return {
     execute: async (q) => {
       const sql = typeof q === "string" ? q : q?.sql || "";
       if (/INSERT\s+INTO\s+contact_tombstones/i.test(sql)) throw new Error("database is locked");
       return realDb.execute(q);
+    },
+    // The prune commits its DELETE and its tombstone in ONE batch. A locked DB fails the
+    // whole transaction — so NEITHER lands, which is precisely the property under test.
+    batch: async (stmts) => {
+      if (hasTombstoneWrite(stmts)) throw new Error("database is locked");
+      return realDb.batch(stmts);
     },
   };
 }
@@ -294,14 +302,14 @@ test("pruneAdvertisedContact reports {ok:false, reason:'tombstone-failed'} when 
     console.warn = origWarn;
   }
 
-  assert.deepEqual(res, { ok: false, reason: "tombstone-failed" },
+  assert.deepEqual(res, { ok: false, reason: "prune-txn-failed" },
     "the caller is TOLD. The existing guard already refuses a falsy crow_id for exactly this reason " +
     "(a tombstone that cannot be written makes the delete resurrectable); the same distrust must extend " +
     "to the write actually LANDING, not merely being attempted.");
   assert.deepEqual(await contactIds(), [1], "and the row is still there");
 });
 
-test("the prune still succeeds normally — the tombstone lands BEFORE the row is destroyed", async () => {
+test("the prune still succeeds normally — the DELETE and the tombstone commit TOGETHER", async () => {
   await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
   const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
 
@@ -310,6 +318,42 @@ test("the prune still succeeds normally — the tombstone lands BEFORE the row i
   assert.deepEqual(res, { ok: true });
   assert.deepEqual(await contactIds(), [], "the row is gone");
   assert.equal(Number((await tombstone("crow:gone")).lamport_ts), 4382, "…and the tombstone is there, at the row's own lamport");
+});
+
+test("a concurrent apply during unwire CANNOT strip the tombstone — the DELETE and the tombstone are ATOMIC", async () => {
+  // THE RACE (found re-reviewing the fix for the previous race — this is why atomicity, not
+  // ordering, is the answer): `_applyContact` rule (a) clears any tombstone whenever a LOCAL
+  // ROW EXISTS. So writing the tombstone BEFORE the delete leaves tombstone-beside-live-row —
+  // and `unwireContact` awaits real network teardown (hypercore close, DHT leave), a wide
+  // window. Nothing serializes the receive path against the render that calls the prune, and
+  // peers are touching this very contact right now (they all see the same directory change).
+  // An inbound entry landing in that window strips the tombstone; the DELETE then lands
+  // UNTOMBSTONED and the next peer `update` re-INSERTs the contact. Defect D3, restored.
+  //
+  // Simulate it faithfully: rule (a) fires (clearTombstone) from inside unwireContact.
+  const { clearTombstone } = await import("../servers/sharing/contact-delete.js");
+  const { pruneAdvertisedContact } = await import("../servers/sharing/contact-prune.js");
+  await seedContact({ id: 1, crowId: "crow:gone", pk: PK_BOT, advertisedBy: ADV, lamport: 4382 });
+
+  const managers = {
+    nostrManager: {
+      unsubscribeFromContact: async (crowId) => {
+        // ← an inbound contacts entry for this crow_id is applied here; the row is still
+        //   alive, so rule (a) wipes any tombstone standing beside it.
+        await clearTombstone(db, crowId);
+      },
+    },
+  };
+
+  const res = await pruneAdvertisedContact(db, managers, { id: 1, crow_id: "crow:gone", lamport_ts: 4382 });
+
+  assert.deepEqual(res, { ok: true });
+  assert.deepEqual(await contactIds(), [], "the row is gone");
+  const t = await tombstone("crow:gone");
+  assert.ok(t, "THE ASSERTION: the row must NEVER be deleted without a surviving tombstone. " +
+    "The tombstone is written INSIDE the same transaction as the DELETE, so a concurrent " +
+    "rule-(a) clear cannot land between them.");
+  assert.equal(Number(t.lamport_ts), 4382, "and it still carries the pruned row's own lamport");
 });
 
 // ── unwireContact runs BEFORE the delete (Nostr-subscription leak fix) ───────


### PR DESCRIPTION
Builds **Item 2a** of the autonomous arc plan from spec `docs/superpowers/specs/2026-07-12-advertised-contact-prune-design.md`. Fixes the `pruneStaleAdvertisedContacts` resurrection bug — and, along the way, **five more bugs, four of them permanent-divergence or data-loss class.**

⚠️ **This is a SCHEMA BUMP (`SCHEMA_GENERATION` 6 → 7).** The migration rail was followed; evidence below.

## The defect

An advertised bot contact (auto-added from a paired peer's bot directory) was garbage-collected with a **bare `DELETE`** — no tombstone, no emit. The row survived on every peer, so any later emit (all of which are `op="update"`) arrived with no local row and no tombstone, hit `_applyContact`'s `!localRow` branch, and **re-INSERTed. Resurrection.**

The trigger was also unsound: it fired if **any single** peer answered, pruning rows advertised by a peer that may have been offline, timed out, or answered `200` with a bot silently missing.

## What ships

The insight that survived every round: **`origin` is a *judgment*** ("I may GC this") — view-relative, must not sync. **"Instance X advertised this bot" is a *FACT*** — it syncs safely, and lets every instance re-derive prunability from *its own* view. That converges with **no broadcast, no delete on the wire, and no host authority.**

- **F1** — completeness is a **positive assertion checked on both sides**. The sender asserts `complete:true` only if it skipped zero bots; the receiver also requires that it dropped no entry. A non-`{bots:[…]}` body is now `unavailable`, not "this peer advertises nothing" (a claim the prune acts on by *deleting*). An old peer sends no key ⇒ `complete:false` ⇒ **never prunes** — fail-safe across the whole rolling-deploy window.
- **F2** — new column `contacts.advertised_by_instance_id` (the fact). NULL ⇒ **never prunable**, so manual and pasted-invite contacts are structurally safe.
- **F3** — `origin` stripped from the wire (emit **and** apply). Replicating it would let a peer relabel the bot's **host's own** row `'advertised'` — and a host never sees its own bots in its directory, so it would **prune its own bot**, FK-CASCADING the DM history away.
- **F4** — the prune rewritten: five rules, deletes locally, writes a **local tombstone**, emits nothing. Also fixes a real bug: `getBotDirectory` **pruned as a side effect of a read**, so the *add* path would have deleted contacts on a click. `prune` now defaults to **false**; only the two renders opt in.
- **F5** — one shared `acceptBotInvite()`. Classification rides the **INSERT**, followed by exactly **one** emit. Provenance is resolved **server-side** from a prune-free directory read — never from a form, and **never from a tool argument** (the MCP schema is deliberately unchanged: a model must never be able to stamp a contact garbage-collectable).

## 🔴 The bug three adversarial review rounds missed

v4's convergence proof claimed a re-add "is emitted at the re-adder's next lamport, which is necessarily `> R.lamport_ts` ⇒ applies and clears the tombstone."

**False.** The gate runs on the **peer**, against the **peer's** tombstone — which sits at the **peer's** row lamport. Two instances' row lamports are equal only when every emit has been applied *both ways*:

| step | A | B |
|---|---|---|
| A adds the bot, emits `insert@1` | row 1, counter 1 | row 1 |
| B renames it → emits `update@3`. **A never receives it** | counter still 1 | row **3** |
| advertiser un-advertises ⇒ **both prune** | tombstone **@1** | tombstone **@3** |
| user re-adds on A ⇒ emits `insert@2` | row back | — |
| B applies: `2 <= 3` ⇒ **DROPPED** | has the bot | **gone, forever** |

Every later emit from A is `op="update"`, dropped unconditionally by the tombstone ⇒ the contact lives on A and is gone from B **permanently**, with **zero `sync_conflicts` and nothing logged**. Neither existing counter-floor saves it (both verified in code): `emitChange` floors at the *outgoing row's* lamport, but a re-added row is a **fresh INSERT** (`lamport_ts` 0) with nothing to floor against.

**Root cause:** a prune tombstone's lamport is a **local row lamport** — comparing a **global** insert lamport against it compares incommensurable things. An authoritative user delete (#155) is different: it was **broadcast**, so its lamport *is* global and its stale-replay gate is correct.

**Fix — `contact_tombstones.kind`:** `NULL` = authoritative (keeps its lamport gate); `'prune'` = GC (blocks `op="update"`, which is *all* of the resurrection defect, but **never gates an insert**). `ON CONFLICT` resolves **authoritative-always-wins**, so GC can never weaken a real user delete. Safe because every `op="insert"` emitter was enumerated (a genuine re-add and an accepted message-request must land; manual/vCard adds are never prunable; `backfillContactsOnce` excludes `is_bot=1` *and* emits `op="update"`).

A redelivered *original* insert re-creates the row, and the next render re-prunes it as a fresh zero-message row — **but only until the bot's next DM.** The re-created row is Nostr-wired, so if the still-running bot messages the user first, the row acquires a message and rule 5 (never destroy history) makes it permanently un-prunable. That end state is the design's fail-safe axis (keep, never delete) and is strictly better than resurrecting the contact by stealing the message request's DM — but it is **not** "self-healing", and an earlier draft of this PR claimed it was. It is scoped honestly in the code, because an unfalsified guarantee is how three of the bugs below shipped.

**It was found by an executable two-instance test, not by prose review.**

## …and then five more, most introduced by the previous fix

Every review of this branch found a real bug. Three were **introduced by the fix for the one before**. Recorded plainly, because the pattern is the most useful thing here:

| # | Found by | Bug |
|---|---|---|
| 1 | two-instance durability suite | v4's convergence proof false ⇒ permanent silent divergence (above) |
| 2 | whole-branch review | the `kind` fix's `ON CONFLICT` **`MAX`ed lamports across kinds**, laundering a prune's local lamport into an authoritative tombstone — re-arming the exact divergence it had just fixed |
| 3 | whole-branch review | dropping the lamport gate made the **secp-rebind** reachable. The spec had dropped finding **F6** *because* that gate made it unreachable — the fix deleted the premise and nothing re-opened it. A replayed insert could rebind the bot's `req:` row, resurrecting the contact **with a DM attached**, which makes rule 5 (never destroy history) block re-pruning **forever** |
| 4 | re-review | the fix for #3 wrote the tombstone **before** the DELETE — but `_applyContact` rule (a) clears any tombstone whenever a **live row** exists, so a concurrent apply during `unwireContact`'s awaited network teardown **stripped it**, and the DELETE landed untombstoned |
| 5 | re-review | the fix for #4 left a failed prune with a contact **alive but unwired** ⇒ `boot.js`'s inbox catch-all early-returns for a full contact ("the per-contact sub is handling it" — which we had just closed) ⇒ the bot's next DM **silently vanishes** |

**Neither ordering of DELETE-and-tombstone is safe** (tombstone-first can be stripped by a concurrent apply; delete-first can be lost to a locked DB). The answer was never ordering — it was **atomicity**. Both now commit in one transaction.

**And a finding dropped as "unreachable" is only as good as the premise that made it so.** When a later change removes that premise, the dropped finding is live again and nothing in the process reopens it. That is exactly how #3 shipped.

## Test vacuity — three instances, all with the same tell

Three tests here **asserted a property they did not exercise**, each passing for an unrelated reason:
- the unit test naming "tombstone at the row's own lamport" stayed **green** under the mutation that breaks it (its harness has no SyncManager);
- "the prune emits nothing" would have passed **vacuously** (the emit sink is a module global tests leave `null`);
- the atomicity test fired its simulated race from inside `unwireContact` — which runs *before* the tombstone is written, so the race hit an **empty table** and did nothing. A non-atomic prune passed it happily.

The tell is always the same: **the harness cannot reach the mechanism the assertion names.** All three are fixed, and the final review rebuilt the repo and ran 8 mutants to prove the atomicity test now fails on the *DB end-state* (row deleted, no tombstone), not on a return value.

## Gates

- **Suite (scratch env):** 1705 pass / 3 fail / 1 skip — the 3 are **exactly** the known pre-existing failures (2× `bundles-validate-install`, 1× `instance-sync` crow_context lamport), zero others.
- `check-port-allocation.js`: the single known `capstone-tracker` error (untracked WIP); `build-registry.mjs --check`: OK.
- **Dry-run migration gate, re-run from this branch, against copies of all four prod DBs** (crow / MPA / grackle / black-swan): `user_version` 6→7, **zero row-count deltas, zero tables lost**, integrity ok. Both new columns verified present on a migrated copy, and all four *existing* tombstones migrate to `kind = NULL` (**authoritative** — a `'prune'` default would have weakened real user-deletes). Evidence: `~/.crow/p4/2a-prune/dryrun-branch-final.txt`.
- Auto-update disabled fleet-wide and all four DBs backed up before merge; re-enabled after deploy + verify.
- Every guard carries a **mutation check** (comment it out → a *named* test goes red → restore).

## Follow-up filed

`scripts/schema-migration-dryrun.sh` diffs `sqlite_master` **object names**, so `ALTER TABLE … ADD COLUMN` is **invisible** to it. It proves nothing was *lost*; it cannot prove your migration *happened*. Needs a per-table `PRAGMA table_info` diff.