### PR TITLE
feat(sync): live in-feed key rotation + feed-keyed applied-seq (Item 2d)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-item2d-feed-key-rotation.md
+++ b/docs/superpowers/plans/2026-07-15-item2d-feed-key-rotation.md
@@ -1,0 +1,1258 @@
+# Item 2d — Feed-Key Rotation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a paired instance's outbound Hypercore feed key changes, the peer swaps its in-feed live (no restart) and its applied-seq record follows the feed it was earned on — closing defects D1–D4 of spec `docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md` (rev 4, READY; read it first — §3 is the contract, §7 the gate, §11 the review record with three R3 must-fixes already folded).
+
+**Architecture:** Key-aware `_initInstanceInner` (swap = detach listener → unmap → bounded close → open new core in the same multi-core store dir → reconcile applied-seq → attach to live streams), feed-keyed `{k,s}` applied-seq records with the legacy decision frozen at feed-open, stream tracking for late-key attach, a 60s heal loop, and boot-time backfill-flag premise reset. No schema bump.
+
+**Tech Stack:** Node 20, hypercore 11.27.7 (vendored), @hyperswarm/secret-stream, node:test, SQLite (libsql client), ws.
+
+## Global Constraints
+
+- **Suite runs on scratch env ONLY** (prod-contamination incidents on record):
+  `T=$(mktemp -d); CROW_HOME=$T CROW_DATA_DIR=$T/data CROW_DISABLE_NOSTR=1 CROW_DISABLE_INSTANCE_SYNC=1 node --test tests/<file>.test.js`
+- Real `initInstance` in tests REQUIRES `mgr.dataDir = <mkdtemp>` (else it writes `~/.crow/data/instance-sync/`).
+- Managers built by test harnesses must force-enable feeds (`mgr.feedsDisabled = false`) because the scratch env sets `CROW_DISABLE_INSTANCE_SYNC=1` (2c C6 lesson).
+- Suite baseline: **1953 pass / 2 known fails (both bundles-validate-install) / 0 skips.** Any third failure is yours.
+- Git: positional-path commits only (`git add <newfile>` first, then `git commit <paths> -m ...`); verify `git show --stat HEAD` after every commit; never `--amend`; no backticks in `-m`; never attribute Claude.
+- Every guard gets a **mutation check**: comment it out, watch the NAMED test go red, restore. Record the matrix.
+- **No new unbounded awaits reachable from boot** (2c boot-liveness lesson). The only new boot await is the 5s-capped close.
+- Branch: `feat/item2d-feed-key-rotation` (spec revs already on it).
+- Barriers and wrapped promises in tests, never sleeps (R3 F-G).
+
+## File Structure
+
+- Modify: `servers/sharing/instance-sync.js` — C1 swap + C2 seq format/reconcile + C3 streams + C5 flag reset + shared key validation (the file is the established home of all feed lifecycle logic).
+- Modify: `servers/sharing/tailnet-sync.js` — `:238` null-key init (F3), C4 refresh heal, client-side validate-before-init.
+- Modify: `servers/sharing/boot.js` — validation before persist in `onInstanceKeyReceived`.
+- Modify: `servers/gateway/boot/mcp-mounts.js` — C5 call between eager-init and the once-backfills.
+- Create: `tests/feed-rotation.test.js` — the executable gate (G1–G13), real feeds + real replication.
+- Modify: `tests/instance-sync.test.js` — F6 migration (stub-feed `.key`, new signatures, Test-3 non-vacuity comment).
+
+---
+
+### Task 1: Rotation harness + baseline real-replication proof
+
+**Files:**
+- Create: `tests/feed-rotation.test.js`
+- Reference (read, don't copy blindly): `tests/lamport-reemit.test.js` (its `newFleet()` builds two managers on real init-db SQLite), `tests/instance-sync.test.js:40-107`.
+
+**Interfaces:**
+- Produces: `makeFleet()` → `{ a, b, cleanup }` where each side is `{ mgr, db, dir, id }`; `linkPeers(a, b)` → `{ streams: [nsA, nsB], close() }` — real NoiseSecretStream pair over a real TCP socketpair, both managers replicating. Later tasks build every G-case on these two helpers.
+- Consumes: `InstanceSyncManager`, `initDb` (however `lamport-reemit.test.js` obtains per-side DBs — reuse its exact mechanism), `deriveIdentity` or the identity shape used there (both managers MUST share one identity — entries are verified against the shared ed25519).
+
+- [ ] **Step 1: Write the harness + a baseline test that must FAIL only because the file is new (it exercises existing behavior, so it should PASS once the harness is right — the "red" here is harness bugs, which you fix until green).**
+
+```js
+/**
+ * Item 2d gate: feed-key rotation (spec 2026-07-15-feed-key-rotation-design.md §7).
+ * REAL Hypercores + REAL replication over NoiseSecretStream on a TCP socketpair —
+ * the existing suites apply entries directly and cannot see replication-layer
+ * defects (that blindness is what let D1/D2 ship).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import net from "node:net";
+import NoiseSecretStream from "@hyperswarm/secret-stream";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+// DB + identity setup: copy the exact per-side mechanism from tests/lamport-reemit.test.js
+// (real init-db SQLite per side, one SHARED identity object for both managers).
+
+async function makeSide(identity, id) {
+  const dir = mkdtempSync(join(tmpdir(), `rot-${id}-`));
+  const db = await makeRealDb(dir); // ← same helper style as lamport-reemit.test.js
+  const mgr = new InstanceSyncManager(identity, db, id);
+  mgr.dataDir = join(dir, "instance-sync"); // MUST: keep test feeds out of ~/.crow
+  mgr.feedsDisabled = false;                // MUST: scratch env disables feeds (2c C6)
+  return { mgr, db, dir, id };
+}
+
+export async function makeFleet() {
+  const identity = makeSharedIdentity(); // same object for both sides
+  const a = await makeSide(identity, "instA");
+  const b = await makeSide(identity, "instB");
+  // Register each other in crow_instances so eager/boot paths see a paired row.
+  await registerPeerRow(a.db, b.id);
+  await registerPeerRow(b.db, a.id);
+  return {
+    a, b,
+    async cleanup() {
+      await a.mgr.close(); await b.mgr.close();
+      rmSync(a.dir, { recursive: true, force: true });
+      rmSync(b.dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Real socketpair: two net.Sockets connected through an ephemeral local server. */
+function socketPair() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((serverSide) => {
+      server.close();
+      resolve([serverSide, clientSide]);
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      var clientSide = net.connect(server.address().port, "127.0.0.1");
+      clientSide.on("error", reject);
+    });
+  });
+}
+
+export async function linkPeers(a, b) {
+  const [sockA, sockB] = await socketPair();
+  const nsA = new NoiseSecretStream(true, sockA);
+  const nsB = new NoiseSecretStream(false, sockB);
+  nsA.on("error", () => {}); nsB.on("error", () => {});
+  // Exchange feed keys the way the real handshake does, then replicate.
+  await a.mgr.initInstance(b.id, b.mgr.getOutFeedKey(a.id));
+  await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id));
+  await a.mgr.replicate(b.id, nsA);
+  await b.mgr.replicate(a.id, nsB);
+  return { streams: [nsA, nsB], close: () => { nsA.destroy(); nsB.destroy(); } };
+}
+
+/** Await until fn() is truthy or the deadline passes — condition-based, no bare sleeps. */
+export async function until(fn, ms = 5000, step = 25) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if (await fn()) return true;
+    await new Promise((r) => setTimeout(r, step));
+  }
+  return false;
+}
+
+test("G0 baseline: real replication applies an emitted row across the socketpair", async () => {
+  const fleet = await makeFleet();
+  try {
+    // Arm feeds by exchanging real keys BEFORE linking (linkPeers does both).
+    const link = await linkPeers(fleet.a, fleet.b);
+    await fleet.a.mgr.emitChange("memories", "insert",
+      { id: "rot-g0", content: "hello", lamport_ts: null });
+    const applied = await until(async () => {
+      const { rows } = await fleet.b.db.execute({
+        sql: "SELECT id FROM memories WHERE id = ?", args: ["rot-g0"] });
+      return rows.length === 1;
+    });
+    assert.equal(applied, true, "row emitted on A must apply on B via real replication");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+```
+
+Fill `makeRealDb` / `makeSharedIdentity` / `registerPeerRow` from `tests/lamport-reemit.test.js`'s working pattern — do NOT invent a parallel mechanism; that harness already solved per-side init-db, the shared identity, and the `crow_instances` row shape.
+
+- [ ] **Step 2: Run it**
+
+Run: `T=$(mktemp -d); CROW_HOME=$T CROW_DATA_DIR=$T/data CROW_DISABLE_NOSTR=1 CROW_DISABLE_INSTANCE_SYNC=1 node --test tests/feed-rotation.test.js`
+Expected: `G0` PASS (iterate on harness bugs until it does; typical failures: identity not shared → signature warns; dataDir not set → feeds land in `$T` fine but assert it, never `~/.crow`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/feed-rotation.test.js
+git commit tests/feed-rotation.test.js -m "test(sync): 2d gate harness -- two managers, real hypercores, real NoiseSecretStream replication over a TCP socketpair (G0 baseline)"
+```
+
+---
+
+### Task 2: C2 storage format — feed-keyed `{k,s}` applied-seq + F6 suite migration
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js:2649-2699` (`_getLastAppliedSeq`, `_setLastAppliedSeq`), `:2704-2721` (`getSyncStatus`), `:1404-1420` (`_processNewEntriesInner`).
+- Modify: `tests/instance-sync.test.js` (`makeStubFeed` :98-107; direct seq callers :243, :270, :288-293, :354; every `_processNewEntries` call on a stub feed — ~20 sites).
+
+**Interfaces:**
+- Produces: `_setLastAppliedSeq(remoteInstanceId, seq, feedKeyHex)` (writes `{"k":feedKeyHex,"s":seq}` via `json(?)`); `_getLastAppliedSeq(remoteInstanceId, feed)` (key-gated; `feed=null` → coerce both shapes to a number); `_appliedSeqRecord(remoteInstanceId)` (internal: returns the raw parsed record or null). `_processNewEntriesInner` bails at entry when `this.inFeeds.get(id) !== feed` **unless the feed was passed explicitly by a caller that isn't tracking inFeeds (the existing test suite drives stub feeds)** — implement the bail as: `const current = this.inFeeds.get(remoteInstanceId); if (current !== undefined && current !== feed) return;` (an unmapped peer — `undefined` — still processes, preserving the stub-feed tests' semantics; a REPLACED feed bails).
+- Consumes: Task 1's harness (for one integration case); the rest are unit-level in the existing file's style.
+
+- [ ] **Step 1: Write failing unit tests (append to `tests/feed-rotation.test.js` — unit section)**
+
+```js
+test("C2 unit: set writes {k,s} object; get is key-gated; null-feed coerces both shapes", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { mgr, db } = fleet.a;
+    const PEER = fleet.b.id;
+    const keyX = "aa".repeat(32), keyY = "bb".repeat(32);
+    await mgr._setLastAppliedSeq(PEER, 7, keyX);
+    // Raw storage shape: a JSON object, not a string (spec C2 SQL note / R2 #7).
+    const { rows } = await db.execute({
+      sql: "SELECT last_applied_seq_per_peer AS b FROM sync_state WHERE instance_id = ?",
+      args: [mgr.localInstanceId] });
+    const rec = JSON.parse(rows[0].b)[PEER];
+    assert.equal(typeof rec, "object", "must store an object, not a JSON string");
+    assert.equal(rec.k, keyX); assert.equal(rec.s, 7);
+    // Key-gated reads:
+    assert.equal(await mgr._getLastAppliedSeq(PEER, { key: Buffer.from(keyX, "hex") }), 7);
+    assert.equal(await mgr._getLastAppliedSeq(PEER, { key: Buffer.from(keyY, "hex") }), 0,
+      "foreign-key record must read 0");
+    // Display path (feed=null) coerces the object:
+    assert.equal(await mgr._getLastAppliedSeq(PEER, null), 7);
+    // Legacy numeric display coercion (R3 F-F): write a bare number the old way.
+    await db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 42) WHERE instance_id = ?`,
+      args: [`$."${PEER}"`, mgr.localInstanceId] });
+    assert.equal(await mgr._getLastAppliedSeq(PEER, null), 42, "legacy bare number coerces");
+  } finally { await fleet.cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`_setLastAppliedSeq` takes 2 args today; stored shape is numeric).
+
+- [ ] **Step 3: Implement.** Replace the two methods (keep the `"` guard and `json_set` atomicity comment):
+
+```js
+  /**
+   * Applied-seq record, keyed to the feed it was earned on (2d C2).
+   * Shape: {"k": "<feedKeyHex>", "s": <nextUnprocessedSeq>}. Legacy bare
+   * numbers exist on disk until _reconcileAppliedSeqAtOpen upgrades them.
+   */
+  async _appliedSeqRecord(remoteInstanceId) {
+    try {
+      const { rows } = await this.db.execute({
+        sql: "SELECT last_applied_seq_per_peer FROM sync_state WHERE instance_id = ?",
+        args: [this.localInstanceId],
+      });
+      if (rows.length > 0 && rows[0].last_applied_seq_per_peer) {
+        const rec = JSON.parse(rows[0].last_applied_seq_per_peer)[remoteInstanceId];
+        return rec === undefined ? null : rec;
+      }
+    } catch {}
+    return null;
+  }
+
+  /**
+   * Key-gated read (2d C2). feed=null is the display path: coerce BOTH shapes
+   * (legacy bare number → itself; {k,s} → s) — never used to gate application.
+   * A record whose k differs from the feed's key belongs to a dead feed → 0.
+   * A legacy numeric reaching a keyed read is treated as foreign (defensive;
+   * reconcile-at-open makes it unreachable in production).
+   */
+  async _getLastAppliedSeq(remoteInstanceId, feed = null) {
+    const rec = await this._appliedSeqRecord(remoteInstanceId);
+    if (rec === null) return 0;
+    if (feed == null) return typeof rec === "number" ? rec : Number(rec.s) || 0;
+    if (typeof rec !== "object") return 0;
+    const feedKeyHex = feed.key ? Buffer.from(feed.key).toString("hex") : null;
+    return rec.k === feedKeyHex ? Number(rec.s) || 0 : 0;
+  }
+
+  async _setLastAppliedSeq(remoteInstanceId, seq, feedKeyHex) {
+    if (remoteInstanceId.includes('"')) {
+      console.warn(`[instance-sync] _setLastAppliedSeq: skipping id with quote char: ${remoteInstanceId}`);
+      return;
+    }
+    try {
+      await this._ensureCounter();
+      // json(?) — NOT CAST — so the object lands as JSON, not a quoted string
+      // (spec C2 SQL note): json_set with a plain string param stores a string
+      // and every reader's .k/.s would be undefined.
+      await this.db.execute({
+        sql: `UPDATE sync_state
+              SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer, '{}'), ?, json(?)),
+                  updated_at = datetime('now')
+              WHERE instance_id = ?`,
+        args: [`$."${remoteInstanceId}"`, JSON.stringify({ k: feedKeyHex ?? null, s: Number(seq) }), this.localInstanceId],
+      });
+    } catch (err) {
+      console.warn(`[instance-sync] Failed to update checkpoint for ${remoteInstanceId}:`, err.message);
+    }
+  }
+```
+
+In `_processNewEntriesInner` (`:1404`):
+
+```js
+  async _processNewEntriesInner(remoteInstanceId, feed) {
+    // 2d C1/C2 (R1 F1): a run bound to a REPLACED feed must not read or stamp
+    // the successor's record. `undefined` (peer unmapped / stub-feed harness)
+    // still processes — only a swapped-out feed bails.
+    const current = this.inFeeds.get(remoteInstanceId);
+    if (current !== undefined && current !== feed) return;
+    const feedKeyHex = feed.key ? Buffer.from(feed.key).toString("hex") : null;
+    const lastSeq = await this._getLastAppliedSeq(remoteInstanceId, feed);
+    for (let seq = lastSeq; seq < feed.length; seq++) {
+      try {
+        const entry = await feed.get(seq);
+        await this._applyEntry(remoteInstanceId, entry);
+      } catch (err) {
+        console.warn(`[instance-sync] Failed to process entry ${seq} from ${remoteInstanceId}:`, err.message);
+      }
+      // Stamp with the PROCESSED feed's key (2d C2 / R1 F1) — never "the
+      // current in-feed": a stale run must leave a record the successor's
+      // key-gated reads ignore.
+      await this._setLastAppliedSeq(remoteInstanceId, seq + 1, feedKeyHex);
+    }
+  }
+```
+
+In `getSyncStatus` (`:2704`), replace the `_getLastAppliedSeq(instanceId)` call with `_getLastAppliedSeq(instanceId, inFeed ?? null)`.
+
+- [ ] **Step 4: Migrate `tests/instance-sync.test.js` (F6, scope per spec §7).**
+  - `makeStubFeed` gains a key:
+    ```js
+    function makeStubFeed(keyHex = randomBytes(32).toString("hex")) {
+      const feed = {
+        key: Buffer.from(keyHex, "hex"),
+        entries: [],
+        get length() { return feed.entries.length; },
+        async get(seq) { return feed.entries[seq]; },
+        push(entry) { feed.entries.push(entry); return feed.entries.length - 1; },
+      };
+      return feed;
+    }
+    ```
+    (add `randomBytes` to the file's `node:crypto` import).
+  - Direct callers: `_setLastAppliedSeq(PEER, n)` → `_setLastAppliedSeq(PEER, n, "aa".repeat(32))` (or the driving feed's key where one exists); `_getLastAppliedSeq(PEER)` → `_getLastAppliedSeq(PEER, feed)` where the test has a feed, else `(PEER, null)`.
+  - **Test 3 non-vacuity (spec §7 / R2 #3):** its `feed2` MUST be built with the SAME key as `feed` — `const feed2 = makeStubFeed(feed.key.toString("hex"))` — with the comment: `// SAME key as feed: different keys would make the key-gate return 0 and the "seqs 0-1 not re-applied" assertion pass vacuously (2a vacuous-test tell).`
+  - Any test seeding a checkpoint by raw SQL keeps working via the reader's both-shape coercion — leave those as legacy-shape coverage.
+
+- [ ] **Step 5: Run both files**
+
+Run: `T=$(mktemp -d); CROW_HOME=$T CROW_DATA_DIR=$T/data CROW_DISABLE_NOSTR=1 CROW_DISABLE_INSTANCE_SYNC=1 node --test tests/feed-rotation.test.js tests/instance-sync.test.js`
+Expected: all PASS (Test 3 must still exercise resumption — eyeball its assertions ran non-vacuously by temporarily giving `feed2` a different key and watching it still pass for the WRONG reason, then restoring the same-key line; that manual check is the mutation for this task).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit servers/sharing/instance-sync.js tests/feed-rotation.test.js tests/instance-sync.test.js -m "feat(sync): feed-keyed applied-seq records -- {k,s} via json(), key-gated reads, processed-feed stamping, stub-feed suite migration (2d C2 core)"
+```
+
+---
+
+### Task 3: C2 reconcile-at-open — the frozen legacy/rotation decision
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js` — new `_reconcileAppliedSeqAtOpen`; call it in `_initInstanceInner`'s in-feed open path (between `await inFeed.ready()` and wiring the `append` listener).
+- Test: `tests/feed-rotation.test.js` (G4a, G4b, G4c, G6b).
+
+**Interfaces:**
+- Produces: `_reconcileAppliedSeqAtOpen(remoteInstanceId, feed)` — freezes the record for this feed exactly once per open. Task 4's swap path relies on it running on EVERY open (it does — it's in the open path, and rotation opens go through the same path).
+- Consumes: Task 2's record shape + accessors.
+
+- [ ] **Step 1: Failing tests**
+
+```js
+test("G4a/G4b: legacy numeric adopted when n <= length at open; reset when n > length", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    // Build a real feed pair, replicate 3 entries so B's in-feed has length 3.
+    const link = await linkPeers(a, b);
+    for (let i = 0; i < 3; i++) {
+      await a.mgr.emitChange("memories", "insert", { id: `g4-${i}`, content: "x", lamport_ts: null });
+    }
+    await until(async () => (b.mgr.inFeeds.get(a.id)?.length ?? 0) >= 3);
+    link.close();
+    // Simulate legacy state: overwrite B's record with a bare number, then
+    // force a re-open (close feeds, re-init) — reconcile must run at open.
+    const K = b.mgr.inFeeds.get(a.id).key.toString("hex");
+    await b.db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 2) WHERE instance_id = ?`,
+      args: [`$."${a.id}"`, b.mgr.localInstanceId] });
+    await b.mgr.closeInstanceFeeds(a.id);
+    await b.mgr.initInstance(a.id, Buffer.from(K, "hex"));   // n=2 <= length 3 → adopt
+    let rec = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual({ k: rec.k, s: rec.s }, { k: K, s: 2 }, "G4a: adopted as {k, s:n}");
+    // G4b: n > length → provably foreign → reset to 0.
+    await b.db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 99) WHERE instance_id = ?`,
+      args: [`$."${a.id}"`, b.mgr.localInstanceId] });
+    await b.mgr.closeInstanceFeeds(a.id);
+    await b.mgr.initInstance(a.id, Buffer.from(K, "hex"));
+    rec = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual({ k: rec.k, s: rec.s }, { k: K, s: 0 }, "G4b: impossible mark reset to 0");
+  } finally { await fleet.cleanup(); }
+});
+
+test("G4c burst-crossing: legacy n vs fresh rotated feed that replicates a backlog past n in one link", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    // A pre-populates FIVE entries in its out-feed to B while UNLINKED (so the
+    // whole backlog arrives as one burst after B opens its fresh in-feed).
+    await a.mgr.initInstance(b.id, null);
+    for (let i = 0; i < 5; i++) {
+      await a.mgr.emitChange("memories", "insert", { id: `g4c-${i}`, content: "x", lamport_ts: null });
+    }
+    // B holds a stale legacy mark n=3 for A (as if earned on a long-dead feed).
+    await b.db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 3) WHERE instance_id = ?`,
+      args: [`$."${a.id}"`, b.mgr.localInstanceId] });
+    // B opens A's feed fresh (length 0 at open → reset to {k,s:0}), THEN the
+    // burst replicates. Lazy evaluation would flip to "trust 3" once length=5.
+    const link = await linkPeers(a, b);
+    const allApplied = await until(async () => {
+      const { rows } = await b.db.execute({
+        sql: "SELECT COUNT(*) AS n FROM memories WHERE id LIKE 'g4c-%'" });
+      return Number(rows[0].n) === 5;
+    });
+    assert.equal(allApplied, true, "entries 0..2 must NOT be skipped (burst-crossing, R1 F2)");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G6b: a restarted manager (same dirs+DB, new objects) completes a rotation via reconcile", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: "g6b-pre", content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id='g6b-pre'" })).rows.length === 1);
+    link.close();
+    // A "rotates": wipe its out-feed dir for B and re-init → new key minted.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    // B "restarts": build a NEW manager over B's same db+dataDir, sync_url = new key.
+    await b.mgr.close();
+    const b2mgr = new (b.mgr.constructor)(b.mgr.identity, b.db, b.mgr.localInstanceId);
+    b2mgr.dataDir = b.mgr.dataDir; b2mgr.feedsDisabled = false;
+    await b2mgr.initInstance(a.id, newKey); // reconcile: k differs → {k:new, s:0}
+    const rec = await b2mgr._appliedSeqRecord(a.id);
+    assert.equal(rec.k, newKey.toString("hex"));
+    assert.equal(rec.s, 0, "restart completes rotation: record reset for the new feed");
+    await b2mgr.close();
+    b.mgr = b2mgr; // let cleanup close the live one
+  } finally { await fleet.cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run — expect G4a/G4b/G4c/G6b FAIL** (no reconcile exists; legacy numeric is treated as foreign → G4a fails; G4c may pass accidentally — verify it fails for the right reason by checking the record after open; if it passes, tighten: assert the record equals `{k,s:0}` immediately after `linkPeers` opened the feed and before the burst lands).
+
+- [ ] **Step 3: Implement** — in `instance-sync.js`, next to the seq accessors:
+
+```js
+  /**
+   * Freeze the applied-seq decision for THIS feed, once, at open (2d C2 /
+   * R1 F2). Runs inside the _initLocks chain before the append listener is
+   * wired, so feed.length cannot grow concurrently:
+   *   {k,s} k matches   → keep (normal restart)
+   *   {k,s} k differs   → rotated → {k: this feed, s: 0}
+   *   legacy numeric n  → n <= length: plausibly ours → adopt {k, s:n}
+   *                       n >  length: provably foreign (a mark earned on F
+   *                       satisfies n <= F.length) → {k, s:0}
+   * NEVER re-derived later: lazy evaluation flips to "trust" once a burst
+   * pushes length past n (R1 F2's hole).
+   */
+  async _reconcileAppliedSeqAtOpen(remoteInstanceId, feed) {
+    const feedKeyHex = feed.key ? Buffer.from(feed.key).toString("hex") : null;
+    const rec = await this._appliedSeqRecord(remoteInstanceId);
+    if (rec === null) { await this._setLastAppliedSeq(remoteInstanceId, 0, feedKeyHex); return; }
+    if (typeof rec === "object") {
+      if (rec.k === feedKeyHex) return; // normal restart — keep
+      console.warn(`[instance-sync] applied-seq record for ${remoteInstanceId.slice(0,12)}… belonged to a dead feed — reset to 0`);
+      await this._setLastAppliedSeq(remoteInstanceId, 0, feedKeyHex);
+      return;
+    }
+    const n = Number(rec) || 0;
+    const adopted = n <= feed.length ? n : 0;
+    if (adopted !== n) {
+      console.warn(`[instance-sync] legacy applied-seq ${n} > feed length ${feed.length} for ${remoteInstanceId.slice(0,12)}… — provably foreign, reset to 0`);
+    }
+    await this._setLastAppliedSeq(remoteInstanceId, adopted, feedKeyHex);
+  }
+```
+
+Call it in `_initInstanceInner`'s in-feed branch, after `await inFeed.ready()` and **before** `inFeed.on("append", ...)`:
+
+```js
+      await inFeed.ready();
+      // 2d C2: freeze the applied-seq decision for this feed BEFORE any
+      // replication can grow it (listener not wired yet; feed unattached).
+      await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
+```
+
+- [ ] **Step 4: Run — expect PASS.** Then the **mutation checks** (do each, watch the NAMED test go red, restore):
+  1. Remove the legacy-adopt branch (always reset) → **G4a red**.
+  2. Remove the `n > length` impossibility check (always adopt) → **G4b red**.
+  3. Re-introduce lazy evaluation: skip `_reconcileAppliedSeqAtOpen` and instead put the legacy rule inside `_getLastAppliedSeq` → **G4c red**.
+  4. Remove reconcile call entirely → **G6b red**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/instance-sync.js tests/feed-rotation.test.js -m "feat(sync): applied-seq reconcile frozen at feed open -- legacy adopt/reset by length impossibility, rotation reset on key mismatch (2d C2, gates G4a/G4b/G4c/G6b)"
+```
+
+---
+
+### Task 4: C1 — the live swap (rotation branch, bounded close, defer machinery)
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js` — constructor (`:286-314`: add `this._inFeedListeners = new Map()`, `this._deferredRotations = new Set()`), `_initInstanceInner` (`:439-474`: rotation branch + try/catch open + listener refs), `_closeInstanceFeedsInner` (`:2747`: clear `_inFeedListeners` + `_deferredRotations`), new `boundedClose` helper.
+- Test: `tests/feed-rotation.test.js` (G1, G5, G6, G6c, G12).
+
+**Interfaces:**
+- Produces: the rotation behavior itself; `_deferredRotations: Set<peerId>`; `_inFeedListeners: Map<peerId, fn>`. Task 6 attaches streams inside the same open path; Task 7's G13 and Task 8's C4 both go through `initInstance` unchanged.
+- Consumes: Tasks 2-3 (reconcile + key-gated records).
+
+- [ ] **Step 1: Failing tests**
+
+```js
+test("G1: live rotation single actor -- B swaps without restart, new emits apply, conflicts flat", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    let link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: "g1-pre", content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id='g1-pre'" })).rows.length === 1);
+    const conflictsBefore = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    link.close();
+    // A rotates its out-feed to B (storage wiped, new key minted).
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    // Key delivered to B live (as every receipt point does) — NO b restart:
+    await b.mgr.initInstance(a.id, newKey);
+    assert.notEqual(b.mgr.inFeeds.get(a.id), oldFeed, "in-feed object must be swapped");
+    assert.equal(b.mgr.inFeeds.get(a.id).key.toString("hex"), newKey.toString("hex"));
+    // Replication resumes on a fresh link; post-rotation emit applies.
+    link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: "g1-post", content: "y", lamport_ts: null });
+    const applied = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id='g1-post'" })).rows.length === 1);
+    assert.equal(applied, true, "post-rotation emit must apply with no restart on B");
+    const conflictsAfter = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    assert.equal(conflictsAfter, conflictsBefore, "sync_conflicts flat");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G5: same-key re-exchange is a no-op -- feed identity and seq preserved", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: "g5", content: "x", lamport_ts: null });
+    await until(async () => (await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id))) >= 1);
+    const feedBefore = b.mgr.inFeeds.get(a.id);
+    const seqBefore = await b.mgr._getLastAppliedSeq(a.id, feedBefore);
+    await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id)); // same key again
+    assert.equal(b.mgr.inFeeds.get(a.id), feedBefore, "same feed object");
+    assert.equal(await b.mgr._getLastAppliedSeq(a.id, feedBefore), seqBefore, "seq untouched");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G6/G6c: hung close defers boundedly; reopen attempts do not throw; settle (resolve OR reject) un-defers and heals", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    // Injection seam (R3 F-G): wrap the REAL feed's close in a controllable promise.
+    let settle;
+    const gate = new Promise((res) => { settle = res; });
+    const realClose = oldFeed.close.bind(oldFeed);
+    oldFeed.close = () => gate.then(() => realClose());
+    // Rotate A, deliver the new key to B: close hangs → defer within the cap.
+    link.close();
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    const t0 = Date.now();
+    await b.mgr.initInstance(a.id, newKey);          // must return, not hang
+    assert.ok(Date.now() - t0 < 8000, "G6: bounded (5s cap + slack), no hang");
+    assert.equal(b.mgr.inFeeds.has(a.id), false, "deferred: no in-feed mapped");
+    assert.ok(b.mgr._deferredRotations.has(a.id), "deferred set");
+    // G6c: subsequent attempts (the C4-interval shape) must NOT throw.
+    await assert.doesNotReject(() => b.mgr.initInstance(a.id, newKey));
+    assert.equal(b.mgr.inFeeds.has(a.id), false, "still suppressed while lock held");
+    // Now the slow close settles → un-defer → next call completes the rotation.
+    settle();
+    await until(() => !b.mgr._deferredRotations.has(a.id));
+    await b.mgr.initInstance(a.id, newKey);
+    assert.equal(b.mgr.inFeeds.get(a.id)?.key.toString("hex"), newKey.toString("hex"), "healed after settle");
+  } finally { await fleet.cleanup(); }
+});
+
+test("G6c-reject: a REJECTING close un-defers with no unhandled rejection", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    let link = await linkPeers(a, b);
+    link.close();
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    let reject;
+    const gate = new Promise((_, rej) => { reject = rej; });
+    oldFeed.close = () => gate; // close() = pending, then REJECTS
+    const unhandled = [];
+    const onUR = (err) => unhandled.push(err);
+    process.on("unhandledRejection", onUR);
+    try {
+      await a.mgr.closeInstanceFeeds(b.id);
+      rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+      await a.mgr.initInstance(b.id, null);
+      const newKey = a.mgr.getOutFeedKey(b.id);
+      await b.mgr.initInstance(a.id, newKey);           // defers
+      reject(new Error("close blew up"));               // the R3 F-A case
+      await until(() => !b.mgr._deferredRotations.has(a.id));
+      await new Promise((r) => setImmediate(r));        // let any UR surface
+      assert.equal(unhandled.length, 0, "no unhandled rejection from the abandoned close");
+      assert.equal(b.mgr._deferredRotations.has(a.id), false, "reject also un-defers (.finally)");
+    } finally { process.off("unhandledRejection", onUR); }
+  } finally { await fleet.cleanup(); }
+});
+
+test("G12: in-flight old-feed processing across the swap cannot corrupt the new record", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    // Seed 2 entries and let B apply them (record {k:old, s:2}).
+    for (let i = 0; i < 2; i++) await a.mgr.emitChange("memories", "insert", { id: `g12-${i}`, content: "x", lamport_ts: null });
+    await until(async () => (await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id))) >= 2);
+    // Trap B's _applyEntry so the NEXT processing run parks mid-loop.
+    let releaseApply; const applyGate = new Promise((r) => { releaseApply = r; });
+    const realApply = b.mgr._applyEntry.bind(b.mgr);
+    let trapped = false;
+    b.mgr._applyEntry = async (...args) => { if (!trapped) { trapped = true; await applyGate; } return realApply(...args); };
+    // Third entry arrives → old-feed run starts and parks inside _applyEntry.
+    await a.mgr.emitChange("memories", "insert", { id: "g12-2", content: "x", lamport_ts: null });
+    await until(() => trapped);
+    link.close();
+    // Swap while the old-feed run is mid-flight.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await b.mgr.initInstance(a.id, newKey);
+    releaseApply();                                    // old run resumes, stamps {k:old}
+    await new Promise((r) => setTimeout(r, 100));      // let it finish its write
+    // The record must be usable by the NEW feed: either {k:new,...} already, or
+    // {k:old,...} which the key-gated read maps to 0 — NEVER {k:new, s:oldMark}.
+    const rec = await b.mgr._appliedSeqRecord(a.id);
+    if (rec.k === newKey.toString("hex")) {
+      assert.equal(rec.s, 0, "a new-key record written during the race must be the reset, not the old mark");
+    }
+    const effective = await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id));
+    assert.equal(effective === 0 || rec.k === newKey.toString("hex"), true,
+      "new feed must start from 0 -- the old run's stamp must not masquerade under the new key");
+    // And a queued post-swap run on the OLD feed must bail with no stamp:
+    const before = JSON.stringify(await b.mgr._appliedSeqRecord(a.id));
+    const oldFeedRef = { key: Buffer.from("cc".repeat(32), "hex"), length: 50, async get() { throw new Error("n/a"); } };
+    await b.mgr._processNewEntries(a.id, oldFeedRef);  // replaced feed → entry bail
+    assert.equal(JSON.stringify(await b.mgr._appliedSeqRecord(a.id)), before, "bailed run stamps nothing");
+  } finally { await fleet.cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run — expect G1/G6/G6c/G6c-reject FAIL** (no rotation branch exists; today's `initInstance` no-ops). G5 passes today (it pins the fast path so the swap can't regress it); G12's bail half fails.
+
+- [ ] **Step 3: Implement.** Constructor additions (after `:314`):
+
+```js
+    this._inFeedListeners = new Map();  // remoteInstanceId → append handler (2d C1: removable on swap)
+    this._deferredRotations = new Set(); // remoteInstanceId → swap deferred, old close still pending (2d C1)
+```
+
+`boundedClose` helper (near the class top or as a module function):
+
+```js
+/** Race a feed close against a cap. Returns true if it settled in time.
+ *  2d C1: the abandoned promise gets .finally-based cleanup at the call site
+ *  (.finally, NOT .then — a rejecting close must also un-defer and must not
+ *  become an unhandled rejection; R3 F-A). */
+async function boundedClose(feed, capMs) {
+  let timer;
+  const timeout = new Promise((res) => { timer = setTimeout(() => res(false), capMs); timer.unref?.(); });
+  const closed = feed.close().then(() => true, () => true); // settle either way
+  const result = await Promise.race([closed, timeout]);
+  clearTimeout(timer);
+  return result;
+}
+```
+
+`_initInstanceInner` in-feed section becomes:
+
+```js
+    // 2d C1: key-aware — a changed key swaps the open in-feed live.
+    const currentIn = this.inFeeds.get(remoteInstanceId);
+    if (currentIn && theirFeedKey && !Buffer.from(currentIn.key).equals(theirFeedKey)) {
+      const oldKey8 = Buffer.from(currentIn.key).toString("hex").slice(0, 8);
+      const newKey8 = theirFeedKey.toString("hex").slice(0, 8);
+      const handler = this._inFeedListeners.get(remoteInstanceId);
+      if (handler) currentIn.removeListener("append", handler);
+      this._inFeedListeners.delete(remoteInstanceId);
+      currentIn.on("error", () => {}); // swallow late close-races (R3/R2 #9)
+      this.inFeeds.delete(remoteInstanceId); // entry-bail kills queued runs (R1 F1)
+      const closePromise = currentIn.close();
+      // .finally, NOT .then: a REJECTING close must also un-defer, and the
+      // derived promise must never become an unhandled rejection (R3 F-A).
+      closePromise.catch(() => {}).finally(() => this._deferredRotations.delete(remoteInstanceId));
+      const closed = await Promise.race([
+        closePromise.then(() => true, () => true),
+        new Promise((res) => { const t = setTimeout(() => res(false), this._rotationCloseCapMs ?? 5000); t.unref?.(); }),
+      ]);
+      if (!closed) {
+        // rocksdb lock still held by the zombie session — a same-dir open
+        // would throw. Defer loudly; sync_url is persisted, so a later settle
+        // (via the .finally above) or a restart completes the rotation.
+        console.error(`[instance-sync] ROTATION DEFERRED for ${remoteInstanceId.slice(0,12)}…: old in-feed close timed out (cap ${this._rotationCloseCapMs ?? 5000}ms); will retry after close settles or on restart`);
+        this._deferredRotations.add(remoteInstanceId);
+        return this.outFeeds.get(remoteInstanceId);
+      }
+      console.warn(`[instance-sync] in-feed ROTATED for ${remoteInstanceId.slice(0,12)}…: ${oldKey8}… → ${newKey8}…`);
+    }
+
+    if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey
+        && !this._deferredRotations.has(remoteInstanceId)) {
+      let inFeed = null;
+      try {
+        inFeed = new Hypercore(resolve(dir, "in"), theirFeedKey, { valueEncoding: "json" });
+        await inFeed.ready();
+        // 2d C2: freeze the applied-seq decision BEFORE wiring the listener.
+        await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
+        const onAppend = async () => { await this._processNewEntries(remoteInstanceId, inFeed); };
+        inFeed.on("append", onAppend);
+        this._inFeedListeners.set(remoteInstanceId, onAppend);
+        this.inFeeds.set(remoteInstanceId, inFeed);
+      } catch (err) {
+        // 2d C1 (R2 #1): open failure degrades to out-only — NEVER throws out
+        // of initInstance (a still-held lock after a deferred rotation would
+        // otherwise kill the tailnet client handshake and, on the C4 interval,
+        // crash the gateway via unhandled rejection).
+        console.error(`[instance-sync] in-feed open failed for ${remoteInstanceId.slice(0,12)}…: ${err.message} — continuing out-only`);
+        if (inFeed) inFeed.close().catch(() => {}); // release partial handle/fd (R3 F-D)
+      }
+    }
+```
+
+(The existing plain open block is replaced by this; note the `_rotationCloseCapMs` field enables the gate to shrink the cap — set `this._rotationCloseCapMs = 200` in G6/G6c tests to keep the suite fast; default 5000 in the constructor.)
+
+`_closeInstanceFeedsInner` additions (with the existing deletions):
+
+```js
+    this._inFeedListeners.delete(remoteInstanceId);
+    // 2d C1 (R3 F-B): a deferred peer that is revoked then re-paired must not
+    // stay suppressed forever.
+    this._deferredRotations.delete(remoteInstanceId);
+```
+
+- [ ] **Step 4: Run — expect PASS.** Then **mutation checks**:
+  1. Remove the key-compare (make the swap branch unreachable) → **G1 red**.
+  2. Remove the equality fast-path semantics (force swap even on equal keys — e.g. compare against a wrong buffer) → **G5 red**.
+  3. Remove the `Promise.race` cap (await the close directly) → **G6 red** (timeout).
+  4. Remove the open try/catch (let open throw) → **G6c red** (`doesNotReject` fails).
+  5. Replace `.finally` un-defer with `.then(onFulfilled-only)` → **G6c-reject red**.
+  6. Remove the un-defer entirely → **G6c red** (never heals after settle).
+  7. Stamp `_setLastAppliedSeq` with the current in-feed's key instead of the processed feed's → **G12 red**.
+  8. Remove `_processNewEntriesInner`'s entry bail → **G12 red** (bailed-run half).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/instance-sync.js tests/feed-rotation.test.js -m "feat(sync): live in-feed swap on key change -- bounded close, defer-with-finally un-defer, out-only degrade on open failure (2d C1, gates G1/G5/G6/G6c/G12)"
+```
+
+---
+
+### Task 5: Shared feed-key validation at all three receipt points
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js` — new method `validateIncomingFeedKey(remoteInstanceId, feedKeyHex)` → `Buffer | null`.
+- Modify: `servers/sharing/boot.js:850-874` (`onInstanceKeyReceived` — validate before persist), `servers/sharing/tailnet-sync.js:249-260` (server) and `:433-452` (client — validate before the `:435` init AND the persist).
+- Test: `tests/feed-rotation.test.js` (G11, G11b).
+
+**Interfaces:**
+- Produces: `validateIncomingFeedKey(remoteInstanceId, feedKeyHex)` — returns the parsed 32-byte Buffer, or null (logged) for: non-string, non-hex, length ≠ 64 chars, or equal to OUR out-feed key for that peer (self-echo, R1 F7).
+- Consumes: `getOutFeedKey` (existing).
+
+- [ ] **Step 1: Failing tests**
+
+```js
+test("G11/G11b: malformed and self-echoed feed keys are rejected -- no persist-shape swap, no crash", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    await b.mgr.initInstance(a.id, null); // arm out-feed so self-key exists
+    for (const bad of ["zz".repeat(32), "aa".repeat(16), "aa".repeat(33), "", null, 42]) {
+      assert.equal(b.mgr.validateIncomingFeedKey(a.id, bad), null, `rejects ${String(bad).slice(0,8)}`);
+    }
+    const selfKey = b.mgr.getOutFeedKey(a.id).toString("hex");
+    assert.equal(b.mgr.validateIncomingFeedKey(a.id, selfKey), null, "G11b: self-echo rejected");
+    const good = "ab".repeat(32);
+    const buf = b.mgr.validateIncomingFeedKey(a.id, good);
+    assert.equal(buf?.toString("hex"), good, "valid key parses");
+  } finally { await fleet.cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (method missing).
+
+- [ ] **Step 3: Implement** in `instance-sync.js`:
+
+```js
+  /**
+   * Validate a peer-advertised feed key BEFORE persisting or opening (2d C1;
+   * R2 #8 persist-gating, R1 F7 self-echo). Returns Buffer or null.
+   */
+  validateIncomingFeedKey(remoteInstanceId, feedKeyHex) {
+    if (typeof feedKeyHex !== "string" || !/^[0-9a-fA-F]{64}$/.test(feedKeyHex)) {
+      console.warn(`[instance-sync] rejecting malformed feed key from ${String(remoteInstanceId).slice(0,12)}…`);
+      return null;
+    }
+    const ours = this.getOutFeedKey(remoteInstanceId);
+    if (ours && ours.toString("hex") === feedKeyHex.toLowerCase()) {
+      console.warn(`[instance-sync] rejecting self-echoed feed key from ${String(remoteInstanceId).slice(0,12)}… (would re-apply our own history)`);
+      return null;
+    }
+    return Buffer.from(feedKeyHex, "hex");
+  }
+```
+
+Wire it (each site: validate FIRST; on null, skip persist AND init):
+- `boot.js` `onInstanceKeyReceived`: after the paired-row check (`:856`), before the `sync_url` compare: `const keyBuf = instanceSyncManager.validateIncomingFeedKey(remoteInstanceId, feedKeyHex); if (!keyBuf) return;` — then use `keyBuf` in the `initInstance` call.
+- `tailnet-sync.js` server block `:249`: `if (peerKeyMsg?.feed_key_hex && peerKeyMsg.feed_key_hex !== peerRow.sync_url) { const keyBuf = instanceSyncManager.validateIncomingFeedKey(remoteInstanceId, peerKeyMsg.feed_key_hex); if (keyBuf) { …persist…; await instanceSyncManager.initInstance(remoteInstanceId, keyBuf); } }`
+- `tailnet-sync.js` client: before `:435` — `const incomingKeyBuf = peerKeyMsg?.feed_key_hex ? instanceSyncManager.validateIncomingFeedKey(remoteInstanceId, peerKeyMsg.feed_key_hex) : null;` (R3 F-E: this path inits before persisting); gate the `:440-452` persist on the same non-null result.
+
+- [ ] **Step 4: Run — PASS. Mutations:** remove the hex/length check → **G11 red**; remove the self-key check → **G11b red**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/instance-sync.js servers/sharing/boot.js servers/sharing/tailnet-sync.js tests/feed-rotation.test.js -m "feat(sync): validate peer feed keys before persist and open -- malformed and self-echo rejected at all three receipt points (2d, gates G11/G11b)"
+```
+
+---
+
+### Task 6: C3 — active-stream tracking and post-swap attach
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js` — constructor (`this._activeStreams = new Map()`), `replicate` (`:1187`), the C1 open path (attach after set), `_closeInstanceFeedsInner` (teardown).
+- Test: `tests/feed-rotation.test.js` (G8, G9).
+
+**Interfaces:**
+- Produces: `_activeStreams: Map<peerId, Set<stream>>`. Bound: ≤ live transport connections per active peer; entries removed on stream `close` and on `closeInstanceFeeds`.
+- Consumes: Task 4's swap path.
+
+- [ ] **Step 1: Failing tests**
+
+```js
+test("G8: rotation while a stream is actively replicating -- new feed attaches to the SAME stream", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b); // old core actively replicating on this stream
+    await a.mgr.emitChange("memories", "insert", { id: "g8-pre", content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id='g8-pre'" })).rows.length === 1);
+    // A rotates; the key is delivered to B while the ORIGINAL stream stays open.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await a.mgr.replicate(b.id, /* A's side of the SAME stream */ linkStreamFor(a)); // see note below
+    await b.mgr.initInstance(a.id, newKey); // swap: real bounded close of old core, then attach
+    await a.mgr.emitChange("memories", "insert", { id: "g8-post", content: "y", lamport_ts: null });
+    const applied = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id='g8-post'" })).rows.length === 1);
+    assert.equal(applied, true, "post-rotation data must flow over the pre-existing stream");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G9: old core blocks remain readable after the swap (acceptance pin)", async () => {
+  // After G1-style rotation on side B: open B's in-dir with the OLD key and read block 0.
+  // (Build inline: rotate as in G1, keep oldKey; then:)
+  //   const reopened = new Hypercore(join(b.mgr.dataDir, a.id, "in"), oldKey, { valueEncoding: "json" });
+  //   await reopened.ready();
+  //   assert.ok(reopened.length >= 1); assert.ok(await reopened.get(0));
+  //   await reopened.close();
+});
+```
+
+Note on G8: `linkPeers` must be extended to return per-side stream handles (`{ nsA, nsB }`) so the test can re-`replicate` A's NEW out-feed onto A's existing stream (`nsA`) — on A's side the out-feed was closed and re-created, so A re-attaches its side too; B's side is what C3 must handle automatically. Import `Hypercore` at the top of the test file for G9.
+
+- [ ] **Step 2: Run — G8 FAIL** (new in-feed never attaches to the existing stream), G9 skeleton filled and passing only after implementation.
+
+- [ ] **Step 3: Implement.** Constructor: `this._activeStreams = new Map();`. In `replicate`:
+
+```js
+  async replicate(remoteInstanceId, stream) {
+    // 2d C3: track live streams so a rotation can attach the successor feed
+    // to connections that predate the key receipt (hyperswarm ordering hole).
+    let set = this._activeStreams.get(remoteInstanceId);
+    if (!set) { set = new Set(); this._activeStreams.set(remoteInstanceId, set); }
+    if (!set.has(stream)) {
+      set.add(stream);
+      const drop = () => {
+        set.delete(stream);
+        if (set.size === 0) this._activeStreams.delete(remoteInstanceId);
+      };
+      stream.on("close", drop);
+      stream.on("error", () => {}); // never let a tracked stream's error escape
+    }
+    const outFeed = this.outFeeds.get(remoteInstanceId);
+    const inFeed = this.inFeeds.get(remoteInstanceId);
+    if (outFeed) outFeed.replicate(stream, { live: true });
+    if (inFeed) inFeed.replicate(stream, { live: true });
+  }
+```
+
+In the C1 open path, after `this.inFeeds.set(remoteInstanceId, inFeed)`:
+
+```js
+        // 2d C3: attach the successor feed to every live stream for this peer.
+        for (const s of this._activeStreams.get(remoteInstanceId) ?? []) {
+          try { inFeed.replicate(s, { live: true }); } catch (err) {
+            console.warn(`[instance-sync] post-swap stream attach failed for ${remoteInstanceId.slice(0,12)}…: ${err.message}`);
+          }
+        }
+```
+
+In `_closeInstanceFeedsInner` (R2 #2): `this._activeStreams.delete(remoteInstanceId);`
+
+- [ ] **Step 4: Run — PASS. Mutation:** remove the post-swap attach loop → **G8 red**. Also verify (no mutation, just assert in G8) the out-feed replication was not disturbed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/instance-sync.js tests/feed-rotation.test.js -m "feat(sync): track live replication streams and attach rotated in-feeds to them -- closes the hyperswarm key-after-replicate ordering hole (2d C3, gates G8/G9)"
+```
+
+---
+
+### Task 7: F3 — tailnet server passes null pre-exchange; G13 real-WS race gate
+
+**Files:**
+- Modify: `servers/sharing/tailnet-sync.js:238`.
+- Test: `tests/feed-rotation.test.js` (G13 — drives the REAL `setupTailnetSyncServer`).
+
+**Interfaces:**
+- Consumes: `setupTailnetSyncServer(server, ctx)` (exported), `buildHandshakePayload` shape (test re-implements the client handshake with `sign` from `servers/sharing/identity.js`).
+
+- [ ] **Step 1: Failing test** — the test drives the real WS server; the barrier is a wrapped `ctx.db.execute` that parks the server's peer-row SELECT (`:222`) until the "hyperswarm path" lands the new key:
+
+```js
+test("G13: stale-snapshot tailnet handshake cannot swap back a concurrently-received new key", async () => {
+  const fleet = await makeFleet();
+  const http = await import("node:http");
+  const { WebSocket } = await import("ws");
+  const { setupTailnetSyncServer } = await import("../servers/sharing/tailnet-sync.js");
+  const { sign } = await import("../servers/sharing/identity.js");
+  try {
+    const { a, b } = fleet;
+    // B hosts the WS server. Seed B's row for A with the OLD key.
+    const oldLink = await linkPeers(a, b);
+    oldLink.close();
+    const oldKeyHex = a.mgr.getOutFeedKey(b.id).toString("hex");
+    await b.db.execute({ sql: "UPDATE crow_instances SET sync_url = ? WHERE id = ?", args: [oldKeyHex, a.id] });
+    // Barrier: park the server's :222 snapshot SELECT until the new key lands.
+    let releaseLookup; const lookupGate = new Promise((r) => { releaseLookup = r; });
+    let parked = false;
+    const realExec = b.db.execute.bind(b.db);
+    const dbWrapper = { ...b.db, execute: async (q) => {
+      if (!parked && typeof q?.sql === "string" && q.sql.includes("WHERE id = ? AND status IN ('active','offline') LIMIT 1")) {
+        parked = true; await lookupGate;
+      }
+      return realExec(q);
+    }};
+    const server = http.createServer();
+    setupTailnetSyncServer(server, { identity: b.mgr.identity, instanceSyncManager: b.mgr, db: dbWrapper });
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    // Dial as A with a REAL signed handshake.
+    const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}/api/instance-sync/stream`);
+    await new Promise((r) => ws.once("open", r));
+    const nonce = "00".repeat(16);
+    ws.send(JSON.stringify({ instance_id: a.id, nonce_hex: nonce, sig_hex: sign(`${a.id}:${nonce}`, a.mgr.identity.ed25519Priv) }));
+    await until(() => parked); // server is now parked holding the OLD snapshot
+    // Hyperswarm path lands A's rotated key on B.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await b.db.execute({ sql: "UPDATE crow_instances SET sync_url = ? WHERE id = ?", args: [newKey.toString("hex"), a.id] });
+    await b.mgr.initInstance(a.id, newKey);
+    const swappedFeed = b.mgr.inFeeds.get(a.id);
+    releaseLookup(); // server resumes with its stale snapshot → hits :238
+    // Give the handler time to run its init + key-exchange frames.
+    await ws.send(JSON.stringify({ feed_key_hex: newKey.toString("hex") }));
+    await new Promise((r) => setTimeout(r, 300));
+    assert.equal(b.mgr.inFeeds.get(a.id), swappedFeed,
+      "the stale-snapshot :238 init must NOT have swapped the in-feed back (F3)");
+    assert.equal(b.mgr.inFeeds.get(a.id).key.toString("hex"), newKey.toString("hex"));
+    ws.close(); server.close();
+  } finally { await fleet.cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`:238` passes the stale snapshot key → swap-back → feed object differs).
+
+- [ ] **Step 3: Implement** — `tailnet-sync.js:238`:
+
+```js
+  // 2d F3: pass NO key here. This call's only job is arming the out-feed for
+  // getOutFeedKey below. Passing the :222 snapshot's sync_url was harmless
+  // when a mismatched key no-oped, but under key-aware initInstance a stale
+  // snapshot would swap a concurrently-rotated in-feed BACK to its dead key.
+  // The authenticated receipt at the feed-key exchange below drives any swap.
+  await instanceSyncManager.initInstance(remoteInstanceId, null);
+```
+
+- [ ] **Step 4: Run — PASS. Mutation:** restore the snapshot-key argument at `:238` → **G13 red**.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/tailnet-sync.js tests/feed-rotation.test.js -m "fix(sharing): tailnet server pre-exchange init passes no key -- stale row snapshot can no longer swap a rotated in-feed back (2d F3, gate G13)"
+```
+
+---
+
+### Task 8: C4 — 60s heal loop in refresh()
+
+**Files:**
+- Modify: `servers/sharing/tailnet-sync.js:503-535` (`refresh()` inside `startTailnetSyncClients`).
+- Test: `tests/feed-rotation.test.js` (C4 unit).
+
+**Interfaces:**
+- Consumes: `startTailnetSyncClients(ctx)` (exported; returns `{ dialers, stop }`).
+
+- [ ] **Step 1: Failing test**
+
+```js
+test("C4: refresh heals sync_url drift for ALREADY-DIALING peers and survives initInstance throws", async () => {
+  const calls = [];
+  const stubMgr = {
+    localInstanceId: "me",
+    initInstance: async (id, key) => {
+      calls.push([id, key ? key.toString("hex") : null]);
+      if (calls.length === 1) throw new Error("boom"); // first tick throws
+    },
+  };
+  const peerRow = { id: "peer1", gateway_url: "http://127.0.0.1:1", tailscale_ip: null, sync_url: "ab".repeat(32), status: "active" };
+  const stubDb = { execute: async () => ({ rows: [peerRow] }) };
+  const { startTailnetSyncClients } = await import("../servers/sharing/tailnet-sync.js");
+  const clients = await startTailnetSyncClients({ db: stubDb, instanceSyncManager: stubMgr, identity: {} });
+  try {
+    // First refresh already ran inside startTailnetSyncClients: the throw must
+    // not have escaped (this test completing IS the assertion), and the call
+    // must have carried the persisted key.
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], ["peer1", "ab".repeat(32)]);
+    assert.ok(clients.dialers.has("peer1"), "dialer was still created after the throw");
+    // Second refresh: peer is ALREADY dialing — the heal call must still fire
+    // (placed BEFORE the dialers.has() continue; R3 F-C).
+    peerRow.sync_url = "cd".repeat(32);
+    await clients.__refreshForTest();
+    assert.deepEqual(calls[1], ["peer1", "cd".repeat(32)], "already-dialing peer still healed");
+  } finally { clients.stop(); }
+});
+```
+
+- [ ] **Step 2: Run — FAIL** (no heal call; no `__refreshForTest`).
+
+- [ ] **Step 3: Implement.** In `refresh()`'s peer loop, immediately after `seenIds.add(peer.id)` and BEFORE `if (!peer.gateway_url) continue;` / `if (dialers.has(peer.id))` (R3 F-C — after the continue it never heals the steady state):
+
+```js
+      // 2d C4: converge the in-feed with the persisted sync_url every rescan —
+      // heals manual crow_update_instance edits and any missed key exchange
+      // within 60s, no restart. Cheap fast-path (Map lookup + Buffer compare)
+      // when nothing changed. Own try/catch: refresh runs on a bare
+      // setInterval and an escaped rejection would crash the gateway (no
+      // unhandledRejection handler exists in servers/).
+      try {
+        const keyBuf = peer.sync_url ? instanceSyncManager.validateIncomingFeedKey?.(peer.id, peer.sync_url) ?? null : null;
+        await instanceSyncManager.initInstance(peer.id, keyBuf);
+      } catch (err) {
+        console.warn(`[tailnet-sync] refresh heal for ${peer.id.slice(0,12)}…: ${err.message}`);
+      }
+```
+
+Expose the test hook on the return object: `return { dialers, __refreshForTest: refresh, stop() {...} };`
+Note: `validateIncomingFeedKey` (optional-chained for stub managers) also screens a hand-edited malformed `sync_url` here.
+
+- [ ] **Step 4: Run — PASS. Mutations:** move the heal call below the `dialers.has() continue` → **C4 test red** (second call missing); remove its try/catch → **C4 test red** (throw escapes the first refresh).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/tailnet-sync.js tests/feed-rotation.test.js -m "feat(sharing): 60s refresh converges in-feeds with persisted sync_url -- heals manual edits and missed exchanges live, throw-isolated (2d C4)"
+```
+
+---
+
+### Task 9: C5 — backfill-flag premise reset at boot
+
+**Files:**
+- Modify: `servers/sharing/instance-sync.js` — new `resetBackfillPremiseFlags()`.
+- Modify: `servers/gateway/boot/mcp-mounts.js` — call it right after the `eagerInitPairedPeers` try-block (`:66`) and before the settings/contacts/groups/providers once-backfills.
+- Test: `tests/feed-rotation.test.js` (G10).
+
+**Interfaces:**
+- Produces: `resetBackfillPremiseFlags()` → number of flags cleared. Reads `this.outFeeds`; deletes `__providers_backfill_v1:<peerId>` per empty-out-feed peer; deletes the three global flags (`__contacts_backfill_v1`, `__sync_reemit_allowlist_v2`, `__groups_backfill_v1`) if ANY armed out-feed is empty.
+
+- [ ] **Step 1: Failing test**
+
+```js
+test("G10: empty armed out-feed clears premise flags BEFORE the once-backfills; non-empty leaves them", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    await a.mgr.initInstance(b.id, null); // armed, length 0 (fresh = post-rotation shape)
+    const setFlag = (k, v) => a.db.execute({ sql: "INSERT OR REPLACE INTO dashboard_settings (key, value) VALUES (?, ?)", args: [k, v] });
+    await setFlag("__contacts_backfill_v1", "done:5");
+    await setFlag("__sync_reemit_allowlist_v2", "done:9");
+    await setFlag("__groups_backfill_v1", "done:2");
+    await setFlag(`__providers_backfill_v1:${b.id}`, "done:3");
+    const cleared = await a.mgr.resetBackfillPremiseFlags();
+    assert.equal(cleared, 4, "three globals + one per-peer flag cleared");
+    const read = async (k) => (await a.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [k] })).rows[0]?.value;
+    assert.equal(await read("__contacts_backfill_v1"), undefined);
+    assert.equal(await read(`__providers_backfill_v1:${b.id}`), undefined);
+    // Ordering semantics (G10 mutation target): flags cleared → the once-backfill
+    // re-runs in the same sequence. reemitSyncableSettingsOnce with the flag
+    // GONE returns >= 0 and re-stamps done:, proving it executed its body.
+    await setFlag("sync.allowlisted.example", "x"); // ensure at least a no-op run completes
+    await a.mgr.reemitSyncableSettingsOnce();
+    assert.match(String(await read("__sync_reemit_allowlist_v2")), /^done:/, "backfill re-ran this boot");
+    // Negative control: non-empty out-feed → flags untouched.
+    await a.mgr.emitChange("memories", "insert", { id: "g10", content: "x", lamport_ts: null });
+    await setFlag("__contacts_backfill_v1", "done:5");
+    assert.equal(await a.mgr.resetBackfillPremiseFlags(), 0, "non-empty feed: nothing cleared");
+    assert.equal(await read("__contacts_backfill_v1"), "done:5");
+  } finally { await fleet.cleanup(); }
+});
+```
+
+- [ ] **Step 2: Run — FAIL** (method missing).
+
+- [ ] **Step 3: Implement** in `instance-sync.js`:
+
+```js
+  /**
+   * 2d C5 (D4): a length-0 armed out-feed means the once-backfill flags'
+   * premise ("peers already received this") died with the feed — rotation,
+   * or a brand-new pairing (desirable re-run either way; a never-emitted-to
+   * peer re-triggers this each boot until a first emit lands — accepted,
+   * re-runs are preserve-mode + deduped no-ops). MUST run between
+   * eagerInitPairedPeers and the once-backfill calls (mcp-mounts ordering,
+   * R1 F4). Returns the number of flags cleared.
+   */
+  async resetBackfillPremiseFlags() {
+    if (this.feedsDisabled || this.outFeeds.size === 0) return 0;
+    const emptyPeers = [...this.outFeeds.entries()]
+      .filter(([, feed]) => feed.length === 0)
+      .map(([peerId]) => peerId);
+    if (emptyPeers.length === 0) return 0;
+    let cleared = 0;
+    const del = async (key) => {
+      try {
+        const r = await this.db.execute({ sql: "DELETE FROM dashboard_settings WHERE key = ? AND value LIKE 'done:%'", args: [key] });
+        if ((r.rowsAffected ?? 0) > 0) cleared++;
+      } catch (err) { console.warn(`[instance-sync] flag reset ${key}: ${err.message}`); }
+    };
+    for (const peerId of emptyPeers) await del(`__providers_backfill_v1:${peerId}`);
+    for (const key of ["__contacts_backfill_v1", "__sync_reemit_allowlist_v2", "__groups_backfill_v1"]) await del(key);
+    if (cleared > 0) {
+      console.warn(`[instance-sync] C5: ${cleared} backfill premise flag(s) reset — empty out-feed(s) for ${emptyPeers.map((p) => p.slice(0, 12)).join(", ")}; once-backfills will re-run this boot`);
+    }
+    return cleared;
+  }
+```
+
+In `mcp-mounts.js`, directly after the `eagerInitPairedPeers` try-block:
+
+```js
+  // 2d C5: reset once-backfill flags whose premise died with a lost out-feed
+  // (rotation / restore-from-backup). MUST run BEFORE the once-backfills
+  // below so they re-run this same boot (spec §3 C5 / R1 F4 ordering).
+  try {
+    if (syncManager?.resetBackfillPremiseFlags) {
+      await syncManager.resetBackfillPremiseFlags();
+    }
+  } catch (err) {
+    console.warn(`[instance-sync] resetBackfillPremiseFlags failed: ${err.message}`);
+  }
+```
+
+- [ ] **Step 4: Run — PASS. Mutations:** remove the `length === 0` premise check (always clear) → **G10 red** (negative control); remove the per-peer providers deletion → **G10 red** (cleared-count 4 → 3); simulate wrong ordering by calling `reemitSyncableSettingsOnce` BEFORE `resetBackfillPremiseFlags` in the test's sequence → the `done:` re-stamp assertion documents why mcp-mounts order matters (keep as a comment, the mcp-mounts wiring itself is review-pinned).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit servers/sharing/instance-sync.js servers/gateway/boot/mcp-mounts.js tests/feed-rotation.test.js -m "feat(sync): reset once-backfill premise flags when an armed out-feed is empty -- rotated instances repopulate peers this same boot (2d C5, gate G10)"
+```
+
+---
+
+### Task 10: Integration closers — G2, G3 (MUTUAL), G7 + full verification
+
+**Files:**
+- Test: `tests/feed-rotation.test.js` (G2, G3, G7).
+
+- [ ] **Step 1: Write the three remaining gate cases**
+
+```js
+test("G2: rotation resets the mark -- fresh feed seqs 0..2 all apply despite an old high mark", async () => {
+  // G1 shape, but before delivering the new key, force B's record to {k: old, s: 40}
+  // via _setLastAppliedSeq(a.id, 40, oldKeyHex). After swap + relink, emit 3 rows on A
+  // and assert all 3 applied on B (the mark followed the feed, not the peer).
+});
+
+test("G3 MUTUAL: both sides rotate simultaneously -- both swap, both directions converge, conflicts flat", async () => {
+  // Rotate BOTH sides' out-feeds (close + rm out dirs + re-init on each), exchange the
+  // two new keys via initInstance on each side concurrently (Promise.all), relink,
+  // then emit one row from EACH side and assert both apply on the opposite side.
+  // Assert sync_conflicts unchanged on both DBs. (2a lesson: the mutual case is
+  // where convergence designs die — this case is mandatory.)
+});
+
+test("G7: replay safety at seq 0 -- insert-then-delete converges deleted; newer local row survives older replayed entry", async () => {
+  // On the rotated fresh feed: A emits insert then delete for one id → B ends without
+  // the row. Second half: B holds a row with a HIGH lamport (insert directly + set
+  // lamport via _advanceCounter pattern from lamport-reemit.test.js); A's replayed
+  // older update for that id must NOT overwrite it (LWW gate holds at reset-replay).
+});
+```
+
+Implement each fully (the comments above are the recipe; every assertion concrete, `until()`-based).
+
+- [ ] **Step 2: Run the whole gate file** — all G-cases green.
+
+- [ ] **Step 3: Full verification (record ALL outputs in the ledger):**
+
+```bash
+fuser ~/.crow/data/crow.db   # confirm only the systemd gateways hold prod
+T=$(mktemp -d); CROW_HOME=$T CROW_DATA_DIR=$T/data CROW_DISABLE_NOSTR=1 CROW_DISABLE_INSTANCE_SYNC=1 node --test tests/*.test.js
+# Expected: 1953+N pass / 2 known fails (bundles-validate-install) / 0 skips
+node scripts/check-port-allocation.js   # green iff EXACTLY one error line: Port 8090 (capstone-tracker)
+node scripts/build-registry.mjs --check
+node servers/gateway/index.js --no-auth # boots clean, ctrl-C
+```
+
+- [ ] **Step 4: Full mutation matrix** — re-run every mutation from Tasks 2-9 in one recorded pass (guard → named red test → restore → green). Paste the matrix into the PR body.
+
+- [ ] **Step 5: Commit any stragglers, then hand off to the ship pipeline below.**
+
+```bash
+git commit tests/feed-rotation.test.js -m "test(sync): 2d gate complete -- G2 mark-follows-feed, G3 mutual rotation, G7 replay safety (mutation matrix recorded)"
+```
+
+---
+
+## Ship pipeline (after Task 10 — session workflow, not TDD tasks)
+
+1. **Whole-branch adversarial review** — fresh Opus subagent over the full branch diff; verdict must be READY TO MERGE (fix + re-review otherwise). It must check the spec's §11 R3 mandatory fixes (F-A `.finally`, F-B revoke-clears-defer, F-C heal-before-continue) landed.
+2. **PR** via GitHub MCP (repo `kh0pper/crow`), title `feat(sync): live in-feed key rotation + feed-keyed applied-seq (Item 2d)`; body: spec link, defect table, gate table + mutation matrix, no-schema-bump note. `git pull --rebase --autostash` before push.
+3. **Merge** after local gates (check-runs `total_count: 0` is normal). **No migration rail needed** (no schema bump) — auto-update may stay ON.
+4. **Deploy fleet** in runbook order: crow (`systemctl restart crow-gateway crow-mpa-gateway` via askpass helper) → grackle (bridge THEN gateway; check `grackle "curl -s localhost:3002/health"`) → black-swan (`~/.crow/app`, wait ~75s). Watch grackle's boot for the 2c wedge class — the C1 cap must never let boot hang.
+5. **Live rotation proof** (spec §9): baselines → stop grackle gateway → move `~/.crow/data/instance-sync/<crow-peer-id>/out` aside (KEEP it) → start → on crow WITHOUT restart: journal shows `in-feed ROTATED`, sync_url updated, throwaway grackle row converges, `getSyncStatus` advancing from 0, conflicts flat ×4 (219/182/162/0), MPA untouched; grackle's C5 log line + repopulated out-feed. **Deadman:** the stop window carries a detached watchdog that restarts grackle's gateway after 10 minutes regardless (unattended-window rule — write it BEFORE stopping, `at`/`systemd-run` style, remove after).
+6. **Soak** (health ×4, integrity ×4, conflicts vs baseline, stash 4/17, auto-update true ×4, zero new err classes; known-benign: nostr NOTICE lines, grackle stale-bswan handshake spam ~1/min).
+7. **Post-item CDP bug-hunt round** (`~/.crow/p4/bughunt-item5/{cdp,checks,round}.mjs` — mint session into its sess-prod file, REVOKE after).
+8. **Record**: ledger append; update the plan doc §4 Item 2d block; write/refresh the arc memory file.
+
+## Self-review notes (done at write time)
+
+- Spec coverage: C1→T4, C2→T2+T3, C3→T6, C4→T8, C5→T9, F3→T7, validation→T5, G1-G13 all placed, F6 migration→T2, R3 F-A/F-B→T4, F-C→T8, F-D→T4 catch, F-E→T5 client wiring, F-F→T2 reader, F-G→T4/T7 seams. Live plan §9→ship step 5.
+- The `_rotationCloseCapMs` test knob is new here (not in the spec) — it changes nothing semantically (default 5000) and keeps G6 fast; note it in the PR.
+- Type consistency: `_setLastAppliedSeq(id, seq, feedKeyHex:string|null)`, `_getLastAppliedSeq(id, feed:{key:Buffer}|null)`, `validateIncomingFeedKey(id, hex)→Buffer|null`, `resetBackfillPremiseFlags()→number` — used identically across tasks.
+- G13's db wrapper spreads `b.db` — if the db client's methods live on a prototype, replace the spread with a Proxy delegating everything except `execute` (implementer note).

