### PR TITLE
Item 2c: lamport-preserving re-emit, boot-window emit delivery, contact-delete durability, conflict dedupe

### DIFF
--- a/servers/sharing/group-sync.js
+++ b/servers/sharing/group-sync.js
@@ -34,7 +34,7 @@ async function sink() {
  * group_uid, attach the full member-crow_id wire-map, forward the FULL local row
  * (id retained for emitChange's lamport stamp). Never throws.
  */
-export async function emitGroupUpsert(db, groupId) {
+export async function emitGroupUpsert(db, groupId, opts = {}) {
   try {
     if (!db || !groupId) return;
     const { rows } = await db.execute({
@@ -64,7 +64,13 @@ export async function emitGroupUpsert(db, groupId) {
       args: [groupId],
     });
     row.members = mem.map((r) => r.crow_id).filter(Boolean);
-    await (await sink())?.emitChange("contact_groups", "update", row);
+    // 2c C2: a boot backfill (the only caller passing preserveLamport) is
+    // redelivery — keep the row's ORIGINAL lamport so it cannot fabricate
+    // recency over a peer's newer group edit. Live create/rename paths mint.
+    const emitOpts = opts && opts.preserveLamport === true
+      ? { lamportTs: Number(row.lamport_ts) || 0 }
+      : undefined;
+    await (await sink())?.emitChange("contact_groups", "update", row, emitOpts);
   } catch { /* never throw — group sync is best-effort */ }
 }
 

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -299,6 +299,13 @@ export class InstanceSyncManager {
     // Per-peer serialization for _processNewEntries — see D4 fix below.
     this._processLocks = new Map(); // remoteInstanceId → tail Promise
 
+    // 2c C3: per-peer ordered append pipeline. ALL writes toward a peer's outFeed
+    // flow through one FIFO promise chain (_appendLocks, the _initLocks pattern);
+    // entries emitted while the peer's feed is not yet armed park in
+    // _pendingPeerEmits and drain on arm — the boot-window fix (spec §3 C3).
+    this._appendLocks = new Map();      // remoteInstanceId → tail Promise
+    this._pendingPeerEmits = new Map(); // remoteInstanceId → [signed entries]
+
     // Flag that _ensureCounter has seeded the sync_state row at least once.
     // The DB row is the authority; this is only a cheap short-circuit.
     this._counterSeeded = false;
@@ -434,6 +441,11 @@ export class InstanceSyncManager {
       });
       await outFeed.ready();
       this.outFeeds.set(remoteInstanceId, outFeed);
+      // 2c C3: drain entries parked while this feed was unarmed. The enqueue MUST
+      // be synchronously adjacent to the set above (spec §3 C3) — an emit task
+      // slipping in between would append ahead of older parked entries.
+      const drainDone = this._drainPendingEmits(remoteInstanceId);
+      await drainDone.catch(() => {});
     }
 
     // Their incoming feed (writable by them)
@@ -1041,6 +1053,76 @@ export class InstanceSyncManager {
     if (inFeed) inFeed.replicate(stream, { live: true });
   }
 
+  /** Chain helper: run taskFn as the next link on peerId's append chain. */
+  async _chainAppendTask(peerId, taskFn) {
+    const prior = this._appendLocks.get(peerId) || Promise.resolve();
+    const next = prior.catch(() => {}).then(taskFn);
+    this._appendLocks.set(peerId, next);
+    try {
+      return await next;
+    } finally {
+      if (this._appendLocks.get(peerId) === next) this._appendLocks.delete(peerId);
+    }
+  }
+
+  /**
+   * Append an entry toward a peer, or park it while the feed is unarmed.
+   * The decision is made INSIDE the chained task, against current state — a
+   * check-then-push outside the chain can strand entries or reorder the feed
+   * (spec R2/F2). A failed append is logged and NOT retried (pre-existing
+   * semantics; deletes self-heal via the tombstone re-emit).
+   */
+  async _appendToPeer(peerId, entry) {
+    return this._chainAppendTask(peerId, async () => {
+      const feed = this.outFeeds.get(peerId);
+      if (feed) {
+        try {
+          await feed.append(entry);
+        } catch (err) {
+          console.warn(`[instance-sync] Failed to append to feed for ${peerId}:`, err.message);
+        }
+        return;
+      }
+      const slot = this._pendingPeerEmits.get(peerId) || [];
+      slot.push(entry);
+      if (slot.length > 256) {
+        slot.shift();
+        console.warn(`[instance-sync] pending emit queue overflow for ${peerId} — dropped oldest (LWW-safe direction)`);
+      }
+      this._pendingPeerEmits.set(peerId, slot);
+    });
+  }
+
+  /**
+   * Drain a peer's parked entries onto its (now armed) outFeed, FIFO. Chained,
+   * so a live emit can never interleave mid-drain. Enqueued by _initInstanceInner
+   * SYNCHRONOUSLY ADJACENT to outFeeds.set — no await between them (spec §3 C3
+   * MUST: an emit slipping into that gap would reorder the feed).
+   * @returns {Promise<number>} entries appended
+   */
+  async _drainPendingEmits(peerId) {
+    return this._chainAppendTask(peerId, async () => {
+      const slot = this._pendingPeerEmits.get(peerId);
+      this._pendingPeerEmits.delete(peerId);
+      if (!slot || slot.length === 0) return 0;
+      const feed = this.outFeeds.get(peerId);
+      if (!feed) {
+        this._pendingPeerEmits.set(peerId, slot); // feed vanished — re-park
+        return 0;
+      }
+      let n = 0;
+      for (const entry of slot) {
+        try {
+          await feed.append(entry);
+          n++;
+        } catch (err) {
+          console.warn(`[instance-sync] pending drain append failed for ${peerId}: ${err.message}`);
+        }
+      }
+      return n;
+    });
+  }
+
   /**
    * Emit a sync entry for a local data change.
    * Called by memory/context/sharing servers after mutations.
@@ -1127,14 +1209,23 @@ export class InstanceSyncManager {
       }
     }
 
-    // Append to all outgoing feeds (broadcast to all connected instances)
-    for (const [instanceId, feed] of this.outFeeds) {
-      try {
-        await feed.append(entry);
-      } catch (err) {
-        console.warn(`[instance-sync] Failed to append to feed for ${instanceId}:`, err.message);
-      }
+    // Broadcast through the per-peer chains: every PAIRED peer (armed or not)
+    // plus any armed feed not (yet) in the registry. Entries for unarmed paired
+    // peers park in _pendingPeerEmits and ride when the feed arms (2c C3 — the
+    // boot-window fix; previously they were silently dropped while the caller
+    // saw a valid lamport).
+    let pairedIds = [];
+    try {
+      const { rows } = await this.db.execute({
+        sql: "SELECT id FROM crow_instances WHERE status IN ('active','offline') AND id != ?",
+        args: [this.localInstanceId],
+      });
+      pairedIds = rows.map((r) => r.id);
+    } catch {
+      pairedIds = []; // degraded: armed feeds below still get the entry
     }
+    const targets = new Set([...pairedIds, ...this.outFeeds.keys()]);
+    await Promise.all([...targets].map((peerId) => this._appendToPeer(peerId, entry)));
 
     return lamportTs;
   }
@@ -2525,6 +2616,9 @@ export class InstanceSyncManager {
       try { await inFeed.close(); } catch {}
       this.inFeeds.delete(remoteInstanceId);
     }
+    // 2c C3: a closed/revoked peer keeps no parked entries or chain tail.
+    this._pendingPeerEmits.delete(remoteInstanceId);
+    this._appendLocks.delete(remoteInstanceId);
   }
 
   /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1430,14 +1430,14 @@ export class InstanceSyncManager {
       // stale delete → conflict, local kept
       const rowIdJson = JSON.stringify({ section_key: sk, device_id: devId, project_id: projId });
       try {
-        await this._insertConflictRow(
+        const inserted = await this._insertConflictRow(
           "crow_context", rowIdJson,
           localRow.instance_id || this.localInstanceId, instanceId,
           localTs, lamportTs,
           JSON.stringify(localRow), JSON.stringify(filteredRow),
           "delete",
         );
-        await this._notifyConflict();
+        if (inserted) await this._notifyConflict();
       } catch (err) {
         console.warn(`[instance-sync] crow_context conflict LOGGING failed (local data preserved):`, err.message);
       }
@@ -1505,14 +1505,14 @@ export class InstanceSyncManager {
     // Real conflict (includes tie + different data): local kept
     const rowIdJson = JSON.stringify({ section_key: sk, device_id: devId, project_id: projId });
     try {
-      await this._insertConflictRow(
+      const inserted = await this._insertConflictRow(
         "crow_context", rowIdJson,
         localRow.instance_id || this.localInstanceId, instanceId,
         localTs, lamportTs,
         JSON.stringify(localRow), JSON.stringify(filteredRow),
         op || "update",
       );
-      await this._notifyConflict();
+      if (inserted) await this._notifyConflict();
     } catch (err) {
       console.warn(`[instance-sync] crow_context conflict LOGGING failed (local data preserved):`, err.message);
     }
@@ -1633,10 +1633,10 @@ export class InstanceSyncManager {
         return;
       }
       try {
-        await this._insertConflictRow("contacts", rowIdJson,
+        const inserted = await this._insertConflictRow("contacts", rowIdJson,
           localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
           JSON.stringify(localRow), JSON.stringify(filtered), "delete");
-        await this._notifyConflict();
+        if (inserted) await this._notifyConflict();
       } catch (err) {
         console.warn("[instance-sync] contacts delete conflict LOGGING failed (local kept):", err.message);
       }
@@ -1793,10 +1793,10 @@ export class InstanceSyncManager {
     // incomingTs <= localTs
     if (rowsEquivalent(localRow, filtered)) return; // re-delivery noise
     try {
-      await this._insertConflictRow("contacts", rowIdJson,
+      const inserted = await this._insertConflictRow("contacts", rowIdJson,
         localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
         JSON.stringify(localRow), JSON.stringify(filtered), op || "update");
-      await this._notifyConflict();
+      if (inserted) await this._notifyConflict();
     } catch (err) {
       console.warn("[instance-sync] contacts conflict LOGGING failed (local kept):", err.message);
     }
@@ -2005,10 +2005,10 @@ export class InstanceSyncManager {
         // WINNER, the discarded local edit the LOSER — this row is the only
         // surviving record of the edit that lost (e.g. B's offline rename).
         try {
-          await this._insertConflictRow("contact_groups", rowIdJson,
+          const inserted = await this._insertConflictRow("contact_groups", rowIdJson,
             instanceId, localRow.instance_id || this.localInstanceId, lamportTs, localTs,
             JSON.stringify(filtered), JSON.stringify(localRow), "delete");
-          await this._notifyConflict();
+          if (inserted) await this._notifyConflict();
         } catch (err) {
           console.warn("[instance-sync] contact_groups delete-won conflict LOGGING failed (delete applied):", err.message);
         }
@@ -2068,10 +2068,10 @@ export class InstanceSyncManager {
     // in Known limitations — acceptable for a single user's low-contention groups).
     if (rowsEquivalent(localRow, filtered)) return; // re-delivery noise
     try {
-      await this._insertConflictRow("contact_groups", rowIdJson,
+      const inserted = await this._insertConflictRow("contact_groups", rowIdJson,
         localRow.instance_id || this.localInstanceId, instanceId, localTs, lamportTs,
         JSON.stringify(localRow), JSON.stringify(filtered), op || "update");
-      await this._notifyConflict();
+      if (inserted) await this._notifyConflict();
     } catch (err) {
       console.warn("[instance-sync] contact_groups conflict LOGGING failed (local kept):", err.message);
     }
@@ -2187,14 +2187,14 @@ export class InstanceSyncManager {
       // differs) — a failure to LOG must not flip it to "apply" and overwrite
       // newer local data, so logging gets its own guard and we skip regardless.
       try {
-        await this._insertConflictRow(
+        const inserted = await this._insertConflictRow(
           table, String(rowId),
           localRow.instance_id || this.localInstanceId, incomingInstanceId,
           localTs, incomingTs,
           JSON.stringify(localRow), JSON.stringify(incomingRow),
           op || "update",
         );
-        await this._notifyConflict();
+        if (inserted) await this._notifyConflict();
       } catch (err) {
         console.warn(`[instance-sync] Conflict LOGGING failed for ${table}:${rowId} (local data still preserved):`, err.message);
       }
@@ -2213,8 +2213,44 @@ export class InstanceSyncManager {
    * the gateway-boot migration also closes this, but a non-gateway host or a
    * mid-boot race must not lose the conflict trace, and in _checkConflict a
    * thrown INSERT must never cascade into applying a stale row).
+   *
+   * @returns {Promise<boolean>} true when a row was inserted; false when an
+   * identical unresolved conflict already exists (repeat delivery — 2c C5).
+   * Stable key (table_name,row_id,op,winning_lamport_ts,losing_lamport_ts,
+   * losing_instance_id): data blobs are EXCLUDED (winning_data carries volatile
+   * never-synced columns — contacts.last_seen moves without lamport movement),
+   * origin is INCLUDED (per-instance counters collide across peers; spec §3 C5).
    */
   async _insertConflictRow(tableName, rowId, winInst, loseInst, winTs, loseTs, winData, loseData, conflictOp) {
+    const dedupeArgs = [tableName, rowId, winTs, loseTs, loseInst];
+    try {
+      const { rows } = await this.db.execute({
+        sql: `SELECT id FROM sync_conflicts
+               WHERE table_name = ? AND row_id = ? AND winning_lamport_ts = ?
+                 AND losing_lamport_ts = ? AND losing_instance_id = ?
+                 AND op IS ? AND resolved = 0 LIMIT 1`,
+        args: [...dedupeArgs, conflictOp ?? null],
+      });
+      if (rows.length > 0) return false;
+    } catch (err) {
+      // Pre-migration DB without the op column: degrade like the INSERT fallback
+      // below — dedupe without the op predicate rather than letting the error
+      // escape (which would silently kill ALL conflict logging; spec R2/F4).
+      if (/no such column: op|no column named op/i.test(err.message || "")) {
+        try {
+          const { rows } = await this.db.execute({
+            sql: `SELECT id FROM sync_conflicts
+                   WHERE table_name = ? AND row_id = ? AND winning_lamport_ts = ?
+                     AND losing_lamport_ts = ? AND losing_instance_id = ?
+                     AND resolved = 0 LIMIT 1`,
+            args: dedupeArgs,
+          });
+          if (rows.length > 0) return false;
+        } catch { /* dedupe is best-effort; fall through to insert */ }
+      }
+      // Any other pre-check error: fall through — logging the conflict matters
+      // more than deduping it.
+    }
     const legacyCols = `table_name, row_id, winning_instance_id, losing_instance_id,
                  winning_lamport_ts, losing_lamport_ts, winning_data, losing_data`;
     const legacyArgs = [tableName, rowId, winInst, loseInst, winTs, loseTs, winData, loseData];
@@ -2230,6 +2266,7 @@ export class InstanceSyncManager {
         args: legacyArgs,
       });
     }
+    return true;
   }
 
   /**
@@ -2328,7 +2365,7 @@ export class InstanceSyncManager {
 
       // Id collision with different data — surface it (D7 minimal fix).
       // The incoming insert is still not applied; the trace is preserved.
-      await this._insertConflictRow(
+      const inserted = await this._insertConflictRow(
         table, String(row.id),
         localRow.instance_id || this.localInstanceId, instanceId,
         localRow.lamport_ts || 0, lamportTs,
@@ -2336,7 +2373,7 @@ export class InstanceSyncManager {
         "insert",
       );
 
-      await this._notifyConflict();
+      if (inserted) await this._notifyConflict();
     }
   }
 

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -604,6 +604,27 @@ export class InstanceSyncManager {
   }
 
   /**
+   * 2c C4 (design §3): contacts mirror of W4's flagless group-tombstone re-emit.
+   * Thin wrapper — the #147-gated body (`_backfillContactsOnceGated`) runs at most
+   * once per instance lifetime, but the `finally` runs `reemitContactTombstones()`
+   * on EVERY boot. External contract is UNCHANGED (returns the gated body's count):
+   * mcp-mounts.js and tests/messages-contacts-backfill.test.js call this wrapper.
+   *
+   * Only safe because the tombstone re-emit preserves each delete's ORIGINAL global
+   * lamport (preserve-mode) — a fresh mint here would beat a peer's genuinely-newer
+   * re-add and wipe it (contacts allow re-add-after-delete, unlike groups: G5).
+   */
+  async backfillContactsOnce() {
+    try {
+      return await this._backfillContactsOnceGated();
+    } finally {
+      // W4 pattern (mirrors backfillGroupsOnce): FLAGLESS every-boot tombstone
+      // re-emit on EVERY exit path of the gated body. Guarded — never throws.
+      await this.reemitContactTombstones();
+    }
+  }
+
+  /**
    * One-shot idempotent backfill (Phase 3 PR-B / I-4): re-emit every existing
    * SYNCABLE full contact so a peer can resolve crow_id → local contact_id for
    * contacts that predate PR-A (they never emitted a contact-sync entry, so
@@ -614,8 +635,11 @@ export class InstanceSyncManager {
    * an unchanged re-emit as an effective no-op (fresh lamport → UPDATE with
    * identical values; onContactSynced re-subscribe is idempotent). Mirrors
    * reemitSyncableSettingsOnce(). Never throws out of the loop.
+   *
+   * The gated BODY of backfillContactsOnce() (2c C4 wrapped it with a finally-path
+   * tombstone re-emit; return value contract is unchanged).
    */
-  async backfillContactsOnce() {
+  async _backfillContactsOnceGated() {
     const FLAG_KEY = "__contacts_backfill_v1";
     // Only a real completed run ("done:<n>") is terminal. The boot call races
     // the async sharing boot that opens the sync feeds — on a slow host the
@@ -696,6 +720,72 @@ export class InstanceSyncManager {
     if (emitted > 0) {
       console.log(`[instance-sync] one-shot contacts backfill: ${emitted} contact(s) re-emitted → peers resolve legacy contacts`);
     }
+    return emitted;
+  }
+
+  /**
+   * 2c C4 (design §3): the W4 mirror for contacts. Re-emit every AUTHORITATIVE
+   * contact tombstone as an op=delete on EVERY boot — deliberately NO flag. Sync
+   * feeds are born EMPTY at pairing (no history replay, see _initInstanceInner),
+   * so a delete that missed its peers — a crash inside the boot window, a re-pair,
+   * a secondary-process delete whose feeds never armed — is otherwise never
+   * re-delivered (silent divergence, defect D-C). Groups solved exactly this with
+   * reemitGroupTombstones; contacts had no mirror.
+   *
+   * Unlike groups (strict delete-wins, re-adds LOSE by design), this mirror is
+   * ONLY safe with lamport PRESERVATION: the envelope carries the tombstone's
+   * ORIGINAL global delete lamport, so the re-emit beats exactly what the original
+   * broadcast would have — no more. A fresh mint would beat a peer's genuinely-newer
+   * re-add and wipe it (contacts allow re-add-after-delete; G5).
+   *
+   * Filters (both load-bearing):
+   *   - kind IS NULL: authoritative user deletes ONLY. A `kind='prune'` tombstone
+   *     is local GC (2a) and must NEVER ride the wire.
+   *   - no coexisting live `contacts` row (LEFT JOIN): the anomalous
+   *     row-beside-tombstone state is reachable via races/manual edits; never
+   *     broadcast a delete for a contact this instance still holds (m-3; mirrors
+   *     emitGroupUpsert's belt-and-braces).
+   *
+   * Drains inbound FIRST (I-B1, load-bearing here): an already-delivered
+   * re-add-as-insert must clear our tombstone BEFORE we re-emit it. Guarded —
+   * never throws; a missing contact_tombstones table (un-migrated DB) is a no-op.
+   */
+  async reemitContactTombstones() {
+    if (this.feedsDisabled) return 0;
+    if (this.outFeeds.size === 0) return 0; // no peers armed yet — retry next boot; flagless by design (W4 rationale)
+    // I-B1 drain: apply the peer's already-replicated backlog so a genuine
+    // re-add-as-insert clears our tombstone before we re-emit it (rule order is
+    // load-bearing; design §3 C4).
+    try {
+      for (const [peerId, inFeed] of this.inFeeds) {
+        await this._processNewEntries(peerId, inFeed);
+      }
+    } catch (err) {
+      console.warn(`[instance-sync] contact tombstone re-emit drain failed: ${err.message}`);
+    }
+    let rows = [];
+    try {
+      const r = await this.db.execute({
+        sql: `SELECT t.crow_id, t.lamport_ts FROM contact_tombstones t
+               LEFT JOIN contacts c ON c.crow_id = t.crow_id
+               WHERE t.kind IS NULL AND c.crow_id IS NULL`,
+      });
+      rows = r.rows || [];
+    } catch {
+      return 0; // missing table / read failure → no-op (never throw at boot)
+    }
+    let emitted = 0;
+    for (const row of rows) {
+      try {
+        // 2c C2/C4: preserve the delete's ORIGINAL global lamport (no fresh mint).
+        const ts = await this.emitChange("contacts", "delete", { crow_id: row.crow_id },
+          { lamportTs: Number(row.lamport_ts) || 0 });
+        if (ts != null) emitted++;
+      } catch (err) {
+        console.warn(`[instance-sync] contact tombstone re-emit failed for ${row.crow_id}: ${err.message}`);
+      }
+    }
+    if (emitted > 0) console.log(`[instance-sync] re-emitted ${emitted} contact tombstone delete(s) to all peers`);
     return emitted;
   }
 

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1049,23 +1049,32 @@ export class InstanceSyncManager {
    * @param {"insert"|"update"|"delete"} op - Operation type
    * @param {object} row - The row data (for insert/update) or { id } (for delete)
    */
-  async emitChange(table, op, row) {
+  async emitChange(table, op, row, opts = {}) {
     // --no-auth companion doesn't drive fleet sync (and has no outFeeds).
     if (this.feedsDisabled) return null;
     if (!SYNCED_TABLES.includes(table)) return null;
     if (!shouldSyncRow(table, row)) return null; // local-only row; don't broadcast
 
-    // Envelope counter floor: after a sync_state reset (e.g. DB recovery) the
-    // local counter can sit BELOW lamports already stamped on rows; an emit
-    // would then look stale to peers (they order on the envelope) and the
-    // divergence is silent and permanent. Floor the counter at the outgoing
-    // row's own lamport first — _advanceCounter is an atomic
-    // MAX(counter, ts+1), so the _nextLamport below strictly exceeds it.
+    // 2c C1: a re-emit passes opts.lamportTs to preserve the row's ORIGINAL emit
+    // lamport — a redelivery must never fabricate recency over a peer's newer
+    // write. Preserve-mode skips the mint AND the local re-stamp; the counter is
+    // still floored so future fresh mints strictly exceed every re-emitted value.
+    // Live mutations MUST NOT pass opts.lamportTs.
+    const preservedTs =
+      opts != null && Number.isFinite(Number(opts.lamportTs)) && Number(opts.lamportTs) >= 0
+        ? Number(opts.lamportTs)
+        : null;
+
+    // Envelope counter floor (see original comment): floor at the outgoing row's
+    // own lamport, and in preserve-mode also at the preserved envelope value.
     const rowTs = Number(row?.lamport_ts);
     if (Number.isFinite(rowTs) && rowTs > 0) {
       await this._advanceCounter(rowTs);
     }
-    const lamportTs = await this._nextLamport();
+    if (preservedTs !== null && preservedTs > 0) {
+      await this._advanceCounter(preservedTs);
+    }
+    const lamportTs = preservedTs !== null ? preservedTs : await this._nextLamport();
 
     // Strip excluded columns
     const excluded = EXCLUDED_COLUMNS[table] || [];
@@ -1089,8 +1098,9 @@ export class InstanceSyncManager {
     const payload = JSON.stringify(entry);
     entry.signature = sign(payload, this.identity.ed25519Priv);
 
-    // Update the row's lamport_ts in the local database
-    if (op !== "delete") {
+    // Update the row's lamport_ts in the local database (NEVER in preserve-mode —
+    // the row keeps its original lamport; 2c C1).
+    if (op !== "delete" && preservedTs === null) {
       try {
         if (table === "dashboard_settings" && row.key !== undefined) {
           await this.db.execute({

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -575,11 +575,13 @@ export class InstanceSyncManager {
       // this guard is scoped to the re-emit reconciliation only.
       if (PROFILE_SYNC_KEYS.includes(row.key) && (typeof row.value !== "string" || row.value.trim() === "")) continue;
       try {
+        // 2c C2: preserve the row's ORIGINAL lamport (already SELECTed) — a
+        // re-emit is redelivery and must not out-stamp a peer's newer save.
         await this.emitChange("dashboard_settings", "update", {
           key: row.key,
           value: row.value,
           instance_id: null,
-        });
+        }, { lamportTs: Number(row.lamport_ts) || 0 });
         emitted++;
       } catch (err) {
         console.warn(`[instance-sync] reemit ${row.key} failed: ${err.message}`);
@@ -670,7 +672,11 @@ export class InstanceSyncManager {
       try {
         // shouldSyncRow("contacts", …) is the final gate inside emitChange;
         // EXCLUDED_COLUMNS.contacts strips verified/last_seen/id/created_at.
-        await this.emitChange("contacts", "update", row);
+        // 2c C2: preserve the row's ORIGINAL lamport — a backfill is redelivery,
+        // not a new write; a fresh mint here fabricated recency over any peer
+        // write still in flight (I-B1). NULL-lamport legacy rows emit at 0: they
+        // land where the peer has nothing and lose everywhere else.
+        await this.emitChange("contacts", "update", row, { lamportTs: Number(row.lamport_ts) || 0 });
         emitted++;
       } catch (err) {
         console.warn(`[instance-sync] contacts backfill emit failed for ${row.crow_id}: ${err.message}`);
@@ -965,7 +971,7 @@ export class InstanceSyncManager {
     let emitted = 0;
     for (const row of rows) {
       try {
-        await emitGroupUpsert(this.db, row.id); // shouldSyncRow + room skip are the final gate
+        await emitGroupUpsert(this.db, row.id, { preserveLamport: true }); // 2c C2: backfill keeps original lamports; shouldSyncRow + room skip are the final gate
         emitted++;
       } catch (err) {
         console.warn(`[instance-sync] groups backfill emit failed for group ${row.id}: ${err.message}`);

--- a/servers/sharing/sync-conflict-resolve.js
+++ b/servers/sharing/sync-conflict-resolve.js
@@ -123,20 +123,28 @@ export async function restoreConflict(db, conflictId, { instanceSync = null } = 
   const table = conflict.table_name;
   const rowId = conflict.row_id;
 
-  // crow_context conflicts cannot be auto-restored: the row_id is a JSON composite
-  // key, not a numeric id, so the id-keyed stale-snapshot guard below would run
-  // SELECT … WHERE id = '{…}', find nothing, re-snapshot to 'null', and silently
-  // destroy the recorded local snapshot.  Use crow_update_context_section to apply
-  // the losing data manually.  (Placement BEFORE the stale guard is load-bearing —
-  // see spec §4 C3.)
-  if (table === "crow_context") {
-    return {
-      status: "refused",
-      message:
-        "This version cannot be restored automatically. crow_context rows are keyed " +
-        "by a composite key (section_key, device_id, project_id), not a single id. " +
-        "Use crow_update_context_section to apply the values shown below.",
-    };
+  // Natural-key tables cannot be auto-restored: their conflict row_id is a JSON
+  // key (crow_context: {section_key,device_id,project_id}; contacts: {crow_id};
+  // contact_groups: {group_uid}), not a numeric id, so the id-keyed stale-snapshot
+  // guard below would run SELECT ... WHERE id = '{...}', find nothing, re-snapshot
+  // winning_data to 'null', and silently destroy the recorded local snapshot
+  // (2c C7 / spec R3-Q4). Placement BEFORE the stale guard is load-bearing.
+  const NATURAL_KEY_RESTORE_REFUSALS = {
+    crow_context:
+      "This version cannot be restored automatically. crow_context rows are keyed " +
+      "by a composite key (section_key, device_id, project_id), not a single id. " +
+      "Use crow_update_context_section to apply the values shown below.",
+    contacts:
+      "This version cannot be restored automatically. Contact conflicts are keyed " +
+      "by crow_id, not a numeric id. Review the values shown below and re-apply " +
+      "the change manually from the Contacts panel.",
+    contact_groups:
+      "This version cannot be restored automatically. Group conflicts are keyed " +
+      "by group_uid, not a numeric id. Review the values shown below and re-apply " +
+      "the change manually from the Groups panel.",
+  };
+  if (NATURAL_KEY_RESTORE_REFUSALS[table]) {
+    return { status: "refused", message: NATURAL_KEY_RESTORE_REFUSALS[table] };
   }
 
   // ── 2. Validate table ─────────────────────────────────────────────────────

--- a/tests/group-tombstones.test.js
+++ b/tests/group-tombstones.test.js
@@ -705,62 +705,67 @@ test("G2: emitGroupUpsert on a live-row-beside-tombstone zombie emits NOTHING; a
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// T11 — G3 (design R2 F3'): the sync-conflicts RESTORE button must not
-// re-INSERT a tombstoned uid. The conflict row is seeded in the EXACT shape
-// _insertConflictRow writes on the local-wins path (op="update": row_id = JSON
-// {group_uid}, losing_data = the filtered wire row — the shape T1 asserts).
-// Driven the way the settings UI does (sync-conflicts.js handleAction →
-// restoreConflict): the first call trips the stale-snapshot guard (the
-// winning_data snapshot vs. the now-gone row) and re-snapshots — the UI's
-// confirm-again flow; the SECOND call reaches the INSERT branch G3 guards.
+// T11 — superseded by 2c C7 (design spec §3 C7 "required revision (folded)"):
+// restoreConflict now refuses ALL natural-key tables (crow_context, contacts,
+// contact_groups) by table property, BEFORE the id-keyed stale-snapshot guard
+// even runs. contact_groups conflicts are JSON-row_id (`{group_uid}`), so they
+// now hit that refusal unconditionally — the tombstone-specific G3 statement-
+// level guard below (the `INSERT ... SELECT WHERE NOT EXISTS` in
+// sync-conflict-resolve.js) sits further down in the op='update' INSERT branch
+// and is no longer reachable via restoreConflict (contact_groups never gets
+// that far). It's left in place as defense-in-depth for a future real
+// natural-key restore path (spec §3 C7: "recorded follow-up"), but these two
+// tests — which drove that INSERT branch via a first-click "stale" re-snapshot
+// then a second click — now updated to assert the actual (and correct, per C7)
+// behavior: refused on the FIRST call, unconditionally, tombstoned or not.
+// See tests/lamport-reemit.test.js G10 for the executable C7 gate.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Seed a contact_groups op="update" conflict + drive restore twice (stale → outcome). */
-async function seedConflictAndRestore(inst, uid, tombstoned) {
+/** Seed a contact_groups op="update" conflict in the EXACT shape _insertConflictRow
+ * writes on the local-wins path (row_id = JSON {group_uid}). Returns {id, winning_data}. */
+async function seedGroupConflict(inst, uid) {
   const losing = { group_uid: uid, name: "Restored Zombie" };
   const winning = { id: 950, group_uid: uid, name: "Local Winner", lamport_ts: 9 };
   await inst.mgr._insertConflictRow("contact_groups", JSON.stringify({ group_uid: uid }),
     A_ID, B_ID, 9, 12, JSON.stringify(winning), JSON.stringify(losing), "update");
-  const conflictId = (await inst.db.execute(
-    "SELECT id FROM sync_conflicts ORDER BY id DESC LIMIT 1")).rows[0].id;
-  if (tombstoned) await inst.db.execute(groupTombstoneStatement(uid, 12));
-
-  const first = await restoreConflict(inst.db, String(conflictId), { instanceSync: null });
-  assert.equal(first.status, "stale", "first click re-snapshots (the UI's double-confirm flow)");
-  const second = await restoreConflict(inst.db, String(conflictId), { instanceSync: null });
-  return { conflictId, outcome: second };
+  return (await inst.db.execute(
+    "SELECT id, winning_data FROM sync_conflicts ORDER BY id DESC LIMIT 1")).rows[0];
 }
 
-test("T11: restoring a contact_groups conflict whose uid is TOMBSTONED is REFUSED — no row inserted, tombstone intact, conflict left unresolved", async () => {
+test("T11: restoring a contact_groups conflict whose uid is TOMBSTONED is REFUSED by the C7 natural-key guard — no row inserted, tombstone intact, winning_data byte-identical, conflict left unresolved", async () => {
   const f = newFleet();
   const uid = "t11-" + "0".repeat(28);
+  await f.A.db.execute(groupTombstoneStatement(uid, 12));
 
-  const { conflictId, outcome } = await seedConflictAndRestore(f.A, uid, true);
+  const seed = await seedGroupConflict(f.A, uid);
+  const outcome = await restoreConflict(f.A.db, String(seed.id), { instanceSync: null });
 
-  assert.equal(outcome.status, "refused", "G3 refuses the restore (not applied, not error)");
-  assert.match(outcome.message || "", /deleted fleet-wide/i,
-    "the refusal surfaces the reason instead of claiming success");
+  assert.equal(outcome.status, "refused", "C7 natural-key guard refuses the restore (not applied, not error)");
+  assert.match(outcome.message || "", /group_uid/i,
+    "the refusal names the natural key (group_uid), not a numeric id");
   assert.equal(await groupRow(f.A, uid), null, "NO contact_groups row was inserted");
   assert.ok(await tomb(f.A, uid), "tombstone intact");
   const c = (await f.A.db.execute({
-    sql: "SELECT resolved FROM sync_conflicts WHERE id = ?", args: [conflictId] })).rows[0];
+    sql: "SELECT winning_data, resolved FROM sync_conflicts WHERE id = ?", args: [seed.id] })).rows[0];
   assert.equal(Number(c.resolved), 0,
     "conflict left UNRESOLVED on refusal (the data stays visible, like the D7 refusal)");
+  assert.equal(c.winning_data, seed.winning_data,
+    "winning_data byte-identical — not corrupted to the JSON string 'null' by the id-keyed stale guard (2c C7)");
 });
 
-test("T11 negative control: the SAME conflict WITHOUT a tombstone restores — row inserted, conflict resolved (proves the harness reaches the INSERT branch)", async () => {
+test("T11 negative control: the SAME conflict WITHOUT a tombstone is ALSO refused — the C7 refusal is unconditional on the table's natural-key property, independent of tombstone state", async () => {
   const f = newFleet();
   const uid = "t11-neg-" + "0".repeat(24);
 
-  const { conflictId, outcome } = await seedConflictAndRestore(f.A, uid, false);
+  const seed = await seedGroupConflict(f.A, uid);
+  const outcome = await restoreConflict(f.A.db, String(seed.id), { instanceSync: null });
 
-  assert.equal(outcome.status, "applied", "non-tombstoned restore succeeds");
-  const row = await groupRow(f.A, uid);
-  assert.ok(row, "the losing row was re-INSERTed");
-  assert.equal(row.name, "Restored Zombie", "restored with the losing_data values");
+  assert.equal(outcome.status, "refused", "still refused even without a tombstone — C7 does not consult tombstone state");
+  assert.equal(await groupRow(f.A, uid), null, "no row inserted regardless of tombstone state");
   const c = (await f.A.db.execute({
-    sql: "SELECT resolved FROM sync_conflicts WHERE id = ?", args: [conflictId] })).rows[0];
-  assert.equal(Number(c.resolved), 1, "conflict marked resolved on success");
+    sql: "SELECT winning_data, resolved FROM sync_conflicts WHERE id = ?", args: [seed.id] })).rows[0];
+  assert.equal(Number(c.resolved), 0, "conflict left unresolved");
+  assert.equal(c.winning_data, seed.winning_data, "winning_data byte-identical");
 });
 
 test("T9: W4 flagless boot re-emit — a peer that paired after the delete converges (stale copy gone, tombstoned, exactly one delete-won conflict row); a second re-emit is idempotent", async () => {

--- a/tests/instance-sync.test.js
+++ b/tests/instance-sync.test.js
@@ -1420,6 +1420,43 @@ test("18. crow_context emitChange stamps local row's lamport_ts (global and devi
   db.close();
 });
 
+test("2c-C1a. emitChange opts.lamportTs: envelope preserved, local row NOT re-stamped, counter floored", async () => {
+  const { mgr, db } = makeManager("inst-2c-c1");
+  const captured = [];
+  mgr.outFeeds = new Map([["peer-x", { append: async (e) => captured.push(e) }]]);
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:c1a', '', 'a1', 'Old Name', 5)",
+    args: [],
+  });
+  const { rows: r0 } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:c1a'", args: [] });
+  const ts = await mgr.emitChange("contacts", "update", r0[0], { lamportTs: 5 });
+  assert.equal(ts, 5, "returns the preserved envelope lamport");
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].lamport_ts, 5, "envelope carries the preserved lamport");
+  const { rows: r1 } = await db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:c1a'", args: [] });
+  assert.equal(Number(r1[0].lamport_ts), 5, "local row lamport NOT re-stamped");
+  // Counter floored: the next fresh mint must exceed the preserved value.
+  const fresh = await mgr._nextLamport();
+  assert.ok(fresh > 5, `next mint ${fresh} must exceed preserved 5`);
+  db.close();
+});
+
+test("2c-C1b. emitChange without opts: behavior unchanged (fresh mint + local stamp)", async () => {
+  const { mgr, db } = makeManager("inst-2c-c1b");
+  const captured = [];
+  mgr.outFeeds = new Map([["peer-x", { append: async (e) => captured.push(e) }]]);
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, lamport_ts) VALUES ('crow:c1b', '', 'b1', 5)",
+    args: [],
+  });
+  const { rows: r0 } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:c1b'", args: [] });
+  const ts = await mgr.emitChange("contacts", "update", r0[0]);
+  assert.ok(ts > 5, "fresh mint exceeds row lamport (counter floor)");
+  const { rows: r1 } = await db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:c1b'", args: [] });
+  assert.equal(Number(r1[0].lamport_ts), ts, "local row re-stamped with the fresh mint");
+  db.close();
+});
+
 // ── Test 19: Upsert (update for missing row) ──────────────────────────────────
 
 test("19. crow_context upsert: update for absent section creates row with lamport_ts=incomingTs; stale follow-up → conflict/skip not applied; partial old-sender entry missing content → skipped; resurrection case", async () => {

--- a/tests/instance-sync.test.js
+++ b/tests/instance-sync.test.js
@@ -1762,3 +1762,24 @@ test("22b. crow_update_context_section emits post-UPDATE values (not pre-update 
   await client.close();
   rmSync(testDir, { recursive: true, force: true });
 });
+
+test("2c-C5a. conflict dedupe: identical redelivery adds no row; losing_instance_id distinguishes peers; resolved=1 re-surfaces once", async () => {
+  const { mgr, db } = makeManager("inst-2c-c5");
+  const count = async () => Number((await db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts", args: [] })).rows[0].n);
+  const args = ["contacts", '{"crow_id":"crow:c5"}', "inst-2c-c5", "peer-A", 12, 10, '{"v":1}', '{"v":0}', "update"];
+  assert.equal(await mgr._insertConflictRow(...args), true, "first insert rides");
+  const base = await count();
+  // Identical redelivery — even with DIFFERENT winning_data (volatile last_seen class)
+  const argsVolatile = [...args]; argsVolatile[6] = '{"v":1,"last_seen":"moved"}';
+  assert.equal(await mgr._insertConflictRow(...argsVolatile), false, "stable key ignores data blobs");
+  assert.equal(await count(), base, "no growth on redelivery");
+  // Different origin peer, same lamport pair → genuinely distinct → logs (G2b)
+  const argsPeerB = [...args]; argsPeerB[3] = "peer-B";
+  assert.equal(await mgr._insertConflictRow(...argsPeerB), true, "losing_instance_id distinguishes");
+  assert.equal(await count(), base + 1);
+  // Resolve the peer-A row, redeliver → re-surfaces EXACTLY once (G5c)
+  await db.execute({ sql: "UPDATE sync_conflicts SET resolved = 1 WHERE losing_instance_id = 'peer-A'", args: [] });
+  assert.equal(await mgr._insertConflictRow(...args), true, "re-surfaces once after resolve");
+  assert.equal(await mgr._insertConflictRow(...args), false, "then dedupes against the new unresolved row");
+  db.close();
+});

--- a/tests/instance-sync.test.js
+++ b/tests/instance-sync.test.js
@@ -1424,20 +1424,24 @@ test("2c-C1a. emitChange opts.lamportTs: envelope preserved, local row NOT re-st
   const { mgr, db } = makeManager("inst-2c-c1");
   const captured = [];
   mgr.outFeeds = new Map([["peer-x", { append: async (e) => captured.push(e) }]]);
+  // Row's own lamport_ts (9) diverges from opts.lamportTs (5) on purpose: this
+  // is the only way to tell "envelope preserves opts.lamportTs" apart from a
+  // bug where preserve-mode reuses the row's own current lamport instead.
   await db.execute({
-    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:c1a', '', 'a1', 'Old Name', 5)",
+    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:c1a', '', 'a1', 'Old Name', 9)",
     args: [],
   });
   const { rows: r0 } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:c1a'", args: [] });
   const ts = await mgr.emitChange("contacts", "update", r0[0], { lamportTs: 5 });
-  assert.equal(ts, 5, "returns the preserved envelope lamport");
+  assert.equal(ts, 5, "returns the preserved envelope lamport (opts.lamportTs), not the row's own lamport");
   assert.equal(captured.length, 1);
-  assert.equal(captured[0].lamport_ts, 5, "envelope carries the preserved lamport");
+  assert.equal(captured[0].lamport_ts, 5, "envelope carries the preserved opts.lamportTs, not the row's own lamport");
   const { rows: r1 } = await db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:c1a'", args: [] });
-  assert.equal(Number(r1[0].lamport_ts), 5, "local row lamport NOT re-stamped");
-  // Counter floored: the next fresh mint must exceed the preserved value.
+  assert.equal(Number(r1[0].lamport_ts), 9, "local row lamport NOT re-stamped (stays at its original 9)");
+  // Counter floored: the next fresh mint must exceed BOTH the row's own
+  // lamport (9) and the preserved value (5) — i.e. > 9, the higher of the two.
   const fresh = await mgr._nextLamport();
-  assert.ok(fresh > 5, `next mint ${fresh} must exceed preserved 5`);
+  assert.ok(fresh > 9, `next mint ${fresh} must exceed row lamport 9`);
   db.close();
 });
 
@@ -1454,6 +1458,27 @@ test("2c-C1b. emitChange without opts: behavior unchanged (fresh mint + local st
   assert.ok(ts > 5, "fresh mint exceeds row lamport (counter floor)");
   const { rows: r1 } = await db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:c1b'", args: [] });
   assert.equal(Number(r1[0].lamport_ts), ts, "local row re-stamped with the fresh mint");
+  db.close();
+});
+
+test("2c-C1c. emitChange opts.lamportTs === 0 (NULL-legacy sentinel): preserved not minted, local row stays NULL", async () => {
+  const { mgr, db } = makeManager("inst-2c-c1c");
+  const captured = [];
+  mgr.outFeeds = new Map([["peer-x", { append: async (e) => captured.push(e) }]]);
+  // lamport_ts explicitly NULL (the column has DEFAULT 0, so merely omitting
+  // it would NOT produce NULL) — this is the legacy-row sentinel that later
+  // tasks rely on.
+  await db.execute({
+    sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:c1c', '', 'c1', 'Legacy Name', NULL)",
+    args: [],
+  });
+  const { rows: r0 } = await db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:c1c'", args: [] });
+  const ts = await mgr.emitChange("contacts", "update", r0[0], { lamportTs: 0 });
+  assert.equal(ts, 0, "returns the preserved envelope lamport (0), not a fresh mint");
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].lamport_ts, 0, "envelope carries the preserved 0, not a freshly minted value");
+  const { rows: r1 } = await db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:c1c'", args: [] });
+  assert.equal(r1[0].lamport_ts, null, "local row lamport stays NULL (not re-stamped)");
   db.close();
 });
 

--- a/tests/instance-sync.test.js
+++ b/tests/instance-sync.test.js
@@ -72,7 +72,13 @@ const REMOTE_ID = "bbbbbbbb-0000-0000-0000-000000000002";
  */
 function makeManager(instanceId = LOCAL_ID) {
   const db = createDbClient(DB_PATH);
-  return { mgr: new InstanceSyncManager(IDENTITY, db, instanceId), db };
+  const mgr = new InstanceSyncManager(IDENTITY, db, instanceId);
+  // The scratch suite env sets CROW_DISABLE_INSTANCE_SYNC=1, which the constructor
+  // reads into feedsDisabled — emitChange would return before stamping and every
+  // emit-path assertion would go vacuous. These tests drive stub feeds, never real
+  // Hypercores, so force-enable (same as tests/group-tombstones.test.js:80).
+  mgr.feedsDisabled = false;
+  return { mgr, db };
 }
 
 /**

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { createDbClient } from "../servers/db.js";
 import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
 import { __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
+import { emitGroupUpsert, __setEmitSinkForTest as __setGroupSink } from "../servers/sharing/group-sync.js";
 import * as ed from "../node_modules/@noble/ed25519/index.js";
 
 // ── identities ───────────────────────────────────────────────────────────────
@@ -194,4 +195,165 @@ test("G3c: chain preserves emit order across the open transition; nothing duplic
   await Promise.all([drainP, liveP]);
   assert.deepEqual(appended, ["E1", "E2"], "E1 strictly before E2");
   assert.equal((f.A.mgr._pendingPeerEmits.get(f.B.id) || []).length, 0, "nothing stranded");
+});
+
+// ── Task 5 (C2): preserved-lamport re-emitters — G1/G2/G6/G6b/G7/G8 ────────────
+// The contacts/settings/groups backfills persist a #147 done-flag in the SHARED
+// on-disk DB; every backfill test clears its flag first so the run actually fires.
+// sync_conflicts also accumulates across tests on the shared file — every conflict
+// assertion is SCOPED to a per-test crow_id via the JSON row_id.
+const SYNCED_CONTACT_COLS = ["crow_id", "display_name", "ed25519_pubkey", "secp256k1_pubkey"];
+const CONTACTS_FLAG = "__contacts_backfill_v1";
+const clearBackfillFlag = async (db) =>
+  db.execute({ sql: "DELETE FROM dashboard_settings WHERE key = ?", args: [CONTACTS_FLAG] });
+const contactConflicts = async (db, crowId) =>
+  Number((await db.execute({
+    sql: "SELECT COUNT(*) AS n FROM sync_conflicts WHERE table_name = 'contacts' AND row_id = ? AND resolved = 0",
+    args: [JSON.stringify({ crow_id: crowId })],
+  })).rows[0].n);
+
+test("G1: backfill re-emit preserves lamport -- stale cannot clobber newer; mutual convergence", async () => {
+  const f = newFleet();
+  await clearBackfillFlag(f.A.db);
+  await f.A.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g1', '', 'g1aa', 'Stale Name', 5)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g1', '', 'g1aa', 'Newer Name', 10)", args: [] });
+  const emitted = await f.A.mgr.backfillContactsOnce();
+  assert.ok(emitted >= 1, "backfill ran and emitted");
+  const g1Wire = f.wire.filter((w) => w.from === f.A.id && w.entry.row?.crow_id === "crow:g1");
+  assert.equal(Number(g1Wire.at(-1).entry.lamport_ts), 5, "envelope preserved the row lamport");
+  await f.deliver(); // A→B: stale@5 vs local@10
+  const rowB = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g1'", args: [] })).rows[0];
+  assert.equal(rowB.display_name, "Newer Name", "B keeps its newer value");
+  assert.equal(Number(rowB.lamport_ts), 10);
+  const rowA0 = (await f.A.db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:g1'", args: [] })).rows[0];
+  assert.equal(Number(rowA0.lamport_ts), 5, "A's local row was NOT re-stamped");
+  // B's live emit reaches A → mutual convergence over the synced projection.
+  const rowBFull = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g1'", args: [] })).rows[0];
+  await act(f.B, async () => { await f.B.mgr.emitChange("contacts", "update", rowBFull); });
+  await f.deliver();
+  const a = (await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g1'", args: [] })).rows[0];
+  const b = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g1'", args: [] })).rows[0];
+  for (const col of SYNCED_CONTACT_COLS) {
+    assert.equal(String(a[col] ?? ""), String(b[col] ?? ""), `converged on ${col}`);
+  }
+});
+
+test("G2: mutual backfill converges; 1 conflict on the higher-lamport side; redelivery adds 0", async () => {
+  const f = newFleet();
+  await clearBackfillFlag(f.A.db);
+  await clearBackfillFlag(f.B.db);
+  await f.A.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g2', '', 'g2aa', 'A Name', 5)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g2', '', 'g2aa', 'B Name', 10)", args: [] });
+  const before = f.wire.length;
+  await f.A.mgr.backfillContactsOnce(); // emits g2@5
+  await f.B.mgr.backfillContactsOnce(); // emits g2@10
+  const g2Items = f.wire.slice(before).filter((w) => w.entry.row?.crow_id === "crow:g2");
+  await f.deliver(); // interleaved both ways
+  // Both converge to the @10 value.
+  const a = (await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g2'", args: [] })).rows[0];
+  const b = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g2'", args: [] })).rows[0];
+  assert.equal(a.display_name, "B Name", "A converged to the winner");
+  assert.equal(Number(a.lamport_ts), 10);
+  assert.equal(b.display_name, "B Name", "B kept its winner");
+  assert.equal(Number(b.lamport_ts), 10);
+  // Exactly 1 conflict row total, on the HIGHER-lamport side (B), asserted by its columns.
+  assert.equal(await contactConflicts(f.A.db, "crow:g2"), 0, "no conflict on the lower-lamport side (A)");
+  assert.equal(await contactConflicts(f.B.db, "crow:g2"), 1, "1 conflict on the higher-lamport side (B)");
+  const conf = (await f.B.db.execute({
+    sql: "SELECT winning_lamport_ts, losing_lamport_ts FROM sync_conflicts WHERE table_name='contacts' AND row_id=? AND resolved=0",
+    args: [JSON.stringify({ crow_id: "crow:g2" })],
+  })).rows[0];
+  assert.equal(Number(conf.winning_lamport_ts), 10, "winning lamport is the local 10");
+  assert.equal(Number(conf.losing_lamport_ts), 5, "losing lamport is the stale 5");
+  // Re-deliver the SAME wire slice — Task 3 dedupe holds sync_conflicts flat.
+  for (const it of g2Items) await f.applyItem(f.other(it.from), it);
+  assert.equal(await contactConflicts(f.B.db, "crow:g2"), 1, "re-delivery added 0 conflict rows");
+});
+
+test("G6: NULL legacy re-emits at lamport 0 -- loses to a peer's real row, but lands where the peer has nothing", async () => {
+  const f = newFleet();
+  await clearBackfillFlag(f.A.db);
+  await f.A.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g6', '', 'g6aa', 'A Legacy', NULL)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g6', '', 'g6aa', 'B Real', 7)", args: [] });
+  await f.A.mgr.backfillContactsOnce();
+  const g6Item = f.wire.find((w) => w.from === f.A.id && w.entry.row?.crow_id === "crow:g6");
+  assert.equal(Number(g6Item.entry.lamport_ts), 0, "envelope lamport is 0 for a NULL-lamport legacy row");
+  await f.deliver(); // A@0 vs B@7 → B keeps its real row
+  const rowB = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g6'", args: [] })).rows[0];
+  assert.equal(rowB.display_name, "B Real", "B's real row is untouched");
+  assert.equal(Number(rowB.lamport_ts), 7);
+  const rowA = (await f.A.db.execute({ sql: "SELECT lamport_ts FROM contacts WHERE crow_id = 'crow:g6'", args: [] })).rows[0];
+  assert.equal(rowA.lamport_ts, null, "A's local row lamport stays NULL (no re-stamp)");
+  // A peer that lacks the row entirely receives it (insert-on-missing is lamport-independent).
+  await f.B.db.execute({ sql: "DELETE FROM contacts WHERE crow_id = 'crow:g6'", args: [] });
+  await f.applyItem(f.B, g6Item);
+  const rowB2 = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g6'", args: [] })).rows[0];
+  assert.ok(rowB2, "missing-row peer received the @0 row");
+  assert.equal(rowB2.display_name, "A Legacy");
+});
+
+test("G6b: MUTUAL NULL-vs-NULL divergent legacy -- accepted non-convergence, 1 conflict per side, second delivery adds 0", async () => {
+  const f = newFleet();
+  await clearBackfillFlag(f.A.db);
+  await clearBackfillFlag(f.B.db);
+  await f.A.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g6b', '', 'g6baa', 'A Value', NULL)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g6b', '', 'g6baa', 'B Value', NULL)", args: [] });
+  const before = f.wire.length;
+  await f.A.mgr.backfillContactsOnce();
+  await f.B.mgr.backfillContactsOnce();
+  const g6bItems = f.wire.slice(before).filter((w) => w.entry.row?.crow_id === "crow:g6b");
+  await f.deliver(); // both ways
+  const a = (await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g6b'", args: [] })).rows[0];
+  const b = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g6b'", args: [] })).rows[0];
+  assert.equal(a.display_name, "A Value", "A keeps its value (0 > 0 is false)");
+  assert.equal(b.display_name, "B Value", "B keeps its value");
+  assert.equal(await contactConflicts(f.A.db, "crow:g6b"), 1, "exactly 1 conflict on A");
+  assert.equal(await contactConflicts(f.B.db, "crow:g6b"), 1, "exactly 1 conflict on B");
+  for (const it of g6bItems) await f.applyItem(f.other(it.from), it);
+  assert.equal(await contactConflicts(f.A.db, "crow:g6b"), 1, "second delivery added 0 on A");
+  assert.equal(await contactConflicts(f.B.db, "crow:g6b"), 1, "second delivery added 0 on B");
+});
+
+test("G7: #147 flag -- first backfill writes done:<n>, second emits 0 (wire unchanged)", async () => {
+  const f = newFleet();
+  await clearBackfillFlag(f.A.db);
+  await f.A.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g7', '', 'g7aa', 'G7', 3)", args: [] });
+  const e1 = await f.A.mgr.backfillContactsOnce();
+  assert.ok(e1 >= 1, "first run emitted");
+  const flag = (await f.A.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [CONTACTS_FLAG] })).rows[0];
+  assert.equal(flag.value, `done:${e1}`, "first run wrote the done:<n> flag");
+  const wireAfterFirst = f.wire.length;
+  const e2 = await f.A.mgr.backfillContactsOnce();
+  assert.equal(e2, 0, "second run emits 0 (flag terminal)");
+  assert.equal(f.wire.length, wireAfterFirst, "wire length unchanged on the second run");
+});
+
+test("G8: settings + groups re-emit preserve their lamport (envelope == L; local lamport unchanged)", async () => {
+  const f = newFleet();
+  // ── settings: an allowlisted key at lamport 40 ──
+  await f.A.db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value, lamport_ts) VALUES ('nav_groups', 'x', 40) ON CONFLICT(key) DO UPDATE SET value = excluded.value, lamport_ts = excluded.lamport_ts",
+    args: [],
+  });
+  await f.A.mgr.reemitSyncableSettingsOnce();
+  const setEntry = f.wire.filter((w) => w.from === f.A.id && w.entry.table === "dashboard_settings" && w.entry.row?.key === "nav_groups").at(-1);
+  assert.ok(setEntry, "settings re-emit rode the wire");
+  assert.equal(Number(setEntry.entry.lamport_ts), 40, "settings envelope lamport == 40 (not a fresh mint)");
+  const setLocal = (await f.A.db.execute({ sql: "SELECT lamport_ts FROM dashboard_settings WHERE key = 'nav_groups'", args: [] })).rows[0];
+  assert.equal(Number(setLocal.lamport_ts), 40, "settings local lamport unchanged");
+  // ── groups: a group_uid'd row at lamport 30 via its own sink ──
+  await f.A.db.execute({ sql: "INSERT INTO contact_groups (name, group_uid, lamport_ts) VALUES ('G8 Group', 'uid-g8', 30)", args: [] });
+  const gid = Number((await f.A.db.execute({ sql: "SELECT id FROM contact_groups WHERE group_uid = 'uid-g8'", args: [] })).rows[0].id);
+  const beforeG = f.wire.length;
+  __setGroupSink(f.A.mgr);
+  try {
+    await emitGroupUpsert(f.A.db, gid, { preserveLamport: true });
+  } finally {
+    __setGroupSink(null);
+  }
+  const grpEntry = f.wire.slice(beforeG).filter((w) => w.entry.table === "contact_groups" && w.entry.row?.group_uid === "uid-g8").at(-1);
+  assert.ok(grpEntry, "group re-emit rode the wire");
+  assert.equal(Number(grpEntry.entry.lamport_ts), 30, "group envelope lamport == 30 (not a fresh mint)");
+  const grpLocal = (await f.A.db.execute({ sql: "SELECT lamport_ts FROM contact_groups WHERE group_uid = 'uid-g8'", args: [] })).rows[0];
+  assert.equal(Number(grpLocal.lamport_ts), 30, "group local lamport unchanged");
 });

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -477,6 +477,54 @@ test("G5b: concurrent edit-vs-delete stays divergent -- B's update is dropped on
   assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 1, "divergence persists: B present");
 });
 
+test("G5c: C5 resolve-scope -- resolving a conflict row re-surfaces the divergence exactly once on redelivery, then dedupes again", async () => {
+  const f = newFleet();
+  // A: authoritative tombstone@10, row-less. B: the contact re-added, live@20
+  // (G5 shape) -- A's re-emit of the tombstone loses LWW to B's row every boot,
+  // producing a real, repeatable conflict row on B to exercise the resolve-scope.
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g5c', 10, 1, NULL)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g5c', '', 'g5caa', 'G5c ReAdd', 20)", args: [] });
+  // A's counter well above B's row lamport (20), same rationale as G5: the
+  // tombstone re-emit must preserve@10, not mint fresh, or it would wipe B's row
+  // and never produce a conflict to resolve in the first place.
+  await f.A.mgr._advanceCounter(30);
+  const bootA = async () => { await setBackfillDone(f.A.db); await f.A.mgr.backfillContactsOnce(); };
+  const totalConflicts = async (db, crowId) =>
+    Number((await db.execute({
+      sql: "SELECT COUNT(*) AS n FROM sync_conflicts WHERE table_name = 'contacts' AND row_id = ?",
+      args: [JSON.stringify({ crow_id: crowId })],
+    })).rows[0].n);
+
+  // Boot 1: A re-emits delete@10 -> loses LWW to B's row@20 -> 1 unresolved conflict on B.
+  await bootA();
+  await f.deliver();
+  assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5c'", args: [] })).rows.length, 1, "B's row survived boot 1");
+  assert.equal(await contactConflicts(f.B.db, "crow:g5c"), 1, "boot 1 logged exactly 1 unresolved conflict on B");
+  assert.equal(await totalConflicts(f.B.db, "crow:g5c"), 1, "total conflict rows = 1 after boot 1");
+
+  // Operator resolves it (dashboard Resolve action, modeled directly).
+  await f.B.db.execute({
+    sql: "UPDATE sync_conflicts SET resolved = 1 WHERE table_name = 'contacts' AND row_id = ?",
+    args: [JSON.stringify({ crow_id: "crow:g5c" })],
+  });
+  assert.equal(await contactConflicts(f.B.db, "crow:g5c"), 0, "resolved row no longer counts as unresolved");
+
+  // Boot 2: A re-emits the IDENTICAL delete@10 entry again. The underlying
+  // divergence is still live (resolving didn't fix it) -- C5's dedupe pre-check
+  // is scoped to resolved=0 (R2/F5), so it finds no unresolved match against the
+  // now-resolved row and inserts a NEW one: exactly one re-surfaced row, once.
+  await bootA();
+  await f.deliver();
+  assert.equal(await contactConflicts(f.B.db, "crow:g5c"), 1, "exactly one NEW unresolved row re-surfaced");
+  assert.equal(await totalConflicts(f.B.db, "crow:g5c"), 2, "total rows = 2 (the resolved one + the new one)");
+
+  // Boot 3: redeliver again -> C5 dedupes against the NEW unresolved row -> 0 new rows.
+  await bootA();
+  await f.deliver();
+  assert.equal(await contactConflicts(f.B.db, "crow:g5c"), 1, "still exactly 1 unresolved (deduped against the re-surfaced row)");
+  assert.equal(await totalConflicts(f.B.db, "crow:g5c"), 2, "total rows unchanged at 2 (redelivery added 0)");
+});
+
 // ── G10: C7 -- restoreConflict refuses ALL natural-key tables ──────────────────
 // crow_context, contacts, and contact_groups all key their sync_conflicts row_id
 // as a JSON object, not a numeric id. Without the natural-key refusal placed

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -322,10 +322,15 @@ test("G7: #147 flag -- first backfill writes done:<n>, second emits 0 (wire unch
   assert.ok(e1 >= 1, "first run emitted");
   const flag = (await f.A.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [CONTACTS_FLAG] })).rows[0];
   assert.equal(flag.value, `done:${e1}`, "first run wrote the done:<n> flag");
-  const wireAfterFirst = f.wire.length;
+  // Scope to crow:g7: Task 6's C4 wrapped backfillContactsOnce with a FLAGLESS
+  // per-boot tombstone re-emit (finally), which legitimately appends standing
+  // authoritative tombstones (e.g. crow:g3 from G3) to the shared wire on EVERY
+  // call. The #147 flag governs the GATED BODY's contact re-emits only, so assert
+  // no NEW crow:g7 entry rides on the second run rather than a total wire length.
+  const g7WireAfterFirst = f.wire.filter((w) => w.entry.row?.crow_id === "crow:g7").length;
   const e2 = await f.A.mgr.backfillContactsOnce();
   assert.equal(e2, 0, "second run emits 0 (flag terminal)");
-  assert.equal(f.wire.length, wireAfterFirst, "wire length unchanged on the second run");
+  assert.equal(f.wire.filter((w) => w.entry.row?.crow_id === "crow:g7").length, g7WireAfterFirst, "no new crow:g7 entry rode on the second run (gated body flag-terminal)");
 });
 
 test("G8: settings + groups re-emit preserve their lamport (envelope == L; local lamport unchanged)", async () => {
@@ -356,4 +361,113 @@ test("G8: settings + groups re-emit preserve their lamport (envelope == L; local
   assert.equal(Number(grpEntry.entry.lamport_ts), 30, "group envelope lamport == 30 (not a fresh mint)");
   const grpLocal = (await f.A.db.execute({ sql: "SELECT lamport_ts FROM contact_groups WHERE group_uid = 'uid-g8'", args: [] })).rows[0];
   assert.equal(Number(grpLocal.lamport_ts), 30, "group local lamport unchanged");
+});
+
+// ── Task 6 (C4): flagless per-boot contact-tombstone re-emit — G4/G4b/G5/G5b ───
+// backfillContactsOnce is now a thin wrapper: the #147-gated body no-ops on a
+// `done:` flag, and a `finally` runs reemitContactTombstones() on EVERY boot —
+// mirroring W4's backfillGroupsOnce/reemitGroupTombstones. These cases seed the
+// done-flag so ONLY the finally-path re-emit fires (the true boot semantics).
+// The shared on-disk DBs accumulate authoritative tombstones across tests, so
+// every re-emit assertion is SCOPED to a per-test crow_id.
+const setBackfillDone = async (db) =>
+  db.execute({ sql: "INSERT INTO dashboard_settings (key, value) VALUES ('__contacts_backfill_v1', 'done:0') ON CONFLICT(key) DO UPDATE SET value = 'done:0'", args: [] });
+
+test("G4: tombstone re-emit heals a peer that never received the delete", async () => {
+  const f = newFleet();
+  for (const inst of [f.A, f.B]) {
+    await inst.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g4', '', 'g4aa', 'G4', 5)", args: [] });
+  }
+  const { deleteContactLocal } = await import("../servers/sharing/contact-delete.js");
+  const rowsA = (await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g4'", args: [] })).rows;
+  await act(f.A, () => deleteContactLocal(f.A.db, {}, rowsA[0]));
+  f.skimWire(); // the live delete is LOST (never delivered) — the D-C scenario
+  // Seed a 'prune' tombstone too: it must NOT ride (kind IS NULL filter).
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g4prune', 3, 1, 'prune')", args: [] });
+  // Mark the gated backfill done so ONLY the finally-path re-emit can deliver.
+  await setBackfillDone(f.A.db);
+  const before = f.wire.length;
+  await f.A.mgr.backfillContactsOnce(); // boot path: gated body no-ops, finally re-emits
+  const rode = f.wire.slice(before);
+  assert.equal(rode.filter((w) => w.entry.op === "delete" && w.entry.row.crow_id === "crow:g4").length, 1, "authoritative tombstone rode");
+  assert.equal(rode.filter((w) => w.entry.row.crow_id === "crow:g4prune").length, 0, "prune tombstone did NOT ride");
+  await f.deliver();
+  assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g4'", args: [] })).rows.length, 0, "B healed: row deleted");
+});
+
+test("G4b: C4 live-row filter -- a tombstone coexisting with a live row does NOT ride; a row-less one in the same run does", async () => {
+  const f = newFleet();
+  // Anomalous state on A: an authoritative tombstone AND a live contacts row, same crow_id.
+  await f.A.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g4b', '', 'g4baa', 'G4b Live', 5)", args: [] });
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g4b', 9, 1, NULL)", args: [] });
+  // A second, row-less authoritative tombstone in the SAME run — MUST ride (the filter is per-row).
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g4b2', 9, 1, NULL)", args: [] });
+  await setBackfillDone(f.A.db);
+  const before = f.wire.length;
+  await f.A.mgr.backfillContactsOnce();
+  const rode = f.wire.slice(before);
+  assert.equal(rode.filter((w) => w.entry.op === "delete" && w.entry.row.crow_id === "crow:g4b").length, 0, "tombstone coexisting with a live row did NOT ride");
+  assert.equal(rode.filter((w) => w.entry.op === "delete" && w.entry.row.crow_id === "crow:g4b2").length, 1, "the row-less tombstone in the same run DID ride");
+});
+
+test("G5: preserved-lamport re-emit -- a genuine re-add survives; C5 holds conflicts flat across a last_seen bump; insert clears the tombstone", async () => {
+  const f = newFleet();
+  // A: authoritative tombstone@10, row-less. B: the contact re-added, live@20.
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g5', 10, 1, NULL)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts, last_seen) VALUES ('crow:g5', '', 'g5aa', 'G5 ReAdd', 20, 100)", args: [] });
+  // A's counter well ABOVE B's row lamport (20): if the re-emit MINTED a fresh
+  // lamport instead of preserving the tombstone's 10, the delete would ride above
+  // 20 and WIPE B's re-add — this makes the "mint instead of preserve" mutation
+  // actually turn G5 red (2a lesson 3: the mutation must reach the mechanism).
+  await f.A.mgr._advanceCounter(30);
+  const bootA = async () => { await setBackfillDone(f.A.db); await f.A.mgr.backfillContactsOnce(); };
+  // Boot 1: A re-emits delete@10 → loses LWW to B's row@20 → 1 conflict on B, re-add survives.
+  await bootA();
+  await f.deliver();
+  assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5'", args: [] })).rows.length, 1, "B's re-add survived boot 1");
+  assert.equal(await contactConflicts(f.B.db, "crow:g5"), 1, "boot 1 logged exactly 1 conflict on B");
+  // Bump last_seen (a non-lamport, never-synced column) between boots — C5's stable key must ignore it.
+  await f.B.db.execute({ sql: "UPDATE contacts SET last_seen = 999 WHERE crow_id = 'crow:g5'", args: [] });
+  // Boot 2: re-emit delete@10 again → C5 dedupe → 0 new conflicts despite the last_seen change.
+  await bootA();
+  await f.deliver();
+  assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5'", args: [] })).rows.length, 1, "B's re-add survived boot 2");
+  assert.equal(await contactConflicts(f.B.db, "crow:g5"), 1, "boot 2 added 0 conflicts (C5 ignores last_seen)");
+  // B's re-add rides to A as op=insert (contact-promote semantics) → 20 > 10 → A applies it, clears the tombstone.
+  const rowBFull = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5'", args: [] })).rows[0];
+  await f.B.mgr.emitChange("contacts", "insert", rowBFull, { lamportTs: 20 });
+  await f.deliver();
+  assert.equal((await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5'", args: [] })).rows.length, 1, "A applied the re-add insert (20 > 10)");
+  assert.equal((await f.A.db.execute({ sql: "SELECT * FROM contact_tombstones WHERE crow_id = 'crow:g5'", args: [] })).rows.length, 0, "A cleared the tombstone (clearTombAfterApply)");
+  // Boot 3: A now holds a live row and no tombstone → nothing rides for crow:g5.
+  const before3 = f.wire.length;
+  await bootA();
+  const rode3 = f.wire.slice(before3).filter((w) => w.entry.row?.crow_id === "crow:g5" && w.entry.op === "delete");
+  assert.equal(rode3.length, 0, "boot 3 re-emitted nothing for crow:g5");
+});
+
+test("G5b: concurrent edit-vs-delete stays divergent -- B's update is dropped on A, B keeps its row; exactly 1 conflict on B; accepted #155 semantics", async () => {
+  const f = newFleet();
+  // A: authoritative tombstone@10, row-less. B: the contact edited, live@12.
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g5b', 10, 1, NULL)", args: [] });
+  await f.B.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g5b', '', 'g5baa', 'B Edit', 12)", args: [] });
+  const bootA = async () => { await setBackfillDone(f.A.db); await f.A.mgr.backfillContactsOnce(); };
+  // Boot 1: A re-emits delete@10. B concurrently rides its newer edit as op=update@12.
+  await bootA();
+  const rowBFull = (await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows[0];
+  await f.B.mgr.emitChange("contacts", "update", rowBFull, { lamportTs: 12 });
+  await f.deliver(); // both ways
+  // A dropped B's update (delete-wins over a concurrent update, #155): no row, tombstone stands.
+  assert.equal((await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 0, "A has no row (B's update was DROPPED, delete wins)");
+  assert.equal((await f.A.db.execute({ sql: "SELECT * FROM contact_tombstones WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 1, "A's tombstone stands");
+  // B kept its row (delete@10 lost to row@12); exactly 1 conflict logged on B.
+  assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 1, "B kept its row (delete@10 loses)");
+  assert.equal(await contactConflicts(f.B.db, "crow:g5b"), 1, "1 conflict on B after boot 1");
+  // Two more boots: C5 dedupe holds sync_conflicts flat on B.
+  await bootA(); await f.deliver();
+  await bootA(); await f.deliver();
+  assert.equal(await contactConflicts(f.B.db, "crow:g5b"), 1, "still exactly 1 conflict on B across all boots (C5)");
+  // Divergence PERSISTS — the accepted #155 edit-vs-delete semantics, asserted explicitly.
+  assert.equal((await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 0, "divergence persists: A gone");
+  assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 1, "divergence persists: B present");
 });

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -1,0 +1,197 @@
+// tests/lamport-reemit.test.js
+//
+// Item 2c — Lamport-preserving re-emit + boot-window emit loss: the EXECUTABLE
+// two-instance acceptance gate (design §5, spec
+// docs/superpowers/specs/2026-07-14-lamport-preserving-reemit-design.md).
+//
+// This file (Task 4) carries the SHARED harness that Tasks 5–7 extend, plus the
+// C3 gate cases G3/G3b/G3c: the per-peer ordered append chain (_appendLocks),
+// the boot-window pending queue (_pendingPeerEmits), and the drain-on-arm seam
+// (_drainPendingEmits) wired into _initInstanceInner.
+//
+// HARNESS: two real instances (each its own mkdtemp CROW_DATA_DIR + real init-db +
+// real InstanceSyncManager) joined by a fake out-feed that captures every entry a
+// chained append/drain writes and hands it to the peer's _applyEntry() — adapted
+// from tests/group-tombstones.test.js. Deltas: outFeeds are keyed by the OTHER
+// instance's REAL id (not "peer"); each instance's crow_instances is seeded with
+// the other as an active paired peer (so emitChange's per-peer broadcast targets
+// it even while unarmed); the emit sink helper act() binds contact-sync.js's
+// __setEmitSinkForTest (contact emits route there — a SEPARATE sink from groups).
+//
+// NEVER point this file at ~/.crow — it DELETES contacts.
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+// ── identities ───────────────────────────────────────────────────────────────
+// One shared ed25519 identity: instance-sync verifies every entry against
+// `this.identity.ed25519Pubkey`, and a user's instances share one identity.
+const TEST_PRIV = Buffer.alloc(32, 0x2c);
+const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+const IDENTITY = { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+
+const A_ID = "inst-aaaa-0000-0000-0000-00000000000a";
+const B_ID = "inst-bbbb-0000-0000-0000-00000000000b";
+
+// ── two real instances ───────────────────────────────────────────────────────
+function initInstance(label) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-2c-reemit-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    // CROW_DB_PATH outranks CROW_DATA_DIR in init-db (init-db.js:11) — blank it, or a
+    // shell exporting it (grackle's .env did, PR #180) would run the migration
+    // against the REAL DB, outside the deploy rail's backups.
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DB_PATH: "", CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    stdio: "pipe",
+  });
+  return { dir, path: join(dir, "crow.db") };
+}
+const A_FILES = initInstance("a");
+const B_FILES = initInstance("b");
+
+// Seed each instance's crow_instances with the OTHER as an active paired peer,
+// ONCE, in the on-disk file — every fresh newFleet() db handle sees the row.
+// emitChange's per-peer broadcast reads this table to find unarmed paired peers
+// (the boot-window target set), so without it G3's park-while-closed never fires.
+{
+  const sa = createDbClient(A_FILES.path);
+  await sa.execute({ sql: "INSERT INTO crow_instances (id, name, crow_id, status) VALUES (?, ?, ?, 'active')", args: [B_ID, "B", "crow:b"] });
+  const sb = createDbClient(B_FILES.path);
+  await sb.execute({ sql: "INSERT INTO crow_instances (id, name, crow_id, status) VALUES (?, ?, ?, 'active')", args: [A_ID, "A", "crow:a"] });
+}
+
+after(() => {
+  __setEmitSinkForTest(null);
+  rmSync(A_FILES.dir, { recursive: true, force: true });
+  rmSync(B_FILES.dir, { recursive: true, force: true });
+});
+
+/**
+ * The shared feed. `wire` holds EVERY entry either instance appended. deliver()
+ * drains in append order. Out-feeds are keyed by the OTHER instance's real id so
+ * emitChange's per-peer broadcast (targets = paired ids ∪ outFeeds.keys()) both
+ * finds the stub and never double-appends.
+ */
+function newFleet() {
+  const wire = [];
+  const A = { id: A_ID, db: createDbClient(A_FILES.path) };
+  const B = { id: B_ID, db: createDbClient(B_FILES.path) };
+  const attach = (inst) => {
+    inst.mgr = new InstanceSyncManager(IDENTITY, inst.db, inst.id);
+    inst.mgr.feedsDisabled = false; // scratch env sets CROW_DISABLE_INSTANCE_SYNC=1
+    const otherId = inst.id === A_ID ? B_ID : A_ID;
+    inst.mgr.outFeeds = new Map([[otherId, {
+      append: async (e) => { wire.push({ from: inst.id, entry: JSON.parse(JSON.stringify(e)) }); },
+    }]]);
+  };
+  attach(A);
+  attach(B);
+  let cursor = 0;
+  const other = (fromId) => (fromId === A.id ? B : A);
+  /** Apply one captured wire item to a destination instance (JSON round-tripped). */
+  const applyItem = async (dest, item) =>
+    dest.mgr._applyEntry(item.from, JSON.parse(JSON.stringify(item.entry)));
+  /** Replicate every un-delivered entry to the other side, in append order. */
+  const deliver = async () => {
+    while (cursor < wire.length) {
+      const item = wire[cursor++];
+      await applyItem(other(item.from), item);
+    }
+  };
+  /** Mark everything currently on the wire as delivered WITHOUT applying. */
+  const skimWire = () => { const items = wire.slice(cursor); cursor = wire.length; return items; };
+  /** Restart an instance: brand-new db handle + manager over the SAME file. */
+  const restart = async (inst) => {
+    inst.db = createDbClient(inst.id === A_ID ? A_FILES.path : B_FILES.path);
+    attach(inst);
+  };
+  return { A, B, wire, deliver, applyItem, skimWire, restart, other };
+}
+
+/** Run `fn` with `inst` as the CONTACT emit sink — an emit belongs to exactly one instance. */
+async function act(inst, fn) {
+  __setEmitSinkForTest(inst.mgr);
+  try { return await fn(); } finally { __setEmitSinkForTest(null); }
+}
+
+export { newFleet, act, A_ID, B_ID, IDENTITY };
+
+// ── G3: boot-window delete queues, drains on arm, peer converges ───────────────
+test("G3: boot-window delete queues, drains on arm, peer converges", async () => {
+  const f = newFleet();
+  // Seed the same contact on both sides, converged at lamport 5.
+  for (const inst of [f.A, f.B]) {
+    await inst.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:g3', '', 'aa11', 'G3', 5)", args: [] });
+  }
+  // A's counter reflects the converged lamport: in prod A reached lamport 5 by
+  // emitting, so its originating delete mints ABOVE 5. Without this, a
+  // fresh-counter delete rides @1 and loses the (unrelated, pre-existing) #155
+  // delete-LWW gate (lamportTs > localTs) to B's row@5 — masking the C3 mechanism
+  // this case exercises (the queue/drain seam, not delete LWW).
+  await f.A.mgr._advanceCounter(5);
+  // A's boot window: NO armed feeds (but B is paired in crow_instances via the harness).
+  f.A.mgr.outFeeds = new Map();
+  const { deleteContactLocal } = await import("../servers/sharing/contact-delete.js");
+  const { rows } = await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g3'", args: [] });
+  await act(f.A, () => deleteContactLocal(f.A.db, {}, rows[0]));
+  assert.equal(f.wire.length, 0, "nothing rode while feeds were closed");
+  const { rows: tombA } = await f.A.db.execute({ sql: "SELECT * FROM contact_tombstones WHERE crow_id = 'crow:g3'", args: [] });
+  assert.ok(tombA[0], "local tombstone written in the window");
+  // Arm A→B and drain through the REAL seam.
+  f.A.mgr.outFeeds = new Map([[f.B.id, { append: async (e) => f.wire.push({ from: f.A.id, entry: JSON.parse(JSON.stringify(e)) }) }]]);
+  const drained = await f.A.mgr._drainPendingEmits(f.B.id);
+  assert.equal(drained, 1, "the queued delete drained");
+  assert.equal(f.wire.length, 1);
+  assert.equal(Number(f.wire[0].entry.lamport_ts), Number(tombA[0].lamport_ts), "tombstone lamport == envelope lamport");
+  await f.deliver();
+  const { rows: rowB } = await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g3'", args: [] });
+  assert.equal(rowB.length, 0, "B's row deleted");
+  const { rows: tombB } = await f.B.db.execute({ sql: "SELECT * FROM contact_tombstones WHERE crow_id = 'crow:g3'", args: [] });
+  assert.ok(tombB[0], "B tombstoned");
+});
+
+// ── G3b: real initInstance invokes the drain after arming (scratch dataDir) ────
+test("G3b: real initInstance invokes the drain after arming (scratch dataDir)", async () => {
+  const f = newFleet();
+  const scratch = mkdtempSync(join(tmpdir(), "crow-2c-g3b-"));
+  f.A.mgr.dataDir = join(scratch, "instance-sync"); // isolate from process default (tests/instance-sync-noauth-feeds.test.js:71)
+  f.A.mgr.outFeeds = new Map();
+  // Park one entry for B.
+  await f.A.mgr._appendToPeer(f.B.id, { table: "contacts", op: "update", row: { crow_id: "crow:g3b" }, lamport_ts: 1, instance_id: f.A.id });
+  const calls = [];
+  const realDrain = f.A.mgr._drainPendingEmits.bind(f.A.mgr);
+  f.A.mgr._drainPendingEmits = async (peerId) => { calls.push(peerId); return realDrain(peerId); };
+  try {
+    await f.A.mgr.initInstance(f.B.id, null); // real Hypercore on scratch disk
+    assert.ok(calls.includes(f.B.id), "initInstance drained the pending slot after arming");
+    const feed = f.A.mgr.outFeeds.get(f.B.id);
+    assert.equal(feed.length, 1, "pending entry is readable from the REAL Hypercore");
+    const block = await feed.get(0);
+    assert.equal(block.row.crow_id, "crow:g3b");
+  } finally {
+    try { await f.A.mgr.outFeeds.get(f.B.id)?.close(); } catch {}
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+// ── G3c: chain preserves emit order across the open transition ─────────────────
+test("G3c: chain preserves emit order across the open transition; nothing duplicated or stranded", async () => {
+  const f = newFleet();
+  f.A.mgr.outFeeds = new Map();
+  const appended = [];
+  // E1 parks (feed closed).
+  await f.A.mgr._appendToPeer(f.B.id, { marker: "E1" });
+  // Arm with a SLOW stub append so the drain is in flight when E2 is emitted.
+  f.A.mgr.outFeeds = new Map([[f.B.id, { append: async (e) => { await new Promise((r) => setTimeout(r, 20)); appended.push(e.marker); } }]]);
+  const drainP = f.A.mgr._drainPendingEmits(f.B.id);      // chained task 1 (slow)
+  const liveP = f.A.mgr._appendToPeer(f.B.id, { marker: "E2" }); // chained task 2
+  await Promise.all([drainP, liveP]);
+  assert.deepEqual(appended, ["E1", "E2"], "E1 strictly before E2");
+  assert.equal((f.A.mgr._pendingPeerEmits.get(f.B.id) || []).length, 0, "nothing stranded");
+});

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -380,6 +380,10 @@ test("G4: tombstone re-emit heals a peer that never received the delete", async 
   }
   const { deleteContactLocal } = await import("../servers/sharing/contact-delete.js");
   const rowsA = (await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g4'", args: [] })).rows;
+  // Rows were INSERTed directly (counter never advanced) — in prod an instance
+  // converged at lamport 5 has a counter past 5. Without this the delete mints
+  // low and loses the #155 LWW gate in isolation runs (same as G3/G5).
+  await f.A.mgr._advanceCounter(6);
   await act(f.A, () => deleteContactLocal(f.A.db, {}, rowsA[0]));
   f.skimWire(); // the live delete is LOST (never delivered) — the D-C scenario
   // Seed a 'prune' tombstone too: it must NOT ride (kind IS NULL filter).

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -29,6 +29,7 @@ import { createDbClient } from "../servers/db.js";
 import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
 import { __setEmitSinkForTest } from "../servers/sharing/contact-sync.js";
 import { emitGroupUpsert, __setEmitSinkForTest as __setGroupSink } from "../servers/sharing/group-sync.js";
+import { restoreConflict } from "../servers/sharing/sync-conflict-resolve.js";
 import * as ed from "../node_modules/@noble/ed25519/index.js";
 
 // ── identities ───────────────────────────────────────────────────────────────
@@ -474,4 +475,81 @@ test("G5b: concurrent edit-vs-delete stays divergent -- B's update is dropped on
   // Divergence PERSISTS — the accepted #155 edit-vs-delete semantics, asserted explicitly.
   assert.equal((await f.A.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 0, "divergence persists: A gone");
   assert.equal((await f.B.db.execute({ sql: "SELECT * FROM contacts WHERE crow_id = 'crow:g5b'", args: [] })).rows.length, 1, "divergence persists: B present");
+});
+
+// ── G10: C7 -- restoreConflict refuses ALL natural-key tables ──────────────────
+// crow_context, contacts, and contact_groups all key their sync_conflicts row_id
+// as a JSON object, not a numeric id. Without the natural-key refusal placed
+// BEFORE the stale-snapshot guard, `SELECT ... WHERE id = '{"crow_id":...}'`
+// finds nothing, and the guard "helpfully" re-snapshots winning_data to the JSON
+// string 'null' -- silently destroying the recorded winning-side snapshot. This
+// gate proves the refusal fires for all three tables and that winning_data
+// survives byte-identical (design spec C7 / gate row G10).
+
+/** Seed a sync_conflicts row with a JSON row_id and return {id, winning_data}. */
+async function seedNaturalKeyConflict(db, table, rowIdObj, winningData, losingData) {
+  const rowIdJson = JSON.stringify(rowIdObj);
+  await db.execute({
+    sql: `INSERT INTO sync_conflicts
+            (table_name, row_id, winning_instance_id, losing_instance_id,
+             winning_lamport_ts, losing_lamport_ts, winning_data, losing_data, op)
+          VALUES (?, ?, ?, ?, 50, 10, ?, ?, 'update')`,
+    args: [table, rowIdJson, A_ID, B_ID, JSON.stringify(winningData), JSON.stringify(losingData)],
+  });
+  const { rows } = await db.execute({
+    sql: "SELECT id, winning_data FROM sync_conflicts WHERE table_name = ? AND row_id = ? ORDER BY id DESC LIMIT 1",
+    args: [table, rowIdJson],
+  });
+  return rows[0];
+}
+
+test("G10: restoreConflict refuses ALL natural-key tables (contacts, contact_groups join crow_context) -- C7", async () => {
+  const f = newFleet();
+
+  // contacts: row_id = {crow_id}
+  const contactsSeed = await seedNaturalKeyConflict(
+    f.A.db, "contacts",
+    { crow_id: "crow:g10" },
+    { crow_id: "crow:g10", display_name: "Local Winner", lamport_ts: 50 },
+    { crow_id: "crow:g10", display_name: "Remote Loser", lamport_ts: 10 },
+  );
+  const contactsOutcome = await restoreConflict(f.A.db, contactsSeed.id, { instanceSync: null });
+  assert.equal(contactsOutcome.status, "refused", "contacts restore refused (C7)");
+  const contactsAfter = (await f.A.db.execute({
+    sql: "SELECT winning_data, resolved FROM sync_conflicts WHERE id = ?", args: [contactsSeed.id],
+  })).rows[0];
+  assert.equal(contactsAfter.winning_data, contactsSeed.winning_data,
+    "contacts winning_data byte-identical (not corrupted to the JSON string 'null')");
+  assert.equal(Number(contactsAfter.resolved), 0, "contacts conflict stays unresolved after refused restore");
+
+  // contact_groups: row_id = {group_uid}
+  const groupsSeed = await seedNaturalKeyConflict(
+    f.A.db, "contact_groups",
+    { group_uid: "g10-uid-0000000000000000000000" },
+    { group_uid: "g10-uid-0000000000000000000000", name: "Local Winner", lamport_ts: 50 },
+    { group_uid: "g10-uid-0000000000000000000000", name: "Remote Loser", lamport_ts: 10 },
+  );
+  const groupsOutcome = await restoreConflict(f.A.db, groupsSeed.id, { instanceSync: null });
+  assert.equal(groupsOutcome.status, "refused", "contact_groups restore refused (C7)");
+  const groupsAfter = (await f.A.db.execute({
+    sql: "SELECT winning_data, resolved FROM sync_conflicts WHERE id = ?", args: [groupsSeed.id],
+  })).rows[0];
+  assert.equal(groupsAfter.winning_data, groupsSeed.winning_data,
+    "contact_groups winning_data byte-identical (not corrupted to the JSON string 'null')");
+  assert.equal(Number(groupsAfter.resolved), 0, "contact_groups conflict stays unresolved after refused restore");
+
+  // crow_context: no regression -- still refused, still byte-identical.
+  const ctxSeed = await seedNaturalKeyConflict(
+    f.A.db, "crow_context",
+    { section_key: "g10_ctx", device_id: null, project_id: null },
+    { section_key: "g10_ctx", content: "local-kept", lamport_ts: 50 },
+    { section_key: "g10_ctx", content: "remote-version", lamport_ts: 10 },
+  );
+  const ctxOutcome = await restoreConflict(f.A.db, ctxSeed.id, { instanceSync: null });
+  assert.equal(ctxOutcome.status, "refused", "crow_context restore still refused (no regression)");
+  const ctxAfter = (await f.A.db.execute({
+    sql: "SELECT winning_data FROM sync_conflicts WHERE id = ?", args: [ctxSeed.id],
+  })).rows[0];
+  assert.equal(ctxAfter.winning_data, ctxSeed.winning_data,
+    "crow_context winning_data byte-identical (regression check)");
 });


### PR DESCRIPTION
Item 2c of the autonomous improvement arc (spec APPROVED rev 4: `docs/superpowers/specs/2026-07-14-lamport-preserving-reemit-design.md`; plan: `docs/superpowers/plans/2026-07-14-item2c-lamport-preserving-reemit.md`).

## What this fixes

- **D-A (2c core):** boot backfills (contacts, settings, groups) re-emitted rows with fresh lamports, fabricating recency over in-flight peer writes (I-B1 class). Re-emits now preserve the row's original lamport via `emitChange(..., { lamportTs })` (C1/C2). Providers backfill deliberately untouched (INSERT OR IGNORE is clobber-proof).
- **D-B (Item-3 folded bug):** `emitChange` with unarmed outFeeds minted a lamport, appended to nobody, and returned success — a #155 contact delete in the boot window tombstoned locally and broadcast to nobody (observed live on grackle 2026-07-06). All appends now flow through a per-peer FIFO chain; entries for paired-but-unarmed peers park in a capped pending queue and drain on feed-arm (C3).
- **D-C (durability):** contact deletes were emitted exactly once, ever — a missed delivery (crash, re-pair) diverged silently forever. New flagless per-boot `reemitContactTombstones` (W4 groups mirror) re-emits authoritative tombstones at their ORIGINAL lamport, so lost deletes heal while genuinely-newer re-adds survive (C4).
- **C5:** repeat deliveries no longer grow `sync_conflicts` — dedupe on a stable key (lamport pair + losing origin, `resolved=0`-scoped, op-absent fallback for pre-migration DBs).
- **C7 (latent corruption):** `restoreConflict` destroyed `winning_data` snapshots for `contacts`/`contact_groups` (JSON row_id vs id-keyed stale guard) — now refused like `crow_context`.
- **C6:** known-fail suite test 18 was a harness-env artifact — fixed; suite baseline moves 1931/3/0 → **1951 pass / 2 known fails / 0 skips**.

## Rigor

- Spec: 2-round adversarial review + round-3 closure (2 CRITICAL, 6 MAJOR, 7 minor findings folded across revisions).
- Executable two-instance gate `tests/lamport-reemit.test.js` (15 cases, G1–G10 incl. mutual/divergent/NULL-lamport/re-add/update-vs-delete cases) + unit gates in `tests/instance-sync.test.js`.
- Full 12-mutation matrix run red-then-green against the final tree; every guard mutation flips its NAMED test.
- Per-task review (8 tasks) + final whole-branch review: READY TO MERGE.
- No schema change, no wire-format change; mixed-fleet safe both directions.

Local gates: full suite 1951/2/0 (both fails = known bundles-validate-install); check-port-allocation exactly the known capstone-tracker line; build-registry --check clean.