### PR TITLE
Item 4 PR2: onboarding wizard grows AI-provider and starter-collections steps; show-password toggle

### DIFF
--- a/servers/gateway/dashboard/panels/onboarding.js
+++ b/servers/gateway/dashboard/panels/onboarding.js
@@ -9,12 +9,14 @@
  *   - Reaching the "done" step sets onboarding_completed_at (first time only)
  *   - Done step shows a subtle CSS-only celebration + "what to try" cards
  */
-import { stepper, section, callout, button } from "../shared/components.js";
+import { stepper, section, callout, button, escapeHtml } from "../shared/components.js";
 import { t, SUPPORTED_LANGS } from "../shared/i18n.js";
 import { parseCookies } from "../auth.js";
 import { upsertSetting, readSetting } from "../settings/registry.js";
+import { loadCollections } from "./extensions/collections.js";
 
-const STEP_KEYS = ["welcome", "integrations", "bot", "connect", "done"];
+/** Exported so tests derive step positions (indexOf/length) instead of pinning indices. */
+export const STEP_KEYS = ["welcome", "ai", "integrations", "bot", "starter", "connect", "done"];
 
 /**
  * Resolve language cookie-first. The panel-dispatch lang derives from the DB
@@ -99,7 +101,25 @@ function renderActionCards(lang) {
       ${button(t(c.actionKey, lang), { variant: "secondary", size: "sm", href: c.href, attrs: cardLinkAttrs(c.href) })}
     </div>`).join("");
 
-  return `<div class="onboarding-action-cards">${cardHtml}</div>`;
+  return `${CARD_CSS}<div class="onboarding-action-cards">${cardHtml}</div>`;
+}
+
+/**
+ * Starter-collection cards (4d): one card per registry/collections.json entry —
+ * title, description, member count. Orientation only: install UX lives on the
+ * extensions page, so the single deepLink below the grid is the only action.
+ * loadCollections() never throws (missing/corrupt file → []); empty → no grid.
+ */
+function renderStarterCards(lang) {
+  const collections = loadCollections();
+  if (!collections.length) return "";
+  const cardHtml = collections.map((c) => `
+    <div class="onboarding-action-card">
+      <div class="onboarding-action-card-title">${escapeHtml(c.name || c.id)}</div>
+      <div class="onboarding-action-card-body">${escapeHtml(c.description || "")}</div>
+      <div class="onboarding-action-card-count">${t("onboarding.starterMemberCount", lang).replace("{n}", String(c.members.length))}</div>
+    </div>`).join("");
+  return `${CARD_CSS}<div class="onboarding-action-cards">${cardHtml}</div>`;
 }
 
 /**
@@ -142,6 +162,16 @@ const CELEBRATION_CSS = `
   color: var(--crow-success);
   font-size: var(--crow-text-base);
 }
+</style>
+`;
+
+/**
+ * Action-card grid CSS — shared by the done step's "what to try" cards and the
+ * starter step's collection cards (each step is its own page, so emitting the
+ * <style> block per step never duplicates it in one document).
+ */
+const CARD_CSS = `
+<style>
 .onboarding-action-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -168,13 +198,56 @@ const CELEBRATION_CSS = `
   line-height: var(--crow-leading-relaxed);
   flex: 1;
 }