--- a/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
+++ b/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
@@ -1,9 +1,10 @@
 # Item 2d — In-feed key rotation: live swap + applied-seq integrity
 
-**Date:** 2026-07-15 · **Status:** DRAFT (rev 1, pre-review) · **Author:** autonomous arc session
+**Date:** 2026-07-15 · **Status:** rev 2 (R1 findings folded; awaiting round-2 review) · **Author:** autonomous arc session
 **Plan doc:** `docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md` §4 Item 2d
 **Prereq reading:** the 2a six-bug lesson (executable/multi-instance/mutual gates) and the 2c
 boot-liveness lesson (no unbounded boot awaits) — both shaped this design.
+**Review record:** §11.
 
 ## 0. TL;DR
 
@@ -13,7 +14,9 @@ in-feed** — replication in that direction is silently dead until restart; and 
 restart, keeps the **old feed's applied-seq high-water mark**, so every entry of the new feed
 below that mark is **silently skipped forever**. This spec fixes both: a key-aware
 `initInstance` that swaps the in-feed live (bounded, boot-safe), and an applied-seq record
-that is keyed to the feed it was earned on.
+that is keyed to the feed it was earned on — with the key **stamped by the feed being
+processed** and the legacy/reset decision **frozen at feed-open time** (both R1 CRITICAL
+fixes; §11).
 
 No schema bump (the applied-seq store is an existing JSON TEXT column). No new transport or
 trust surface.
