### PR TITLE
Hotfix: bound the 2c boot-path inbound drain and contact-unwire teardown awaits (grackle boot hang)

### DIFF
--- a/servers/sharing/contact-delete.js
+++ b/servers/sharing/contact-delete.js
@@ -141,20 +141,50 @@ async function loadSyncMod() {
 }
 
 /**
+ * 2c hotfix: per-step cap for unwireContact. On grackle (2026-07-15) a contact-
+ * delete apply awaited a teardown step (hypercore feed-close / hyperswarm-leave)
+ * that NEVER resolved. Because this teardown runs inside the inbound apply chain
+ * (onContactDeleted), a step that never resolves wedges ALL subsequent sync from
+ * that peer until restart — strictly worse than a leaked background promise, and
+ * on the boot path it took the whole gateway down. Cap each step; abandon a hung
+ * one. Overridable per-call via opts.stepCapMs (tests).
+ */
+const UNWIRE_STEP_CAP_MS = 5_000;
+
+/**
+ * Await one teardown step, capped at `cap` ms. Each step is ALREADY
+ * try/caught by unwireContact (a failed step is designed-tolerated — the
+ * `wireFullContact` convention), so an abandoned hung step is semantically just a
+ * step failure. Never rejects (a rejected step resolves the same as a completed
+ * one); we do NOT cancel the underlying op, only stop awaiting it. Warns on cap.
+ */
+function withStepCap(promise, cap, step) {
+  let timer;
+  const guard = new Promise((resolve) => { timer = setTimeout(() => resolve("__cap__"), cap); });
+  const done = Promise.resolve(promise).then(() => "__ok__", () => "__ok__");
+  return Promise.race([done, guard])
+    .then((r) => { if (r === "__cap__") console.warn(`[contact-delete] unwireContact: ${step} exceeded ${cap}ms — abandoning (hung teardown?)`); })
+    .finally(() => clearTimeout(timer));
+}
+
+/**
  * Tear down a contact's live wiring BEFORE its row is removed (design §4.1).
  * Each step is independently guarded — the `wireFullContact` convention
- * (contact-promote.js:76). A partial `managers` object (e.g. missing peerManager
- * in tests) must not throw. Load-bearing ordering: unwire runs before the DELETE
- * so an in-flight `subscribeToContact` onevent INSERT against a deleted
- * contact_id cannot raise FOREIGN KEY constraint failed.
+ * (contact-promote.js:76) — AND capped (2c hotfix, see withStepCap). A partial
+ * `managers` object (e.g. missing peerManager in tests) must not throw.
+ * Load-bearing ordering: unwire runs before the DELETE so an in-flight
+ * `subscribeToContact` onevent INSERT against a deleted contact_id cannot raise
+ * FOREIGN KEY constraint failed.
  * @param {object} managers { nostrManager?, syncManager?, peerManager? }
  * @param {{id:number, crow_id:string}} row the contact being deleted
+ * @param {{stepCapMs?:number}} [opts] override the per-step cap (tests)
  */