+.onboarding-action-card-count {
+  font-size: var(--crow-text-sm);
+  color: var(--crow-text-tertiary);
+}
 </style>
 `;
 
-function renderStepBody(stem, lang) {
+/**
+ * Count enabled rows in the providers table. Returns null when there is no db
+ * or the query fails — the caller renders no count claim at all in that case
+ * (asserting "nothing configured yet" on a db error could be a lie, and the
+ * wizard must never 500 over an orientation detail).
+ * @returns {Promise<number|null>}
+ */
+async function countProviders(db) {
+  if (!db) return null;
+  try {
+    const { rows } = await db.execute("SELECT COUNT(*) AS n FROM providers WHERE disabled = 0");
+    const n = Number(rows?.[0]?.n);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string} stem - STEP_KEYS entry
+ * @param {string} lang
+ * @param {{providersCount?: number|null}} [ctx] - server-fetched data the step
+ *   body needs (only the ai step today); handler-populated so this stays sync.
+ */
+function renderStepBody(stem, lang, ctx = {}) {
   const body = `<p style="font-size:var(--crow-text-base);line-height:var(--crow-leading-relaxed);color:var(--crow-text-secondary);margin-bottom:var(--crow-space-4)">${t(`onboarding.${stem}.body`, lang)}</p>`;
   const linkWrap = (html) => `<div style="margin-top:var(--crow-space-4)">${html}</div>`;
   switch (stem) {
+    case "ai": {
+      const n = ctx.providersCount;
+      let note = "";
+      if (n === 0) {
+        note = callout(t("onboarding.aiEmptyNote", lang), "info");
+      } else if (typeof n === "number" && n > 0) {
+        note = callout(t("onboarding.aiConfiguredNote", lang).replace("{n}", String(n)), "info");
+      }
+      // n == null (no db / query failed): no count claim either way.
+      return body + note
+        + linkWrap(deepLink(t("onboarding.openProviders", lang), "/dashboard/settings?section=llm&tab=providers"));
+    }
+    case "starter":
+      return body + renderStarterCards(lang)
+        + linkWrap(deepLink(t("onboarding.openCollections", lang), "/dashboard/extensions#collections"));
     case "integrations":
       return body + callout(t("onboarding.integrationsNote", lang), "info")
         + linkWrap(deepLink(t("onboarding.openIntegrations", lang), "/dashboard/settings?section=integrations"));
@@ -245,10 +318,14 @@ export default {
       } catch {}
     }
 
+    // The ai step's copy is conditional on whether any provider is configured;
+    // fetch the count server-side only when that step is the one rendering.
+    const ctx = stem === "ai" ? { providersCount: await countProviders(db) } : {};
+
     const steps = STEP_KEYS.map((k) => ({ label: t(`onboarding.${k}.title`, lang) }));
     const content =
       stepper(steps, current) +
-      section(t(`onboarding.${stem}.title`, lang), renderStepBody(stem, lang)) +
+      section(t(`onboarding.${stem}.title`, lang), renderStepBody(stem, lang, ctx)) +
       renderNav(current, lang);
 
     return layout({ title: t("onboarding.title", lang), content });

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -49,6 +49,7 @@ export const translations = {
   "login.passwordPlaceholder": { en: "Password", es: "Contraseña" },
   "login.choosePasswordPlaceholder": { en: "Choose a password (12+ characters)", es: "Elige una contraseña (12+ caracteres)" },
   "login.confirmPlaceholder": { en: "Confirm password", es: "Confirmar contraseña" },
+  "login.showPassword": { en: "Show password", es: "Mostrar contraseña" },
   "login.loginButton": { en: "Login", es: "Iniciar sesión" },
   "login.setPasswordButton": { en: "Set Password", es: "Establecer contraseña" },
   "login.setupTokenError": { en: "Use the link you were sent to set up your password.", es: "Usa el enlace que te enviaron para establecer tu contraseña." },
@@ -1335,6 +1336,20 @@ export const translations = {
     en: "Crow is your persistent memory and research assistant. It remembers what matters and works across the AI clients you already use. This short tour points you to the few things worth setting up.",
     es: "Crow es tu asistente de memoria persistente e investigación. Recuerda lo importante y funciona con los clientes de IA que ya usas. Este breve recorrido te muestra las pocas cosas que vale la pena configurar.",
   },
+  "onboarding.ai.title": { en: "Set up an AI model", es: "Configura un modelo de IA" },
+  "onboarding.ai.body": {
+    en: "Agents, chat, and voice all need a model provider — a local model server or a cloud API key. You manage providers in Settings, and Crow routes each feature to the right one.",
+    es: "Los agentes, el chat y la voz necesitan un proveedor de modelos: un servidor de modelos local o una clave API en la nube. Administra los proveedores en Ajustes y Crow dirige cada función al adecuado.",
+  },
+  "onboarding.aiEmptyNote": {
+    en: "No model provider is configured yet, so AI features won't work until you add one.",
+    es: "Aún no hay ningún proveedor de modelos configurado, así que las funciones de IA no funcionarán hasta que agregues uno.",
+  },
+  "onboarding.aiConfiguredNote": {
+    en: "{n} model provider(s) are already available on this instance.",
+    es: "{n} proveedor(es) de modelos ya están disponibles en esta instancia.",
+  },
+  "onboarding.openProviders": { en: "Open Providers", es: "Abrir Proveedores" },
   "onboarding.integrations.title": { en: "Connect your tools", es: "Conecta tus herramientas" },
   "onboarding.integrations.body": {
     en: "Link services like Google, Slack, and GitHub so Crow can act on them for you. You add API keys in Settings, where each integration explains what it needs.",
@@ -1351,6 +1366,13 @@ export const translations = {
     es: "Crow puede ejecutar agentes en canales como Gmail y Discord, cada uno con su propia personalidad, habilidades y herramientas. Crea uno en el Bot Builder.",
   },
   "onboarding.openBotBuilder": { en: "Open Bot Builder", es: "Abrir Bot Builder" },
+  "onboarding.starter.title": { en: "Starter collections", es: "Colecciones iniciales" },
+  "onboarding.starter.body": {
+    en: "Themed collections bundle a few extensions that work well together — a one-click starting point instead of browsing the whole store. Install them from the Extensions page.",
+    es: "Las colecciones temáticas agrupan algunas extensiones que funcionan bien juntas: un punto de partida con un clic en lugar de explorar toda la tienda. Instálalas desde la página de Extensiones.",
+  },
+  "onboarding.starterMemberCount": { en: "{n} extensions", es: "{n} extensiones" },
+  "onboarding.openCollections": { en: "Browse collections", es: "Explorar colecciones" },
   "onboarding.connect.title": { en: "Connect an AI client", es: "Conecta un cliente de IA" },
   "onboarding.connect.body": {
     en: "Use Crow's memory and tools from Claude Code, claude.ai, and other clients over MCP.",

--- a/servers/gateway/dashboard/shared/layout.js
+++ b/servers/gateway/dashboard/shared/layout.js
@@ -586,6 +586,34 @@ export function renderLayout({ title, content, activePanel, panels, theme, glass
 }
 
 /**
+ * Show/hide-password toggle (F-ONBOARD-4): a checkbox per form that flips every
+ * data-pw input in that form between type=password and type=text. These auth
+ * pages are outside the Turbo shell and otherwise ship no client JS, so a tiny
+ * inline <script> is the accepted mechanism (CSP allows 'unsafe-inline').
+ * Deliberately NO paste handling of any kind — paste blocking harms password
+ * managers and is a tested-against anti-pattern here.
+ */
+function pwToggle(lang) {
+  return `<label style="display:flex;align-items:center;gap:0.5rem;margin:0.25rem 0 0.5rem;font-size:0.85rem;color:var(--crow-text-secondary);cursor:pointer">
+          <input type="checkbox" class="pw-toggle"> ${escapeHtml(t("login.showPassword", lang))}
+        </label>`;
+}
+
+function pwToggleScript() {
+  return `<script>
+    document.querySelectorAll('.pw-toggle').forEach(function (cb) {
+      cb.addEventListener('change', function () {
+        var form = cb.closest('form');
+        if (!form) return;
+        form.querySelectorAll('input[data-pw]').forEach(function (inp) {
+          inp.type = cb.checked ? 'text' : 'password';
+        });
+      });
+    });
+  </script>`;
+}
+
+/**
  * Render the login page.
  * @param {object} opts
  * @param {string} [opts.error] - Error message to display
@@ -612,15 +640,17 @@ export function renderLogin({ error, isSetup, setupToken, lockoutHelp, lang } = 
       ${error ? `<div class="login-error">${escapeHtml(error)}</div>` : ""}
       <form method="POST" action="/dashboard/login">
         ${isSetup ? `${setupToken ? `<input type="hidden" name="setup_token" value="${setupToken}">` : ""}