@@ -87,9 +90,11 @@ Live state note: crow's blob today is legacy-numeric — `{"49cf…": 2412, "520
 
 ## 3. Design
 
-All changes live in `servers/sharing/instance-sync.js` plus one line-level touch each in
-`tailnet-sync.js` (C4) and none elsewhere. Detection points are untouched — they already
-call `initInstance` with the new key; the fix makes that call honest.
+Changes live in `servers/sharing/instance-sync.js`, plus **two** line-level touches in
+`tailnet-sync.js` (C4's refresh call, and the R1-F3 fix at `:238` — see C1) and one
+insertion point in `servers/gateway/boot/mcp-mounts.js` (C5 ordering). Detection points are
+otherwise untouched — they already call `initInstance` with the new key; the fix makes that
+call honest.
 
 ### C1 — Key-aware in-feed open/swap (fixes D1)
 
@@ -98,35 +103,57 @@ In `_initInstanceInner`, replace the in-feed guard with key-aware logic:
 ```
 const current = this.inFeeds.get(remoteInstanceId);
 if (current && theirFeedKey && !current.key.equals(theirFeedKey)) {
-  // ROTATION: bounded close, then open the new core in the same dir.
-  this.inFeeds.delete(remoteInstanceId);          // unmap first — no new reads route to it
+  // ROTATION: detach, unmap, bounded close, then open the new core in the same dir.
+  current.removeListener("append", <its handler>);   // stop new processing runs (R1 F8)
+  this.inFeeds.delete(remoteInstanceId);             // entry-bail kills queued runs (R1 F1)
   const closed = await boundedClose(current, 5_000); // Promise.race close vs cap
   if (!closed) {
     // rocksdb lock still held by the zombie session — same-dir open would throw.
     // Defer: loud log; sync_url is already persisted, so the next boot heals
-    // (multi-core store + C2 seq reset). Do NOT hang the _initLocks chain.
+    // (multi-core store + C2 open-time reconcile). Do NOT hang the _initLocks chain.
     console.error(`[instance-sync] ROTATION DEFERRED for ${id}: old in-feed close timed out; restart will complete it`);
     return this.outFeeds.get(remoteInstanceId);
   }
-  await this._resetAppliedSeqForKey(remoteInstanceId, theirFeedKey); // C2, s=0
   console.warn(`[instance-sync] in-feed ROTATED for ${id}: ${oldKey8}… → ${newKey8}…`);
 }
 if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey) {
-  … existing open path, PLUS: reconcile C2 record (if stored k ≠ this key → reset s=0),
-  PLUS: attach to tracked live streams (C3) …
+  … open new Hypercore(dir, theirFeedKey) …
+  await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);  // C2 — ALWAYS, every open
+  … wire append listener (handler kept referenceable for removeListener) …
+  … attach to tracked live streams (C3) …
+  this.inFeeds.set(remoteInstanceId, inFeed);
 }
 ```
 
 Properties:
 - Runs inside the existing `_initLocks` per-peer chain — no concurrent-swap races, and
-  close cannot interleave with another `initInstance` (same serialization
-  `closeInstanceFeeds` already relies on).
+  close cannot interleave with another `initInstance` (the serialization
+  `closeInstanceFeeds` already relies on). Coordination with the **separate**
+  `_processLocks` chain is NOT by locking — it is by the C2 stamping rules (see C2's
+  interleave analysis), the listener removal, and `_processNewEntriesInner`'s
+  feed-identity bail. This trio was R1 finding F1; the convergence argument is §3.1.
 - **Bounded** (2c lesson): the only await added to a boot-reachable path is the 5s-capped
-  close. A hung close (the real grackle incident class) degrades to today's behavior
-  (stale until restart) with a loud, greppable log line — never a boot hang.
-- Key validation: `theirFeedKey` must be exactly 32 bytes (`feed_key_hex` = 64 hex chars)
-  at all three receipt points' entry into `initInstance`; malformed keys are logged and
-  ignored (today they'd flow into `Buffer.from(hex,"hex")` unchecked).
+  close. A hung close (the real grackle incident class) degrades to today's dataflow
+  (that direction receives nothing) with a loud, greppable log line — never a boot hang.
+  The abandoned close promise's eventual resolution touches only the already-unmapped
+  feed object (no Map access, no double-close hazard: `closeInstanceFeeds` tolerates
+  closed feeds, and the swap already deleted the entry).
+- Key validation at all three receipt points' entry into `initInstance`: exactly 32 bytes
+  (64 hex chars), and **not equal to our own out-feed key for that peer** (a peer echoing
+  our key back would otherwise make us re-apply our own history — R1 F7; entries verify
+  against the *shared* identity so they would apply). Malformed/self keys are logged and
+  ignored.
+- **R1 F3 fix — the tailnet server's pre-exchange init no longer passes a key:**
+  `tailnet-sync.js:238` becomes `initInstance(remoteInstanceId, null)`. That call's only
+  job is arming the out-feed for `getOutFeedKey` (`:239`); passing the *snapshot*
+  `peerRow.sync_url` read at `:222` was harmless under D1 but becomes a
+  swap-back-to-stale-key vector once C1 is destructive (hyperswarm updates the key
+  mid-handshake → the stale snapshot swaps it back → re-swap forward: thrash + double
+  reset). The authenticated receipt at `:249-255` remains the swap driver. The tailnet
+  *client* (`:435`) keeps passing its received key — that value is the fresh
+  authenticated exchange, not a snapshot (its init-before-persist ordering is therefore
+  safe). Boot/eager/refresh paths pass the persisted `sync_url`, which is authoritative
+  at rest.
 - The unmap-before-close ordering means `replicate()`/`getSyncStatus` see either the old
   feed (pre-swap) or the new one (post-swap), never a closing zombie.
 - The rotated old core is left in the store (acceptance: blocks readable). GC is an
@@ -138,27 +165,62 @@ Properties:
 `{"k": "<feedKeyHex>", "s": 2412}`. This is a JSON-blob format evolution inside an existing
 TEXT column — **no schema generation bump, no migration rail**.
 
-- `_setLastAppliedSeq(peerId, seq)` gains the current in-feed's key and always writes the
-  new format.
-- `_getLastAppliedSeq(peerId)` becomes `_getLastAppliedSeq(peerId, feed)`:
-  - New-format value: `k === feed.key.hex` → return `s`; `k ≠ feed.key.hex` → the record
-    belongs to a dead feed → return 0 (and the next set overwrites `k`).
-  - Display-only callers without a feed handle (`getSyncStatus` when the in-feed is not
-    open) pass `feed = null` and get the raw `s` back — a cosmetic counter, never used
-    to gate application.
-  - **Legacy numeric `n`:** if `n > feed.length` the mark is *provably foreign* (a mark
-    earned on feed F always satisfies `mark ≤ F.length`) → return 0. Otherwise trust it
-    (`return n`) — it is *plausibly* this feed's mark, and replaying a long-lived feed
-    from 0 is NOT safe (see below). First subsequent write upgrades the format.
-- **Why not replay legacy feeds from 0 to heal past skips:** replaying a long-established
-  feed re-applies old `insert` entries for rows that were later deleted *locally with no
-  tombstone table* (`memories`, `research_notes`, …) → resurrection. The seq mechanism is
-  what protects that class today. Fresh (rotated) feeds carry only post-rotation history,
-  so reset-to-0 on an actual key change replays nothing stale. Consequence stated
-  honestly: entries already skipped by D2 *in the past* are unrecoverable for
-  non-re-emitted tables; 2c's boot re-emits heal contacts/settings/groups/tombstones over
-  subsequent boots. (Fleet check found no currently-broken peer: crow↔grackle↔MPA marks
-  are all plausible for their live feeds.)
+**Writers.** `_setLastAppliedSeq(peerId, seq, feedKeyHex)` — the key is **threaded from the
+feed being processed** (`_processNewEntriesInner` is the sole production caller, `:1418`),
+NEVER read from "the current in-feed" (R1 F1: a stale processing run bound to the old feed
+object must stamp the OLD key, so key-gated readers ignore it). The existing suite's direct
+callers (`tests/instance-sync.test.js:288-293` etc.) are migrated to pass a key (R1 F6).
+
+**Readers.** `_getLastAppliedSeq(peerId, feed)`:
+- record `k === feed.key.hex` → return `s`; `k ≠ feed.key.hex` → foreign record → return 0.
+- Display-only callers without a feed handle (`getSyncStatus` when the in-feed is not open)
+  pass `feed = null` and get the raw `s` back — cosmetic, never gates application.
+- A legacy numeric reaching a *processing* read is impossible after the open-time
+  reconcile below; if seen (defensive), treat as foreign → 0.
+
+**Open-time reconcile — the decision is frozen once, at feed open (R1 F2).**
+`_reconcileAppliedSeqAtOpen(peerId, feed)` runs on EVERY in-feed open (boot, eager,
+rotation, un-revoke), inside the `_initLocks` chain, before the append listener is wired:
+- record is `{k,s}` with `k === feed.key.hex` → keep (normal restart).
+- record is `{k,s}` with `k ≠ feed.key.hex` → rotated → write `{k: feed.key.hex, s: 0}`.
+- record is legacy numeric `n`: compare against `feed.length` **at open** — a mark earned
+  on feed F always satisfies `n ≤ F.length` (checkpoints write at most `seq+1 = length`,
+  `:1408-1418`), and a rotated fresh core has `length 0` at open, before any replication
+  can grow it (the listener isn't wired yet and `_processNewEntries` bails on unmapped
+  feeds). `n > length` → provably foreign → `{k, s: 0}`; `n ≤ length` → plausibly this
+  feed's → `{k, s: n}`. Either way the record is now new-format — the decision is **never
+  re-derived against a growing length** (R1 F2's burst-crossing hole: a lazily-evaluated
+  rule flips from reset to trust once a backlog batch pushes `length ≥ n` before the
+  first checkpoint).
+- residual, stated honestly: a peer that rotated *long before this code deploys*, whose
+  fresh feed already regrew past the stale mark, is indistinguishable from a healthy feed
+  (`n ≤ length`) — the pre-deploy gap is unrecoverable (§4.4). Post-deploy rotations
+  always hit the `length 0 < n` or `k ≠` branches and are exact.
+
+**Why not replay legacy feeds from 0 to heal past skips:** replaying a long-established
+feed re-applies old `insert` entries for rows later deleted *locally with no tombstone
+table* (`memories`, `research_notes`, …) → resurrection. Fresh (rotated) feeds carry only
+post-rotation history, so reset-to-0 on an actual key change replays nothing stale.
+2c's boot re-emits heal contacts/settings/groups/tombstones across boots; that class is
+covered regardless.
+
+#### 3.1 Interleave analysis (the F1 scenario, post-fix)
+
+An in-flight `_processNewEntriesInner` bound to the OLD feed across a swap:
+- Started pre-swap: it read its start seq under the old record (old key match) — it
+  continues applying *old-feed* entries (legitimately emitted pre-rotation; signature-valid,
+  LWW-gated, idempotent) and stamps `{k: old, s}`. If it stamps AFTER the swap's reset, the
+  record's `k` flips to `old` — but every new-feed read is key-gated (`k ≠ new` → 0), so
+  the worst case is the new feed re-processing entries `0..m` it already applied: a fresh
+  rotated feed replayed from 0 is safe (post-rotation history only; LWW + conflict-dedupe
+  make re-application convergent), and the first new-feed checkpoint rewrites `{k: new}`.
+  Convergent under every interleaving; no divergence, bounded waste.
+- Started post-swap (queued): `_processNewEntriesInner` **bails at entry** when
+  `this.inFeeds.get(id) !== feed` (the swap deleted/replaced the entry) — no old-feed
+  replay-from-0 (which WOULD have been the resurrection hazard), no stamp.
+- Mid-loop after close: `feed.get` on the closed feed throws per entry; the loop's
+  poison-skip advances. A per-iteration `inFeeds.get(id) !== feed` bail is added to cut
+  that churn short (correctness does not depend on it).
 
 ### C3 — Live-stream attach after swap
 
@@ -170,7 +232,9 @@ tracked live stream. This closes the Hyperswarm ordering hole: `onInstanceConnec
 triggering connection would otherwise carry only the dead core. (On the tailnet paths the
 key exchange strictly precedes `replicate()`, so the triggering connection there picks up
 the new feed naturally.) Multiplexing an additional core onto an already-active stream is
-standard hypercore protomux behavior; the gate proves it with real streams (G8).
+standard hypercore protomux behavior — but the load-bearing case is attaching **after the
+old core (which was replicating on that same stream) was just closed**; the gate exercises
+exactly that precondition (G8, tightened per R1 F5).
 
 ### C4 — 60s convergence loop (fixes D3, belt-and-suspenders for everything)
 
@@ -179,19 +243,31 @@ each peer's row. Add: `instanceSyncManager.initInstance(peer.id, syncUrlKeyOrNul
 refreshed peer. With C1's key-equality fast path this is a Map lookup + Buffer compare per
 minute per peer when nothing changed; when `sync_url` changed by any means (manual tool
 edit, missed exchange), the swap converges within 60s with no restart. Not a boot-path
-call (interval only).
+call (interval only). Passing `null` (peer with no stored key) never closes or swaps
+anything (verified: the swap branch requires `theirFeedKey`).
 
 ### C5 — Backfill-flag premise reset (fixes D4)
 
-At boot, after `eagerInitPairedPeers` arms feeds: if any armed out-feed with a paired row
-has `length === 0` while `__contacts_backfill_v1` / `__sync_reemit_allowlist_v2` read
-`done:` — the flags' premise ("peers have received this") died with the feed — clear both
-flags so the once-backfills re-run this boot. Post-2c this is safe by construction:
-re-emits are preserve-mode (no lamport fabrication), redelivery-noise-skipped on the
-receiving side, and conflict-deduped. Side effect: a brand-new pairing (also a length-0
-out-feed) triggers the same re-run — desirable (the new peer needs the backfill; existing
-peers no-op it). Separable if review judges it scope creep, but without it a real rotation
-leaves the peer permanently missing whatever the once-backfills cover.
+At boot, **between** `eagerInitPairedPeers` and the once-backfill calls — concretely in
+`servers/gateway/boot/mcp-mounts.js` after `:62` and before `reemitSyncableSettingsOnce`
+(`:110`) / `backfillContactsOnce` (`:122`), the ordering R1 F4 requires — check: if any
+armed out-feed with a paired row has `length === 0` while `__contacts_backfill_v1` /
+`__sync_reemit_allowlist_v2` read `done:`, the flags' premise ("peers have received this")
+died with the feed → clear both flags so the once-backfills re-run **this same boot**.
+Post-2c this is safe by construction: re-emits are preserve-mode (no lamport fabrication),
+redelivery-noise-skipped on the receiving side, and conflict-deduped.
+
+Two accepted side effects, stated plainly:
+- A brand-new pairing (also a length-0 out-feed) triggers a re-run — desirable (the new
+  peer needs the backfill; existing peers no-op it).
+- A paired peer to whom nothing syncable was ever emitted keeps a length-0 out-feed with
+  no rotation → the flags clear and the backfills re-run **every boot** until a first
+  emit lands (R1 F9). Harmless (each re-run is a no-op wire-wise for peers that have the
+  data, and the flags are global) but not zero-cost; accepted for simplicity and noted
+  in the re-run log line.
+
+Separable if round-2 review judges it scope creep, but without it a real rotation leaves
+the peer permanently missing whatever the once-backfills cover.
 
 ## 4. Alternatives considered and rejected
 
@@ -207,14 +283,20 @@ leaves the peer permanently missing whatever the once-backfills cover.
    defer the swap. Robust against the hung-close case, but adds dir-resolution state that
    must stay consistent across restarts (which dir serves which key), a probe-open on
    every boot, and a restart-divergence trap (boot opening the legacy dir would silently
-   create an empty twin of a sibling-dir core). The hung-close case is rare (one incident; its known
-   instance — the contact-teardown chain — was bounded by PR #195, though hypercore close
-   in general remains unbounded) and its degraded mode here equals today's dataflow (that
-   direction receives nothing) plus a complete restart heal. Simplicity wins (the 2a six-bug lesson cuts both
-   ways: every mechanism added is a bug surface). Rejected.
+   create an empty twin of a sibling-dir core). The hung-close case is rare (one incident;
+   its known instance — the contact-teardown chain — was bounded by PR #195, though
+   hypercore close in general remains unbounded) and its degraded mode here equals today's
+   dataflow (that direction receives nothing) plus a complete restart heal. Simplicity
+   wins (the 2a six-bug lesson cuts both ways: every mechanism added is a bug surface).
+   Rejected.
 4. **Replay legacy feeds from seq 0 to heal past D2 skips.** Resurrection hazard for
    deleted rows in tables without tombstones (§3 C2). Rejected — with the residual loss
    stated honestly.
+5. **Cross-chain locking (`_initLocks` ↔ `_processLocks`) to serialize swap vs processing.**
+   Considered for R1 F1; rejected in favor of feed-keyed stamping + feed-identity bails
+   (§3.1) — a lock spanning both chains would put `_applyEntry`'s DB awaits inside the
+   boot-reachable `_initLocks` chain, recreating the 2c boot-liveness hazard the bounded
+   close exists to avoid.
 
 ## 5. Security / trust model (unchanged)
 
@@ -225,22 +307,25 @@ is trusted. The frames ride channels authenticated by the shared instance identi
 Noise-wrapped; Hyperswarm conns are NoiseSecretStreams). The frame itself is not
 independently signed — same as today; an attacker who can forge it holds the shared
 identity key and has full sync authority anyway. Net new hardening: 32-byte key
-validation (C1) where today malformed hex flows unchecked into `Buffer.from`.
+validation and self-key rejection (C1) where today malformed hex flows unchecked into
+`Buffer.from` and an echoed own-key would open a self-applying in-feed.
 
 Rollback/thrash: swaps fire only on key *difference*, serialized per peer via
-`_initLocks`; each connection delivers its key once at handshake; a re-rotation back to a
-previously-seen key is just another swap (seq record follows `k`). No hot loop exists
-(C4 is 1/min and fast-paths on equality).
+`_initLocks`; each connection delivers its key once at handshake; the one stale-snapshot
+init that could thrash (tailnet server `:238`) is defanged by passing null (C1/R1 F3); a
+re-rotation back to a previously-seen key is just another swap (seq record follows `k`).
+No hot loop exists (C4 is 1/min and fast-paths on equality).
 
 ## 6. Boot-liveness analysis (2c lesson applied)
 
 New awaits reachable from boot (`eagerInitPairedPeers` → `initInstance`): exactly one —
 the 5s-capped old-feed close, only on the rotation path, only when a key actually changed
-across a restart boundary (rare). The defer branch returns immediately. C3's
-`.replicate()` is synchronous setup on an existing stream. C4 is interval-only. C5 runs
-after feed-arm in the existing boot sequence and adds two flag reads/writes (local SQLite).
-Gate rows G6/G6b make the hung-close case explicit (the 2c G11/G12 precedent: harness
-stubs must not be allowed to hide a hang class).
+across a restart boundary (rare). The defer branch returns immediately. The open-time
+reconcile (C2) is one local SQLite read + write. C3's `.replicate()` is synchronous setup
+on an existing stream. C4 is interval-only. C5 runs between existing boot steps and adds
+two flag reads/writes (local SQLite). No cross-chain lock exists (§4.5). Gate rows G6/G6b
+make the hung-close case explicit (the 2c G11/G12 precedent: harness stubs must not be
+allowed to hide a hang class).
 
 ## 7. Executable gate — `tests/feed-rotation.test.js`
 
@@ -253,27 +338,35 @@ defects; that blindness is exactly what let D1/D2 ship).
 | # | Case | Mutation check (guard → named red test) |
 |---|------|------------------------------------------|
 | G1 | Live rotation, single actor: A rotates (out storage wiped, re-init mints new key), key delivered to B live, B swaps without restart, A's new emit applies on B, `sync_conflicts` flat | Remove C1 key-compare → G1 red (entry never applies) |
-| G2 | Seq reset on rotation: B held `{k: old, s: 40}`; fresh feed's seq 0..2 all apply | Remove `_resetAppliedSeqForKey` → G2 red |
+| G2 | Seq reset on rotation: B held `{k: old, s: 40}`; fresh feed's seq 0..2 all apply | Remove open-time `k ≠` reset → G2 red |
 | G3 | **MUTUAL** simultaneous rotation (both sides) → both swap, both directions converge, conflicts flat | (covered by G1/G2 mutations firing on either side) |
-| G4a | Legacy numeric `n ≤ feed.length` → trusted, no replay (apply-count 0 on reconnect) | Remove legacy-trust branch → G4a red (spurious replay) |
-| G4b | Legacy numeric `n > feed.length` → reset to 0, full apply | Remove impossibility check → G4b red (entries skipped) |
+| G4a | Legacy numeric `n ≤ feed.length` at open → adopted as `{k, s:n}`, no replay (apply-count 0 on reconnect) | Remove legacy-adopt branch → G4a red (spurious replay) |
+| G4b | Legacy numeric `n > feed.length` at open → `{k, s:0}`, full apply | Remove impossibility check → G4b red (entries skipped) |
+| G4c | **Burst-crossing (R1 F2):** legacy `n`, rotated fresh feed opens at length 0, then replicates a backlog `> n` in one batch → ALL entries `0..n-1` apply | Re-introduce lazy per-read legacy evaluation → G4c red |
 | G5 | Same-key re-exchange: no swap (feed object identity preserved), seq untouched | Remove equality fast-path → G5 red |
 | G6 | Hung old-feed close: `close()` never resolves → `initInstance` returns ≤ cap, no hang, loud defer log | Remove `boundedClose` cap → G6 red (timeout) |
