### PR TITLE
Item 3: minors batch — findContactByPubkey determinism, receive-health test hardening, invite-page light-mode fix

### DIFF
--- a/docs/public/invite/index.html
+++ b/docs/public/invite/index.html
@@ -10,7 +10,16 @@
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
          max-width: 560px; margin: 0 auto; padding: 24px 16px; line-height: 1.5;
          background: #0f1115; color: #e6e6e6; }
-  @media (prefers-color-scheme: light) { body { background: #fafafa; color: #1a1a1a; } .card { background:#fff !important; border-color:#ddd !important; } code { background:#eee !important; } }
+  @media (prefers-color-scheme: light) {
+    body { background: #fafafa; color: #1a1a1a; }
+    .card { background:#fff !important; border-color:#ddd !important; }
+    code { background:#eee !important; }
+    /* F-UI-2: these kept their dark backgrounds while the text color flipped
+       near-black — dark-on-dark invite code and buttons in light mode. */
+    .code { background:#eef0f4 !important; }
+    button { background:#eef0f4 !important; border-color:#c8ccd4 !important; }
+    a { color:#2456c8; }
+  }
   h1 { font-size: 1.3rem; } h2 { font-size: 1rem; margin-top: 1.4rem; }
   .card { background: #181b22; border: 1px solid #2a2f3a; border-radius: 10px; padding: 16px; margin: 14px 0; }
   code, .code { font-family: ui-monospace, Menlo, Consolas, monospace; }

--- a/servers/sharing/contact-promote.js
+++ b/servers/sharing/contact-promote.js
@@ -144,8 +144,8 @@ export async function upsertFullContact(db, managers, { crowId, ed25519Pub, secp
   // identical to today (MERGE/PROMOTE emit `update`, CREATE emits `insert`).
   const tomb = await readTombstone(db, crowId);
 
-  // Deterministic resolution — do NOT use findContactByPubkey (no ORDER BY →
-  // arbitrary single row). Get the crowId owner (unique) and ALL secp matches.
+  // Do NOT use findContactByPubkey here — it returns a single row, and the
+  // MERGE path below needs the crowId owner (unique) plus ALL secp matches.
   const byCrow = (await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = ?", args: [crowId] })).rows[0] || null;
   const secpRows = (await db.execute({
     sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ? ORDER BY id ASC",

--- a/servers/sharing/pubkey-util.js
+++ b/servers/sharing/pubkey-util.js
@@ -30,13 +30,19 @@ export function normalizePubkey(pk) {
  * 64 hex chars so a 66-hex compressed key and its 64-hex x-only tail
  * resolve to the same contact. Returns the row or null. Never throws
  * (bad/missing db, null/short pk, or a query error all resolve to null).
+ *
+ * Multi-row matches are legal (no unique index on secp256k1_pubkey — a real
+ * `crow:` contact and a `req:<secp>` placeholder coexist on the same key), so
+ * the pick must be deterministic: a real contact beats a `req:` placeholder
+ * (every caller wants the row that carries block status / receipts / the
+ * user-visible conversation), then lowest id as a stable tiebreak.
  */
 export async function findContactByPubkey(db, pk) {
   try {
     const normalized = normalizePubkey(pk);
     if (!normalized) return null;
     const { rows } = await db.execute({
-      sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ?",
+      sql: "SELECT * FROM contacts WHERE lower(substr(secp256k1_pubkey,-64)) = ? ORDER BY (crow_id LIKE 'req:%') ASC, id ASC",
       args: [normalized],
     });
     return rows && rows.length > 0 ? rows[0] : null;

--- a/tests/nostr-receive-health-hooks.test.js
+++ b/tests/nostr-receive-health-hooks.test.js
@@ -37,6 +37,22 @@ function encryptToUs(plaintext) {
   return nip44.v2.encrypt(plaintext, convKey);
 }
 
+// The captured onevent is resilient-subscribe.js's `wrapped()`, which invokes
+// the real async handler WITHOUT awaiting it (a relay callback must never
+// block on our work). `await onevent(event)` therefore gives no happens-after
+// guarantee for the handler's chain — today the health stamps happen before
+// the handler's first await, but that ordering is incidental, not contractual.
+// Poll for the eventually-consistent outcome instead (the
+// tests/block-onevent-guard.test.js pattern).
+async function waitFor(predicate, { timeoutMs = 2000, intervalMs = 10 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 test("_doConnectRelays mirrors relay count into receive-health", async () => {
   _resetReceiveHealth();
   const mgr = new NostrManager(identity, null);
@@ -57,7 +73,7 @@ test("subscribeToContact: successful decrypt stamps lastInboundAt", async () => 
   await relay.subscribeCalls[0].onevent({
     id: "e1", pubkey: theirPub, created_at: 1_700_000_000, content: encryptToUs("hello"),
   });
-  assert.notEqual(getReceiveHealth().lastInboundAt, null);
+  assert.ok(await waitFor(() => getReceiveHealth().lastInboundAt !== null), "lastInboundAt never stamped");
   assert.equal(getReceiveHealth().decryptFailures, 0);
   await mgr.destroy();
 });
@@ -71,7 +87,7 @@ test("subscribeToContact: failed decrypt increments decryptFailures, no inbound 
   await relay.subscribeCalls[0].onevent({
     id: "e2", pubkey: theirPub, created_at: 1_700_000_000, content: "not-nip44-garbage",
   });
-  assert.equal(getReceiveHealth().decryptFailures, 1);
+  assert.ok(await waitFor(() => getReceiveHealth().decryptFailures === 1), "decryptFailures never incremented");
   assert.equal(getReceiveHealth().lastInboundAt, null);
   await mgr.destroy();
 });
@@ -85,10 +101,10 @@ test("subscribeToIncoming: decrypt stamps inbound; garbage increments counter", 
   await relay.subscribeCalls[0].onevent({
     id: "e3", pubkey: theirPub, created_at: 1_700_000_000, content: encryptToUs("plain hi"),
   });
-  assert.notEqual(getReceiveHealth().lastInboundAt, null);
+  assert.ok(await waitFor(() => getReceiveHealth().lastInboundAt !== null), "lastInboundAt never stamped");
   await relay.subscribeCalls[0].onevent({
     id: "e4", pubkey: theirPub, created_at: 1_700_000_001, content: "garbage",
   });
-  assert.equal(getReceiveHealth().decryptFailures, 1);
+  assert.ok(await waitFor(() => getReceiveHealth().decryptFailures === 1), "decryptFailures never incremented");
   await mgr.destroy();
 });

--- a/tests/pubkey-util.test.js
+++ b/tests/pubkey-util.test.js
@@ -80,6 +80,44 @@ test("findContactByPubkey: 66-hex compressed key stored, found by its 64-hex x-o
   assert.equal(notFound, null, "unknown key must resolve to null");
 });
 
+test("findContactByPubkey: multi-row pubkey match resolves deterministically — real crow: row beats req: placeholder, then lowest id", async () => {
+  // No unique index on secp256k1_pubkey (documented at instance-sync.js §GC
+  // tombstone notes): a real `crow:` contact and a `req:<secp>` placeholder
+  // legitimately coexist on the same key. Every boot.js caller wants the REAL
+  // contact (block status, receipts, display-name all live there; the
+  // catch-all DM path double-stores if it picks the placeholder).
+  const xonly = "d".repeat(64);
+  const compressed = "02" + xonly;
+
+  // Insert the placeholder FIRST so natural scan order would return it.
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey, request_status) VALUES (?,?,?,?,?)",
+    args: ["req:" + xonly, "Request placeholder", "", compressed, "pending"],
+  });
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
+    args: ["crow:pubkeyutil-real", "Real Contact", "ed25519-placeholder", compressed],
+  });
+
+  const found = await findContactByPubkey(db, xonly);
+  assert.ok(found, "expected a contact");
+  assert.equal(found.crow_id, "crow:pubkeyutil-real", "real crow: row must beat the req: placeholder");
+
+  // Two real rows on the same key → lowest id wins (stable tiebreak, the
+  // contact-promote.js ORDER BY id ASC precedent).
+  const xonly2 = "e".repeat(64);
+  const a = await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
+    args: ["crow:pubkeyutil-a", "A", "", "02" + xonly2],
+  });
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, display_name, ed25519_pubkey, secp256k1_pubkey) VALUES (?,?,?,?)",
+    args: ["crow:pubkeyutil-b", "B", "", "03" + xonly2],
+  });
+  const picked = await findContactByPubkey(db, xonly2);
+  assert.equal(Number(picked.id), Number(a.lastInsertRowid), "lowest id must win among equal-rank rows");
+});
+
 test("findContactByPubkey never throws on null/short input", async () => {
   assert.equal(await findContactByPubkey(db, null), null);
   assert.equal(await findContactByPubkey(db, ""), null);


### PR DESCRIPTION
Pooled minors batch (master plan §4 Item 3). Triage pass ran first against current main; the PR contains only survivors.

## Shipped

**M1 — findContactByPubkey deterministic pick** (`servers/sharing/pubkey-util.js`)
No ORDER BY meant an arbitrary single row on multi-row pubkey matches (a real `crow:` contact and a `req:<secp>` placeholder legitimately coexist — no unique index on secp256k1_pubkey). Now: real contact beats `req:` placeholder, then lowest id. All five boot.js callers want the real row (block status, receipts, display-name live there; the catch-all DM path could double-store when picking the placeholder). RED-first test covers preference + tiebreak; the RED run doubles as the mutation check.

**M2 — receive-health test hardening** (`tests/nostr-receive-health-hooks.test.js`, test-only)
The captured onevent is resilient-subscribe's `wrapped()`, which fires the async handler without awaiting — `await onevent(...)` gives no happens-after guarantee. The tests passed only because the health stamps happen before the handler's first await today. Now polls via the block-onevent-guard `waitFor` pattern. Mutation-checked live: disabling `markInbound()` reddens the named test.

**M6 / F-UI-2 — invite page dark-on-dark in light mode** (`docs/public/invite/index.html`, public site — authorized 2026-07-12)
The light-mode media query overrode body/.card/code but not `.code` (invite code box) or `button` — dark backgrounds with near-black inherited text. CDP computed-style proof: light-mode contrast was **1.07:1 / 1.19:1**, now **15.25:1**; dark mode ratios unchanged (14.89 / 11.75). Evidence: `~/.crow/p4/item3-minors/`. Rides deploy-docs → GitHub Pages; rollback = revert this file, re-run deploy-docs.

Plus a review fix: `contact-promote.js` comment cited the now-stale "no ORDER BY" reason.

## Dropped at triage (with why)

- **null-syncManager no-heal guard** — DEAD: the manager is constructed unconditionally (`createSharingServer` → `getSharedManagers` at `mcp-mounts.js:28`) before the gate at `:30`; the null arm is unreachable in a real boot, and the `feedsDisabled` no-op is deliberate R2 MAJOR-A design (`profile-heal.js` docblock).
- **req:-row delete propagation** — deliberate per-instance design, documented at the decline site (`messages/api-handlers.js:351`) and `contact-delete.js` §D3; `req:` rows never sync, so there is no resurrection bug. Cross-instance dismissal visibility would be sync-layer design work (needs the executable two-instance gate per the 2a lesson), not a minor.
- **F-SETTINGS-2 raw i18n keys** — STRUCK: the two live keys (`settings.section.unifiedDashboard`/`sharedStorage`, bughunt-20260711) were fixed by #165; live sweep of all 27 registered settings sections on prod = zero raw keys. The four remaining missing labelKeys belong to unregistered legacy section files (`panels/settings.js:52`) — dead code.
- **black-swan dormant crow feed** (follow-up pool) — NOT A DEFECT: the crow↔black-swan pairing was deliberately deleted at the messages-arc close (07-11); black-swan runs its own identity now, so it is not expected to receive instance-sync group events. Side observation: grackle still holds a stale trusted "Cloud (black-swan)" instance row and dials its tailnet-sync endpoint ~1/min (`handshake sig invalid` in bswan's journal) — that is the known out-of-scope grackle↔black-swan re-pair operator matter.

## Gates

- Suite on scratch env: 1769 pass / 3 fails = exactly the known baseline trio (2× bundles-validate-install, 1× instance-sync lamport) / 0 skips.
- check-port-allocation: error block is exactly the one known line (Port 8090 capstone-tracker).
- build-registry --check: OK (94 bundles).
- Reviewer verdict on the branch diff: READY TO MERGE (one MINOR, fixed in-branch).