### PR TITLE
Item 4 PR3: identity backup — encrypted wizard download, honest CLI export/import

### DIFF
--- a/docs/guide/sharing.md
+++ b/docs/guide/sharing.md
@@ -143,26 +143,35 @@ If your Crow gateway is cloud-deployed (always online), you can volunteer as a r
 
 This is opt-in and only serves your existing contacts.
 
-## Device Migration
+## Identity Backup and Device Migration
 
-Moving Crow to a new device? Export your identity:
+Your identity is the master seed behind your Crow ID, contacts, and shared data — if the machine dies without a backup, contacts have to re-connect from scratch. There are two ways to make a backup, and both produce the same passphrase-encrypted format:
+
+**From the dashboard:** the first-run wizard's final step (replayable from Settings → Help & Setup → "Download identity backup") has a backup form. Choose a passphrase (minimum 12 characters), confirm it, and the browser downloads `crow-identity-backup.json`.
+
+**From the CLI:**
 
 ```bash
-# On the old device:
+# On the old device — prompts for a passphrase, prints a base64 blob:
 npm run identity:export
-# Saves encrypted archive to data/identity-export.enc
+# (non-interactive: npm run identity:export -- -- --passphrase <passphrase>)
 
-# On the new device:
-npm run identity:import
-# Prompts for passphrase, restores identity
+# On the new device — prompts for the same passphrase:
+npm run identity:import -- <base64-blob>
+# (a downloaded crow-identity-backup.json imports the same way:
+#  npm run identity:import -- "$(base64 -w0 crow-identity-backup.json)")
 ```
 
-Your Crow ID stays the same. Contacts don't need to re-connect.
+The backup keeps your Crow ID and public keys in the clear (so the file is identifiable), but the seed itself is encrypted with scrypt (N=16384, r=8, p=1) + AES-256-GCM under your passphrase — the plaintext seed never appears in the file. Without the passphrase the backup cannot be restored, so store both safely.
+
+Restoring **decrypts the backup and writes a plaintext-seed `identity.json`** — the file encryption protects the download, not the disk; the gateway can only boot from a plaintext seed. The import refuses to overwrite an existing `identity.json`. There is deliberately no dashboard restore flow: re-keying a running instance has sync and pairing implications, so restore is a CLI-on-a-fresh-install operation.
+
+Your Crow ID stays the same after a restore. Contacts don't need to re-connect.
 
 ## Security Notes
 
 - All shares are **end-to-end encrypted** — only the intended recipient can read them
-- Your identity seed is encrypted at rest with your passphrase
+- Identity **backups** are passphrase-encrypted (scrypt + AES-256-GCM); the on-disk `identity.json` keeps a plaintext seed so the gateway can boot unattended — protect the machine, and keep an encrypted backup
 - Invite codes expire after 24 hours and are single-use
 - Safety numbers let you verify connections weren't intercepted
 - Relays only see encrypted blobs — they cannot read your data

--- a/servers/gateway/dashboard/index.js
+++ b/servers/gateway/dashboard/index.js
@@ -74,7 +74,7 @@ import contactsPanel from "./panels/contacts.js";
 import botBuilderPanel from "./panels/bot-builder.js";
 import botBoardPanel from "./panels/bot-board.js";
 import designSystemPanel from "./panels/design-system.js";
-import onboardingPanel from "./panels/onboarding.js";
+import onboardingPanel, { handleIdentityBackupPost } from "./panels/onboarding.js";
 import connectPanel from "./panels/connect.js";
 import fediversePanel from "./panels/fediverse.js";
 import meteringPanel from "./panels/metering.js";
@@ -645,6 +645,12 @@ export default function dashboardRouter(mcpAuthMiddleware) {
       try { db.close(); } catch {}
     }
   });
+
+  // 4-PR3: identity backup download (onboarding done step + Settings → Help &
+  // Setup). Hand-registered — panels expose GET handlers only — and mounted
+  // AFTER dashboardAuth + csrfMiddleware above, so it is session-authed and
+  // CSRF-protected exactly like the fix-it action POST.
+  router.post("/dashboard/onboarding/identity-backup", handleIdentityBackupPost);
 
   // Federation companion router (Phase 3) — session-authed, under dashboard
   // auth. Mounted AFTER dashboardAuth so session cookies are validated.

--- a/servers/gateway/dashboard/panels/onboarding.js
+++ b/servers/gateway/dashboard/panels/onboarding.js
@@ -243,7 +243,7 @@ function renderBackupSection(lang, ctx = {}) {
   }
   const rawError = req && req.query ? req.query.backup_error : "";
   const errorHtml = rawError
-    ? `<p style="color:var(--crow-danger);font-size:var(--crow-text-sm);margin-bottom:var(--crow-space-2)">${escapeHtml(String(rawError))}</p>`
+    ? `<p style="color:var(--crow-error);font-size:var(--crow-text-sm);margin-bottom:var(--crow-space-2)">${escapeHtml(String(rawError))}</p>`
     : "";
   const fieldStyle = "display:block;width:100%;max-width:320px;margin-top:2px;padding:0.4rem 0.6rem;background:var(--crow-bg-surface);border:1px solid var(--crow-border);border-radius:6px;color:var(--crow-text-primary)";
   const labelStyle = "display:block;font-size:var(--crow-text-sm);color:var(--crow-text-secondary);margin-bottom:var(--crow-space-2)";

--- a/servers/gateway/dashboard/panels/onboarding.js
+++ b/servers/gateway/dashboard/panels/onboarding.js
@@ -14,6 +14,9 @@ import { t, SUPPORTED_LANGS } from "../shared/i18n.js";
 import { parseCookies } from "../auth.js";
 import { upsertSetting, readSetting } from "../settings/registry.js";
 import { loadCollections } from "./extensions/collections.js";
+import { csrfInput } from "../shared/csrf.js";
+import { buildIdentityBackup, loadInstanceSeed, deriveInstanceIdentity } from "../../../sharing/identity.js";
+import { instanceSeedDir } from "../../../../scripts/pi-bots/instance-paths.mjs";
 
 /** Exported so tests derive step positions (indexOf/length) instead of pinning indices. */
 export const STEP_KEYS = ["welcome", "ai", "integrations", "bot", "starter", "connect", "done"];