-        <input type="password" name="password" placeholder="${escapeHtml(t("login.choosePasswordPlaceholder", lang))}" required minlength="12" autofocus>
-        <input type="password" name="confirm" placeholder="${escapeHtml(t("login.confirmPlaceholder", lang))}" required minlength="12">` :
-        `<input type="password" name="password" placeholder="${escapeHtml(t("login.passwordPlaceholder", lang))}" required autofocus>`}
+        <input type="password" data-pw name="password" placeholder="${escapeHtml(t("login.choosePasswordPlaceholder", lang))}" required minlength="12" autofocus>
+        <input type="password" data-pw name="confirm" placeholder="${escapeHtml(t("login.confirmPlaceholder", lang))}" required minlength="12">` :
+        `<input type="password" data-pw name="password" placeholder="${escapeHtml(t("login.passwordPlaceholder", lang))}" required autofocus>`}
+        ${pwToggle(lang)}
         <button type="submit">${isSetup ? escapeHtml(t("login.setPasswordButton", lang)) : escapeHtml(t("login.loginButton", lang))}</button>
       </form>
       ${!isSetup ? `<p style="margin-top:1rem;font-size:0.8rem;color:var(--crow-text-tertiary)"><a href="/dashboard/reset">${escapeHtml(t("login.forgotPassword", lang))}</a></p>` : ""}
       ${lockoutHelp || ""}
     </div>
   </div>
