### PR TITLE
Item 3.5: registry provenance — third-party listings get an honest Community badge instead of a forced official stamp

### DIFF
--- a/docs/developers/bundles.md
+++ b/docs/developers/bundles.md
@@ -43,6 +43,34 @@ Unknown fields are allowed (the schema is lenient) — bundle-specific extras li
 - `"draft": true` excludes a bundle from the generated registry.
 - An **untracked** bundle dir (not committed to git) is treated as an implicit draft — excluded and reported, never auto-published. This keeps work-in-progress out of the registry.
 
+## Contributing a third-party bundle (provenance)
+
+Third-party contributions are welcome, and they are listed honestly — never presented
+as first-party. Declare provenance in the manifest:
+
+```json
+{ "origin": "community" }
+```
+
+- `origin: "community"` → the generated registry entry carries `official: false`
+  (plus the `origin` field), and the store renders a **Community** badge on the card
+  and a "not verified by Crow" caution in the install modal.
+- Omitting `origin` (or `origin: "official"`) keeps `official: true`. A manifest
+  `official` field is always ignored — the registry derives it; you cannot opt into
+  the Official badge by declaring it.
+- Community bundles are not eligible for `featured` placement or curated collections.
+
+The bar for a third-party listing (reviewers will check all of these):
+
+- A **real, reachable upstream** with a disclosed operator (who runs the service,
+  and under what terms — a public terms/privacy page counts; anonymity does not).
+- An **accurate `author`** — the contributor or vendor, never "Crow".
+- **Functional out of the box**: the bundle's declared surfaces (skills, server,
+  docker) must actually work with what the bundle installs. A skill describing API
+  workflows nothing in the bundle can execute is not functional.
+- Scope honesty: the skill/manifest must not claim less access than the upstream
+  API grants without saying so (e.g. "read-only" atop a write-capable key).
+
 ## Validate + generate
 
 ```bash

--- a/registry/manifest.schema.json
+++ b/registry/manifest.schema.json
@@ -15,6 +15,7 @@
     "author": { "type": "string", "minLength": 1 },
     "draft": { "type": "boolean" },
     "official": { "type": "boolean" },
+    "origin": { "type": "string", "enum": ["official", "community"] },
     "icon": { "type": "string" },
     "tags": { "type": "array", "items": { "type": "string" } },
     "notes": { "type": "string" },

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -73,8 +73,13 @@ export function buildRegistry(opts = {}) {
     else if (!isTracked) status = "untracked";
     audit.push({ id, type: manifest.type, surfaces: detectSurfaces(manifest), ok, errors, status });
     if (ok && !isDraft && isTracked) {
+      // `official` is DERIVED, never trusted from the manifest: first-party
+      // (no `origin`, or `origin: "official"`) stamps true; a third-party
+      // listing declares `origin: "community"` and gets false. The `origin`
+      // field itself rides through via ...rest so the store can render
+      // provenance. Bogus origin values are rejected by the schema enum.
       const { official: _ignored, ...rest } = manifest;
-      entries.push({ ...rest, official: true });
+      entries.push({ ...rest, official: rest.origin !== "community" });
     }
   }
   entries.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));

--- a/servers/gateway/dashboard/panels/extensions/data-queries.js
+++ b/servers/gateway/dashboard/panels/extensions/data-queries.js
@@ -130,8 +130,12 @@ export async function fetchRegistryData() {
     ...localAddons,
   ];
 
-  // Merge official add-ons with community store add-ons
-  const officialAddons = mergedAddons.map((a) => ({ ...a, _community: false }));
+  // Merge registry add-ons with community store add-ons. A registry entry can
+  // itself be a third-party listing (manifest origin: "community" → the
+  // generated entry carries official: false) — those get the same Community
+  // badge + install-modal caution as community-store add-ons, so _community
+  // means "not maintained by Crow", not "came from a community store".
+  const officialAddons = mergedAddons.map((a) => ({ ...a, _community: a.official === false }));
   const communityStores = getStores();
   const communityResults = await Promise.all(communityStores.map((s) => fetchCommunityStore(s.url)));
   const communityAddons = communityResults.flatMap((r) => r.addons);

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -1674,7 +1674,7 @@ export async function runInstallJob(bundleId, envVars, { job, installedSnapshot,
  * stops a tampered file from one-click-installing a privileged, consent-required,
  * or host-networking bundle without the consent ceremony.
  */
-export function validateCollectionServerSide(collection) {
+export function validateCollectionServerSide(collection, { manifestFor = getManifest } = {}) {
   if (!collection || !Array.isArray(collection.members) || collection.members.length === 0) {
     return { ok: false, error: "Collection has no members" };
   }
@@ -1682,7 +1682,13 @@ export function validateCollectionServerSide(collection) {
   for (const m of collection.members) {
     if (!m?.id || !isValidBundleId(m.id)) return { ok: false, error: `Invalid member id '${m?.id}'` };
     if (!existsSync(join(APP_BUNDLES, m.id))) return { ok: false, error: `Member '${m.id}' is not a known bundle` };
-    const man = getManifest(m.id);
+    const man = manifestFor(m.id);
+    if (man?.origin === "community") {
+      // Provenance: curated collections are first-party only. A third-party
+      // listing must be installed individually, where the store surfaces its
+      // Community badge and caution (docs/developers/bundles.md).
+      return { ok: false, error: `Member '${m.id}' is a community bundle — install it individually` };
+    }
     if (man?.privileged === true || man?.consent_required === true) {
       return { ok: false, error: `Member '${m.id}' requires explicit consent — install it individually` };
     }

--- a/tests/bundle-contract.test.js
+++ b/tests/bundle-contract.test.js
@@ -182,6 +182,37 @@ test("buildRegistry: invalid manifest excluded and flagged", () => {
   assert.equal(audit.find((a) => a.id === "bad").status, "invalid");
 });
 
+test("buildRegistry: manifest origin community → official:false, origin passed through (third-party provenance)", () => {
+  const root = fakeBundlesRoot({
+    thirdparty: mk("thirdparty", { origin: "community", author: "Some Vendor" }),
+    firstparty: mk("firstparty"),
+  });
+  const { registry } = buildRegistry({ bundlesRoot: root, tracked: null });
+  const third = registry["add-ons"].find((e) => e.id === "thirdparty");
+  const first = registry["add-ons"].find((e) => e.id === "firstparty");
+  assert.equal(third.official, false, "community-origin entry must not be stamped official");
+  assert.equal(third.origin, "community", "origin must pass through to the registry entry");
+  assert.equal(first.official, true, "origin-less entry keeps official:true (back-compat)");
+  assert.equal("origin" in first, false, "origin-less entry gains no origin key (registry byte-compat)");
+});
+
+test("buildRegistry: origin official is accepted and equals the default; bogus origin → invalid", () => {
+  const root = fakeBundlesRoot({ explicit: mk("explicit", { origin: "official" }) });
+  const { registry } = buildRegistry({ bundlesRoot: root, tracked: null });
+  assert.equal(registry["add-ons"][0].official, true);
+
+  const root2 = fakeBundlesRoot({ sneaky: mk("sneaky", { origin: "totally-legit" }) });
+  const { registry: r2, audit } = buildRegistry({ bundlesRoot: root2, tracked: null });
+  assert.equal(r2["add-ons"].length, 0, "an unknown origin value must not publish");
+  assert.equal(audit.find((a) => a.id === "sneaky").status, "invalid");
+});
+
+test("buildRegistry: a community manifest cannot smuggle official:true (field is derived, never trusted)", () => {
+  const root = fakeBundlesRoot({ liar: mk("liar", { origin: "community", official: true }) });
+  const { registry } = buildRegistry({ bundlesRoot: root, tracked: null });
+  assert.equal(registry["add-ons"][0].official, false, "manifest official must be ignored; origin decides");
+});
+
 test("formatRegistry: 2-space indent + trailing newline", () => {
   const out = formatRegistry({ version: 2, "add-ons": [] });
   assert.ok(out.endsWith("}\n"));

--- a/tests/bundles-install-set.test.js
+++ b/tests/bundles-install-set.test.js
@@ -44,3 +44,14 @@ test("needsConfigKeys reports manifest-required keys that are EMPTY in the writt
   assert.deepEqual(keys, ["JELLYFIN_API_KEY"]);
   assert.deepEqual(needsConfigKeys("jellyfin", { JELLYFIN_URL: "http://x", JELLYFIN_API_KEY: "abc" }), []);
 });
+
+test("server-side re-validation REFUSES a community-origin member (provenance: collections are first-party only)", () => {
+  // 'podcast' exists on disk (the existsSync gate must pass); the injected
+  // manifestFor stubs its manifest as a third-party listing. Community bundles
+  // must never ride the one-click install-set path — install individually,
+  // where the store shows the provenance caution.
+  const col = { id: "c", name: "C", description: "", icon: "home", members: [{ id: "podcast", kind: "deploys" }] };
+  const r = validateCollectionServerSide(col, { manifestFor: () => ({ origin: "community" }) });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /community/i);
+});

--- a/tests/extensions-collections.test.js
+++ b/tests/extensions-collections.test.js
@@ -35,6 +35,20 @@ test("HARD RULE: every member exists in the official registry and on disk", () =
   }
 });
 
+test("HARD RULE: every member is first-party — community-origin bundles are collection-ineligible", () => {
+  // Provenance (docs/developers/bundles.md): a third-party listing must be
+  // installed individually, where the store shows its Community badge and
+  // caution. The registry entry is the derived truth (official comes from
+  // manifest origin); validateCollectionServerSide enforces the same rule live.
+  for (const c of loadCollections()) {
+    for (const m of c.members) {
+      const entry = byId.get(m.id);
+      assert.notEqual(entry?.official, false, `${c.id}: '${m.id}' is a community bundle — not eligible for curated collections`);
+      assert.notEqual(manifestOf(m.id)?.origin, "community", `${c.id}: bundles/${m.id} declares origin community`);
+    }
+  }
+});
+
 test("HARD RULE: no member is privileged, consent_required, or GPU-gated", () => {
   for (const c of loadCollections()) {
     for (const m of c.members) {

--- a/tests/extensions-data-queries.test.js
+++ b/tests/extensions-data-queries.test.js
@@ -20,7 +20,7 @@ const fixtureInstalled = {
 };
 writeFileSync(join(scratchHome, "installed.json"), JSON.stringify(fixtureInstalled, null, 2));
 
-const { getInstalled, CROW_DIR, INSTALLED_PATH } = await import("../servers/gateway/dashboard/panels/extensions/data-queries.js");
+const { getInstalled, fetchRegistryData, CROW_DIR, INSTALLED_PATH } = await import("../servers/gateway/dashboard/panels/extensions/data-queries.js");
 
 test("getInstalled() resolves CROW_DIR from CROW_HOME, not the operator's real ~/.crow", () => {
   // The module must have derived its paths from the scratch CROW_HOME we set above,
@@ -39,6 +39,37 @@ test("getInstalled() resolves CROW_DIR from CROW_HOME, not the operator's real ~
   // show up here.
   for (const id of ids) {
     assert.doesNotMatch(id, /maker/i, "an operator-prod entry leaked into the scratch-home result");
+  }
+});
+
+test("fetchRegistryData derives _community from the entry's own official field (registry provenance)", async () => {
+  // Stub the remote-registry fetch: one third-party entry (official:false, the
+  // build-registry output for manifest origin:"community"), one pre-provenance
+  // entry with official ABSENT (a stale remote mirror) — the conservative
+  // default must treat it as first-party. The repo's local registry entries
+  // (all official:true) merge in and must all stay _community:false.
+  const remote = {
+    "add-ons": [
+      { id: "zz-thirdparty-fixture", name: "ZZ Third Party", description: "d", type: "skill", category: "misc", official: false, origin: "community" },
+      { id: "zz-stale-mirror-fixture", name: "ZZ Stale", description: "d", type: "skill", category: "misc" },
+    ],
+  };
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, json: async () => remote });
+  try {
+    const { available } = await fetchRegistryData();
+    const third = available.find((a) => a.id === "zz-thirdparty-fixture");
+    const stale = available.find((a) => a.id === "zz-stale-mirror-fixture");
+    assert.ok(third, "stubbed community entry missing from available");
+    assert.equal(third._community, true, "official:false entry must be _community (Community badge + install caution)");
+    assert.equal(stale._community, false, "official-absent entry must default to first-party, never falsely badged");
+    const locals = available.filter((a) => !a.id.startsWith("zz-"));
+    assert.ok(locals.length > 50, "local registry entries should have merged in");
+    for (const a of locals) {
+      assert.equal(a._community, false, `local first-party entry '${a.id}' must not be _community`);
+    }
+  } finally {
+    globalThis.fetch = realFetch;
   }
 });
 


### PR DESCRIPTION
Kevin authorized third-party listings (2026-07-13); PR #99's review showed the store STRUCTURALLY could not list one honestly — `build-registry.mjs` stripped any manifest `official` field and force-stamped `official: true` on every in-repo bundle.

## What changed

- **Manifest `origin` field** (`registry/manifest.schema.json`): optional enum `"official" | "community"`. A bogus value fails the schema → bundle is `invalid`, never published.
- **`scripts/build-registry.mjs`**: `official` is now DERIVED (`origin !== "community"`), never trusted from the manifest (a community manifest cannot smuggle `official: true`). `origin` rides through to the registry entry. **The committed registry regenerates byte-identical** — no existing bundle declares `origin`.
- **Store UI** (`extensions/data-queries.js`): `_community` now means "not maintained by Crow" — a registry entry with `official: false` gets the same treatment as community-store add-ons: Community badge + "Not verified by Crow" tooltip on the card, caution box in the install modal, excluded from `featured`. The badge/caution rendering already existed for community stores; this bridges in-repo third-party entries into it. Entries with `official` absent (stale remote mirrors) conservatively stay first-party.
- **Collections enforcement** (review MAJOR): the docs' "community bundles are not eligible for curated collections" claim is now enforced in code — `validateCollectionServerSide` rejects `origin: "community"` members (injectable `manifestFor` seam, prod call site unchanged), plus a static curation gate over shipped `collections.json`.
- **Docs** (`docs/developers/bundles.md`): "Contributing a third-party bundle" — the `origin` declaration, badge behavior, and the listing bar (disclosed operator, accurate author, functional out of the box, scope honesty).

## Verification

- Contract tests (RED-first): community origin → `official: false` + `origin` pass-through; origin-less byte-compat; bogus origin invalid; official-smuggle blocked; `_community` derivation incl. the official-absent default (mutation-checked: inverting the derivation reddens the named test); collection guard (RED run = mutation evidence).
- **CDP proof on a scratch gateway** (throwaway clone + fixture bundle with `origin: "community"`, scratch CROW_HOME): 6/6 — Community badge + tooltip + `data-community="true"` on the fixture card, Official badge on the control card, install-modal caution present for the fixture and absent for the official control. Evidence: `~/.crow/p4/item35-provenance/` (assertions.jsonl + 3 screenshots).
- Install-path safety (reviewer-traced): `official`/`origin`/`_community` never touch install resolution — `validateInstall`/`runInstallJob` resolve purely by bundle id from the local `bundles/` dir; the flag only affects badges, the caution, and featured/collections eligibility.
- Suite on scratch env: 1775 pass / 3 fails = exactly the known baseline trio / 0 skips. check-ports: exactly the one known capstone line. build-registry --check: OK, registry in sync.
- Review: 2 rounds (initial FIX FIRST with 2 MAJORs → both closed → **READY TO MERGE**).

## Operator note (no action taken)

`bundles/rookery/manifest.json` declares `official: false` — a dead field both before and after this PR (build-registry ignores it). If rookery should carry the Community badge, migrate it to `origin: "community"`; that changes its live store presentation, so it's your call.

PR #99 remains declined-as-is per the Item 2.9 record (upstream transparency), independent of this mechanism.