### PR TITLE
Item 4 PR4: personal-hardcode sweep — HOME-derived paths, fail-closed gmail sender wall, honest pi-exit surface

### DIFF
--- a/bundles/browser/docker-compose.yml
+++ b/bundles/browser/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - CDP_PORT=9222
       - CHROME_PROXY=${CROW_BROWSER_PROXY:-}
     volumes:
-      - /home/kh0pp/.crow/browser-downloads:/downloads
+      - ${CROW_HOME:-${HOME}/.crow}/browser-downloads:/downloads
     init: true
     mem_limit: 2g
     shm_size: 1g

--- a/bundles/browser/server/server.js
+++ b/bundles/browser/server/server.js
@@ -16,6 +16,7 @@ import { getRandomProfile } from "./profiles.js";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 
 /**
@@ -124,7 +125,9 @@ export function createBrowserServer(options = {}) {
             composeFile = execFileSync("docker", ["inspect", "crow-browser", "--format", '{{index .Config.Labels "com.docker.compose.project.config_files"}}'], { timeout: 10000 }).toString().trim();
           } catch { /* fall through to error */ }
           if (!vncpw) return { content: [{ type: "text", text: "Could not read VNC password from the running container — set CROW_BROWSER_PROXY in the environment and recreate the container manually." }], isError: true };