-| G6b | After G6's defer, a restarted manager (new objects, same dirs+DB) completes the rotation and applies backlog | Remove C2 reconcile-on-open → G6b red |
+| G6b | After G6's defer, a restarted manager (new objects, same dirs+DB) completes the rotation and applies backlog | Remove open-time reconcile → G6b red |
 | G7 | Replay safety: rotated fresh feed carrying insert→delete converges deleted; locally-newer row survives an older replayed entry (LWW holds at seq 0) | (LWW gates pre-exist; case pins them under rotation) |
-| G8 | Rotation while a real stream is actively replicating: new feed's data flows over the EXISTING stream (C3) | Remove `_activeStreams` attach → G8 red |
+| G8 | **Old core actively replicating on a real stream** → rotation (real bounded close of that core) → new feed attached to the SAME still-open stream → new data flows (R1 F5 preconditions) | Remove `_activeStreams` attach → G8 red |
 | G9 | Old core's blocks still readable after swap (open by old key, read block 0) | — acceptance pin, no guard |
-| G10 | C5: armed out-feed length 0 + flags `done:` → flags cleared, backfill re-runs; non-empty out-feed → flags untouched | Remove premise check → G10 red |
+| G10 | C5: armed out-feed length 0 + flags `done:` → flags cleared **before** `reemitSyncableSettingsOnce`/`backfillContactsOnce` run, and the backfill re-runs in the same boot sequence (R1 F4 ordering); non-empty out-feed → flags untouched | Remove premise check → G10 red; reorder after backfills → G10 red |
 | G11 | Malformed `feed_key_hex` (odd length, non-hex, 16 bytes) → ignored, logged, no swap, no crash | Remove validation → G11 red |
+| G11b | Peer echoes OUR out-feed key → rejected, no in-feed opened on our own key (R1 F7) | Remove self-key check → G11b red |
+| G12 | **Cross-chain interleave (R1 F1):** a `_processNewEntries` run in flight on the OLD feed across the swap → new feed's record ends `{k: new}` with no skipped entries; queued post-swap runs on the old feed bail with no stamp | Stamp with "current in-feed" key instead of processed-feed key → G12 red; remove entry bail → G12 red |
+| G13 | Stale-snapshot swap-back (R1 F3): hyperswarm-delivered new key + concurrent tailnet-server handshake holding the old snapshot → converges on the NEW key, exactly one swap | Restore `:238` snapshot-key init → G13 red |
 
 Full mutation matrix run recorded in the PR (the 2c precedent). The MUTUAL case (G3) is
-mandatory per the 2a lesson.
+mandatory per the 2a lesson. **Existing-suite migration (R1 F6):**
+`tests/instance-sync.test.js`'s direct `_getLastAppliedSeq`/`_setLastAppliedSeq` callers
+(:243, :270, :288-293, :354) are updated to the new signatures in the same PR; the
+no-feed display read is pinned by a small case there.
 
 ## 8. Non-goals / follow-ups
 
 - **GC of dead cores** in the in-feed store after rotation (unbounded only in number of
   rotations; each is small). Follow-up if ever needed.
-- **Healing past D2 skips** for non-re-emitted tables — unrecoverable safely (§4.4).
+- **Healing past D2 skips** for non-re-emitted tables — unrecoverable safely (§4.4),
+  including the pre-deploy regrown-feed case (§3 C2 residual).
 - **Per-peer backfill flags** (`backfillProvidersForNewPeers`' flag survives revoke/re-pair —
   pre-existing hole noted at 2b; own PR, already in the pool).
 - **Identity-key rotation** — different problem, no code path, out of scope.
@@ -307,3 +400,30 @@ mandatory per the 2a lesson.
 - "conflicts flat" → every gate case asserts it; live baselines 219/182/162/0.
 - "which key / what path / how detected / what recreate means" → §1, answered from code
   with empirical probes.
+
+## 11. Review record
+
+**Round 1 (fresh Opus subagent, 2026-07-15) — verdict REVISE.** Three CRITICALs, three
+IMPORTANTs, one MINOR, two NOTEs; all folded into rev 2:
+- **F1 (CRITICAL)** current-in-feed key stamping + uncoordinated `_processLocks` chain →
+  old-feed run across a swap corrupts the new record and replays the old feed from 0.
+  *Fixed:* stamp threaded from the processed feed; entry + per-iteration feed-identity
+  bail; listener removal on swap; interleave analysis §3.1; gate G12.
+- **F2 (CRITICAL)** legacy `n > length` rule evaluated lazily flips to "trust" once a
+  replication burst crosses `n`. *Fixed:* decision frozen at feed-open
+  (`_reconcileAppliedSeqAtOpen`), always stamps new format; gate G4c.
+- **F3 (CRITICAL)** `tailnet-sync.js:238` stale-snapshot init becomes a swap-back vector.
+  *Fixed:* pass null there; scope statement corrected; gate G13.
+- **F4 (IMPORTANT)** C5 ordering unpinned vs the once-backfill readers. *Fixed:* pinned in
+  `mcp-mounts.js` between `:62` and `:110`; G10 extended with the ordering mutation.
+- **F5 (IMPORTANT)** G8 risked vacuity (must exercise old-core-was-replicating + real
+  bounded close on the same stream). *Fixed:* preconditions pinned in G8.
+- **F6 (IMPORTANT)** existing suite calls the old signatures/format. *Fixed:* migration
+  scoped into the PR; no-feed display read defined (§3 C2) and pinned.
+- **F7 (MINOR)** self-key echo unguarded. *Fixed:* C1 validation + G11b.
+- **F8 (NOTE)** old append listener leak. *Fixed:* removeListener in C1.
+- **F9 (NOTE)** never-emitted peers re-trigger C5 each boot. *Documented* as accepted
+  cost (§3 C5).
+- Reviewer verified-holds worth keeping: `boot.js:793-803` passes null (no thrash vector
+  there); C4 null-key safety; feedsDisabled inertness; revoked/paused exclusion at every
+  path; happy-path boot-liveness.