-export async function unwireContact(managers, row) {
+export async function unwireContact(managers, row, opts = {}) {
+  const cap = Number(opts.stepCapMs) > 0 ? Number(opts.stepCapMs) : UNWIRE_STEP_CAP_MS;
   const { nostrManager, syncManager, peerManager } = managers || {};
-  try { if (nostrManager) await nostrManager.unsubscribeFromContact(row.crow_id); } catch { /* guarded */ }
-  try { if (syncManager) await syncManager.closeContactFeeds(row.id); } catch { /* guarded */ }
-  try { if (peerManager) await peerManager.leaveContact(row.crow_id); } catch { /* guarded */ }
+  try { if (nostrManager) await withStepCap(nostrManager.unsubscribeFromContact(row.crow_id), cap, "nostr unsubscribe"); } catch { /* guarded */ }
+  try { if (syncManager) await withStepCap(syncManager.closeContactFeeds(row.id), cap, "closeContactFeeds"); } catch { /* guarded */ }
+  try { if (peerManager) await withStepCap(peerManager.leaveContact(row.crow_id), cap, "leaveContact"); } catch { /* guarded */ }
 }
 
 /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -299,6 +299,13 @@ export class InstanceSyncManager {
     // Per-peer serialization for _processNewEntries — see D4 fix below.
     this._processLocks = new Map(); // remoteInstanceId → tail Promise
 
+    // 2c hotfix: hard cap on how long the boot-path contact-tombstone re-emit
+    // will AWAIT a per-peer inbound drain (reemitContactTombstones). A wedged
+    // apply chain (grackle 2026-07-15: a contact-delete apply awaiting a
+    // hypercore feed-close / hyperswarm-leave that never resolves) must never
+    // block the gateway from reaching HTTP listen. Overridable in tests.
+    this._drainCapMs = 10_000;
+
     // 2c C3: per-peer ordered append pipeline. ALL writes toward a peer's outFeed
     // flow through one FIFO promise chain (_appendLocks, the _initLocks pattern);
     // entries emitted while the peer's feed is not yet armed park in
@@ -755,13 +762,23 @@ export class InstanceSyncManager {
     if (this.outFeeds.size === 0) return 0; // no peers armed yet — retry next boot; flagless by design (W4 rationale)
     // I-B1 drain: apply the peer's already-replicated backlog so a genuine
     // re-add-as-insert clears our tombstone before we re-emit it (rule order is
-    // load-bearing; design §3 C4).
-    try {
-      for (const [peerId, inFeed] of this.inFeeds) {
-        await this._processNewEntries(peerId, inFeed);
+    // load-bearing; design §3 C4). BUT each per-peer drain await is CAPPED at
+    // this._drainCapMs (2c hotfix): this runs on the boot-to-HTTP-listen path
+    // (backfillContactsOnce's finally), and on grackle a contact-delete apply
+    // WEDGED FOREVER (its onContactDeleted → unwireContact → hypercore feed-close
+    // / hyperswarm-leave never resolved) ⇒ the gateway never listened ⇒ prod down.
+    // Pre-2c the backfill early-returned before draining, so this await was never
+    // on the boot path. On cap we PROCEED without the drain; the I-B1 ordering it
+    // provides degrades to the already-analyzed truthful-conflict case (spec §4.4),
+    // which sync_conflicts records — safe by design. We do NOT cancel the
+    // underlying _processNewEntries promise: it stays chained in the background
+    // exactly as pre-2c.
+    for (const [peerId, inFeed] of this.inFeeds) {
+      try {
+        await this._drainInboundCapped(peerId, inFeed);
+      } catch (err) {
+        console.warn(`[instance-sync] contact tombstone re-emit drain failed: ${err.message}`);
       }
-    } catch (err) {
-      console.warn(`[instance-sync] contact tombstone re-emit drain failed: ${err.message}`);
     }
     let rows = [];
     try {
@@ -787,6 +804,32 @@ export class InstanceSyncManager {
     }
     if (emitted > 0) console.log(`[instance-sync] re-emitted ${emitted} contact tombstone delete(s) to all peers`);
     return emitted;
+  }
+
+  /**
+   * 2c hotfix: await a per-peer inbound drain but never longer than
+   * this._drainCapMs. If the underlying apply chain is wedged (grackle: a
+   * contact-delete apply awaiting a hypercore feed-close / hyperswarm-leave that
+   * never resolves), we stop AWAITING it and proceed — the _processNewEntries
+   * promise stays chained in the background exactly as pre-2c (we do NOT cancel
+   * it). Returns true if the drain completed within the cap, false if capped.
+   */
+  async _drainInboundCapped(peerId, inFeed) {
+    let timer;
+    const cap = new Promise((resolve) => { timer = setTimeout(() => resolve("__cap__"), this._drainCapMs); });
+    try {
+      const outcome = await Promise.race([
+        this._processNewEntries(peerId, inFeed).then(() => "__done__"),
+        cap,
+      ]);
+      if (outcome === "__cap__") {
+        console.warn(`[instance-sync] contact tombstone re-emit: inbound drain for ${peerId} exceeded ${this._drainCapMs}ms — proceeding without it (wedged apply chain?)`);
+        return false;
+      }
+      return true;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**

--- a/tests/lamport-reemit.test.js
+++ b/tests/lamport-reemit.test.js
@@ -601,3 +601,60 @@ test("G10: restoreConflict refuses ALL natural-key tables (contacts, contact_gro
   assert.equal(ctxAfter.winning_data, ctxSeed.winning_data,
     "crow_context winning_data byte-identical (regression check)");
 });
+
+// ── 2c hotfix (boot-liveness): bounded awaits — G11/G12 ────────────────────────
+// PR #194 put reemitContactTombstones on the boot-to-HTTP-listen path (its drain
+// awaits _processNewEntries). On grackle a contact-delete apply WEDGED FOREVER
+// (hypercore feed-close / hyperswarm-leave never resolving) ⇒ the gateway never
+// reached listen ⇒ prod down. Two bounded-await caps fix it. These gates prove the
+// caps unblock a wedged chain and still do their real work (re-emit / step-tolerant).
+
+/** Await `promise`, but reject with `msg` after `ms` — so a broken cap fails cleanly
+ *  instead of hanging the whole test file forever. clears its timer either way. */
+async function withDeadline(promise, ms, msg) {
+  let timer;
+  const guard = new Promise((_, rej) => { timer = setTimeout(() => rej(new Error(msg)), ms); });
+  try { return await Promise.race([promise, guard]); }
+  finally { clearTimeout(timer); }
+}
+
+test("G11: boot-drain cap -- a wedged apply chain cannot block tombstone re-emit", async () => {
+  const f = newFleet();
+  // An authoritative, row-less tombstone: it MUST re-emit as op=delete on boot.
+  await f.A.db.execute({ sql: "INSERT INTO contact_tombstones (crow_id, lamport_ts, deleted_at, kind) VALUES ('crow:g11', 12, 1, NULL)", args: [] });
+  // Gated backfill body done ⇒ ONLY the finally-path reemitContactTombstones fires.
+  await setBackfillDone(f.A.db);
+  // Wedge the inbound drain: _processNewEntries never resolves (the grackle class).
+  f.A.mgr._processNewEntries = () => new Promise(() => {});
+  f.A.mgr._drainCapMs = 200;
+  // Arm an inFeeds entry so the drain loop actually iterates and awaits the wedge.
+  f.A.mgr.inFeeds.set(f.B.id, { length: 0 });
+  const before = f.wire.length;
+  const t0 = Date.now();
+  // Without the cap this await never resolves ⇒ withDeadline rejects at 5s (red).
+  await withDeadline(f.A.mgr.backfillContactsOnce(), 5000,
+    "boot-drain cap did not fire: contact tombstone re-emit blocked >5s by a wedged drain");
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed < 4000, `re-emit completed under the wedge in ${elapsed}ms (cap ~200ms)`);
+  const rode = f.wire.slice(before);
+  assert.equal(rode.filter((w) => w.entry.op === "delete" && w.entry.row.crow_id === "crow:g11").length, 1,
+    "tombstone re-emitted despite the wedged (capped) drain");
+});
+
+test("G12: unwireContact caps each hung teardown step -- never wedges the apply chain", async () => {
+  const { unwireContact } = await import("../servers/sharing/contact-delete.js");
+  const hung = () => new Promise(() => {});
+  const t0 = Date.now();
+  // All three steps hang forever; each must be capped at 100ms ⇒ resolves ~300ms.
+  // Remove any one race → that step hangs → withDeadline rejects at 2s (red).
+  await withDeadline(
+    unwireContact({
+      nostrManager: { unsubscribeFromContact: hung },
+      syncManager: { closeContactFeeds: hung },
+      peerManager: { leaveContact: hung },
+    }, { id: 1, crow_id: "crow:g12" }, { stepCapMs: 100 }),
+    2000,
+    "unwireContact step cap did not fire: a hung teardown step blocked >2s");
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed < 2000, `unwireContact resolved under three hung steps in ${elapsed}ms`);
+});


### PR DESCRIPTION
Urgent follow-up to #194. Live incident on grackle (reproduced twice, deterministic): the new flagless `reemitContactTombstones` awaits the per-peer inbound drain on every boot; on grackle that chain wedged forever behind a contact-delete apply whose `unwireContact` teardown (hypercore close / hyperswarm leave) never resolved — the gateway never reached HTTP listen (public blog 502). Pre-2c the same wedge existed but was invisible (fire-and-forget catch-up); 2c made boot await it.

Two bounded awaits, both TDD-gated:
- **Boot-drain cap** (`instance-sync.js`): each per-peer `_processNewEntries` await in `reemitContactTombstones` races a 10s cap (test-overridable `_drainCapMs`); on cap, warn and proceed — the I-B1 ordering degrades to the spec §4.4 truthful-conflict case (C5-deduped), analyzed safe. Gate G11 (wedged drain must not block `backfillContactsOnce`; tombstone still rides).
- **Teardown cap** (`contact-delete.js` `unwireContact`): each of the three already-individually-try/caught steps races a 5s cap — an abandoned hung step is semantically the designed-for step-failure case. This unwedges the apply chain class that blocked grackle (a hung teardown otherwise wedges ALL further sync from that peer until restart). Gate G12.

Adversarial review: READY TO MERGE — race-loser rejection safety and timer-leak-on-happy-path both empirically verified (forced late rejections: no unhandledRejection; happy-path process exit at 3ms, timers cleared). Suite: lamport-reemit 17/17 + instance-sync + group-tombstones green; mutations (bypass either cap) flip G11/G12 red.

Root-cause follow-ups recorded (pre-existing, not addressed here): uncaught `SendingOnClosedConnection` crash from `resilient-subscribe`/nostr-tools when a relay closes mid-subscribe (crashed grackle once during the incident); unbounded network awaits in apply-path hooks generally.