-          if (!composeFile) composeFile = "/home/kh0pp/crow/bundles/browser/docker-compose.yml";
+          // Fallback: this bundle's own compose file, derived from our location
+          // (never an assumed checkout path).
+          if (!composeFile) composeFile = fileURLToPath(new URL("../docker-compose.yml", import.meta.url));
           try {
             execFileSync("docker", ["compose", "-f", composeFile, "up", "-d", "--force-recreate"], {
               timeout: 90000,

--- a/bundles/knowledge-base/routes/kb-public.js
+++ b/bundles/knowledge-base/routes/kb-public.js
@@ -384,7 +384,7 @@ function kbPageShell({ title, lang, content, collection, breadcrumbs }) {
     ${content}
   </main>
   <footer class="kb-footer" role="contentinfo">
-    <p>Powered by <a href="https://github.com/kh0pp/crow">Crow</a></p>
+    <p>Powered by <a href="https://github.com/kh0pper/crow">Crow</a></p>
   </footer>
 </body>
 </html>`;

--- a/bundles/llamacpp-vulkan-glm-45-air/docker-compose.yml
+++ b/bundles/llamacpp-vulkan-glm-45-air/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     entrypoint: ["llama-server"]
     command:
       # Pre-download (~55GB across 2 shards; llama.cpp auto-loads shard 2):
-      #   mkdir -p /home/kh0pp/llm/hf-cache/glm-45-air/
+      #   mkdir -p $LLM_CACHE/glm-45-air/
       #   for i in 1 2; do
-      #     curl -L -o /home/kh0pp/llm/hf-cache/glm-45-air/GLM-4.5-Air-Q5_K_M-0000${i}-of-00002.gguf \
+      #     curl -L -o $LLM_CACHE/glm-45-air/GLM-4.5-Air-Q5_K_M-0000${i}-of-00002.gguf \
       #       "https://huggingface.co/unsloth/GLM-4.5-Air-GGUF/resolve/main/Q5_K_M/GLM-4.5-Air-Q5_K_M-0000${i}-of-00002.gguf"
       #   done
       - -m

--- a/bundles/llamacpp-vulkan-qwen3-coder/docker-compose.yml
+++ b/bundles/llamacpp-vulkan-qwen3-coder/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - "${CROW_TAILSCALE_IP}:8003:8000"
     entrypoint: ["llama-server"]
     command:
-      # Pre-downloaded to /home/kh0pp/llm/hf-cache/qwen3-coder-30b/ by:
-      #   curl -L -o /home/kh0pp/llm/hf-cache/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q8_0.gguf \
+      # Pre-downloaded to $LLM_CACHE/qwen3-coder-30b/ by:
+      #   curl -L -o $LLM_CACHE/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q8_0.gguf \
       #        https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/resolve/main/Qwen3-Coder-30B-A3B-Instruct-Q8_0.gguf
       - -m
       - /models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q8_0.gguf

--- a/bundles/llamacpp-vulkan-qwen3-embed/docker-compose.yml
+++ b/bundles/llamacpp-vulkan-qwen3-embed/docker-compose.yml
@@ -18,9 +18,9 @@ services:
     command:
       # Qwen3-Embedding-0.6B Q8_0 GGUF (~640 MB).
       # Pre-download once:
-      #   mkdir -p /home/kh0pp/llm/hf-cache/qwen3-embedding-0.6b/
+      #   mkdir -p $LLM_CACHE/qwen3-embedding-0.6b/
       #   curl -L \
-      #     -o /home/kh0pp/llm/hf-cache/qwen3-embedding-0.6b/Qwen3-Embedding-0.6B-Q8_0.gguf \
+      #     -o $LLM_CACHE/qwen3-embedding-0.6b/Qwen3-Embedding-0.6B-Q8_0.gguf \
       #     https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
       - -m
       - /models/qwen3-embedding-0.6b/Qwen3-Embedding-0.6B-Q8_0.gguf

--- a/bundles/llamacpp-vulkan-qwen36-35b-a3b/docker-compose.yml
+++ b/bundles/llamacpp-vulkan-qwen36-35b-a3b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "${CROW_TAILSCALE_IP}:8003:8000"
     entrypoint: ["llama-server"]
     command:
-      # MTP GGUF + mmproj pre-downloaded to /home/kh0pp/llm/hf-cache/qwen36-35b-a3b-mtp/
+      # MTP GGUF + mmproj pre-downloaded to $LLM_CACHE/qwen36-35b-a3b-mtp/
       # from unsloth/Qwen3.6-35B-A3B-MTP-GGUF (UD-Q5_K_XL + mmproj-F16; Q6_K kept as fallback).
       - -m
       - /models/qwen36-35b-a3b-mtp/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf

--- a/bundles/media/panel/routes.js
+++ b/bundles/media/panel/routes.js
@@ -791,7 +791,7 @@ export function mediaPublicRouter() {
     <h1>${escapeHtml(playlist.name)}</h1>
     <div class="meta">${items.length} articles${playlist.description ? " \u00b7 " + escapeHtml(playlist.description) : ""}</div>
     <div>${itemsHtml || "<p style='color:#888'>This playlist is empty.</p>"}</div>
-    <p style="margin-top:2rem;font-size:0.75rem;color:#555">Powered by <a href="https://github.com/kh0pp/crow">Crow</a></p>
+    <p style="margin-top:2rem;font-size:0.75rem;color:#555">Powered by <a href="https://github.com/kh0pper/crow">Crow</a></p>
   </div>
 </body></html>`;
 

--- a/bundles/media/server/feed-fetcher.js
+++ b/bundles/media/server/feed-fetcher.js
@@ -6,7 +6,7 @@
  */
 
 const FETCH_TIMEOUT = 10000;
-const USER_AGENT = "Crow/1.0 (RSS Reader; +https://github.com/kh0pp/crow)";
+const USER_AGENT = "Crow/1.0 (RSS Reader; +https://github.com/kh0pper/crow)";
 
 /**
  * Fetch a feed URL and return the raw XML text.

--- a/bundles/ntfy/docker-compose.yml
+++ b/bundles/ntfy/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ntfy-cache:/var/cache/ntfy
     ports:
       # Bind only to 127.0.0.1 so Docker's publish doesn't collide with
-      # Tailscale's serve rule on the tailnet IP (100.121.254.89:2586).
+      # Tailscale's serve rule on the host's tailnet IP (port 2586).
       # External/tailnet access is routed by `tailscale serve 2586` ->
       # http://localhost:2586 with HTTPS termination at the tailnet edge.
       - "127.0.0.1:${NTFY_PORT:-2586}:80"

--- a/docs/getting-started/multi-device.md
+++ b/docs/getting-started/multi-device.md
@@ -26,26 +26,25 @@ On `server-a`:
 ```bash
 cd ~/crow
 npm run identity:export
+# (non-interactive: npm run identity:export -- -- --passphrase <passphrase>)
 ```
 
-You'll be prompted for a passphrase to encrypt the export. The command outputs a file path — something like `~/.crow/identity-export.enc`.
+You'll be prompted for a passphrase (minimum 12 characters) to encrypt the export. The command prints a **base64 blob** to the terminal — the master seed inside it is scrypt + AES-256-GCM encrypted under your passphrase. Copy the whole string.
 
-Copy the file to `server-b`:
-
-```bash
-scp ~/.crow/identity-export.enc user@server-b:~/
-```
+Alternatively, download a backup file from the dashboard: the first-run wizard's final step (replayable from Settings → Help & Setup → "Download identity backup") saves `crow-identity-backup.json` in the same encrypted format.
 
 ## Step 3: Import Identity on Satellite
 
-On `server-b`:
+On `server-b` (before the first gateway start, while it has no identity yet — the import refuses to overwrite an existing `identity.json`):
 
 ```bash
 cd ~/crow
-npm run identity:import
+npm run identity:import -- <base64-blob>
+# (a downloaded crow-identity-backup.json imports the same way:
+#  npm run identity:import -- "$(base64 -w0 crow-identity-backup.json)")
 ```
 
-Enter the same passphrase you used during export. This replaces `server-b`'s identity with the shared one.
+You'll be prompted for the passphrase you chose during export. The import decrypts the backup and writes `server-b`'s `identity.json` with the shared identity. If `server-b` already created its own identity, move `~/.crow/data/identity.json` aside first.
 
 Verify both machines have the same Crow ID:
 

--- a/scripts/pi-bots-phase1-setup.mjs
+++ b/scripts/pi-bots-phase1-setup.mjs
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 /**
+ * HISTORICAL — one-time Phase 1 (May 2026) bring-up fixture. NOT part of the
+ * product install path and NOT maintained: it bakes the original operator's
+ * instance paths, Gmail addresses, and a pre-Item-4 bot def
+ * (spawn_env.PI_PROVIDER, non-empty gateways) that the Bot Builder no longer
+ * generates (defaultDefinition ships gateways:[] and no PI_PROVIDER since
+ * PR #184). Kept only as a record of the v0.1 seed data shape. Do not run on
+ * a fresh install; create bots through the Bot Builder panel instead.
+ *
  * Crow Bot Builder — Phase 1 setup fixture (idempotent).
  *
  * Stands up the minimal v0.1 data the bridge + GUI operate on:

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -21,7 +21,7 @@
 import Database from "better-sqlite3";
 import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, appendFileSync, existsSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 import { countLivePi, LIFECYCLE_DEFAULTS } from "./pi_lifecycle.mjs";
 import { writeBotMcp } from "./mcp_writer.mjs";
@@ -42,7 +42,7 @@ import { statusToStage } from "../../servers/gateway/routes/board-stages.js";
 import { parsePlanRef, containedRealPath } from "../../servers/gateway/routes/plan-ref.js";
 import { extractPlanFileLine, buildPlanPrompt } from "./plan_dispatch.mjs";
 
-const HOME = "/home/kh0pp";
+const HOME = process.env.HOME || homedir();
 const NODE = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
 // Package was renamed from @mariozechner/pi-coding-agent to
 // @earendil-works/pi-coding-agent (still 'pi' binary; v0.74.2 verified).
@@ -105,7 +105,12 @@ export class PiRpc {
     // model_resolver.resolveModel() and passed in via opts.resolved — there
     // is NO hardcoded crow-local anywhere in the spawn path anymore.
     const resolved = opts.resolved;
-    const args = [PI_CLI, "--mode", "rpc", "--provider", resolved.provider, "--model", resolved.model,
+    this.resolved = resolved;
+    // Test seam: nodeBin/cliPath let tests drive the exit-surface path with a
+    // stub child instead of a real pi (which would wire live MCP servers).
+    const nodeBin = opts.nodeBin || NODE;
+    const cliPath = opts.cliPath || PI_CLI;
+    const args = [cliPath, "--mode", "rpc", "--provider", resolved.provider, "--model", resolved.model,
       "--session-dir", sessionDir + "/sessions"];
     // Phase 3.1 (R9/R11): multi-agent is allowed iff the operator opted in
     // (def.permission_policy.multi_agent) AND the POST-resolution model is
@@ -154,8 +159,14 @@ export class PiRpc {
     // the whole tree (pi + its MCP children). Without this, killing pi leaves
     // its MCP server children (brave-search, google-workspace, github, etc.)
     // running indefinitely — observed leak of ~5 MCP procs per turn.
-    this.proc = spawn(NODE, args, { cwd: sessionDir, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
+    this.proc = spawn(nodeBin, args, { cwd: sessionDir, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
     this.events = []; this.responses = []; this.stderr = ""; this._b = ""; this._w = []; this.badStdout = 0;
+    this._exitCode = null;
+    // A write after pi died early (e.g. unknown provider on a fresh install)
+    // raises EPIPE on stdin asynchronously — without a listener that is an
+    // uncaught exception that kills the whole bridge. Swallow it; the exit
+    // handler below surfaces the real cause.
+    this.proc.stdin.on("error", () => {});
     this.proc.stdout.on("data", (c) => {
       this._b += c.toString("utf8");
       let nl;
@@ -169,14 +180,32 @@ export class PiRpc {
       }
     });
     this.proc.stderr.on("data", (d) => { this.stderr += d.toString(); });
-    this.exited = new Promise((res) => this.proc.on("exit", (c) => res(c == null ? -1 : c)));
+    this.exited = new Promise((res) => this.proc.on("exit", (c) => {
+      this._exitCode = c == null ? -1 : c;
+      // Fail any pending waiters NOW with the real cause instead of leaving
+      // them to time out cryptically (a fresh install resolving to a model
+      // no provider serves makes pi print "Unknown provider" and exit — the
+      // Gmail/Discord user must see that, fast, not a 60s "timeout:prompt-ack").
+      for (const w of this._w.splice(0)) if (w.j) w.j(this._exitError(w.label));
+      res(this._exitCode);
+    }));
   }
-  send(o) { this.proc.stdin.write(JSON.stringify(o) + "\n"); }
+  _exitError(label) {
+    const key = this.resolved && this.resolved.key;
+    return new Error("pi exited (code " + this._exitCode + ") before " + (label || "responding") +
+      " — the model " + key + " may not be available on this instance" +
+      " (configure providers in Settings → AI Models). pi said: " + (this.stderr.trim().slice(-300) || "(no stderr)"));
+  }
+  send(o) {
+    if (this._exitCode != null) throw this._exitError("send");
+    this.proc.stdin.write(JSON.stringify(o) + "\n");
+  }
   waitFor(p, ms, label) {
     return new Promise((resolve, reject) => {
       const hit = this.events.find(p) || this.responses.find(p);
       if (hit) return resolve(hit);
-      const w = { p, r: resolve }; this._w.push(w);
+      if (this._exitCode != null) return reject(this._exitError(label));
+      const w = { p, r: resolve, j: reject, label }; this._w.push(w);
       setTimeout(() => { const i = this._w.indexOf(w); if (i >= 0) { this._w.splice(i, 1); reject(new Error("timeout:" + label + " (stderr " + this.stderr.slice(-200) + ")")); } }, ms);
     });
   }

--- a/scripts/pi-bots/bridge_tick.mjs
+++ b/scripts/pi-bots/bridge_tick.mjs
@@ -16,14 +16,18 @@
 import Database from "better-sqlite3";
 import { execFile } from "node:child_process";
 import { openSync, closeSync, existsSync, statSync, unlinkSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { handleInbound } from "./bridge.mjs";
 import { reapStalePi } from "./pi_lifecycle.mjs";
+import { gmailSenderAllowed } from "./gateways/base.mjs";
 import { botsDbPath } from "./instance-paths.mjs";
 import { botRuntimeEnabledSync } from "./runtime-gate.mjs";
 
-const HOME = "/home/kh0pp";
-const NODE = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
-const GIO = HOME + "/crow/scripts/pi-bots/gmail_io.mjs";
+// gmail_io.mjs is dependency-free and lives beside this file — run it with
+// the SAME node running this tick (process.execPath) and derive its path from
+// our own location, never from an assumed /home/<user>/crow checkout.
+const NODE = process.execPath;
+const GIO = fileURLToPath(new URL("./gmail_io.mjs", import.meta.url));
 const CROW_DB = botsDbPath();
 const LOCK = "/tmp/pibot-bridge-tick.lock";
 
@@ -80,7 +84,7 @@ function acquireLock() {
     let def; try { def = JSON.parse(row.definition || "{}"); } catch { continue; }
     const gw = (def.gateways || []).find((g) => g.type === "gmail" && g.address);
     if (!gw) continue;
-    const alias = gw.address;                         // kevin.hopper+<x>@maestro.press
+    const alias = gw.address;                         // e.g. user+<x>@example.com
     const plus = (alias.match(/\+([^@]+)@/) || [])[1]; // <x>
 
     const srch = await gio(["search", "--query", `to:${alias} newer_than:2d`, "--max", "10"]);
@@ -107,21 +111,18 @@ function acquireLock() {
       const msgDate = Date.parse(newest.date || (newest.headers && newest.headers.date) || "") || Date.now();
 
       // Reply-recipient = actual sender of `newest` (so the bot's reply lands
-      // back in the user's inbox, not the bot's own mailbox). Was previously
-      // hardcoded to kevin.hopper@maestro.press which routed replies to the
-      // bot itself. The send-allowlist on gmail_send_threaded_to_self is also
-      // enforced here at the bridge level so we never even attempt to send to
-      // a non-allowlisted sender — that's the safety wall against a third
-      // party emailing the +alias and getting a bot reply.
-      const SENDER_ALLOWLIST = new Set([
-        "kevin.hopper1@gmail.com",
-        "kevin.hopper@maestro.press",
-      ]);
+      // back in the user's inbox, not the bot's own mailbox — it was once
+      // hardcoded to the operator's address, which routed replies to the bot
+      // itself). The sender wall derives from the bot def's per-gateway
+      // allowlist (gw.allowlist — the same field the Bot Builder edits) and
+      // FAILS CLOSED when unconfigured: an empty allowlist means nobody can
+      // trigger a bot reply, never everybody. That's the safety wall against
+      // a third party emailing the +alias and getting a bot reply.
       const fromHeader = String(newest.from || (newest.headers && newest.headers.from) || "");
       const fromMatch = fromHeader.match(/<([^>]+)>/);
       const replyTo = (fromMatch ? fromMatch[1] : fromHeader).trim().toLowerCase();
-      if (!SENDER_ALLOWLIST.has(replyTo)) {
-        console.log(`[tick] skip thread=${tid} — sender '${replyTo}' not in allowlist`);
+      if (!gmailSenderAllowed(gw.allowlist, replyTo)) {
+        console.log(`[tick] skip thread=${tid} — sender '${replyTo}' not in this gateway's allowlist${Array.isArray(gw.allowlist) && gw.allowlist.length ? "" : " (no allowlist configured — set one on the bot's Gateways tab)"}`);
         continue;
       }
 
@@ -142,7 +143,7 @@ function acquireLock() {
             // so when the user clicks Reply in Gmail, it routes back to the
             // bot's +alias (which bridge_tick monitors) rather than the
             // bot's bare From: address (which nothing monitors). Without
-            // this, the user's reply lands at kevin.hopper@maestro.press
+            // this, the user's reply lands at the bot's bare From: address
             // and the bot never sees the follow-up.
             await gio(["reply", "--to", replyTo,
               "--reply-to", alias,

--- a/scripts/pi-bots/discord_gateway.mjs
+++ b/scripts/pi-bots/discord_gateway.mjs
@@ -34,7 +34,6 @@ import { chunkedSend, downloadImages, passesAllowlist, SerialQueue, typingHeartb
 import { botsDbPath } from "./instance-paths.mjs";
 import { runtimeGate } from "./runtime-gate.mjs";
 
-const HOME = "/home/kh0pp";
 const CROW_DB = botsDbPath();
 const MAX_QUEUE = 5;
 const CHUNK_LIMIT = 1990;        // safe margin under Discord's 2000-char hard limit

--- a/scripts/pi-bots/gateways/base.mjs
+++ b/scripts/pi-bots/gateways/base.mjs
@@ -115,6 +115,19 @@ export function passesAllowlist(senderId, allow) {
 }
 
 /**
+ * Gmail sender wall (bridge_tick): unlike passesAllowlist, an empty/absent
+ * allowlist FAILS CLOSED — the +alias is reachable by anyone on the internet,
+ * so "unconfigured" must mean "nobody triggers a bot reply", never "everybody".
+ * Comparison is case-insensitive (email addresses).
+ */
+export function gmailSenderAllowed(allow, sender) {
+  if (!Array.isArray(allow) || allow.length === 0) return false;
+  const s = String(sender || "").trim().toLowerCase();
+  if (!s) return false;
+  return allow.some((a) => String(a || "").trim().toLowerCase() === s);
+}
+
+/**
  * A per-bot FIFO serial queue: at most one turn runs at a time for a bot.
  * push() returns false (and invokes onFull) when the queue is at capacity, so
  * the caller can tell the user "still working". (Generalized from Discord's

--- a/scripts/pi-bots/gmail_io.mjs
+++ b/scripts/pi-bots/gmail_io.mjs
@@ -2,12 +2,23 @@
 /**
  * Crow Bot Builder — Gmail I/O helper (the bridge's real Gmail adapter).
  *
- * Dependency-free MCP stdio client to the crow `google-workspace` server (the
- * same server + tools the production MPA bots use). Sends self-guarded mail
- * (gmail_send_to_self / gmail_send_threaded_to_self — recipients restricted to
- * kevin.hopper1@gmail.com / kevin.hopper@maestro.press; +pibot is a self-alias)
- * and reads threads (gmail_search_threads / gmail_get_thread). Used by the
- * bridge for outbound, and by bridge_gmail_e2e.mjs to drive the user side.
+ * Dependency-free MCP stdio client to the crow `google-workspace` server.
+ * Sends self-guarded mail (gmail_send_to_self / gmail_send_threaded_to_self —
+ * recipients restricted server-side to the authenticated account plus any
+ * addresses in GMAIL_SEND_TO_SELF_ALLOWLIST) and reads threads
+ * (gmail_search_threads / gmail_get_thread). Used by the bridge for outbound,
+ * and by bridge_gmail_e2e.mjs to drive the user side.
+ *
+ * Configuration (env; HOME-derived defaults):
+ *   PIBOT_GWS_MCP_DIR   — google-workspace-mcp checkout (default
+ *                         $HOME/spring-2026/google-workspace-mcp)
+ *   PIBOT_GWS_MCP_BIN   — server binary (default <dir>/.venv/bin/google-workspace-mcp)
+ *   GOOGLE_CREDENTIALS_FILE / GOOGLE_TOKEN_FILE — workspace-account creds
+ *                         (default $HOME/.config/google-workspace-mcp-mpa/…)
+ *   GOOGLE_PERSONAL_CREDENTIALS_FILE / GOOGLE_PERSONAL_TOKEN_FILE — personal-
+ *                         account creds (default $HOME/.config/google-workspace-mcp/…)
+ *   GMAIL_SEND_TO_SELF_ALLOWLIST — extra self-send addresses (comma-separated;
+ *                         passed through from the caller's env, never baked in)
  *
  * CLI:
  *   node gmail_io.mjs send  --to A --subject S --body B [--thread TID] [--reply-to R]
@@ -17,23 +28,43 @@
  * Prints the tool's JSON result (last line = RESULT <json>).
  */
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
-const GW = "/home/kh0pp/spring-2026/google-workspace-mcp";
-const BIN = GW + "/.venv/bin/google-workspace-mcp";
+const HOME = process.env.HOME || homedir();
+const GW = process.env.PIBOT_GWS_MCP_DIR || join(HOME, "spring-2026", "google-workspace-mcp");
+const BIN = process.env.PIBOT_GWS_MCP_BIN || join(GW, ".venv", "bin", "google-workspace-mcp");
+const CONF = join(HOME, ".config");
 const ENV = {
-  GOOGLE_CREDENTIALS_FILE: "/home/kh0pp/.config/google-workspace-mcp-mpa/credentials.json",
-  GOOGLE_TOKEN_FILE: "/home/kh0pp/.config/google-workspace-mcp-mpa/gws-token.json",
-  GOOGLE_PERSONAL_CREDENTIALS_FILE: "/home/kh0pp/.config/google-workspace-mcp/credentials.json",
-  GOOGLE_PERSONAL_TOKEN_FILE: "/home/kh0pp/.config/google-workspace-mcp/token.json",
-  // +pibot is a self-alias of kevin.hopper@maestro.press; sanctioned override
-  // (gmail.py:26 documents GMAIL_SEND_TO_SELF_ALLOWLIST for new self addresses)
-  GMAIL_SEND_TO_SELF_ALLOWLIST: "kevin.hopper1@gmail.com,kevin.hopper@maestro.press,kevin.hopper+pibot@maestro.press",
+  GOOGLE_CREDENTIALS_FILE: process.env.GOOGLE_CREDENTIALS_FILE || join(CONF, "google-workspace-mcp-mpa", "credentials.json"),
+  GOOGLE_TOKEN_FILE: process.env.GOOGLE_TOKEN_FILE || join(CONF, "google-workspace-mcp-mpa", "gws-token.json"),
+  GOOGLE_PERSONAL_CREDENTIALS_FILE: process.env.GOOGLE_PERSONAL_CREDENTIALS_FILE || join(CONF, "google-workspace-mcp", "credentials.json"),
+  GOOGLE_PERSONAL_TOKEN_FILE: process.env.GOOGLE_PERSONAL_TOKEN_FILE || join(CONF, "google-workspace-mcp", "token.json"),
+  // GMAIL_SEND_TO_SELF_ALLOWLIST intentionally NOT set here: it flows through
+  // from the caller's environment (process.env below). The server's own
+  // default (self-send to the authenticated address only) applies when unset.
 };
+
+// Honest failure when unconfigured: a missing server binary means this host
+// has no google-workspace-mcp install — say so and name the knobs, instead of
+// dying on a cryptic spawn ENOENT.
+if (!existsSync(BIN)) {
+  console.error(
+    `gmail_io: google-workspace-mcp not found at ${BIN}.\n` +
+    "The Gmail channel needs a google-workspace-mcp install: set PIBOT_GWS_MCP_DIR " +
+    "(checkout dir) or PIBOT_GWS_MCP_BIN (server binary), plus GOOGLE_CREDENTIALS_FILE / " +
+    "GOOGLE_TOKEN_FILE for its credentials."
+  );
+  process.exit(1);
+}
 
 function arg(name, def) { const i = process.argv.indexOf("--" + name); return i >= 0 ? process.argv[i + 1] : def; }
 const cmd = process.argv[2];
 
-const child = spawn(BIN, [], { cwd: GW, env: Object.assign({}, process.env, ENV), stdio: ["pipe", "pipe", "pipe"] });
+// cwd is best-effort: PIBOT_GWS_MCP_BIN may point at a binary outside the
+// default checkout dir; never fail the spawn on a missing cwd.
+const child = spawn(BIN, [], { cwd: existsSync(GW) ? GW : undefined, env: Object.assign({}, process.env, ENV), stdio: ["pipe", "pipe", "pipe"] });
 let buf = "", nextId = 1; const pending = new Map(); let stderr = "";
 child.stderr.on("data", (d) => { stderr += d.toString(); });
 child.stdout.on("data", (d) => {

--- a/scripts/pi-bots/mcp_writer.mjs
+++ b/scripts/pi-bots/mcp_writer.mjs
@@ -31,10 +31,11 @@
 import { spawn } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { homedir } from "node:os";
 import { botsDbPath } from "./instance-paths.mjs";
 import { mintRemoteBlocks } from "./remote-blocks.mjs";
 
-const HOME = "/home/kh0pp";
+const HOME = process.env.HOME || homedir();
 export const CANONICAL_MCP_PATH = HOME + "/.pi/agent/mcp.json";
 
 export function readCanonicalMcp(path = CANONICAL_MCP_PATH) {

--- a/scripts/pi-bots/model_resolver.mjs
+++ b/scripts/pi-bots/model_resolver.mjs
@@ -32,9 +32,10 @@
  * crowdb-wal-flip-new-consumers), same as bridge.mjs.
  */
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { botsDbPath } from "./instance-paths.mjs";
 
-const HOME = "/home/kh0pp";
+const HOME = process.env.HOME || homedir();
 const MODELS_JSON = process.env.PI_MODELS_JSON || HOME + "/.pi/agent/models.json";
 export const LOCAL_FALLBACK = "crow-local/qwen3.6-35b-a3b";
 

--- a/scripts/pi-bots/s0_mcp_probe.mjs
+++ b/scripts/pi-bots/s0_mcp_probe.mjs
@@ -19,8 +19,9 @@
  */
 
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
 
-const HOME = "/home/kh0pp";
+const HOME = process.env.HOME || homedir();
 
 // Mirrors the live ~/.crow-mpa/mcp-addons.json launch config, but with the
 // db-path env set EXPLICITLY to the live MPA databases (the whole point of S0:

--- a/scripts/pi-bots/skill_provenance.mjs
+++ b/scripts/pi-bots/skill_provenance.mjs
@@ -17,7 +17,6 @@
 import Database from "better-sqlite3";
 import { botsDbPath } from "./instance-paths.mjs";
 
-const HOME = "/home/kh0pp";
 const CROW_DB = botsDbPath();
 
 function db() { const d = new Database(CROW_DB); d.pragma("busy_timeout = 10000"); return d; }

--- a/scripts/pi-bots/systemd/pibot-bridge@.service
+++ b/scripts/pi-bots/systemd/pibot-bridge@.service
@@ -1,3 +1,6 @@
+# OPERATOR-EDITED TEMPLATE: adjust User=, WorkingDirectory=, and paths for
+# your host before installing (install-runtime.sh writes the per-instance
+# /etc/crow/pibot-<i>.env this unit loads). Values here reflect a deploy example.
 [Unit]
 Description=Crow Bot Builder — Gmail bridge tick [%i]
 After=network-online.target

--- a/scripts/pi-bots/systemd/pibot-discord@.service
+++ b/scripts/pi-bots/systemd/pibot-discord@.service
@@ -1,3 +1,6 @@
+# OPERATOR-EDITED TEMPLATE: adjust User=, WorkingDirectory=, and paths for
+# your host before installing (install-runtime.sh writes the per-instance
+# /etc/crow/pibot-<i>.env this unit loads). Values here reflect a deploy example.
 [Unit]
 Description=Crow Bot Builder — Discord gateway [%i]
 After=network-online.target

--- a/scripts/pi-bots/systemd/pibot-gateways@.service
+++ b/scripts/pi-bots/systemd/pibot-gateways@.service
@@ -1,3 +1,6 @@
+# OPERATOR-EDITED TEMPLATE: adjust User=, WorkingDirectory=, and paths for
+# your host before installing (install-runtime.sh writes the per-instance
+# /etc/crow/pibot-<i>.env this unit loads). Values here reflect a deploy example.
 [Unit]
 Description=Crow Bot Builder — gateway host (Telegram/Slack) [%i]
 After=network-online.target

--- a/scripts/pi-bots/tracker.mjs
+++ b/scripts/pi-bots/tracker.mjs
@@ -15,7 +15,6 @@
 import Database from "better-sqlite3";
 import { botsDbPath, tasksDbPath } from "./instance-paths.mjs";
 
-const HOME = "/home/kh0pp";
 const CROW_DB = botsDbPath();
 const TASKS_DB = tasksDbPath();
 

--- a/servers/gateway/boot/feature-mounts.js
+++ b/servers/gateway/boot/feature-mounts.js
@@ -264,7 +264,7 @@ export async function mountFeatureRoutes(app, deps) {
 
   // Markdown file viewer — read-only, auth-gated, tailnet-only. Under /dashboard/
   // so rejectFunneledMiddleware() blocks Funnel; renders allowlisted local .md
-  // files (default root /home/kh0pp) as sanitized HTML. NOT in PUBLIC_FUNNEL_PREFIXES.
+  // files (default root: the user's home dir) as sanitized HTML. NOT in PUBLIC_FUNNEL_PREFIXES.
   try {
     const { default: fileviewRouter } = await import("../routes/fileview.js");
     app.use(fileviewRouter(dashboardAuth));

--- a/servers/gateway/dashboard/panels/bot-board/client.js
+++ b/servers/gateway/dashboard/panels/bot-board/client.js
@@ -13,7 +13,12 @@ export function clientJs(botId, trackerType, projectId, trackerSlug, contextFiel
   const pj = projectId == null ? "null" : JSON.stringify(Number(projectId));
   const ts = trackerSlug ? JSON.stringify(String(trackerSlug)) : "null";
   const cf = contextFields ? JSON.stringify(contextFields) : "[]";
+  // Optional notes viewer base URL (e.g. "https://host/notes/"). When unset,
+  // the drawer shows plain "note #<id>" text — honest absence over a dead
+  // link to somebody's lab host.
+  const nb = JSON.stringify(String(process.env.CROW_BOT_BOARD_NOTES_URL || ""));
   return `<script>(function(){
+  var NOTES_BASE=${nb};
   var BOT_ID=${bi};
   var TRACKER_TYPE=${tt};
   var PROJECT=${pj};
@@ -171,7 +176,7 @@ export function clientJs(botId, trackerType, projectId, trackerSlug, contextFiel
           fieldsDiv.appendChild(linkH);
           var linkDiv=document.createElement('div');
           if(data.pir_number){var pn=document.createElement('div');pn.style.fontWeight='600';pn.style.fontSize='.95rem';pn.textContent='PIR #'+data.pir_number;linkDiv.appendChild(pn);}
-          if(data.note_id){var nl=document.createElement('a');nl.className='bb-td-link';nl.href='http://10.0.0.39:8080/notes/'+data.note_id;nl.target='_blank';nl.textContent='View note \\u2192 #'+data.note_id;linkDiv.appendChild(nl);}
+          if(data.note_id){var nl;if(NOTES_BASE){nl=document.createElement('a');nl.className='bb-td-link';nl.href=NOTES_BASE+data.note_id;nl.target='_blank';nl.textContent='View note \\u2192 #'+data.note_id;}else{nl=document.createElement('span');nl.className='bb-td-link';nl.textContent='note #'+data.note_id;}linkDiv.appendChild(nl);}
           if(data.review_thread_id){var rt=document.createElement('div');rt.className='bb-td-link';rt.textContent='Thread: '+data.review_thread_id;rt.style.cursor='pointer';rt.title='Click to copy';rt.onclick=function(ev){ev.stopPropagation();navigator.clipboard.writeText(data.review_thread_id);msg($('bb-td-msg'),'Copied thread ID.','ok');};linkDiv.appendChild(rt);}
           fieldsDiv.appendChild(linkDiv);
         }

--- a/servers/gateway/dashboard/settings/sections/llm/vision-profiles.js
+++ b/servers/gateway/dashboard/settings/sections/llm/vision-profiles.js
@@ -154,7 +154,7 @@ export default {
         <div class="vp-mode-section disabled" id="vpf-direct-section">
           <div class="vp-field">
             <label class="vp-label">Base URL</label>
-            <input type="text" id="vpf-url" placeholder="e.g. http://100.121.254.89:9102/v1" class="vp-input vp-input-mono">
+            <input type="text" id="vpf-url" placeholder="e.g. http://localhost:9102/v1" class="vp-input vp-input-mono">
           </div>
           <div class="vp-field">
             <label class="vp-label">API key (optional)</label>

--- a/servers/gateway/dashboard/settings/sections/shared-storage.js
+++ b/servers/gateway/dashboard/settings/sections/shared-storage.js
@@ -106,7 +106,7 @@ export default {
 
     <form id="ss-form" class="ss-grid" onsubmit="return false">
       <label>Endpoint</label>
-      <input name="endpoint" type="text" value="${escapeHtml(cfg.endpoint)}" placeholder="100.118.41.122:9000" />
+      <input name="endpoint" type="text" value="${escapeHtml(cfg.endpoint)}" placeholder="localhost:9000" />
 
       <label>Use SSL</label>
       <div><input name="use_ssl" type="checkbox" ${cfg.useSSL ? "checked" : ""}/> <span style="font-size:0.85rem;color:var(--crow-text-muted)">HTTPS instead of HTTP</span></div>

--- a/servers/gateway/routes/admin-backup.js
+++ b/servers/gateway/routes/admin-backup.js
@@ -26,10 +26,18 @@ import { performBackup, createDbClient } from "../../db.js";
 
 const DEFAULT_DIR = path.join(os.homedir(), "backups", "crow");
 
-function getInstanceLabel() {
+// Label for backup notifications. NTFY_TOPIC is used verbatim; an operator
+// whose topics share a personal prefix (e.g. "myname-mpa") can set
+// CROW_NTFY_LABEL_PREFIX=myname to have it stripped. Exported for tests.
+export function getInstanceLabel() {
   const topic = (process.env.NTFY_TOPIC || "").toLowerCase();
-  const m = topic.match(/^kevin-(.+)$/);
-  if (m) return m[1];
+  if (topic) {
+    const prefix = (process.env.CROW_NTFY_LABEL_PREFIX || "").toLowerCase();
+    if (prefix && topic.startsWith(prefix + "-") && topic.length > prefix.length + 1) {
+      return topic.slice(prefix.length + 1);
+    }
+    return topic;
+  }
   const dbPath = (process.env.CROW_DB_PATH || "").toLowerCase();
   if (dbPath.includes("crow-mpa")) return "mpa";
   if (dbPath.includes("home-finance")) return "finance";

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -46,6 +46,8 @@
 import { Router } from "express";
 import { existsSync, readFileSync, writeFileSync, realpathSync, statSync, readdirSync, unlinkSync, mkdirSync, lstatSync } from "node:fs";
 import { join } from "node:path";
+import { homedir } from "node:os";
+import { tasksDbPath } from "../../../scripts/pi-bots/instance-paths.mjs";
 import { createDbClient } from "../../db.js";
 import { jsonError } from "./_error.js";
 import { listProvidersAll } from "../../shared/providers-db.js";
@@ -59,10 +61,10 @@ import { isStage, stageToStatus, effectiveStage } from "./board-stages.js";
 
 // Slice C: operator-approved promotion target (the PRIMARY skills dir both the
 // pi bridge and the glasses voice path search via skill_resolver).
-const CROW_USER_SKILLS = "/home/kh0pp/.crow/skills";
+const CROW_USER_SKILLS = join(process.env.CROW_HOME || join(homedir(), ".crow"), "skills");
 
-const HOME = "/home/kh0pp";
-const TASKS_DB = process.env.CROW_TASKS_DB_PATH || HOME + "/.crow-mpa/data/tasks.db";
+const HOME = process.env.HOME || homedir();
+const TASKS_DB = tasksDbPath();
 const CARD_STATUSES = new Set(["pending", "in_progress", "done", "cancelled"]);
 const PROJECT_STATUSES = new Set(["active", "paused", "completed", "archived"]);
 const LOCK_STATUSES = new Set(["active", "waiting-user"]);

--- a/servers/gateway/routes/fileview.js
+++ b/servers/gateway/routes/fileview.js
@@ -10,7 +10,7 @@
  *     rejectFunneledMiddleware() already blocks it from Tailscale Funnel, so it
  *     is tailnet-only. It is NOT in PUBLIC_FUNNEL_PREFIXES (must never be).
  *   - Path is canonicalized with realpathSync (resolves .. and symlinks) and
- *     must land UNDER the allowlist root (default /home/kh0pp) and end in .md
+ *     must land UNDER the allowlist root (default: the user's home dir) and end in .md
  *     and be a regular file — otherwise 404. This defeats path traversal and
  *     symlink-escape.
  *   - renderMarkdown() (servers/blog/renderer.js) sanitizes the HTML.

--- a/servers/gateway/routes/streams.js
+++ b/servers/gateway/routes/streams.js
@@ -26,6 +26,9 @@ import { createDbClient } from "../../db.js";
 import bus from "../../shared/event-bus.js";
 import { openAuthedStream } from "../streams/authed-stream.js";
 import { html, raw, sseTurbo } from "../streams/turbo-stream.js";
+// Instance-aware tasks.db resolution (CROW_TASKS_DB_PATH wins; else the db
+// sits beside the crow.db actually in use). Same resolver bot-board-api uses.
+import { tasksDbPath } from "../../../scripts/pi-bots/instance-paths.mjs";
 
 export default function streamsRouter(dashboardAuth) {
   const router = Router();
@@ -312,7 +315,7 @@ export default function streamsRouter(dashboardAuth) {
     const stream = openAuthedStream(req, res);
     if (!stream) return;
     const { sendRaw } = stream;
-    const TASKS_DB = process.env.CROW_TASKS_DB_PATH || "/home/kh0pp/.crow-mpa/data/tasks.db";
+    const TASKS_DB = tasksDbPath();
     const LOCK = new Set(["active", "waiting-user"]);
 
     // Resolve bot or project at connection time (once, not per tick)

--- a/servers/sharing/identity.js
+++ b/servers/sharing/identity.js
@@ -604,6 +604,14 @@ export async function importIdentity() {
   }
 
   // Legacy plaintext-base64 blob (already-valid identity.json content).
+  // Guard: the blob must actually carry a usable master seed (64 hex chars)
+  // before we write it as-is — a garbage blob would otherwise produce an
+  // identity.json the gateway can never boot from.
+  const legacySeed = parsed && typeof parsed === "object" ? parsed.seed : null;
+  if (typeof legacySeed !== "string" || !/^[0-9a-fA-F]{64}$/.test(legacySeed)) {
+    console.error("Not a valid identity export — a legacy blob must contain a 64-hex `seed`. Nothing was written.");
+    process.exit(1);
+  }
   writeFileSync(IDENTITY_PATH, data);
   console.log("Identity imported successfully.");
 }

--- a/servers/storage/s3-client.js
+++ b/servers/storage/s3-client.js
@@ -127,7 +127,7 @@ export function defaultBucket() {
 
 /**
  * Browser-reachable origin for the configured storage endpoint — e.g.
- * "http://100.118.41.122:9000" or "https://s3.example.com:443". Returns
+ * "http://localhost:9000" or "https://s3.example.com:443". Returns
  * null when storage isn't configured. Used by the gateway CSP middleware
  * to allow <img src="..."> with presigned URLs without enabling a
  * blanket host. The origin is taken from the DB config if present; env

--- a/tests/admin-backup-label.test.js
+++ b/tests/admin-backup-label.test.js
@@ -1,0 +1,49 @@
+/**
+ * admin-backup getInstanceLabel generalization (Item 4-PR4, B9).
+ *
+ * The label used to be derived via a personal /^kevin-(.+)$/ regex on
+ * NTFY_TOPIC. Now: an optional CROW_NTFY_LABEL_PREFIX is stripped when it
+ * matches; otherwise the topic is used verbatim; the CROW_DB_PATH heuristics
+ * remain the fallback when no topic is set.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getInstanceLabel } from "../servers/gateway/routes/admin-backup.js";
+
+function withEnv(vars, fn) {
+  const saved = {};
+  for (const k of Object.keys(vars)) { saved[k] = process.env[k]; if (vars[k] == null) delete process.env[k]; else process.env[k] = vars[k]; }
+  try { return fn(); } finally {
+    for (const k of Object.keys(vars)) { if (saved[k] == null) delete process.env[k]; else process.env[k] = saved[k]; }
+  }
+}
+
+test("no prefix configured -> topic verbatim (no kevin special-case)", () => {
+  withEnv({ NTFY_TOPIC: "kevin-mpa", CROW_NTFY_LABEL_PREFIX: null }, () => {
+    assert.equal(getInstanceLabel(), "kevin-mpa");
+  });
+});
+
+test("configured prefix is stripped when it matches", () => {
+  withEnv({ NTFY_TOPIC: "kevin-mpa", CROW_NTFY_LABEL_PREFIX: "kevin" }, () => {
+    assert.equal(getInstanceLabel(), "mpa");
+  });
+});
+
+test("configured prefix that does not match -> topic verbatim", () => {
+  withEnv({ NTFY_TOPIC: "alerts-prod", CROW_NTFY_LABEL_PREFIX: "kevin" }, () => {
+    assert.equal(getInstanceLabel(), "alerts-prod");
+  });
+});
+
+test("no topic -> CROW_DB_PATH heuristics still apply", () => {
+  withEnv({ NTFY_TOPIC: null, CROW_NTFY_LABEL_PREFIX: null, CROW_DB_PATH: "/x/.crow-mpa/data/crow.db" }, () => {
+    assert.equal(getInstanceLabel(), "mpa");
+  });
+  withEnv({ NTFY_TOPIC: null, CROW_NTFY_LABEL_PREFIX: null, CROW_DB_PATH: "/x/home-finance/crow.db" }, () => {
+    assert.equal(getInstanceLabel(), "finance");
+  });
+  withEnv({ NTFY_TOPIC: null, CROW_NTFY_LABEL_PREFIX: null, CROW_DB_PATH: null }, () => {
+    assert.equal(getInstanceLabel(), "primary");
+  });
+});

--- a/tests/bot-board-notes-link.test.js
+++ b/tests/bot-board-notes-link.test.js
@@ -1,0 +1,30 @@
+/**
+ * Bot-board "View note" link (Item 4-PR4 lab-value sweep, B7).
+ *
+ * The note link used to hardcode a lab host (http://10.0.0.39:8080/...) —
+ * a dead link on every other install. Now the link renders ONLY when
+ * CROW_BOT_BOARD_NOTES_URL is configured; otherwise the drawer shows plain
+ * "note #<id>" text (honest absence over dead link).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { clientJs } from "../servers/gateway/dashboard/panels/bot-board/client.js";
+
+test("no notes base URL configured -> no lab host, no dead link", () => {
+  delete process.env.CROW_BOT_BOARD_NOTES_URL;
+  const js = clientJs("botx", "kanban", 1, null, [], "en");
+  assert.ok(!js.includes("10.0.0.39"), "lab host must not appear");
+  // Unconfigured: note id renders as plain text, not an anchor.
+  assert.match(js, /createElement\('span'\)|createElement\("span"\)/, "should render a non-link note element when unconfigured");
+});
+
+test("configured notes base URL -> link renders from config", () => {
+  process.env.CROW_BOT_BOARD_NOTES_URL = "https://notes.example.com/notes/";
+  try {
+    const js = clientJs("botx", "kanban", 1, null, [], "en");
+    assert.ok(js.includes("https://notes.example.com/notes/"), "configured base must be interpolated");
+    assert.ok(!js.includes("10.0.0.39"), "lab host must not appear");
+  } finally {
+    delete process.env.CROW_BOT_BOARD_NOTES_URL;
+  }
+});

--- a/tests/identity-import-legacy-guard.test.js
+++ b/tests/identity-import-legacy-guard.test.js
@@ -1,0 +1,54 @@
+/**
+ * importIdentity legacy-blob guard (Item 4-PR4 fold-in C12).
+ *
+ * The legacy import branch used to write ANY base64-JSON blob as-is to
+ * identity.json — a garbage blob (valid JSON, no usable seed) produced a
+ * corrupt identity file the gateway would then fail to boot from. The guard
+ * validates parsed.seed is 64-hex before the as-is write and exits cleanly
+ * otherwise (no file written).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO = fileURLToPath(new URL("..", import.meta.url));
+
+function runImport(dataDir, blob) {
+  return spawnSync(
+    process.execPath,
+    ["-e", "import('./servers/sharing/identity.js').then(m => m.importIdentity())", blob],
+    { cwd: REPO, env: { ...process.env, CROW_DATA_DIR: dataDir }, encoding: "utf8", timeout: 30000 }
+  );
+}
+
+test("garbage legacy blob (JSON, no seed) -> clean exit 1, no identity.json written", () => {
+  const dir = mkdtempSync(join(tmpdir(), "crow-idimport-"));
+  const blob = Buffer.from(JSON.stringify({ hello: "world" })).toString("base64");
+  const r = runImport(dir, blob);
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}; stderr=${r.stderr}`);
+  assert.match(r.stderr, /seed/i, "error should name the missing/invalid seed");
+  assert.ok(!existsSync(join(dir, "identity.json")), "identity.json must NOT be written");
+});
+
+test("legacy blob with non-64-hex seed -> clean exit 1, no file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "crow-idimport-"));
+  const blob = Buffer.from(JSON.stringify({ version: 1, seed: "abc123" })).toString("base64");
+  const r = runImport(dir, blob);
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}; stderr=${r.stderr}`);
+  assert.ok(!existsSync(join(dir, "identity.json")), "identity.json must NOT be written");
+});
+
+test("valid legacy blob (64-hex seed) still imports as-is", () => {
+  const dir = mkdtempSync(join(tmpdir(), "crow-idimport-"));
+  const seed = "ab".repeat(32); // 64 hex chars
+  const content = { version: 1, seed, createdAt: new Date().toISOString() };
+  const blob = Buffer.from(JSON.stringify(content)).toString("base64");
+  const r = runImport(dir, blob);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr=${r.stderr}`);
+  const written = JSON.parse(readFileSync(join(dir, "identity.json"), "utf8"));
+  assert.equal(written.seed, seed, "legacy blob must be written as-is");
+});

--- a/tests/pibot-bridge-exit-surface.test.js
+++ b/tests/pibot-bridge-exit-surface.test.js
@@ -1,0 +1,84 @@
+/**
+ * PiRpc exit-fast surface (Item 4-PR4, spec §2.1 item 7).
+ *
+ * When pi dies before responding (the canonical fresh-install case: the
+ * resolver fell to LOCAL_FALLBACK and pi prints `Unknown provider "crow-local"`
+ * and exits), the turn used to burn 2x15s swallowed get_state timeouts and
+ * then reject with a cryptic "timeout:prompt-ack". PiRpc now rejects pending
+ * (and future) waiters immediately with a message naming the resolved model
+ * and pi's stderr — which handleInbound's catch relays to the user via
+ * sendReply as "(bridge error: ...)".
+ *
+ * Uses the PiRpc nodeBin/cliPath test seam with a stub child so no real pi
+ * (and none of its live MCP servers) is ever spawned.
+ */
+process.env.PIBOT_PROMPT_ACK_TIMEOUT_MS = "8000"; // read at module load — set BEFORE import
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { PiRpc } = await import("../scripts/pi-bots/bridge.mjs");
+
+function makeStub(dir, body) {
+  const p = join(dir, "stub-pi.mjs");
+  writeFileSync(p, body);
+  return p;
+}
+
+test("pi exits before responding -> prompt rejects fast with model + stderr, no hang, no EPIPE crash", async () => {
+  const scratch = mkdtempSync(join(tmpdir(), "crow-pirpc-"));
+  mkdirSync(join(scratch, "sessions"), { recursive: true });
+  const stub = makeStub(
+    scratch,
+    'console.error(\'Error: Unknown provider "bogus-local". Use --list-models to see available providers/models.\');\nprocess.exit(1);\n'
+  );
+  const pi = new PiRpc({
+    def: {},
+    sessionDir: scratch,
+    resolved: { provider: "bogus-local", model: "no-such-model", key: "bogus-local/no-such-model" },
+    nodeBin: process.execPath,
+    cliPath: stub,
+  });
+  const t0 = Date.now();
+  // Same call shape as the turn: swallowed getState, then prompt.
+  const st0 = await pi.getState().catch(() => null);
+  assert.equal(st0, null, "getState on a dead pi resolves null via its catch");
+  await assert.rejects(
+    () => pi.prompt("hi", 8000),
+    (e) => {
+      assert.match(e.message, /pi exited/, "message must say pi exited");
+      assert.match(e.message, /bogus-local\/no-such-model/, "message must name the resolved model");
+      assert.match(e.message, /may not be available on this instance/, "message must explain the likely cause");
+      assert.match(e.message, /Unknown provider/, "message must carry pi's stderr");
+      return true;
+    }
+  );
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed < 7000, `must fail fast via exit detection, not the ack timeout (took ${elapsed}ms)`);
+  await pi.close();
+});
+
+test("waiters pending at exit time are rejected by the exit handler", async () => {
+  const scratch = mkdtempSync(join(tmpdir(), "crow-pirpc-"));
+  mkdirSync(join(scratch, "sessions"), { recursive: true });
+  // Stub lingers briefly so the waiter registers BEFORE exit.
+  const stub = makeStub(
+    scratch,
+    'console.error("boom: provider misconfigured");\nsetTimeout(() => process.exit(3), 300);\n'
+  );
+  const pi = new PiRpc({
+    def: {},
+    sessionDir: scratch,
+    resolved: { provider: "p", model: "m", key: "p/m" },
+    nodeBin: process.execPath,
+    cliPath: stub,
+  });
+  await assert.rejects(
+    () => pi.waitFor((m) => m.type === "never", 8000, "prompt-ack"),
+    (e) => /pi exited \(code 3\)/.test(e.message) && /boom: provider misconfigured/.test(e.message)
+  );
+  await pi.close();
+});

--- a/tests/pibot-gmail-io-unconfigured.test.js
+++ b/tests/pibot-gmail-io-unconfigured.test.js
@@ -1,0 +1,35 @@
+/**
+ * gmail_io.mjs honest-failure guard (Item 4-PR4, A5).
+ *
+ * gmail_io used to bake the maintainer's google-workspace-mcp checkout and
+ * creds paths; on a host without that install it died on a cryptic spawn
+ * ENOENT. Now paths are env-overridable with HOME-derived defaults, and a
+ * missing server binary exits 1 with a message naming the config knobs.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const GIO = fileURLToPath(new URL("../scripts/pi-bots/gmail_io.mjs", import.meta.url));
+
+test("missing google-workspace-mcp binary -> exit 1 with config guidance (no cryptic ENOENT)", () => {
+  const scratch = mkdtempSync(join(tmpdir(), "crow-gio-"));
+  const r = spawnSync(process.execPath, [GIO, "search", "--query", "x"], {
+    env: {
+      ...process.env,
+      // Point BOTH knobs into empty scratch so no real install is found even
+      // on the maintainer's machines.
+      PIBOT_GWS_MCP_DIR: scratch,
+      PIBOT_GWS_MCP_BIN: join(scratch, "no-such-bin"),
+    },
+    encoding: "utf8",
+    timeout: 20000,
+  });
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}; stderr=${r.stderr}`);
+  assert.match(r.stderr, /PIBOT_GWS_MCP_DIR/, "error must name the config env vars");
+  assert.match(r.stderr, /google-workspace-mcp not found/, "error must say what is missing");
+});

--- a/tests/pibot-gmail-sender-allowlist.test.js
+++ b/tests/pibot-gmail-sender-allowlist.test.js
@@ -1,0 +1,28 @@
+/**
+ * Gmail sender allowlist helper (Item 4-PR4, bridge_tick de-hardcode).
+ *
+ * bridge_tick used to carry a hardcoded personal SENDER_ALLOWLIST (the
+ * maintainer's emails). The wall now derives from the bot def's per-gateway
+ * allowlist (gw.allowlist) and FAILS CLOSED when it is empty/absent — unlike
+ * passesAllowlist (Discord), where empty means allow-all, an unconfigured
+ * Gmail allowlist must never let a third party trigger a bot reply.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { gmailSenderAllowed } from "../scripts/pi-bots/gateways/base.mjs";
+
+test("empty/absent allowlist fails closed", () => {
+  assert.equal(gmailSenderAllowed([], "a@b.com"), false);
+  assert.equal(gmailSenderAllowed(null, "a@b.com"), false);
+  assert.equal(gmailSenderAllowed(undefined, "a@b.com"), false);
+  assert.equal(gmailSenderAllowed("not-an-array", "a@b.com"), false);
+});
+
+test("listed sender allowed, case-insensitive", () => {
+  assert.equal(gmailSenderAllowed(["User@Example.com"], "user@example.com"), true);
+  assert.equal(gmailSenderAllowed(["user@example.com"], "User@Example.COM"), true);
+});
+
+test("unlisted sender rejected", () => {
+  assert.equal(gmailSenderAllowed(["user@example.com"], "evil@example.com"), false);
+});

--- a/tests/pibot-model-resolver-unavailable.test.js
+++ b/tests/pibot-model-resolver-unavailable.test.js
@@ -1,0 +1,49 @@
+/**
+ * model_resolver unavailable-surface pin (Item 4-PR4, spec §2.1 item 7).
+ *
+ * On a fresh install (no models.json anywhere, no providers rows) an unknown
+ * provider/model resolves fail-closed to LOCAL_FALLBACK with an attributed
+ * source, and an explicit !escalate with nothing usable sets the
+ * escalationRequestedButUnavailable flag the bridge surfaces in-band.
+ * This pins that contract.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const scratch = mkdtempSync(join(tmpdir(), "crow-resolver-"));
+// No models.json anywhere + no providers table: point both lookups at
+// nonexistent scratch paths BEFORE importing the module.
+process.env.PI_MODELS_JSON = join(scratch, "no-such-models.json");
+process.env.CROW_DB_PATH = join(scratch, "no-such-crow.db");
+
+const { test } = await import("node:test");
+const { default: assert } = await import("node:assert/strict");
+const { resolveModel, LOCAL_FALLBACK, splitKey } = await import("../scripts/pi-bots/model_resolver.mjs");
+
+const fb = splitKey(LOCAL_FALLBACK);
+
+test("unknown provider, no models.json -> falls to LOCAL_FALLBACK, source=fallback", async () => {
+  const r = await resolveModel({ models: { default: "no-such-provider/no-such-model" } });
+  assert.deepEqual(r, {
+    provider: fb.provider,
+    model: fb.model,
+    key: LOCAL_FALLBACK,
+    escalated: false,
+    source: "fallback",
+    escalationRequestedButUnavailable: false,
+  });
+});
+
+test("escalate requested with nothing usable -> unavailable flag set", async () => {
+  const r = await resolveModel({ models: { default: "no-such-provider/no-such-model" } }, { escalate: true });
+  assert.equal(r.key, LOCAL_FALLBACK);
+  assert.equal(r.source, "fallback");
+  assert.equal(r.escalated, false);
+  assert.equal(r.escalationRequestedButUnavailable, true);
+});
+
+test("no def.models at all -> fallback without throwing", async () => {
+  const r = await resolveModel({});
+  assert.equal(r.key, LOCAL_FALLBACK);
+});

--- a/tests/pibot-units-portable.test.js
+++ b/tests/pibot-units-portable.test.js
@@ -24,6 +24,13 @@ test("service units are instance-portable (no hardcoded ~/.crow-mpa, use Environ
   }
 });
 
+test("service units carry the operator-edited-template header (allowlisted personal values live behind it)", () => {
+  for (const u of units.filter((f) => f.endsWith(".service"))) {
+    const s = readFileSync(`${DIR}/${u}`, "utf8");
+    assert.ok(/OPERATOR-EDITED TEMPLATE/.test(s), `${u} missing the operator-edited-template header`);
+  }
+});
+
 test("installer is portable + idempotent-flavored", () => {
   const sh = readFileSync("scripts/pi-bots/install-runtime.sh", "utf8");
   assert.ok(!/\.crow-mpa/.test(sh), "installer hardcodes ~/.crow-mpa");


### PR DESCRIPTION
Fourth PR of the Item 4 generalization theme (spec §2.2 + §2.1 item 7 + the §3.1 allowlist), plus three review fold-ins from PR1/PR3. 43 files; every change verified to resolve to the old literal value on the operator's boxes (env wins / HOME-derived), so the fleet is behaviorally unchanged where it matters.

## Highlights

- **Path fallbacks**: `/home/kh0pp` literals across pi-bots runtime (`bridge`, `bridge_tick`, `mcp_writer`, `model_resolver`, `s0_mcp_probe`; unused HOME consts deleted in 3 more) and gateway routes (`streams.js`, `bot-board-api.js`, `fileview.js` docstrings) → env/`homedir()`/`tasksDbPath()`. The primary gateway's tasks-DB fallback no longer cross-reads the MPA instance's file (a latent cross-instance leak; the MPA unit's `CROW_DB_PATH` reproduces the old path exactly, and the live board — 85 cards — is served there, verified).
- **Gmail sender wall fails closed from the bot's own config**: `bridge_tick` no longer carries the maintainer's hardcoded email allowlist — the wall derives from the gateway's `gw.allowlist` (the field the Bot Builder edits) via `gmailSenderAllowed()`, and an empty allowlist means *nobody*, never everybody. All deployed bot defs carry allowlists (verified live).
- **PiRpc surfaces early pi exit honestly**: an unknown-provider pi death used to raise an uncaught stdin EPIPE that could crash the whole bridge, or a cryptic 60s timeout. Now pending waiters fail immediately with the model key + pi's stderr tail, relayed in-band to the user. Test seam added so tests stub the child (never spawn real pi).
- **gmail_io** creds paths env-derived with honest failure when unconfigured; the baked personal send-allowlist removed (the underlying server self-defaults; the env knob now passes through instead of being clobbered).
- **Browser bundle location-independent** (compose `${CROW_HOME:-${HOME}/.crow}` interpolation — rookery precedent; `docker compose config`-validated both ways).
- Lab-IP placeholders → localhost examples; dead `10.0.0.39` note link → optional `CROW_BOT_BOARD_NOTES_URL` (honest plain text when unset); ntfy backup label de-`kevin-`-cased (verbatim topic unless `CROW_NTFY_LABEL_PREFIX` set); 3× `kh0pp/crow`→`kh0pper/crow` org typos.
- **Fold-ins**: legacy `identity:import` blobs must carry a 64-hex seed (garbage no longer writes an unbootable identity.json); `pi-bots-phase1-setup.mjs` marked historical; `multi-device.md` rewritten to the real PR3 backup/restore flow.

## Verification

- Suite (scratch env): 1849 pass / 3 fail = exactly the pre-existing known trio / 0 skips (+19 tests, 7 new files)
- 6 parse-clean mutation checks with named red tests
- Whole-branch adversarial review: READY TO MERGE, zero must-fix (verified live: bot defs' allowlist shapes, MPA unit env reproducing the old tasks.db path, compose interpolation under docker compose v5.1.2, the google-workspace server's self-send default). Known-remaining documented: bridge's nvm-pinned NODE (unreachable on fresh installs — new bots ship `gateways:[]`) and the separate google-workspace repo's own default allowlist.
- Closing sweep: 82 hits → 41, every survivor classified (org/comments/systemd-templates/test-harnesses/untracked-WIP/false-positive CIDR); **zero bare `kh0pp` in tracked runtime code**. Two bundle *markdown* docs with maintainer content flagged for a future docs sweep.
- check-ports: exactly the one known capstone line; build-registry: OK

Operator notes: backup ntfy labels read `kevin-mpa` verbatim now (set `CROW_NTFY_LABEL_PREFIX=kevin` to restore the stripped form); if `/etc/crow/pibot-*.env` should keep the `+pibot` alias self-send override, add `GMAIL_SEND_TO_SELF_ALLOWLIST` there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrmujaUpg9W5sFvhQyWqTz