@@ -206,6 +209,89 @@ const CARD_CSS = `
 `;
 
 /**
+ * The instance crowId for the done step's backup section, or null when there
+ * is no readable plaintext-seed identity.json (fresh install where the sharing
+ * server has not run yet, or an encrypted-at-rest identity). Null → the
+ * section renders an honest "no identity yet" note instead of the form; the
+ * wizard must never crash over it. Same seed anchor as the backup endpoint
+ * (identity.js's resolveDataDir, via instanceSeedDir()).
+ * @returns {string|null}
+ */
+function readInstanceCrowId() {
+  try {
+    const seed = loadInstanceSeed(instanceSeedDir());
+    return deriveInstanceIdentity(seed).crowId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * "Back up your identity" section on the done step (4-PR3). Passphrase +
+ * confirm POST to the hand-registered /dashboard/onboarding/identity-backup
+ * route (dashboard-authed + CSRF-protected in dashboard/index.js). data-pw is
+ * carried for parity with the settings password-toggle pattern, but the wizard
+ * page has no toggle script — plain password fields by design.
+ * @param {string} lang
+ * @param {{crowId: string|null, req?: object}} ctx
+ */
+function renderBackupSection(lang, ctx = {}) {
+  const req = ctx.req || null;
+  const heading = `<h3 style="font-size:var(--crow-text-base);font-weight:600;margin:var(--crow-space-5) 0 var(--crow-space-2)">${t("onboarding.backup.title", lang)}</h3>`;
+  if (!ctx.crowId) {
+    return `${heading}<p style="font-size:var(--crow-text-sm);color:var(--crow-text-secondary)">${t("onboarding.backup.noIdentity", lang)}</p>`;
+  }
+  const rawError = req && req.query ? req.query.backup_error : "";
+  const errorHtml = rawError
+    ? `<p style="color:var(--crow-danger);font-size:var(--crow-text-sm);margin-bottom:var(--crow-space-2)">${escapeHtml(String(rawError))}</p>`
+    : "";
+  const fieldStyle = "display:block;width:100%;max-width:320px;margin-top:2px;padding:0.4rem 0.6rem;background:var(--crow-bg-surface);border:1px solid var(--crow-border);border-radius:6px;color:var(--crow-text-primary)";
+  const labelStyle = "display:block;font-size:var(--crow-text-sm);color:var(--crow-text-secondary);margin-bottom:var(--crow-space-2)";
+  return `${heading}
+    <p style="font-size:var(--crow-text-sm);color:var(--crow-text-secondary);margin-bottom:var(--crow-space-2)">${t("onboarding.backup.crowIdLabel", lang)}: <code>${escapeHtml(ctx.crowId)}</code></p>
+    <p style="font-size:var(--crow-text-sm);color:var(--crow-text-secondary);line-height:var(--crow-leading-relaxed);margin-bottom:var(--crow-space-3)">${t("onboarding.backup.body", lang)}</p>
+    ${errorHtml}
+    <form method="POST" action="/dashboard/onboarding/identity-backup">
+      ${csrfInput(req)}
+      <label style="${labelStyle}">${t("onboarding.backup.passphraseLabel", lang)}
+        <input type="password" name="passphrase" data-pw minlength="12" required autocomplete="new-password" style="${fieldStyle}">
+      </label>
+      <label style="${labelStyle}">${t("onboarding.backup.confirmLabel", lang)}
+        <input type="password" name="confirm" data-pw minlength="12" required autocomplete="new-password" style="${fieldStyle}">
+      </label>
+      <p style="font-size:var(--crow-text-sm);color:var(--crow-text-tertiary);margin-bottom:var(--crow-space-3)">${t("onboarding.backup.hint", lang)}</p>
+      ${button(t("onboarding.backup.submit", lang), { variant: "secondary", size: "sm", type: "submit" })}
+    </form>`;
+}
+
+/**
+ * POST /dashboard/onboarding/identity-backup — hand-registered in
+ * dashboard/index.js BEHIND dashboardAuth + csrfMiddleware (same mounting slot
+ * as the fix-it action POST). Validates passphrase (minlength 12 + confirm
+ * match), then streams the buildIdentityBackup payload as an attachment.
+ * Never logs or echoes the passphrase; unexpected failures redirect with a
+ * generic message instead of 500ing.
+ */
+export async function handleIdentityBackupPost(req, res) {
+  const lang = resolveLang(req);
+  const doneIdx = STEP_KEYS.indexOf("done");
+  const back = (msgKey) =>
+    res.redirectAfterPost(`/dashboard/onboarding?step=${doneIdx}&backup_error=${encodeURIComponent(t(msgKey, lang))}`);
+  try {
+    const passphrase = typeof req.body?.passphrase === "string" ? req.body.passphrase : "";
+    const confirm = typeof req.body?.confirm === "string" ? req.body.confirm : "";
+    if (passphrase.length < 12) return back("onboarding.backup.errTooShort");
+    if (passphrase !== confirm) return back("onboarding.backup.errMismatch");
+    const payload = buildIdentityBackup(passphrase);
+    res.setHeader("Content-Disposition", 'attachment; filename="crow-identity-backup.json"');
+    return res.type("application/json").send(JSON.stringify(payload, null, 2));
+  } catch (err) {
+    console.error("[onboarding] identity backup failed:", err.message); // message only — never the passphrase
+    return back("onboarding.backup.errGeneric");
+  }
+}
+
+/**
  * Count enabled rows in the providers table. Returns null when there is no db
  * or the query fails — the caller renders no count claim at all in that case
  * (asserting "nothing configured yet" on a db error could be a lie, and the
@@ -226,8 +312,9 @@ async function countProviders(db) {
 /**
  * @param {string} stem - STEP_KEYS entry
  * @param {string} lang
- * @param {{providersCount?: number|null}} [ctx] - server-fetched data the step
- *   body needs (only the ai step today); handler-populated so this stays sync.
+ * @param {{providersCount?: number|null, crowId?: string|null, req?: object}} [ctx]
+ *   - server-fetched data the step body needs (ai: providersCount; done:
+ *     crowId + req for the backup form); handler-populated so this stays sync.
  */
 function renderStepBody(stem, lang, ctx = {}) {
   const body = `<p style="font-size:var(--crow-text-base);line-height:var(--crow-leading-relaxed);color:var(--crow-text-secondary);margin-bottom:var(--crow-space-4)">${t(`onboarding.${stem}.body`, lang)}</p>`;
@@ -262,6 +349,7 @@ function renderStepBody(stem, lang, ctx = {}) {
         <span class="onboarding-celebrate-label">${t("onboarding.celebration", lang)}</span>
       </div>`;
       return celebrateHtml + body + callout(t("onboarding.doneNote", lang), "success")
+        + renderBackupSection(lang, ctx)
         + renderActionCards(lang);
     }
     case "welcome":
@@ -320,7 +408,11 @@ export default {
 
     // The ai step's copy is conditional on whether any provider is configured;
     // fetch the count server-side only when that step is the one rendering.
-    const ctx = stem === "ai" ? { providersCount: await countProviders(db) } : {};
+    // The done step needs the instance crowId (nullable) + req for the backup
+    // form (csrf token, backup_error query).
+    const ctx = stem === "ai" ? { providersCount: await countProviders(db) }
+      : stem === "done" ? { crowId: readInstanceCrowId(), req }
+      : {};
 
     const steps = STEP_KEYS.map((k) => ({ label: t(`onboarding.${k}.title`, lang) }));
     const content =

--- a/servers/gateway/dashboard/settings/sections/help-setup.js
+++ b/servers/gateway/dashboard/settings/sections/help-setup.js
@@ -5,6 +5,7 @@
 import { escapeHtml } from "../../shared/components.js";
 import { t } from "../../shared/i18n.js";
 import { getProxyStatus } from "../../../proxy.js";
+import { STEP_KEYS } from "../../panels/onboarding.js";
 
 export default {
   id: "help-setup",
@@ -62,8 +63,12 @@ export default {
     const routerDisabled = process.env.CROW_DISABLE_ROUTER === "1";
 
     const replayHtml = `<p style="margin-bottom:1rem"><a href="/dashboard/onboarding?step=0" style="color:var(--crow-accent);text-decoration:none;font-weight:600"><span aria-hidden="true">&#8635;</span> ${escapeHtml(t("onboarding.replayLink", currentLang))}</a></p>`;
+    // 4-PR3: identity backup lives on the wizard's done step; link straight to
+    // it (index derived from STEP_KEYS, never hardcoded).
+    const backupHtml = `<p style="margin-bottom:1rem"><a href="/dashboard/onboarding?step=${STEP_KEYS.indexOf("done")}" style="color:var(--crow-accent);text-decoration:none;font-weight:600"><span aria-hidden="true">&#8681;</span> ${escapeHtml(t("onboarding.backup.settingsLink", currentLang))}</a></p>`;
     return `
       ${replayHtml}
+      ${backupHtml}
       <h4 style="font-size:0.9rem;color:var(--crow-text-muted);margin-bottom:0.5rem">${ht.connectGuide}</h4>
       <p style="font-size:0.85rem;line-height:1.6;margin-bottom:0.75rem">${ht.connectPointer}</p>
       <p><a href="/dashboard/connect" style="color:var(--crow-accent);text-decoration:none;font-weight:600">${ht.openWizard} &rarr;</a></p>

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1392,6 +1392,37 @@ export const translations = {
     en: "You can replay this guide anytime from Settings, Help and Setup.",
     es: "Puedes repetir esta guía cuando quieras desde Ajustes, Ayuda y configuración.",
   },
+  // 4-PR3 identity backup (done step + settings pointer)
+  "onboarding.backup.title": { en: "Back up your identity", es: "Respalda tu identidad" },
+  "onboarding.backup.crowIdLabel": { en: "This instance's Crow ID", es: "Crow ID de esta instancia" },
+  "onboarding.backup.body": {
+    en: "Your identity is the cryptographic key behind your Crow ID, contacts, and shared data. If this machine is lost, the identity is gone with it — contacts would have to re-connect from scratch. Download an encrypted backup now: choose a passphrase (12+ characters) and keep the file somewhere safe.",
+    es: "Tu identidad es la clave criptográfica detrás de tu Crow ID, tus contactos y tus datos compartidos. Si pierdes esta máquina, la identidad se pierde con ella y tus contactos tendrían que reconectarse desde cero. Descarga ahora un respaldo cifrado: elige una frase de contraseña (12+ caracteres) y guarda el archivo en un lugar seguro.",
+  },
+  "onboarding.backup.passphraseLabel": { en: "Passphrase (min 12 characters)", es: "Frase de contraseña (mín. 12 caracteres)" },
+  "onboarding.backup.confirmLabel": { en: "Confirm passphrase", es: "Confirma la frase de contraseña" },
+  "onboarding.backup.hint": {
+    en: "The passphrase encrypts the seed inside the file — without it, the backup cannot be restored.",
+    es: "La frase de contraseña cifra la semilla dentro del archivo: sin ella, el respaldo no se puede restaurar.",
+  },
+  "onboarding.backup.submit": { en: "Download encrypted backup", es: "Descargar respaldo cifrado" },
+  "onboarding.backup.noIdentity": {
+    en: "No identity has been created on this instance yet — the sharing server generates one on first start. Come back here (Settings, Help and Setup) once it exists.",
+    es: "Esta instancia aún no tiene una identidad: el servidor de compartición genera una en su primer arranque. Vuelve aquí (Ajustes, Ayuda y configuración) cuando exista.",
+  },
+  "onboarding.backup.errTooShort": {
+    en: "The passphrase must be at least 12 characters.",
+    es: "La frase de contraseña debe tener al menos 12 caracteres.",
+  },
+  "onboarding.backup.errMismatch": {
+    en: "The passphrases do not match.",
+    es: "Las frases de contraseña no coinciden.",
+  },
+  "onboarding.backup.errGeneric": {
+    en: "The backup could not be created. Check the gateway logs for details.",
+    es: "No se pudo crear el respaldo. Revisa los registros del gateway para más detalles.",
+  },
+  "onboarding.backup.settingsLink": { en: "Download identity backup", es: "Descargar respaldo de identidad" },
   "onboarding.btnNext": { en: "Next", es: "Siguiente" },
   "onboarding.btnBack": { en: "Back", es: "Atrás" },
   "onboarding.btnSkip": { en: "Skip to dashboard", es: "Ir al panel" },

--- a/servers/sharing/identity.js
+++ b/servers/sharing/identity.js
@@ -53,7 +53,7 @@ function deriveKey(seed, info, length = 32) {
 /**
  * Encrypt data with a passphrase using scrypt + AES-256-GCM.
  */
-function encryptSeed(seed, passphrase) {
+export function encryptSeed(seed, passphrase) {
   const salt = randomBytes(32);
   const key = scryptSync(passphrase, salt, 32, { N: 16384, r: 8, p: 1 });
   const iv = randomBytes(12);
@@ -71,7 +71,7 @@ function encryptSeed(seed, passphrase) {
 /**
  * Decrypt seed with passphrase.
  */
-function decryptSeed(encData, passphrase) {
+export function decryptSeed(encData, passphrase) {
   const salt = Buffer.from(encData.salt, "hex");
   const key = scryptSync(passphrase, salt, 32, { N: 16384, r: 8, p: 1 });
   const iv = Buffer.from(encData.iv, "hex");
@@ -230,6 +230,39 @@ export function loadInstanceSeed(dataDir) {
   if (stored.encrypted) throw new Error("loadInstanceSeed: encrypted identity requires a passphrase (unsupported in the gateway host)");
   if (!stored.seed) throw new Error("loadInstanceSeed: identity.json has no plaintext seed");
   return Buffer.from(stored.seed, "hex");
+}
+
+/**
+ * Build the passphrase-encrypted identity backup payload (4-PR3). Public
+ * identification fields (crowId, pubkeys, createdAt) stay in the CLEAR so a
+ * backup file is recognizable without the passphrase; the master seed is
+ * present ONLY inside the encryptSeed blob (scrypt N=16384,r=8,p=1 +
+ * AES-256-GCM). The plaintext seed hex must never appear in this object.
+ * Consumed by the onboarding download endpoint and `npm run identity:export`.
+ */
+export function buildIdentityBackup(passphrase) {
+  if (!passphrase || typeof passphrase !== "string") {
+    throw new Error("buildIdentityBackup requires a passphrase");
+  }
+  if (!existsSync(IDENTITY_PATH)) {
+    throw new Error(`No identity file at ${IDENTITY_PATH} — nothing to back up. Run \`npm run identity\` first.`);
+  }
+  const stored = JSON.parse(readFileSync(IDENTITY_PATH, "utf-8"));
+  if (!stored.seed) {
+    throw new Error("identity.json has no plaintext seed to back up (encrypted-at-rest identities are not supported by the gateway host)");
+  }
+  const seed = Buffer.from(stored.seed, "hex");
+  const identity = deriveIdentity(seed, stored);
+  return {
+    version: 1,
+    kind: "crow-identity-backup",
+    crowId: identity.crowId,
+    ed25519Pubkey: identity.ed25519Pubkey,
+    secp256k1Pubkey: identity.secp256k1Pubkey,
+    createdAt: stored.createdAt || new Date().toISOString(),
+    encrypted: encryptSeed(seed, passphrase),
+    _restore: "npm run identity:import -- <this whole file's JSON, base64-encoded>  (prompts for the passphrase)",
+  };
 }
 
 /**
@@ -433,27 +466,91 @@ export function displayIdentity() {
 }
 
 /**
- * Export encrypted identity (for `npm run identity:export`).
+ * CLI argument extraction. package.json runs these entry points via
+ * `node -e "import(...).then(...)"`, where user args start at process.argv[1]
+ * (there is no script path). Under a direct `node <file>.js` run they start at
+ * argv[2]. The old `slice(2)` silently dropped every arg under the npm path.
  */
-export function exportIdentity() {
+function cliArgs() {
+  const argv = process.argv;
+  const first = argv[1] || "";
+  const args = first.endsWith(".js") || first.endsWith(".mjs") ? argv.slice(2) : argv.slice(1);
+  // Node consumes leading `-…` args after `-e <script>` as its OWN options, so
+  // flag-first invocations need a `--` separator (e.g.
+  // `npm run identity:export -- -- --passphrase <p>`); drop any literal `--`.
+  return args.filter((a) => a !== "--");
+}
+
+/** Pull `--passphrase <value>` out of args (mutates args). Returns null if absent. */
+function takePassphraseArg(args) {
+  const i = args.indexOf("--passphrase");
+  if (i !== -1 && typeof args[i + 1] === "string") {
+    const [, value] = args.splice(i, 2);
+    return value;
+  }
+  return null;
+}
+
+/** Prompt for a passphrase on a TTY; returns null when non-interactive. */
+async function promptPassphrase(promptText) {
+  if (!process.stdin.isTTY) return null;
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const answer = await new Promise((resolveAnswer) => rl.question(promptText, resolveAnswer));
+  rl.close();
+  return answer || null;
+}
+
+/**
+ * Export encrypted identity (for `npm run identity:export`).
+ * Requires a passphrase (--passphrase <p>, or a TTY prompt); the output is a
+ * base64-encoded buildIdentityBackup payload — the seed is scrypt+AES-256-GCM
+ * encrypted, so the "Encrypted Identity Export" label is true.
+ */
+export async function exportIdentity() {
   if (!existsSync(IDENTITY_PATH)) {
     console.error("No identity found. Run `npm run identity` first.");
     process.exit(1);
   }
-  const data = readFileSync(IDENTITY_PATH, "utf-8");
-  const exportData = Buffer.from(data).toString("base64");
+  const args = cliArgs();
+  let passphrase = takePassphraseArg(args);
+  if (!passphrase) passphrase = await promptPassphrase("Passphrase to encrypt the backup (min 12 chars): ");
+  if (!passphrase) {
+    console.error("A passphrase is required: pass `--passphrase <passphrase>` or run interactively.");
+    process.exit(1);
+  }
+  if (passphrase.length < 12) {
+    console.error("Passphrase too short — use at least 12 characters (it protects your master seed offline).");
+    process.exit(1);
+  }
+  let payload;
+  try {
+    payload = buildIdentityBackup(passphrase);
+  } catch (err) {
+    console.error("Export failed:", err.message);
+    process.exit(1);
+  }
+  const exportData = Buffer.from(JSON.stringify(payload)).toString("base64");
   console.log("\n  Encrypted Identity Export\n");
-  console.log("  Copy this entire string to import on another device:\n");
+  console.log("  Copy this entire string to import on another device");
+  console.log("  (npm run identity:import -- <string> — it will prompt for the passphrase):\n");
   console.log(`  ${exportData}\n`);
 }
 
 /**
  * Import identity (for `npm run identity:import`).
+ * Accepts both formats, sniffed by JSON keys:
+ *   - crow-identity-backup (or any blob with an `encrypted` object): asks for
+ *     the passphrase, decrypts, and writes a PLAINTEXT-seed identity.json —
+ *     the gateway host cannot boot from an encrypted one (loadInstanceSeed).
+ *   - legacy plaintext-base64 identity.json content: written as-is.
+ * Refuses to overwrite an existing identity.json.
  */
-export function importIdentity() {
-  const args = process.argv.slice(2);
+export async function importIdentity() {
+  const args = cliArgs();
+  const passphraseArg = takePassphraseArg(args);
   if (args.length === 0) {
-    console.error("Usage: npm run identity:import -- <base64-encoded-identity>");
+    console.error("Usage: npm run identity:import -- <base64-encoded-identity> [--passphrase <passphrase>]");
     process.exit(1);
   }
 
@@ -462,9 +559,51 @@ export function importIdentity() {
     process.exit(1);
   }
 
-  mkdirSync(DATA_DIR, { recursive: true });
   const data = Buffer.from(args[0], "base64").toString("utf-8");
-  JSON.parse(data); // Validate JSON
+  let parsed;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    console.error("Not a valid identity export (expected base64-encoded JSON).");
+    process.exit(1);
+  }
+
+  mkdirSync(DATA_DIR, { recursive: true });
+
+  const isEncryptedBackup = parsed && typeof parsed === "object"
+    && (parsed.kind === "crow-identity-backup" || (parsed.encrypted && !parsed.seed));
+
+  if (isEncryptedBackup) {
+    let passphrase = passphraseArg;
+    if (!passphrase) passphrase = await promptPassphrase("Passphrase to decrypt the backup: ");
+    if (!passphrase) {
+      console.error("This backup is passphrase-encrypted. Pass `--passphrase <passphrase>` or run interactively.");
+      process.exit(1);
+    }
+    let seed;
+    try {
+      seed = decryptSeed(parsed.encrypted, passphrase);
+    } catch {
+      console.error("Wrong passphrase (or corrupted backup) — could not decrypt the seed.");
+      process.exit(1);
+    }
+    // The gateway host boots only from a plaintext-seed identity.json — the
+    // backup's encryption protects the download, not the disk.
+    const identity = deriveIdentity(seed, null);
+    const toStore = {
+      version: 1,
+      crowId: identity.crowId,
+      ed25519Pubkey: identity.ed25519Pubkey,
+      secp256k1Pubkey: identity.secp256k1Pubkey,
+      createdAt: parsed.createdAt || new Date().toISOString(),
+      seed: seed.toString("hex"),
+    };
+    writeFileSync(IDENTITY_PATH, JSON.stringify(toStore, null, 2));
+    console.log(`Identity ${identity.crowId} imported successfully.`);
+    return;
+  }
+
+  // Legacy plaintext-base64 blob (already-valid identity.json content).
   writeFileSync(IDENTITY_PATH, data);
   console.log("Identity imported successfully.");
 }

--- a/tests/identity-backup.test.js
+++ b/tests/identity-backup.test.js
@@ -1,0 +1,281 @@
+/**
+ * 4-PR3 identity backup — encryptSeed/decryptSeed exports, buildIdentityBackup,
+ * the onboarding identity-backup POST handler, the done-step backup form, and
+ * the CLI export/import honesty fixes.
+ *
+ * Ordering matters within this file: the "identity.json missing" tests run
+ * BEFORE loadOrCreateIdentity() creates the scratch identity (identity.js pins
+ * its DATA_DIR at import time, so one process = one identity dir). CLI tests
+ * spawn child processes with their own scratch dirs and are order-independent.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, existsSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const identityModulePath = resolve(repoRoot, "servers/sharing/identity.js");
+
+// Pin the scratch dir BEFORE importing identity.js (it resolves DATA_DIR at import).
+const scratch = mkdtempSync(join(tmpdir(), "crow-idbackup-"));
+const dataDir = join(scratch, "data");
+process.env.CROW_DATA_DIR = dataDir;
+process.env.CROW_DISABLE_NOSTR = "1";
+process.env.CROW_DISABLE_INSTANCE_SYNC = "1";
+
+const identity = await import("../servers/sharing/identity.js");
+const {
+  encryptSeed, decryptSeed, buildIdentityBackup,
+  loadOrCreateIdentity, deriveInstanceIdentity, loadInstanceSeed,
+} = identity;
+const onboardingMod = await import("../servers/gateway/dashboard/panels/onboarding.js");
+const { handleIdentityBackupPost, STEP_KEYS } = onboardingMod;
+const onboardingPanel = onboardingMod.default;
+const i18n = await import("../servers/gateway/dashboard/shared/i18n.js");
+
+const DONE_IDX = STEP_KEYS.indexOf("done");
+const PASSPHRASE = "correct horse battery staple";
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+async function renderDoneStep(query = {}) {
+  let captured = "";
+  const layout = ({ content }) => content;
+  const res = { send(h) { captured = h; }, setHeader() {} };
+  const req = { method: "GET", query: { step: String(DONE_IDX), ...query }, headers: {} };
+  const out = await onboardingPanel.handler(req, res, { layout, lang: "en" });
+  return typeof out === "string" ? out : captured;
+}
+
+function makeRes() {
+  return {
+    headers: {}, redirected: null, body: null, contentType: null,
+    setHeader(k, v) { this.headers[k] = v; },
+    redirectAfterPost(url) { this.redirected = url; },
+    type(t) { this.contentType = t; return this; },
+    send(b) { this.body = b; return this; },
+  };
+}
+
+function makePostReq(body) {
+  return { method: "POST", headers: {}, query: {}, body };
+}
+
+/** Spawn the identity CLI exactly the way package.json does (node -e import chain). */
+function runCli(fnName, args, envOverrides = {}) {
+  const script = `import(${JSON.stringify(pathToFileURL(identityModulePath).href)}).then(m => m.${fnName}())`;
+  return spawnSync(process.execPath, ["-e", script, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CROW_DISABLE_NOSTR: "1",
+      CROW_DISABLE_INSTANCE_SYNC: "1",
+      ...envOverrides,
+    },
+  });
+}
+
+// ── 1. encryptSeed / decryptSeed exports ────────────────────────────────────
+
+test("encryptSeed/decryptSeed are exported and round-trip; wrong passphrase throws", () => {
+  assert.equal(typeof encryptSeed, "function", "encryptSeed is exported");
+  assert.equal(typeof decryptSeed, "function", "decryptSeed is exported");
+  const seed = Buffer.from("aa".repeat(32), "hex");
+  const enc = encryptSeed(seed, PASSPHRASE);
+  assert.ok(enc.salt && enc.iv && enc.encrypted && enc.tag, "encrypted blob has salt/iv/encrypted/tag");
+  assert.ok(!JSON.stringify(enc).includes(seed.toString("hex")), "ciphertext never carries the seed hex");
+  assert.deepEqual(decryptSeed(enc, PASSPHRASE), seed, "round-trip reproduces the seed");
+  assert.throws(() => decryptSeed(enc, "wrong-passphrase-1"), "wrong passphrase throws (GCM tag failure)");
+});
+
+// ── 2. missing-identity states (must run before the identity is created) ────
+
+test("buildIdentityBackup throws a clear error when identity.json is missing", () => {
+  assert.equal(existsSync(join(dataDir, "identity.json")), false, "precondition: no identity yet");
+  assert.throws(() => buildIdentityBackup(PASSPHRASE), /identity/i, "names the missing identity file");
+});
+
+test("done step renders the honest no-identity note and NO backup form when identity.json is missing", async () => {
+  const html = await renderDoneStep();
+  assert.ok(!html.includes("/dashboard/onboarding/identity-backup"), "no backup form action");
+  assert.ok(!html.includes('name="passphrase"'), "no passphrase field");
+  assert.ok(html.includes(i18n.t("onboarding.backup.noIdentity", "en")), "honest note rendered");
+});
+
+// ── 3. buildIdentityBackup payload ──────────────────────────────────────────
+
+test("buildIdentityBackup payload never contains the plaintext seed hex", () => {
+  const id = loadOrCreateIdentity(); // creates the scratch identity (plaintext seed)
+  const payload = buildIdentityBackup(PASSPHRASE);
+  const json = JSON.stringify(payload);
+  assert.ok(!json.includes(id.seed.toString("hex")), "plaintext seed hex is ABSENT from the payload JSON");
+  assert.ok(payload.encrypted && typeof payload.encrypted === "object", "encrypted blob present");
+});
+
+test("buildIdentityBackup: shape, clear identification fields, decrypt round-trip, crowId derivation", () => {
+  const stored = JSON.parse(readFileSync(join(dataDir, "identity.json"), "utf-8"));
+  const payload = buildIdentityBackup(PASSPHRASE);
+  assert.equal(payload.version, 1);
+  assert.equal(payload.kind, "crow-identity-backup");
+  assert.equal(payload.crowId, stored.crowId);
+  assert.equal(payload.ed25519Pubkey, stored.ed25519Pubkey);
+  assert.equal(payload.secp256k1Pubkey, stored.secp256k1Pubkey);
+  assert.equal(payload.createdAt, stored.createdAt);
+  assert.ok(typeof payload._restore === "string" && payload._restore.includes("identity:import"), "_restore names the import command");
+  const seed = decryptSeed(payload.encrypted, PASSPHRASE);
+  assert.equal(seed.toString("hex"), stored.seed, "decrypt round-trip reproduces the original seed");
+  assert.equal(deriveInstanceIdentity(seed).crowId, payload.crowId, "crowId matches deriveInstanceIdentity(seed)");
+  assert.throws(() => decryptSeed(payload.encrypted, "not-the-passphrase"), "wrong passphrase cannot decrypt the backup");
+});
+
+// ── 4. endpoint handler (handleIdentityBackupPost) ──────────────────────────
+
+test("endpoint: passphrase shorter than 12 chars redirects back with backup_error", async () => {
+  const res = makeRes();
+  await handleIdentityBackupPost(makePostReq({ passphrase: "short", confirm: "short" }), res);
+  assert.ok(res.redirected, "redirects instead of sending a file");
+  assert.ok(res.redirected.includes(`/dashboard/onboarding?step=${DONE_IDX}`), "redirects to the done step");
+  assert.ok(res.redirected.includes("backup_error="), "carries a backup_error message");
+  assert.equal(res.body, null, "no payload sent");
+});
+
+test("endpoint: mismatched confirm redirects back with backup_error", async () => {
+  const res = makeRes();
+  await handleIdentityBackupPost(makePostReq({ passphrase: PASSPHRASE, confirm: PASSPHRASE + "x" }), res);
+  assert.ok(res.redirected && res.redirected.includes("backup_error="), "redirects with backup_error");
+  assert.equal(res.body, null, "no payload sent");
+});
+
+test("endpoint: valid passphrase → attachment download with encrypted payload, no plaintext seed", async () => {
+  const stored = JSON.parse(readFileSync(join(dataDir, "identity.json"), "utf-8"));
+  const res = makeRes();
+  await handleIdentityBackupPost(makePostReq({ passphrase: PASSPHRASE, confirm: PASSPHRASE }), res);
+  assert.equal(res.redirected, null, "no redirect on success");
+  assert.equal(res.headers["Content-Disposition"], 'attachment; filename="crow-identity-backup.json"');
+  assert.equal(res.contentType, "application/json");
+  const payload = JSON.parse(res.body);
+  assert.equal(payload.kind, "crow-identity-backup");
+  assert.equal(payload.crowId, stored.crowId);
+  assert.ok(payload.encrypted, "encrypted seed present");
+  assert.ok(!res.body.includes(stored.seed), "response body never contains the plaintext seed hex");
+});
+
+test("endpoint: unexpected failure redirects with a generic error (no 500)", async () => {
+  const res = makeRes();
+  // Missing body entirely → treated as invalid input, redirect (never a throw).
+  await handleIdentityBackupPost({ method: "POST", headers: {}, query: {} }, res);
+  assert.ok(res.redirected && res.redirected.includes("backup_error="), "redirects with backup_error");
+});
+
+// ── 5. done-step render with identity present ───────────────────────────────
+
+test("done step renders the backup form: csrf, two password fields, minlength 12, crowId", async () => {
+  const stored = JSON.parse(readFileSync(join(dataDir, "identity.json"), "utf-8"));
+  const html = await renderDoneStep();
+  assert.ok(html.includes('action="/dashboard/onboarding/identity-backup"'), "form posts to the endpoint");
+  assert.ok(html.includes('method="POST"') || html.includes('method="post"'), "form is a POST");
+  assert.ok(html.includes('name="_csrf"'), "csrf input present");
+  assert.ok(html.includes('name="passphrase"'), "passphrase field present");
+  assert.ok(html.includes('name="confirm"'), "confirm field present");
+  const pwFields = html.match(/type="password"/g) || [];
+  assert.ok(pwFields.length >= 2, "two password-type fields");
+  const minlengths = html.match(/minlength="12"/g) || [];
+  assert.ok(minlengths.length >= 2, "minlength=12 on both fields");
+  assert.ok(html.includes(stored.crowId), "crowId shown for identification");
+  assert.ok(!html.includes(stored.seed), "seed never rendered");
+});
+
+test("done step renders backup_error escaped", async () => {
+  const html = await renderDoneStep({ backup_error: '<script>alert(1)</script>' });
+  assert.ok(!html.includes("<script>alert(1)</script>"), "raw script tag never rendered");
+  assert.ok(html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"), "error text rendered escaped");
+});
+
+test("i18n: every onboarding.backup.* key has non-empty en AND es values", () => {
+  const keys = Object.keys(i18n.translations).filter((k) => k.startsWith("onboarding.backup."));
+  assert.ok(keys.length >= 8, `expected the backup key block, found ${keys.length}`);
+  for (const k of keys) {
+    const entry = i18n.translations[k];
+    assert.ok(entry.en && entry.en.trim(), `missing en for ${k}`);
+    assert.ok(entry.es && entry.es.trim(), `missing es for ${k}`);
+  }
+});
+
+// ── 6. CLI (child processes, independent scratch dirs) ──────────────────────
+
+test("CLI export: refuses without a passphrase when non-interactive", () => {
+  const out = runCli("exportIdentity", [], { CROW_DATA_DIR: dataDir });
+  assert.equal(out.status, 1, "exit 1");
+  assert.match(out.stderr, /passphrase/i, "clear message names the passphrase");
+});
+
+test("CLI export → import round-trip: encrypted output, restore writes a plaintext-seed identity.json", () => {
+  const stored = JSON.parse(readFileSync(join(dataDir, "identity.json"), "utf-8"));
+  // Flag-first args need the `--` separator or node -e eats them as node options.
+  const exp = runCli("exportIdentity", ["--", "--passphrase", PASSPHRASE], { CROW_DATA_DIR: dataDir });
+  assert.equal(exp.status, 0, `export succeeds: ${exp.stderr}`);
+  assert.ok(!exp.stdout.includes(stored.seed), "export output never contains the plaintext seed hex");
+  const b64 = (exp.stdout.match(/[A-Za-z0-9+/=]{40,}/) || [])[0];
+  assert.ok(b64, "export output contains the base64 blob");
+  const payload = JSON.parse(Buffer.from(b64, "base64").toString("utf-8"));
+  assert.equal(payload.kind, "crow-identity-backup", "export blob is the encrypted backup format");
+
+  const restoreDir = join(scratch, "restore", "data");
+  mkdirSync(restoreDir, { recursive: true });
+  const imp = runCli("importIdentity", [b64, "--passphrase", PASSPHRASE], { CROW_DATA_DIR: restoreDir });
+  assert.equal(imp.status, 0, `import succeeds: ${imp.stderr}`);
+  const restored = JSON.parse(readFileSync(join(restoreDir, "identity.json"), "utf-8"));
+  assert.equal(restored.seed, stored.seed, "restore writes the PLAINTEXT seed");
+  assert.equal(restored.crowId, stored.crowId, "crowId preserved");
+  // The gateway host must be able to boot from the restored file.
+  const seed = loadInstanceSeed(restoreDir);
+  assert.equal(seed.toString("hex"), stored.seed, "loadInstanceSeed accepts the restored identity.json");
+});
+
+test("CLI import refuses to overwrite an existing identity.json", () => {
+  const payload = buildIdentityBackup(PASSPHRASE);
+  const b64 = Buffer.from(JSON.stringify(payload)).toString("base64");
+  // dataDir already holds the scratch identity — import must refuse.
+  const out = runCli("importIdentity", [b64, "--passphrase", PASSPHRASE], { CROW_DATA_DIR: dataDir });
+  assert.equal(out.status, 1, "exit 1");
+  assert.match(out.stderr, /already exists/i, "clear refusal message");
+});
+
+test("CLI import: wrong passphrase fails cleanly (message, not a stack trace)", () => {
+  const payload = buildIdentityBackup(PASSPHRASE);
+  const b64 = Buffer.from(JSON.stringify(payload)).toString("base64");
+  const dir = join(scratch, "wrongpass", "data");
+  mkdirSync(dir, { recursive: true });
+  const out = runCli("importIdentity", [b64, "--passphrase", "not-the-passphrase"], { CROW_DATA_DIR: dir });
+  assert.equal(out.status, 1, "exit 1");
+  assert.match(out.stderr, /passphrase/i, "message names the passphrase");
+  assert.ok(!out.stderr.includes("Uncaught"), "no unhandled rejection");
+  assert.ok(!/at .*identity\.js/.test(out.stderr), "no stack trace");
+  assert.equal(existsSync(join(dir, "identity.json")), false, "no identity written on failure");
+});
+
+test("CLI import: encrypted backup without passphrase (non-interactive) refuses", () => {
+  const payload = buildIdentityBackup(PASSPHRASE);
+  const b64 = Buffer.from(JSON.stringify(payload)).toString("base64");
+  const dir = join(scratch, "nopass", "data");
+  mkdirSync(dir, { recursive: true });
+  const out = runCli("importIdentity", [b64], { CROW_DATA_DIR: dir });
+  assert.equal(out.status, 1, "exit 1");
+  assert.match(out.stderr, /passphrase/i, "message names the passphrase");
+  assert.equal(existsSync(join(dir, "identity.json")), false, "no identity written");
+});
+
+test("CLI import: legacy plaintext-base64 blob still works", () => {
+  const raw = readFileSync(join(dataDir, "identity.json"), "utf-8");
+  const b64 = Buffer.from(raw).toString("base64");
+  const dir = join(scratch, "legacy", "data");
+  mkdirSync(dir, { recursive: true });
+  const out = runCli("importIdentity", [b64], { CROW_DATA_DIR: dir });
+  assert.equal(out.status, 0, `legacy import succeeds: ${out.stderr}`);
+  assert.equal(readFileSync(join(dir, "identity.json"), "utf-8"), raw, "legacy blob written as-is");
+});


### PR DESCRIPTION
Third PR of the Item 4 generalization theme (spec `docs/superpowers/specs/2026-07-13-generalization-firstrun-design.md` §2.3 identity parts). Fixes F-ONBOARD-1 (a lost box = permanently lost identity, and the user was never told) and F4-EXPORT-HONESTY (`identity:export` printed "Encrypted Identity Export" over plaintext-base64).

## What

- **Wizard done-step backup**: shows the instance crowId + what losing the identity costs, and a passphrase form (min 12 chars + confirm) that POSTs to a new hand-registered `POST /dashboard/onboarding/identity-backup` (behind dashboardAuth + CSRF, unreachable via Funnel/HMAC-bypass/MCP) and downloads `crow-identity-backup.json`. The payload keeps crowId/pubkeys in the clear for identification; the master seed exists **only** inside a scrypt(N=16384)+AES-256-GCM blob — the plaintext seed hex is asserted absent from the download. Identity-missing state renders an honest note, never crashes. Linked from Settings → Help & Setup.
- **CLI honesty**: `identity:export` now requires a passphrase and actually encrypts (the label finally tells the truth). `identity:import` sniffs both formats — encrypted backups decrypt and write a **plaintext-seed** identity.json (the gateway host can't boot from an encrypted one; the encryption protects the download, not the disk), legacy plaintext-base64 blobs still work. Wrong passphrase = clean error, not a stack trace.
- **Found + fixed a pre-existing bug**: `npm run identity:import` never worked — the `node -e` invocation puts user args at `argv[1]`, so `process.argv.slice(2)` dropped them all. New `cliArgs()` handles both invocation shapes (proved by the RED test run before any change).
- `encryptSeed`/`decryptSeed` exported; new `buildIdentityBackup(passphrase)`.
- Docs: `docs/guide/sharing.md` rewritten — also retracts that page's false claim that the seed is "encrypted at rest".
- 12 new i18n keys EN+ES (parity asserted).

## Verification

- New `tests/identity-backup.test.js`: 18 tests (RED-first), incl. decrypt round-trip against the real stored seed, crowId re-derivation, seed-absence via genuine-seed string compare, endpoint validation, XSS-escape of the error param, CLI round-trip/wrong-pass/no-pass/legacy in child processes
- 4 parse-clean mutation checks with named red tests (minlength, match, no-plaintext-seed property, overwrite refusal)
- Security-focused whole-branch adversarial review: READY TO MERGE, zero blocking findings (verified: crafted-body typeof bypass impossible with this body parser, mount order behind auth+CSRF, Funnel guard applies, HMAC bypass can't reach it, no seed/passphrase in any error path; one pre-existing LOW noted for the PR4 sweep: legacy import writes unvalidated JSON — unchanged from main)
- Live proof on a scratch gateway (evidence `~/.crow/p4/item4-pr3/`, 9 assertions + screenshot): real downloaded blob decrypts to the exact stored seed, wrong passphrase fails on the GCM tag, plaintext seed absent, `npm run identity:import` restores a bootable plaintext-seed identity.json, short/mismatch POSTs redirect with i18n'd errors
- Suite (scratch env): pass with exactly the 3 pre-existing known fails / 0 skips (+18 tests); a `--crow-danger`→`--crow-error` token defect was caught by the design-system test and fixed in-branch; two transient orphan-guard failures were proven environmental (a live scratch gateway perturbs that test's process scans — green on clean re-run)
- check-ports: exactly the one known capstone line; build-registry: OK

No schema changes; no fleet choreography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrmujaUpg9W5sFvhQyWqTz