+  ${pwToggleScript()}
 </body>
 </html>`;
 }
@@ -801,12 +831,14 @@ export function renderResetForm({ error, token, lang } = {}) {
       ${error ? `<div class="login-error">${escapeHtml(error)}</div>` : ""}
       <form method="POST" action="/dashboard/reset/complete">
         <input type="hidden" name="token" value="${escapeHtml(token || "")}">
-        <input type="password" name="password" placeholder="${escapeHtml(t("login.choosePasswordPlaceholder", lang))}" required minlength="12" autofocus>
-        <input type="password" name="confirm" placeholder="${escapeHtml(t("login.confirmPlaceholder", lang))}" required minlength="12">
+        <input type="password" data-pw name="password" placeholder="${escapeHtml(t("login.choosePasswordPlaceholder", lang))}" required minlength="12" autofocus>
+        <input type="password" data-pw name="confirm" placeholder="${escapeHtml(t("login.confirmPlaceholder", lang))}" required minlength="12">
+        ${pwToggle(lang)}
         <button type="submit">${escapeHtml(t("login.resetPasswordButton", lang))}</button>
       </form>
     </div>
   </div>
+  ${pwToggleScript()}
 </body>
 </html>`;
 }

--- a/tests/login-password-toggle.test.js
+++ b/tests/login-password-toggle.test.js
@@ -1,0 +1,51 @@
+// tests/login-password-toggle.test.js
+//
+// Item 4 PR2, F-ONBOARD-4 — show/hide-password toggle on the setup, login, and
+// reset forms (shared/layout.js). These auth pages are outside the Turbo shell,
+// so a tiny inline <script> is the accepted mechanism. Explicitly asserts NO
+// paste blocking exists anywhere on these pages.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as i18n from "../servers/gateway/dashboard/shared/i18n.js";
+import { renderLogin, renderResetForm } from "../servers/gateway/dashboard/shared/layout.js";
+
+const pages = {
+  setup: renderLogin({ isSetup: true, lang: "en" }),
+  login: renderLogin({ lang: "en" }),
+  reset: renderResetForm({ token: "tok", lang: "en" }),
+};
+
+test("login.showPassword resolves in en AND es", () => {
+  const entry = i18n.translations["login.showPassword"];
+  assert.ok(entry, "missing translations entry for login.showPassword");
+  assert.ok(entry.en && entry.en.trim(), "missing/empty en value");
+  assert.ok(entry.es && entry.es.trim(), "missing/empty es value");
+});
+
+for (const [name, html] of Object.entries(pages)) {
+  test(`${name} page: password fields carry a show/hide toggle`, () => {
+    assert.match(html, /type="password"/, "page has a password field");
+    assert.match(html, /class="pw-toggle"/, "toggle control present");
+    assert.match(html, /data-pw/, "password inputs are tagged for the toggle script");
+    assert.ok(html.includes(i18n.t("login.showPassword", "en")), "toggle uses the i18n label");
+    assert.match(html, /<script>[\s\S]*pw-toggle[\s\S]*<\/script>/, "inline toggle script present");
+  });
+
+  test(`${name} page: no paste blocking anywhere`, () => {
+    assert.doesNotMatch(html, /onpaste/i, "no onpaste attribute");
+    assert.doesNotMatch(html, /preventDefault\(\)[^]*paste|paste[^]*preventDefault\(\)/i,
+      "no paste suppression in scripts");
+  });
+}
+
+test("toggle flips type between password and text (script wiring)", () => {
+  // The script must set input type from the checkbox state — both directions.
+  const html = pages.login;
+  assert.match(html, /'text'\s*:\s*'password'|"text"\s*:\s*"password"/,
+    "script switches between text and password");
+});
+
+test("Spanish pages use the Spanish toggle label", () => {
+  const es = renderLogin({ lang: "es" });
+  assert.ok(es.includes(i18n.t("login.showPassword", "es")), "ES label present");
+});

--- a/tests/onboarding-cards.test.js
+++ b/tests/onboarding-cards.test.js
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import * as i18n from "../servers/gateway/dashboard/shared/i18n.js";
-import onboardingPanel from "../servers/gateway/dashboard/panels/onboarding.js";
+import onboardingPanel, { STEP_KEYS } from "../servers/gateway/dashboard/panels/onboarding.js";
 
 const SRC = readFileSync(new URL("../servers/gateway/dashboard/panels/onboarding.js", import.meta.url), "utf8");
 
