### PR TITLE
Item 2b: contact_groups offline-peer tombstones (schema gen 7→8, strict delete-wins)

### DIFF
--- a/docs/superpowers/specs/2026-07-13-group-tombstones-design.md
+++ b/docs/superpowers/specs/2026-07-13-group-tombstones-design.md
@@ -1,0 +1,380 @@
+# Item 2b — contact_groups offline-peer tombstones (design)
+
+**Status: v3 — both adversarial rounds folded (R1: 2 blocking; R2: 3 blocking, ALL in
+R1's fixes — the 2a fix-introduces-bug pattern, caught in prose this time). The
+executable multi-instance gate (§5) is the final arbiter per the 2a lesson.**
+- R1 blocking: (F1) tombstone gate must be atomic with the write → STATEMENT-LEVEL
+  `NOT EXISTS` guards; (F2) a peer that pairs after the delete never hears it →
+  tombstone re-emit at boot (§3.7).
+- R2 blocking, each against an R1 fix: (F1') the per-peer backfill FLAG survives
+  revoke/re-pair (peer ids are install-stable; revoke clears neither flags nor feed
+  dirs) → §3.7 now uses NO flag, every-boot re-emit; (F2') rooms ARE listed in the
+  Groups view with working delete buttons — refusal would break live UI → W1 routes
+  room ids to `deleteRoom()`; (F3') the sync-conflicts RESTORE button re-INSERTs a
+  tombstoned uid through a supported UI path → G3 guard added, §2 audit corrected.
+Arc: `docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md` §4 Item 2b.
+Precedent: `contact_tombstones` (#155, `servers/sharing/contact-delete.js`) — but this
+design deliberately DIVERGES from it (see §3.1: strict delete-wins, no lamport gate).
+Mandatory prior reading: the 2a lesson (plan §4 Item 2a) — prose review is not
+sufficient for distributed state; the acceptance gate here is EXECUTABLE,
+MULTI-INSTANCE, and exercises the MUTUAL case (§5).
+
+## 1. The defect (verified in current code, main `d7a5f93a`, 2026-07-13)
+
+Group delete PROPAGATES live: `emitGroupDelete` (`servers/sharing/group-sync.js:61`)
+is wired at `panels/contacts/api-handlers.js:332`. But nothing remembers the delete:
+
+- `_applyGroup` (`servers/sharing/instance-sync.js:1859`) applies `op=delete` only if
+  `lamportTs > localTs` (`:1894`), writes NO tombstone, and its insert branch
+  (`:1911`) inserts unconditionally whenever no local row exists.
+- So a peer OFFLINE at delete time keeps the row; ANY later local touch on that peer
+  (rename `:315`, membership change, C4 contacts-follow-user side effects) calls
+  `emitGroupUpsert` at a fresh lamport, and every other instance — having no local row
+  and no memory of the delete — re-INSERTs the group. Resurrection, fleet-wide.
+
+### 1.1 The mutual case (S2) — why the #155 lamport-gated pattern is NOT sufficient
+
+A deletes group G (delete emitted at lamport `d`). B, offline, renames G — B's emit
+counter was already ahead, so the rename row carries lamport `r > d`. On reconnect:
+
+- A→B: the delete arrives with `d < r` → B keeps its renamed row (`:1899` conflict row).
+- B→A: the rename arrives; A has no row → unconditional INSERT → G is back on A.
+
+Result: the delete is silently lost on BOTH sides. Now add a #155-style tombstone with
+its `insert <= tomb.lamport ⇒ drop` gate: `r > d` **passes** the gate — the tombstone
+clears and G resurrects anyway. **A lamport-gated tombstone does not fix the mutual
+case for groups.** The gate exists for contacts because a contact (a stable external
+identity, `crow_id`) can genuinely be re-added and the tombstone must be able to lose.
+Groups are different — see §2.
+
+## 2. The load-bearing fact: a group uid can never legitimately return
+
+`contact_groups_group_uid_ai` (`scripts/init-db.js:1960`) assigns every newly inserted
+group a **random** uid (`lower(hex(randomblob(16)))`). A user who deletes "Family" and
+later re-creates "Family" gets a NEW uid; the tombstoned uid never reappears on any
+legitimate path. Therefore an incoming insert/update for a tombstoned `group_uid` is
+**always stale state** and can be dropped unconditionally.
+
+**Sole exception — the legacy deterministic backfill.** `_assignDeterministicGroupUids`
+(`instance-sync.js:826`) assigns `sha256(pubkey ":" lower(trim(name)))[..32]` to
+pre-trigger rows still carrying `group_uid IS NULL`. Two instances that both hold the
+same legacy group converge on the SAME uid — so an instance that was offline through a
+fleet-wide delete of that legacy group can *regenerate* the tombstoned uid at boot.
+Handled in §3.4 (already-paired case) and §3.7 (paired-after-the-delete case).
+
+Full insert/uid-setter audit (R1 F6): `api-handlers.js:306` (create_group,
+trigger-random uid), `tools/messaging.js:93` (`crow_create_message_group` — plain-group
+creator, trigger-random uid, emits via `emitGroupUpsert` so G2 covers it),
+`rooms-store.js:16/:33` (rooms — trigger-random uid, never synced),
+`instance-sync.js:1918` (sync apply — G1's statement guard), `instance-sync.js:846`
+(deterministic backfill — W3), **`sync-conflict-resolve.js:290-309` (conflict-restore
+INSERT — R2 F3', guarded by G3)**, and the trigger itself. Premise holds on every
+path — but only WITH G1 and G3 in place; v2's unconditional "holds on every path" was
+falsified by the restore path.
+
+Rooms (`room_uid NOT NULL`) are out of scope end to end: `shouldSyncRow` (`:227`) drops
+them both directions, the room-close delete (`rooms-store.js:92`) is `getRoom`-guarded,
+and `_applyGroup` never matches them (`... AND room_uid IS NULL`). No room tombstones.
+
+## 3. Design
+
+### 3.1 Semantics: STRICT delete-wins, keyed on group_uid, no lamport gate
+
+A standing tombstone for `group_uid` U means: drop every incoming `insert`/`update` for
+U, forever. There is no clear-on-higher-lamport path (contrast `contact_tombstones`),
+because §2 makes every same-uid reappearance stale by construction. This also removes
+the entire lamport-commensurability hazard class that produced three of 2a's six bugs —
+`lamport_ts` is recorded on the tombstone for observability only and is consumed by
+**nothing**.
+
+Trade-off accepted: in S2, B's offline rename is discarded when the delete wins.
+Delete-wins is the documented semantic (#155 set the precedent for contacts); a group
+is an organizational label, and losing a rename to a concurrent delete is the correct
+resolution of that pair.
+
+### 3.2 Schema (SCHEMA_GENERATION 7 → 8)
+
+```sql
+CREATE TABLE IF NOT EXISTS group_tombstones (
+  group_uid  TEXT PRIMARY KEY,
+  lamport_ts INTEGER NOT NULL DEFAULT 0,   -- observability only; gates nothing
+  deleted_at INTEGER NOT NULL              -- unix seconds, first write wins
+);
+```
+
+- DDL in `scripts/init-db.js` beside the `contact_groups` block (~`:1857`).
+- Bump `SCHEMA_GENERATION` in `servers/shared/schema-version.js:13` (7 → 8). That
+  module must stay free of side-effecting imports.
+- No FTS shadow. Tombstones are LOCAL state — `group_tombstones` is NOT added to
+  `SYNCED_TABLES`; each instance derives its own from the delete op (§3.3).
+- UPSERT (mirrors `tombstoneStatement` minus the kind machinery):
+  `INSERT ... ON CONFLICT(group_uid) DO UPDATE SET lamport_ts = MAX(...)` —
+  `deleted_at` preserved on conflict. Single kind — there is exactly one writer class
+  (authoritative user delete); no `kind` column, and §3.1 means no cross-clock MAX
+  hazard (the field gates nothing).
+
+### 3.3 Write and gate sites (all in existing files; new primitives in a new
+`servers/sharing/group-delete.js`, import-free like `contact-delete.js`)
+
+**W1 — originating delete** (`api-handlers.js` `delete_group`, `:327-334`): the local
+DELETE and the tombstone MUST be ATOMIC — one `db.batch()` (confirmed available on the
+gateway's db client, `servers/db.js:371`, a true single transaction) — per 2a lesson 4
+(neither ordering survives its failure modes). Only when the row is a plain group
+(`room_uid IS NULL`) with a non-NULL `group_uid`. `emitGroupDelete(gUid)` stays after
+the batch, unchanged.
+- **Room-id hardening (R1 F3, corrected by R2 F2'):** the handler currently DELETEs
+  whatever id it is given, including a ROOM row — and this is a LIVE UI path, not just
+  a forged POST: `getGroups` (`panels/contacts/data-queries.js:110`) has no
+  `room_uid IS NULL` filter, so rooms render in the Groups view with working Delete
+  buttons. v2's "refuse" would have turned that button into a silent no-op. Fix:
+  SELECT `group_uid, room_uid`; if `room_uid IS NOT NULL`, ROUTE to
+  `deleteRoom(db, gid)` (`rooms-store.js:80` — proper teardown) with NO tombstone and
+  NO emit; additionally add `WHERE g.room_uid IS NULL` to `getGroups` so rooms stop
+  rendering in the Groups list at all (they have their own UI).
+- A NULL-uid plain group (legacy row never booted since C1) deletes WITHOUT a tombstone
+  and emits nothing — same as today. Its deterministic uid may later be regenerated by
+  a peer's backfill; that peer's copy survives locally but W3's tombstone-check-on-
+  assign (§3.4) protects the deleting instance. Documented limitation (pre-existing:
+  such rows never synced at all).
+
+**W2 — receive-side apply** (`_applyGroup` delete branch, `:1892-1908`): make it strict
+delete-wins —
+- Write the tombstone FIRST, unconditionally (even when `!localRow`, protecting against
+  update-after-delete arrival reordering and pre-arming third instances), then DELETE
+  the local row regardless of lamport comparison, both in one `db.batch()`.
+- When the local row was newer (`lamportTs <= localTs`), STILL delete, but keep writing
+  the conflict row (`_insertConflictRow`, op "delete") so today's observability
+  (`sync_conflicts` + notify) is preserved — the row records that a local edit lost to
+  a delete. **R2 F6: the winner/loser arguments must be SWAPPED** (delete = winning,
+  the discarded local row = losing) — v2's "update the comment" was insufficient: the
+  discarded rename is the only surviving record of the S2 trade-off and must be
+  labeled truthfully in the UI.
+
+**G3 — conflict-restore guard (R2 F3', blocking):** `restoreConflict`
+(`servers/sharing/sync-conflict-resolve.js:290-309`) plain-INSERTs `losing_data` when
+the live row is gone — an operator clicking Restore on an old `contact_groups`
+conflict re-inserts a tombstoned uid, manufacturing the zombie through a SUPPORTED UI
+path (G1 then quarantines it on peers: permanent, silent). Fix: for `contact_groups`,
+apply the same `WHERE NOT EXISTS (SELECT 1 FROM group_tombstones WHERE group_uid=?)`
+guard to that INSERT; when it no-ops, surface "group was deleted fleet-wide —
+restore refused" rather than success.
+
+**G1 — apply gate, STATEMENT-LEVEL (R1 F1, CRITICAL).** The invariant lives IN the
+write statements, not in a prior read: `_processNewEntries` serializes per peer but
+different peers' feeds drain CONCURRENTLY, and any read-then-write crosses await
+boundaries — a delete applying in that window yields a permanent
+live-row-beside-tombstone zombie on the applier (silent, zero `sync_conflicts`).
+- Insert branch (`:1917`): `INSERT INTO contact_groups (…) SELECT ?,… WHERE NOT EXISTS
+  (SELECT 1 FROM group_tombstones WHERE group_uid = ?)` — one statement, atomic in
+  better-sqlite3 — and run `_reconcileGroupMembers` ONLY if `rowsAffected > 0`.
+- Update branch (`:1931`): append `AND NOT EXISTS (SELECT 1 FROM group_tombstones
+  WHERE group_uid = ?)` to the UPDATE; reconcile members only if `rowsAffected > 0`.
+- An early tombstone read MAY remain as a fast-path skip (silent drop, no conflict
+  row), but it is an optimization — the statement guard is the correctness mechanism,
+  and the mutation check targets the statement guard (T8).
+- The same race exists on the ORIGINATING instance (inbound upsert vs. W1's batch in
+  `delete_group`) — the statement guard covers it identically.
+`op=delete` skips the gate (it re-writes the tombstone idempotently via W2).
+
+**G2 — emit gate** (`emitGroupUpsert`, `group-sync.js:35`): skip the emit when the
+row's uid is tombstoned. Defense in depth for the anomalous live-row-beside-tombstone
+state; G1 on the receiving side already protects peers, so this is belt-and-braces,
+not load-bearing. **FAIL-OPEN (R1 F4):** the tombstone read gets its OWN try/catch —
+a read failure (e.g. an un-migrated DB under a stale session-spawned stdio server)
+means "not tombstoned", never "swallow the emit"; otherwise a missing table silently
+kills ALL group sync emits from that process, including `crow_create_message_group`
+(`tools/messaging.js:122`) and the boot backfill.
+
+### 3.4 W3 — the legacy deterministic-uid edge
+
+In `_assignDeterministicGroupUids` (`:826`): after deriving the candidate uid and
+BEFORE assigning it, check `group_tombstones`. If tombstoned, the logical group was
+deleted fleet-wide while this instance was offline (or pre-C1): DELETE the local legacy
+row instead of assigning the uid (log one line, count separately in the boot summary).
+Collision-retry slots (`\x1f` suffix) get the same check per candidate. Without W3, a
+legacy instance regenerates the tombstoned uid and (G1 on peers) diverges silently —
+its copy would live locally forever while every peer drops its emits.
+
+### 3.7 W4 — per-peer tombstone backfill (R1 F2, MAJOR — delivery, not semantics)
+
+Sync feeds are created **EMPTY at first pairing** (`_initInstanceInner` — no history
+replay; documented at `instance-sync.js:684-690`). So a peer that pairs (or re-pairs —
+this fleet has deleted and re-formed a pairing before) AFTER the delete never receives
+the delete op, and W3 reads a tombstone table that peer never populated: it
+regenerates the deterministic uid at boot, emits, every established peer G1-drops it,
+and that node holds the group forever — silent permanent one-node divergence. The same
+gap covers non-full-mesh topologies (applying a synced entry never re-emits) and a
+dropped `feed.append` (`:1040` warns and drops; no outbox).
+
+**Fix — NO FLAG, re-emit every boot (R2 F1' replaced v2's per-peer flag design):**
+v2 mirrored `backfillProvidersForNewPeers`' per-peer flag — but R2 showed that flag
+lifecycle is broken for exactly the motivating case: peer ids are install-stable
+(`registerInstance` is `ON CONFLICT(id) DO UPDATE`), revoke clears neither the
+`dashboard_settings` flags nor the feed dirs, so a revoke→re-pair reuses the id, the
+`done:` flag still stands, and the backfill never fires again — silently reproducing
+R1 F2's divergence. (The providers backfill has this same pre-existing hole — recorded
+as a follow-up, NOT in 2b's scope.)
+
+Instead: **at boot (after `backfillGroupsOnce`'s drain point), emit
+`op=delete { group_uid }` for every `group_tombstones` row, unconditionally, every
+boot.** Safe and cheap because:
+- Idempotent on receivers: W2 re-writes the tombstone (UPSERT), the DELETE matches
+  nothing on converged peers; a stale-copy holder gets exactly one delete-won
+  conflict row and converges.
+- No lamport thrash: delete ops never stamp row lamports (`emitChange:1009` skips
+  `op=delete`), so unlike the contacts/providers backfills there is nothing to guard
+  with a one-shot flag — that flag existed to stop re-emit churn on live rows.
+- Bounded: group deletes are rare, rows tiny; the emit loop is
+  `SELECT group_uid FROM group_tombstones` per boot.
+- This also closes R2 F7's residuals for free: a warn-dropped `feed.append` (`:1040`)
+  and any missed window heal on the next boot, and a freshly-paired peer hears every
+  historical delete on the first boot after pairing.
+
+### 3.5 Retention: NONE (deviation from the plan item's text — deliberate)
+
+The plan item says "retention pruning". Recommendation: **do not prune.** Rows are
+~50 bytes, group deletes are rare (single-user organizational labels), and any
+retention window re-opens the resurrection hole for peers offline longer than the
+window — the exact defect this item exists to close. `contact_tombstones` set the
+never-prune precedent for the same reason (#155 design §D3). If growth ever matters, a
+future prune can safely target tombstones older than the oldest possible peer state,
+but nothing forces that decision now. R1 F8 challenged this and upheld never-prune:
+any horizon would have to exceed "time since a peer last paired", which W4's
+motivating case shows is unbounded. The real residual cost — a bug-written tombstone
+is permanent with no operator surface — is best met with observability (a follow-up
+can list tombstones in the sync-conflicts settings section; NOT in 2b's scope), not
+with a pruner.
+
+### 3.6 Known limitations (documented, out of scope)
+
+- **Boot-window emit loss (2c's finding):** `emitChange` returns a valid lamport when
+  `outFeeds.size === 0`, so a delete during the boot window broadcasts to nobody. The
+  tombstone still lands locally (W1 is atomic with the DELETE), so THIS instance can
+  never resurrect — and W4's per-peer backfill now retro-delivers the delete on the
+  next peer-generation detection, narrowing the gap further. 2c closes the channel
+  itself.
+- **Live-row-beside-tombstone anomaly:** the STATEMENT-LEVEL guard (G1) closes the
+  concurrent-apply race R1 F1 identified (v1 wrongly claimed the state was
+  unreachable); if manufactured manually (direct DB edit), G2 mutes its emits and G1
+  drops inbound writes. No auto-heal.
+- **A NULL-uid legacy group deleted before its C1 boot** never had a wire identity;
+  see W1. Note (R1 F7): `_assignDeterministicGroupUids` runs EVERY boot before the
+  backfill flag gate, so on any instance that has booted 2b-era code this branch is
+  near-dead — do not build ceremony around it.
+- **DB-restore-from-backup** can resurrect rows and lose tombstones on one instance —
+  pre-existing class shared with `contact_tombstones` (#155); W4's every-boot re-emit
+  heals the peers (the restored instance itself heals on receiving any peer's W4
+  re-emit of its own tombstones — if no peer holds the tombstone either, the delete is
+  simply lost, same as #155).
+- **FK-ON is a load-bearing premise (R2 F4):** G1 closes the row race, but a W2 delete
+  landing between the guarded INSERT and `_reconcileGroupMembers` leaves the reconcile
+  inserting members against a dead group_id — converged only because `foreign_keys=ON`
+  (better-sqlite3 default here, verified at `rooms-store.js:84-87`) rejects each
+  insert. On any FK-OFF connection these would be permanent orphan rows. Documented
+  premise, no code change.
+- **The providers backfill's per-peer flag survives revoke/re-pair** (R2 F1' collateral
+  discovery) — pre-existing hole in `backfillProvidersForNewPeers`, same class as the
+  one W4 avoids by being flagless. Follow-up, NOT 2b scope.
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `servers/sharing/group-delete.js` | NEW — import-free tombstone primitives: `groupTombstoneStatement`, `readGroupTombstone`, `isGroupTombstoned` |
+| `scripts/init-db.js` | `group_tombstones` DDL |
+| `servers/shared/schema-version.js` | `SCHEMA_GENERATION` 7 → 8 |
+| `servers/sharing/instance-sync.js` | W2 strict delete (+F6 winner/loser swap) + G1 STATEMENT guards in `_applyGroup`; W3 in `_assignDeterministicGroupUids`; W4 flagless boot re-emit |
+| `servers/gateway/dashboard/panels/contacts/api-handlers.js` | W1 atomic batch + room-id routing to `deleteRoom` in `delete_group` |
+| `servers/gateway/dashboard/panels/contacts/data-queries.js` | `getGroups` gains `WHERE g.room_uid IS NULL` |
+| `servers/sharing/sync-conflict-resolve.js` | G3 restore guard for `contact_groups` |
+| `servers/sharing/group-sync.js` | G2 emit gate (fail-open) |
+| `tests/group-tombstones.test.js` | NEW — the executable gate (§5) |
+
+## 5. Acceptance gate — EXECUTABLE, MULTI-INSTANCE, MUTUAL (written FIRST, red)
+
+Harness: reuse the two-real-`InstanceSyncManager`s + captured-fake-out-feed pattern
+from `tests/advertised-prune-durability.test.js` (two scratch DBs, entries drained
+manually in controlled order — both directions, BOTH orders).
+
+⚠️ Harness trap (R1 F5a): the prune harness installs `contact-sync.js`'s test sink;
+groups route through `group-sync.js`'s SEPARATE `__setEmitSinkForTest` (`:22`). Wire
+the GROUP sink (and/or call `mgr.emitChange` directly) and assert wire-length > 0
+before relying on any drain. T1's lamport interleaving must be explicit: advance B's
+counter (harness `setCounter`) above the delete's lamport before B's rename.
+
+- **T1 (S1 resurrection, the defect):** A deletes G; B (offline) renames G at a higher
+  lamport; drain A→B then B→A. BOTH sides end with no row for G's uid and a standing
+  tombstone. **RED-ON-MAIN REQUIRED:** on unmodified main this test must FAIL by
+  resurrecting G on A — that failure is the proof the harness reaches the mechanism
+  (2a lesson 3, anti-vacuous).
+- **T2 (S1 reversed order):** drain B→A first, then A→B. Same converged end state.
+  **RED-ON-MAIN REQUIRED.**
+- **T3 (mutual delete):** A and B delete G concurrently; drain both. Converged, both
+  tombstoned, `sync_conflicts` growth = 0.
+- **T4 (negative control):** a live group's rename + membership change still sync
+  normally end-to-end; creating a brand-new group after deleting a same-named one
+  syncs (fresh uid ≠ tombstoned uid).
+- **T5 (restart durability):** rebuild manager B on the same DB (fresh instance, same
+  files); a stale upsert for the tombstoned uid is still dropped after restart.
+  **RED-ON-MAIN REQUIRED.**
+- **T6 (W3 legacy edge):** seed a NULL-uid legacy row on B whose deterministic uid is
+  tombstoned; run `_assignDeterministicGroupUids`; the row is deleted, nothing emitted.
+  ⚠️ Seeding trap (R1 F5b): the `contact_groups_group_uid_ai` trigger makes a NULL-uid
+  INSERT impossible — seed with INSERT then `UPDATE ... SET group_uid = NULL`. Do NOT
+  weaken the assertion if the naive seed fails; fix the seed.
+- **T7 (W1 atomicity):** batch such that the tombstone write fails ⇒ the DELETE must
+  not land (and vice versa) — assert via an injected failing batch. Drive the REAL W1
+  site (`handleContactAction` with a fake req — the pattern ten existing tests use).
+- **T8 (G1 statement-guard race, R1 F1):** the guarded INSERT/UPDATE statements are
+  no-ops against a pre-written tombstone even when a prior read said "no tombstone" —
+  unit-test the statements directly against a pre-seeded tombstone.
+  ⚠️ Mutation-check trap (R2 F5): on the INSERT branch, forgetting the
+  `rowsAffected > 0` reconcile gate is INVISIBLE (`_groupIdByUid` returns null →
+  reconcile early-returns) — the "no member rows" assertion passes vacuously. The
+  reconcile-gate mutation check must seed the zombie state (tombstone + live row) and
+  drive the UPDATE branch, where `localRow.id` is real; that is the only place the
+  gate is load-bearing.
+- **T9 (W4 every-boot re-emit):** delete G on A (tombstone standing); pair a FRESH
+  manager C (new empty feeds) seeded with a stale live copy of G; run A's boot re-emit;
+  C converges to deleted + tombstoned with exactly one delete-won conflict row. Also:
+  a second boot re-emit produces NO further state change on any peer (idempotence) and
+  no `sync_conflicts` growth.
+- **T10 (room routing, R2 F2'):** `delete_group` with a room's id calls `deleteRoom`
+  (room + members + room_messages gone), writes NO tombstone, emits NOTHING; and
+  `getGroups` no longer returns rooms.
+- **T11 (restore guard, R2 F3'):** seed a `contact_groups` conflict row whose
+  losing_data carries uid U; tombstone U; operator-restore via `restoreConflict` →
+  refused/no-op, no live row, tombstone intact.
+- **Conflict-row assertions in every T:** exact expected `sync_conflicts` delta (T1/T2
+  allow exactly the one delete-won row from W2; others 0).
+- **Mutation checks (each must redden the NAMED test that claims to catch it, not a
+  neighbor):** remove the statement guard's NOT EXISTS → T8 red (and T1/T2/T5 red via
+  the fast path removed too — verify T8 specifically); comment out W2's tombstone
+  write → T1 red; comment out W3 → T6 red; split W1's batch into two executes with the
+  injected failure → T7 red; comment out W4's emit loop → T9 red; remove the room
+  routing → T10 red; remove G3's guard → T11 red. The T8 reconcile-gate mutation runs
+  against the UPDATE branch per the F5 trap above.
+
+## 6. Ship sequence
+
+Full §2 pipeline + the §3 migration rail (MANDATORY — schema bump):
+1. Branch `fix/2b-group-tombstones`. Test first (T1 red on main's code).
+2. Build (SDD tasks per §4 rows), per-task review, final whole-branch review.
+3. Gates: full suite on scratch env (baseline 1738 / 3 known fails / 0 skips),
+   check-ports (exactly the one capstone-tracker line), build-registry.
+4. RAIL: disable auto-update ×4 → confirm; **verify no FIFTH DB exists anywhere in
+   the fleet first (R1 F7)** — `servers/db.js:22` mentions a "finance" instance that
+   does not exist on disk today; the 2a lesson was precisely a DB the rail forgot, so
+   sweep for `*/data/crow.db` under each host's home before backing up; back up all
+   FOUR DBs (crow, MPA `~/.crow-mpa`, grackle, black-swan);
+   `scripts/schema-migration-dryrun.sh` FROM THE BRANCH on copies of all four — the output MUST show `group_tombstones` as the only
+   schema delta, `user_version` 7→8, zero row-count deltas; merge; deploy in runbook
+   order (crow+MPA → grackle bridge-then-gateway → black-swan); verify each
+   (`/health`, `integrity_check`, row-count diff, `user_version=8`); re-enable
+   auto-update ×4 and CONFIRM `'true'` ×4.
+5. Live verify (crow↔grackle, throwaway group): create + sync; stop grackle's gateway
+   briefly (short window, prod restored immediately after); delete on crow; restart
+   grackle; touch/rename the still-present group on grackle → crow must NOT resurrect
+   it, and grackle must converge to deleted on draining the feed. `sync_conflicts`
+   baseline 219/182/162/0 — only the expected W2 delta. Clean up the throwaway group.
+6. Record in plan doc + ledger + memory.

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -1909,6 +1909,23 @@ await initTable("contact_tombstones table", `
 // contact-delete.js's `tombstoneStatement()` ON CONFLICT clause, not here.
 await addColumnIfMissing("contact_tombstones", "kind", "TEXT");
 
+// --- Item 2b (group tombstones design §3.2): group deletion tombstones.
+// LOCAL state, never synced, never pruned — one small row per plain group ever
+// deleted. Keyed on group_uid (the trigger-assigned random uid), deliberately
+// NO foreign key to contact_groups: the whole point is that the row is gone.
+// STRICT delete-wins (contrast contact_tombstones): a random uid can never
+// legitimately return, so there is no clear path and NO `kind` column — groups
+// have exactly one writer class (the authoritative user delete). lamport_ts is
+// observability only and gates NOTHING; deleted_at is unix-seconds diagnostics,
+// first write wins. UPSERT lives in servers/sharing/group-delete.js.
+await initTable("group_tombstones table", `
+  CREATE TABLE IF NOT EXISTS group_tombstones (
+    group_uid   TEXT PRIMARY KEY,
+    lamport_ts  INTEGER NOT NULL DEFAULT 0,
+    deleted_at  INTEGER NOT NULL
+  );
+`);
+
 // --- F-CONTACT-1 (design §D4): clock-free replay hygiene for authenticated
 // control events (invite_accepted). Record every successfully-handled event.id so
 // a stale ~60h retry cannot resurrect a deleted contact. Rows older than 30 days

--- a/scripts/schema-migration-dryrun.sh
+++ b/scripts/schema-migration-dryrun.sh
@@ -103,8 +103,20 @@ dryrun_one() { # $1=label  $2=src-db
   [ "$integ" != "ok" ] && FAILED=1
 
   echo "  ── schema objects added/removed ──"
-  if diff "$work/pre.schema" "$work/post.schema" | grep -qE '^[<>]'; then
-    diff "$work/pre.schema" "$work/post.schema" | grep -E '^[<>]' | sed 's/^/    /'
+  # Capture, don't branch on the pipeline: under `set -o pipefail` the old
+  # `if diff | grep -q` inverted — diff exits 1 exactly when differences exist,
+  # so this section printed "(none)" for EVERY real delta (found 2026-07-13 by
+  # 2b's own gate run: the new table showed in the column diff but not here).
+  # Indexes/triggers/views are covered ONLY by this section, so a removed one is
+  # a STOP, not just display.
+  local obj_delta
+  obj_delta=$(diff "$work/pre.schema" "$work/post.schema" | grep -E '^[<>]' || true)
+  if [ -n "$obj_delta" ]; then
+    printf '%s\n' "$obj_delta" | sed 's/^/    /'
+    if printf '%s\n' "$obj_delta" | grep -q '^<'; then
+      echo "    ^^^ STOP — schema object(s) REMOVED (index/trigger/view loss is invisible to every other section)"
+      FAILED=1
+    fi
   else
     echo "    (none)"
   fi

--- a/servers/gateway/dashboard/panels/contacts/api-handlers.js
+++ b/servers/gateway/dashboard/panels/contacts/api-handlers.js
@@ -14,6 +14,8 @@ import { deleteContactLocal, unwireContact } from "../../../../sharing/contact-d
 import { wireSyncedContact } from "../../../../sharing/contact-promote.js";
 import { sanitizeDisplayName } from "../../../../sharing/display-name.js";
 import { emitGroupUpsert, emitGroupDelete } from "../../../../sharing/group-sync.js";
+import { groupTombstoneStatement } from "../../../../sharing/group-delete.js";
+import { deleteRoom } from "../messages/rooms-store.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createSharingServer } from "../../../../sharing/server.js";
@@ -326,10 +328,39 @@ export async function handleContactAction(req, db, {
 
   if (action === "delete_group" && req.body.group_id) {
     const gid = parseInt(req.body.group_id);
-    let gUid = null;
-    try { const { rows } = await db.execute({ sql: "SELECT group_uid FROM contact_groups WHERE id = ?", args: [gid] }); gUid = rows[0]?.group_uid || null; } catch {}
+    let row = null;
+    try {
+      const { rows } = await db.execute({
+        sql: "SELECT group_uid, room_uid, lamport_ts FROM contact_groups WHERE id = ?",
+        args: [gid],
+      });
+      row = rows[0] || null;
+    } catch {}
+    if (row && row.room_uid != null) {
+      // 2b R2 F2': a ROOM row (rooms render alongside groups historically, and
+      // a forged id must not bypass this) routes to the room teardown — room +
+      // members + room_messages. Rooms are never group-synced (they have their
+      // own Nostr fan-out), so NO tombstone and NO emit.
+      await deleteRoom(db, gid);
+      return { redirect: "/dashboard/contacts?view=groups" };
+    }
+    if (row && row.group_uid) {
+      // W1 (2b design §3.3): the local DELETE and the group tombstone MUST land
+      // together — one db.batch() = one transaction (the 2a lesson: neither
+      // ordering of two separate executes survives its failure modes). The
+      // tombstone's lamport is the row's own clock — observability only, gates
+      // nothing (§3.2).
+      await db.batch([
+        { sql: "DELETE FROM contact_groups WHERE id = ?", args: [gid] },
+        groupTombstoneStatement(row.group_uid, Number(row.lamport_ts) || 0),
+      ]);
+      try { await emitGroupDelete(row.group_uid); } catch {}
+      return { redirect: "/dashboard/contacts?view=groups" };
+    }
+    // Missing row (harmless DELETE no-op) or a NULL-uid legacy plain group that
+    // never had a wire identity (2b design §3.3 W1 / §3.6 — near-dead branch):
+    // DELETE only, no tombstone, no emit — unchanged behavior.
     await db.execute({ sql: "DELETE FROM contact_groups WHERE id = ?", args: [gid] });
-    if (gUid) { try { await emitGroupDelete(gUid); } catch {} }
     return { redirect: "/dashboard/contacts?view=groups" };
   }
 

--- a/servers/gateway/dashboard/panels/contacts/data-queries.js
+++ b/servers/gateway/dashboard/panels/contacts/data-queries.js
@@ -108,10 +108,13 @@ export async function getContactActivity(db, contactId) {
  * Get all contact groups with member counts.
  */
 export async function getGroups(db) {
+  // room_uid IS NULL (2b R2 F2'): rooms are contact_groups rows too, but they
+  // have their own Messages UI — they must not render in the Groups view.
   const { rows } = await db.execute(
     `SELECT g.*, COUNT(gm.id) as member_count
      FROM contact_groups g
      LEFT JOIN contact_group_members gm ON gm.group_id = g.id
+     WHERE g.room_uid IS NULL
      GROUP BY g.id
      ORDER BY g.sort_order ASC, g.name ASC`
   );

--- a/servers/shared/schema-version.js
+++ b/servers/shared/schema-version.js
@@ -10,7 +10,10 @@
 // by servers/gateway/index.js during boot; importing scripts/init-db.js here
 // (or anything that runs DB work at module top-level) would execute init-db
 // as an unwanted side effect.
-export const SCHEMA_GENERATION = 7;
+//
+// Generation history:
+//   7 -> 8: group_tombstones (Item 2b)
+export const SCHEMA_GENERATION = 8;
 
 // Pure decision helper for the gateway boot gate. Returns true when the DB
 // needs init-db to run: either core tables are missing (fresh/incomplete

--- a/servers/sharing/group-delete.js
+++ b/servers/sharing/group-delete.js
@@ -1,0 +1,112 @@
+/**
+ * Group deletion primitives — tombstones (Item 2b, design §3.2/§3.3).
+ *
+ * Pure DB helpers with ZERO imports from the sharing layer, mirroring
+ * contact-delete.js: sharing-side modules (group-sync.js, instance-sync.js)
+ * import this module, and any sharing-side import here would risk the import
+ * cycle the lazy dynamic imports in contact-sync.js exist to avoid. Keep this
+ * module dependency-free.
+ *
+ * Semantics DIVERGE from contact_tombstones deliberately (design §3.1): a
+ * group tombstone is STRICT delete-wins, keyed on group_uid, with NO lamport
+ * gate and NO clear path. The `contact_groups_group_uid_ai` trigger assigns
+ * every new group a random uid, so a tombstoned uid can never legitimately
+ * return (design §2) — every same-uid reappearance is stale by construction
+ * and is dropped forever.
+ *
+ * Tombstones are LOCAL state, never synced, never pruned (design §3.5): any
+ * retention window would re-open the resurrection hole for peers offline
+ * longer than the window — the exact defect Item 2b exists to close.
+ */
+
+/**
+ * The tombstone UPSERT as a STATEMENT, so a caller can commit it atomically
+ * with other writes via `db.batch()` (one transaction). W1 (the originating
+ * `delete_group`) needs exactly that: the local DELETE and the tombstone MUST
+ * land together, or not at all — neither ordering of two separate executes
+ * survives its failure modes (the 2a lesson).
+ *
+ * No `kind` column (contrast contact_tombstones): groups have exactly ONE
+ * writer class — the authoritative user delete — so there is no cross-clock
+ * precedence to resolve. And because §3.1 is strict delete-wins, `lamport_ts`
+ * is recorded for OBSERVABILITY ONLY and is consumed by nothing — it gates no
+ * decision, so the blanket MAX on conflict cannot arm any gate wrongly (the
+ * commensurability hazard class that produced three of 2a's six bugs simply
+ * does not exist here).
+ *
+ * `deleted_at` is set to now (unix seconds) on first write and PRESERVED on
+ * conflict — first write wins; it is wall-clock diagnostics only.
+ *
+ * @param {string} groupUid
+ * @param {number} lamportTs the delete's Lamport clock (observability only)
+ * @returns {{sql: string, args: Array}}
+ */
+export function groupTombstoneStatement(groupUid, lamportTs) {
+  return {
+    sql: `INSERT INTO group_tombstones (group_uid, lamport_ts, deleted_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT(group_uid) DO UPDATE SET
+            lamport_ts = MAX(group_tombstones.lamport_ts, excluded.lamport_ts)`,
+    args: [groupUid, Number(lamportTs) || 0, Math.floor(Date.now() / 1000)],
+  };
+}
+
+/**
+ * UPSERT a tombstone. Guarded — it runs on the receive path and must never
+ * throw; no-ops on a falsy db or uid.
+ * @param {object} db async db client ({ execute })
+ * @param {string} groupUid
+ * @param {number} lamportTs
+ */
+export async function writeGroupTombstone(db, groupUid, lamportTs) {
+  if (!db || !groupUid) return;
+  try {
+    await db.execute(groupTombstoneStatement(groupUid, lamportTs));
+  } catch { /* never throw into a receive path */ }
+}
+
+/**
+ * Read a tombstone row. Guarded: returns null on a missing row, a falsy
+ * arg, or ANY error (e.g. missing table on an un-migrated DB).
+ * @param {object} db async db client
+ * @param {string} groupUid
+ * @returns {Promise<{group_uid:string,lamport_ts:number,deleted_at:number}|null>}
+ */
+export async function readGroupTombstone(db, groupUid) {
+  if (!db || !groupUid) return null;
+  try {
+    const { rows } = await db.execute({
+      sql: `SELECT group_uid, lamport_ts, deleted_at FROM group_tombstones WHERE group_uid = ?`,
+      args: [groupUid],
+    });
+    return rows[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is this uid tombstoned? Guarded and FAIL-OPEN (design G2): ANY error —
+ * e.g. a missing group_tombstones table under a stale session-spawned server
+ * on an un-migrated DB — returns false, meaning "not tombstoned". A read
+ * failure must NEVER swallow the caller's work: fail-closed here would
+ * silently kill every group sync emit from that process (including
+ * crow_create_message_group and the boot backfill), which is exactly the
+ * failure mode G2 exists to prevent. The receive-side correctness mechanism
+ * is the statement-level NOT EXISTS guard (G1), not this read.
+ * @param {object} db async db client
+ * @param {string} groupUid
+ * @returns {Promise<boolean>}
+ */
+export async function isGroupTombstoned(db, groupUid) {
+  if (!db || !groupUid) return false;
+  try {
+    const { rows } = await db.execute({
+      sql: `SELECT 1 AS one FROM group_tombstones WHERE group_uid = ? LIMIT 1`,
+      args: [groupUid],
+    });
+    return rows.length > 0;
+  } catch {
+    return false; // FAIL-OPEN — see doc comment
+  }
+}

--- a/servers/sharing/group-sync.js
+++ b/servers/sharing/group-sync.js
@@ -17,6 +17,8 @@
  * static import; the cached lazy dynamic import keeps the graph acyclic — identical
  * to contact-sync.js / message-sync.js. Do NOT "simplify" to a static import.
  */
+import { isGroupTombstoned } from "./group-delete.js";
+
 let _mgrMod = null;
 let _testSink = null;
 export function __setEmitSinkForTest(sink) { _testSink = sink; }
@@ -41,6 +43,15 @@ export async function emitGroupUpsert(db, groupId) {
     });
     const row = rows[0];
     if (!row || row.room_uid != null || !row.group_uid) return; // room / keyless → skip
+    // G2 (design §3.3): never emit for a tombstoned uid. Belt-and-braces for
+    // the anomalous live-row-beside-tombstone state (§3.6 — reachable only via
+    // a race or manual DB edit; G1 on receivers is the load-bearing guard, so
+    // this just stops the pointless emit at the source). isGroupTombstoned is
+    // FAIL-OPEN: a read failure (e.g. a missing group_tombstones table under a
+    // stale session-spawned server on an un-migrated DB) returns false and the
+    // emit PROCEEDS — a read failure must never silently kill every group sync
+    // emit from this process (crow_create_message_group, the boot backfill).
+    if (await isGroupTombstoned(db, row.group_uid)) return;
     // I2: attach ONLY syncable members — exclude local-bot origin and pending
     // (unestablished) memberships, which the peer must never learn about.
     const { rows: mem } = await db.execute({

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -22,6 +22,7 @@ import { resolveDataDir } from "../db.js";
 import { isSyncable, PROFILE_SYNC_KEYS } from "../gateway/dashboard/settings/sync-allowlist.js";
 import { normalizePubkey } from "./pubkey-util.js";
 import { readTombstone, writeTombstone, clearTombstone } from "./contact-delete.js";
+import { groupTombstoneStatement } from "./group-delete.js";
 import { sanitizeDisplayName } from "./display-name.js";
 import bus from "../shared/event-bus.js";
 
@@ -1855,6 +1856,10 @@ export class InstanceSyncManager {
    * members skipped — never conjure a contact, never add a local-bot the peer named).
    * A synced group can never become a room: room_uid/host_crow_id/mode are dropped
    * from every applied write.
+   *
+   * Item 2b: deletes are STRICT delete-wins (no lamport gate — see the delete
+   * branch below), and inserts/updates carry statement-level group_tombstones
+   * guards (G1) so a tombstoned uid can never be re-applied.
    */
   async _applyGroup(op, row, lamportTs, instanceId) {
     const groupUid = row && row.group_uid;
@@ -1888,36 +1893,58 @@ export class InstanceSyncManager {
     const localTs = localRow?.lamport_ts || 0;
     const rowIdJson = JSON.stringify({ group_uid: groupUid });
 
-    // ── delete ──────────────────────────────────────────────────────────────
+    // ── delete: STRICT delete-wins (2b W2, design §3.1/§3.3) ────────────────
+    // Tombstone + DELETE land in ONE transaction, UNCONDITIONALLY — even when
+    // there is no local row (arms this instance against out-of-order
+    // update-after-delete arrival and pre-arms third instances' stale copies).
+    // NO lamport gate: a trigger-random group_uid can never legitimately return
+    // (design §2), so the delete wins even over a NEWER local edit — a
+    // lamport-gated tombstone provably loses the mutual case (design §1.1).
+    // ON DELETE CASCADE reaps contact_group_members.
     if (op === "delete") {
-      if (!localRow) return;
-      if (lamportTs > localTs) {
-        // ON DELETE CASCADE reaps contact_group_members.
-        await this.db.execute({ sql: "DELETE FROM contact_groups WHERE group_uid = ? AND room_uid IS NULL", args: [groupUid] });
-        return;
-      }
-      try {
-        await this._insertConflictRow("contact_groups", rowIdJson,
-          localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
-          JSON.stringify(localRow), JSON.stringify(filtered), "delete");
-        await this._notifyConflict();
-      } catch (err) {
-        console.warn("[instance-sync] contact_groups delete conflict LOGGING failed (local kept):", err.message);
+      await this.db.batch([
+        groupTombstoneStatement(groupUid, lamportTs),
+        { sql: "DELETE FROM contact_groups WHERE group_uid = ? AND room_uid IS NULL", args: [groupUid] },
+      ]);
+      if (localRow && lamportTs <= localTs) {
+        // The local row was NEWER and the delete STILL won. Keep the conflict
+        // row for observability, labeled truthfully (R2 F6): the delete is the
+        // WINNER, the discarded local edit the LOSER — this row is the only
+        // surviving record of the edit that lost (e.g. B's offline rename).
+        try {
+          await this._insertConflictRow("contact_groups", rowIdJson,
+            instanceId, localRow.instance_id || this.localInstanceId, lamportTs, localTs,
+            JSON.stringify(filtered), JSON.stringify(localRow), "delete");
+          await this._notifyConflict();
+        } catch (err) {
+          console.warn("[instance-sync] contact_groups delete-won conflict LOGGING failed (delete applied):", err.message);
+        }
       }
       return;
     }
 
-    // ── insert / update (LWW) ───────────────────────────────────────────────
+    // ── insert / update (LWW, gated by G1 STATEMENT-LEVEL tombstone guards) ──
+    // The tombstone invariant lives IN the write statements (design R1 F1):
+    // different peers' feeds drain concurrently and any read-then-write crosses
+    // await boundaries — a delete applying in that window would otherwise leave
+    // a permanent live-row-beside-tombstone zombie. NEVER add RETURNING to
+    // these statements: stmt.reader would flip and rowsAffected hardcodes 0
+    // (servers/db.js:153-172), silently disarming both guards' gates.
     if (!localRow) {
       const cols = Object.keys(filtered).filter((k) => filtered[k] !== undefined);
       if (!cols.includes("group_uid")) cols.push("group_uid");
       const insertCols = [...new Set(cols)];
       const placeholders = insertCols.map(() => "?").join(", ");
       const values = insertCols.map((k) => (k === "group_uid" ? groupUid : filtered[k] ?? null));
-      await this.db.execute({
-        sql: `INSERT INTO contact_groups (${insertCols.join(", ")}, lamport_ts) VALUES (${placeholders}, ?)`,
-        args: [...values, lamportTs],
+      const res = await this.db.execute({
+        sql: `INSERT INTO contact_groups (${insertCols.join(", ")}, lamport_ts)
+              SELECT ${placeholders}, ?
+              WHERE NOT EXISTS (SELECT 1 FROM group_tombstones WHERE group_uid = ?)`,
+        args: [...values, lamportTs, groupUid],
       });
+      // Tombstoned (or a delete raced in) → dropped silently, NO conflict row
+      // (design §3.1: every same-uid reappearance is stale by construction).
+      if (!(Number(res?.rowsAffected) > 0)) return;
       const gid = await this._groupIdByUid(groupUid);
       await this._reconcileGroupMembers(gid, row.members);
       return;
@@ -1928,7 +1955,16 @@ export class InstanceSyncManager {
       const setClauses = updateKeys.map((k) => `${k} = ?`);
       const vals = updateKeys.map((k) => filtered[k] ?? null);
       setClauses.push("lamport_ts = ?"); vals.push(lamportTs);
-      await this.db.execute({ sql: `UPDATE contact_groups SET ${setClauses.join(", ")} WHERE group_uid = ?`, args: [...vals, groupUid] });
+      const res = await this.db.execute({
+        sql: `UPDATE contact_groups SET ${setClauses.join(", ")} WHERE group_uid = ?
+                AND NOT EXISTS (SELECT 1 FROM group_tombstones WHERE group_uid = ?)`,
+        args: [...vals, groupUid, groupUid],
+      });
+      // Reconcile ONLY on a real write (R2 F5): rowsAffected === 0 means the
+      // uid is tombstoned (zombie local row) or a delete raced in — reconciling
+      // here would mutate membership of a row the fleet has deleted, against
+      // localRow.id which is REAL on this branch (the gate is load-bearing).
+      if (!(Number(res?.rowsAffected) > 0)) return;
       await this._reconcileGroupMembers(localRow.id, row.members);
       return;
     }

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -22,7 +22,7 @@ import { resolveDataDir } from "../db.js";
 import { isSyncable, PROFILE_SYNC_KEYS } from "../gateway/dashboard/settings/sync-allowlist.js";
 import { normalizePubkey } from "./pubkey-util.js";
 import { readTombstone, writeTombstone, clearTombstone } from "./contact-delete.js";
-import { groupTombstoneStatement } from "./group-delete.js";
+import { groupTombstoneStatement, isGroupTombstoned } from "./group-delete.js";
 import { sanitizeDisplayName } from "./display-name.js";
 import bus from "../shared/event-bus.js";
 
@@ -826,6 +826,7 @@ export class InstanceSyncManager {
   async _assignDeterministicGroupUids() {
     const MAX_COLLISION_RETRIES = 16;
     let assigned = 0;
+    let tombstoneDeleted = 0;
     let rows = [];
     try {
       const r = await this.db.execute({ sql: "SELECT id, name FROM contact_groups WHERE room_uid IS NULL AND group_uid IS NULL ORDER BY id ASC" });
@@ -842,6 +843,27 @@ export class InstanceSyncManager {
       let settled = false;
       for (let n = 0; n <= MAX_COLLISION_RETRIES && !settled; n++) {
         const uid = this.deterministicGroupUid(row.name, n);
+        // W3 (design §3.4): a tombstoned candidate means the logical group was
+        // deleted FLEET-WIDE while this instance was offline (or pre-C1).
+        // Assigning would regenerate the dead uid — every peer G1-drops its
+        // emits and the copy diverges silently forever. DELETE the legacy row
+        // instead; its group_uid is NULL so W2/G1 machinery is not involved
+        // (plain local DELETE, nothing emitted). Collision-retry slots get
+        // the same check per candidate. FAIL-OPEN (G2 rationale):
+        // isGroupTombstoned returns false on ANY read error (e.g. missing
+        // table on an un-migrated DB) — a tombstone-read failure must never
+        // kill uid assignment for every group.
+        if (await isGroupTombstoned(this.db, uid)) {
+          try {
+            const res = await this.db.execute({ sql: "DELETE FROM contact_groups WHERE id = ? AND group_uid IS NULL", args: [row.id] });
+            if ((res?.rowsAffected ?? 0) > 0) tombstoneDeleted++;
+            console.log(`[instance-sync] W3: legacy group ${row.id} ("${row.name}") — deterministic uid is tombstoned (deleted fleet-wide while offline); deleted locally instead of assigning`);
+          } catch (err) {
+            console.warn(`[instance-sync] W3: delete of tombstoned legacy group ${row.id} failed: ${err.message}`);
+          }
+          settled = true;
+          break;
+        }
         try {
           // group_uid IS NULL guard makes the UPDATE a no-op if a concurrent path already set it.
           await this.db.execute({ sql: "UPDATE contact_groups SET group_uid = ? WHERE id = ? AND group_uid IS NULL", args: [uid, row.id] });
@@ -861,7 +883,7 @@ export class InstanceSyncManager {
         console.warn(`[instance-sync] deterministic group_uid: ${MAX_COLLISION_RETRIES} collisions for group ${row.id} — left NULL (re-attempted next boot)`);
       }
     }
-    if (assigned > 0) console.log(`[instance-sync] assigned ${assigned} deterministic group_uid(s) to pre-existing groups`);
+    if (assigned > 0 || tombstoneDeleted > 0) console.log(`[instance-sync] assigned ${assigned} deterministic group_uid(s) to pre-existing groups (${tombstoneDeleted} tombstoned legacy row(s) deleted — W3)`);
     return assigned;
   }
 
@@ -881,8 +903,25 @@ export class InstanceSyncManager {
     // C1: assign deterministic frozen uids to legacy NULL-uid plain groups BEFORE the
     // flag gate (R2 F2 — every boot; usually 0 rows) and BEFORE the peer gate — so even
     // a peerless instance gets stable, convergent uids and stranded NULLs self-heal.
+    // (W3 inside: a legacy row whose deterministic uid is tombstoned is deleted, so
+    // the gated re-emit below can never regenerate a fleet-deleted uid.)
     await this._assignDeterministicGroupUids();
 
+    try {
+      return await this._backfillGroupsOnceGated();
+    } finally {
+      // W4 (design §3.7): FLAGLESS every-boot tombstone re-emit — on EVERY exit
+      // path of the gated backfill. On the one boot where the gated body runs
+      // its I-B1 drain, this sits after it, so a just-applied inbound delete's
+      // tombstone rides the same boot's re-emit; on flag-hit boots there is no
+      // drain here (feed watchers handle inbound continuously) and a later
+      // tombstone simply rides the NEXT boot — flaglessness self-heals.
+      // Guarded — never throws.
+      await this.reemitGroupTombstones();
+    }
+  }
+
+  async _backfillGroupsOnceGated() {
     const FLAG_KEY = "__groups_backfill_v1";
     let alreadyRan = false;
     try {
@@ -929,6 +968,50 @@ export class InstanceSyncManager {
     } catch {}
 
     if (emitted > 0) console.log(`[instance-sync] one-shot groups backfill: ${emitted} group(s) re-emitted → peers resolve legacy groups`);
+    return emitted;
+  }
+
+  /**
+   * W4 (design §3.7): re-emit EVERY group_tombstones row as an op=delete on
+   * every boot — deliberately NO flag. Sync feeds are born EMPTY at pairing
+   * (no history replay, see _initInstanceInner), so a peer that pairs — or
+   * RE-pairs — after a delete never hears it and holds the group forever
+   * (silent one-node divergence). A per-peer done-flag cannot fix that case:
+   * peer ids are install-stable (registerInstance is ON CONFLICT(id) DO
+   * UPDATE) and revoke clears neither the flags nor the feed dirs, so a
+   * revoke→re-pair would reuse the id, find the stale flag, and never
+   * backfill (R2 F1' — the providers backfill's pre-existing hole).
+   *
+   * Flagless is safe and cheap: receivers are idempotent (W2 UPSERTs the
+   * tombstone; the DELETE matches nothing on converged peers; a stale-copy
+   * holder gets exactly one delete-won conflict row and converges), delete
+   * ops never stamp row lamports (emitChange skips op=delete) so there is no
+   * per-boot re-emit churn to guard, and the loop is one tiny SELECT over
+   * rare rows. Also heals warn-dropped feed.appends and missed boot windows
+   * on the next boot (R2 F7 residuals).
+   *
+   * Same wire shape as emitGroupDelete: { group_uid } only, broadcast to all
+   * outFeeds. Guarded — never throws; a missing group_tombstones table
+   * (un-migrated DB) is a no-op.
+   */
+  async reemitGroupTombstones() {
+    let rows = [];
+    try {
+      const r = await this.db.execute({ sql: "SELECT group_uid, lamport_ts FROM group_tombstones" });
+      rows = r.rows || [];
+    } catch {
+      return 0; // missing table / read failure → no-op (never throw at boot)
+    }
+    let emitted = 0;
+    for (const row of rows) {
+      try {
+        const ts = await this.emitChange("contact_groups", "delete", { group_uid: row.group_uid });
+        if (ts != null) emitted++;
+      } catch (err) {
+        console.warn(`[instance-sync] W4 tombstone re-emit failed for ${row.group_uid}: ${err.message}`);
+      }
+    }
+    if (emitted > 0) console.log(`[instance-sync] W4: re-emitted ${emitted} group tombstone delete(s) to all peers`);
     return emitted;
   }
 

--- a/servers/sharing/sync-conflict-resolve.js
+++ b/servers/sharing/sync-conflict-resolve.js
@@ -302,10 +302,42 @@ export async function restoreConflict(db, conflictId, { instanceSync = null } = 
       const colList = insertKeys.join(", ");
       const placeholders = insertKeys.map(() => "?").join(", ");
       const values = insertKeys.map((k) => losingData[k] ?? null);
-      await db.execute({
-        sql: `INSERT INTO ${table} (${colList}) VALUES (${placeholders})`,
-        args: values,
-      });
+      if (table === "contact_groups") {
+        // G3 (2b design R2 F3'): an operator clicking Restore on an old
+        // contact_groups conflict must NOT re-insert a tombstoned group_uid —
+        // that would manufacture the resurrection zombie through a SUPPORTED
+        // UI path (G1 then quarantines it on peers: permanent, silent).
+        // STATEMENT-LEVEL guard (INSERT…SELECT WHERE NOT EXISTS), same shape
+        // as G1's apply gate, so the check is atomic with the write. A NULL
+        // uid never matches the subquery → the insert proceeds (a keyless row
+        // cannot be tombstoned; fail-open like isGroupTombstoned). NEVER add
+        // RETURNING here: stmt.reader would flip and rowsAffected hardcodes 0
+        // (servers/db.js:153-172), silently turning every restore into a
+        // refusal.
+        const uid = typeof losingData.group_uid === "string" ? losingData.group_uid : null;
+        const res = await db.execute({
+          sql: `INSERT INTO ${table} (${colList})
+                SELECT ${placeholders}
+                WHERE NOT EXISTS (SELECT 1 FROM group_tombstones WHERE group_uid = ?)`,
+          args: [...values, uid],
+        });
+        if (!(Number(res?.rowsAffected) > 0)) {
+          // Refused, not applied: leave the conflict UNRESOLVED (its data
+          // stays visible, like the op='insert' D7 refusal) and emit nothing.
+          return {
+            status: "refused",
+            message:
+              "This group was deleted fleet-wide — restore refused. Deleted " +
+              "groups stay deleted on every instance; re-create the group " +
+              "instead (it will get a fresh identity and sync normally).",
+          };
+        }
+      } else {
+        await db.execute({
+          sql: `INSERT INTO ${table} (${colList}) VALUES (${placeholders})`,
+          args: values,
+        });
+      }
     }
   } catch {
     return {

--- a/tests/group-delete.test.js
+++ b/tests/group-delete.test.js
@@ -1,0 +1,157 @@
+/**
+ * Item 2b (group tombstones design §3.2/§3.3) — Task 1.
+ *
+ * Task 1: schema — group_tombstones table (SCHEMA_GENERATION 8) — and the
+ * import-free primitives in servers/sharing/group-delete.js:
+ * groupTombstoneStatement / writeGroupTombstone / readGroupTombstone /
+ * isGroupTombstoned.
+ *
+ * Harness mirrors tests/contact-tombstones.test.js: real init-db into a
+ * tmpdir, the async createDbClient handle for the primitives.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { SCHEMA_GENERATION } from "../servers/shared/schema-version.js";
+import {
+  groupTombstoneStatement,
+  writeGroupTombstone,
+  readGroupTombstone,
+  isGroupTombstoned,
+} from "../servers/sharing/group-delete.js";
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-group-tombstone-test-"));
+function initDb() {
+  // CROW_DB_PATH outranks CROW_DATA_DIR in init-db (init-db.js:11) — blank it, or a
+  // shell exporting it (grackle's .env did exactly this, PR #180) misroutes the
+  // migration onto the REAL DB.
+  execFileSync(process.execPath, ["scripts/init-db.js"], { env: { ...process.env, CROW_DATA_DIR: tmpDir, CROW_DB_PATH: "" }, stdio: "pipe" });
+}
+initDb();
+const DB_PATH = join(tmpDir, "crow.db");
+after(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+const db = createDbClient(DB_PATH);
+
+// A db stub whose every call throws — the un-migrated-DB / missing-table case
+// the fail-open guarantees (spec G2) are about.
+const throwingDb = { execute() { throw new Error("x"); } };
+
+// ── Task 1: schema ──────────────────────────────────────────────────────────
+
+test("group_tombstones table exists after init-db with the exact columns", async () => {
+  const { rows } = await db.execute("PRAGMA table_info(group_tombstones)");
+  assert.deepEqual(rows.map((r) => r.name).sort(), ["deleted_at", "group_uid", "lamport_ts"],
+    "exactly group_uid + lamport_ts + deleted_at — deliberately NO kind column (single writer class, spec §3.2)");
+  const pk = rows.find((r) => r.name === "group_uid");
+  assert.equal(pk.pk, 1, "group_uid is the PRIMARY KEY");
+});
+
+test("init-db stamps PRAGMA user_version with the current SCHEMA_GENERATION (>= 8)", async () => {
+  const { rows } = await db.execute("PRAGMA user_version");
+  assert.equal(Number(rows[0].user_version), SCHEMA_GENERATION);
+  assert.ok(SCHEMA_GENERATION >= 8, "Item 2b bumped the generation to 8");
+});
+
+test("init-db is idempotent — re-run preserves group_tombstones rows and does not throw", async () => {
+  await db.execute({ sql: "INSERT OR REPLACE INTO group_tombstones (group_uid, lamport_ts, deleted_at) VALUES (?,?,?)", args: ["uid-idem", 7, 1000] });
+  initDb(); // must not throw
+  const fresh = createDbClient(DB_PATH);
+  const { rows } = await fresh.execute({ sql: "SELECT lamport_ts, deleted_at FROM group_tombstones WHERE group_uid = ?", args: ["uid-idem"] });
+  assert.equal(rows[0].lamport_ts, 7);
+  assert.equal(rows[0].deleted_at, 1000);
+});
+
+// ── UPSERT semantics (groupTombstoneStatement via writeGroupTombstone) ──────
+
+test("first write sets deleted_at and lamport_ts", async () => {
+  await writeGroupTombstone(db, "uid-first", 100);
+  const t = await readGroupTombstone(db, "uid-first");
+  assert.equal(t.group_uid, "uid-first");
+  assert.equal(t.lamport_ts, 100);
+  assert.ok(t.deleted_at > 0, "deleted_at stamped (unix seconds) on first write");
+});
+
+test("second write with HIGHER lamport keeps deleted_at (first write wins) but raises lamport_ts to the MAX", async () => {
+  // Seed a row with a deleted_at that CANNOT equal "now" — a same-second re-write
+  // would make the preservation assertion vacuous (a mutant that overwrites
+  // deleted_at with excluded.deleted_at would still pass). 1234 is unambiguous.
+  await db.execute({ sql: "INSERT INTO group_tombstones (group_uid, lamport_ts, deleted_at) VALUES (?,?,?)", args: ["uid-max", 100, 1234] });
+  await writeGroupTombstone(db, "uid-max", 150);
+  const t = await readGroupTombstone(db, "uid-max");
+  assert.equal(t.lamport_ts, 150, "MAX(100, 150) = 150");
+  assert.equal(t.deleted_at, 1234, "deleted_at preserved on conflict — first write wins");
+});
+
+test("second write with LOWER lamport changes NOTHING", async () => {
+  await db.execute({ sql: "INSERT INTO group_tombstones (group_uid, lamport_ts, deleted_at) VALUES (?,?,?)", args: ["uid-low", 100, 1234] });
+  await writeGroupTombstone(db, "uid-low", 50);
+  const t = await readGroupTombstone(db, "uid-low");
+  assert.equal(t.lamport_ts, 100, "MAX(100, 50) = 100 — the lower lamport must not lower the recorded value");
+  assert.equal(t.deleted_at, 1234);
+});
+
+test("groupTombstoneStatement returns a {sql, args} statement usable in db.batch()", async () => {
+  const stmt = groupTombstoneStatement("uid-batch", 42);
+  assert.equal(typeof stmt.sql, "string");
+  assert.ok(Array.isArray(stmt.args));
+  await db.batch([
+    stmt,
+    { sql: "INSERT OR REPLACE INTO group_tombstones (group_uid, lamport_ts, deleted_at) VALUES (?,?,?)", args: ["uid-batch2", 1, 1] },
+  ]);
+  assert.equal((await readGroupTombstone(db, "uid-batch")).lamport_ts, 42);
+});
+
+// ── Guards: falsy args ──────────────────────────────────────────────────────
+
+test("writeGroupTombstone no-ops on falsy db / falsy uid (never throws)", async () => {
+  await writeGroupTombstone(null, "uid-x", 1);   // must not throw
+  await writeGroupTombstone(db, "", 1);          // must not throw
+  await writeGroupTombstone(db, null, 1);        // must not throw
+  const { rows } = await db.execute({ sql: "SELECT COUNT(*) AS n FROM group_tombstones WHERE group_uid IN ('', 'null')", args: [] });
+  assert.equal(rows[0].n, 0);
+});
+
+// ── isGroupTombstoned ───────────────────────────────────────────────────────
+
+test("isGroupTombstoned returns true for a tombstoned uid, false for a live one", async () => {
+  await writeGroupTombstone(db, "uid-tomb", 5);
+  assert.equal(await isGroupTombstoned(db, "uid-tomb"), true);
+  assert.equal(await isGroupTombstoned(db, "uid-never-deleted"), false);
+});
+
+test("isGroupTombstoned is FAIL-OPEN: a throwing db handle returns false, never throws (spec G2)", async () => {
+  // A read failure (e.g. missing table under a stale server) must mean "not
+  // tombstoned" — never swallow the caller's work.
+  assert.equal(await isGroupTombstoned(throwingDb, "uid-any"), false);
+});
+
+test("isGroupTombstoned no-ops on falsy args", async () => {
+  assert.equal(await isGroupTombstoned(null, "uid-x"), false);
+  assert.equal(await isGroupTombstoned(db, ""), false);
+  assert.equal(await isGroupTombstoned(db, null), false);
+});
+
+// ── readGroupTombstone ──────────────────────────────────────────────────────
+
+test("readGroupTombstone returns the row for a tombstoned uid", async () => {
+  await writeGroupTombstone(db, "uid-read", 9);
+  const t = await readGroupTombstone(db, "uid-read");
+  assert.equal(t.group_uid, "uid-read");
+  assert.equal(t.lamport_ts, 9);
+  assert.ok(t.deleted_at > 0);
+});
+
+test("readGroupTombstone returns null on a missing row", async () => {
+  assert.equal(await readGroupTombstone(db, "uid-missing"), null);
+});
+
+test("readGroupTombstone returns null on error and on falsy args (guarded)", async () => {
+  assert.equal(await readGroupTombstone(throwingDb, "uid-any"), null);
+  assert.equal(await readGroupTombstone(null, "uid-x"), null);
+  assert.equal(await readGroupTombstone(db, ""), null);
+});

--- a/tests/group-tombstones.test.js
+++ b/tests/group-tombstones.test.js
@@ -50,7 +50,10 @@ const SECP = "a".repeat(64);
 function initInstance(label) {
   const dir = mkdtempSync(join(tmpdir(), `crow-grp-tomb-${label}-`));
   execFileSync(process.execPath, ["scripts/init-db.js"], {
-    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    // CROW_DB_PATH outranks CROW_DATA_DIR in init-db (init-db.js:11) — blank it, or a
+    // shell exporting it (grackle's .env did, PR #180) would run the gen-8 migration
+    // against the REAL DB, outside the deploy rail's backups.
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DB_PATH: "", CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
     stdio: "pipe",
   });
   return { dir, path: join(dir, "crow.db") };

--- a/tests/group-tombstones.test.js
+++ b/tests/group-tombstones.test.js
@@ -1,0 +1,471 @@
+// tests/group-tombstones.test.js
+//
+// Item 2b — contact_groups offline-peer tombstones: the EXECUTABLE acceptance gate
+// (design §5, spec docs/superpowers/specs/2026-07-13-group-tombstones-design.md).
+// Covers W2 (strict delete-wins in _applyGroup) + G1 (STATEMENT-LEVEL tombstone
+// guards on the insert/update writes): tests T1, T2, T3, T4, T5, T8.
+//
+// HARNESS: two real instances (each its own mkdtemp CROW_DATA_DIR + real init-db +
+// real InstanceSyncManager) joined by a fake out-feed that captures every entry
+// emitChange() appends and hands it to the peer's _applyEntry() — adapted from
+// tests/advertised-prune-durability.test.js. ⚠️ Harness trap (design R1 F5a): that
+// file installs contact-sync.js's test sink; GROUP emits route through
+// group-sync.js's SEPARATE __setEmitSinkForTest — wired here — and every emit
+// asserts wire growth before any drain (an emit into a null sink would make every
+// wire-order assertion below pass vacuously).
+//
+// W1 (the originating delete_group handler) is Task 3; deleteGroupLocalW1() below
+// simulates its specced shape (tombstone + DELETE in ONE db.batch, then
+// emitGroupDelete) so T1/T2/T3 exercise the full two-instance flow.
+//
+// NEVER point this file at ~/.crow or ~/.crow-mpa — this code path DELETES groups.
+import { test, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { emitGroupUpsert, emitGroupDelete, __setEmitSinkForTest } from "../servers/sharing/group-sync.js";
+import { groupTombstoneStatement, readGroupTombstone } from "../servers/sharing/group-delete.js";
+import { sign } from "../servers/sharing/identity.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+// ── identities ───────────────────────────────────────────────────────────────
+// One shared ed25519 identity: instance-sync verifies every entry against
+// `this.identity.ed25519Pubkey`, and a user's instances share one identity.
+const TEST_PRIV = Buffer.alloc(32, 0x2b);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+const A_ID = "inst-aaaa-0000-0000-0000-00000000000a";
+const B_ID = "inst-bbbb-0000-0000-0000-00000000000b";
+const SECP = "a".repeat(64);
+
+// ── two real instances ───────────────────────────────────────────────────────
+function initInstance(label) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-grp-tomb-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    stdio: "pipe",
+  });
+  return { dir, path: join(dir, "crow.db") };
+}
+const A_FILES = initInstance("a");
+const B_FILES = initInstance("b");
+after(() => {
+  __setEmitSinkForTest(null);
+  rmSync(A_FILES.dir, { recursive: true, force: true });
+  rmSync(B_FILES.dir, { recursive: true, force: true });
+});
+
+/**
+ * The shared feed. `wire` holds EVERY entry either instance appended. deliver()
+ * drains in append order (T1's "A→B then B→A" when the delete was emitted first);
+ * applyItem() lets T2 drain in the REVERSED order explicitly.
+ */
+function newFleet() {
+  const wire = [];
+  const A = { id: A_ID, db: createDbClient(A_FILES.path) };
+  const B = { id: B_ID, db: createDbClient(B_FILES.path) };
+  const attach = (inst) => {
+    inst.mgr = new InstanceSyncManager(IDENTITY, inst.db, inst.id);
+    inst.mgr.feedsDisabled = false;
+    inst.mgr.outFeeds = new Map([["peer", {
+      append: async (e) => { wire.push({ from: inst.id, entry: JSON.parse(JSON.stringify(e)) }); },
+    }]]);
+  };
+  attach(A);
+  attach(B);
+  let cursor = 0;
+  const other = (fromId) => (fromId === A.id ? B : A);
+  /** Apply one captured wire item to a destination instance (JSON round-tripped). */
+  const applyItem = async (dest, item) =>
+    dest.mgr._applyEntry(item.from, JSON.parse(JSON.stringify(item.entry)));
+  /** Replicate every un-delivered entry to the other side, in append order. */
+  const deliver = async () => {
+    while (cursor < wire.length) {
+      const item = wire[cursor++];
+      await applyItem(other(item.from), item);
+    }
+  };
+  /** Mark everything currently on the wire as delivered WITHOUT applying (T2 uses applyItem manually). */
+  const skimWire = () => { const items = wire.slice(cursor); cursor = wire.length; return items; };
+  /** Restart an instance: brand-new db handle + manager over the SAME file. */
+  const restart = async (inst) => {
+    inst.db = createDbClient(inst.id === A_ID ? A_FILES.path : B_FILES.path);
+    attach(inst);
+  };
+  return { A, B, wire, deliver, applyItem, skimWire, restart, other };
+}
+
+/** Run `fn` with `inst` as the GROUP emit sink — an emit belongs to exactly one instance. */
+async function act(inst, fn) {
+  __setEmitSinkForTest(inst.mgr);
+  try { return await fn(); } finally { __setEmitSinkForTest(null); }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+const groupRow = async (inst, uid) => (await inst.db.execute({
+  sql: "SELECT * FROM contact_groups WHERE group_uid = ?", args: [uid],
+})).rows[0] || null;
+
+const conflicts = async (inst) =>
+  Number((await inst.db.execute("SELECT COUNT(*) c FROM sync_conflicts")).rows[0].c);
+
+const conflictRows = async (inst) => (await inst.db.execute(
+  "SELECT * FROM sync_conflicts ORDER BY id",
+)).rows;
+
+const tomb = (inst, uid) => readGroupTombstone(inst.db, uid);
+
+const members = async (inst, uid) => {
+  const { rows } = await inst.db.execute({
+    sql: `SELECT c.crow_id FROM contact_group_members gm
+            JOIN contacts c ON c.id = gm.contact_id
+            JOIN contact_groups g ON g.id = gm.group_id
+           WHERE g.group_uid = ? ORDER BY c.crow_id`, args: [uid],
+  });
+  return rows.map((r) => r.crow_id);
+};
+
+const setCounter = async (inst, n) => {
+  await inst.mgr._ensureCounter();
+  await inst.db.execute({ sql: "UPDATE sync_state SET local_counter = ? WHERE instance_id = ?", args: [n, inst.id] });
+};
+
+/** Seed the same syncable contact on an instance (members resolve by crow_id). */
+async function seedContact(inst, id, crowId) {
+  await inst.db.execute({
+    sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (?, ?, '', ?)",
+    args: [id, crowId, SECP],
+  });
+}
+
+/**
+ * Create a plain group locally (trigger assigns the random group_uid) and emit
+ * it through the REAL group-sync path. Asserts the emit reached the wire
+ * (harness trap: a null sink would pass every downstream assertion vacuously).
+ */
+async function createGroupAndEmit(fleet, inst, name) {
+  const wireBefore = fleet.wire.length;
+  await inst.db.execute({ sql: "INSERT INTO contact_groups (name) VALUES (?)", args: [name] });
+  const { rows } = await inst.db.execute({
+    sql: "SELECT id, group_uid FROM contact_groups WHERE name = ? ORDER BY id DESC LIMIT 1", args: [name],
+  });
+  const { id, group_uid: uid } = rows[0];
+  assert.ok(uid, "trigger assigned a group_uid");
+  await act(inst, () => emitGroupUpsert(inst.db, id));
+  assert.ok(fleet.wire.length > wireBefore, "group upsert reached the wire (GROUP sink wired)");
+  return { id, uid };
+}
+
+/** Rename + re-emit through the real path. Returns the emitted entry's lamport. */
+async function renameAndEmit(fleet, inst, uid, newName) {
+  const wireBefore = fleet.wire.length;
+  await inst.db.execute({ sql: "UPDATE contact_groups SET name = ? WHERE group_uid = ?", args: [newName, uid] });
+  const { rows } = await inst.db.execute({ sql: "SELECT id FROM contact_groups WHERE group_uid = ?", args: [uid] });
+  await act(inst, () => emitGroupUpsert(inst.db, rows[0].id));
+  assert.ok(fleet.wire.length > wireBefore, "rename reached the wire (GROUP sink wired)");
+  return Number(fleet.wire.at(-1).entry.lamport_ts);
+}
+
+/**
+ * W1 simulation (Task 3 ships the real delete_group handler): tombstone + local
+ * DELETE in ONE db.batch, then emitGroupDelete through the real group-sync path.
+ * Returns the delete entry's wire lamport.
+ */
+async function deleteGroupLocalW1(fleet, inst, uid) {
+  const wireBefore = fleet.wire.length;
+  await inst.db.batch([
+    groupTombstoneStatement(uid, 0),
+    { sql: "DELETE FROM contact_groups WHERE group_uid = ? AND room_uid IS NULL", args: [uid] },
+  ]);
+  await act(inst, () => emitGroupDelete(uid));
+  assert.ok(fleet.wire.length > wireBefore, "delete reached the wire (GROUP sink wired)");
+  return Number(fleet.wire.at(-1).entry.lamport_ts);
+}
+
+/** Forge a signed sync entry (T5/T8 drive _applyEntry directly, like groups-sync.test.js). */
+function signedEntry(table, op, row, lamport_ts, instance_id) {
+  const e = { table, op, row, lamport_ts, instance_id };
+  e.signature = sign(JSON.stringify(e), IDENTITY.ed25519Priv);
+  return e;
+}
+
+beforeEach(async () => {
+  const dbs = [createDbClient(A_FILES.path), createDbClient(B_FILES.path)];
+  for (const db of dbs) {
+    await db.execute("DELETE FROM contact_group_members");
+    await db.execute("DELETE FROM contact_groups");
+    await db.execute("DELETE FROM group_tombstones");
+    await db.execute("DELETE FROM contacts");
+    await db.execute("DELETE FROM sync_conflicts");
+    await db.execute("DELETE FROM notifications");
+    db.close();
+  }
+  __setEmitSinkForTest(null);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1 — S1 resurrection, THE defect (design §1.1). Drain A→B then B→A.
+// RED-ON-UNMODIFIED-CODE REQUIRED: fails by resurrecting G on A.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T1: A deletes G; offline B renames at a HIGHER lamport; drain A→B then B→A — both converge to deleted+tombstoned, exactly one delete-won conflict row", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  const g = await createGroupAndEmit(f, f.A, "Family");
+  await f.deliver();
+  assert.ok(await groupRow(f.B, g.uid), "setup: B holds the synced group");
+
+  // A deletes (delete emitted at lamport d); B — offline, counter already ahead —
+  // renames at r > d (explicit interleave per the spec's harness note).
+  const d = await deleteGroupLocalW1(f, f.A, g.uid);
+  await setCounter(f.B, d + 10);
+  const r = await renameAndEmit(f, f.B, g.uid, "Renamed");
+  assert.ok(r > d, `setup: rename lamport ${r} exceeds delete lamport ${d}`);
+
+  // Wire order is delete-then-rename, so deliver() IS "A→B then B→A".
+  await f.deliver();
+
+  assert.equal(await groupRow(f.A, g.uid), null, "A: group NOT resurrected by B's rename");
+  assert.equal(await groupRow(f.B, g.uid), null, "B: group deleted despite its newer rename (strict delete-wins)");
+  assert.ok(await tomb(f.A, g.uid), "A: standing tombstone");
+  assert.ok(await tomb(f.B, g.uid), "B: standing tombstone");
+
+  // Conflict rows: exactly ONE, on B, labeled truthfully (R2 F6): the delete WON,
+  // B's discarded rename is the LOSER — the only surviving record of the S2 trade-off.
+  assert.equal(await conflicts(f.A), c0.a, "A: no conflict rows (silent drop of the stale upsert)");
+  assert.equal(await conflicts(f.B), c0.b + 1, "B: exactly one delete-won conflict row");
+  const cr = (await conflictRows(f.B)).at(-1);
+  assert.equal(cr.table_name, "contact_groups");
+  assert.equal(cr.op, "delete");
+  assert.equal(cr.winning_instance_id, A_ID, "winner = the deleting instance");
+  assert.equal(cr.losing_instance_id, B_ID, "loser = the local editor");
+  assert.equal(Number(cr.winning_lamport_ts), d, "winning lamport = the delete's");
+  assert.equal(Number(cr.losing_lamport_ts), r, "losing lamport = the discarded rename's");
+  assert.equal(JSON.parse(cr.losing_data).name, "Renamed", "losing_data = the discarded LOCAL row");
+  const winData = JSON.parse(cr.winning_data);
+  assert.equal(winData.group_uid, g.uid, "winning_data = the wire delete row");
+  assert.equal(winData.name, undefined, "winning_data carries no name (it IS the delete, not the rename)");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1b — W2's UNCONDITIONAL tombstone: a delete for a uid this instance NEVER
+// held must still stand a tombstone (protects against update-after-delete
+// arrival reordering and pre-arms third instances holding stale copies).
+// Kills the `if (!localRow) return;` mutation, which every other test survives
+// (their receive-side tombstones all form with a local row present).
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T1b: op=delete for a uid B NEVER held stands a tombstone with zero conflict rows; a later higher-lamport upsert is dropped", async () => {
+  const f = newFleet();
+  const uid = "t1b-" + "0".repeat(28);
+  const c0 = await conflicts(f.B);
+
+  assert.equal(await groupRow(f.B, uid), null, "setup: B never held the uid");
+  await f.B.mgr._applyEntry(A_ID, signedEntry("contact_groups", "delete", { group_uid: uid }, 40, A_ID));
+
+  assert.ok(await tomb(f.B, uid), "tombstone standing despite NO local row (W2 unconditional)");
+  assert.equal(await groupRow(f.B, uid), null, "still no row");
+  assert.equal(await conflicts(f.B), c0, "zero conflict rows from a no-row delete");
+
+  // The reordered/stale upsert the unconditional tombstone exists to stop.
+  await f.B.mgr._applyEntry(A_ID, signedEntry("contact_groups", "update",
+    { group_uid: uid, name: "Zombie", members: [] }, 99, A_ID));
+  assert.equal(await groupRow(f.B, uid), null, "higher-lamport upsert dropped");
+  assert.ok(await tomb(f.B, uid), "tombstone intact");
+  assert.equal(await conflicts(f.B), c0, "still zero conflict rows (silent drop)");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T2 — S1 with the drain order REVERSED: B→A first, then A→B.
+// RED-ON-UNMODIFIED-CODE REQUIRED: fails by resurrecting G on A.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T2: same as T1 but drained B→A first, then A→B — same converged end state", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  const g = await createGroupAndEmit(f, f.A, "Chess Club");
+  await f.deliver();
+  assert.ok(await groupRow(f.B, g.uid), "setup: B holds the synced group");
+
+  const d = await deleteGroupLocalW1(f, f.A, g.uid);
+  await setCounter(f.B, d + 10);
+  const r = await renameAndEmit(f, f.B, g.uid, "Renamed");
+  assert.ok(r > d, "setup: rename lamport exceeds delete lamport");
+
+  // Reversed drain: B's rename → A first, then A's delete → B.
+  const pending = f.skimWire();
+  const deleteItem = pending.find((i) => i.entry.op === "delete");
+  const renameItem = pending.find((i) => i.from === B_ID && i.entry.op !== "delete");
+  assert.ok(deleteItem && renameItem, "setup: both entries captured on the wire");
+  await f.applyItem(f.A, renameItem); // B→A first
+  await f.applyItem(f.B, deleteItem); // then A→B
+
+  assert.equal(await groupRow(f.A, g.uid), null, "A: rename-first drain did NOT resurrect the group");
+  assert.equal(await groupRow(f.B, g.uid), null, "B: delete applied despite newer local rename");
+  assert.ok(await tomb(f.A, g.uid), "A: standing tombstone");
+  assert.ok(await tomb(f.B, g.uid), "B: standing tombstone");
+
+  assert.equal(await conflicts(f.A), c0.a, "A: zero conflict growth");
+  assert.equal(await conflicts(f.B), c0.b + 1, "B: exactly one delete-won conflict row");
+  const cr = (await conflictRows(f.B)).at(-1);
+  assert.equal(cr.op, "delete");
+  assert.equal(cr.winning_instance_id, A_ID, "winner = the deleting instance");
+  assert.equal(JSON.parse(cr.losing_data).name, "Renamed", "losing_data = the discarded local row");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T3 — mutual delete: converged, both tombstoned, ZERO conflict growth.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T3: A and B delete G concurrently; drain both — converged, both tombstoned, zero sync_conflicts growth", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  const g = await createGroupAndEmit(f, f.A, "Doomed Twice");
+  await f.deliver();
+  assert.ok(await groupRow(f.B, g.uid), "setup: B holds the synced group");
+
+  await deleteGroupLocalW1(f, f.A, g.uid);
+  await deleteGroupLocalW1(f, f.B, g.uid);
+  await f.deliver();
+
+  assert.equal(await groupRow(f.A, g.uid), null, "A: deleted");
+  assert.equal(await groupRow(f.B, g.uid), null, "B: deleted");
+  assert.ok(await tomb(f.A, g.uid), "A: standing tombstone");
+  assert.ok(await tomb(f.B, g.uid), "B: standing tombstone");
+  assert.equal(await conflicts(f.A), c0.a, "A: zero conflict growth");
+  assert.equal(await conflicts(f.B), c0.b, "B: zero conflict growth");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T4 — negative control: live groups still sync normally; a NEW same-named group
+// after a delete syncs under its fresh uid.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T4: live-group rename + membership still sync end-to-end; a re-created same-named group (fresh uid) syncs; zero conflict growth", async () => {
+  const f = newFleet();
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+  await seedContact(f.A, 501, "crow:mem1");
+  await seedContact(f.B, 501, "crow:mem1");
+
+  // Create on A → syncs to B.
+  const g = await createGroupAndEmit(f, f.A, "Family");
+  await f.deliver();
+  assert.ok(await groupRow(f.B, g.uid), "create synced A→B");
+
+  // Membership add on A → syncs to B.
+  await f.A.db.execute({ sql: "INSERT INTO contact_group_members (group_id, contact_id) VALUES (?, 501)", args: [g.id] });
+  await act(f.A, () => emitGroupUpsert(f.A.db, g.id));
+  await f.deliver();
+  assert.deepEqual(await members(f.B, g.uid), ["crow:mem1"], "membership synced A→B");
+
+  // Rename on B → syncs back to A.
+  await renameAndEmit(f, f.B, g.uid, "Familia");
+  await f.deliver();
+  assert.equal((await groupRow(f.A, g.uid)).name, "Familia", "rename synced B→A");
+
+  // Delete, then re-create the SAME NAME on A: the fresh trigger-random uid is not
+  // tombstoned, so the new group syncs while the old uid stays dead.
+  await deleteGroupLocalW1(f, f.A, g.uid);
+  await f.deliver();
+  assert.equal(await groupRow(f.B, g.uid), null, "old uid deleted on B");
+
+  const g2 = await createGroupAndEmit(f, f.A, "Familia");
+  assert.notEqual(g2.uid, g.uid, "re-created group has a FRESH uid");
+  await f.deliver();
+  assert.ok(await groupRow(f.B, g2.uid), "re-created group synced under its fresh uid");
+  assert.equal(await groupRow(f.B, g.uid), null, "old uid still dead on B");
+  assert.ok(await tomb(f.B, g.uid), "old uid still tombstoned on B");
+
+  assert.equal(await conflicts(f.A), c0.a, "A: zero conflict growth");
+  assert.equal(await conflicts(f.B), c0.b, "B: zero conflict growth");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T5 — restart durability. RED-ON-UNMODIFIED-CODE REQUIRED: fails by accepting
+// the stale upsert after B's restart.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T5: after a restart of B (fresh manager, same DB) a stale upsert for the tombstoned uid is still dropped", async () => {
+  const f = newFleet();
+
+  const g = await createGroupAndEmit(f, f.A, "Book Club");
+  await f.deliver();
+  const d = await deleteGroupLocalW1(f, f.A, g.uid);
+  await f.deliver();
+  assert.equal(await groupRow(f.B, g.uid), null, "setup: delete applied on B");
+
+  // Restart B: brand-new db handle + manager over the same files.
+  await f.restart(f.B);
+  assert.ok(await tomb(f.B, g.uid), "setup: tombstone survived the restart");
+  const c0 = await conflicts(f.B);
+
+  // A stale peer's upsert for the dead uid, at a lamport ABOVE the delete's
+  // (the mutual-case shape — under strict delete-wins ANY lamport must drop).
+  await f.B.mgr._applyEntry(A_ID, signedEntry("contact_groups", "update",
+    { group_uid: g.uid, name: "Zombie", members: [] }, d + 5, A_ID));
+
+  assert.equal(await groupRow(f.B, g.uid), null, "B: stale upsert dropped after restart");
+  assert.ok(await tomb(f.B, g.uid), "B: tombstone intact");
+  assert.equal(await conflicts(f.B), c0, "B: zero conflict growth (silent drop)");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T8 — G1 statement-guard unit tests (design R1 F1): the guarded INSERT/UPDATE
+// are no-ops against a pre-seeded tombstone, and the rowsAffected reconcile gate
+// is proven on the UPDATE branch (R2 F5: on the INSERT branch the gate mutation
+// is INVISIBLE — null gid early-returns the reconcile — so the load-bearing
+// check seeds the ZOMBIE state, tombstone + live row, where localRow.id is real).
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T8a: guarded INSERT is a no-op against a pre-seeded tombstone — no row, no member rows, no conflict rows", async () => {
+  const f = newFleet();
+  const uid = "t8a-" + "0".repeat(28);
+  await seedContact(f.A, 601, "crow:t8a");
+  await f.A.db.execute(groupTombstoneStatement(uid, 3));
+  const c0 = await conflicts(f.A);
+
+  // Drive the REAL apply path (op=update, no local row → insert branch).
+  await f.A.mgr._applyEntry(B_ID, signedEntry("contact_groups", "update",
+    { group_uid: uid, name: "Zombie", members: ["crow:t8a"] }, 999, B_ID));
+
+  assert.equal(await groupRow(f.A, uid), null, "guarded INSERT dropped the tombstoned uid");
+  const gm = (await f.A.db.execute("SELECT COUNT(*) c FROM contact_group_members")).rows[0].c;
+  assert.equal(Number(gm), 0, "reconcile did not run (no member rows)");
+  assert.ok(await tomb(f.A, uid), "tombstone intact");
+  assert.equal(await conflicts(f.A), c0, "zero conflict growth");
+});
+
+test("T8b: guarded UPDATE is a no-op against the zombie state (tombstone + live row) — metadata unchanged AND membership untouched (reconcile gated on rowsAffected)", async () => {
+  const f = newFleet();
+  await seedContact(f.A, 602, "crow:t8b");
+
+  // Manufacture the zombie: a live row whose uid is tombstoned (direct DB writes —
+  // reachable in prod only via a race/manual edit; G1 must still hold).
+  await f.A.db.execute({ sql: "INSERT INTO contact_groups (id, name, lamport_ts) VALUES (700, 'Zombie', 5)", args: [] });
+  const uid = (await f.A.db.execute("SELECT group_uid FROM contact_groups WHERE id = 700")).rows[0].group_uid;
+  await f.A.db.execute({ sql: "INSERT INTO contact_group_members (group_id, contact_id) VALUES (700, 602)", args: [] });
+  await f.A.db.execute(groupTombstoneStatement(uid, 6));
+  const c0 = await conflicts(f.A);
+
+  // A HIGHER-lamport update with an explicit members wire-array that would wipe
+  // the membership if the reconcile ran against localRow.id (real, non-null).
+  await f.A.mgr._applyEntry(B_ID, signedEntry("contact_groups", "update",
+    { group_uid: uid, name: "Hacked", members: [] }, 50, B_ID));
+
+  const row = await groupRow(f.A, uid);
+  assert.ok(row, "zombie row still present (this test does not assert healing)");
+  assert.equal(row.name, "Zombie", "guarded UPDATE did not touch metadata");
+  assert.equal(Number(row.lamport_ts), 5, "lamport not stamped by the dropped update");
+  assert.deepEqual(await members(f.A, uid), ["crow:t8b"],
+    "membership UNTOUCHED — reconcile must be gated on rowsAffected > 0 (R2 F5)");
+  assert.ok(await tomb(f.A, uid), "tombstone intact");
+  assert.equal(await conflicts(f.A), c0, "zero conflict growth");
+});

--- a/tests/group-tombstones.test.js
+++ b/tests/group-tombstones.test.js
@@ -581,3 +581,137 @@ test("T10: delete_group on a ROOM routes to deleteRoom — room+members+room_mes
   // The plain group beside it is untouched.
   assert.ok(await groupRow(f.A, plain.uid), "the plain group survives");
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T6 — W3 (design §3.4): a NULL-uid legacy row whose DETERMINISTIC uid is
+// tombstoned means the logical group was deleted fleet-wide while this instance
+// was offline (or pre-C1) — the assignment pass must DELETE it, not regenerate
+// the dead uid. ⚠️ Seeding trap (design §5): the contact_groups_group_uid_ai
+// trigger makes a NULL-uid INSERT impossible — seed with INSERT then
+// UPDATE ... SET group_uid = NULL.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T6: W3 — a legacy NULL-uid row whose deterministic uid is tombstoned is DELETED at assignment time (nothing emitted, tombstone stands); a non-tombstoned sibling is assigned normally", async () => {
+  const f = newFleet();
+
+  // Two legacy rows on B (INSERT then NULL the trigger-assigned uid — spec §5 trap).
+  await f.B.db.execute({ sql: "INSERT INTO contact_groups (name) VALUES ('Dead Legacy')", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contact_groups (name) VALUES ('Live Legacy')", args: [] });
+  await f.B.db.execute("UPDATE contact_groups SET group_uid = NULL WHERE name IN ('Dead Legacy','Live Legacy')");
+  const nulls = Number((await f.B.db.execute(
+    "SELECT COUNT(*) c FROM contact_groups WHERE group_uid IS NULL")).rows[0].c);
+  assert.equal(nulls, 2, "setup: both legacy rows are NULL-uid");
+
+  // Tombstone the DETERMINISTIC uid of one — via the SAME derivation the code uses.
+  const deadUid = f.B.mgr.deterministicGroupUid("Dead Legacy");
+  const liveUid = f.B.mgr.deterministicGroupUid("Live Legacy");
+  await f.B.db.execute(groupTombstoneStatement(deadUid, 7));
+
+  const wireBefore = f.wire.length;
+  await f.B.mgr._assignDeterministicGroupUids();
+
+  // The tombstoned legacy row is GONE — deleted, not assigned.
+  const dead = (await f.B.db.execute({
+    sql: "SELECT * FROM contact_groups WHERE name = 'Dead Legacy'", args: [] })).rows;
+  assert.equal(dead.length, 0, "W3 deleted the tombstoned legacy row");
+  assert.equal(await groupRow(f.B, deadUid), null, "no row holds the tombstoned uid");
+  assert.ok(await tomb(f.B, deadUid), "the tombstone still stands");
+
+  // NEGATIVE CONTROL: the non-tombstoned sibling got its uid assigned normally.
+  const live = await groupRow(f.B, liveUid);
+  assert.ok(live, "negative control: non-tombstoned legacy row assigned its deterministic uid");
+  assert.equal(live.name, "Live Legacy");
+
+  assert.equal(f.wire.length, wireBefore, "nothing emitted for the W3 local delete (wire unchanged)");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T6b — fail-open (design §3.4 / G2 rationale): a group_tombstones read failure
+// (e.g. missing table on an un-migrated DB) means "not tombstoned" — it must
+// NEVER kill uid assignment for every group; and W4's re-emit must no-op
+// without throwing. Mutation check (c): letting the read error propagate out
+// of the W3 check reds this test.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T6b: W3/W4 fail-open — group_tombstones reads that THROW do not kill uid assignment, and reemitGroupTombstones no-ops without throwing", async () => {
+  const f = newFleet();
+  await f.B.db.execute({ sql: "INSERT INTO contact_groups (name) VALUES ('Fail Open')", args: [] });
+  await f.B.db.execute("UPDATE contact_groups SET group_uid = NULL WHERE name = 'Fail Open'");
+
+  // Pass-through wrapper over the REAL db: any statement touching
+  // group_tombstones throws (the un-migrated-DB shape).
+  const realDb = f.B.db;
+  const throwingDb = {
+    execute: (arg) => {
+      const sql = typeof arg === "string" ? arg : arg.sql;
+      if (/group_tombstones/i.test(sql)) throw new Error("boom: group_tombstones unavailable");
+      return realDb.execute(arg);
+    },
+    batch: (stmts) => realDb.batch(stmts),
+  };
+  f.B.mgr.db = throwingDb;
+  try {
+    const n = await f.B.mgr._assignDeterministicGroupUids();
+    assert.equal(n, 1, "uid assignment proceeded despite throwing tombstone reads (fail-open)");
+    const reemitted = await f.B.mgr.reemitGroupTombstones();
+    assert.equal(reemitted, 0, "W4 re-emit no-ops (guarded) when the table read throws");
+  } finally {
+    f.B.mgr.db = realDb;
+  }
+
+  const uid = f.B.mgr.deterministicGroupUid("Fail Open");
+  assert.ok(await groupRow(f.B, uid), "the legacy row holds its deterministic uid");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T9 — W4 (design §3.7): FLAGLESS every-boot tombstone re-emit. Sync feeds are
+// born EMPTY at pairing, so a peer that pairs AFTER the delete never hears it —
+// B below stands in for that peer: it never received the delete entry (skimmed
+// off the wire) and holds a stale live copy of the group. A's boot re-emit must
+// converge it; a second re-emit (next boot) must change nothing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T9: W4 flagless boot re-emit — a peer that paired after the delete converges (stale copy gone, tombstoned, exactly one delete-won conflict row); a second re-emit is idempotent", async () => {
+  const f = newFleet();
+
+  // A: a REAL prior delete (group created + deleted through the W1 shape).
+  const g = await createGroupAndEmit(f, f.A, "Ghost");
+  const d = await deleteGroupLocalW1(f, f.A, g.uid);
+  assert.ok(await tomb(f.A, g.uid), "setup: A holds the tombstone");
+  // B "paired after the delete": it never receives the create/delete entries.
+  f.skimWire();
+
+  // B: fresh peer seeded with a stale live copy of the group (same uid, direct
+  // INSERT then uid overwrite past the trigger) at a lamport ABOVE the delete's.
+  await f.B.db.execute({ sql: "INSERT INTO contact_groups (name, lamport_ts) VALUES ('Ghost', ?)", args: [d + 5] });
+  await f.B.db.execute({ sql: "UPDATE contact_groups SET group_uid = ? WHERE name = 'Ghost'", args: [g.uid] });
+  assert.ok(await groupRow(f.B, g.uid), "setup: B holds the stale live copy");
+  assert.equal(await tomb(f.B, g.uid), null, "setup: B never saw the delete (no tombstone)");
+  const c0 = { a: await conflicts(f.A), b: await conflicts(f.B) };
+
+  // A's boot re-emit (W4) → drain to B.
+  const wireBefore = f.wire.length;
+  const n1 = await f.A.mgr.reemitGroupTombstones();
+  assert.equal(n1, 1, "one tombstone re-emitted");
+  assert.ok(f.wire.length > wireBefore, "the re-emit reached the wire");
+  assert.equal(f.wire.at(-1).entry.op, "delete", "re-emit is an op=delete");
+  assert.equal(f.wire.at(-1).entry.row.group_uid, g.uid, "same wire shape as emitGroupDelete ({ group_uid })");
+  await f.deliver();
+
+  assert.equal(await groupRow(f.B, g.uid), null, "B: stale live copy deleted");
+  assert.ok(await tomb(f.B, g.uid), "B: tombstone standing");
+  assert.equal(await conflicts(f.B), c0.b + 1, "B: exactly one delete-won conflict row");
+  const cr = (await conflictRows(f.B)).at(-1);
+  assert.equal(cr.table_name, "contact_groups");
+  assert.equal(cr.op, "delete");
+  assert.equal(cr.winning_instance_id, A_ID, "winner = the (re-emitting) deleting instance");
+
+  // Idempotence: a second boot's re-emit produces NO further state change.
+  const n2 = await f.A.mgr.reemitGroupTombstones();
+  assert.equal(n2, 1, "re-emits every boot — deliberately flagless");
+  await f.deliver();
+  assert.equal(await groupRow(f.B, g.uid), null, "B: still deleted");
+  assert.ok(await tomb(f.B, g.uid), "B: tombstone intact");
+  assert.equal(await conflicts(f.B), c0.b + 1, "B: NO conflict growth on the second re-emit");
+  assert.equal(await conflicts(f.A), c0.a, "A: zero conflict growth throughout");
+});

--- a/tests/group-tombstones.test.js
+++ b/tests/group-tombstones.test.js
@@ -29,6 +29,7 @@ import { createDbClient } from "../servers/db.js";
 import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
 import { emitGroupUpsert, emitGroupDelete, __setEmitSinkForTest } from "../servers/sharing/group-sync.js";
 import { groupTombstoneStatement, readGroupTombstone } from "../servers/sharing/group-delete.js";
+import { restoreConflict } from "../servers/sharing/sync-conflict-resolve.js";
 import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
 import { getGroups } from "../servers/gateway/dashboard/panels/contacts/data-queries.js";
 import { sign } from "../servers/sharing/identity.js";
@@ -670,6 +671,94 @@ test("T6b: W3/W4 fail-open — group_tombstones reads that THROW do not kill uid
 // off the wire) and holds a stale live copy of the group. A's boot re-emit must
 // converge it; a second re-emit (next boot) must change nothing.
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// G2 (design §3.3): emit gate. Belt-and-braces for the anomalous
+// live-row-beside-tombstone state (§3.6) — G1 on receivers is the load-bearing
+// mechanism; G2 stops this instance from even emitting for a dead uid.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("G2: emitGroupUpsert on a live-row-beside-tombstone zombie emits NOTHING; a non-tombstoned row still emits (negative control)", async () => {
+  const f = newFleet();
+
+  // Manufacture the anomalous state directly (design §3.6: reachable in prod
+  // only via a race/manual edit): a live plain group whose uid is tombstoned.
+  await f.A.db.execute({ sql: "INSERT INTO contact_groups (id, name) VALUES (901, 'Zombie Emitter')", args: [] });
+  const uid = (await f.A.db.execute(
+    "SELECT group_uid FROM contact_groups WHERE id = 901")).rows[0].group_uid;
+  assert.ok(uid, "trigger assigned a group_uid");
+  await f.A.db.execute(groupTombstoneStatement(uid, 4));
+
+  const wireBefore = f.wire.length;
+  await act(f.A, () => emitGroupUpsert(f.A.db, 901));
+  assert.equal(f.wire.length, wireBefore, "G2 muted the tombstoned row's emit (wire unchanged)");
+
+  // NEGATIVE CONTROL: a non-tombstoned group emits through the SAME sink —
+  // proves the muted emit above was G2, not a dead sink (anti-vacuous).
+  await f.A.db.execute({ sql: "INSERT INTO contact_groups (id, name) VALUES (902, 'Live Emitter')", args: [] });
+  await act(f.A, () => emitGroupUpsert(f.A.db, 902));
+  assert.equal(f.wire.length, wireBefore + 1, "negative control: non-tombstoned row emitted (wire +1)");
+  assert.equal(f.wire.at(-1).entry.row.name, "Live Emitter", "the emitted entry is the live group's");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T11 — G3 (design R2 F3'): the sync-conflicts RESTORE button must not
+// re-INSERT a tombstoned uid. The conflict row is seeded in the EXACT shape
+// _insertConflictRow writes on the local-wins path (op="update": row_id = JSON
+// {group_uid}, losing_data = the filtered wire row — the shape T1 asserts).
+// Driven the way the settings UI does (sync-conflicts.js handleAction →
+// restoreConflict): the first call trips the stale-snapshot guard (the
+// winning_data snapshot vs. the now-gone row) and re-snapshots — the UI's
+// confirm-again flow; the SECOND call reaches the INSERT branch G3 guards.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Seed a contact_groups op="update" conflict + drive restore twice (stale → outcome). */
+async function seedConflictAndRestore(inst, uid, tombstoned) {
+  const losing = { group_uid: uid, name: "Restored Zombie" };
+  const winning = { id: 950, group_uid: uid, name: "Local Winner", lamport_ts: 9 };
+  await inst.mgr._insertConflictRow("contact_groups", JSON.stringify({ group_uid: uid }),
+    A_ID, B_ID, 9, 12, JSON.stringify(winning), JSON.stringify(losing), "update");
+  const conflictId = (await inst.db.execute(
+    "SELECT id FROM sync_conflicts ORDER BY id DESC LIMIT 1")).rows[0].id;
+  if (tombstoned) await inst.db.execute(groupTombstoneStatement(uid, 12));
+
+  const first = await restoreConflict(inst.db, String(conflictId), { instanceSync: null });
+  assert.equal(first.status, "stale", "first click re-snapshots (the UI's double-confirm flow)");
+  const second = await restoreConflict(inst.db, String(conflictId), { instanceSync: null });
+  return { conflictId, outcome: second };
+}
+
+test("T11: restoring a contact_groups conflict whose uid is TOMBSTONED is REFUSED — no row inserted, tombstone intact, conflict left unresolved", async () => {
+  const f = newFleet();
+  const uid = "t11-" + "0".repeat(28);
+
+  const { conflictId, outcome } = await seedConflictAndRestore(f.A, uid, true);
+
+  assert.equal(outcome.status, "refused", "G3 refuses the restore (not applied, not error)");
+  assert.match(outcome.message || "", /deleted fleet-wide/i,
+    "the refusal surfaces the reason instead of claiming success");
+  assert.equal(await groupRow(f.A, uid), null, "NO contact_groups row was inserted");
+  assert.ok(await tomb(f.A, uid), "tombstone intact");
+  const c = (await f.A.db.execute({
+    sql: "SELECT resolved FROM sync_conflicts WHERE id = ?", args: [conflictId] })).rows[0];
+  assert.equal(Number(c.resolved), 0,
+    "conflict left UNRESOLVED on refusal (the data stays visible, like the D7 refusal)");
+});
+
+test("T11 negative control: the SAME conflict WITHOUT a tombstone restores — row inserted, conflict resolved (proves the harness reaches the INSERT branch)", async () => {
+  const f = newFleet();
+  const uid = "t11-neg-" + "0".repeat(24);
+
+  const { conflictId, outcome } = await seedConflictAndRestore(f.A, uid, false);
+
+  assert.equal(outcome.status, "applied", "non-tombstoned restore succeeds");
+  const row = await groupRow(f.A, uid);
+  assert.ok(row, "the losing row was re-INSERTed");
+  assert.equal(row.name, "Restored Zombie", "restored with the losing_data values");
+  const c = (await f.A.db.execute({
+    sql: "SELECT resolved FROM sync_conflicts WHERE id = ?", args: [conflictId] })).rows[0];
+  assert.equal(Number(c.resolved), 1, "conflict marked resolved on success");
+});
 
 test("T9: W4 flagless boot re-emit — a peer that paired after the delete converges (stale copy gone, tombstoned, exactly one delete-won conflict row); a second re-emit is idempotent", async () => {
   const f = newFleet();

--- a/tests/group-tombstones.test.js
+++ b/tests/group-tombstones.test.js
@@ -29,6 +29,8 @@ import { createDbClient } from "../servers/db.js";
 import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
 import { emitGroupUpsert, emitGroupDelete, __setEmitSinkForTest } from "../servers/sharing/group-sync.js";
 import { groupTombstoneStatement, readGroupTombstone } from "../servers/sharing/group-delete.js";
+import { handleContactAction } from "../servers/gateway/dashboard/panels/contacts/api-handlers.js";
+import { getGroups } from "../servers/gateway/dashboard/panels/contacts/data-queries.js";
 import { sign } from "../servers/sharing/identity.js";
 import * as ed from "../node_modules/@noble/ed25519/index.js";
 
@@ -197,6 +199,7 @@ function signedEntry(table, op, row, lamport_ts, instance_id) {
 beforeEach(async () => {
   const dbs = [createDbClient(A_FILES.path), createDbClient(B_FILES.path)];
   for (const db of dbs) {
+    await db.execute("DELETE FROM room_messages");
     await db.execute("DELETE FROM contact_group_members");
     await db.execute("DELETE FROM contact_groups");
     await db.execute("DELETE FROM group_tombstones");
@@ -468,4 +471,113 @@ test("T8b: guarded UPDATE is a no-op against the zombie state (tombstone + live 
     "membership UNTOUCHED — reconcile must be gated on rowsAffected > 0 (R2 F5)");
   assert.ok(await tomb(f.A, uid), "tombstone intact");
   assert.equal(await conflicts(f.A), c0, "zero conflict growth");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T7 — W1 atomicity through the REAL delete_group handler (design §3.3 W1):
+// handleContactAction with a fake req, the pattern the existing panel tests use.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T7: delete_group on a plain group — row gone AND tombstone standing (row's own lamport) in one call, exactly one delete emitted", async () => {
+  const f = newFleet();
+  const g = await createGroupAndEmit(f, f.A, "Handler Target");
+  // Give the row a real lamport so the tombstone's observability field is provable.
+  await f.A.db.execute({ sql: "UPDATE contact_groups SET lamport_ts = 42 WHERE id = ?", args: [g.id] });
+
+  const wireBefore = f.wire.length;
+  const res = await act(f.A, () => handleContactAction(
+    { body: { action: "delete_group", group_id: String(g.id) } }, f.A.db, { managers: {} }));
+  assert.equal(res.redirect, "/dashboard/contacts?view=groups");
+
+  assert.equal(await groupRow(f.A, g.uid), null, "row gone");
+  const t = await tomb(f.A, g.uid);
+  assert.ok(t, "tombstone standing");
+  assert.equal(Number(t.lamport_ts), 42, "tombstone carries the row's own lamport (observability only, spec §3.2)");
+
+  const emitted = f.wire.slice(wireBefore);
+  assert.equal(emitted.length, 1, "exactly one emit from the handler");
+  assert.equal(emitted[0].entry.op, "delete");
+  assert.equal(emitted[0].entry.row.group_uid, g.uid, "the delete carries the group_uid");
+});
+
+test("T7 (injected failure): when the batch's tombstone statement fails, NEITHER the DELETE nor the tombstone lands, and nothing is emitted", async () => {
+  const f = newFleet();
+  const g = await createGroupAndEmit(f, f.A, "Survivor");
+
+  // Pass-through wrapper over the REAL db: the batch runs for real, but the
+  // tombstone statement is swapped for one that violates deleted_at NOT NULL —
+  // so the batch's OTHER statement (the DELETE) executes inside the transaction
+  // and must roll back with it. This proves batch-atomicity through the real
+  // handler: two sequential db.execute calls would leave the DELETE committed.
+  const failingDb = {
+    execute: (arg) => f.A.db.execute(arg),
+    batch: (stmts) => f.A.db.batch(stmts.map((s) =>
+      typeof s !== "string" && /group_tombstones/i.test(s.sql)
+        ? { sql: "INSERT INTO group_tombstones (group_uid, lamport_ts, deleted_at) VALUES (?, 0, NULL)", args: [g.uid] }
+        : s)),
+  };
+
+  const wireBefore = f.wire.length;
+  await assert.rejects(
+    act(f.A, () => handleContactAction(
+      { body: { action: "delete_group", group_id: String(g.id) } }, failingDb, { managers: {} })),
+    /NOT NULL/i,
+    "the failed batch propagates (handler does not swallow it)",
+  );
+
+  assert.ok(await groupRow(f.A, g.uid), "DELETE rolled back — row still present");
+  assert.equal(await tomb(f.A, g.uid), null, "no tombstone landed");
+  assert.equal(f.wire.length, wireBefore, "nothing emitted after the failed batch");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T10 — room-id routing (design R2 F2') + the Groups-list filter: delete_group
+// on a ROOM must route to deleteRoom (full teardown), never tombstone, never
+// emit; and getGroups must stop returning rooms (they have their own UI).
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("T10: delete_group on a ROOM routes to deleteRoom — room+members+room_messages gone, NO tombstone, NOTHING emitted; getGroups excludes rooms", async () => {
+  const f = newFleet();
+  await seedContact(f.A, 801, "crow:roomie");
+
+  // A room row, shaped the way rooms-store.createRoom writes it
+  // (room_uid + host_crow_id + mode), with a member and a room message.
+  await f.A.db.execute({
+    sql: "INSERT INTO contact_groups (name, room_uid, host_crow_id, mode) VALUES ('War Room', ?, 'crow:host', 'addressed')",
+    args: ["f".repeat(32)],
+  });
+  const room = (await f.A.db.execute(
+    "SELECT id, group_uid, room_uid FROM contact_groups WHERE room_uid IS NOT NULL")).rows[0];
+  assert.ok(room.group_uid, "trigger stamped the room row with a group_uid too");
+  await f.A.db.execute({ sql: "INSERT INTO contact_group_members (group_id, contact_id) VALUES (?, 801)", args: [room.id] });
+  await f.A.db.execute({
+    sql: "INSERT INTO room_messages (group_id, msg_uid, content, direction) VALUES (?, 'm1', 'hi', 'received')",
+    args: [room.id],
+  });
+
+  // A plain group beside it — getGroups must keep returning plain groups.
+  const plain = await createGroupAndEmit(f, f.A, "Plain Group");
+  const listed = await getGroups(f.A.db);
+  assert.ok(listed.some((r) => Number(r.id) === Number(plain.id)), "getGroups returns the plain group");
+  assert.ok(!listed.some((r) => Number(r.id) === Number(room.id)), "getGroups does NOT return rooms (WHERE room_uid IS NULL)");
+
+  const wireBefore = f.wire.length;
+  const res = await act(f.A, () => handleContactAction(
+    { body: { action: "delete_group", group_id: String(room.id) } }, f.A.db, { managers: {} }));
+  assert.equal(res.redirect, "/dashboard/contacts?view=groups");
+
+  // deleteRoom teardown: row + members + room_messages all gone.
+  const count = async (sql, args) => Number((await f.A.db.execute({ sql, args })).rows[0].c);
+  assert.equal(await count("SELECT COUNT(*) c FROM contact_groups WHERE id = ?", [room.id]), 0, "room row gone");
+  assert.equal(await count("SELECT COUNT(*) c FROM contact_group_members WHERE group_id = ?", [room.id]), 0, "room members gone");
+  assert.equal(await count("SELECT COUNT(*) c FROM room_messages WHERE group_id = ?", [room.id]), 0, "room messages gone");
+
+  // Rooms are never synced (their own Nostr fan-out): no tombstone under EITHER
+  // of the row's uids, and the group sink captured zero entries for the delete.
+  assert.equal(await tomb(f.A, room.group_uid), null, "no tombstone for the room's group_uid");
+  assert.equal(await tomb(f.A, room.room_uid), null, "no tombstone for the room_uid");
+  assert.equal(f.wire.length, wireBefore, "NOTHING emitted for a room delete");
+
+  // The plain group beside it is untouched.
+  assert.ok(await groupRow(f.A, plain.uid), "the plain group survives");
 });

--- a/tests/groups-sync.test.js
+++ b/tests/groups-sync.test.js
@@ -113,17 +113,29 @@ test("_applyGroup: I2 — a wire-map naming a LOCAL-BOT contact does NOT add it 
   assert.deepEqual(await members(db, "gg5b"), ["crow:h2"], "resolved-but-non-syncable members (local-bot, pending) skipped on add");
 });
 
-test("_applyGroup: delete is lamport-gated + cascades membership; stale delete logs a conflict and keeps local", async () => {
+test("_applyGroup: STRICT delete-wins (2b spec §3.1) — even a LOWER-lamport delete removes the row, cascades membership, stands a tombstone, logs ONE delete-won conflict; a later higher-lamport upsert is silently dropped", async () => {
   const m = mgr(); const db = m.db;
   await db.execute({ sql: "INSERT INTO contacts (id, crow_id, ed25519_pubkey, secp256k1_pubkey) VALUES (90,'crow:z','', ?)", args: [SECP] });
   await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg6", name: "Doomed", members: ["crow:z"] }, 5));
-  // Stale delete (lower lamport) → kept.
+  // Delete at lamport 3 vs local row at lamport 5: NO lamport gate — the delete wins
+  // (a lamport-gated delete provably loses the mutual case, spec §1.1).
   await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "delete", { group_uid: "gg6" }, 3));
-  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg6'" })).rows[0].c, 1, "stale delete ignored");
-  // Newer delete → removed + membership cascade-reaped.
-  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "delete", { group_uid: "gg6" }, 9));
-  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg6'" })).rows[0].c, 0);
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg6'" })).rows[0].c, 0, "row GONE despite its newer lamport (strict delete-wins)");
   assert.deepEqual(await members(db, "gg6"), [], "membership cascade-reaped on delete");
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM group_tombstones WHERE group_uid='gg6'" })).rows[0].c, 1, "tombstone standing");
+  // Exactly ONE conflict row for this uid, labeled truthfully (spec R2 F6): delete = WINNER,
+  // the discarded local row = LOSER.
+  const rowId = JSON.stringify({ group_uid: "gg6" });
+  const { rows: cr } = await db.execute({ sql: "SELECT * FROM sync_conflicts WHERE row_id = ?", args: [rowId] });
+  assert.equal(cr.length, 1, "exactly one delete-won conflict row");
+  assert.equal(cr[0].op, "delete");
+  assert.equal(cr[0].winning_instance_id, REMOTE_ID, "winner = the deleting (remote) instance");
+  assert.equal(Number(cr[0].winning_lamport_ts), 3, "winning lamport = the delete's");
+  assert.equal(Number(cr[0].losing_lamport_ts), 5, "losing lamport = the discarded local row's");
+  // A HIGHER-lamport upsert for the tombstoned uid: silently dropped (G1 statement guard).
+  await m._applyEntry(REMOTE_ID, signedEntry("contact_groups", "update", { group_uid: "gg6", name: "Zombie", members: ["crow:z"] }, 99));
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM contact_groups WHERE group_uid='gg6'" })).rows[0].c, 0, "higher-lamport upsert dropped");
+  assert.equal((await db.execute({ sql: "SELECT COUNT(*) c FROM sync_conflicts WHERE row_id = ?", args: [rowId] })).rows[0].c, 1, "no new conflict row (silent drop)");
 });
 
 test("_applyGroup: a forged wire id/room_uid cannot hijack — id ignored, room dropped, never throws", async () => {

--- a/tests/schema-dryrun-column-diff.test.js
+++ b/tests/schema-dryrun-column-diff.test.js
@@ -119,3 +119,62 @@ test("REMOVED column (table rebuilt narrower): STOP line and exit 1", () => {
   assert.match(r.stdout, /DRY-RUN GATE FAILED/);
   assert.equal(sha256(fixtureDb), fixtureHash, "gate must never mutate the source DB");
 });
+
+// ── Item 2b follow-on: the OBJECT diff section (pipefail inversion bug) ───────
+//
+// Under `set -o pipefail`, `if diff | grep -q` took diff's exit 1 whenever
+// differences existed, so "schema objects added/removed" printed "(none)" for
+// EVERY real delta — found live by 2b's own gate run (the new table showed in
+// the column diff but not here). Indexes/triggers/views are covered ONLY by
+// that section, so a removed one must be a STOP, not just display.
+
+const addTableScript = join(dir, "migrate-add-table.mjs");
+const dropIndexScript = join(dir, "migrate-drop-index.mjs");
+const indexedDb = join(dir, "indexed-fixture.db");
+
+test("ADDED object (new table) is DISPLAYED in the object-diff section", () => {
+  writeFileSync(addTableScript, `
+    import Database from ${JSON.stringify(bsqlite)};
+    const db = new Database(process.env.CROW_DB_PATH);
+    db.exec("CREATE TABLE gadgets (id INTEGER PRIMARY KEY)");
+    db.pragma("user_version = 2");
+    db.close();
+  `);
+  const r = runGate(addTableScript);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /> table gadgets/,
+    "the new table must appear in the object-diff section (pipefail regression)");
+  assert.match(r.stdout, /DRY-RUN GATE PASSED/);
+  assert.equal(sha256(fixtureDb), fixtureHash, "gate must never mutate the source DB");
+});
+
+test("REMOVED index: named in the object diff, STOP line, exit 1", () => {
+  const db = new Database(indexedDb);
+  db.exec(`
+    CREATE TABLE parts (id INTEGER PRIMARY KEY, sku TEXT);
+    CREATE INDEX idx_parts_sku ON parts(sku);
+    INSERT INTO parts (sku) VALUES ('a'), ('b');
+  `);
+  db.pragma("user_version = 1");
+  db.close();
+  const indexedHash = sha256(indexedDb);
+  writeFileSync(dropIndexScript, `
+    import Database from ${JSON.stringify(bsqlite)};
+    const db = new Database(process.env.CROW_DB_PATH);
+    db.exec("DROP INDEX idx_parts_sku");
+    db.pragma("user_version = 2");
+    db.close();
+  `);
+  const r = spawnSync("bash", [gateScript, "indexed", indexedDb], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, DRYRUN_INIT_SCRIPT: dropIndexScript },
+  });
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /< index idx_parts_sku/,
+    "the removed index must be named in the object-diff section");
+  assert.match(r.stdout, /STOP — schema object\(s\) REMOVED/,
+    "a removed index is invisible to counts/columns — the object section must FAIL the gate");
+  assert.match(r.stdout, /DRY-RUN GATE FAILED/);
+  assert.equal(sha256(indexedDb), indexedHash, "gate must never mutate the source DB");
+});


### PR DESCRIPTION
## Problem

Group delete propagates live (`emitGroupDelete`), but nothing remembers it: a peer offline at delete time keeps the row, and any later touch (rename, membership change) re-emits it at a fresh lamport — every other instance re-INSERTs the group. Resurrection, fleet-wide. Worse, the mutual case (peer renamed the group offline at a lamport above the delete's) silently loses the delete on **both** sides — and a #155-style lamport-gated tombstone would not fix it (the higher-lamport rename would pass the gate).

## Design (spec: `docs/superpowers/specs/2026-07-13-group-tombstones-design.md`, 2 adversarial rounds)

**Strict delete-wins keyed on `group_uid`, no lamport gate.** Sound because the `contact_groups_group_uid_ai` trigger gives every genuinely new group a fresh random uid — a tombstoned uid can only ever reappear as stale state. `group_tombstones` (gen 7→8): `group_uid` PK, `lamport_ts` (observability only, gates nothing), `deleted_at`. Never pruned (any retention window re-opens the exact hole this closes).

- **W1** originating delete: DELETE + tombstone in one `db.batch`; room ids now route to `deleteRoom` (rooms were rendering in the Groups view with working delete buttons); `getGroups` filters rooms out.
- **W2** receive side: op=delete tombstones + deletes unconditionally (incl. never-held uids, pre-arming reordered arrivals); a newer local row loses but the conflict row records it truthfully (delete = winner).
- **G1** statement-level guards: `INSERT…SELECT WHERE NOT EXISTS(tombstone)` / guarded UPDATE — the invariant lives in the statement because per-peer feed drains interleave at await boundaries; member reconcile gated on `rowsAffected`.
- **W3** the deterministic legacy-uid backfill checks tombstones before regenerating a fleet-deleted uid.
- **W4** flagless every-boot tombstone re-emit — covers peers paired *after* the delete (feeds are born empty; a per-peer done-flag would survive revoke/re-pair and strand exactly the peer this exists for).
- **G2** emit gate (fail-open) + **G3** the sync-conflicts Restore button can no longer re-insert a fleet-deleted uid.
- Bonus: the schema dry-run gate's object-diff section was pipefail-inverted (always printed "(none)"); fixed, and a removed index/trigger/view is now a STOP.

## Verification

- Two-instance executable gate (`tests/group-tombstones.test.js`, 17 tests): the resurrection defect reproduced RED-first in both drain orders; mutual case, restart durability, mutual delete, negative controls, atomicity via injected batch failure through the real handler, boot re-emit convergence + idempotence, restore-guard. Every guard mutation-checked against its NAMED test (incl. one vacuous-test catch and one mutation hole found in per-task review, both fixed).
- Full suite on scratch env: 1769 tests, 1766 pass — the 3 fails are the known pre-existing baseline. check-ports + build-registry green.
- Schema dry-run gate run from this branch against copies of all four prod DBs: `+ table group_tombstones` is the sole object delta, `user_version` 7→8, zero row-count deltas, integrity ok ×4.

Deploy per the §3 migration rail (auto-update disabled fleet-wide for the window; backups taken; manual deploy in runbook order; auto-update re-enabled and confirmed after).