--- a/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
+++ b/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
@@ -1,0 +1,309 @@
+# Item 2d — In-feed key rotation: live swap + applied-seq integrity
+
+**Date:** 2026-07-15 · **Status:** DRAFT (rev 1, pre-review) · **Author:** autonomous arc session
+**Plan doc:** `docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md` §4 Item 2d
+**Prereq reading:** the 2a six-bug lesson (executable/multi-instance/mutual gates) and the 2c
+boot-liveness lesson (no unbounded boot awaits) — both shaped this design.
+
+## 0. TL;DR
+
+When a peer's outbound Hypercore feed key changes (storage loss → hypercore mints a fresh
+keypair), the receiving side today: (a) persists the new key but **never swaps the open
+in-feed** — replication in that direction is silently dead until restart; and (b) even after
+restart, keeps the **old feed's applied-seq high-water mark**, so every entry of the new feed
+below that mark is **silently skipped forever**. This spec fixes both: a key-aware
+`initInstance` that swaps the in-feed live (bounded, boot-safe), and an applied-seq record
+that is keyed to the feed it was earned on.
+
+No schema bump (the applied-seq store is an existing JSON TEXT column). No new transport or
+trust surface.
+
+## 1. The four questions the plan doc required answering from code
+
+**Q1 — Which key rotates?** The per-peer **outbound Hypercore feed keypair**. It is minted by
+hypercore itself (`crypto.keyPair()`, `node_modules/hypercore/lib/core.js:186`) the first time
+the out-feed storage at `~/.crow/data/instance-sync/<peerId>/out` is created, and it lives
+*only* in that feed's storage header — not in the DB, not derived from identity. Explicitly
+NOT rotating: the shared instance-identity ed25519 (`identity.json` — signs handshakes and
+entries; no rotation path exists and none is in scope) and Noise statics (`NoiseSecretStream`
+is constructed per-connection without a keyPair → ephemeral).
+
+**Q2 — What code path performs a rotation today?** None deliberately. Rotation is *implicit*:
+any event that loses the `out/` storage while the pairing row persists — restore-from-backup
+that misses `instance-sync/`, incident-recovery deletion of feed dirs, a data-dir migration —
+causes the next `_initInstanceInner` (`servers/sharing/instance-sync.js:446`) to mint a fresh
+keypair. Verified empirically: key-less reopen of existing storage resumes the same key;
+key-less open of empty storage mints a new one. Additionally `crow_update_instance`
+(`servers/sharing/tools/instances.js`) can rewrite `sync_url` by hand with no feed action.
+
+**Q3 — How does a peer detect it today?** The feed-key exchange runs on **every** connection
+on both transports and all three receipt points persist a changed key and call
+`initInstance`:
+- tailnet-sync server: `servers/sharing/tailnet-sync.js:249` (persist + initInstance :255)
+- tailnet-sync client: `tailnet-sync.js:433–452`
+- Hyperswarm challenge-response piggyback: `peer-manager.js:269/:301` →
+  `boot.js:850 onInstanceKeyReceived` (persist :858, initInstance :867)
+
+But `_initInstanceInner`'s in-feed guard is `!this.inFeeds.has(remoteInstanceId)`
+(`instance-sync.js:459`) — with a stale-keyed feed already open, the call **no-ops**. That is
+defect **D1**. After a restart the new key opens a fresh core (see Q4), but
+`last_applied_seq_per_peer` (JSON blob in `sync_state`, keyed **by peer id only**,
+`instance-sync.js:2652–2698`) still holds the old feed's high-water mark, and
+`_processNewEntriesInner` starts its loop at that mark (`instance-sync.js:1408`) — every
+entry of the new feed below it is silently skipped, forever. That is defect **D2**, and it
+is the more dangerous of the two (silent divergence for `memories`, `research_notes`, etc.,
+which have no re-emit healing).
+
+**Q4 — What does "recreate the storage" mean for an open Hypercore?** Empirically (probes run
+against the vendored hypercore 11.27.7, 2026-07-15): the feed directory is a **multi-core
+store**, not a single-core store —
+- Opening existing storage with a *different* key does **not** throw `STORAGE_CONFLICT`; it
+  creates/joins a fresh core (length 0) alongside the old one.
+- The old core's blocks remain readable by reopening with the old key (verified: 3 blocks
+  survived a different-key open in the same dir).
+- Key-less reopen resumes the original (default) core with its data — out-feed keys are
+  stable across restarts.
+- **Constraint:** a second core in the same dir cannot be opened while another core in that
+  dir is open in the same process — rocksdb `File descriptor could not be locked`. So a live
+  swap must close-then-open, and a hung close blocks the swap (mitigation in §3 C1).
+
+So "recreate the storage" requires **no destructive filesystem operation at all**: close the
+old in-feed session, open `new Hypercore(sameDir, newKey)`, reset the applied-seq. Old blocks
+stay readable (acceptance's "existing blocks still readable" is satisfied by the store
+itself).
+
+## 2. Defect inventory
+
+| # | Defect | Effect | Fixed by |
+|---|--------|--------|----------|
+| D1 | Open in-feed never swapped on key change (`!inFeeds.has()` guard) | That direction silently dead until restart | C1 |
+| D2 | `last_applied_seq_per_peer` not keyed to the feed it was earned on | After restart, new feed's entries below the stale mark skipped forever — silent divergence | C2 |
+| D3 | Manual `sync_url` edit (`crow_update_instance`) touches DB only | Live manager never notices | C4 (60s heal loop) |
+| D4 | Rotated instance's once-flags (`__contacts_backfill_v1`, `__sync_reemit_allowlist_v2`) survive its own out-feed loss | Fresh out-feed never carries the catch-up backfill | C5 |
+
+Live state note: crow's blob today is legacy-numeric — `{"49cf…": 2412, "520a…": 1109}`
+(grackle, MPA). Black-swan is NOT a stale-feed case (its pairing was deliberately deleted
+2026-07-11; crow holds no bswan row) — do not "heal" it.
+
+## 3. Design
+
+All changes live in `servers/sharing/instance-sync.js` plus one line-level touch each in
+`tailnet-sync.js` (C4) and none elsewhere. Detection points are untouched — they already
+call `initInstance` with the new key; the fix makes that call honest.
+
+### C1 — Key-aware in-feed open/swap (fixes D1)
+
+In `_initInstanceInner`, replace the in-feed guard with key-aware logic:
+
+```
+const current = this.inFeeds.get(remoteInstanceId);
+if (current && theirFeedKey && !current.key.equals(theirFeedKey)) {
+  // ROTATION: bounded close, then open the new core in the same dir.
+  this.inFeeds.delete(remoteInstanceId);          // unmap first — no new reads route to it
+  const closed = await boundedClose(current, 5_000); // Promise.race close vs cap
+  if (!closed) {
+    // rocksdb lock still held by the zombie session — same-dir open would throw.
+    // Defer: loud log; sync_url is already persisted, so the next boot heals
+    // (multi-core store + C2 seq reset). Do NOT hang the _initLocks chain.
+    console.error(`[instance-sync] ROTATION DEFERRED for ${id}: old in-feed close timed out; restart will complete it`);
+    return this.outFeeds.get(remoteInstanceId);
+  }
+  await this._resetAppliedSeqForKey(remoteInstanceId, theirFeedKey); // C2, s=0
+  console.warn(`[instance-sync] in-feed ROTATED for ${id}: ${oldKey8}… → ${newKey8}…`);
+}
+if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey) {
+  … existing open path, PLUS: reconcile C2 record (if stored k ≠ this key → reset s=0),
+  PLUS: attach to tracked live streams (C3) …
+}
+```
+
+Properties:
+- Runs inside the existing `_initLocks` per-peer chain — no concurrent-swap races, and
+  close cannot interleave with another `initInstance` (same serialization
+  `closeInstanceFeeds` already relies on).
+- **Bounded** (2c lesson): the only await added to a boot-reachable path is the 5s-capped
+  close. A hung close (the real grackle incident class) degrades to today's behavior
+  (stale until restart) with a loud, greppable log line — never a boot hang.
+- Key validation: `theirFeedKey` must be exactly 32 bytes (`feed_key_hex` = 64 hex chars)
+  at all three receipt points' entry into `initInstance`; malformed keys are logged and
+  ignored (today they'd flow into `Buffer.from(hex,"hex")` unchecked).
+- The unmap-before-close ordering means `replicate()`/`getSyncStatus` see either the old
+  feed (pre-swap) or the new one (post-swap), never a closing zombie.
+- The rotated old core is left in the store (acceptance: blocks readable). GC is an
+  explicit non-goal (§8).
+
+### C2 — Feed-keyed applied-seq (fixes D2)
+
+`last_applied_seq_per_peer` values change from `2412` (numeric) to
+`{"k": "<feedKeyHex>", "s": 2412}`. This is a JSON-blob format evolution inside an existing
+TEXT column — **no schema generation bump, no migration rail**.
+
+- `_setLastAppliedSeq(peerId, seq)` gains the current in-feed's key and always writes the
+  new format.
+- `_getLastAppliedSeq(peerId)` becomes `_getLastAppliedSeq(peerId, feed)`:
+  - New-format value: `k === feed.key.hex` → return `s`; `k ≠ feed.key.hex` → the record
+    belongs to a dead feed → return 0 (and the next set overwrites `k`).
+  - Display-only callers without a feed handle (`getSyncStatus` when the in-feed is not
+    open) pass `feed = null` and get the raw `s` back — a cosmetic counter, never used
+    to gate application.
+  - **Legacy numeric `n`:** if `n > feed.length` the mark is *provably foreign* (a mark
+    earned on feed F always satisfies `mark ≤ F.length`) → return 0. Otherwise trust it
+    (`return n`) — it is *plausibly* this feed's mark, and replaying a long-lived feed
+    from 0 is NOT safe (see below). First subsequent write upgrades the format.
+- **Why not replay legacy feeds from 0 to heal past skips:** replaying a long-established
+  feed re-applies old `insert` entries for rows that were later deleted *locally with no
+  tombstone table* (`memories`, `research_notes`, …) → resurrection. The seq mechanism is
+  what protects that class today. Fresh (rotated) feeds carry only post-rotation history,
+  so reset-to-0 on an actual key change replays nothing stale. Consequence stated
+  honestly: entries already skipped by D2 *in the past* are unrecoverable for
+  non-re-emitted tables; 2c's boot re-emits heal contacts/settings/groups/tombstones over
+  subsequent boots. (Fleet check found no currently-broken peer: crow↔grackle↔MPA marks
+  are all plausible for their live feeds.)
+
+### C3 — Live-stream attach after swap
+
+`replicate(remoteInstanceId, stream)` records the stream in
+`_activeStreams: Map<peerId, Set<stream>>` (entry removed on the stream's `close` event).
+After a C1 swap, the new in-feed calls `.replicate(existingStream, {live:true})` on every
+tracked live stream. This closes the Hyperswarm ordering hole: `onInstanceConnected` may
+`replicate()` *before* the challenge-response key reaches `onInstanceKeyReceived`, so the
+triggering connection would otherwise carry only the dead core. (On the tailnet paths the
+key exchange strictly precedes `replicate()`, so the triggering connection there picks up
+the new feed naturally.) Multiplexing an additional core onto an already-active stream is
+standard hypercore protomux behavior; the gate proves it with real streams (G8).
+
+### C4 — 60s convergence loop (fixes D3, belt-and-suspenders for everything)
+
+`startTailnetSyncClients`' existing 60s `refresh()` (`tailnet-sync.js:503`) already re-reads
+each peer's row. Add: `instanceSyncManager.initInstance(peer.id, syncUrlKeyOrNull)` per
+refreshed peer. With C1's key-equality fast path this is a Map lookup + Buffer compare per
+minute per peer when nothing changed; when `sync_url` changed by any means (manual tool
+edit, missed exchange), the swap converges within 60s with no restart. Not a boot-path
+call (interval only).
+
+### C5 — Backfill-flag premise reset (fixes D4)
+
+At boot, after `eagerInitPairedPeers` arms feeds: if any armed out-feed with a paired row
+has `length === 0` while `__contacts_backfill_v1` / `__sync_reemit_allowlist_v2` read
+`done:` — the flags' premise ("peers have received this") died with the feed — clear both
+flags so the once-backfills re-run this boot. Post-2c this is safe by construction:
+re-emits are preserve-mode (no lamport fabrication), redelivery-noise-skipped on the
+receiving side, and conflict-deduped. Side effect: a brand-new pairing (also a length-0
+out-feed) triggers the same re-run — desirable (the new peer needs the backfill; existing
+peers no-op it). Separable if review judges it scope creep, but without it a real rotation
+leaves the peer permanently missing whatever the once-backfills cover.
+
+## 4. Alternatives considered and rejected
+
+1. **Explicit `rotateInFeed()` API called from the three detection points.** Same mechanics,
+   more wiring, and every *future* caller of `initInstance` (boot, eager, refresh) must
+   remember to call it. Key-awareness inside `_initInstanceInner` heals every path that
+   exists or will exist. Rejected.
+2. **Connection-bounce:** on key receipt, close feeds + drop the connection; let the
+   dialer/swarm reconnect and reopen. Least code, but: does nothing about D2; reconnect
+   timing is transport-dependent (Hyperswarm reconnection is not promptly guaranteed);
+   and it races the deterministic dialer election. Rejected.
+3. **Per-key sibling dirs (`in-<key16>/`)** to dodge the rocksdb lock so a hung close can't
+   defer the swap. Robust against the hung-close case, but adds dir-resolution state that
+   must stay consistent across restarts (which dir serves which key), a probe-open on
+   every boot, and a restart-divergence trap (boot opening the legacy dir would silently
+   create an empty twin of a sibling-dir core). The hung-close case is rare (one incident; its known
+   instance — the contact-teardown chain — was bounded by PR #195, though hypercore close
+   in general remains unbounded) and its degraded mode here equals today's dataflow (that
+   direction receives nothing) plus a complete restart heal. Simplicity wins (the 2a six-bug lesson cuts both
+   ways: every mechanism added is a bug surface). Rejected.
+4. **Replay legacy feeds from seq 0 to heal past D2 skips.** Resurrection hazard for
+   deleted rows in tables without tombstones (§3 C2). Rejected — with the residual loss
+   stated honestly.
+
+## 5. Security / trust model (unchanged)
+
+`feed_key_hex` frames already rewrite `sync_url` today on all three receipt points; this
+design changes what the *local manager* does with the same authenticated signal, not who
+is trusted. The frames ride channels authenticated by the shared instance identity
+(ed25519 challenge/handshake; tailnet WS is additionally TLS'd via Serve or
+Noise-wrapped; Hyperswarm conns are NoiseSecretStreams). The frame itself is not
+independently signed — same as today; an attacker who can forge it holds the shared
+identity key and has full sync authority anyway. Net new hardening: 32-byte key
+validation (C1) where today malformed hex flows unchecked into `Buffer.from`.
+
+Rollback/thrash: swaps fire only on key *difference*, serialized per peer via
+`_initLocks`; each connection delivers its key once at handshake; a re-rotation back to a
+previously-seen key is just another swap (seq record follows `k`). No hot loop exists
+(C4 is 1/min and fast-paths on equality).
+
+## 6. Boot-liveness analysis (2c lesson applied)
+
+New awaits reachable from boot (`eagerInitPairedPeers` → `initInstance`): exactly one —
+the 5s-capped old-feed close, only on the rotation path, only when a key actually changed
+across a restart boundary (rare). The defer branch returns immediately. C3's
+`.replicate()` is synchronous setup on an existing stream. C4 is interval-only. C5 runs
+after feed-arm in the existing boot sequence and adds two flag reads/writes (local SQLite).
+Gate rows G6/G6b make the hung-close case explicit (the 2c G11/G12 precedent: harness
+stubs must not be allowed to hide a hang class).
+
+## 7. Executable gate — `tests/feed-rotation.test.js`
+
+Real two-manager harness: two `InstanceSyncManager`s with `mgr.dataDir = mkdtemp` (per the
+2c harness gotcha), real init-db SQLite per side, **real Hypercores and real replication**
+over paired `NoiseSecretStream`s on an in-process duplex pair (new harness capability —
+existing suites apply entries directly and by design cannot see replication-layer
+defects; that blindness is exactly what let D1/D2 ship).
+
+| # | Case | Mutation check (guard → named red test) |
+|---|------|------------------------------------------|
+| G1 | Live rotation, single actor: A rotates (out storage wiped, re-init mints new key), key delivered to B live, B swaps without restart, A's new emit applies on B, `sync_conflicts` flat | Remove C1 key-compare → G1 red (entry never applies) |
+| G2 | Seq reset on rotation: B held `{k: old, s: 40}`; fresh feed's seq 0..2 all apply | Remove `_resetAppliedSeqForKey` → G2 red |
+| G3 | **MUTUAL** simultaneous rotation (both sides) → both swap, both directions converge, conflicts flat | (covered by G1/G2 mutations firing on either side) |
+| G4a | Legacy numeric `n ≤ feed.length` → trusted, no replay (apply-count 0 on reconnect) | Remove legacy-trust branch → G4a red (spurious replay) |
+| G4b | Legacy numeric `n > feed.length` → reset to 0, full apply | Remove impossibility check → G4b red (entries skipped) |
+| G5 | Same-key re-exchange: no swap (feed object identity preserved), seq untouched | Remove equality fast-path → G5 red |
+| G6 | Hung old-feed close: `close()` never resolves → `initInstance` returns ≤ cap, no hang, loud defer log | Remove `boundedClose` cap → G6 red (timeout) |
+| G6b | After G6's defer, a restarted manager (new objects, same dirs+DB) completes the rotation and applies backlog | Remove C2 reconcile-on-open → G6b red |
+| G7 | Replay safety: rotated fresh feed carrying insert→delete converges deleted; locally-newer row survives an older replayed entry (LWW holds at seq 0) | (LWW gates pre-exist; case pins them under rotation) |
+| G8 | Rotation while a real stream is actively replicating: new feed's data flows over the EXISTING stream (C3) | Remove `_activeStreams` attach → G8 red |
+| G9 | Old core's blocks still readable after swap (open by old key, read block 0) | — acceptance pin, no guard |
+| G10 | C5: armed out-feed length 0 + flags `done:` → flags cleared, backfill re-runs; non-empty out-feed → flags untouched | Remove premise check → G10 red |
+| G11 | Malformed `feed_key_hex` (odd length, non-hex, 16 bytes) → ignored, logged, no swap, no crash | Remove validation → G11 red |
+
+Full mutation matrix run recorded in the PR (the 2c precedent). The MUTUAL case (G3) is
+mandatory per the 2a lesson.
+
+## 8. Non-goals / follow-ups
+
+- **GC of dead cores** in the in-feed store after rotation (unbounded only in number of
+  rotations; each is small). Follow-up if ever needed.
+- **Healing past D2 skips** for non-re-emitted tables — unrecoverable safely (§4.4).
+- **Per-peer backfill flags** (`backfillProvidersForNewPeers`' flag survives revoke/re-pair —
+  pre-existing hole noted at 2b; own PR, already in the pool).
+- **Identity-key rotation** — different problem, no code path, out of scope.
+- The `local-cli-mcp` feed dir (session MCP servers) — untouched by this design.
+
+## 9. Live verification plan (crow↔grackle, real rotation)
+
+1. Pre-check fleet baselines (health ×4, conflicts 219/182/162/0, feed lengths, marks).
+2. Deploy through the standard pipeline (no rail needed — no schema bump).
+3. **Real rotation:** stop grackle's gateway briefly, move
+   `~/.crow/data/instance-sync/<crow-peer-id>/out` aside (kept, not deleted), start.
+   Grackle mints a new out-feed key at boot. The stop window is minutes, monitored, with
+   prod restored before anything else proceeds (unattended-window rule).
+4. Prove on **crow, without any crow restart**: journal shows the ROTATED line; `sync_url`
+   updated; a fresh grackle-side row (throwaway memory/contact) converges on crow;
+   `getSyncStatus` shows the new in-feed advancing from 0; conflicts flat ×4; MPA
+   unaffected.
+5. Prove grackle's own C5: its fresh out-feed repopulates via the re-run backfills; crow's
+   dedupe keeps conflicts flat.
+6. Confirm the moved-aside old feed dir is inert; restore-path not needed (blocks were
+   also duplicated nowhere — the moved dir IS the archive).
+7. Post-item CDP bug-hunt round per standing rule.
+
+## 10. Acceptance mapping (item text → this design)
+
+- "rotate, replication resumes with NO restart on either side" → C1+C3 (G1/G3/G8; live §9.4
+  — the *detecting* side never restarts; the rotated side's restart is the rotation event
+  itself in the wild, and the executable gate additionally proves a fully live-swap on
+  both sides in G3).
+- "existing blocks readable" → multi-core store keeps the old core (G9; §9.6).
+- "conflicts flat" → every gate case asserts it; live baselines 219/182/162/0.
+- "which key / what path / how detected / what recreate means" → §1, answered from code
+  with empirical probes.

--- a/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
+++ b/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
@@ -1,6 +1,6 @@
 # Item 2d — In-feed key rotation: live swap + applied-seq integrity
 
-**Date:** 2026-07-15 · **Status:** rev 3 (R1+R2 findings folded; awaiting round-3 closure review) · **Author:** autonomous arc session
+**Date:** 2026-07-15 · **Status:** rev 4 — **READY FOR IMPLEMENTATION PLANNING** (R3 closure verdict; R3's three mandatory fixes folded below) · **Author:** autonomous arc session
 **Plan doc:** `docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md` §4 Item 2d
 **Prereq reading:** the 2a six-bug lesson (executable/multi-instance/mutual gates) and the 2c
 boot-liveness lesson (no unbounded boot awaits) — both shaped this design.
@@ -141,12 +141,20 @@ if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey
 
 The `_deferredRotations` set suppresses repeated same-process open attempts against a dir
 whose rocksdb lock is still held by the zombie session. The abandoned close promise keeps
-a `.then(() => this._deferredRotations.delete(id))` attached — a close that was merely
-SLOW (resolves after the cap) releases the lock and un-defers the peer, so the next
+a **`.finally(() => this._deferredRotations.delete(id))`** attached — `.finally`, NOT
+`.then` (R3 F-A: a bare `.then` does nothing on a REJECTED close and its derived promise
+becomes an unhandled rejection — the exact gateway-crash class R2 #1 killed, reintroduced
+by the fix's own sub-mechanism; G6c gains a rejecting-close sub-case). A close that was
+merely SLOW (settles after the cap) releases the lock and un-defers the peer, so the next
 connection or C4 tick completes the rotation without a restart; a truly hung close keeps
-the suppression until the restart that also releases the lock. The try/catch is the real
-safety net: it also covers open failures from any other cause (disk, corruption) with the
-same out-only degradation the spec promises. C4's per-peer `initInstance` call is
+the suppression until the restart that also releases the lock. `_closeInstanceFeedsInner`
+also deletes the peer's `_deferredRotations` entry (R3 F-B: a deferred peer that is
+revoked then re-paired with the same id must not stay suppressed forever — the same
+revoke-survival class as D4). The try/catch is the real safety net: it also covers open
+failures from any other cause (disk, corruption) with the same out-only degradation the
+spec promises — and its catch closes the partial handle (`inFeed.close().catch(()=>{})`,
+R3 F-D: a `ready()` failure after lock acquisition would otherwise turn every retry into
+a lock error and leak an fd per C4 tick). C4's per-peer `initInstance` call is
 additionally wrapped in its own try/catch (defense in depth for the interval path).
 
 Properties:
@@ -168,6 +176,9 @@ Properties:
   our own out-feed key for that peer** (a peer echoing our key back would otherwise make
   us re-apply our own history — R1 F7; entries verify against the *shared* identity so
   they would apply). Malformed/self keys are logged and ignored — no persist, no open.
+  On the tailnet *client* path the helper gates before `initInstance` at `:435` as well
+  as before the persist at `:446` (R3 F-E: that path inits before persisting, so
+  persist-side validation alone would still let a poison key reach the open).
 - **R1 F3 fix — the tailnet server's pre-exchange init no longer passes a key:**
   `tailnet-sync.js:238` becomes `initInstance(remoteInstanceId, null)`. That call's only
   job is arming the out-feed for `getOutFeedKey` (`:239`); passing the *snapshot*
@@ -199,9 +210,10 @@ callers (`tests/instance-sync.test.js:288-293` etc.) are migrated to pass a key 
 **Readers.** `_getLastAppliedSeq(peerId, feed)`:
 - record `k === feed.key.hex` → return `s`; `k ≠ feed.key.hex` → foreign record → return 0.
 - Display-only callers without a feed handle (`getSyncStatus` when the in-feed is not open)
-  pass `feed = null` and get the raw `s` back — cosmetic, never gates application. Every
-  `getSyncStatus` consumer of the blob unwraps `.s` (a raw-object read would make
-  `pendingEntries = length - {object} = NaN` — R2 #7).
+  pass `feed = null` and get the numeric position back — coercing BOTH shapes (legacy bare
+  number → itself; `{k,s}` → `s`; R3 F-F: the live blob is all-legacy until reconcile, so
+  an `.s`-only read would yield `undefined` → `pendingEntries = NaN` in the window). Every
+  `getSyncStatus` consumer of the blob goes through this coercion (R2 #7).
 - A legacy numeric reaching a *processing* read is impossible after the open-time
   reconcile below; if seen (defensive), treat as foreign → 0.
 
@@ -285,7 +297,9 @@ exactly that precondition (G8, tightened per R1 F5).
 
 `startTailnetSyncClients`' existing 60s `refresh()` (`tailnet-sync.js:503`) already re-reads
 each peer's row. Add: `instanceSyncManager.initInstance(peer.id, syncUrlKeyOrNull)` per
-refreshed peer. With C1's key-equality fast path this is a Map lookup + Buffer compare per
+refreshed peer — placed **before** the `dialers.has(peer.id) → continue` short-circuit at
+`:519-526` (R3 F-C: after the `continue`, an already-dialing peer — the common steady
+state — would never be healed, defeating D3's primary case). With C1's key-equality fast path this is a Map lookup + Buffer compare per
 minute per peer when nothing changed; when `sync_url` changed by any means (manual tool
 edit, missed exchange), the swap converges within 60s with no restart. Not a boot-path
 call (interval only). Passing `null` (peer with no stored key) never closes or swaps
@@ -398,7 +412,7 @@ defects; that blindness is exactly what let D1/D2 ship).
 | G5 | Same-key re-exchange: no swap (feed object identity preserved), seq untouched | Remove equality fast-path → G5 red |
 | G6 | Hung old-feed close: `close()` never resolves → `initInstance` returns ≤ cap, no hang, loud defer log | Remove `boundedClose` cap → G6 red (timeout) |
 | G6b | After G6's defer, a restarted manager (new objects, same dirs+DB) completes the rotation and applies backlog | Remove open-time reconcile → G6b red |
-| G6c | **Defer-then-reopen (R2 #1):** after a defer with the lock still held, a subsequent `initInstance(id, newKey)` returns the out-feed WITHOUT throwing; a C4-style call wrapped the same way; when the slow close finally resolves, the next `initInstance` completes the rotation | Remove the open try/catch → G6c red (throw escapes); remove the `_deferredRotations` un-defer `.then` → G6c red (rotation never completes) |
+| G6c | **Defer-then-reopen (R2 #1):** after a defer with the lock still held, a subsequent `initInstance(id, newKey)` returns the out-feed WITHOUT throwing; a C4-style call wrapped the same way; when the slow close finally SETTLES — one sub-case resolving, one sub-case **rejecting** (R3 F-A) — no unhandled rejection escapes and the next `initInstance` completes the rotation | Remove the open try/catch → G6c red (throw escapes); replace `.finally` un-defer with `.then` → G6c-reject red (unhandled rejection / never heals); remove un-defer entirely → G6c red (rotation never completes) |
 | G7 | Replay safety: rotated fresh feed carrying insert→delete converges deleted; locally-newer row survives an older replayed entry (LWW holds at seq 0) | (LWW gates pre-exist; case pins them under rotation) |
 | G8 | **Old core actively replicating on a real stream** → rotation (real bounded close of that core) → new feed attached to the SAME still-open stream → new data flows (R1 F5 preconditions) | Remove `_activeStreams` attach → G8 red |
 | G9 | Old core's blocks still readable after swap (open by old key, read block 0) | — acceptance pin, no guard |
@@ -409,7 +423,11 @@ defects; that blindness is exactly what let D1/D2 ship).
 | G13 | Stale-snapshot swap-back (R1 F3): hyperswarm-delivered new key + concurrent tailnet-server handshake holding the old snapshot → converges on the NEW key, exactly one swap. **Must drive the REAL tailnet WS server** (R2 #6): the harness mounts `setupTailnetSyncServer` on a real local http server and dials it with a real signed WS handshake, pausing between the server's `:222` snapshot read and its `:238` init to land the hyperswarm-path key write — simulating the race by calling `initInstance` twice directly would not execute `:238` and the mutation could never go red | Restore `:238` snapshot-key init → G13 red |
 
 Full mutation matrix run recorded in the PR (the 2c precedent). The MUTUAL case (G3) is
-mandatory per the 2a lesson.
+mandatory per the 2a lesson. **Harness seams (R3 F-G):** G6/G6b/G6c force the hung/slow/
+rejecting close by wrapping the REAL feed's `close` (injection seam, not a stub feed);
+G13 uses an explicit barrier between the server's `:222` snapshot read and its `:238`
+init (plus a swap counter) — barriers and wrapped promises, never sleeps, to keep the
+suite deterministic.
 
 **Existing-suite migration (R1 F6, scope corrected per R2 #3):** the change is NOT limited
 to the four direct `_getLastAppliedSeq`/`_setLastAppliedSeq` call lines — every test that
@@ -526,3 +544,24 @@ all folded into rev 3:
   open after null-key no-ops; `emitChange`/out-feed untouched by swap; C5's length read
   ordering valid (`mcp-mounts.js:62` awaited); `.key` readable after close; boot stays
   clean (fresh process holds no zombie lock).
+
+**Round 3 — closure (fresh Opus subagent, 2026-07-15) — verdict: READY FOR IMPLEMENTATION
+PLANNING.** Three mandatory build fixes + four build notes, all folded into rev 4 (no
+further spec round required):
+- **F-A (HIGH)** rev 3's un-defer `.then` missed close REJECTION → unhandled rejection =
+  the same gateway-crash class R2 #1 killed, reintroduced by the fix itself; and G6c was
+  blind to it. *Folded:* `.finally` un-defer; G6c rejecting-close sub-case + `.then`
+  mutation.
+- **F-B (MEDIUM)** deferred peer revoked then re-paired stayed suppressed forever.
+  *Folded:* `_closeInstanceFeedsInner` clears `_deferredRotations`.
+- **F-C (MEDIUM)** C4's call placed after `refresh()`'s `dialers.has() → continue` would
+  never heal an already-dialing peer (D3's primary case). *Folded:* placement pinned
+  before the continue.
+- **F-D/F-E/F-F/F-G (build notes, folded):** close the partial handle in the open catch;
+  validate before init on the tailnet client path; `feed=null` display read coerces both
+  legacy and `{k,s}` shapes; harness uses injection seams/barriers, not sleeps.
+- R3 verified-folds: R1-F1/F2/F3 groundings all re-checked against code and hold; C5's
+  mcp-mounts ordering + per-peer providers scoping correct; clearing
+  `__groups_backfill_v1` has no tombstone side effect (tombstone re-emit is flagless,
+  every boot); F6 migration scope + Test-3 vacuity trap confirmed; §3.1 convergence,
+  boot-liveness, and the F2 closure are unbroken by rev 3.

--- a/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
+++ b/docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md
@@ -1,6 +1,6 @@
 # Item 2d — In-feed key rotation: live swap + applied-seq integrity
 
-**Date:** 2026-07-15 · **Status:** rev 2 (R1 findings folded; awaiting round-2 review) · **Author:** autonomous arc session
+**Date:** 2026-07-15 · **Status:** rev 3 (R1+R2 findings folded; awaiting round-3 closure review) · **Author:** autonomous arc session
 **Plan doc:** `docs/superpowers/plans/2026-07-11-opus-autonomous-arc.md` §4 Item 2d
 **Prereq reading:** the 2a six-bug lesson (executable/multi-instance/mutual gates) and the 2c
 boot-liveness lesson (no unbounded boot awaits) — both shaped this design.
@@ -104,26 +104,50 @@ In `_initInstanceInner`, replace the in-feed guard with key-aware logic:
 const current = this.inFeeds.get(remoteInstanceId);
 if (current && theirFeedKey && !current.key.equals(theirFeedKey)) {
   // ROTATION: detach, unmap, bounded close, then open the new core in the same dir.
-  current.removeListener("append", <its handler>);   // stop new processing runs (R1 F8)
+  current.removeListener("append", this._inFeedListeners.get(id)); // per-peer stored ref (R2 #9)
+  current.on("error", () => {});                     // swallow late close-races (R2 #9)
   this.inFeeds.delete(remoteInstanceId);             // entry-bail kills queued runs (R1 F1)
   const closed = await boundedClose(current, 5_000); // Promise.race close vs cap
   if (!closed) {
-    // rocksdb lock still held by the zombie session — same-dir open would throw.
-    // Defer: loud log; sync_url is already persisted, so the next boot heals
-    // (multi-core store + C2 open-time reconcile). Do NOT hang the _initLocks chain.
+    // rocksdb lock still held by the zombie session — same-dir open below would
+    // throw. Defer: loud log; sync_url is already persisted, so the next boot
+    // heals (multi-core store + C2 open-time reconcile). Do NOT hang the chain.
     console.error(`[instance-sync] ROTATION DEFERRED for ${id}: old in-feed close timed out; restart will complete it`);
+    this._deferredRotations.add(remoteInstanceId);   // suppress repeat open attempts (R2 #1)
     return this.outFeeds.get(remoteInstanceId);
   }
   console.warn(`[instance-sync] in-feed ROTATED for ${id}: ${oldKey8}… → ${newKey8}…`);
 }
-if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey) {
-  … open new Hypercore(dir, theirFeedKey) …
-  await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);  // C2 — ALWAYS, every open
-  … wire append listener (handler kept referenceable for removeListener) …
-  … attach to tracked live streams (C3) …
-  this.inFeeds.set(remoteInstanceId, inFeed);
+if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey
+    && !this._deferredRotations.has(remoteInstanceId)) {
+  try {
+    … open new Hypercore(dir, theirFeedKey), await ready() …
+    await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);  // C2 — ALWAYS, every open
+    … wire append listener; store its ref in _inFeedListeners (R2 #9) …
+    … attach to tracked live streams (C3) …
+    this.inFeeds.set(remoteInstanceId, inFeed);
+  } catch (err) {
+    // R2 #1 (CRITICAL): an open failure must degrade to out-only, never throw
+    // out of initInstance. Without this, a still-held rocksdb lock after a
+    // deferred rotation turns every subsequent open attempt into a throw that
+    // kills the tailnet client's whole handshake (both directions dead,
+    // reconnect throw-loop) and, on the C4 interval, an unhandled rejection
+    // that would CRASH the gateway once a minute (no unhandledRejection
+    // handler exists in servers/).
+    console.error(`[instance-sync] in-feed open failed for ${id}: ${err.message} — continuing out-only`);
+  }
 }
 ```
+
+The `_deferredRotations` set suppresses repeated same-process open attempts against a dir
+whose rocksdb lock is still held by the zombie session. The abandoned close promise keeps
+a `.then(() => this._deferredRotations.delete(id))` attached — a close that was merely
+SLOW (resolves after the cap) releases the lock and un-defers the peer, so the next
+connection or C4 tick completes the rotation without a restart; a truly hung close keeps
+the suppression until the restart that also releases the lock. The try/catch is the real
+safety net: it also covers open failures from any other cause (disk, corruption) with the
+same out-only degradation the spec promises. C4's per-peer `initInstance` call is
+additionally wrapped in its own try/catch (defense in depth for the interval path).
 
 Properties:
 - Runs inside the existing `_initLocks` per-peer chain — no concurrent-swap races, and
@@ -138,11 +162,12 @@ Properties:
   The abandoned close promise's eventual resolution touches only the already-unmapped
   feed object (no Map access, no double-close hazard: `closeInstanceFeeds` tolerates
   closed feeds, and the swap already deleted the entry).
-- Key validation at all three receipt points' entry into `initInstance`: exactly 32 bytes
-  (64 hex chars), and **not equal to our own out-feed key for that peer** (a peer echoing
-  our key back would otherwise make us re-apply our own history — R1 F7; entries verify
-  against the *shared* identity so they would apply). Malformed/self keys are logged and
-  ignored.
+- Key validation via a shared helper called at all three receipt points **before the
+  `sync_url` persist** (R2 #8 — validating only at open would persist a poison key that
+  then fails every subsequent open): exactly 32 bytes (64 hex chars), and **not equal to
+  our own out-feed key for that peer** (a peer echoing our key back would otherwise make
+  us re-apply our own history — R1 F7; entries verify against the *shared* identity so
+  they would apply). Malformed/self keys are logged and ignored — no persist, no open.
 - **R1 F3 fix — the tailnet server's pre-exchange init no longer passes a key:**
   `tailnet-sync.js:238` becomes `initInstance(remoteInstanceId, null)`. That call's only
   job is arming the out-feed for `getOutFeedKey` (`:239`); passing the *snapshot*
@@ -174,9 +199,18 @@ callers (`tests/instance-sync.test.js:288-293` etc.) are migrated to pass a key 
 **Readers.** `_getLastAppliedSeq(peerId, feed)`:
 - record `k === feed.key.hex` → return `s`; `k ≠ feed.key.hex` → foreign record → return 0.
 - Display-only callers without a feed handle (`getSyncStatus` when the in-feed is not open)
-  pass `feed = null` and get the raw `s` back — cosmetic, never gates application.
+  pass `feed = null` and get the raw `s` back — cosmetic, never gates application. Every
+  `getSyncStatus` consumer of the blob unwraps `.s` (a raw-object read would make
+  `pendingEntries = length - {object} = NaN` — R2 #7).
 - A legacy numeric reaching a *processing* read is impossible after the open-time
   reconcile below; if seen (defensive), treat as foreign → 0.
+
+**SQL note (R2 #7):** the current writer uses `json_set(..., ?, CAST(? AS INTEGER))`
+(`:2691`); the object format requires `json_set(..., ?, json(?))` — keeping the CAST (or
+passing a pre-stringified object without `json()`) stores a JSON *string*, and every
+reader's `.s`/`.k` reads `undefined`. This is a named implementation checkpoint, mutation-
+covered by G2 (a string-stored record makes the key-gate read return 0 forever → visible
+as perpetual replay, and G4a's apply-count-0 assertion goes red).
 
 **Open-time reconcile — the decision is frozen once, at feed open (R1 F2).**
 `_reconcileAppliedSeqAtOpen(peerId, feed)` runs on EVERY in-feed open (boot, eager,
@@ -214,20 +248,31 @@ An in-flight `_processNewEntriesInner` bound to the OLD feed across a swap:
   the worst case is the new feed re-processing entries `0..m` it already applied: a fresh
   rotated feed replayed from 0 is safe (post-rotation history only; LWW + conflict-dedupe
   make re-application convergent), and the first new-feed checkpoint rewrites `{k: new}`.
-  Convergent under every interleaving; no divergence, bounded waste.
+  Convergent under every interleaving; no divergence, bounded waste. One honest caveat
+  (R2 #10): "the first new-feed checkpoint rewrites `{k:new}`" is not guaranteed terminal
+  within the session — a slow old-feed run can land the LAST write as `{k:old}`; in that
+  case convergence completes at the next reconcile (next open/boot) at the cost of one
+  extra fresh-feed reprocess. Safe either way.
 - Started post-swap (queued): `_processNewEntriesInner` **bails at entry** when
   `this.inFeeds.get(id) !== feed` (the swap deleted/replaced the entry) — no old-feed
   replay-from-0 (which WOULD have been the resurrection hazard), no stamp.
-- Mid-loop after close: `feed.get` on the closed feed throws per entry; the loop's
-  poison-skip advances. A per-iteration `inFeeds.get(id) !== feed` bail is added to cut
-  that churn short (correctness does not depend on it).
+- Mid-loop after close: probe-verified (R2 #5), `feed.length` reads **0** after `close()`
+  and `feed.get` throws `SESSION_CLOSED` — so an in-flight loop's `seq < feed.length`
+  condition goes false and it terminates immediately on its next iteration. No poison-skip
+  churn occurs; no per-iteration bail is needed (rev 2's was defending a mechanism that
+  doesn't exist — dropped, YAGNI). The old feed's `.key` remains readable after close
+  (probe-verified), so a post-close stamp still carries the OLD key and stays key-gated.
 
 ### C3 — Live-stream attach after swap
 
 `replicate(remoteInstanceId, stream)` records the stream in
-`_activeStreams: Map<peerId, Set<stream>>` (entry removed on the stream's `close` event).
-After a C1 swap, the new in-feed calls `.replicate(existingStream, {live:true})` on every
-tracked live stream. This closes the Hyperswarm ordering hole: `onInstanceConnected` may
+`_activeStreams: Map<peerId, Set<stream>>` (entry removed on the stream's `close` event,
+AND the peer's whole set dropped by `_closeInstanceFeedsInner` — R2 #2: revoke closes
+feeds but not transports, so without that teardown the set leaks per revoke/re-pair cycle
+and a later swap would attach the new feed to a stale stream whose cores were all closed).
+Memory bound: ≤ live transport connections per active peer, cleared on stream close and
+on revoke. After a C1 swap, the new in-feed calls `.replicate(existingStream, {live:true})`
+on every tracked live stream. This closes the Hyperswarm ordering hole: `onInstanceConnected` may
 `replicate()` *before* the challenge-response key reaches `onInstanceKeyReceived`, so the
 triggering connection would otherwise carry only the dead core. (On the tailnet paths the
 key exchange strictly precedes `replicate()`, so the triggering connection there picks up
@@ -244,16 +289,23 @@ refreshed peer. With C1's key-equality fast path this is a Map lookup + Buffer c
 minute per peer when nothing changed; when `sync_url` changed by any means (manual tool
 edit, missed exchange), the swap converges within 60s with no restart. Not a boot-path
 call (interval only). Passing `null` (peer with no stored key) never closes or swaps
-anything (verified: the swap branch requires `theirFeedKey`).
+anything (verified: the swap branch requires `theirFeedKey`). The call is wrapped in its
+own try/catch (R2 #1): `refresh()` runs on a bare `setInterval` and the repo has no
+`unhandledRejection` handler — an escaped rejection here would crash the gateway.
 
 ### C5 — Backfill-flag premise reset (fixes D4)
 
 At boot, **between** `eagerInitPairedPeers` and the once-backfill calls — concretely in
 `servers/gateway/boot/mcp-mounts.js` after `:62` and before `reemitSyncableSettingsOnce`
-(`:110`) / `backfillContactsOnce` (`:122`), the ordering R1 F4 requires — check: if any
-armed out-feed with a paired row has `length === 0` while `__contacts_backfill_v1` /
-`__sync_reemit_allowlist_v2` read `done:`, the flags' premise ("peers have received this")
-died with the feed → clear both flags so the once-backfills re-run **this same boot**.
+(`:110`) / `backfillContactsOnce` (`:122`) / `backfillGroupsOnce` (`:132`) /
+`backfillProvidersForNewPeers` (`:144`), the ordering R1 F4 requires — check each armed
+out-feed with a paired row for `length === 0`. For each such peer: delete its per-peer
+`__providers_backfill_v1:<peerId>` flag (R2 #4 — the providers backfill has the identical
+premise-death; skipping it would leave provider rows permanently missing on the rotated
+peer while everything else re-flows). If ANY such peer exists: clear the three global
+flags (`__contacts_backfill_v1`, `__sync_reemit_allowlist_v2`, `__groups_backfill_v1` —
+the groups flag has the same premise and was missed by both the original draft and R1/R2;
+folded here for completeness) so the once-backfills re-run **this same boot**.
 Post-2c this is safe by construction: re-emits are preserve-mode (no lamport fabrication),
 redelivery-noise-skipped on the receiving side, and conflict-deduped.
 
@@ -346,6 +398,7 @@ defects; that blindness is exactly what let D1/D2 ship).
 | G5 | Same-key re-exchange: no swap (feed object identity preserved), seq untouched | Remove equality fast-path → G5 red |
 | G6 | Hung old-feed close: `close()` never resolves → `initInstance` returns ≤ cap, no hang, loud defer log | Remove `boundedClose` cap → G6 red (timeout) |
 | G6b | After G6's defer, a restarted manager (new objects, same dirs+DB) completes the rotation and applies backlog | Remove open-time reconcile → G6b red |
+| G6c | **Defer-then-reopen (R2 #1):** after a defer with the lock still held, a subsequent `initInstance(id, newKey)` returns the out-feed WITHOUT throwing; a C4-style call wrapped the same way; when the slow close finally resolves, the next `initInstance` completes the rotation | Remove the open try/catch → G6c red (throw escapes); remove the `_deferredRotations` un-defer `.then` → G6c red (rotation never completes) |
 | G7 | Replay safety: rotated fresh feed carrying insert→delete converges deleted; locally-newer row survives an older replayed entry (LWW holds at seq 0) | (LWW gates pre-exist; case pins them under rotation) |
 | G8 | **Old core actively replicating on a real stream** → rotation (real bounded close of that core) → new feed attached to the SAME still-open stream → new data flows (R1 F5 preconditions) | Remove `_activeStreams` attach → G8 red |
 | G9 | Old core's blocks still readable after swap (open by old key, read block 0) | — acceptance pin, no guard |
@@ -353,13 +406,21 @@ defects; that blindness is exactly what let D1/D2 ship).
 | G11 | Malformed `feed_key_hex` (odd length, non-hex, 16 bytes) → ignored, logged, no swap, no crash | Remove validation → G11 red |
 | G11b | Peer echoes OUR out-feed key → rejected, no in-feed opened on our own key (R1 F7) | Remove self-key check → G11b red |
 | G12 | **Cross-chain interleave (R1 F1):** a `_processNewEntries` run in flight on the OLD feed across the swap → new feed's record ends `{k: new}` with no skipped entries; queued post-swap runs on the old feed bail with no stamp | Stamp with "current in-feed" key instead of processed-feed key → G12 red; remove entry bail → G12 red |
-| G13 | Stale-snapshot swap-back (R1 F3): hyperswarm-delivered new key + concurrent tailnet-server handshake holding the old snapshot → converges on the NEW key, exactly one swap | Restore `:238` snapshot-key init → G13 red |
+| G13 | Stale-snapshot swap-back (R1 F3): hyperswarm-delivered new key + concurrent tailnet-server handshake holding the old snapshot → converges on the NEW key, exactly one swap. **Must drive the REAL tailnet WS server** (R2 #6): the harness mounts `setupTailnetSyncServer` on a real local http server and dials it with a real signed WS handshake, pausing between the server's `:222` snapshot read and its `:238` init to land the hyperswarm-path key write — simulating the race by calling `initInstance` twice directly would not execute `:238` and the mutation could never go red | Restore `:238` snapshot-key init → G13 red |
 
 Full mutation matrix run recorded in the PR (the 2c precedent). The MUTUAL case (G3) is
-mandatory per the 2a lesson. **Existing-suite migration (R1 F6):**
-`tests/instance-sync.test.js`'s direct `_getLastAppliedSeq`/`_setLastAppliedSeq` callers
-(:243, :270, :288-293, :354) are updated to the new signatures in the same PR; the
-no-feed display read is pinned by a small case there.
+mandatory per the 2a lesson.
+
+**Existing-suite migration (R1 F6, scope corrected per R2 #3):** the change is NOT limited
+to the four direct `_getLastAppliedSeq`/`_setLastAppliedSeq` call lines — every test that
+drives `_processNewEntries` on a `makeStubFeed()` (`tests/instance-sync.test.js:98-107`,
+used at :240, :254, :333-334 and ~10 more sites) breaks, because the stub has no `.key`.
+`makeStubFeed` grows a synthetic 32-byte `.key` (deterministic per harness, overridable).
+**Non-vacuity guard:** Test 3's cross-restart resumption asserts seqs 0-1 are NOT
+re-applied — that only tests resumption when `feed2` and `feed` carry the SAME synthetic
+key; the migration must set that deliberately and comment it (different keys would make
+the key-gate return 0, replay from a fresh db2, and pass the assertion vacuously — the
+exact 2a vacuous-test tell). The no-feed display read is pinned by a small case there.
 
 ## 8. Non-goals / follow-ups
 
@@ -427,3 +488,41 @@ IMPORTANTs, one MINOR, two NOTEs; all folded into rev 2:
 - Reviewer verified-holds worth keeping: `boot.js:793-803` passes null (no thrash vector
   there); C4 null-key safety; feedsDisabled inertness; revoked/paused exclusion at every
   path; happy-path boot-liveness.
+
+**Round 2 (fresh Opus subagent, 2026-07-15) — verdict REVISE.** One CRITICAL, three
+IMPORTANTs, three MINORs, three NOTEs — concentrated, as predicted, in rev 2's own fixes;
+all folded into rev 3:
+- **#1 (CRITICAL)** the C1 defer branch left `inFeeds` absent with the rocksdb lock held;
+  the NEXT open attempt throws out of `initInstance` — killing the tailnet client's whole
+  handshake (both directions dead, reconnect throw-loop) and crashing the gateway via
+  unhandled rejection on the C4 interval. *Fixed:* try/catch around the in-feed open
+  (degrade out-only), `_deferredRotations` suppression with un-defer on late close
+  resolution, C4 per-peer wrap; gate G6c with two mutations.
+- **#2 (IMPORTANT)** `_activeStreams` leaked on revoke and could attach a swap to a stale
+  stream. *Fixed:* teardown in `_closeInstanceFeedsInner`; memory bound stated (C3).
+- **#3 (IMPORTANT)** F6 migration scope was understated (~10+ `makeStubFeed` sites break;
+  Test 3 could go vacuous under different synthetic keys). *Fixed:* scope corrected in §7
+  with an explicit non-vacuity guard.
+- **#4 (IMPORTANT)** C5 skipped the providers per-peer backfill flag (identical premise-
+  death → provider rows permanently missing post-rotation). *Fixed:* per-peer providers
+  flag reset folded into C5, plus the `__groups_backfill_v1` global flag both rounds
+  missed.
+- **#5 (MINOR)** §3.1's mid-loop poison-skip mechanism was wrong (probe: `length` reads 0
+  after close; loop exits immediately). *Fixed:* analysis corrected; rev 2's per-iteration
+  bail dropped (YAGNI — defended a nonexistent mechanism).
+- **#6 (MINOR)** G13 as written could be simulated into vacuity. *Fixed:* pinned to drive
+  the real `setupTailnetSyncServer` WS endpoint.
+- **#7 (MINOR)** `json_set` needs `json(?)` not `CAST` for the object format;
+  `getSyncStatus` must unwrap `.s`. *Fixed:* SQL note in C2.
+- **#8 (NOTE)** validate before persist. *Fixed:* shared helper gates the `sync_url`
+  write at all three receipt points.
+- **#9 (NOTE)** listener refs must be per-peer; add a no-op error listener during swap.
+  *Fixed* in C1.
+- **#10 (NOTE)** §3.1 finality overstated. *Fixed:* caveat added (next-boot reconcile is
+  the terminal guarantee).
+- R2 verified-holds worth keeping: §3.1 interleave convergence under the per-entry
+  checkpoint pattern; `json_set` single-statement atomicity (no cross-chain lost update);
+  open→reconcile→listen→attach ordering closes F2 airtight; reconcile runs on first key'd
+  open after null-key no-ops; `emitChange`/out-feed untouched by swap; C5's length read
+  ordering valid (`mcp-mounts.js:62` awaited); `.key` readable after close; boot stays
+  clean (fresh process holds no zombie lock).

--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -65,6 +65,17 @@ export async function mountMcpServers(app, deps) {
     console.warn(`[instance-sync] eagerInitPairedPeers at boot failed: ${err.message}`);
   }
 
+  // 2d C5: reset once-backfill flags whose premise died with a lost out-feed
+  // (rotation / restore-from-backup). MUST run BEFORE the once-backfills
+  // below so they re-run this same boot (spec §3 C5 / R1 F4 ordering).
+  try {
+    if (syncManager?.resetBackfillPremiseFlags) {
+      await syncManager.resetBackfillPremiseFlags();
+    }
+  } catch (err) {
+    console.warn(`[instance-sync] resetBackfillPremiseFlags failed: ${err.message}`);
+  }
+
   // Scoped-settings sync: wire the registry's writeSetting to emitChange so
   // operator edits on one instance propagate to paired peers. MUST happen
   // BEFORE the heal/re-emit one-shots below (R1 MAJOR-1): the heal promotes

--- a/servers/gateway/boot/mcp-mounts.js
+++ b/servers/gateway/boot/mcp-mounts.js
@@ -68,6 +68,10 @@ export async function mountMcpServers(app, deps) {
   // 2d C5: reset once-backfill flags whose premise died with a lost out-feed
   // (rotation / restore-from-backup). MUST run BEFORE the once-backfills
   // below so they re-run this same boot (spec §3 C5 / R1 F4 ordering).
+  // Also MUST precede the settings-scope heal blocks below: once
+  // setSettingsSyncManager wires the manager (just below), those heals emit
+  // via writeSetting — a post-heal C5 would see that emission and
+  // false-negative the exact rotation-boot premise it exists to catch (T9 review).
   try {
     if (syncManager?.resetBackfillPremiseFlags) {
       await syncManager.resetBackfillPremiseFlags();

--- a/servers/sharing/boot.js
+++ b/servers/sharing/boot.js
@@ -854,6 +854,8 @@ export async function initSharingRuntime(managers, helpers) {
         args: [remoteInstanceId, instanceSyncManager.localInstanceId],
       });
       if (rows.length === 0) return; // Not paired with this instance_id — drop
+      const keyBuf = instanceSyncManager.validateIncomingFeedKey(remoteInstanceId, feedKeyHex);
+      if (!keyBuf) return; // malformed or self-echoed — skip persist AND init
       if (rows[0].sync_url === feedKeyHex) return; // unchanged — skip
       await db.execute({
         sql: "UPDATE crow_instances SET sync_url = ?, updated_at = datetime('now') WHERE id = ?",
@@ -864,7 +866,7 @@ export async function initSharingRuntime(managers, helpers) {
       // idempotent — re-calling with a non-null feedKey adds the inFeed
       // without disturbing the already-open outFeed.
       try {
-        await instanceSyncManager.initInstance(remoteInstanceId, Buffer.from(feedKeyHex, "hex"));
+        await instanceSyncManager.initInstance(remoteInstanceId, keyBuf);
       } catch (err) {
         console.warn(`[sharing] Failed to open inbound feed after key exchange: ${err.message}`);
       }

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -488,10 +488,12 @@ export class InstanceSyncManager {
       // Promise.race (repro: node:test's own "Promise resolution is still
       // pending but the event loop has already resolved" abort). Ref'd, the
       // race resolves deterministically every time.
+      let capTimer;
       const closed = await Promise.race([
         closePromise.then(() => true, () => true),
-        new Promise((res) => { setTimeout(() => res(false), this._rotationCloseCapMs ?? 5000); }),
+        new Promise((res) => { capTimer = setTimeout(() => res(false), this._rotationCloseCapMs ?? 5000); }),
       ]);
+      clearTimeout(capTimer); // no-op on the defer path; kills the stray timer on a real (fast) rotation
       if (!closed) {
         // rocksdb lock still held by the zombie session — a same-dir open
         // would throw. Defer loudly; sync_url is persisted, so a later settle
@@ -512,6 +514,9 @@ export class InstanceSyncManager {
         await inFeed.ready();
         // 2d C2: freeze the applied-seq decision BEFORE wiring the listener.
         await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
+        // 2d C1 review fix: a live-feed error on the successor must not become
+        // an uncaught exception (only the discarded old feed had a swallow).
+        inFeed.on("error", (err) => console.warn(`[instance-sync] in-feed error for ${remoteInstanceId.slice(0,12)}…: ${err.message}`));
         const onAppend = async () => { await this._processNewEntries(remoteInstanceId, inFeed); };
         inFeed.on("append", onAppend);
         this._inFeedListeners.set(remoteInstanceId, onAppend);

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1287,7 +1287,13 @@ export class InstanceSyncManager {
       set.add(stream);
       const drop = () => {
         set.delete(stream);
-        if (set.size === 0) this._activeStreams.delete(remoteInstanceId);
+        // Identity-guard the map-level delete: after a revoke→re-pair churn the
+        // map may hold a FRESH Set while this closure still captures the stale
+        // one — an unguarded delete here would destroy the live Set and a later
+        // rotation's attach loop would silently attach to nothing.
+        if (set.size === 0 && this._activeStreams.get(remoteInstanceId) === set) {
+          this._activeStreams.delete(remoteInstanceId);
+        }
       };
       stream.on("close", drop);
       stream.on("error", () => {}); // never let a tracked stream's error escape

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -461,6 +461,9 @@ export class InstanceSyncManager {
         valueEncoding: "json",
       });
       await inFeed.ready();
+      // 2d C2: freeze the applied-seq decision for this feed BEFORE any
+      // replication can grow it (listener not wired yet; feed unattached).
+      await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
 
       // Listen for new entries
       inFeed.on("append", async () => {
@@ -2726,6 +2729,36 @@ export class InstanceSyncManager {
     } catch (err) {
       console.warn(`[instance-sync] Failed to update checkpoint for ${remoteInstanceId}:`, err.message);
     }
+  }
+
+  /**
+   * Freeze the applied-seq decision for THIS feed, once, at open (2d C2 /
+   * R1 F2). Runs inside the _initLocks chain before the append listener is
+   * wired, so feed.length cannot grow concurrently:
+   *   {k,s} k matches   → keep (normal restart)
+   *   {k,s} k differs   → rotated → {k: this feed, s: 0}
+   *   legacy numeric n  → n <= length: plausibly ours → adopt {k, s:n}
+   *                       n >  length: provably foreign (a mark earned on F
+   *                       satisfies n <= F.length) → {k, s:0}
+   * NEVER re-derived later: lazy evaluation flips to "trust" once a burst
+   * pushes length past n (R1 F2's hole).
+   */
+  async _reconcileAppliedSeqAtOpen(remoteInstanceId, feed) {
+    const feedKeyHex = feed.key ? Buffer.from(feed.key).toString("hex") : null;
+    const rec = await this._appliedSeqRecord(remoteInstanceId);
+    if (rec === null) { await this._setLastAppliedSeq(remoteInstanceId, 0, feedKeyHex); return; }
+    if (typeof rec === "object") {
+      if (rec.k === feedKeyHex) return; // normal restart — keep
+      console.warn(`[instance-sync] applied-seq record for ${remoteInstanceId.slice(0,12)}… belonged to a dead feed — reset to 0`);
+      await this._setLastAppliedSeq(remoteInstanceId, 0, feedKeyHex);
+      return;
+    }
+    const n = Number(rec) || 0;
+    const adopted = n <= feed.length ? n : 0;
+    if (adopted !== n) {
+      console.warn(`[instance-sync] legacy applied-seq ${n} > feed length ${feed.length} for ${remoteInstanceId.slice(0,12)}… — provably foreign, reset to 0`);
+    }
+    await this._setLastAppliedSeq(remoteInstanceId, adopted, feedKeyHex);
   }
 
   /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -602,6 +602,36 @@ export class InstanceSyncManager {
   }
 
   /**
+   * 2d C5 (D4): a length-0 armed out-feed means the once-backfill flags'
+   * premise ("peers already received this") died with the feed — rotation,
+   * or a brand-new pairing (desirable re-run either way; a never-emitted-to
+   * peer re-triggers this each boot until a first emit lands — accepted,
+   * re-runs are preserve-mode + deduped no-ops). MUST run between
+   * eagerInitPairedPeers and the once-backfill calls (mcp-mounts ordering,
+   * R1 F4). Returns the number of flags cleared.
+   */
+  async resetBackfillPremiseFlags() {
+    if (this.feedsDisabled || this.outFeeds.size === 0) return 0;
+    const emptyPeers = [...this.outFeeds.entries()]
+      .filter(([, feed]) => feed.length === 0)
+      .map(([peerId]) => peerId);
+    if (emptyPeers.length === 0) return 0;
+    let cleared = 0;
+    const del = async (key) => {
+      try {
+        const r = await this.db.execute({ sql: "DELETE FROM dashboard_settings WHERE key = ? AND value LIKE 'done:%'", args: [key] });
+        if ((r.rowsAffected ?? 0) > 0) cleared++;
+      } catch (err) { console.warn(`[instance-sync] flag reset ${key}: ${err.message}`); }
+    };
+    for (const peerId of emptyPeers) await del(`__providers_backfill_v1:${peerId}`);
+    for (const key of ["__contacts_backfill_v1", "__sync_reemit_allowlist_v2", "__groups_backfill_v1"]) await del(key);
+    if (cleared > 0) {
+      console.warn(`[instance-sync] C5: ${cleared} backfill premise flag(s) reset — empty out-feed(s) for ${emptyPeers.map((p) => p.slice(0, 12)).join(", ")}; once-backfills will re-run this boot`);
+    }
+    return cleared;
+  }
+
+  /**
    * One-shot reconciliation: re-emit every sync-allowlisted dashboard_settings
    * row so that peers whose pre-fix outFeed dropped entries can catch up.
    * Guarded by a flag row so it runs once per instance lifetime (post-fix).

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -313,6 +313,11 @@ export class InstanceSyncManager {
     this._appendLocks = new Map();      // remoteInstanceId → tail Promise
     this._pendingPeerEmits = new Map(); // remoteInstanceId → [signed entries]
 
+    // 2d C3: live replication streams per peer, so a rotation can attach the
+    // successor feed to connections that predate the key receipt (hyperswarm
+    // delivers keys and streams in either order — this closes that hole).
+    this._activeStreams = new Map(); // remoteInstanceId → Set<stream>
+
     // 2d C1: live in-feed key-rotation bookkeeping.
     this._inFeedListeners = new Map();  // remoteInstanceId → append handler (2d C1: removable on swap)
     this._deferredRotations = new Set(); // remoteInstanceId → swap deferred, old close still pending (2d C1)
@@ -511,16 +516,27 @@ export class InstanceSyncManager {
       let inFeed = null;
       try {
         inFeed = new Hypercore(resolve(dir, "in"), theirFeedKey, { valueEncoding: "json" });
+        // 2d C1 review fix (moved ahead of ready()/reconcile — T6 re-review):
+        // a live-feed error on the successor must not become an uncaught
+        // exception (only the discarded old feed had a swallow), and a
+        // reconcile-throw below must not leave a partially-opened feed
+        // without this listener attached.
+        inFeed.on("error", (err) => console.warn(`[instance-sync] in-feed error for ${remoteInstanceId.slice(0,12)}…: ${err.message}`));
         await inFeed.ready();
         // 2d C2: freeze the applied-seq decision BEFORE wiring the listener.
         await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
-        // 2d C1 review fix: a live-feed error on the successor must not become
-        // an uncaught exception (only the discarded old feed had a swallow).
-        inFeed.on("error", (err) => console.warn(`[instance-sync] in-feed error for ${remoteInstanceId.slice(0,12)}…: ${err.message}`));
         const onAppend = async () => { await this._processNewEntries(remoteInstanceId, inFeed); };
         inFeed.on("append", onAppend);
         this._inFeedListeners.set(remoteInstanceId, onAppend);
         this.inFeeds.set(remoteInstanceId, inFeed);
+        // 2d C3: attach the successor feed to every live stream for this peer
+        // (hyperswarm may have delivered the new key AFTER a stream that
+        // already carried the old feed — that stream must not go dark).
+        for (const s of this._activeStreams.get(remoteInstanceId) ?? []) {
+          try { inFeed.replicate(s, { live: true }); } catch (err) {
+            console.warn(`[instance-sync] post-swap stream attach failed for ${remoteInstanceId.slice(0,12)}…: ${err.message}`);
+          }
+        }
       } catch (err) {
         // 2d C1 (R2 #1): open failure degrades to out-only — NEVER throws out
         // of initInstance (a still-held lock after a deferred rotation would
@@ -1263,6 +1279,19 @@ export class InstanceSyncManager {
    * @param {object} stream - NoiseSecretStream (Hypercore reads .noiseStream from it)
    */
   async replicate(remoteInstanceId, stream) {
+    // 2d C3: track live streams so a rotation can attach the successor feed
+    // to connections that predate the key receipt (hyperswarm ordering hole).
+    let set = this._activeStreams.get(remoteInstanceId);
+    if (!set) { set = new Set(); this._activeStreams.set(remoteInstanceId, set); }
+    if (!set.has(stream)) {
+      set.add(stream);
+      const drop = () => {
+        set.delete(stream);
+        if (set.size === 0) this._activeStreams.delete(remoteInstanceId);
+      };
+      stream.on("close", drop);
+      stream.on("error", () => {}); // never let a tracked stream's error escape
+    }
     const outFeed = this.outFeeds.get(remoteInstanceId);
     const inFeed = this.inFeeds.get(remoteInstanceId);
 
@@ -2900,6 +2929,8 @@ export class InstanceSyncManager {
     // 2c C3: a closed/revoked peer keeps no parked entries or chain tail.
     this._pendingPeerEmits.delete(remoteInstanceId);
     this._appendLocks.delete(remoteInstanceId);
+    // 2d C3: a closed/revoked peer keeps no tracked live streams either.
+    this._activeStreams.delete(remoteInstanceId);
   }
 
   /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -313,6 +313,15 @@ export class InstanceSyncManager {
     this._appendLocks = new Map();      // remoteInstanceId → tail Promise
     this._pendingPeerEmits = new Map(); // remoteInstanceId → [signed entries]
 
+    // 2d C1: live in-feed key-rotation bookkeeping.
+    this._inFeedListeners = new Map();  // remoteInstanceId → append handler (2d C1: removable on swap)
+    this._deferredRotations = new Set(); // remoteInstanceId → swap deferred, old close still pending (2d C1)
+    // Hard cap on how long a rotation swap will race the old in-feed's close()
+    // before deferring loudly (rocksdb fd-lock: a second core in the same
+    // multi-core dir cannot open while the old session's close is still
+    // pending). Overridable in tests.
+    this._rotationCloseCapMs = 5000;
+
     // Flag that _ensureCounter has seeded the sync_state row at least once.
     // The DB row is the authority; this is only a cheap short-circuit.
     this._counterSeeded = false;
@@ -455,22 +464,66 @@ export class InstanceSyncManager {
       await drainDone.catch(() => {});
     }
 
+    // 2d C1: key-aware — a changed key swaps the open in-feed live.
+    const currentIn = this.inFeeds.get(remoteInstanceId);
+    if (currentIn && theirFeedKey && !Buffer.from(currentIn.key).equals(theirFeedKey)) {
+      const oldKey8 = Buffer.from(currentIn.key).toString("hex").slice(0, 8);
+      const newKey8 = theirFeedKey.toString("hex").slice(0, 8);
+      const handler = this._inFeedListeners.get(remoteInstanceId);
+      if (handler) currentIn.removeListener("append", handler);
+      this._inFeedListeners.delete(remoteInstanceId);
+      currentIn.on("error", () => {}); // swallow late close-races (R3/R2 #9)
+      this.inFeeds.delete(remoteInstanceId); // entry-bail kills queued runs (R1 F1)
+      const closePromise = currentIn.close();
+      // .finally, NOT .then: a REJECTING close must also un-defer, and the
+      // derived promise must never become an unhandled rejection (R3 F-A).
+      closePromise.catch(() => {}).finally(() => this._deferredRotations.delete(remoteInstanceId));
+      // NOTE (T4 deviation from brief's literal `t.unref?.()`): this timer is
+      // deliberately left ref'd. It's bounded (capMs, default 5000/test 200)
+      // either way, so ref'd costs at most one capped tick of process-exit
+      // delay -- but unref'd, it is provably wrong: proven via a controlled
+      // A/B run in this exact harness (link closed, no other live handles),
+      // an unref'd sole timer let the event loop consider itself idle and
+      // exit BEFORE the timer fired, permanently stranding the awaited
+      // Promise.race (repro: node:test's own "Promise resolution is still
+      // pending but the event loop has already resolved" abort). Ref'd, the
+      // race resolves deterministically every time.
+      const closed = await Promise.race([
+        closePromise.then(() => true, () => true),
+        new Promise((res) => { setTimeout(() => res(false), this._rotationCloseCapMs ?? 5000); }),
+      ]);
+      if (!closed) {
+        // rocksdb lock still held by the zombie session — a same-dir open
+        // would throw. Defer loudly; sync_url is persisted, so a later settle
+        // (via the .finally above) or a restart completes the rotation.
+        console.error(`[instance-sync] ROTATION DEFERRED for ${remoteInstanceId.slice(0,12)}…: old in-feed close timed out (cap ${this._rotationCloseCapMs ?? 5000}ms); will retry after close settles or on restart`);
+        this._deferredRotations.add(remoteInstanceId);
+        return this.outFeeds.get(remoteInstanceId);
+      }
+      console.warn(`[instance-sync] in-feed ROTATED for ${remoteInstanceId.slice(0,12)}…: ${oldKey8}… → ${newKey8}…`);
+    }
+
     // Their incoming feed (writable by them)
-    if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey) {
-      const inFeed = new Hypercore(resolve(dir, "in"), theirFeedKey, {
-        valueEncoding: "json",
-      });
-      await inFeed.ready();
-      // 2d C2: freeze the applied-seq decision for this feed BEFORE any
-      // replication can grow it (listener not wired yet; feed unattached).
-      await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
-
-      // Listen for new entries
-      inFeed.on("append", async () => {
-        await this._processNewEntries(remoteInstanceId, inFeed);
-      });
-
-      this.inFeeds.set(remoteInstanceId, inFeed);
+    if (!this.inFeeds.has(remoteInstanceId) && theirFeedKey
+        && !this._deferredRotations.has(remoteInstanceId)) {
+      let inFeed = null;
+      try {
+        inFeed = new Hypercore(resolve(dir, "in"), theirFeedKey, { valueEncoding: "json" });
+        await inFeed.ready();
+        // 2d C2: freeze the applied-seq decision BEFORE wiring the listener.
+        await this._reconcileAppliedSeqAtOpen(remoteInstanceId, inFeed);
+        const onAppend = async () => { await this._processNewEntries(remoteInstanceId, inFeed); };
+        inFeed.on("append", onAppend);
+        this._inFeedListeners.set(remoteInstanceId, onAppend);
+        this.inFeeds.set(remoteInstanceId, inFeed);
+      } catch (err) {
+        // 2d C1 (R2 #1): open failure degrades to out-only — NEVER throws out
+        // of initInstance (a still-held lock after a deferred rotation would
+        // otherwise kill the tailnet client handshake and, on the C4 interval,
+        // crash the gateway via unhandled rejection).
+        console.error(`[instance-sync] in-feed open failed for ${remoteInstanceId.slice(0,12)}…: ${err.message} — continuing out-only`);
+        if (inFeed) inFeed.close().catch(() => {}); // release partial handle/fd (R3 F-D)
+      }
     }
 
     return this.outFeeds.get(remoteInstanceId);
@@ -2818,6 +2871,10 @@ export class InstanceSyncManager {
       try { await inFeed.close(); } catch {}
       this.inFeeds.delete(remoteInstanceId);
     }
+    this._inFeedListeners.delete(remoteInstanceId);
+    // 2d C1 (R3 F-B): a deferred peer that is revoked then re-paired must not
+    // stay suppressed forever.
+    this._deferredRotations.delete(remoteInstanceId);
     // 2c C3: a closed/revoked peer keeps no parked entries or chain tail.
     this._pendingPeerEmits.delete(remoteInstanceId);
     this._appendLocks.delete(remoteInstanceId);

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1237,6 +1237,23 @@ export class InstanceSyncManager {
   }
 
   /**
+   * Validate a peer-advertised feed key BEFORE persisting or opening (2d C1;
+   * R2 #8 persist-gating, R1 F7 self-echo). Returns Buffer or null.
+   */
+  validateIncomingFeedKey(remoteInstanceId, feedKeyHex) {
+    if (typeof feedKeyHex !== "string" || !/^[0-9a-fA-F]{64}$/.test(feedKeyHex)) {
+      console.warn(`[instance-sync] rejecting malformed feed key from ${String(remoteInstanceId).slice(0,12)}…`);
+      return null;
+    }
+    const ours = this.getOutFeedKey(remoteInstanceId);
+    if (ours && ours.toString("hex") === feedKeyHex.toLowerCase()) {
+      console.warn(`[instance-sync] rejecting self-echoed feed key from ${String(remoteInstanceId).slice(0,12)}… (would re-apply our own history)`);
+      return null;
+    }
+    return Buffer.from(feedKeyHex, "hex");
+  }
+
+  /**
    * Replicate feeds over a NoiseSecretStream-wrapped transport. Hyperswarm
    * connections are already NoiseSecretStream instances; for plain WebSocket
    * or other Duplex transports, wrap with `new NoiseSecretStream(isInitiator,

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1402,8 +1402,14 @@ export class InstanceSyncManager {
    * skipping one bad entry. The trailing whole-batch checkpoint is removed.
    */
   async _processNewEntriesInner(remoteInstanceId, feed) {
+    // 2d C1/C2 (R1 F1): a run bound to a REPLACED feed must not read or stamp
+    // the successor's record. `undefined` (peer unmapped / stub-feed harness)
+    // still processes — only a swapped-out feed bails.
+    const current = this.inFeeds.get(remoteInstanceId);
+    if (current !== undefined && current !== feed) return;
+    const feedKeyHex = feed.key ? Buffer.from(feed.key).toString("hex") : null;
     // Re-read lastSeq inside the lock — the prior chained run may have advanced it.
-    const lastSeq = await this._getLastAppliedSeq(remoteInstanceId);
+    const lastSeq = await this._getLastAppliedSeq(remoteInstanceId, feed);
 
     for (let seq = lastSeq; seq < feed.length; seq++) {
       try {
@@ -1415,7 +1421,10 @@ export class InstanceSyncManager {
       }
       // Checkpoint after every attempted entry — outside the try so it advances
       // even when _applyEntry threw (intentional skip-log-advance semantics).
-      await this._setLastAppliedSeq(remoteInstanceId, seq + 1);
+      // Stamp with the PROCESSED feed's key (2d C2 / R1 F1) — never "the
+      // current in-feed": a stale run must leave a record the successor's
+      // key-gated reads ignore.
+      await this._setLastAppliedSeq(remoteInstanceId, seq + 1, feedKeyHex);
     }
   }
 
@@ -2647,22 +2656,38 @@ export class InstanceSyncManager {
   }
 
   /**
-   * Get the last applied sequence number for a remote instance's feed.
+   * Applied-seq record, keyed to the feed it was earned on (2d C2).
+   * Shape: {"k": "<feedKeyHex>", "s": <nextUnprocessedSeq>}. Legacy bare
+   * numbers exist on disk until _reconcileAppliedSeqAtOpen upgrades them.
    */
-  async _getLastAppliedSeq(remoteInstanceId) {
+  async _appliedSeqRecord(remoteInstanceId) {
     try {
       const { rows } = await this.db.execute({
         sql: "SELECT last_applied_seq_per_peer FROM sync_state WHERE instance_id = ?",
         args: [this.localInstanceId],
       });
-
       if (rows.length > 0 && rows[0].last_applied_seq_per_peer) {
-        const seqs = JSON.parse(rows[0].last_applied_seq_per_peer);
-        return seqs[remoteInstanceId] || 0;
+        const rec = JSON.parse(rows[0].last_applied_seq_per_peer)[remoteInstanceId];
+        return rec === undefined ? null : rec;
       }
     } catch {}
+    return null;
+  }
 
-    return 0;
+  /**
+   * Key-gated read (2d C2). feed=null is the display path: coerce BOTH shapes
+   * (legacy bare number → itself; {k,s} → s) — never used to gate application.
+   * A record whose k differs from the feed's key belongs to a dead feed → 0.
+   * A legacy numeric reaching a keyed read is treated as foreign (defensive;
+   * reconcile-at-open makes it unreachable in production).
+   */
+  async _getLastAppliedSeq(remoteInstanceId, feed = null) {
+    const rec = await this._appliedSeqRecord(remoteInstanceId);
+    if (rec === null) return 0;
+    if (feed == null) return typeof rec === "number" ? rec : Number(rec.s) || 0;
+    if (typeof rec !== "object") return 0;
+    const feedKeyHex = feed.key ? Buffer.from(feed.key).toString("hex") : null;
+    return rec.k === feedKeyHex ? Number(rec.s) || 0 : 0;
   }
 
   /**
@@ -2676,9 +2701,11 @@ export class InstanceSyncManager {
    *
    * Semantics unchanged: `seq` is the NEXT unprocessed sequence number
    * (i.e. the last successfully attempted seq + 1). getSyncStatus and
-   * _getLastAppliedSeq consume the same blob.
+   * _getLastAppliedSeq consume the same blob. 2d C2: the record is now
+   * feed-keyed — {"k": feedKeyHex, "s": seq} — so a rotated feed never
+   * inherits a stale mark from its predecessor.
    */
-  async _setLastAppliedSeq(remoteInstanceId, seq) {
+  async _setLastAppliedSeq(remoteInstanceId, seq, feedKeyHex) {
     // Guard: a `"` in the id would break the json_set path literal.
     if (remoteInstanceId.includes('"')) {
       console.warn(`[instance-sync] _setLastAppliedSeq: skipping id with quote char: ${remoteInstanceId}`);
@@ -2686,12 +2713,15 @@ export class InstanceSyncManager {
     }
     try {
       await this._ensureCounter();
+      // json(?) — NOT CAST — so the object lands as JSON, not a quoted string
+      // (spec C2 SQL note): json_set with a plain string param stores a string
+      // and every reader's .k/.s would be undefined.
       await this.db.execute({
         sql: `UPDATE sync_state
-              SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer, '{}'), ?, CAST(? AS INTEGER)),
+              SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer, '{}'), ?, json(?)),
                   updated_at = datetime('now')
               WHERE instance_id = ?`,
-        args: [`$."${remoteInstanceId}"`, seq, this.localInstanceId],
+        args: [`$."${remoteInstanceId}"`, JSON.stringify({ k: feedKeyHex ?? null, s: Number(seq) }), this.localInstanceId],
       });
     } catch (err) {
       console.warn(`[instance-sync] Failed to update checkpoint for ${remoteInstanceId}:`, err.message);
@@ -2706,7 +2736,7 @@ export class InstanceSyncManager {
 
     for (const [instanceId, feed] of this.outFeeds) {
       const inFeed = this.inFeeds.get(instanceId);
-      const lastSeq = await this._getLastAppliedSeq(instanceId);
+      const lastSeq = await this._getLastAppliedSeq(instanceId, inFeed ?? null);
 
       status.push({
         instanceId,

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -525,6 +525,21 @@ export async function startTailnetSyncClients(ctx) {
     const seenIds = new Set();
     for (const peer of rows) {
       seenIds.add(peer.id);
+      // 2d C4: converge the in-feed with the persisted sync_url every rescan —
+      // heals manual crow_update_instance edits and any missed key exchange
+      // within 60s, no restart. Cheap fast-path (Map lookup + Buffer compare)
+      // when nothing changed. Own try/catch: refresh runs on a bare
+      // setInterval and an escaped rejection would crash the gateway (no
+      // unhandledRejection handler exists in servers/). Placed BEFORE both
+      // continues below (R3 F-C): after the dialers.has() continue it would
+      // never heal the steady state, which is exactly the case that needs
+      // healing (an already-dialing peer whose row drifted).
+      try {
+        const keyBuf = peer.sync_url ? instanceSyncManager.validateIncomingFeedKey?.(peer.id, peer.sync_url) ?? null : null;
+        await instanceSyncManager.initInstance(peer.id, keyBuf);
+      } catch (err) {
+        console.warn(`[tailnet-sync] refresh heal for ${peer.id.slice(0,12)}…: ${err.message}`);
+      }
       if (!peer.gateway_url) continue;
       if (dialers.has(peer.id)) {
         // #144 minor: keep the dialer's row snapshot fresh — a changed
@@ -551,6 +566,7 @@ export async function startTailnetSyncClients(ctx) {
 
   return {
     dialers,
+    __refreshForTest: refresh,
     stop() {
       clearInterval(rescan);
       for (const d of dialers.values()) d.stop();

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -235,7 +235,12 @@ async function handleAcceptedConnection(ws, peerHandshake, frameReader, ctx) {
   }
 
   // Ensure our outFeed exists, then exchange feed keys.
-  await instanceSyncManager.initInstance(remoteInstanceId, peerRow.sync_url ? Buffer.from(peerRow.sync_url, "hex") : null);
+  // 2d F3: pass NO key here. This call's only job is arming the out-feed for
+  // getOutFeedKey below. Passing the :222 snapshot's sync_url was harmless
+  // when a mismatched key no-oped, but under key-aware initInstance a stale
+  // snapshot would swap a concurrently-rotated in-feed BACK to its dead key.
+  // The authenticated receipt at the feed-key exchange below drives any swap.
+  await instanceSyncManager.initInstance(remoteInstanceId, null);
   const ourOutKey = instanceSyncManager.getOutFeedKey(remoteInstanceId);
   ws.send(JSON.stringify({ feed_key_hex: ourOutKey ? ourOutKey.toString("hex") : null }));
 

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -247,15 +247,18 @@ async function handleAcceptedConnection(ws, peerHandshake, frameReader, ctx) {
     return;
   }
   if (peerKeyMsg?.feed_key_hex && peerKeyMsg.feed_key_hex !== peerRow.sync_url) {
-    try {
-      await db.execute({
-        sql: "UPDATE crow_instances SET sync_url = ?, updated_at = datetime('now') WHERE id = ?",
-        args: [peerKeyMsg.feed_key_hex, remoteInstanceId],
-      });
-      await instanceSyncManager.initInstance(remoteInstanceId, Buffer.from(peerKeyMsg.feed_key_hex, "hex"));
-      console.log(`[tailnet-sync] persisted feed key from peer ${remoteInstanceId.slice(0,12)}…`);
-    } catch (err) {
-      log.warn?.(`[tailnet-sync] persisting feed key failed: ${err.message}`);
+    const keyBuf = instanceSyncManager.validateIncomingFeedKey(remoteInstanceId, peerKeyMsg.feed_key_hex);
+    if (keyBuf) {
+      try {
+        await db.execute({
+          sql: "UPDATE crow_instances SET sync_url = ?, updated_at = datetime('now') WHERE id = ?",
+          args: [peerKeyMsg.feed_key_hex, remoteInstanceId],
+        });
+        await instanceSyncManager.initInstance(remoteInstanceId, keyBuf);
+        console.log(`[tailnet-sync] persisted feed key from peer ${remoteInstanceId.slice(0,12)}…`);
+      } catch (err) {
+        log.warn?.(`[tailnet-sync] persisting feed key failed: ${err.message}`);
+      }
     }
   }
 
@@ -431,13 +434,15 @@ export class PeerDialer {
 
         // Receive server's feed key.
         const peerKeyMsg = await frameReader.readJsonFrame(HANDSHAKE_TIMEOUT_MS);
-        const incomingKeyBuf = peerKeyMsg?.feed_key_hex ? Buffer.from(peerKeyMsg.feed_key_hex, "hex") : null;
+        const incomingKeyBuf = peerKeyMsg?.feed_key_hex
+          ? instanceSyncManager.validateIncomingFeedKey(remoteInstanceId, peerKeyMsg.feed_key_hex)
+          : null;
         await instanceSyncManager.initInstance(remoteInstanceId, incomingKeyBuf);
         const ourOutKey = instanceSyncManager.getOutFeedKey(remoteInstanceId);
         ws.send(JSON.stringify({ feed_key_hex: ourOutKey ? ourOutKey.toString("hex") : null }));
 
-        // Persist peer key if new.
-        if (peerKeyMsg?.feed_key_hex) {
+        // Persist peer key if new (gated on the same validation result used for init above).
+        if (incomingKeyBuf) {
           const { rows } = await db.execute({
             sql: "SELECT sync_url FROM crow_instances WHERE id = ?",
             args: [remoteInstanceId],

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -702,3 +702,43 @@ test("C4: refresh heals sync_url drift for ALREADY-DIALING peers and survives in
     assert.deepEqual(calls[1], ["peer1", "cd".repeat(32)], "already-dialing peer still healed");
   } finally { clients.stop(); }
 });
+
+// ── Task 9 (C5): backfill-flag premise reset at boot ────────────────────────
+
+test("G10: empty armed out-feed clears premise flags BEFORE the once-backfills; non-empty leaves them", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    await a.mgr.initInstance(b.id, null); // armed, length 0 (fresh = post-rotation shape)
+    const setFlag = (k, v) => a.db.execute({ sql: "INSERT OR REPLACE INTO dashboard_settings (key, value) VALUES (?, ?)", args: [k, v] });
+    await setFlag("__contacts_backfill_v1", "done:5");
+    await setFlag("__sync_reemit_allowlist_v2", "done:9");
+    await setFlag("__groups_backfill_v1", "done:2");
+    await setFlag(`__providers_backfill_v1:${b.id}`, "done:3");
+    const cleared = await a.mgr.resetBackfillPremiseFlags();
+    assert.equal(cleared, 4, "three globals + one per-peer flag cleared");
+    const read = async (k) => (await a.db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [k] })).rows[0]?.value;
+    assert.equal(await read("__contacts_backfill_v1"), undefined);
+    assert.equal(await read(`__providers_backfill_v1:${b.id}`), undefined);
+    // Ordering semantics (G10 mutation target): flags cleared → the once-backfill
+    // re-runs in the same sequence. reemitSyncableSettingsOnce with the flag
+    // GONE returns >= 0 and re-stamps done:, proving it executed its body.
+    // (If mcp-mounts called reemitSyncableSettingsOnce BEFORE
+    // resetBackfillPremiseFlags, the flag would still read "done:9" here and
+    // the backfill would short-circuit on alreadyRan — this assertion is what
+    // would catch that wrong ordering.)
+    await setFlag("sync.allowlisted.example", "x"); // ensure at least a no-op run completes
+    await a.mgr.reemitSyncableSettingsOnce();
+    assert.match(String(await read("__sync_reemit_allowlist_v2")), /^done:/, "backfill re-ran this boot");
+    // Negative control: non-empty out-feed → flags untouched.
+    // memories.id is INTEGER PRIMARY KEY (real schema) — a string id like "g10"
+    // throws SQLITE datatype mismatch on emitChange's local INSERT and the
+    // whole call fails silently into the catch, leaving the out-feed at length
+    // 0 and defeating this control (established correction; see G0's comment
+    // for the same class of fix).
+    await a.mgr.emitChange("memories", "insert", { id: 709000, content: "x", lamport_ts: null });
+    await setFlag("__contacts_backfill_v1", "done:5");
+    assert.equal(await a.mgr.resetBackfillPremiseFlags(), 0, "non-empty feed: nothing cleared");
+    assert.equal(await read("__contacts_backfill_v1"), "done:5");
+  } finally { await fleet.cleanup(); }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -109,6 +109,15 @@ export async function linkPeers(a, b) {
   // Exchange feed keys the way the real handshake does, then replicate.
   await a.mgr.initInstance(b.id, b.mgr.getOutFeedKey(a.id));
   await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id));
+  // Second round (2d T10): the first call above is one-way by construction —
+  // it fires before B has armed ITS out-feed to A, so getOutFeedKey(a.id) was
+  // still null and A never got an in-feed for B. Now that B's out-feed IS
+  // armed (the line above), give A a fresh chance at B's real key. On a link
+  // that was already bidirectional (or a second linkPeers call after a prior
+  // link), both keys are already current, so T4's key-aware init treats this
+  // as a same-key no-op — existing single-direction (A -> B) tests are
+  // unaffected.
+  await a.mgr.initInstance(b.id, b.mgr.getOutFeedKey(a.id));
   await a.mgr.replicate(b.id, nsA);
   await b.mgr.replicate(a.id, nsB);
   // 2d C3 (G8): expose per-side handles so a test can re-replicate one side's
@@ -553,7 +562,7 @@ test("C3 churn: a lingering old stream's late close must not drop a re-paired pe
     // stale Set A. Without the identity guard it would delete the map entry —
     // destroying live Set B.
     link1.close();
-    await until(() => oldStream.destroyed);
+    assert.equal(await until(() => oldStream.destroyed), true, "old stream must actually close");
     await new Promise((r) => setImmediate(r)); // let the close listener run after destroy settles
     const liveSet = b.mgr._activeStreams.get(a.id);
     assert.ok(liveSet, "fresh stream set must survive the stale stream's late close");
@@ -741,4 +750,153 @@ test("G10: empty armed out-feed clears premise flags BEFORE the once-backfills; 
     assert.equal(await a.mgr.resetBackfillPremiseFlags(), 0, "non-empty feed: nothing cleared");
     assert.equal(await read("__contacts_backfill_v1"), "done:5");
   } finally { await fleet.cleanup(); }
+});
+
+// ── Task 10: integration closers ────────────────────────────────────────────
+// memories.id is INTEGER PRIMARY KEY — G2 710000-710002 (+710010 pre-row),
+// G3 710300-710303, G7 710100 (insert/delete half) + 710200 (LWW half).
+
+test("G2: rotation resets the mark -- fresh feed seqs 0..2 all apply despite an old high mark", async () => {
+  const fleet = await makeFleet();
+  let link; // declared outside the try -- an assertion throw must not strand
+            // the NoiseSecretStream/TCP sockets open (G0/G4c footgun)
+  try {
+    const { a, b } = fleet;
+    link = await linkPeers(a, b);
+    // Pre-row: prove the link works before rotating.
+    await a.mgr.emitChange("memories", "insert", { id: 710010, content: "pre", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710010" })).rows.length === 1);
+    const oldKeyHex = a.mgr.getOutFeedKey(b.id).toString("hex");
+    link.close();
+    // A rotates its out-feed to B (storage wiped, new key minted) -- G1-style.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    // BEFORE delivering the new key to B, force B's record HIGH under the OLD
+    // key -- if the applied-seq gate were peer-keyed instead of feed-keyed,
+    // this forged mark would suppress every entry on the fresh feed below.
+    await b.mgr._setLastAppliedSeq(a.id, 40, oldKeyHex);
+    const forced = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual({ k: forced.k, s: forced.s }, { k: oldKeyHex, s: 40 }, "precondition: mark forced high under the old key");
+    // Deliver the new key -- live swap; reconcile-at-open must reset for the
+    // NEW key rather than inherit s:40 (which belongs to the dead feed).
+    await b.mgr.initInstance(a.id, newKey);
+    const recAfterSwap = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual({ k: recAfterSwap.k, s: recAfterSwap.s }, { k: newKey.toString("hex"), s: 0 },
+      "swap resets the mark for the new key -- s:40 does not carry over");
+    link = await linkPeers(a, b); // relink over a fresh stream pair
+    for (let i = 0; i < 3; i++) {
+      await a.mgr.emitChange("memories", "insert", { id: 710000 + i, content: "x", lamport_ts: null });
+    }
+    const allApplied = await until(async () => {
+      const { rows } = await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM memories WHERE id BETWEEN 710000 AND 710002" });
+      return Number(rows[0].n) === 3;
+    });
+    assert.equal(allApplied, true, "all 3 rows on the fresh feed apply despite the old high mark -- the mark followed the FEED, not the peer");
+  } finally {
+    if (link) link.close();
+    await fleet.cleanup();
+  }
+});
+
+test("G3 MUTUAL: both sides rotate simultaneously -- both swap, both directions converge, conflicts flat", async () => {
+  const fleet = await makeFleet();
+  let link; // declared outside the try -- see G2's comment
+  try {
+    const { a, b } = fleet;
+    link = await linkPeers(a, b);
+    // Baseline: prove BOTH directions work before rotating (2a lesson --
+    // the mutual case is where convergence designs die; establish the
+    // starting condition is genuinely bidirectional, not a fluke).
+    await a.mgr.emitChange("memories", "insert", { id: 710300, content: "pre-a", lamport_ts: null });
+    await b.mgr.emitChange("memories", "insert", { id: 710301, content: "pre-b", lamport_ts: null });
+    const preAtoB = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710300" })).rows.length === 1);
+    const preBtoA = await until(async () => (await a.db.execute({ sql: "SELECT id FROM memories WHERE id=710301" })).rows.length === 1);
+    assert.equal(preAtoB, true, "precondition: A -> B works before rotation");
+    assert.equal(preBtoA, true, "precondition: B -> A works before rotation");
+    const conflictsBeforeA = Number((await a.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    const conflictsBeforeB = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    link.close();
+    // BOTH sides rotate their own out-feed to the peer.
+    await a.mgr.closeInstanceFeeds(b.id);
+    await b.mgr.closeInstanceFeeds(a.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    rmSync(join(b.mgr.dataDir, a.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    await b.mgr.initInstance(a.id, null);
+    const newKeyForB = a.mgr.getOutFeedKey(b.id); // A's new out-feed -- becomes B's in-feed
+    const newKeyForA = b.mgr.getOutFeedKey(a.id); // B's new out-feed -- becomes A's in-feed
+    // Exchange the two new keys CONCURRENTLY -- the mandatory mutual case:
+    // each side delivers the OTHER's new key at the same time, not in sequence.
+    await Promise.all([
+      a.mgr.initInstance(b.id, newKeyForA),
+      b.mgr.initInstance(a.id, newKeyForB),
+    ]);
+    assert.equal(a.mgr.inFeeds.get(b.id)?.key.toString("hex"), newKeyForA.toString("hex"), "A's in-feed swapped to B's new key");
+    assert.equal(b.mgr.inFeeds.get(a.id)?.key.toString("hex"), newKeyForB.toString("hex"), "B's in-feed swapped to A's new key");
+    link = await linkPeers(a, b); // relink over a fresh stream pair
+    await a.mgr.emitChange("memories", "insert", { id: 710302, content: "post-a", lamport_ts: null });
+    await b.mgr.emitChange("memories", "insert", { id: 710303, content: "post-b", lamport_ts: null });
+    const aToB = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710302" })).rows.length === 1);
+    const bToA = await until(async () => (await a.db.execute({ sql: "SELECT id FROM memories WHERE id=710303" })).rows.length === 1);
+    assert.equal(aToB, true, "post-mutual-rotation A -> B converges");
+    assert.equal(bToA, true, "post-mutual-rotation B -> A converges");
+    const conflictsAfterA = Number((await a.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    const conflictsAfterB = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    assert.equal(conflictsAfterA, conflictsBeforeA, "A's sync_conflicts flat across the mutual rotation");
+    assert.equal(conflictsAfterB, conflictsBeforeB, "B's sync_conflicts flat across the mutual rotation");
+  } finally {
+    if (link) link.close();
+    await fleet.cleanup();
+  }
+});
+
+test("G7: replay safety at seq 0 -- insert-then-delete converges deleted; newer local row survives older replayed entry", async () => {
+  const fleet = await makeFleet();
+  let link; // declared outside the try -- see G2's comment
+  try {
+    const { a, b } = fleet;
+    link = await linkPeers(a, b);
+    link.close();
+    // A rotates its out-feed to B -- fresh feed, next entry lands at seq 0.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await b.mgr.initInstance(a.id, newKey);
+    link = await linkPeers(a, b);
+
+    // (a) insert-then-delete on the rotated fresh feed (seq 0, seq 1) --
+    // B must converge to NO row, not resurrect it via a replay artifact.
+    await a.mgr.emitChange("memories", "insert", { id: 710100, content: "will-be-deleted", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710100" })).rows.length === 1);
+    await a.mgr.emitChange("memories", "delete", { id: 710100 });
+    const deleted = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710100" })).rows.length === 0);
+    assert.equal(deleted, true, "B converges to NO row after insert-then-delete replayed on the rotated fresh feed");
+
+    // (b) LWW at reset-replay: B holds a LOCAL row at a HIGH lamport; A's
+    // rotated feed (seq 2) replays an OLDER update for the same id -- the
+    // LWW gate must hold even though the feed itself just reset to seq 0.
+    const HIGH_LAMPORT = 999999;
+    await b.db.execute({
+      sql: "INSERT INTO memories (id, content, lamport_ts) VALUES (?, ?, ?)",
+      args: [710200, "B's newer content", HIGH_LAMPORT],
+    });
+    await b.mgr._advanceCounter(HIGH_LAMPORT); // keep B's own counter consistent with the stamped row
+    const OLD_LAMPORT = 5; // strictly less than HIGH_LAMPORT
+    await a.mgr.emitChange("memories", "update", { id: 710200, content: "A's older replayed content" }, { lamportTs: OLD_LAMPORT });
+    // Wait for the older entry to actually be ATTEMPTED (checkpoint advances
+    // unconditionally, per-entry, outside the apply try/catch -- see
+    // _processNewEntriesInner) rather than a flat sleep: this targets the
+    // real mechanism instead of racing an arbitrary timeout.
+    const attempted = await until(async () => (await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id))) >= 3);
+    assert.equal(attempted, true, "the older replayed update must have been attempted before asserting LWW held");
+    const bRow = (await b.db.execute({ sql: "SELECT content, lamport_ts FROM memories WHERE id=710200" })).rows[0];
+    assert.equal(bRow.content, "B's newer content", "B's newer content survives the older replayed entry (LWW gate holds at reset-replay)");
+    assert.equal(Number(bRow.lamport_ts), HIGH_LAMPORT, "B's lamport_ts unchanged by the stale replay");
+  } finally {
+    if (link) link.close();
+    await fleet.cleanup();
+  }
 });

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -475,3 +475,19 @@ test("G12: in-flight old-feed processing across the swap cannot corrupt the new 
     assert.equal(JSON.stringify(await b.mgr._appliedSeqRecord(a.id)), before, "bailed run stamps nothing");
   } finally { await fleet.cleanup(); }
 });
+
+test("G11/G11b: malformed and self-echoed feed keys are rejected -- no persist-shape swap, no crash", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    await b.mgr.initInstance(a.id, null); // arm out-feed so self-key exists
+    for (const bad of ["zz".repeat(32), "aa".repeat(16), "aa".repeat(33), "", null, 42]) {
+      assert.equal(b.mgr.validateIncomingFeedKey(a.id, bad), null, `rejects ${String(bad).slice(0,8)}`);
+    }
+    const selfKey = b.mgr.getOutFeedKey(a.id).toString("hex");
+    assert.equal(b.mgr.validateIncomingFeedKey(a.id, selfKey), null, "G11b: self-echo rejected");
+    const good = "ab".repeat(32);
+    const buf = b.mgr.validateIncomingFeedKey(a.id, good);
+    assert.equal(buf?.toString("hex"), good, "valid key parses");
+  } finally { await fleet.cleanup(); }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -150,3 +150,33 @@ test("G0 baseline: real replication applies an emitted row across the socketpair
     await fleet.cleanup();
   }
 });
+
+// ── unit tests ────────────────────────────────────────────────────────────────
+
+test("C2 unit: set writes {k,s} object; get is key-gated; null-feed coerces both shapes", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { mgr, db } = fleet.a;
+    const PEER = fleet.b.id;
+    const keyX = "aa".repeat(32), keyY = "bb".repeat(32);
+    await mgr._setLastAppliedSeq(PEER, 7, keyX);
+    // Raw storage shape: a JSON object, not a string (spec C2 SQL note / R2 #7).
+    const { rows } = await db.execute({
+      sql: "SELECT last_applied_seq_per_peer AS b FROM sync_state WHERE instance_id = ?",
+      args: [mgr.localInstanceId] });
+    const rec = JSON.parse(rows[0].b)[PEER];
+    assert.equal(typeof rec, "object", "must store an object, not a JSON string");
+    assert.equal(rec.k, keyX); assert.equal(rec.s, 7);
+    // Key-gated reads:
+    assert.equal(await mgr._getLastAppliedSeq(PEER, { key: Buffer.from(keyX, "hex") }), 7);
+    assert.equal(await mgr._getLastAppliedSeq(PEER, { key: Buffer.from(keyY, "hex") }), 0,
+      "foreign-key record must read 0");
+    // Display path (feed=null) coerces the object:
+    assert.equal(await mgr._getLastAppliedSeq(PEER, null), 7);
+    // Legacy numeric display coercion (R3 F-F): write a bare number the old way.
+    await db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 42) WHERE instance_id = ?`,
+      args: [`$."${PEER}"`, mgr.localInstanceId] });
+    assert.equal(await mgr._getLastAppliedSeq(PEER, null), 42, "legacy bare number coerces");
+  } finally { await fleet.cleanup(); }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -20,6 +20,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import net from "node:net";
 import NoiseSecretStream from "@hyperswarm/secret-stream";
+import Hypercore from "hypercore";
 import { createDbClient } from "../servers/db.js";
 import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
 import * as ed from "../node_modules/@noble/ed25519/index.js";
@@ -110,7 +111,10 @@ export async function linkPeers(a, b) {
   await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id));
   await a.mgr.replicate(b.id, nsA);
   await b.mgr.replicate(a.id, nsB);
-  return { streams: [nsA, nsB], close: () => { nsA.destroy(); nsB.destroy(); } };
+  // 2d C3 (G8): expose per-side handles so a test can re-replicate one side's
+  // NEW feed onto the SAME still-open stream after that side's own rotation,
+  // without tearing down the link — non-breaking addition alongside `streams`.
+  return { streams: [nsA, nsB], nsA, nsB, close: () => { nsA.destroy(); nsB.destroy(); } };
 }
 
 /** Await until fn() is truthy or the deadline passes — condition-based, no bare sleeps. */
@@ -489,5 +493,72 @@ test("G11/G11b: malformed and self-echoed feed keys are rejected -- no persist-s
     const good = "ab".repeat(32);
     const buf = b.mgr.validateIncomingFeedKey(a.id, good);
     assert.equal(buf?.toString("hex"), good, "valid key parses");
+  } finally { await fleet.cleanup(); }
+});
+
+// ── Task 6 (C3): live-stream tracking + post-swap attach ────────────────────
+// memories.id is INTEGER PRIMARY KEY — G8 706000 (pre) / 706001 (post), G9 706100+.
+
+test("G8: rotation while a stream is actively replicating -- new feed attaches to the SAME stream", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b); // old core actively replicating on this stream
+    let streamErrors = 0;
+    link.nsA.on("error", () => { streamErrors++; });
+    link.nsB.on("error", () => { streamErrors++; });
+    await a.mgr.emitChange("memories", "insert", { id: 706000, content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=706000" })).rows.length === 1);
+    // A rotates; the key is delivered to B while the ORIGINAL stream stays open.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    // A's side of the SAME stream: A's out-feed was closed+recreated, so A must
+    // re-attach its own side explicitly (this harness action, not C3's job).
+    await a.mgr.replicate(b.id, link.nsA);
+    await b.mgr.initInstance(a.id, newKey); // swap: real bounded close of old core, then attach
+    await a.mgr.emitChange("memories", "insert", { id: 706001, content: "y", lamport_ts: null });
+    const applied = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=706001" })).rows.length === 1);
+    assert.equal(applied, true, "post-rotation data must flow over the pre-existing stream");
+    // The out-feed side (A -> B, re-attached above) must not have been disturbed
+    // by B's in-feed swap on the same stream: the pre-rotation row must still be
+    // there and the stream must not have thrown/reset underneath either side.
+    const preStillThere = (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=706000" })).rows.length === 1;
+    assert.equal(preStillThere, true, "pre-rotation row undisturbed by the swap");
+    assert.equal(streamErrors, 0, "out-feed replication over the SAME stream must not surface errors during the swap");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G9: old core blocks remain readable after the swap (acceptance pin)", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: 706100, content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=706100" })).rows.length === 1);
+    const oldKey = Buffer.from(b.mgr.inFeeds.get(a.id).key);
+    link.close();
+    // A rotates its out-feed to B (storage wiped, new key minted) -- G1-style.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await b.mgr.initInstance(a.id, newKey); // live swap, no restart -- old session closes (bounded)
+    // Release B's own live sessions on this peer's corestore dir first: the
+    // probed rocksdb fd-lock is process-wide per directory, so a standalone
+    // reopen below would otherwise collide with B's still-open NEW in-feed
+    // session even though it targets a DIFFERENT key (old vs new core).
+    await b.mgr.closeInstanceFeeds(a.id);
+    // Acceptance pin: the OLD in-feed's on-disk blocks are still directly readable
+    // by reopening the SAME "in" dir keyed with the OLD key -- the swap discards
+    // only the live Hypercore session, never the storage (probed fact: a feed dir
+    // is a multi-core store; old blocks stay readable after the old session closes).
+    const reopened = new Hypercore(join(b.mgr.dataDir, a.id, "in"), oldKey, { valueEncoding: "json" });
+    await reopened.ready();
+    assert.ok(reopened.length >= 1, "old block(s) still present on disk");
+    assert.ok(await reopened.get(0), "old block 0 still readable");
+    await reopened.close();
   } finally { await fleet.cleanup(); }
 });

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -595,3 +595,68 @@ test("G9: old core blocks remain readable after the swap (acceptance pin)", asyn
     await reopened.close();
   } finally { await fleet.cleanup(); }
 });
+
+// ── Task 7 (F3): tailnet server pre-exchange init race ─────────────────────
+
+test("G13: stale-snapshot tailnet handshake cannot swap back a concurrently-received new key", async () => {
+  const fleet = await makeFleet();
+  const http = await import("node:http");
+  const { WebSocket } = await import("ws");
+  const { setupTailnetSyncServer } = await import("../servers/sharing/tailnet-sync.js");
+  const { sign } = await import("../servers/sharing/identity.js");
+  let server, ws;
+  try {
+    const { a, b } = fleet;
+    // B hosts the WS server. Seed B's row for A with the OLD key.
+    const oldLink = await linkPeers(a, b);
+    oldLink.close();
+    const oldKeyHex = a.mgr.getOutFeedKey(b.id).toString("hex");
+    await b.db.execute({ sql: "UPDATE crow_instances SET sync_url = ? WHERE id = ?", args: [oldKeyHex, a.id] });
+    // Barrier: park the server's :222 snapshot SELECT until the new key lands.
+    let releaseLookup; const lookupGate = new Promise((r) => { releaseLookup = r; });
+    let parked = false;
+    const realExec = b.db.execute.bind(b.db);
+    const dbWrapper = { ...b.db, execute: async (q) => {
+      if (!parked && typeof q?.sql === "string" && q.sql.includes("WHERE id = ? AND status IN ('active','offline') LIMIT 1")) {
+        parked = true;
+        // Capture the snapshot NOW (before the concurrent rotation lands) --
+        // the race is that the READ happens-before the rotation but the
+        // CALLER'S USE of that stale result happens after it. Delaying
+        // realExec() itself (rather than just the return) would make the
+        // query observe the already-rotated row and defeat the gate.
+        const result = await realExec(q);
+        await lookupGate; // hold the stale snapshot until the new key lands
+        return result;
+      }
+      return realExec(q);
+    }};
+    server = http.createServer();
+    setupTailnetSyncServer(server, { identity: b.mgr.identity, instanceSyncManager: b.mgr, db: dbWrapper });
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    // Dial as A with a REAL signed handshake.
+    ws = new WebSocket(`ws://127.0.0.1:${server.address().port}/api/instance-sync/stream`);
+    await new Promise((r) => ws.once("open", r));
+    const nonce = "00".repeat(16);
+    ws.send(JSON.stringify({ instance_id: a.id, nonce_hex: nonce, sig_hex: sign(`${a.id}:${nonce}`, a.mgr.identity.ed25519Priv) }));
+    await until(() => parked); // server is now parked holding the OLD snapshot
+    // Hyperswarm path lands A's rotated key on B.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await b.db.execute({ sql: "UPDATE crow_instances SET sync_url = ? WHERE id = ?", args: [newKey.toString("hex"), a.id] });
+    await b.mgr.initInstance(a.id, newKey);
+    const swappedFeed = b.mgr.inFeeds.get(a.id);
+    releaseLookup(); // server resumes with its stale snapshot -> hits :238
+    // Give the handler time to run its init + key-exchange frames.
+    ws.send(JSON.stringify({ feed_key_hex: newKey.toString("hex") }));
+    await new Promise((r) => setTimeout(r, 300)); // grace window for the handler's post-swap writes
+    assert.equal(b.mgr.inFeeds.get(a.id), swappedFeed,
+      "the stale-snapshot :238 init must NOT have swapped the in-feed back (F3)");
+    assert.equal(b.mgr.inFeeds.get(a.id).key.toString("hex"), newKey.toString("hex"));
+  } finally {
+    if (ws) try { ws.close(); } catch {}
+    if (server) await new Promise((r) => server.close(r));
+    await fleet.cleanup();
+  }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -294,3 +294,159 @@ test("G6b: a restarted manager (same dirs+DB, new objects) completes a rotation 
     b.mgr = b2mgr; // let cleanup close the live one
   } finally { await fleet.cleanup(); }
 });
+
+// ── Task 4 (C1): live swap gates ────────────────────────────────────────────
+// memories.id is INTEGER PRIMARY KEY — string ids fail silently (T1-review
+// correction). Use integer ids: G1 704000 (pre) / 704001 (post), G5 704100,
+// G12 704200-704202.
+
+test("G1: live rotation single actor -- B swaps without restart, new emits apply, conflicts flat", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    let link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: 704000, content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=704000" })).rows.length === 1);
+    const conflictsBefore = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    link.close();
+    // A rotates its out-feed to B (storage wiped, new key minted).
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    // Key delivered to B live (as every receipt point does) — NO b restart:
+    await b.mgr.initInstance(a.id, newKey);
+    assert.notEqual(b.mgr.inFeeds.get(a.id), oldFeed, "in-feed object must be swapped");
+    assert.equal(b.mgr.inFeeds.get(a.id).key.toString("hex"), newKey.toString("hex"));
+    // Replication resumes on a fresh link; post-rotation emit applies.
+    link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: 704001, content: "y", lamport_ts: null });
+    const applied = await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=704001" })).rows.length === 1);
+    assert.equal(applied, true, "post-rotation emit must apply with no restart on B");
+    const conflictsAfter = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    assert.equal(conflictsAfter, conflictsBefore, "sync_conflicts flat");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G5: same-key re-exchange is a no-op -- feed identity and seq preserved", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: 704100, content: "x", lamport_ts: null });
+    await until(async () => (await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id))) >= 1);
+    const feedBefore = b.mgr.inFeeds.get(a.id);
+    const seqBefore = await b.mgr._getLastAppliedSeq(a.id, feedBefore);
+    await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id)); // same key again
+    assert.equal(b.mgr.inFeeds.get(a.id), feedBefore, "same feed object");
+    assert.equal(await b.mgr._getLastAppliedSeq(a.id, feedBefore), seqBefore, "seq untouched");
+    link.close();
+  } finally { await fleet.cleanup(); }
+});
+
+test("G6/G6c: hung close defers boundedly; reopen attempts do not throw; settle (resolve OR reject) un-defers and heals", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    b.mgr._rotationCloseCapMs = 200;
+    const link = await linkPeers(a, b);
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    // Injection seam (R3 F-G): wrap the REAL feed's close in a controllable promise.
+    let settle;
+    const gate = new Promise((res) => { settle = res; });
+    const realClose = oldFeed.close.bind(oldFeed);
+    oldFeed.close = () => gate.then(() => realClose());
+    // Rotate A, deliver the new key to B: close hangs → defer within the cap.
+    link.close();
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    const t0 = Date.now();
+    await b.mgr.initInstance(a.id, newKey);          // must return, not hang
+    assert.ok(Date.now() - t0 < 8000, "G6: bounded (5s cap + slack), no hang");
+    assert.equal(b.mgr.inFeeds.has(a.id), false, "deferred: no in-feed mapped");
+    assert.ok(b.mgr._deferredRotations.has(a.id), "deferred set");
+    // G6c: subsequent attempts (the C4-interval shape) must NOT throw.
+    await assert.doesNotReject(() => b.mgr.initInstance(a.id, newKey));
+    assert.equal(b.mgr.inFeeds.has(a.id), false, "still suppressed while lock held");
+    // Now the slow close settles → un-defer → next call completes the rotation.
+    settle();
+    await until(() => !b.mgr._deferredRotations.has(a.id));
+    await b.mgr.initInstance(a.id, newKey);
+    assert.equal(b.mgr.inFeeds.get(a.id)?.key.toString("hex"), newKey.toString("hex"), "healed after settle");
+  } finally { await fleet.cleanup(); }
+});
+
+test("G6c-reject: a REJECTING close un-defers with no unhandled rejection", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    b.mgr._rotationCloseCapMs = 200;
+    let link = await linkPeers(a, b);
+    link.close();
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    let reject;
+    const gate = new Promise((_, rej) => { reject = rej; });
+    oldFeed.close = () => gate; // close() = pending, then REJECTS
+    const unhandled = [];
+    const onUR = (err) => unhandled.push(err);
+    process.on("unhandledRejection", onUR);
+    try {
+      await a.mgr.closeInstanceFeeds(b.id);
+      rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+      await a.mgr.initInstance(b.id, null);
+      const newKey = a.mgr.getOutFeedKey(b.id);
+      await b.mgr.initInstance(a.id, newKey);           // defers
+      reject(new Error("close blew up"));               // the R3 F-A case
+      await until(() => !b.mgr._deferredRotations.has(a.id));
+      await new Promise((r) => setImmediate(r));        // let any UR surface
+      assert.equal(unhandled.length, 0, "no unhandled rejection from the abandoned close");
+      assert.equal(b.mgr._deferredRotations.has(a.id), false, "reject also un-defers (.finally)");
+    } finally { process.off("unhandledRejection", onUR); }
+  } finally { await fleet.cleanup(); }
+});
+
+test("G12: in-flight old-feed processing across the swap cannot corrupt the new record", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    // Seed 2 entries and let B apply them (record {k:old, s:2}).
+    for (let i = 0; i < 2; i++) await a.mgr.emitChange("memories", "insert", { id: 704200 + i, content: "x", lamport_ts: null });
+    await until(async () => (await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id))) >= 2);
+    // Trap B's _applyEntry so the NEXT processing run parks mid-loop.
+    let releaseApply; const applyGate = new Promise((r) => { releaseApply = r; });
+    const realApply = b.mgr._applyEntry.bind(b.mgr);
+    let trapped = false;
+    b.mgr._applyEntry = async (...args) => { if (!trapped) { trapped = true; await applyGate; } return realApply(...args); };
+    // Third entry arrives → old-feed run starts and parks inside _applyEntry.
+    await a.mgr.emitChange("memories", "insert", { id: 704202, content: "x", lamport_ts: null });
+    await until(() => trapped);
+    link.close();
+    // Swap while the old-feed run is mid-flight.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    await b.mgr.initInstance(a.id, newKey);
+    releaseApply();                                    // old run resumes, stamps {k:old}
+    await new Promise((r) => setTimeout(r, 100));      // let it finish its write
+    // The record must be usable by the NEW feed: either {k:new,...} already, or
+    // {k:old,...} which the key-gated read maps to 0 — NEVER {k:new, s:oldMark}.
+    const rec = await b.mgr._appliedSeqRecord(a.id);
+    if (rec.k === newKey.toString("hex")) {
+      assert.equal(rec.s, 0, "a new-key record written during the race must be the reset, not the old mark");
+    }
+    const effective = await b.mgr._getLastAppliedSeq(a.id, b.mgr.inFeeds.get(a.id));
+    assert.equal(effective === 0 || rec.k === newKey.toString("hex"), true,
+      "new feed must start from 0 -- the old run's stamp must not masquerade under the new key");
+    // And a queued post-swap run on the OLD feed must bail with no stamp:
+    const before = JSON.stringify(await b.mgr._appliedSeqRecord(a.id));
+    const oldFeedRef = { key: Buffer.from("cc".repeat(32), "hex"), length: 50, async get() { throw new Error("n/a"); } };
+    await b.mgr._processNewEntries(a.id, oldFeedRef);  // replaced feed → entry bail
+    assert.equal(JSON.stringify(await b.mgr._appliedSeqRecord(a.id)), before, "bailed run stamps nothing");
+  } finally { await fleet.cleanup(); }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -1,0 +1,152 @@
+/**
+ * Item 2d gate: feed-key rotation (spec 2026-07-15-feed-key-rotation-design.md §7).
+ * REAL Hypercores + REAL replication over NoiseSecretStream on a TCP socketpair —
+ * the existing suites apply entries directly and cannot see replication-layer
+ * defects (that blindness is what let D1/D2 ship).
+ *
+ * HARNESS: two real instances (each its own mkdtemp CROW_DATA_DIR + real init-db +
+ * real InstanceSyncManager), joined by a real NoiseSecretStream pair over a real
+ * TCP socketpair — adapted from tests/lamport-reemit.test.js's newFleet() pattern
+ * (per-side real init-db SQLite, one SHARED identity object, crow_instances peer
+ * row seeding), but replicating over the actual wire instead of a fake out-feed.
+ *
+ * NEVER point this file at ~/.crow — it opens real Hypercore feeds.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import net from "node:net";
+import NoiseSecretStream from "@hyperswarm/secret-stream";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+// ── shared identity ──────────────────────────────────────────────────────────
+// instance-sync verifies every entry against `this.identity.ed25519Pubkey`, and
+// a user's instances share one identity — both managers MUST use the same object
+// (tests/lamport-reemit.test.js pattern). getPublicKey is async, so resolve it
+// once into the identity shape InstanceSyncManager expects.
+async function makeSharedIdentity() {
+  const TEST_PRIV = Buffer.alloc(32, 0x2c);
+  const TEST_PUB_HEX = Buffer.from(await ed.getPublicKey(TEST_PRIV)).toString("hex");
+  return { ed25519Priv: TEST_PRIV, ed25519Pubkey: TEST_PUB_HEX };
+}
+
+/** Real init-db.js run against a fresh dir — same mechanism as lamport-reemit.test.js. */
+async function makeRealDb(dir) {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    // CROW_DB_PATH outranks CROW_DATA_DIR in init-db (init-db.js:11) — blank it, or
+    // a shell exporting it would run the migration against the REAL DB.
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DB_PATH: "", CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    stdio: "pipe",
+  });
+  return createDbClient(join(dir, "crow.db"));
+}
+
+/** Seed `db`'s crow_instances with peerId as an active paired peer. */
+async function registerPeerRow(db, peerId) {
+  await db.execute({
+    sql: "INSERT INTO crow_instances (id, name, crow_id, status) VALUES (?, ?, ?, 'active')",
+    args: [peerId, peerId, `crow:${peerId}`],
+  });
+}
+
+async function makeSide(identity, id) {
+  const dir = mkdtempSync(join(tmpdir(), `rot-${id}-`));
+  const db = await makeRealDb(dir); // ← same helper style as lamport-reemit.test.js
+  const mgr = new InstanceSyncManager(identity, db, id);
+  mgr.dataDir = join(dir, "instance-sync"); // MUST: keep test feeds out of ~/.crow
+  mgr.feedsDisabled = false;                // MUST: scratch env disables feeds (2c C6)
+  return { mgr, db, dir, id };
+}
+
+export async function makeFleet() {
+  const identity = await makeSharedIdentity(); // same object for both sides
+  const a = await makeSide(identity, "instA");
+  const b = await makeSide(identity, "instB");
+  // Register each other in crow_instances so eager/boot paths see a paired row.
+  await registerPeerRow(a.db, b.id);
+  await registerPeerRow(b.db, a.id);
+  return {
+    a, b,
+    async cleanup() {
+      await a.mgr.close(); await b.mgr.close();
+      rmSync(a.dir, { recursive: true, force: true });
+      rmSync(b.dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Real socketpair: two net.Sockets connected through an ephemeral local server. */
+function socketPair() {
+  return new Promise((resolve, reject) => {
+    // Declared here (not inside the listen callback below) so both callbacks —
+    // siblings, not nested — close over the SAME binding. `var` inside the
+    // listen callback would hoist only to that inner function's scope and
+    // leave the reference in the connection callback unbound.
+    let clientSide;
+    const server = net.createServer((serverSide) => {
+      server.close();
+      resolve([serverSide, clientSide]);
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      clientSide = net.connect(server.address().port, "127.0.0.1");
+      clientSide.on("error", reject);
+    });
+  });
+}
+
+export async function linkPeers(a, b) {
+  const [sockA, sockB] = await socketPair();
+  const nsA = new NoiseSecretStream(true, sockA);
+  const nsB = new NoiseSecretStream(false, sockB);
+  nsA.on("error", () => {}); nsB.on("error", () => {});
+  // Exchange feed keys the way the real handshake does, then replicate.
+  await a.mgr.initInstance(b.id, b.mgr.getOutFeedKey(a.id));
+  await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id));
+  await a.mgr.replicate(b.id, nsA);
+  await b.mgr.replicate(a.id, nsB);
+  return { streams: [nsA, nsB], close: () => { nsA.destroy(); nsB.destroy(); } };
+}
+
+/** Await until fn() is truthy or the deadline passes — condition-based, no bare sleeps. */
+export async function until(fn, ms = 5000, step = 25) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if (await fn()) return true;
+    await new Promise((r) => setTimeout(r, step));
+  }
+  return false;
+}
+
+test("G0 baseline: real replication applies an emitted row across the socketpair", async () => {
+  const fleet = await makeFleet();
+  let link;
+  try {
+    // Arm feeds by exchanging real keys BEFORE linking (linkPeers does both).
+    link = await linkPeers(fleet.a, fleet.b);
+    // memories.id is INTEGER PRIMARY KEY AUTOINCREMENT (real schema, scripts/init-db.js) —
+    // a text id like "rot-g0" throws SQLITE datatype mismatch on the receiving INSERT,
+    // so the emitted row's id must be a real integer (adapted from the brief's literal
+    // string id, which does not survive against the real table).
+    const G0_ID = 700001;
+    await fleet.a.mgr.emitChange("memories", "insert",
+      { id: G0_ID, content: "rot-g0 hello", lamport_ts: null });
+    const applied = await until(async () => {
+      const { rows } = await fleet.b.db.execute({
+        sql: "SELECT id FROM memories WHERE id = ?", args: [G0_ID] });
+      return rows.length === 1;
+    });
+    assert.equal(applied, true, "row emitted on A must apply on B via real replication");
+  } finally {
+    // link.close() BEFORE fleet.cleanup() regardless of pass/fail — an assertion
+    // throw must not strand the NoiseSecretStream/TCP sockets open (they held the
+    // whole process open past a failing run in early iteration of this harness).
+    if (link) link.close();
+    await fleet.cleanup();
+  }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -409,6 +409,31 @@ test("G6c-reject: a REJECTING close un-defers with no unhandled rejection", asyn
   } finally { await fleet.cleanup(); }
 });
 
+test("C1 open-degrade: unopenable successor key after a live rotation degrades to out-only, never throws", async () => {
+  // Committed guard for the open try/catch (R2 #1 / R3 F-D). A non-32-byte
+  // buffer passes the swap branch's Buffer.equals key-compare (length mismatch
+  // → keys differ → rotation proceeds, old feed closes fast) and then throws
+  // inside the try at `new Hypercore(...)` ("Must pass a 32 byte buffer") —
+  // exercising the CATCH, not an earlier guard. Removing the try/catch turns
+  // this red (initInstance rejects).
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    link.close();
+    const oldFeed = b.mgr.inFeeds.get(a.id);
+    const badKey = Buffer.from("aa".repeat(5), "hex"); // unopenable: wrong length
+    await assert.doesNotReject(() => b.mgr.initInstance(a.id, badKey), "open failure must degrade, not throw");
+    assert.equal(b.mgr.inFeeds.has(a.id), false, "out-only degrade: no in-feed mapped");
+    assert.equal(b.mgr._inFeedListeners.has(a.id), false, "old append listener detached");
+    assert.equal(b.mgr._deferredRotations.has(a.id), false, "not deferred: the close succeeded, this is the degrade path");
+    assert.equal(oldFeed.closed, true, "old feed was detached and closed by the swap branch");
+    // The degrade is recoverable: a later valid key completes the rotation.
+    await b.mgr.initInstance(a.id, a.mgr.getOutFeedKey(b.id));
+    assert.equal(b.mgr.inFeeds.get(a.id)?.key.toString("hex"), a.mgr.getOutFeedKey(b.id).toString("hex"), "valid key heals");
+  } finally { await fleet.cleanup(); }
+});
+
 test("G12: in-flight old-feed processing across the swap cannot corrupt the new record", async () => {
   const fleet = await makeFleet();
   try {

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -660,3 +660,45 @@ test("G13: stale-snapshot tailnet handshake cannot swap back a concurrently-rece
     await fleet.cleanup();
   }
 });
+
+// ── Task 8 (C4): 60s heal loop in refresh() ─────────────────────────────────
+
+test("C4: refresh heals sync_url drift for ALREADY-DIALING peers and survives initInstance throws", async () => {
+  const calls = [];
+  const stubMgr = {
+    localInstanceId: "me",
+    // Mirrors the real InstanceSyncManager.validateIncomingFeedKey contract
+    // (servers/sharing/instance-sync.js): a well-formed 64-hex-char key
+    // decodes to a Buffer; anything else is rejected as null. The brief's
+    // literal stub omits this method entirely, which under the heal call's
+    // `validateIncomingFeedKey?.(...) ?? null` optional-chaining would pass
+    // null (arm-only) for every peer -- failing this test's very first
+    // assertion (calls[0] expects the real hex key, not null). Giving the
+    // stub the real method's observable behavior keeps the test honest
+    // without dragging in a full InstanceSyncManager (Hypercore, inFeeds,
+    // on-disk dirs) that this unit test has no business needing.
+    validateIncomingFeedKey: (_peerId, hex) =>
+      typeof hex === "string" && /^[0-9a-fA-F]{64}$/.test(hex) ? Buffer.from(hex, "hex") : null,
+    initInstance: async (id, key) => {
+      calls.push([id, key ? key.toString("hex") : null]);
+      if (calls.length === 1) throw new Error("boom"); // first tick throws
+    },
+  };
+  const peerRow = { id: "peer1", gateway_url: "http://127.0.0.1:1", tailscale_ip: null, sync_url: "ab".repeat(32), status: "active" };
+  const stubDb = { execute: async () => ({ rows: [peerRow] }) };
+  const { startTailnetSyncClients } = await import("../servers/sharing/tailnet-sync.js");
+  const clients = await startTailnetSyncClients({ db: stubDb, instanceSyncManager: stubMgr, identity: {} });
+  try {
+    // First refresh already ran inside startTailnetSyncClients: the throw must
+    // not have escaped (this test completing IS the assertion), and the call
+    // must have carried the persisted key.
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], ["peer1", "ab".repeat(32)]);
+    assert.ok(clients.dialers.has("peer1"), "dialer was still created after the throw");
+    // Second refresh: peer is ALREADY dialing -- the heal call must still fire
+    // (placed BEFORE the dialers.has() continue; R3 F-C).
+    peerRow.sync_url = "cd".repeat(32);
+    await clients.__refreshForTest();
+    assert.deepEqual(calls[1], ["peer1", "cd".repeat(32)], "already-dialing peer still healed");
+  } finally { clients.stop(); }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -531,6 +531,37 @@ test("G8: rotation while a stream is actively replicating -- new feed attaches t
   } finally { await fleet.cleanup(); }
 });
 
+test("C3 churn: a lingering old stream's late close must not drop a re-paired peer's fresh stream set", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    // Track an OLD stream (Set A) on B for peer A.
+    const link1 = await linkPeers(a, b);
+    const oldStream = link1.nsB;
+    assert.equal(b.mgr._activeStreams.get(a.id)?.has(oldStream), true, "old stream tracked");
+    // Revoke: map entry deleted, but oldStream's close listener still holds Set A.
+    await b.mgr.closeInstanceFeeds(a.id);
+    assert.equal(b.mgr._activeStreams.has(a.id), false, "revoke tears down the tracked set");
+    // Re-pair: a NEW stream creates a FRESH Set B in the map.
+    const link2 = await linkPeers(a, b);
+    const newStream = link2.nsB;
+    assert.equal(b.mgr._activeStreams.get(a.id)?.has(newStream), true, "fresh set holds the new stream");
+    // Precondition for non-vacuousness: the OLD stream must still be open when
+    // the fresh set exists — its close has not fired yet.
+    assert.equal(oldStream.destroyed, false, "precondition: old stream still open when the fresh set is created");
+    // The old stream's socket finally tears down → its drop() runs, emptying
+    // stale Set A. Without the identity guard it would delete the map entry —
+    // destroying live Set B.
+    link1.close();
+    await until(() => oldStream.destroyed);
+    await new Promise((r) => setImmediate(r)); // let the close listener run after destroy settles
+    const liveSet = b.mgr._activeStreams.get(a.id);
+    assert.ok(liveSet, "fresh stream set must survive the stale stream's late close");
+    assert.equal(liveSet.has(newStream), true, "fresh set still contains the new stream");
+    link2.close();
+  } finally { await fleet.cleanup(); }
+});
+
 test("G9: old core blocks remain readable after the swap (acceptance pin)", async () => {
   const fleet = await makeFleet();
   try {
@@ -550,6 +581,8 @@ test("G9: old core blocks remain readable after the swap (acceptance pin)", asyn
     // probed rocksdb fd-lock is process-wide per directory, so a standalone
     // reopen below would otherwise collide with B's still-open NEW in-feed
     // session even though it targets a DIFFERENT key (old vs new core).
+    // NOTE: this narrows what G9 proves — old blocks survive rotation and are
+    // readable once sessions close, NOT concurrent-session coexistence.
     await b.mgr.closeInstanceFeeds(a.id);
     // Acceptance pin: the OLD in-feed's on-disk blocks are still directly readable
     // by reopening the SAME "in" dir keyed with the OLD key -- the swap discards

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -180,3 +180,117 @@ test("C2 unit: set writes {k,s} object; get is key-gated; null-feed coerces both
     assert.equal(await mgr._getLastAppliedSeq(PEER, null), 42, "legacy bare number coerces");
   } finally { await fleet.cleanup(); }
 });
+
+// ── C2 reconcile-at-open (2d Task 3) ───────────────────────────────────────────
+// NOTE ids: memories.id is INTEGER PRIMARY KEY — the brief's string ids
+// (g4-*, g4c-*, g6b-pre) throw a silent datatype-mismatch on the receiving
+// INSERT, which until() only observes as a timeout. Use unique integer ids:
+// G4a/G4b range 703000-703009, G4c range 703100-703104, G6b uses 703200.
+
+test("G4a/G4b: legacy numeric adopted when n <= length at open; reset when n > length", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    // Build a real feed pair, replicate 3 entries so B's in-feed has length 3.
+    const link = await linkPeers(a, b);
+    for (let i = 0; i < 3; i++) {
+      await a.mgr.emitChange("memories", "insert", { id: 703000 + i, content: "x", lamport_ts: null });
+    }
+    // Wait for the real applied-seq record to settle at s:3, not just for
+    // feed.length to reach 3 — feed.length only proves the bytes landed, not
+    // that the receiving side's per-entry processing pipeline (which writes
+    // its OWN {k,s} checkpoint) has finished. Waiting on length alone races
+    // the pipeline's checkpoint writes against this test's manual override
+    // below (observed: the pipeline's write landed AFTER the manual override
+    // and silently clobbered it, corrupting the RED evidence for G4a).
+    await until(async () => {
+      const r = await b.mgr._appliedSeqRecord(a.id);
+      return typeof r === "object" && r !== null && r.s === 3;
+    });
+    link.close();
+    // Simulate legacy state: overwrite B's record with a bare number, then
+    // force a re-open (close feeds, re-init) — reconcile must run at open.
+    const K = b.mgr.inFeeds.get(a.id).key.toString("hex");
+    await b.db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 2) WHERE instance_id = ?`,
+      args: [`$."${a.id}"`, b.mgr.localInstanceId] });
+    await b.mgr.closeInstanceFeeds(a.id);
+    await b.mgr.initInstance(a.id, Buffer.from(K, "hex"));   // n=2 <= length 3 → adopt
+    let rec = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual({ k: rec.k, s: rec.s }, { k: K, s: 2 }, "G4a: adopted as {k, s:n}");
+    // G4b: n > length → provably foreign → reset to 0.
+    await b.db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 99) WHERE instance_id = ?`,
+      args: [`$."${a.id}"`, b.mgr.localInstanceId] });
+    await b.mgr.closeInstanceFeeds(a.id);
+    await b.mgr.initInstance(a.id, Buffer.from(K, "hex"));
+    rec = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual({ k: rec.k, s: rec.s }, { k: K, s: 0 }, "G4b: impossible mark reset to 0");
+  } finally { await fleet.cleanup(); }
+});
+
+test("G4c burst-crossing: legacy n vs fresh rotated feed that replicates a backlog past n in one link", async () => {
+  const fleet = await makeFleet();
+  let link;
+  try {
+    const { a, b } = fleet;
+    // A pre-populates FIVE entries in its out-feed to B while UNLINKED (so the
+    // whole backlog arrives as one burst after B opens its fresh in-feed).
+    await a.mgr.initInstance(b.id, null);
+    for (let i = 0; i < 5; i++) {
+      await a.mgr.emitChange("memories", "insert", { id: 703100 + i, content: "x", lamport_ts: null });
+    }
+    // B holds a stale legacy mark n=3 for A (as if earned on a long-dead feed).
+    await b.db.execute({
+      sql: `UPDATE sync_state SET last_applied_seq_per_peer = json_set(COALESCE(last_applied_seq_per_peer,'{}'), ?, 3) WHERE instance_id = ?`,
+      args: [`$."${a.id}"`, b.mgr.localInstanceId] });
+    // B opens A's feed fresh (length 0 at open → reset to {k,s:0}), THEN the
+    // burst replicates. Lazy evaluation would flip to "trust 3" once length=5.
+    link = await linkPeers(a, b);
+    // Right-reason check (mandatory per T1 review): the record must already be
+    // frozen at {k, s:0} the instant the feed opened, BEFORE the burst lands —
+    // otherwise a pass here could mean "everything happened to apply anyway"
+    // rather than "the impossible mark was actually discarded at open".
+    const K = b.mgr.inFeeds.get(a.id).key.toString("hex");
+    const recAtOpen = await b.mgr._appliedSeqRecord(a.id);
+    assert.deepEqual(recAtOpen && { k: recAtOpen.k, s: recAtOpen.s }, { k: K, s: 0 },
+      "G4c right-reason: record frozen at {k,s:0} at open, before the burst lands");
+    const allApplied = await until(async () => {
+      const { rows } = await b.db.execute({
+        sql: "SELECT COUNT(*) AS n FROM memories WHERE id BETWEEN 703100 AND 703104" });
+      return Number(rows[0].n) === 5;
+    });
+    assert.equal(allApplied, true, "entries 0..2 must NOT be skipped (burst-crossing, R1 F2)");
+  } finally {
+    // link.close() BEFORE fleet.cleanup(), same footgun as G0: an assertion
+    // throw must not strand the NoiseSecretStream/TCP sockets open.
+    if (link) link.close();
+    await fleet.cleanup();
+  }
+});
+
+test("G6b: a restarted manager (same dirs+DB, new objects) completes a rotation via reconcile", async () => {
+  const fleet = await makeFleet();
+  try {
+    const { a, b } = fleet;
+    const link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: 703200, content: "x", lamport_ts: null });
+    await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=703200" })).rows.length === 1);
+    link.close();
+    // A "rotates": wipe its out-feed dir for B and re-init → new key minted.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKey = a.mgr.getOutFeedKey(b.id);
+    // B "restarts": build a NEW manager over B's same db+dataDir, sync_url = new key.
+    await b.mgr.close();
+    const b2mgr = new (b.mgr.constructor)(b.mgr.identity, b.db, b.mgr.localInstanceId);
+    b2mgr.dataDir = b.mgr.dataDir; b2mgr.feedsDisabled = false;
+    await b2mgr.initInstance(a.id, newKey); // reconcile: k differs → {k:new, s:0}
+    const rec = await b2mgr._appliedSeqRecord(a.id);
+    assert.equal(rec.k, newKey.toString("hex"));
+    assert.equal(rec.s, 0, "restart completes rotation: record reset for the new feed");
+    await b2mgr.close();
+    b.mgr = b2mgr; // let cleanup close the live one
+  } finally { await fleet.cleanup(); }
+});

--- a/tests/feed-rotation.test.js
+++ b/tests/feed-rotation.test.js
@@ -852,6 +852,83 @@ test("G3 MUTUAL: both sides rotate simultaneously -- both swap, both directions 
   }
 });
 