@@ -25,7 +25,7 @@ async function render(query = {}) {
 }
 
 test("the rendered done step contains the collections card with its translated title and deep link", async () => {
-  const html = await render({ step: "4" });
+  const html = await render({ step: String(STEP_KEYS.indexOf("done")) });
   assert.ok(html.includes("/dashboard/extensions#collections"), "card links to the store's collections section");
   const title = i18n.t("onboarding.tryCollections.title", "en");
   assert.notEqual(title, "onboarding.tryCollections.title", "the title key must resolve to a translated string");

--- a/tests/onboarding-links.test.js
+++ b/tests/onboarding-links.test.js
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import onboardingPanel, {
   isInternalHref,
   cardLinkAttrs,
+  STEP_KEYS,
 } from "../servers/gateway/dashboard/panels/onboarding.js";
 
 // Same seam as tests/onboarding.test.js: drive the panel handler with a stub layout.
@@ -54,10 +55,14 @@ const CARD_HREFS = [
 // so the wizard stays alive behind it. If 1b's change bleeds into deepLink, this
 // goes red.
 test("mid-tour deep links still open in a new tab (deepLink is out of scope)", async () => {
+  // Keyed by stem, positions derived from STEP_KEYS: a future step insertion
+  // must not re-break this test. hrefs are as-rendered (button() escapes & to &amp;).
   const midTour = [
-    [1, "/dashboard/settings?section=integrations"],
-    [2, "/dashboard/bot-builder"],
-    [3, "/dashboard/connect"],
+    [STEP_KEYS.indexOf("ai"), "/dashboard/settings?section=llm&amp;tab=providers"],
+    [STEP_KEYS.indexOf("integrations"), "/dashboard/settings?section=integrations"],
+    [STEP_KEYS.indexOf("bot"), "/dashboard/bot-builder"],
+    [STEP_KEYS.indexOf("starter"), "/dashboard/extensions#collections"],
+    [STEP_KEYS.indexOf("connect"), "/dashboard/connect"],
   ];
   for (const [step, href] of midTour) {
     const a = anchorFor(await render(step), href);
@@ -68,7 +73,7 @@ test("mid-tour deep links still open in a new tab (deepLink is out of scope)", a
 
 // (b) The done-step cards are all internal today => no target, no rel.
 test("done-step action cards navigate in the same tab (no target attribute)", async () => {
-  const cards = actionCardsSlice(await render(4));
+  const cards = actionCardsSlice(await render(STEP_KEYS.indexOf("done")));
   for (const href of CARD_HREFS) {
     const a = anchorFor(cards, href);
     assert.doesNotMatch(a, /target=/, `internal card ${href} must not set target`);
@@ -80,7 +85,7 @@ test("done-step action cards navigate in the same tab (no target attribute)", as
 
 // (c) Whatever _blank survives anywhere in the tour must still be safe.
 test("every remaining target=_blank anchor carries rel=noopener", async () => {
-  for (const step of [0, 1, 2, 3, 4]) {
+  for (let step = 0; step < STEP_KEYS.length; step++) {
     for (const a of anchors(await render(step))) {
       if (a.includes('target="_blank"')) {
         assert.match(a, /rel="noopener"/, `step ${step}: _blank anchor without rel=noopener: ${a}`);

--- a/tests/onboarding-steps.test.js
+++ b/tests/onboarding-steps.test.js
@@ -1,0 +1,124 @@
+// tests/onboarding-steps.test.js
+//
+// Item 4 PR2 — wizard grows from 5 to 7 steps: "ai" (provider orientation,
+// F-ONBOARD-2) and "starter" (starter collections, sub-scope 4d).
+// STEP_KEYS is exported so tests derive positions instead of re-pinning indices.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as i18n from "../servers/gateway/dashboard/shared/i18n.js";
+import onboardingPanel, { STEP_KEYS } from "../servers/gateway/dashboard/panels/onboarding.js";
+import { loadCollections } from "../servers/gateway/dashboard/panels/extensions/collections.js";
+
+// Same seam as tests/onboarding.test.js: drive the panel handler with a stub layout.
+async function render(query = {}, { db } = {}) {
+  let captured = "";
+  const layout = ({ content }) => content;
+  const res = { send(h) { captured = h; }, setHeader() {} };
+  const req = { method: "GET", query, headers: {} };
+  const out = await onboardingPanel.handler(req, res, { layout, lang: "en", db });
+  return typeof out === "string" ? out : captured;
+}
+
+const stepOf = (stem) => String(STEP_KEYS.indexOf(stem));
+
+// Minimal db stub: answers the providers COUNT query with `n`, everything else empty.
+function providersDb(n) {
+  return {
+    async execute(q) {
+      const sql = typeof q === "string" ? q : q.sql;
+      if (/COUNT\(\*\)/i.test(sql) && /providers/i.test(sql)) {
+        return { rows: [{ n }] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+// ── STEP_KEYS shape ──────────────────────────────────────────────────────────
+
+test("STEP_KEYS is exactly welcome,ai,integrations,bot,starter,connect,done in order", () => {
+  assert.deepEqual(STEP_KEYS, ["welcome", "ai", "integrations", "bot", "starter", "connect", "done"]);
+});
+
+// ── ai step ──────────────────────────────────────────────────────────────────
+
+test("ai step renders the providers deep link (new tab, noopener)", async () => {
+  const html = await render({ step: stepOf("ai") }, { db: providersDb(0) });
+  assert.ok(html.includes("/dashboard/settings?section=llm&amp;tab=providers")
+    || html.includes("/dashboard/settings?section=llm&tab=providers"),
+  "ai step links to the providers tab");
+  assert.ok(html.includes('target="_blank"'), "ai deep link opens a new tab");
+  assert.ok(html.includes('rel="noopener"'), "ai deep link sets rel=noopener");
+  assert.ok(html.includes(i18n.t("onboarding.ai.body", "en")), "ai step renders its body copy");
+});
+
+test("ai step with ZERO providers shows the honest empty-state note", async () => {
+  const html = await render({ step: stepOf("ai") }, { db: providersDb(0) });
+  assert.ok(html.includes(i18n.t("onboarding.aiEmptyNote", "en")), "empty-state note present");
+  assert.ok(!html.includes(i18n.t("onboarding.aiConfiguredNote", "en").replace("{n}", "0")),
+    "configured note absent when nothing is configured");
+});
+
+test("ai step with providers shows the configured note with the count", async () => {
+  const html = await render({ step: stepOf("ai") }, { db: providersDb(3) });
+  const expected = i18n.t("onboarding.aiConfiguredNote", "en").replace("{n}", "3");
+  assert.ok(html.includes(expected), `configured note with count present: ${expected}`);
+  assert.ok(!html.includes(i18n.t("onboarding.aiEmptyNote", "en")), "empty-state note absent");
+});
+
+test("ai step survives a db error: no 500, no count callout, deep link intact", async () => {
+  const db = { async execute() { throw new Error("db is on fire"); } };
+  const html = await render({ step: stepOf("ai") }, { db });
+  assert.ok(html.includes("stepper"), "page still renders");
+  assert.ok(html.includes("/dashboard/settings?section=llm&tab=providers")
+    || html.includes("/dashboard/settings?section=llm&amp;tab=providers"), "deep link intact");
+  assert.ok(!html.includes(i18n.t("onboarding.aiEmptyNote", "en")), "no empty claim on error");
+  const configuredStem = i18n.t("onboarding.aiConfiguredNote", "en").split("{n}")[0].trim();
+  assert.ok(!configuredStem || !html.includes(configuredStem), "no configured claim on error");
+});
+
+test("ai step without a db omits the count callout but still renders", async () => {
+  const html = await render({ step: stepOf("ai") });
+  assert.ok(html.includes("stepper"), "page renders without a db");
+  assert.ok(!html.includes(i18n.t("onboarding.aiEmptyNote", "en")), "no empty claim without a db");
+});
+
+// ── starter step ─────────────────────────────────────────────────────────────
+
+test("starter step renders one card per collection plus the collections deep link", async () => {
+  const collections = loadCollections();
+  assert.ok(collections.length > 0, "repo ships at least one starter collection");
+  const html = await render({ step: stepOf("starter") });
+  const cardCount = (html.match(/onboarding-action-card"/g) || []).length;
+  assert.equal(cardCount, collections.length, "one card per collection");
+  for (const c of collections) {
+    assert.ok(html.includes(c.name), `card for ${c.id} shows its name`);
+    assert.ok(html.includes(String(c.members.length)), `card for ${c.id} shows its member count`);
+  }
+  assert.ok(html.includes("/dashboard/extensions#collections"), "deep link to the collections section");
+  assert.ok(html.includes(i18n.t("onboarding.openCollections", "en")), "deep link uses its i18n label");
+  assert.ok(html.includes('target="_blank"'), "starter deep link opens a new tab");
+});
+
+test("starter step deep link appears exactly once (cards are not install buttons)", async () => {
+  const html = await render({ step: stepOf("starter") });
+  const anchors = (html.match(/<a\b[^>]*href="\/dashboard\/extensions#collections"[^>]*>/g) || []);
+  assert.equal(anchors.length, 1, "exactly one anchor to extensions#collections");
+});
+
+// ── new i18n keys ────────────────────────────────────────────────────────────
+
+test("new ai/starter onboarding keys resolve in en AND es", () => {
+  const KEYS = [
+    "onboarding.ai.title", "onboarding.ai.body",
+    "onboarding.aiEmptyNote", "onboarding.aiConfiguredNote", "onboarding.openProviders",
+    "onboarding.starter.title", "onboarding.starter.body",
+    "onboarding.starterMemberCount", "onboarding.openCollections",
+  ];
+  for (const k of KEYS) {
+    const entry = i18n.translations[k];
+    assert.ok(entry, `missing translations entry for ${k}`);
+    assert.ok(entry.en && entry.en.trim(), `missing/empty en value for ${k}`);
+    assert.ok(entry.es && entry.es.trim(), `missing/empty es value for ${k}`);
+  }
+});

--- a/tests/onboarding.test.js
+++ b/tests/onboarding.test.js
@@ -7,9 +7,13 @@ import * as i18n from "../servers/gateway/dashboard/shared/i18n.js";
 const ONBOARDING_KEYS = [
   "onboarding.title",
   "onboarding.welcome.title", "onboarding.welcome.body",
+  "onboarding.ai.title", "onboarding.ai.body",
+  "onboarding.aiEmptyNote", "onboarding.aiConfiguredNote", "onboarding.openProviders",
   "onboarding.integrations.title", "onboarding.integrations.body",
   "onboarding.integrationsNote", "onboarding.openIntegrations",
   "onboarding.bot.title", "onboarding.bot.body", "onboarding.openBotBuilder",
+  "onboarding.starter.title", "onboarding.starter.body",
+  "onboarding.starterMemberCount", "onboarding.openCollections",
   "onboarding.connect.title", "onboarding.connect.body",
   "onboarding.connectNote", "onboarding.openConnections",
   "onboarding.done.title", "onboarding.done.body", "onboarding.doneNote",
@@ -26,7 +30,9 @@ test("every onboarding.* key has a non-empty en AND es value", () => {
   }
 });
 
-import onboardingPanel from "../servers/gateway/dashboard/panels/onboarding.js";
+import onboardingPanel, { STEP_KEYS } from "../servers/gateway/dashboard/panels/onboarding.js";
+
+const DONE_STEP = String(STEP_KEYS.indexOf("done"));
 
 // Invoke the panel handler with a stubbed layout (returns content for assertions).
 // parseCookies reads req.headers.cookie, so headers must always be an object.
@@ -45,29 +51,36 @@ test("panel identity: id / route / hidden", () => {
   assert.equal(onboardingPanel.hidden, true);
 });
 
-test("renders all 5 steps with the stepper and step-specific deep links", async () => {
-  const deepLinkPerStep = [
-    null,
-    "/dashboard/settings?section=integrations",
-    "/dashboard/bot-builder",
-    "/dashboard/connect",
-    null,
-  ];
-  const calloutSteps = [1, 3, 4]; // integrations, connect, done each render a callout
-  for (let step = 0; step < 5; step++) {
+test("renders every step with the stepper and step-specific deep links", async () => {
+  // Keyed by stem (not index) so a future step insertion doesn't re-break this.
+  const deepLinkPerStem = {
+    welcome: null,
+    // button() renders hrefs through escapeHtml, so & appears as &amp; in HTML.
+    ai: "/dashboard/settings?section=llm&amp;tab=providers",
+    integrations: "/dashboard/settings?section=integrations",
+    bot: "/dashboard/bot-builder",
+    starter: "/dashboard/extensions#collections",
+    connect: "/dashboard/connect",
+    done: null,
+  };
+  // integrations, connect, done each render a callout unconditionally.
+  // (The ai step's callout is db-dependent; tests/onboarding-steps.test.js covers it.)
+  const calloutStems = ["integrations", "connect", "done"];
+  for (let step = 0; step < STEP_KEYS.length; step++) {
+    const stem = STEP_KEYS[step];
     const html = await render({ step: String(step) });
-    assert.ok(html.includes("stepper"), `step ${step} renders the stepper`);
-    assert.ok(html.includes("step-active"), `step ${step} marks the active step`);
-    if (deepLinkPerStep[step]) {
-      assert.ok(html.includes(deepLinkPerStep[step]), `step ${step} links to ${deepLinkPerStep[step]}`);
-      assert.ok(html.includes('target="_blank"'), `step ${step} deep-link opens in a new tab`);
-      assert.ok(html.includes('rel="noopener"'), `step ${step} deep-link sets rel=noopener`);
+    assert.ok(html.includes("stepper"), `step ${stem} renders the stepper`);
+    assert.ok(html.includes("step-active"), `step ${stem} marks the active step`);
+    if (deepLinkPerStem[stem]) {
+      assert.ok(html.includes(deepLinkPerStem[stem]), `step ${stem} links to ${deepLinkPerStem[stem]}`);
+      assert.ok(html.includes('target="_blank"'), `step ${stem} deep-link opens in a new tab`);
+      assert.ok(html.includes('rel="noopener"'), `step ${stem} deep-link sets rel=noopener`);
     }
-    if (calloutSteps.includes(step)) {
-      assert.ok(html.includes("callout"), `step ${step} renders a callout`);
+    if (calloutStems.includes(stem)) {
+      assert.ok(html.includes("callout"), `step ${stem} renders a callout`);
     }
   }
-  const done = await render({ step: "4" });
+  const done = await render({ step: DONE_STEP });
   assert.ok(done.includes('href="/dashboard"'), "last step links to the dashboard");
 });
 
@@ -129,7 +142,7 @@ test("done step sets onboarding_completed_at exactly once", async () => {
   // First visit to done: flag absent -> a write (INSERT/UPDATE/REPLACE) must happen.
   const layout = ({ content }) => content;
   const res = { send() {}, setHeader() {} };
-  const req = { method: "GET", query: { step: "4" }, headers: {} };
+  const req = { method: "GET", query: { step: DONE_STEP }, headers: {} };
   calls.length = 0;
   await onboardingPanel.handler(req, res, { layout, lang: "en", db: mkDb(null) });
   assert.ok(


### PR DESCRIPTION
Second PR of the Item 4 generalization theme (spec `docs/superpowers/specs/2026-07-13-generalization-firstrun-design.md` §2.3–2.4).

## What

- **Wizard 5→7 steps**: `welcome → ai → integrations → bot → starter → connect → done`.
  - **ai step** (F-ONBOARD-2, before bot creation): explains that agents need a model provider, with a server-side honest state — zero providers renders a "nothing configured yet" note, N>0 renders the count; a DB error renders no count claim at all (never a lie, never a 500). Deep-links to Settings → AI Models → Providers with the load-bearing mid-tour `_blank` semantics.
  - **starter step** (4d): one card per themed collection from `loadCollections()` (name, description, member count, all escaped), single deep link to `/dashboard/extensions#collections` — orientation only, no install-from-wizard. The done-step tryCollections card stays.
  - `STEP_KEYS` is now exported; the three previously position-pinned test files derive positions from it, so future step insertions can't silently break them.
- **Show-password toggle** (F-ONBOARD-4 remainder): setup, login, and reset forms get an accessible checkbox flipping `data-pw` inputs between password/text via a tiny inline script (these auth pages are outside the Turbo shell; CSP already allows inline). Zero paste handling — tests assert no `onpaste` anywhere. F-ONBOARD-3 (connect-step copy) verified already accurate; changed nothing.
- New i18n keys EN+ES (parity asserted by tests).

## Verification

- Suite (scratch env): 1812 pass / 3 fail = exactly the pre-existing known trio / 0 skips (+18 tests)
- 6 parse-clean mutation checks with named red tests (incl. swapping STEP_KEYS order — only the order test reds, proving the positional rework derives correctly)
- Whole-branch adversarial review: READY TO MERGE, zero findings (traced stepper/redirect/replay consumers, CSP, XSS, NULL-disabled miscount theory — all closed)
- CDP walkthrough on a scratch gateway (fresh DB, no models.json, password set via the real /setup flow): all 7 steps render EN, ai step shows the empty-state note + providers link, starter step shows 4 collection cards + link, done step marks `onboarding_completed_at` and keeps its 4 action cards; ES spot-checks pass; login toggle flips password→text→password with no onpaste. Evidence: `~/.crow/p4/item4-pr2/` (12 assertions, 5 screenshots). The real first-run redirect (`/setup` POST → 303 `/dashboard/onboarding`) exercised live.
- check-ports: exactly the one known capstone line; build-registry: OK

No schema changes; no fleet choreography needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrmujaUpg9W5sFvhQyWqTz