+// G3b exists because G3 above pins mutual FRESH-REPAIR, not mutual LIVE-SWAP:
+// its closeInstanceFeeds calls tear down each side's in-feed too, so both
+// post-rotation key deliveries take initInstance's fresh-open branch, never
+// the live-swap branch. The realistic mutual scenario — both peers rotate
+// while each still HOLDS a live old in-feed for the other, then each receives
+// the other's new key and must swap the live feed — is what G3b pins.
+// Integer ids 710400-710403 (710300-710303 belong to G3).
+test("G3b MUTUAL live-swap: both sides swap live in-feeds concurrently", async () => {
+  const fleet = await makeFleet();
+  let link; // declared outside the try -- see G2's comment
+  try {
+    const { a, b } = fleet;
+    link = await linkPeers(a, b);
+    // Baseline: converge one row each way (bidirectional linkPeers).
+    await a.mgr.emitChange("memories", "insert", { id: 710400, content: "pre-a", lamport_ts: null });
+    await b.mgr.emitChange("memories", "insert", { id: 710401, content: "pre-b", lamport_ts: null });
+    assert.equal(await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710400" })).rows.length === 1),
+      true, "precondition: A -> B works before rotation");
+    assert.equal(await until(async () => (await a.db.execute({ sql: "SELECT id FROM memories WHERE id=710401" })).rows.length === 1),
+      true, "precondition: B -> A works before rotation");
+    const oldKeyA = Buffer.from(a.mgr.getOutFeedKey(b.id)); // A's old out-feed key (B's old in-feed)
+    const oldKeyB = Buffer.from(b.mgr.getOutFeedKey(a.id)); // B's old out-feed key (A's old in-feed)
+    const conflictsBeforeA = Number((await a.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    const conflictsBeforeB = Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n);
+    link.close();
+    // A rotates its OUT-feed, then RE-ARMS its in-feed with B's OLD key
+    // (opening an in-feed needs no online writer) — A now holds a LIVE old
+    // in-feed alongside its new out-feed, the pre-swap state a real peer is
+    // in when the other side's rotation announcement arrives.
+    await a.mgr.closeInstanceFeeds(b.id);
+    rmSync(join(a.mgr.dataDir, b.id, "out"), { recursive: true, force: true });
+    await a.mgr.initInstance(b.id, null);
+    const newKeyA = a.mgr.getOutFeedKey(b.id);
+    await a.mgr.initInstance(b.id, oldKeyB); // re-arm in-feed on the OLD key
+    assert.equal(a.mgr.inFeeds.get(b.id)?.key.toString("hex"), oldKeyB.toString("hex"),
+      "A holds a live in-feed on B's OLD key before the concurrent delivery");
+    // B: same shape.
+    await b.mgr.closeInstanceFeeds(a.id);
+    rmSync(join(b.mgr.dataDir, a.id, "out"), { recursive: true, force: true });
+    await b.mgr.initInstance(a.id, null);
+    const newKeyB = b.mgr.getOutFeedKey(a.id);
+    await b.mgr.initInstance(a.id, oldKeyA); // re-arm in-feed on the OLD key
+    assert.equal(b.mgr.inFeeds.get(a.id)?.key.toString("hex"), oldKeyA.toString("hex"),
+      "B holds a live in-feed on A's OLD key before the concurrent delivery");
+    // Capture in-feed object identities, then deliver both new keys
+    // CONCURRENTLY — both sides must take the LIVE-SWAP branch (old feed
+    // detached+closed bounded, successor opened) at the same time.
+    const oldInFeedOnA = a.mgr.inFeeds.get(b.id);
+    const oldInFeedOnB = b.mgr.inFeeds.get(a.id);
+    await Promise.all([
+      a.mgr.initInstance(b.id, newKeyB),
+      b.mgr.initInstance(a.id, newKeyA),
+    ]);
+    // Identity assertions — the distinctly-G3b pins (redden under T4's
+    // mutation 1, the key-compare skip, in BOTH directions):
+    assert.notEqual(a.mgr.inFeeds.get(b.id), oldInFeedOnA, "A's in-feed object must be live-swapped");
+    assert.notEqual(b.mgr.inFeeds.get(a.id), oldInFeedOnB, "B's in-feed object must be live-swapped");
+    assert.equal(a.mgr.inFeeds.get(b.id)?.key.toString("hex"), newKeyB.toString("hex"), "A's in-feed carries B's NEW key");
+    assert.equal(b.mgr.inFeeds.get(a.id)?.key.toString("hex"), newKeyA.toString("hex"), "B's in-feed carries A's NEW key");
+    // Convergence over a fresh link, both directions, conflicts flat.
+    link = await linkPeers(a, b);
+    await a.mgr.emitChange("memories", "insert", { id: 710402, content: "post-a", lamport_ts: null });
+    await b.mgr.emitChange("memories", "insert", { id: 710403, content: "post-b", lamport_ts: null });
+    assert.equal(await until(async () => (await b.db.execute({ sql: "SELECT id FROM memories WHERE id=710402" })).rows.length === 1),
+      true, "post-mutual-live-swap A -> B converges");
+    assert.equal(await until(async () => (await a.db.execute({ sql: "SELECT id FROM memories WHERE id=710403" })).rows.length === 1),
+      true, "post-mutual-live-swap B -> A converges");
+    assert.equal(Number((await a.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n),
+      conflictsBeforeA, "A's sync_conflicts flat across the mutual live swap");
+    assert.equal(Number((await b.db.execute({ sql: "SELECT COUNT(*) AS n FROM sync_conflicts" })).rows[0].n),
+      conflictsBeforeB, "B's sync_conflicts flat across the mutual live swap");
+  } finally {
+    if (link) link.close();
+    await fleet.cleanup();
+  }
+});
+
 test("G7: replay safety at seq 0 -- insert-then-delete converges deleted; newer local row survives older replayed entry", async () => {
   const fleet = await makeFleet();
   let link; // declared outside the try -- see G2's comment

--- a/tests/instance-sync.test.js
+++ b/tests/instance-sync.test.js
@@ -23,6 +23,7 @@
 import { test, after, before } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -95,8 +96,9 @@ function signEntry(entry) {
  * Append entries with stubFeed.push(entry).
  * entries array is exposed for direct mutation in tests (e.g. corrupting signatures).
  */
-function makeStubFeed() {
+function makeStubFeed(keyHex = randomBytes(32).toString("hex")) {
   const feed = {
+    key: Buffer.from(keyHex, "hex"),
     entries: [],
     get length() { return feed.entries.length; },
     async get(seq) { return feed.entries[seq]; },
@@ -236,11 +238,13 @@ test("3. Per-entry checkpoint: crash after seqs 0-1 resumes at seq 2; seqs 0-1 n
 
   // "Crash" after processing only seqs 0-1 by limiting feed length.
   // We simulate this by manipulating lastSeq manually — process a 2-item feed.
-  const feed2 = { length: 2, get: async (seq) => feed.entries[seq] };
+  // SAME key as feed: different keys would make the key-gate return 0 and the
+  // "seqs 0-1 not re-applied" assertion pass vacuously (2a vacuous-test tell).
+  const feed2 = { key: feed.key, length: 2, get: async (seq) => feed.entries[seq] };
   await mgr._processNewEntries(REMOTE, feed2);
 
   // Checkpoint for REMOTE should now be 2
-  const cp2 = await mgr._getLastAppliedSeq(REMOTE);
+  const cp2 = await mgr._getLastAppliedSeq(REMOTE, feed2);
   assert.equal(cp2, 2, "checkpoint after 2 entries should be 2");
 
   // Content should reflect seq1 (lamport_ts=20)
@@ -267,7 +271,7 @@ test("3. Per-entry checkpoint: crash after seqs 0-1 resumes at seq 2; seqs 0-1 n
   assert.equal(rowsFinal[0].content, "seq4", "content should be from seq4 after full run");
 
   // Checkpoint advanced to feed.length (5)
-  const cpFinal = await mgr2._getLastAppliedSeq(REMOTE);
+  const cpFinal = await mgr2._getLastAppliedSeq(REMOTE, feed);
   assert.equal(cpFinal, 5, "checkpoint should be 5 after full processing");
 
   db.close();
@@ -285,12 +289,14 @@ test("4. Checkpoint blob concurrency: concurrent _setLastAppliedSeq for two peer
 
   // Both fire at the same time
   await Promise.all([
-    mgr._setLastAppliedSeq(PEER_A, 7),
-    mgr._setLastAppliedSeq(PEER_B, 13),
+    mgr._setLastAppliedSeq(PEER_A, 7, "aa".repeat(32)),
+    mgr._setLastAppliedSeq(PEER_B, 13, "bb".repeat(32)),
   ]);
 
-  const seqA = await mgr._getLastAppliedSeq(PEER_A);
-  const seqB = await mgr._getLastAppliedSeq(PEER_B);
+  // No feed context for this test — display path (feed=null) coerces
+  // regardless of key.
+  const seqA = await mgr._getLastAppliedSeq(PEER_A, null);
+  const seqB = await mgr._getLastAppliedSeq(PEER_B, null);
 
   assert.equal(seqA, 7, "peer A checkpoint should be 7");
   assert.equal(seqB, 13, "peer B checkpoint should be 13");
@@ -351,7 +357,7 @@ test("5. Per-peer serialization: two concurrent _processNewEntries on same feed 
   assert.equal(rows[0].content, "step-6", "last update wins");
 
   // Checkpoint should be 6 (all entries processed once)
-  const cp = await mgr._getLastAppliedSeq(REMOTE);
+  const cp = await mgr._getLastAppliedSeq(REMOTE, feed);
   assert.equal(cp, 6, "checkpoint = feed.length");
 
   db.close();


### PR DESCRIPTION
## Item 2d — feed-key rotation

Spec: `docs/superpowers/specs/2026-07-15-feed-key-rotation-design.md` (rev 4, 3 adversarial review rounds; §3 contract, §7 gate table, §11 review record). Plan: `docs/superpowers/plans/2026-07-15-item2d-feed-key-rotation.md`. Built via subagent-driven TDD, per-task review + whole-branch adversarial review (verdict: READY TO MERGE).

### Defects closed

| # | Defect | Fix |
|---|--------|-----|
| D1 | Open in-feed never swapped on key change — stale until restart | C1 key-aware `_initInstanceInner`: live swap (detach listener → unmap → 5s-capped close → open successor in same multi-core dir), defer-loudly on hung close with `.finally` un-defer, out-only degrade on open failure |
| D2 | `last_applied_seq_per_peer` keyed by peer only — after rotation the fresh feed's entries below the stale mark are skipped FOREVER | C2 feed-keyed `{k,s}` records via `json()`, key-gated reads, processed-feed stamping, reconcile-at-open (frozen legacy adopt/reset decision) |
| D3 | Streams established before key receipt never carry the new feed | C3 `_activeStreams` tracking + post-swap attach (identity-guarded drop across revoke/re-pair churn) |
| D4 | Once-backfill flags' premise dies with a lost out-feed | C5 `resetBackfillPremiseFlags()` at boot, ordered before the settings-scope heals (load-bearing — heals emit once the sync manager is wired) |
| F3 | Tailnet server's stale row snapshot could swap a rotated feed BACK | Pre-exchange init passes null; authenticated exchange drives swaps (gate G13: real-WS race proof) |

Plus `validateIncomingFeedKey` (malformed + self-echo rejected at all three receipt points) and C4 (60s refresh heals sync_url drift for already-dialing peers, throw-isolated).

### Gates

`tests/feed-rotation.test.js` — 22 tests on REAL Hypercores + REAL NoiseSecretStream replication over TCP socketpairs (existing suites drive stub feeds and cannot see replication-layer defects — that blindness is what let D1/D2 ship). G0-G13 all green ×3 stable, including G3 mutual fresh-repair AND G3b mutual live-swap (both sides swap concurrently), G4c burst-crossing (kills lazy legacy evaluation), G6c-reject (rejecting close un-defers, no unhandled rejection), G12 (in-flight old-feed run cannot corrupt the successor's record), G13 (stale-snapshot swap-back race).

### Mutation matrix

Every guard was mutation-checked: comment out → NAMED test red (failure line recorded) → restore → green. ~25 mutations across T2-T10, recorded in `.superpowers/sdd/task-{2..10}-report.md`; several independently reproduced by per-task reviewers. Two of the plan's suggested mutations were replaced with verified adjacent ones for documented structural reasons (read-gate mutation is covered by G12+C2; fresh-open guard mutation covers G3) — adjudicated by the opus reviewer.

### Suite

Full suite on scratch env: **1974 pass / 2 known fails (bundles-validate-install, pre-existing) / 0 skips** (baseline was 1953/2/0; +21 net new). `check-port-allocation` green (exactly the known Port 8090 capstone-tracker line), `build-registry --check` green, gateway boots clean.

### Notes

- **No schema bump** — no migration rail needed; auto-update stays ON.
- **One-way applied-seq migration** (operator note): first 2d boot upgrades legacy numeric marks to `{k,s}` (adopted in place — no re-processing). Rolling an instance back to pre-2d binaries against the same DB silently stalls inbound sync for upgraded peers (no crash/corruption; heals on re-deploy). Consistent with the fleet's fix-forward posture.
- `_rotationCloseCapMs` field (default 5000) is a test knob not in the spec — semantically inert, keeps the G6 family fast.
- Boot-liveness: the only new boot-reachable await is the 5s-capped close race, and the swap branch is unreachable during eager boot (fresh process has empty `inFeeds`); C4 runs in the fire-and-forget post-listen IIFE.