### PR TITLE
2c follow-up pool: nostr crash guard, apply-path await bounds, Restore UX, pending-emit gauge (F1-F5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,9 @@ CROW_DB_PATH=./data/crow.db
 # NTFY_AUTH_TOKEN=
 # NTFY_EXTERNAL_URL=
 
+# Per-send timeout (ms) for all push senders (ntfy, email, web-push)
+# CROW_PUSH_SEND_TIMEOUT_MS=10000
+
 # ── CALLS (WebRTC, optional) ─────────────────────────────
 
 # Enable the calls feature (rooms + signaling)

--- a/docs/developers/configuration.md
+++ b/docs/developers/configuration.md
@@ -97,6 +97,7 @@ link here — there is no built-in fallback model list.
 | `NTFY_AUTH_TOKEN` / `NTFY_EXTERNAL_URL` / `NTFY_EXTRA_TOPICS` | *(unset)* | Auth, external URL for links, extra topics. |
 | `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | *(unset = PWA push disabled)* | Web Push keys (`npx web-push generate-vapid-keys`). |
 | `VAPID_EMAIL` | `mailto:admin@localhost` | VAPID contact. |
+| `CROW_PUSH_SEND_TIMEOUT_MS` | `10000` | Per-send cap for ntfy / email / web-push (a hung endpoint can no longer wedge notification delivery). |
 | `RESEND_API_KEY` / `MPA_EMAIL_FROM` / `MPA_EMAIL_TO` | *(unset)* | Email notifications via Resend. |
 
 ## Sharing, P2P & calls

--- a/docs/superpowers/plans/2026-07-15-2c-followups.md
+++ b/docs/superpowers/plans/2026-07-15-2c-followups.md
@@ -1,0 +1,108 @@
+# 2c follow-up pool (F1–F6) — SDD execution plan
+
+**Date:** 2026-07-15 · **Spec:** `docs/superpowers/specs/2026-07-15-2c-followups-design.md`
+(rev 3, 2 adversarial rounds folded) · **Branch:** `fix/2c-followup-pool` · **No schema bump.**
+
+Standing rules apply (arc plan §3): positional-path commits + `git show --stat HEAD`
+after every commit; no backticks in `-m`; scratch-env suite only; test harnesses on
+real init-db need `mgr.dataDir=mkdtemp` AND `mgr.feedsDisabled=false`; memories.id is
+INTEGER (string test-ids fail silently); park-a-DB-call barriers delay result DELIVERY,
+not the call.
+
+**Baselines:** suite 1974/2/0 (2 = bundles-validate-install); any 3rd failure is new.
+sync_conflicts 219/183/162/0 — growth is red.
+
+Each task: RED test first → implement → mutation check (comment guard out, watch the
+NAMED test go red, restore) → focused test run → per-task fresh reviewer subagent.
+Tasks run SEQUENTIALLY on the one branch (T1 before T6: both touch tailnet-sync.js).
+
+---
+
+## T1 — F1: SendingOnClosedConnection crash class (3 guards + crash net)
+
+Files: `servers/sharing/resilient-subscribe.js` (C1a guard in doSubscribe),
+`scripts/pi-bots/gateways/nostr-client.mjs` (C1a′ guard in raw subscribe()),
+NEW `servers/sharing/nostr-crash-guard.js` (C1b per spec — exported handleRejection,
+install/uninstall, rate-limited log10 counter), install sites: gateway NostrManager
+construction (`servers/sharing/managers.js` or where NostrManager is built — locate,
+don't guess) + `nostr-client.mjs` connect path, `servers/sharing/tailnet-sync.js:531-533`
+comment fix ("no unhandledRejection handler" → now false).
+Tests: NEW `tests/nostr-crash-guard.test.js` — G-F1-1 (async-orphan stub — MUST be an
+un-awaited async throw inside subscribe(), NOT a sync throw; test installs/removes its
+own capture handler), G-F1-2 (mutation: C1a guard), G-F1-3 (unit-call handleRejection
+both legs; install idempotence via listenerCount with uninstall in finally), G-F1-4
+(pi-bots raw-subscribe guard + mutation).
+
+## T2 — F2/C2a: sender-level notification timeouts + fan-out bound
+
+Files: `servers/gateway/push/ntfy.js` (AbortController 10_000ms),
+`servers/gateway/push/email.js` (same), `servers/gateway/push/web-push.js`
+(`timeout: 10_000` in sendNotification options — ms, socket-idle; convert the serial
+subscription loop to `Promise.allSettled` PRESERVING the per-endpoint try/catch and
+410-prune + last_seen bookkeeping — read the loop body first; db.execute is
+synchronous under the hood, parallel sends are DB-safe per R2).
+Tests: NEW `tests/notification-timeouts.test.js` — G-F2-1: hung local HTTP server
+(accepts, never responds) → ntfy and email senders return ≤ cap; web-push: hung local
+endpoint if the lib accepts it, else assert options carry timeout:10000 (record as
+accepted deviation). Mutation: remove abort/timeout → red by hang.
+
+## T3 — F2/C2b: cap the three boot drains; providers defer-on-cap + escape hatch
+
+Files: `servers/sharing/instance-sync.js` — route `_backfillContactsOnceGated` (:786),
+`backfillGroupsOnce` (:1196), `backfillProvidersForNewPeers` (:1003) pre-drains through
+`_drainInboundCapped` (returns boolean already; sole existing caller ignores it).
+Contracts: contacts+groups keep unconditional done-flag writes (lamport-preserving
+re-emits — capped drain is truthful deferred convergence). Providers: on incomplete
+drain → NO emit, flag `deferred:<n>` (UPSERT; non-terminal); on 3rd consecutive
+deferral → emit anyway + `done:*` (escape hatch — spec R2-1).
+Tests: extend/NEW `tests/backfill-drain-caps.test.js` — G-F2-2 (arm BOTH outFeeds
+unflagged peer AND hung inFeed — :977 early-return makes an inFeeds-only test
+vacuous; feed-delivery-level barrier, NOT notification-level; assert deferred:1 → no
+emissions; unparked rerun → done; 3rd deferral → emits anyway), G-F2-3 (contacts/
+groups: capped drain still emits lamport-preserving + writes flags). Mutation checks
+per spec.
+
+## T4 — F2/C2c: cap discovery.flushed() in joinContact
+
+Files: `servers/sharing/peer-manager.js` (:78-79) — 10s race on `discovery.flushed()`
+only, timer cleared on win; topic registration + announce precede it. Do NOT touch
+initContact (rocksdb-lock hazard — spec A2-3).
+Tests: G-F2-4 in NEW/extended test file — never-resolving flushed() at the swarm.join
+boundary (stub swarm, not stubbed joinContact) → returns ≤ cap, topics map has the
+topic. Mutation: remove cap → red by timeout.
+
+## T5 — F3+F4: Restore-button disable + unreachable-guard comment
+
+Files: `servers/sharing/sync-conflict-resolve.js` (export NATURAL_KEY_RESTORE_TABLES
+Set; derive refusals coverage from it; F4 comment at the :313 guard),
+`servers/gateway/dashboard/settings/sections/sync-conflicts.js` (set-membership
+disable, isInsert precedence unchanged), `servers/gateway/dashboard/shared/i18n.js`
+(new key `syncConflicts.naturalKeyRestoreDisabled`, en + es).
+Tests: NEW `tests/sync-conflicts-restore-ui.test.js` — G-F3-1 per spec (RED first
+against current output; mutation check on the render condition).
+
+## T6 — F5: pendingEmitStats + refresh gauge
+
+Files: `servers/sharing/instance-sync.js` (public pendingEmitStats() — fully
+synchronous snapshot, no awaits), `servers/sharing/tailnet-sync.js` (gauge call AFTER
+the per-peer loop in refresh(), own try/catch — post-C1b an escaped throw crashes).
+Tests: G-F5-1 via exported `__refreshForTest` (zero-peer reach verified R2 Q7);
+mutation check on the gauge call.
+
+## T7 — F6: capstone ereader working-tree edit (NEVER committed)
+
+File: `bundles/capstone-tracker/src/templates/ereader.html` er-data island — quoted
+`|e`/raw string interpolations → `|tojson` (drop surrounding quotes), per spec F6
+(JSON-correctness + hardening framing; Jinja2/autoescape verified). Then verify
+`git status bundles/capstone-tracker` still shows untracked and NO capstone path in
+any commit. Done inline by the orchestrator (no subagent — 6-line mechanical edit in
+Kevin's WIP; minimize touch).
+
+## Ship
+
+Whole-branch fresh-Opus review (READY TO MERGE required) → gates (scratch suite,
+check-ports exactly-one-line rule, build-registry --check) → PR via GitHub MCP →
+merge → deploy-docs watch (this plan + spec are docs/**) → fleet deploy (crow →
+grackle bridge-then-gateway → black-swan) → live verify: CDP proof of F3 disabled
+buttons on a real conflicts page; F1/F5 log-grep soak; providers/contacts backfill
+flags intact ×4 → ledger + arc plan §4 pool update + memory.

--- a/docs/superpowers/specs/2026-07-15-2c-followups-design.md
+++ b/docs/superpowers/specs/2026-07-15-2c-followups-design.md
@@ -1,0 +1,454 @@
+# 2c follow-up pool (F1–F6) — design spec
+
+**Date:** 2026-07-15 · **Status:** rev 3 (rounds 1+2 adversarial findings folded — BUILD-READY)
+**Scope:** the six follow-ups pooled in the arc plan §4 Item 2c block, Kevin-approved
+2026-07-15 as one batch PR (except F6, which is an uncommitted working-tree edit — see §F6).
+**Branch:** `fix/2c-followup-pool` · **No schema bump** (no rail needed).
+
+Baselines this PR must not regress: suite 1974 pass / 2 known fails
+(bundles-validate-install) / 0 skips on scratch env; sync_conflicts 219/183/162/0.
+
+---
+
+## F1 — uncaught `SendingOnClosedConnection` crashes the gateway (URGENT-ish)
+
+### Incident
+2026-07-15 23:49:26 (during the 2c deploy): grackle's gateway process died once with an
+unhandled rejection:
+
+```
+SendingOnClosedConnection
+  Relay.send → Subscription.fire → Relay.subscribe → doSubscribe (resilient-subscribe.js:54)
+  → NostrManager.subscribeToContact (nostr.js:600) → wireFullContact (contact-promote.js:85)
+```
+
+### Mechanism (verified against vendored nostr-tools 2.23.3)
+- `AbstractRelay.send()` is an **async** method that `throw`s `SendingOnClosedConnection`
+  when `connectionPromise` is null (`node_modules/nostr-tools/lib/cjs/index.js:856-858`).
+  Because the method is async, that throw is a **rejected promise**, never a synchronous
+  exception.
+- `Subscription.fire()` calls `this.relay.send(...)` **without await or catch**
+  (`index.js:1090`). The rejection is orphaned → Node's default
+  `--unhandled-rejections=throw` kills the process.
+- The `try/catch` in `resilient-subscribe.js` `doSubscribe()` cannot catch it (async
+  rejection, not a sync throw).
+- **The deterministic hole:** `makeResilientSub()` calls `doSubscribe()` at construction
+  (line 62) with **no `connected` guard**. `wireFullContact → subscribeToContact`
+  constructs subs on relays that may have dropped between connect and wire — exactly the
+  crash stack. The `ensureHealthy()` path already checks `relay.connected` with no await
+  before `doSubscribe()` (lines 85-86), so it is safe today.
+- **R1-1.2: a second unguarded path exists outside makeResilientSub** —
+  `scripts/pi-bots/gateways/nostr-client.mjs:93-99` exports a raw `subscribe()` that
+  calls `relay.subscribe(...)` directly. Same crash class, in the **pi-bots host
+  process**.
+
+### Invariant that makes a `connected` guard sufficient (R1-1.1: verified, incl. the
+residual path)
+In nostr-tools 2.23.3, `relay.connected` (getter over `_connected`, `index.js:715`) and
+`connectionPromise` are mutated together at every synchronous quiescent point (`onopen`
+sets `_connected=true` inside the live executor; `handleHardClose` clears both;
+`onerror` clears `connectionPromise` while `_connected` is still false; `close()` sets
+`_connected=false` leaving `connectionPromise` stale — the harmless inverse). So
+`connected === true` ⇒ `connectionPromise` non-null, and a check-then-call with **no
+await between** cannot interleave (single-threaded). Residual: `send()`'s internal
+`connectionPromise.then(() => this.ws?.send(...))` on a CLOSING/CLOSED ws silently
+drops in `ws` (no throw, no emit) — no crash there either. Same argument
+safe-relay-publish.js already relies on.
+Also verified and RECORDED so it isn't re-derived: `Subscription.close()`'s send is
+guarded by `this.relay.connected` (index.js:1101) → safe under the same invariant;
+`resilient-subscribe.js` `close()` likewise.
+
+### Change C1a — guard `doSubscribe()`
+In `servers/sharing/resilient-subscribe.js`:
+
+```js
+function doSubscribe() {
+  if (!relay.connected) { sub = null; return; } // ensureHealthy retries next tick
+  ...existing body...
+}
+```
+
+Single choke point covering construction + ensureHealthy (redundant in the latter —
+fine). A skipped construction-time subscribe is healed by the caller's existing periodic
+`ensureHealthy()` loop.
+
+### Change C1a′ (R1-1.2) — guard the raw pi-bots `subscribe()`
+`scripts/pi-bots/gateways/nostr-client.mjs` raw `subscribe()`: skip relays where
+`!relay.connected` (same no-await check-then-call). Its callers already tolerate
+per-relay skip (multi-relay fan-out).
+
+### Change C1b — process-level narrow net (defense in depth)
+The guards remove the deterministic triggers, but library-internal `fire()` paths we
+cannot wrap (e.g. future nostr-tools changes) would still be fatal. Add a narrowly-scoped
+handler, installed via an **exported, idempotent function** (module-level once flag) in
+a shared module (e.g. `servers/sharing/nostr-crash-guard.js`):
+
+```js
+let installed = false; let swallowed = 0;
+export function handleRejection(err) {           // exported for unit tests (R1 test note)
+  if (err?.name === "SendingOnClosedConnection") {
+    swallowed++;
+    // Rate-limited observability (R1-1.4): don't let a stuck-relay loop hide
+    // behind one warn — log count at 1, 10, 100, 1000, ...
+    if (Number.isInteger(Math.log10(swallowed))) {
+      console.warn(`[nostr] swallowed SendingOnClosedConnection #${swallowed} (relay dropped mid-send)`);
+    }
+    return true;
+  }
+  return false;
+}
+let listener = null;
+export function installNostrCrashGuard() {
+  if (installed) return; installed = true;
+  listener = (err) => { if (!handleRejection(err)) throw err; }; // crash-on-unknown preserved
+  process.on("unhandledRejection", listener);
+}
+// R2-2: test-only uninstall — a permanent throwing global listener in the node:test
+// process would fight the runner (a stray non-nostr rejection in ANY later test in the
+// file becomes an uncaughtException attributed to no test). Tests MUST uninstall in
+// finally; prod never calls this.
+export function uninstallNostrCrashGuard() {
+  if (listener) process.off("unhandledRejection", listener);
+  listener = null; installed = false; swallowed = 0;
+}
+```
+
+Install sites (R1-1.3, both processes that run nostr):
+1. gateway: sharing manager init (where NostrManager is constructed);
+2. pi-bots host: inside `nostr-client.mjs` at connect/start (imported by
+   `crow-messages.mjs`, whose `start()` runs in `gateway_runner.mjs` — the one pi-bots
+   process that talks nostr; bridge_tick/discord_gateway never do — T1 review
+   correction).
+
+Verified 2026-07-15: NO unhandledRejection or uncaughtException handler exists anywhere
+in servers/ or scripts/pi-bots/ today — throw-inside-handler → uncaughtException →
+default fatal, same observable outcome (process dies, systemd restarts). `err.name` is
+reliable (class sets it in its constructor, index.js:654-657). Masking risk accepted
+consciously: the name is library-specific and the rate-limited counter keeps a
+runaway-swallow loop visible (R1-1.4).
+**Consequential comment fix:** `tailnet-sync.js:532-533` ("no unhandledRejection handler
+exists in servers/") becomes false after C1b — update that comment in the same task.
+
+### Tests (RED first)
+- G-F1-1: stub relay with `connected=false` whose `subscribe()` mimics nostr-tools'
+  ASYNC-throw shape — it must orphan a rejection out-of-band (e.g. an un-awaited
+  `(async () => { throw new SendingOnClosedConnectionStub(); })()` inside subscribe),
+  NOT a sync throw (a sync throw is caught by the existing try/catch and passes against
+  OLD code — vacuous; R1 test note). Construct `makeResilientSub` → no
+  unhandledRejection (test installs/removes its own capture handler), `sub` stays null;
+  flip `connected=true` → `ensureHealthy()` subscribes.
+- G-F1-2 (mutation check): comment out the C1a guard → G-F1-1 goes red via the
+  rejection capture.
+- G-F1-3: unit-call the exported `handleRejection`: name-match → true (swallow);
+  other error → false (caller rethrows). NO real process-event emission (flaky, kills
+  the runner; R1 test note). Install-idempotence: `installNostrCrashGuard()` twice →
+  one listener (`process.listenerCount`).
+- G-F1-4: pi-bots raw-subscribe guard — same stub as G-F1-1 against `nostr-client.mjs
+  subscribe()`; mutation check by reverting the guard.
+
+## F2 — apply-path unbounded network awaits (general audit + bounds)
+
+The 2c incident class: an inbound-entry apply hook awaiting a network operation without
+a bound wedges either boot (via the boot drain) or the live apply loop. PR #195 bounded
+the two known: 10s boot-drain cap (`_drainInboundCapped`, instance-sync.js:924 — used
+ONLY by `reemitContactTombstones`), 5s-per-step unwire teardown caps
+(`withStepCap`, contact-delete.js:161-168).
+
+### Audit findings (full apply-path trace + round-1 corrections)
+
+**A2-1 [BOOT- and LIVE-BLOCKING — the real F2]. Notification push fan-out is
+timeout-less.** Two awaited chains from `_applyEntry` reach `createNotification`
+(`servers/shared/notifications.js`): messages via `_notifyMessageApplied`
+(instance-sync.js:2275) and conflicts via `_notifyConflict` (8 call sites; body :2675).
+`createNotification` awaits, **serially**: `sendPushToAll` → `web-push.js:52-76` loops
+`webpush.sendNotification` over EVERY push_subscriptions row with no timeout —
+**R1-2.3: the fan-out compounds serially, so N half-open endpoints = N×cap even with a
+per-send timeout**; `sendNtfyNotification` → `ntfy.js:86 fetch()` no AbortController;
+`sendEmailNotification` → `email.js:103 fetch()` (Resend) no signal. All three senders'
+failures ARE caught today (verified: ntfy.js:85-93 and web-push.js:57-75 swallow
+silently, email.js:102-123 logs) — a capped send == an already-tolerated failed send.
+
+**A2-2 [BOOT-BLOCKING]. Three boot drains are uncapped.** Only the tombstone re-emit
+drain got cap #1. `_backfillContactsOnceGated` (:786), `backfillGroupsOnce` (:1196),
+`backfillProvidersForNewPeers` (:1003) all await `_processNewEntries` directly, before
+HTTP listen (`mcp-mounts.js:137/148/160`).
+**R1-2.4/2.5 (critical correction): the three drains are NOT equivalent under a cap.**
+- contacts backfill re-emits **lamport-preserving** (:817) and groups likewise
+  (`preserveLamport: true`, :1214) → a capped drain degrades to truthful, deferred
+  convergence. Safe; their unconditional done-flag writes keep their existing semantics.
+- providers backfill re-emits with a **FRESH mint** (:1034; `EXCLUDED_COLUMNS.providers`
+  strips `lamport_ts` from the wire, :94) and its I-B1 pre-drain exists precisely to
+  avoid re-emitting stale rows over a peer's newer edit (:1000-1008). Verified apply
+  semantics: `_applyInsert` is INSERT OR IGNORE — the incoming stale row is **never
+  applied** over an existing peer row, so there is NO data loss; the harm is a
+  **spurious (though truthfully-labeled) unresolved conflict row on the peer**
+  (`_insertConflictRow` fires when data differs, :~1116-1131) — i.e. sync_conflicts
+  baseline growth, our red-flag metric. NOTE: this exposure ALREADY exists today when
+  the I-B1 drain throws (its catch proceeds to emit); the cap must not widen it.
+
+**A2-3 [background leak only — NOT boot/live-blocking].** `wireFullContact`
+(contact-promote.js:77) is dispatched fire-and-forget from `_afterContactApplied`
+(:2192). Inside it (R1-2.6 corrections):
+- `syncManager.initContact` → hypercore `ready()` is **local disk I/O, not network** —
+  and MUST NOT be capped: `_initContactInner` (sync.js:70-90) registers feeds in
+  `outFeeds`/`inFeeds` only AFTER `await ready()`; an abandoned Hypercore instance holds
+  the rocksdb dir lock, so a capped-then-retried init hits the known
+  concurrent-same-dir lock error (2d Q4 probe) — capping setup here can wedge the
+  contact's feed until restart. OUT of C2c.
+- `peerManager.joinContact` → `discovery.flushed()` (peer-manager.js:78-79) IS an
+  unbounded network await (DHT announce confirmation). Safe to cap: `topics.set` happens
+  BEFORE `swarm.join`, and the announce still fires — only the confirmation await is
+  abandoned.
+- `subscribeToContact` already 10s-bounded via `connectRelays`.
+
+**Already bounded / no change:** unwireContact steps (cap #2); nostr connectRelays (10s
+per relay); feed-rotation close race (5s, 2d); all DB-only apply handlers.
+**Known adjacent gap, deliberately out of scope (R1 item 10):** the Nostr inbound path
+(`boot.js onSocialMessage` → room fan-out relay publish) can stall a relay's message
+loop; not reachable from `_applyEntry`. Recorded here so it isn't silently omitted;
+candidate for a future pool.
+
+### Changes
+- **C2a — bound the notification senders at the SENDER level** (bounds every caller):
+  - ntfy + Resend fetches: `AbortController` + 10_000 ms timeout (timer cleared on
+    completion).
+  - web-push: pass `timeout: 10_000` in `sendNotification` options — supported by
+    vendored web-push@3.6.7 (web-push-lib.js:222-223 → 356-358 → destroy-on-timeout
+    :395-398; rejects → existing catch). **Units are ms; it is a socket-IDLE timeout,
+    not an overall deadline — a slow-drip endpoint evades it; accepted for the half-open
+    failure mode (R1-2.2).**
+  - **R1-2.3 — bound the fan-out, not just the send:** `sendPushToAll` switches from a
+    serial await-loop to `Promise.allSettled` over the per-subscription sends (each
+    individually try/caught as today, preserving per-endpoint cleanup semantics such as
+    410-pruning — READ the loop body before converting). Overall bound ≈ one send cap
+    instead of N×cap. Push has no cross-endpoint ordering semantics.
+- **C2b — cap the three uncapped boot drains** via `_drainInboundCapped` (same 10s
+  `_drainCapMs`), with per-drain contracts (R1-2.4/2.5):
+  - contacts + groups: route through the cap; keep their unconditional done-flag writes
+    (their re-emits are lamport-preserving — capped-drain degradation is truthful
+    deferred convergence, the #195 semantics).
+  - providers: **defer-on-cap with a bounded escape hatch (R2-1).**
+    `_drainInboundCapped` already returns a boolean (:922/934/936) and its sole caller
+    ignores it — providers consumes it with zero change to the tombstone path (R2
+    verified). If the drain did NOT complete: skip the re-emit, and record the deferral
+    by writing the per-peer flag as `deferred:<n>` (UPSERT; only `done:*` is terminal,
+    so this stays retryable). **After 3 consecutive deferrals, proceed to emit anyway**
+    (today's tolerated exposure: INSERT OR IGNORE means no data loss, at worst
+    truthfully-labeled spurious conflict rows) and write `done:*`. Without the escape
+    hatch, one always-slow inbound feed would permanently block providers backfill to
+    EVERY new peer — a functional regression vs today's emit-on-drain-failure (R2-1:
+    peer B could never route to this instance's models). Deferral bounded ⇒ worst
+    added noise is one boot's worth, same as today's failure mode.
+  **True boot bound, stated honestly (R2-3):** the pre-listen path runs TWO capped
+  drain-loops over the same feeds (tombstone re-emit + providers pre-drain) plus the
+  per-contact `joinContact → flushed()` loop (boot.js:730-744, capped by C2c). A wedged
+  feed's `_processLocks` chain is inherited by the second loop, so worst case ≈
+  `2 × N_wedged_feeds × 10s + N_contacts × 10s` — finite (the goal), NOT a flat 10s.
+  Deduping the two drain loops was considered and DECLINED: it couples the tombstone and
+  providers premise semantics for a constant-factor win on an already-bounded path.
+- **C2c — cap ONLY `discovery.flushed()`** inside `peerManager.joinContact` (10s, timer
+  cleared on win; the topic registration and announce precede it). Do NOT cap
+  `initContact` (see A2-3). `withStepCap` stays a teardown-only primitive.
+  **Build-time extension (T4 finding, folded):** `joinInstanceSync()` (peer-manager.js
+  ~:129) carries the IDENTICAL unbounded `flushed()` on the same boot path
+  (boot.js:754) — same cap applied, gate G-F2-4b. Deliberate semantic delta from
+  withStepCap, both sites: flushed() REJECTIONS still propagate (both callers already
+  try/catch); only the hang is capped — setup keeps its error semantics, teardown
+  swallows.
+
+### Tests (RED first)
+- G-F2-1: hung-socket tests against REAL senders where reachable (R1 test note): a
+  local HTTP server that accepts and never responds → ntfy and email paths complete
+  ≤ cap (AbortController fires). web-push: hung local endpoint if the lib accepts a
+  plain-http endpoint URL in test; if not, assert the options object passed to
+  `webpush.sendNotification` carries `timeout: 10000` (accepted deviation, recorded).
+  Mutation check: remove the abort/timeout → named test red (hang → test timeout).
+- G-F2-2 (providers defer-on-cap): construction constraints (R2-5, anti-vacuity): the
+  harness MUST arm BOTH maps — an unflagged peer in `outFeeds` AND a hung `inFeeds`
+  entry — because :977 early-returns before the drain when `outFeeds` is empty (a
+  test that hangs only inFeeds is vacuous green). The barrier parks at FEED-DELIVERY
+  level (delay the feed `get`/apply delivery — 2d T7 lesson), NOT notification level
+  (C2a now caps notifications at 10s, which would mask the hang and race the drain
+  cap). Assertions: capped → no emissions, flag = `deferred:1`; un-park → next run
+  emits + `done:*`; third consecutive deferral → emits anyway + `done:*` (escape
+  hatch). Mutation checks: revert defer-on-cap → flags written under cap, red; remove
+  escape hatch → 3rd-deferral assertion red.
+- G-F2-3 (contacts/groups under cap): same feed-delivery barrier → drain capped,
+  backfill still emits lamport-preserving entries and writes flags (existing
+  semantics), boot path returns ≤ cap.
+- G-F2-4 (flushed cap): `joinContact` with a never-resolving `discovery.flushed()`
+  (REAL hyperswarm stub at the swarm.join boundary, not a stubbed joinContact —
+  vacuity note) → returns ≤ cap, `topics` map contains the topic. Mutation check:
+  remove the cap → red by timeout.
+
+## F3 — dashboard Restore button not disabled for natural-key tables
+
+`servers/gateway/dashboard/settings/sections/sync-conflicts.js` `renderConflictRow()`
+disables Restore for `op='insert'` and for `crow_context`, but renders a live button for
+`contacts` / `contact_groups` — the backend refuses these (C7
+`NATURAL_KEY_RESTORE_REFUSALS`, sync-conflict-resolve.js:132-148), so the user gets a
+click → refused flash instead of an upfront disabled state.
+
+R1-3.1 verified: the dashboard section already imports from sync-conflict-resolve.js
+(line 24) — no import cycle; the backend refusal fires before the stale guard for all
+three tables and all ops, so UI-disable by table membership can never disable a restore
+the backend would honor. Existing isInsert-first precedence stays (both branches match
+the backend).
+
+### Change
+- Export `NATURAL_KEY_RESTORE_TABLES` (Set) from `sync-conflict-resolve.js`; derive
+  `NATURAL_KEY_RESTORE_REFUSALS`'s coverage from it (single source of truth — UI and
+  backend cannot drift).
+- In `renderConflictRow()`: replace the `isCrowContext` special-case with set
+  membership → muted italic label. Keep the crow_context-specific i18n key for
+  crow_context; one new generic key (`syncConflicts.naturalKeyRestoreDisabled`) for
+  contacts/contact_groups. i18n is a single file
+  (`servers/gateway/dashboard/shared/i18n.js`) with inline `{en, es}` entries; `t()`
+  falls back missing-lang → en → raw key (verified i18n.js:1674-1678). New key ships
+  both en and es.
+- Backend refusal stays (the button is UI sugar, the backend is the gate).
+
+### Tests
+- G-F3-1: render a conflict row for each of contacts/contact_groups/crow_context →
+  no `<form` with `sync_conflicts_restore_other` in the output; a memories row still
+  renders the button. RED first by asserting on current output. Mutation check: revert
+  the render condition → named red.
+- CDP live proof at deploy time (a curl 200 is not proof a page works).
+
+## F4 — unreachable-pointer comment on the dead INSERT-branch group guard
+
+`sync-conflict-resolve.js:313-342`: the statement-level `contact_groups` tombstone guard
+in the INSERT branch became unreachable when 2c C7 added `contact_groups` to
+`NATURAL_KEY_RESTORE_REFUSALS` (line 146 returns first). R1-4.1 verified. Per the 2a
+lesson (a finding dropped as "unreachable" dies the moment a later change deletes its
+premise), the guard STAYS; it gets a comment at the guard site:
+
+```
+// NOTE (2c-F4): currently UNREACHABLE — contact_groups is refused upstream by
+// NATURAL_KEY_RESTORE_REFUSALS (search this file) before the stale guard / INSERT
+// branch. KEEP THIS GUARD: if that refusal is ever relaxed (e.g. natural-key restore
+// gets implemented), this statement-level tombstone check becomes load-bearing again —
+// without it, Restore re-inserts a tombstoned group_uid and manufactures the
+// resurrection zombie (2b design R2 F3').
+```
+
+Comment-only; no test. F3's export refactor touches the same file — sequence F4 in the
+same task.
+
+## F5 — `_pendingPeerEmits` RAM observability + soak check
+
+State: 256-entry cap per peer with an overflow warn exists (instance-sync.js:1370-1373).
+Prod check 2026-07-15: 0 overflow warns in crow's gateway log. Missing: any way to SEE
+parked-queue sizes before overflow.
+
+### Change
+- Public `pendingEmitStats()` on InstanceSyncManager returning `{peerId: count}` for
+  non-empty slots. **Hard requirement (R1-5.2): fully synchronous — a plain loop over
+  the Map with no await points**, so it cannot interleave with `_chainAppendTask`
+  mutations (which are the map's only writers).
+- Call it from the existing 60s rescan loop in `tailnet-sync.js` `refresh()`, logging
+  only when non-empty. **Wrapped in its own try/catch** (R1-5.2): refresh runs on a bare
+  setInterval, and post-C1b an escaped throw becomes an unhandledRejection that the
+  crash guard RETHROWS (non-nostr name) → crash.
+- R1-5.1 verified: MPA runs tailnet-sync (post-listen.js:73-94, ungated for any gateway
+  with an InstanceSyncManager) — the gauge is meaningful fleet-wide.
+- Soak verification at deploy: line absent on crow/grackle/MPA under normal operation;
+  recorded in the ledger.
+
+### Tests
+- G-F5-1: park entries for an unarmed peer → `pendingEmitStats()` returns the count;
+  drain → empty object. Gauge line emitted via the exported `__refreshForTest`
+  (tailnet-sync.js:569) — the gauge call goes AFTER the per-peer for loop in
+  `refresh()`, so a zero-peer test still reaches it (R2 Q7). Nothing emitted when
+  empty. Mutation check: remove the gauge call → named red.
+
+## F6 — capstone-tracker ereader script-block interpolation (Kevin's WIP, uncommitted)
+
+**R1-6.1 reframing (threat model corrected):** the block is
+`<script id="er-data" type="application/json">` (ereader.html:964). The engine is
+Jinja2 via Starlette `Jinja2Templates` (templates_config.py:11-18) with autoescape ON —
+so `|e`/autoescape already entity-encodes `<`, and `&lt;/script&gt;` cannot terminate
+the script element. **This is therefore a JSON-correctness + hardening fix, not a live
+XSS**: today a title containing `&`, `<`, or `"` … lands entity-encoded (or, for a
+double-quote, malformed) inside the JSON island → wrong/corrupt display data. `|tojson`
+emits a correct JS/JSON literal AND escapes `<` (`<`), keeping the `</script`
+hardening independent of autoescape config.
+
+### Change (working-tree only — NEVER committed by this PR)
+In the `er-data` JSON island, replace the five quoted `"{{ x|e }}"` title interpolations
+(lines 972-981) with `{{ x|tojson }}` (dropping the surrounding literal quotes),
+matching the file's own idiom at lines 790/985. The neighbouring raw/`|e` siblings in
+the same island (`content_type`/`material_type`/`material_key`/`short_title`/
+`source_id`/`cache_key`, lines 966-983) get the same treatment ONLY where they are
+quoted-string contexts — one mechanical pass over the island; anything ambiguous is
+left for Kevin with a note (his WIP, his call). The bundle is untracked: the edit lands
+in Kevin's working tree and rides whenever he commits it. The batch PR must contain
+zero capstone-tracker paths; verify with `git show --stat` on every commit plus
+`git status bundles/capstone-tracker` (must remain untracked).
+
+### Verification
+Jinja2 renders `|tojson` on plain str safely (stdlib json + markupsafe escaping) —
+mechanical inspection + (only if the bundle happens to be running on :8090) a manual
+curl with a hostile title. No test harness exists for the WIP bundle; Kevin owns its
+test story.
+
+---
+
+## Sequencing / task shape (SDD)
+
+1. **T1 (F1)** — C1a guard + C1a′ pi-bots guard + C1b exported crash guard installed in
+   both processes + tailnet-sync comment fix. RED G-F1-1..4.
+2. **T2 (F2/C2a)** — sender-level timeouts + allSettled fan-out. RED G-F2-1.
+3. **T3 (F2/C2b)** — cap three boot drains; providers defer-on-cap contract. RED
+   G-F2-2..3.
+4. **T4 (F2/C2c)** — flushed() cap in joinContact. RED G-F2-4.
+5. **T5 (F3+F4)** — natural-key set export + UI disable + i18n (en+es) + F4 comment.
+   RED G-F3-1.
+6. **T6 (F5)** — pendingEmitStats + refresh gauge. RED G-F5-1.
+7. **T7 (F6)** — working-tree-only ereader edit + untracked-ness verification.
+8. Whole-branch review → gates → PR → merge → fleet deploy → live verify (CDP for F3;
+   log-grep soak for F1/F5) → ledger/plan/memory updates.
+
+## Risks
+
+- **F1 stub fidelity**: G-F1-1's stub must orphan an ASYNC rejection (vacuous-test tell:
+  a sync-throw stub passes against OLD code).
+- **F1b global handler**: rethrow-on-unknown is load-bearing; the rate-limited counter
+  keeps swallow volume visible. Any NEW same-name error class from other code would be
+  masked — accepted (name is library-specific).
+- **C2a allSettled conversion**: the current serial loop's per-endpoint bookkeeping
+  (e.g. pruning dead subscriptions on 410) must survive parallelization — read before
+  converting.
+- **C2b defer-on-cap**: providers backfill must remain exactly-once-per-peer across the
+  retry (flag semantics already give this; the deferral just delays flag-writing).
+- **F3 i18n**: new key ships en+es in the single i18n.js.
+- **F6**: any accidental `git add` of Kevin's WIP is a hard failure — checked at every
+  commit via positional-path commits + `git show --stat HEAD`.
+
+## Review record
+
+- **Round 2 (fresh Opus subagent, 2026-07-15):** no new CRITICAL. 4 MUST-folds, all
+  folded above: R2-1 providers defer-on-cap needed an escape hatch (3-deferral
+  fallback to emit-anyway — without it one slow feed permanently blocks providers
+  backfill to every new peer, a functional regression vs today); R2-2 crash guard
+  needed a test-only uninstall (a permanent throwing global listener fights node:test);
+  R2-3 true boot bound stated (`≈2×N_wedged×10s + N_contacts×10s`, dedupe declined);
+  R2-5 G-F2-2/3 anti-vacuity construction constraints encoded (arm both maps;
+  feed-delivery-level barrier). Accepted-and-noted: R2-4 (non-default
+  `--unhandled-rejections` modes change the "same observable outcome" equivalence;
+  fleet runs default). Re-verified round-1 holds: C1a heal path (both call sites start
+  the health loop → no silent blackout), allSettled DB-safety (better-sqlite3 execute
+  is synchronous; 410-prune survives), `_drainInboundCapped` boolean return
+  (non-breaking), C2c all-callers-safe, F3 delete-op precedence, log10 counter at 1.
+- **Round 1 (Opus subagent, 2026-07-15):** 1 CRITICAL (2.4 providers fresh-mint ×
+  drain-cap interaction — folded as defer-on-cap after code verification downgraded
+  "silent data loss" to "spurious conflict rows": `_applyInsert` is INSERT OR IGNORE,
+  incoming never applied over an existing row), 5 MAJOR (1.2 pi-bots raw subscribe →
+  C1a′; 1.3 pi-bots C1b install site → pinned; 2.3 serial fan-out → allSettled; 2.5
+  flag contract → per-drain contracts; 2.6 withStepCap-on-setup → initContact excluded
+  [rocksdb-lock hazard verified], flushed()-only cap), plus test-vacuity notes (G-F1-1
+  async shape, G-F1-3 exported handler, G-F2-1 real-socket split, G-F2-4 boundary) and
+  minors (1.4 rate-limited counter + stale comment; 2.2 ms units/socket-idle; 5.2 sync
+  snapshot + try/catch; 6.1 threat-model reframe) — all folded above. Checks-out list:
+  C1a invariant, web-push timeout support, F3 import-safety, F4 unreachability, F5 MPA
+  coverage.

--- a/scripts/pi-bots/gateways/nostr-client.mjs
+++ b/scripts/pi-bots/gateways/nostr-client.mjs
@@ -25,6 +25,7 @@ import * as nip44 from "nostr-tools/nip44";
 import { Relay, useWebSocketImplementation } from "nostr-tools/relay";
 import { safeRelayPublish } from "../../../servers/sharing/safe-relay-publish.js";
 import { makeResilientSub } from "../../../servers/sharing/resilient-subscribe.js";
+import { installNostrCrashGuard } from "../../../servers/sharing/nostr-crash-guard.js";
 // Pin the implementation explicitly (survives a future nostr-tools that drops
 // the constructor-time `|| WebSocket` fallback).
 if (globalThis.WebSocket) { try { useWebSocketImplementation(globalThis.WebSocket); } catch { /* older nostr-tools: runtime fallback covers it */ } }
@@ -73,6 +74,10 @@ export function openDM(recipientPriv, senderXOnlyPubkey, content) {
 
 /** Connect to relays; returns a Map<url, Relay> of those that connected. */
 export async function connectRelays(urls, timeoutMs = 10000) {
+  // Narrow process-level net for nostr-tools' orphaned close-race rejection
+  // (2c-F1 C1b). Idempotent; the connect path is the choke point every pi-bots
+  // host (bridge_tick, discord_gateway) passes through before touching relays.
+  installNostrCrashGuard();
   const relays = new Map();
   const results = await Promise.allSettled(urls.map(async (url) => {
     const relay = await Promise.race([
@@ -93,6 +98,10 @@ export async function connectRelays(urls, timeoutMs = 10000) {
 export function subscribe(relays, filter, onevent) {
   const subs = [];
   for (const [, relay] of relays) {
+    // A dropped relay's subscribe() orphans an ASYNC rejected send()
+    // (SendingOnClosedConnection) that the catch below cannot see — skip it
+    // (no await between check and call; callers tolerate per-relay skips).
+    if (!relay.connected) continue;
     try { subs.push(relay.subscribe([filter], { onevent })); } catch { /* per-relay */ }
   }
   return subs;

--- a/scripts/pi-bots/gateways/nostr-client.mjs
+++ b/scripts/pi-bots/gateways/nostr-client.mjs
@@ -75,8 +75,8 @@ export function openDM(recipientPriv, senderXOnlyPubkey, content) {
 /** Connect to relays; returns a Map<url, Relay> of those that connected. */
 export async function connectRelays(urls, timeoutMs = 10000) {
   // Narrow process-level net for nostr-tools' orphaned close-race rejection
-  // (2c-F1 C1b). Idempotent; the connect path is the choke point every pi-bots
-  // host (bridge_tick, discord_gateway) passes through before touching relays.
+  // (2c-F1 C1b). Idempotent; connectRelays is the choke point of the one
+  // pi-bots process that talks nostr (crow-messages via gateway_runner).
   installNostrCrashGuard();
   const relays = new Map();
   const results = await Promise.allSettled(urls.map(async (url) => {

--- a/servers/gateway/dashboard/settings/sections/sync-conflicts.js
+++ b/servers/gateway/dashboard/settings/sections/sync-conflicts.js
@@ -21,7 +21,11 @@
 
 import { escapeHtml } from "../../shared/components.js";
 import { t } from "../../shared/i18n.js";
-import { resolveConflict, restoreConflict } from "../../../../sharing/sync-conflict-resolve.js";
+import {
+  resolveConflict,
+  restoreConflict,
+  NATURAL_KEY_RESTORE_TABLES,
+} from "../../../../sharing/sync-conflict-resolve.js";
 import { getInstanceSyncManager } from "../../../../sharing/server.js";
 
 // ── Formatting helpers ────────────────────────────────────────────────────────
@@ -68,21 +72,31 @@ function renderConflictRow(r, lang, csrfToken) {
   const lId = shortId(r.losing_instance_id);
   const isInsert = (r.op === "insert");
   const isDelete = (r.op === "delete");
-  const isCrowContext = (r.table_name === "crow_context");
+  // Natural-key tables (crow_context, contacts, contact_groups): the backend
+  // refuses restore for these (NATURAL_KEY_RESTORE_TABLES is the single source
+  // of truth in sync-conflict-resolve.js), so the button is disabled upfront
+  // instead of click → refused flash (2c-F3).
+  const isNaturalKey = NATURAL_KEY_RESTORE_TABLES.has(r.table_name);
   const resolved = !!r.resolved;
 
   const winJson = prettyJson(r.winning_data);
   const loseJson = prettyJson(r.losing_data);
 
-  // Restore button is disabled for op='insert' conflicts per spec §6.
-  // Also disabled for crow_context (composite key — spec §4).
+  // Restore button is disabled for op='insert' conflicts per spec §6
+  // (precedence FIRST — matches the backend's refusal order), then for
+  // natural-key tables. crow_context keeps its composite-key wording.
   const restoreBtn = isInsert
     ? `<span style="font-size:0.78rem;color:var(--crow-text-muted);font-style:italic">
          ${escapeHtml(t("syncConflicts.insertRestoreDisabled", lang))}
        </span>`
-    : isCrowContext
+    : isNaturalKey
     ? `<span style="font-size:0.78rem;color:var(--crow-text-muted);font-style:italic">
-         ${escapeHtml(t("syncConflicts.compositeRestoreDisabled", lang))}
+         ${escapeHtml(t(
+           r.table_name === "crow_context"
+             ? "syncConflicts.compositeRestoreDisabled"
+             : "syncConflicts.naturalKeyRestoreDisabled",
+           lang,
+         ))}
        </span>`
     : `<form method="POST" action="/dashboard/settings" style="display:inline">
          <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}" />

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1375,6 +1375,10 @@ export const translations = {
     en: "Auto-restore not available (composite key — use crow_update_context_section to apply the values shown).",
     es: "Restauración automática no disponible (clave compuesta — usa crow_update_context_section para aplicar los valores mostrados).",
   },
+  "syncConflicts.naturalKeyRestoreDisabled": {
+    en: "Auto-restore not available (natural key — review the data above and re-apply the change from its panel).",
+    es: "Restauración automática no disponible (clave natural — revisa los datos arriba y vuelve a aplicar el cambio desde su panel).",
+  },
   "syncConflicts.resolveAll": { en: "Resolve all (keep current versions)", es: "Resolver todos (mantener versiones actuales)" },
   "syncConflicts.resolveAllConfirm": {
     en: "Mark all unresolved conflicts as resolved? The current (winning) version of each item will be kept.",

--- a/servers/gateway/push/email.js
+++ b/servers/gateway/push/email.js
@@ -99,6 +99,13 @@ export async function sendEmailNotification({
   const text =
     (body || title) + (clickUrl ? `\n\nOpen in Crow: ${clickUrl}` : "");
 
+  // Bound the send (2c follow-up F2/C2a): createNotification awaits this
+  // sender from the instance-sync apply path — an unbounded hang on a
+  // half-open socket wedges boot or the live apply loop. A timed-out send
+  // lands in the same catch as any other failed send (already tolerated).
+  const timeoutMs = parseInt(process.env.CROW_PUSH_SEND_TIMEOUT_MS, 10) || 10_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
@@ -113,6 +120,7 @@ export async function sendEmailNotification({
         html,
         text,
       }),
+      signal: controller.signal,
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
@@ -120,5 +128,7 @@ export async function sendEmailNotification({
     }
   } catch (err) {
     console.warn(`[push/email] fetch failed: ${err.message}`);
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/servers/gateway/push/ntfy.js
+++ b/servers/gateway/push/ntfy.js
@@ -82,13 +82,23 @@ export async function sendNtfyNotification({ title, body, url, priority = "norma
     headers["Authorization"] = `Bearer ${authToken}`;
   }
 
+  // Bound the send (2c follow-up F2/C2a): createNotification awaits this
+  // sender from the instance-sync apply path — an unbounded hang on a
+  // half-open socket wedges boot or the live apply loop. A timed-out send
+  // lands in the same catch as any other failed send (already tolerated).
+  const timeoutMs = parseInt(process.env.CROW_PUSH_SEND_TIMEOUT_MS, 10) || 10_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     await fetch(ntfyUrl, {
       method: "POST",
       headers,
       body: body || title,
+      signal: controller.signal,
     });
   } catch {
-    // ntfy server not available — fail silently
+    // ntfy server not available or send timed out — fail silently
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/servers/gateway/push/web-push.js
+++ b/servers/gateway/push/web-push.js
@@ -49,31 +49,44 @@ export async function sendPushToAll(db, { title, body, url }) {
     return;
   }
 
-  for (const row of rows) {
-    const subscription = {
-      endpoint: row.endpoint,
-      keys: JSON.parse(row.keys_json),
-    };
-    try {
-      await webpush.sendNotification(
-        subscription,
-        JSON.stringify({ title, body: body || title, url: url || "/dashboard/nest" })
-      );
-      // Update last_seen
-      await db.execute({
-        sql: "UPDATE push_subscriptions SET last_seen = datetime('now') WHERE endpoint = ?",
-        args: [row.endpoint],
-      });
-    } catch (err) {
-      if (err.statusCode === 410 || err.statusCode === 404) {
-        // Stale subscription — auto-remove
+  // Bound each send (2c follow-up F2/C2a): createNotification awaits this
+  // fan-out from the instance-sync apply path — an unbounded hang on a
+  // half-open endpoint wedges boot or the live apply loop. `timeout` is a
+  // socket-idle timeout in ms (web-push@3.6.7); a timed-out send rejects
+  // into the same per-endpoint catch as any other failed send. The sends
+  // run in parallel (Promise.allSettled) so N bad endpoints cost ~one cap,
+  // not N×cap; push has no cross-endpoint ordering semantics, and the
+  // per-endpoint try/catch keeps the 410/404 prune and last_seen
+  // bookkeeping per-endpoint exactly as the serial loop did.
+  const timeoutMs = parseInt(process.env.CROW_PUSH_SEND_TIMEOUT_MS, 10) || 10_000;
+  await Promise.allSettled(
+    rows.map(async (row) => {
+      const subscription = {
+        endpoint: row.endpoint,
+        keys: JSON.parse(row.keys_json),
+      };
+      try {
+        await webpush.sendNotification(
+          subscription,
+          JSON.stringify({ title, body: body || title, url: url || "/dashboard/nest" }),
+          { timeout: timeoutMs }
+        );
+        // Update last_seen
         await db.execute({
-          sql: "DELETE FROM push_subscriptions WHERE endpoint = ?",
+          sql: "UPDATE push_subscriptions SET last_seen = datetime('now') WHERE endpoint = ?",
           args: [row.endpoint],
         });
+      } catch (err) {
+        if (err.statusCode === 410 || err.statusCode === 404) {
+          // Stale subscription — auto-remove
+          await db.execute({
+            sql: "DELETE FROM push_subscriptions WHERE endpoint = ?",
+            args: [row.endpoint],
+          });
+        }
       }
-    }
-  }
+    })
+  );
 }
 
 /**

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -1477,6 +1477,22 @@ export class InstanceSyncManager {
   }
 
   /**
+   * Snapshot of parked emit-queue sizes: plain object {peerId: count} for
+   * NON-EMPTY slots only (2c follow-up F5 — RAM observability BEFORE the
+   * 256-cap overflow warn fires). HARD REQUIREMENT: fully synchronous — a
+   * plain loop over the Map with no await points, so it cannot interleave
+   * with ANY writer (the _chainAppendTask append/drain tasks, or the
+   * revoke-path delete); adding an await here would break that guarantee.
+   */
+  pendingEmitStats() {
+    const stats = {};
+    for (const [peerId, slot] of this._pendingPeerEmits) {
+      if (slot && slot.length > 0) stats[peerId] = slot.length;
+    }
+    return stats;
+  }
+
+  /**
    * Emit a sync entry for a local data change.
    * Called by memory/context/sharing servers after mutations.
    *

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -779,15 +779,21 @@ export class InstanceSyncManager {
 
     // I-B1 ordering guard: drain the locally-replicated inbound backlog FIRST,
     // so a peer's already-delivered newer edit (e.g. a block) is applied before
-    // we re-emit with a fresh lamport and fabricate recency over it.
+    // we re-emit and fabricate recency over it.
     // _processNewEntries' per-peer promise-chain serializes this safely with
     // any concurrent append-listener run; checkpointing makes it idempotent.
-    try {
-      for (const [peerId, inFeed] of this.inFeeds) {
-        await this._processNewEntries(peerId, inFeed);
+    // T3 (F2/C2b): each per-peer await is BOUNDED by _drainInboundCapped — this
+    // runs on the boot-to-HTTP-listen path (mcp-mounts.js) and a wedged apply
+    // chain must never block listen. Capped or not we PROCEED exactly as
+    // before: the re-emit below is lamport-PRESERVING, so a capped drain
+    // degrades to truthful deferred convergence (spec R1-2.4, the #195
+    // semantics) — unlike the fresh-mint providers backfill, which defers.
+    for (const [peerId, inFeed] of this.inFeeds) {
+      try {
+        await this._drainInboundCapped(peerId, inFeed, "contacts backfill");
+      } catch (err) {
+        console.warn(`[instance-sync] contacts backfill drain failed: ${err.message}`);
       }
-    } catch (err) {
-      console.warn(`[instance-sync] contacts backfill drain failed: ${err.message}`);
     }
 
     let rows = [];
@@ -920,8 +926,13 @@ export class InstanceSyncManager {
    * never resolves), we stop AWAITING it and proceed — the _processNewEntries
    * promise stays chained in the background exactly as pre-2c (we do NOT cancel
    * it). Returns true if the drain completed within the cap, false if capped.
+   *
+   * T3 (2c follow-up F2/C2b): now shared by all four boot-path pre-drains
+   * (tombstone re-emit, contacts/groups/providers backfills) — `label` names
+   * the caller in the cap warning. Contract unchanged: the tombstone caller
+   * still ignores the return value; providers consumes it (defer-on-cap).
    */
-  async _drainInboundCapped(peerId, inFeed) {
+  async _drainInboundCapped(peerId, inFeed, label = "contact tombstone re-emit") {
     let timer;
     const cap = new Promise((resolve) => { timer = setTimeout(() => resolve("__cap__"), this._drainCapMs); });
     try {
@@ -930,7 +941,7 @@ export class InstanceSyncManager {
         cap,
       ]);
       if (outcome === "__cap__") {
-        console.warn(`[instance-sync] contact tombstone re-emit: inbound drain for ${peerId} exceeded ${this._drainCapMs}ms — proceeding without it (wedged apply chain?)`);
+        console.warn(`[instance-sync] ${label}: inbound drain for ${peerId} exceeded ${this._drainCapMs}ms — proceeding without it (wedged apply chain?)`);
         return false;
       }
       return true;
@@ -956,7 +967,10 @@ export class InstanceSyncManager {
    * (feeds may not have opened yet this boot — retry next boot; contacts
    * lesson, observed live on grackle 2026-07-06). Inbound backlog is drained
    * first (I-B1) so a peer's already-delivered newer provider edit is applied
-   * before we re-emit with a fresh lamport.
+   * before we re-emit with a fresh lamport. T3 (F2/C2b): that drain is now
+   * CAPPED; a capped (incomplete) drain defers the whole backfill with a
+   * per-peer `deferred:<n>` flag (retryable), escaping to emit-anyway + done
+   * on the 3rd consecutive deferral (spec R2-1) — see the body.
    *
    * emitChange broadcasts to ALL peers as op="insert": fresh peers land the
    * row via _applyInsert's INSERT OR IGNORE; already-current peers IGNORE and
@@ -981,30 +995,83 @@ export class InstanceSyncManager {
       return 0;
     }
 
-    // Which armed peers still need a backfill? Only "done:*" is terminal.
+    // Which armed peers still need a backfill? Only "done:*" is terminal — a
+    // `deferred:<n>` value (T3 defer-on-cap, below) stays retryable. Raw flag
+    // values are kept for the deferral-count parse.
     const newPeers = [];
+    const flagValues = new Map(); // peerId → raw flag value (or null)
     for (const peerId of this.outFeeds.keys()) {
-      let done = false;
+      let value = null;
       try {
         const { rows } = await this.db.execute({
           sql: "SELECT value FROM dashboard_settings WHERE key = ?",
           args: [FLAG_PREFIX + peerId],
         });
-        done = typeof rows?.[0]?.value === "string" && rows[0].value.startsWith("done:");
+        if (typeof rows?.[0]?.value === "string") value = rows[0].value;
       } catch {}
-      if (!done) newPeers.push(peerId);
+      if (value !== null && value.startsWith("done:")) continue;
+      newPeers.push(peerId);
+      flagValues.set(peerId, value);
     }
     if (newPeers.length === 0) return 0; // every armed peer already covered
 
     // I-B1 ordering guard: drain the locally-replicated inbound backlog FIRST,
     // so a peer's already-delivered newer provider edit is applied before we
     // re-emit with a fresh lamport and fabricate recency over it.
-    try {
-      for (const [peerId, inFeed] of this.inFeeds) {
-        await this._processNewEntries(peerId, inFeed);
+    // T3 (F2/C2b): each per-peer await is BOUNDED by _drainInboundCapped (boot
+    // path). Unlike contacts/groups, this backfill re-emits with a FRESH mint,
+    // so a CAPPED (incomplete) drain must not proceed — it would fabricate
+    // recency over the peer's undrained newer edit and manufacture spurious
+    // sync_conflicts rows. Capped ⇒ defer (below). A drain that THROWS keeps
+    // today's proceed-to-emit semantics — the cap must not widen the existing
+    // throw exposure (spec A2-2).
+    let drainCompleted = true;
+    for (const [peerId, inFeed] of this.inFeeds) {
+      try {
+        if (!(await this._drainInboundCapped(peerId, inFeed, "providers backfill"))) {
+          drainCompleted = false;
+        }
+      } catch (err) {
+        console.warn(`[instance-sync] providers backfill drain failed: ${err.message}`);
       }
-    } catch (err) {
-      console.warn(`[instance-sync] providers backfill drain failed: ${err.message}`);
+    }
+
+    if (!drainCompleted) {
+      // T3 defer-on-cap (spec R2-1): record a deferral per pending peer as
+      // `deferred:<n>` (UPSERT; non-terminal — only done:* is, so the next
+      // boot retries). Malformed/absent prior value parses as 0.
+      // ESCAPE HATCH: on the 3rd consecutive deferral, PROCEED to emit anyway
+      // and mark done — without it, one permanently-wedged inbound feed would
+      // block providers backfill to EVERY new peer forever (a functional
+      // regression vs today's emit-on-drain-failure; peer B could never route
+      // to this instance's models). Worst case is one boot's worth of
+      // truthfully-labeled conflict rows — today's tolerated exposure.
+      const MAX_DEFERRALS = 3;
+      let escape = false;
+      const deferrals = new Map();
+      for (const peerId of newPeers) {
+        const m = /^deferred:(\d+)$/.exec(flagValues.get(peerId) ?? "");
+        const n = (m ? Number(m[1]) : 0) + 1;
+        deferrals.set(peerId, n);
+        if (n >= MAX_DEFERRALS) escape = true;
+      }
+      if (!escape) {
+        for (const [peerId, n] of deferrals) {
+          try {
+            await this.db.execute({
+              sql: "INSERT INTO dashboard_settings (key, value, updated_at) VALUES (?, ?, datetime('now')) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+              args: [FLAG_PREFIX + peerId, `deferred:${n}`],
+            });
+          } catch {}
+        }
+        console.warn(`[instance-sync] providers backfill deferred (inbound drain capped) for ${newPeers.length} peer(s) — retrying next boot`);
+        return 0;
+      }
+      // Escape: fall through to the emit. The emit is a BROADCAST to every
+      // armed peer, so ALL pending peers are marked done below — writing
+      // deferred for the non-escaped ones would just schedule a redundant
+      // re-emit (more conflict noise) for rows they already received.
+      console.warn(`[instance-sync] providers backfill escape hatch: ${MAX_DEFERRALS} consecutive capped drains — emitting anyway (spec R2-1)`);
     }
 
     let rows = [];
@@ -1191,12 +1258,16 @@ export class InstanceSyncManager {
     if (this.outFeeds.size === 0) return 0; // no peers armed yet — retry next boot; do NOT mark
 
     // I-B1 ordering guard: apply the peer's already-replicated backlog first.
-    try {
-      for (const [peerId, inFeed] of this.inFeeds) {
-        await this._processNewEntries(peerId, inFeed);
+    // T3 (F2/C2b): each per-peer await is BOUNDED by _drainInboundCapped (boot
+    // path — see the contacts backfill note). Capped or not we PROCEED: the
+    // re-emit is lamport-preserving (emitGroupUpsert preserveLamport), so a
+    // capped drain is truthful deferred convergence; flag written as before.
+    for (const [peerId, inFeed] of this.inFeeds) {
+      try {
+        await this._drainInboundCapped(peerId, inFeed, "groups backfill");
+      } catch (err) {
+        console.warn(`[instance-sync] groups backfill drain failed: ${err.message}`);
       }
-    } catch (err) {
-      console.warn(`[instance-sync] groups backfill drain failed: ${err.message}`);
     }
 
     let rows = [];

--- a/servers/sharing/managers.js
+++ b/servers/sharing/managers.js
@@ -12,6 +12,7 @@ import { PeerManager } from "./peer-manager.js";
 import { SyncManager } from "./sync.js";
 import { InstanceSyncManager } from "./instance-sync.js";
 import { NostrManager } from "./nostr.js";
+import { installNostrCrashGuard } from "./nostr-crash-guard.js";
 import { getOrCreateLocalInstanceId } from "../gateway/instance-registry.js";
 
 // Singleton sharing managers — Hyperswarm and Nostr connections are shared across
@@ -26,6 +27,10 @@ export function getSharedManagers(dbPath) {
   const peerManager = new PeerManager(identity);
   const syncManager = new SyncManager(identity);
   const nostrManager = new NostrManager(identity, db);
+  // Narrow process-level net for nostr-tools' orphaned close-race rejection
+  // (2c-F1 C1b): swallows SendingOnClosedConnection, RETHROWS everything else.
+  // Idempotent; installed once with the singleton that owns all relay use.
+  installNostrCrashGuard();
 
   // Instance sync manager for cross-instance replication
   const localInstanceId = getOrCreateLocalInstanceId();

--- a/servers/sharing/nostr-crash-guard.js
+++ b/servers/sharing/nostr-crash-guard.js
@@ -1,0 +1,55 @@
+/**
+ * Process-level narrow net for nostr-tools' close-race rejection (2c-F1 C1b).
+ *
+ * nostr-tools 2.23.3: AbstractRelay.send() is an ASYNC method that throws
+ * SendingOnClosedConnection when the socket dropped (connectionPromise null);
+ * Subscription.fire() calls it without await or catch, so the throw is an
+ * orphaned rejection — fatal under Node's default --unhandled-rejections=throw.
+ * The connected-guards in resilient-subscribe.js and the pi-bots nostr-client
+ * remove the deterministic triggers; this guard covers library-internal fire()
+ * paths we cannot wrap. Any OTHER rejection is rethrown — crash-on-unknown is
+ * load-bearing (throw inside the listener → uncaughtException → default fatal,
+ * the same observable outcome as having no listener at all).
+ */
+let installed = false;
+let swallowed = 0;
+
+/**
+ * Returns true iff the rejection is the known nostr close-race (swallowed).
+ * Exported so tests can unit-call it without emitting a real process event.
+ */
+export function handleRejection(err) {
+  if (err?.name === "SendingOnClosedConnection") {
+    swallowed++;
+    // Rate-limited observability: a stuck-relay loop must not hide behind a
+    // single warn — log the count at 1, 10, 100, 1000, ...
+    if (Number.isInteger(Math.log10(swallowed))) {
+      console.warn(`[nostr] swallowed SendingOnClosedConnection #${swallowed} (relay dropped mid-send)`);
+    }
+    return true;
+  }
+  return false;
+}
+
+let listener = null;
+
+/** Idempotent: installs exactly one process listener regardless of call count. */
+export function installNostrCrashGuard() {
+  if (installed) return;
+  installed = true;
+  listener = (err) => { if (!handleRejection(err)) throw err; }; // crash-on-unknown preserved
+  process.on("unhandledRejection", listener);
+}
+
+/**
+ * Test-only. A permanent throwing global listener in the node:test process
+ * would fight the runner (a stray non-nostr rejection in ANY later test in
+ * the file becomes an uncaughtException attributed to no test). Tests MUST
+ * uninstall in finally; prod never calls this.
+ */
+export function uninstallNostrCrashGuard() {
+  if (listener) process.off("unhandledRejection", listener);
+  listener = null;
+  installed = false;
+  swallowed = 0;
+}

--- a/servers/sharing/peer-manager.js
+++ b/servers/sharing/peer-manager.js
@@ -12,6 +12,13 @@ import { shouldInitInstanceSync } from "./instance-sync.js";
 import { createHash, randomBytes } from "node:crypto";
 import { sign, verify } from "./identity.js";
 
+// 2c follow-up (spec §F2 C2c): hard cap on awaiting the DHT announce
+// confirmation (`discovery.flushed()`) in joinContact. An unresponsive DHT
+// must not wedge the boot per-contact join loop (boot.js) or the inbound
+// sync apply chain (wireFullContact → joinContact). Overridable per-call via
+// opts.flushedCapMs (tests).
+const FLUSHED_CAP_MS = 10_000;
+
 /**
  * Create a deterministic topic for a contact pair.
  * topic = sha256(sorted(myPubkey, theirPubkey))
@@ -63,10 +70,13 @@ export class PeerManager {
 
   /**
    * Join the DHT topic for a specific contact.
+   * @param {{crowId?:string, crow_id?:string, ed25519Pubkey:string}} contact
+   * @param {{flushedCapMs?:number}} [opts] override the flushed() cap (tests)
    */
-  async joinContact(contact) {
+  async joinContact(contact, opts = {}) {
     if (this.p2pDisabled) return null; // --no-auth companion: no DHT topics
     if (!this.swarm) throw new Error("PeerManager not started");
+    const cap = Number(opts.flushedCapMs) > 0 ? Number(opts.flushedCapMs) : FLUSHED_CAP_MS;
 
     const topic = computeTopic(
       this.identity.ed25519Pubkey,
@@ -76,7 +86,23 @@ export class PeerManager {
     this.topics.set(contact.crow_id || contact.crowId, topic);
 
     const discovery = this.swarm.join(topic, { server: true, client: true });
-    await discovery.flushed();
+    // Cap ONLY the announce-confirmation await (C2c). The topic registration
+    // (topics.set above) and the announce (swarm.join above) have already
+    // fired — flushed() merely confirms the announce reached the DHT. On cap
+    // we proceed: only the confirmation is abandoned, never the announce.
+    // Timer is cleared when flushed() wins (no dangling timer).
+    let timer;
+    const guard = new Promise((resolve) => {
+      timer = setTimeout(() => resolve("__flushed_cap__"), cap);
+    });
+    try {
+      const r = await Promise.race([discovery.flushed(), guard]);
+      if (r === "__flushed_cap__") {
+        console.warn(`[peer-manager] joinContact: discovery.flushed() exceeded ${cap}ms — proceeding without DHT announce confirmation`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
 
     return topic;
   }
@@ -101,17 +127,36 @@ export class PeerManager {
    * Join the instance sync DHT topic.
    * All instances owned by the same Crow ID join this topic for P2P discovery.
    * topic = sha256(crowId + "instance-sync")
+   * @param {{flushedCapMs?:number}} [opts] override the flushed() cap (tests)
    */
-  async joinInstanceSync() {
+  async joinInstanceSync(opts = {}) {
     if (this.p2pDisabled) return null; // --no-auth companion: no instance-sync topic
     if (!this.swarm) throw new Error("PeerManager not started");
+    const cap = Number(opts.flushedCapMs) > 0 ? Number(opts.flushedCapMs) : FLUSHED_CAP_MS;
 
     this.instanceSyncTopic = createHash("sha256")
       .update(this.identity.crowId + "instance-sync")
       .digest();
 
     const discovery = this.swarm.join(this.instanceSyncTopic, { server: true, client: true });
-    await discovery.flushed();
+    // Cap ONLY the announce-confirmation await (C2c, same shape as
+    // joinContact). The topic registration (instanceSyncTopic above) and the
+    // announce (swarm.join above) have already fired — flushed() merely
+    // confirms the announce reached the DHT. On cap we proceed: only the
+    // confirmation is abandoned, never the announce. Timer is cleared when
+    // flushed() wins (no dangling timer).
+    let timer;
+    const guard = new Promise((resolve) => {
+      timer = setTimeout(() => resolve("__flushed_cap__"), cap);
+    });
+    try {
+      const r = await Promise.race([discovery.flushed(), guard]);
+      if (r === "__flushed_cap__") {
+        console.warn(`[peer-manager] joinInstanceSync: discovery.flushed() exceeded ${cap}ms — proceeding without DHT announce confirmation`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
 
     console.log(`[peer-manager] Joined instance sync topic for ${this.identity.crowId}`);
     return this.instanceSyncTopic;

--- a/servers/sharing/resilient-subscribe.js
+++ b/servers/sharing/resilient-subscribe.js
@@ -19,7 +19,7 @@
  * same code usable from the pi-bots adapter (better-sqlite3) and NostrManager
  * (libsql) unchanged.
  *
- * @param {object} relay  connected nostr-tools Relay (or a stub)
+ * @param {object} relay  nostr-tools Relay (or a stub); may already have dropped — subscribe defers to ensureHealthy()
  * @param {object} filter Nostr filter WITHOUT `since` (this injects `since`)
  * @param {function} onevent  called with each event (the caller dedups/decodes)
  * @param {{initialSince?:number, skewSec?:number, connectTimeoutMs?:number}} opts
@@ -48,6 +48,12 @@ export function makeResilientSub(relay, filter, onevent, opts = {}) {
   };
 
   function doSubscribe() {
+    // nostr-tools' subscribe() on a dropped relay orphans an ASYNC rejected
+    // send() (SendingOnClosedConnection) that the try/catch below cannot see —
+    // process-fatal under default --unhandled-rejections=throw. Check-then-call
+    // with no await between is safe: connected ⇒ connectionPromise non-null,
+    // single-threaded (same invariant as safe-relay-publish.js).
+    if (!relay.connected) { sub = null; return; } // ensureHealthy retries next tick
     const since = lastSeen !== null ? lastSeen - skewSec : initialSince;
     const f = since !== null ? { ...filter, since } : { ...filter };
     try {
@@ -57,8 +63,10 @@ export function makeResilientSub(relay, filter, onevent, opts = {}) {
     }
   }
 
-  // Subscribe immediately (relay is connected at construction) so listening
-  // starts right away, exactly like the pre-hardening one-shot subscribe.
+  // Subscribe immediately when the relay is still connected (the usual case
+  // at construction) so listening starts right away. If it dropped between
+  // connect and construction, the connected guard skips this and the caller's
+  // periodic ensureHealthy() loop establishes the subscription on reconnect.
   doSubscribe();
 
   async function ensureHealthy() {

--- a/servers/sharing/sync-conflict-resolve.js
+++ b/servers/sharing/sync-conflict-resolve.js
@@ -24,6 +24,41 @@
 
 import { SYNCED_TABLES, rowsEquivalent } from "./instance-sync.js";
 
+// ── Natural-key restore refusals (2c C7 / 2c-F3) ─────────────────────────────
+// These tables key their conflict row_id on a JSON natural key (crow_context:
+// {section_key,device_id,project_id}; contacts: {crow_id}; contact_groups:
+// {group_uid}), not a numeric id, so the id-keyed stale-snapshot guard in
+// restoreConflict() would run SELECT ... WHERE id = '{...}', find nothing,
+// re-snapshot winning_data to 'null', and silently destroy the recorded local
+// snapshot (2c C7 / spec R3-Q4). Restore is therefore refused for them.
+//
+// SINGLE SOURCE OF TRUTH: the dashboard (settings/sections/sync-conflicts.js
+// renderConflictRow) derives its Restore-button disable from this set, so UI
+// and backend cannot drift. Invariant: set membership ⟺ a per-table refusal
+// message exists in NATURAL_KEY_RESTORE_REFUSALS below.
+export const NATURAL_KEY_RESTORE_TABLES = new Set([
+  "crow_context",
+  "contacts",
+  "contact_groups",
+]);
+
+// Per-table operator-facing refusal messages. Every NATURAL_KEY_RESTORE_TABLES
+// member must have an entry here (and vice versa).
+const NATURAL_KEY_RESTORE_REFUSALS = {
+  crow_context:
+    "This version cannot be restored automatically. crow_context rows are keyed " +
+    "by a composite key (section_key, device_id, project_id), not a single id. " +
+    "Use crow_update_context_section to apply the values shown below.",
+  contacts:
+    "This version cannot be restored automatically. Contact conflicts are keyed " +
+    "by crow_id, not a numeric id. Review the values shown below and re-apply " +
+    "the change manually from the Contacts panel.",
+  contact_groups:
+    "This version cannot be restored automatically. Group conflicts are keyed " +
+    "by group_uid, not a numeric id. Review the values shown below and re-apply " +
+    "the change manually from the Groups panel.",
+};
+
 // ── Outcomes ─────────────────────────────────────────────────────────────────
 
 /**
@@ -123,27 +158,11 @@ export async function restoreConflict(db, conflictId, { instanceSync = null } = 
   const table = conflict.table_name;
   const rowId = conflict.row_id;
 
-  // Natural-key tables cannot be auto-restored: their conflict row_id is a JSON
-  // key (crow_context: {section_key,device_id,project_id}; contacts: {crow_id};
-  // contact_groups: {group_uid}), not a numeric id, so the id-keyed stale-snapshot
-  // guard below would run SELECT ... WHERE id = '{...}', find nothing, re-snapshot
-  // winning_data to 'null', and silently destroy the recorded local snapshot
-  // (2c C7 / spec R3-Q4). Placement BEFORE the stale guard is load-bearing.
-  const NATURAL_KEY_RESTORE_REFUSALS = {
-    crow_context:
-      "This version cannot be restored automatically. crow_context rows are keyed " +
-      "by a composite key (section_key, device_id, project_id), not a single id. " +
-      "Use crow_update_context_section to apply the values shown below.",
-    contacts:
-      "This version cannot be restored automatically. Contact conflicts are keyed " +
-      "by crow_id, not a numeric id. Review the values shown below and re-apply " +
-      "the change manually from the Contacts panel.",
-    contact_groups:
-      "This version cannot be restored automatically. Group conflicts are keyed " +
-      "by group_uid, not a numeric id. Review the values shown below and re-apply " +
-      "the change manually from the Groups panel.",
-  };
-  if (NATURAL_KEY_RESTORE_REFUSALS[table]) {
+  // Natural-key tables cannot be auto-restored — see NATURAL_KEY_RESTORE_TABLES
+  // at module scope for the full rationale (2c C7 / spec R3-Q4). Placement
+  // BEFORE the stale guard is load-bearing: the id-keyed stale-snapshot re-read
+  // below would destroy the recorded snapshot for these tables.
+  if (NATURAL_KEY_RESTORE_TABLES.has(table)) {
     return { status: "refused", message: NATURAL_KEY_RESTORE_REFUSALS[table] };
   }
 
@@ -311,6 +330,13 @@ export async function restoreConflict(db, conflictId, { instanceSync = null } = 
       const placeholders = insertKeys.map(() => "?").join(", ");
       const values = insertKeys.map((k) => losingData[k] ?? null);
       if (table === "contact_groups") {
+        // NOTE (2c-F4): currently UNREACHABLE — contact_groups is refused upstream by
+        // the NATURAL_KEY_RESTORE_TABLES gate (search this file) before the stale guard / INSERT
+        // branch. KEEP THIS GUARD: if that refusal is ever relaxed (e.g. natural-key restore
+        // gets implemented), this statement-level tombstone check becomes load-bearing again —
+        // without it, Restore re-inserts a tombstoned group_uid and manufactures the
+        // resurrection zombie (2b design R2 F3').
+        //
         // G3 (2b design R2 F3'): an operator clicking Restore on an old
         // contact_groups conflict must NOT re-insert a tombstoned group_uid —
         // that would manufacture the resurrection zombie through a SUPPORTED

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -559,6 +559,23 @@ export async function startTailnetSyncClients(ctx) {
     for (const [id, dialer] of dialers) {
       if (!seenIds.has(id)) { dialer.stop(); dialers.delete(id); }
     }
+    // F5 gauge: parked emit-queue sizes ({peerId: count}), visible BEFORE the
+    // 256-cap overflow warn drops entries. Placed AFTER the per-peer loop so a
+    // zero-peer refresh still reports (R2 Q7). Own try/catch: refresh runs on
+    // a bare setInterval, and the process-level nostr crash guard RETHROWS
+    // non-nostr errors — an escaped throw here would crash the gateway.
+    // Optional chaining guards older/stub managers that lack the method.
+    try {
+      const stats = instanceSyncManager.pendingEmitStats?.();
+      const parts = stats
+        ? Object.entries(stats).map(([id, n]) => `${String(id).slice(0, 12)}=${n}`)
+        : [];
+      if (parts.length > 0) {
+        console.warn(`[instance-sync] pending emit queues: ${parts.join(", ")}`);
+      }
+    } catch (err) {
+      console.warn(`[tailnet-sync] pending-emit gauge failed: ${err.message}`);
+    }
   }
 
   await refresh();

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -529,8 +529,10 @@ export async function startTailnetSyncClients(ctx) {
       // heals manual crow_update_instance edits and any missed key exchange
       // within 60s, no restart. Cheap fast-path (Map lookup + Buffer compare)
       // when nothing changed. Own try/catch: refresh runs on a bare
-      // setInterval and an escaped rejection would crash the gateway (no
-      // unhandledRejection handler exists in servers/). Placed BEFORE both
+      // setInterval and an escaped rejection would still crash the gateway —
+      // the nostr crash guard (nostr-crash-guard.js) swallows ONLY
+      // SendingOnClosedConnection and RETHROWS everything else, so this local
+      // catch stays load-bearing. Placed BEFORE both
       // continues below (R3 F-C): after the dialers.has() continue it would
       // never heal the steady state, which is exactly the case that needs
       // healing (an already-dialing peer whose row drifted).

--- a/tests/backfill-drain-caps.test.js
+++ b/tests/backfill-drain-caps.test.js
@@ -1,0 +1,248 @@
+/**
+ * T3 (2c follow-up pool, spec §F2 C2b): the three boot backfills' pre-drain
+ * loops are BOUNDED by _drainInboundCapped, with per-drain contracts:
+ *
+ *   - contacts + groups (G-F2-3): capped or not, PROCEED exactly as today —
+ *     their re-emits are lamport-preserving, so a capped drain degrades to
+ *     truthful deferred convergence (the #195 semantics). Flags written
+ *     unconditionally; the call returns within cap+margin.
+ *   - providers (G-F2-2): defer-on-cap — a capped (incomplete) drain must NOT
+ *     proceed to the FRESH-MINT re-emit (it would fabricate recency over a
+ *     peer's undrained newer edit → spurious sync_conflicts rows). Per-peer
+ *     flag becomes `deferred:<n>` (non-terminal; only done:* is). ESCAPE
+ *     HATCH (spec R2-1): the 3rd consecutive deferral emits anyway + done:*,
+ *     so one permanently-wedged inbound feed cannot block providers backfill
+ *     to every new peer forever.
+ *
+ * ANTI-VACUITY construction (spec R2-5, review round 2):
+ *   - BOTH maps are armed: an unflagged peer in outFeeds (backfillProviders
+ *     early-returns at :977 when outFeeds is empty — an inFeeds-only test is
+ *     vacuous green) AND an inFeed whose entry delivery is parked.
+ *   - The barrier parks at FEED-DELIVERY level: the inFeed is a REAL Hypercore
+ *     holding a REAL appended entry, and its get() is wrapped so the drain's
+ *     `await feed.get(seq)` inside the REAL _processNewEntriesInner genuinely
+ *     hangs until released — delivery of the result is delayed, not the call
+ *     (better-sqlite3 is synchronous under the async wrapper; a barrier that
+ *     delays the SELECT itself is vacuous — 2d T7 lesson).
+ *
+ * Harness idiom from tests/feed-rotation.test.js / tests/lamport-reemit.test.js:
+ * per-test mkdtemp CROW_DATA_DIR + real init-db, mgr.dataDir = scratch,
+ * mgr.feedsDisabled = false, REAL Hypercore in-feed; stub capture out-feed
+ * (the lamport-reemit backfill-gate idiom) so emissions and their envelope
+ * lamports are assertable. NEVER point this file at ~/.crow.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Hypercore from "hypercore";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { __setEmitSinkForTest as __setGroupSink } from "../servers/sharing/group-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const LOCAL_ID = "inst-dddd-0000-0000-0000-00000000000d";
+const PEER_ID = "peer-cccc-0000-0000-0000-00000000000c";
+const PROVIDERS_FLAG = `__providers_backfill_v1:${PEER_ID}`;
+const DRAIN_CAP_MS = 150;
+
+async function makeIdentity() {
+  const priv = Buffer.alloc(32, 0x2c);
+  const pub = Buffer.from(await ed.getPublicKey(priv)).toString("hex");
+  return { ed25519Priv: priv, ed25519Pubkey: pub };
+}
+
+/** Await `promise`, but reject with `msg` after `ms` — so an uncapped drain
+ *  fails cleanly (RED) instead of hanging the whole test file forever. */
+async function withDeadline(promise, ms, msg) {
+  let timer;
+  const guard = new Promise((_, rej) => { timer = setTimeout(() => rej(new Error(msg)), ms); });
+  try { return await Promise.race([promise, guard]); }
+  finally { clearTimeout(timer); }
+}
+
+/** Poll until fn() is truthy or the deadline passes — condition-based, no bare sleeps. */
+async function until(fn, ms = 4000, step = 20) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) {
+    if (await fn()) return true;
+    await new Promise((r) => setTimeout(r, step));
+  }
+  return false;
+}
+
+/**
+ * One fresh instance per test: real init-db scratch DB, a stub CAPTURE
+ * out-feed for PEER_ID (unflagged → :977 gate passes and providers sees a
+ * pending peer), and a REAL Hypercore in-feed for the SAME peer holding one
+ * real entry whose delivery is parked behind a gate (feed-delivery barrier).
+ */
+async function makeRig(label) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-t3-drain-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    // CROW_DB_PATH outranks CROW_DATA_DIR in init-db — blank it, or a shell
+    // exporting it would run the migration against the REAL DB (PR #180).
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DB_PATH: "", CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    stdio: "pipe",
+  });
+  const db = createDbClient(join(dir, "crow.db"));
+  const mgr = new InstanceSyncManager(await makeIdentity(), db, LOCAL_ID);
+  mgr.dataDir = join(dir, "instance-sync"); // MUST: keep test feeds out of ~/.crow
+  mgr.feedsDisabled = false;                // MUST: scratch env disables feeds (2c C6)
+  mgr._drainCapMs = DRAIN_CAP_MS;           // small cap for test speed
+
+  // Out-feed: capture stub keyed by the peer id (lamport-reemit idiom) —
+  // emitChange's broadcast targets outFeeds keys, so every emission lands here.
+  const wire = [];
+  mgr.outFeeds = new Map([[PEER_ID, {
+    append: async (e) => { wire.push(JSON.parse(JSON.stringify(e))); },
+  }]]);
+
+  // In-feed: REAL Hypercore with one REAL entry; delivery parked at get().
+  const inCore = new Hypercore(join(dir, "in-peer"), { valueEncoding: "json" });
+  await inCore.ready();
+  // memories.id is INTEGER PRIMARY KEY — string ids fail silently on apply.
+  // The 64-byte zero signature verifies false → skip-and-checkpoint, which is
+  // all a COMPLETED drain needs (the mechanism under test is the cap/flags).
+  await inCore.append({
+    table: "memories", op: "insert",
+    row: { id: 990001, content: "t3 parked entry", lamport_ts: 1 },
+    lamport_ts: 1, instance_id: PEER_ID, signature: "00".repeat(64),
+  });
+  const realGet = inCore.get.bind(inCore);
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  let parked = true;
+  inCore.get = async (seq, opts) => { if (parked) await gate; return realGet(seq, opts); };
+  const unpark = () => { parked = false; release(); };
+  mgr.inFeeds.set(PEER_ID, inCore);
+
+  return {
+    dir, db, mgr, wire, inCore, unpark,
+    providersOnWire: () => wire.filter((e) => e.table === "providers"),
+    flag: async (key) =>
+      (await db.execute({ sql: "SELECT value FROM dashboard_settings WHERE key = ?", args: [key] })).rows[0]?.value ?? null,
+    async cleanup() {
+      unpark(); // let abandoned background drains finish before closing the core
+      await new Promise((r) => setTimeout(r, 50));
+      try { await inCore.close(); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+// ── G-F2-2: providers defer-on-cap + 3rd-deferral escape hatch ────────────────
+test("G-F2-2: providers defer-on-cap -- capped drains write deferred:<n> with NO emit; 3rd deferral emits anyway + done (escape hatch)", async () => {
+  const rig = await makeRig("prov");
+  try {
+    // Non-loopback base_url — loopback rows are gated off the wire by shouldSyncRow.
+    await rig.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-t3', 'http://10.0.0.99:8000/v1', '[]')", args: [] });
+
+    // Run 1 (parked): capped drain → defer, no emissions.
+    const r1 = await withDeadline(rig.mgr.backfillProvidersForNewPeers(), 5000,
+      "providers backfill blocked >5s by a parked feed delivery (drain uncapped?)");
+    assert.equal(r1, 0, "deferred run returns 0");
+    assert.equal(rig.providersOnWire().length, 0, "NO providers entries rode under a capped drain");
+    assert.equal(await rig.flag(PROVIDERS_FLAG), "deferred:1", "run 1 wrote deferred:1");
+
+    // Run 2 (still parked): deferral count advances, still nothing on the wire.
+    await withDeadline(rig.mgr.backfillProvidersForNewPeers(), 5000,
+      "providers backfill run 2 blocked >5s (drain uncapped?)");
+    assert.equal(rig.providersOnWire().length, 0, "still no providers entries after run 2");
+    assert.equal(await rig.flag(PROVIDERS_FLAG), "deferred:2", "run 2 wrote deferred:2");
+
+    // Run 3 (still parked): ESCAPE HATCH — emits anyway, terminal done:<n>.
+    const r3 = await withDeadline(rig.mgr.backfillProvidersForNewPeers(), 5000,
+      "providers backfill run 3 blocked >5s (drain uncapped?)");
+    assert.ok(r3 >= 1, `escape hatch emitted (got ${r3})`);
+    assert.ok(rig.providersOnWire().some((e) => e.row?.id === "prov-t3"),
+      "the provider row rode the wire on the escape hatch");
+    assert.equal(await rig.flag(PROVIDERS_FLAG), `done:${r3}`, "escape hatch wrote terminal done:<n>");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+test("G-F2-2b: providers deferred run stays retryable -- unpark, next run completes the drain, emits, done", async () => {
+  const rig = await makeRig("prov-unpark");
+  try {
+    await rig.db.execute({ sql: "INSERT INTO providers (id, base_url, models) VALUES ('prov-t3b', 'http://10.0.0.98:8000/v1', '[]')", args: [] });
+
+    // Parked run → deferred, nothing rode.
+    const r1 = await withDeadline(rig.mgr.backfillProvidersForNewPeers(), 5000,
+      "providers backfill blocked >5s by a parked feed delivery (drain uncapped?)");
+    assert.equal(r1, 0);
+    assert.equal(rig.providersOnWire().length, 0, "no emissions while parked");
+    assert.equal(await rig.flag(PROVIDERS_FLAG), "deferred:1", "parked run wrote deferred:1 (non-terminal)");
+
+    // Unpark: the abandoned background drain completes and checkpoints seq 1.
+    rig.unpark();
+    assert.ok(await until(async () => (await rig.mgr._getLastAppliedSeq(PEER_ID, rig.inCore)) >= 1),
+      "background drain checkpointed the parked entry after unpark");
+
+    // Next run: drain completes within the cap → emits + terminal done:<n>.
+    const r2 = await withDeadline(rig.mgr.backfillProvidersForNewPeers(), 5000,
+      "providers backfill after unpark blocked >5s");
+    assert.ok(r2 >= 1, `completed drain emitted (got ${r2})`);
+    assert.ok(rig.providersOnWire().some((e) => e.row?.id === "prov-t3b"), "provider row rode after unpark");
+    assert.equal(await rig.flag(PROVIDERS_FLAG), `done:${r2}`, "completed run wrote terminal done:<n>");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+// ── G-F2-3: contacts + groups proceed under a capped drain, lamport-preserving ─
+test("G-F2-3a: contacts backfill under a capped drain still emits lamport-preserving and writes its flag, within cap+margin", async () => {
+  const rig = await makeRig("contacts");
+  try {
+    await rig.db.execute({ sql: "INSERT INTO contacts (crow_id, ed25519_pubkey, secp256k1_pubkey, display_name, lamport_ts) VALUES ('crow:t3c', '', 't3caa', 'T3 Contact', 5)", args: [] });
+
+    const t0 = Date.now();
+    // Without the drain cap this await never resolves ⇒ withDeadline rejects (RED).
+    const emitted = await withDeadline(rig.mgr.backfillContactsOnce(), 5000,
+      "contacts backfill blocked >5s by a parked feed delivery (drain uncapped?)");
+    const elapsed = Date.now() - t0;
+    // Wrapper runs the gated-body drain AND the tombstone re-emit drain (both
+    // capped) — bound at a small multiple of the cap, not a hang.
+    assert.ok(elapsed < 3000, `returned within cap+margin (${elapsed}ms, cap ${DRAIN_CAP_MS}ms)`);
+
+    assert.ok(emitted >= 1, "capped drain still emitted (contacts PROCEED on cap)");
+    const entry = rig.wire.filter((e) => e.table === "contacts" && e.row?.crow_id === "crow:t3c").at(-1);
+    assert.ok(entry, "contact rode the wire despite the capped drain");
+    assert.equal(Number(entry.lamport_ts), 5, "envelope preserved the row lamport (no fresh mint)");
+    assert.equal(await rig.flag("__contacts_backfill_v1"), `done:${emitted}`,
+      "contacts done-flag written unconditionally (existing semantics)");
+  } finally {
+    await rig.cleanup();
+  }
+});
+
+test("G-F2-3b: groups backfill under a capped drain still emits lamport-preserving and writes its flag, within cap+margin", async () => {
+  const rig = await makeRig("groups");
+  try {
+    await rig.db.execute({ sql: "INSERT INTO contact_groups (name, group_uid, lamport_ts) VALUES ('T3 Group', 'uid-t3-group', 30)", args: [] });
+
+    const t0 = Date.now();
+    __setGroupSink(rig.mgr); // emitGroupUpsert routes through the module sink
+    let emitted;
+    try {
+      emitted = await withDeadline(rig.mgr.backfillGroupsOnce(), 5000,
+        "groups backfill blocked >5s by a parked feed delivery (drain uncapped?)");
+    } finally {
+      __setGroupSink(null);
+    }
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed < 3000, `returned within cap+margin (${elapsed}ms, cap ${DRAIN_CAP_MS}ms)`);
+
+    assert.ok(emitted >= 1, "capped drain still emitted (groups PROCEED on cap)");
+    const entry = rig.wire.filter((e) => e.table === "contact_groups" && e.row?.group_uid === "uid-t3-group").at(-1);
+    assert.ok(entry, "group rode the wire despite the capped drain");
+    assert.equal(Number(entry.lamport_ts), 30, "envelope preserved the row lamport (no fresh mint)");
+    assert.equal(await rig.flag("__groups_backfill_v1"), `done:${emitted}`,
+      "groups done-flag written unconditionally (existing semantics)");
+  } finally {
+    await rig.cleanup();
+  }
+});

--- a/tests/nostr-crash-guard.test.js
+++ b/tests/nostr-crash-guard.test.js
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeResilientSub } from "../servers/sharing/resilient-subscribe.js";
+import { subscribe } from "../scripts/pi-bots/gateways/nostr-client.mjs";
+import { handleRejection, installNostrCrashGuard, uninstallNostrCrashGuard } from "../servers/sharing/nostr-crash-guard.js";
+
+// 2c-F1 crash class: nostr-tools' AbstractRelay.send() is ASYNC and throws
+// SendingOnClosedConnection when the socket dropped; Subscription.fire() calls
+// it without await/catch, so the throw is an ORPHANED rejection — invisible to
+// any try/catch around subscribe(), fatal under Node's default
+// --unhandled-rejections=throw. Stub fidelity is load-bearing: subscribe() on
+// a dropped relay must return a sub handle AND leak an un-awaited rejection
+// (a synchronous throw is caught by the existing try/catch and makes these
+// tests vacuously green against unguarded code).
+function makeAsyncThrowRelay({ connected = false } = {}) {
+  const relay = {
+    connected,
+    connectCalls: 0,
+    subscribeCalls: 0,
+    subscribe(filters, handlers) {
+      relay.subscribeCalls++;
+      if (!relay.connected) {
+        void (async () => { throw Object.assign(new Error("closed"), { name: "SendingOnClosedConnection" }); })();
+      }
+      return { onevent: handlers?.onevent, close() {} };
+    },
+    async connect() { relay.connectCalls++; relay.connected = true; },
+  };
+  return relay;
+}
+
+test("G-F1-1: construction on a dropped relay leaks no rejection, skips subscribe; ensureHealthy heals", async () => {
+  const relay = makeAsyncThrowRelay({ connected: false });
+  const unhandled = [];
+  const onUR = (err) => unhandled.push(err);
+  process.on("unhandledRejection", onUR);
+  try {
+    const h = makeResilientSub(relay, { kinds: [4] }, () => {}, { initialSince: 0 });
+    await new Promise((r) => setImmediate(r)); // let any orphaned rejection surface
+    assert.equal(unhandled.length, 0, `orphaned rejection escaped doSubscribe: ${unhandled[0]?.name}`);
+    assert.equal(relay.subscribeCalls, 0, "guard must skip subscribe on a dropped relay");
+    relay.connected = true;
+    await h.ensureHealthy();
+    assert.equal(relay.subscribeCalls, 1, "subscription heals once the relay is connected");
+    h.close();
+  } finally {
+    process.off("unhandledRejection", onUR);
+  }
+});
+
+// G-F1-2 is the mutation check on G-F1-1: comment out the connected guard in
+// resilient-subscribe.js doSubscribe() → G-F1-1 goes red via the rejection
+// capture (performed and recorded at build time, not encoded as a test).
+
+test("G-F1-3: handleRejection swallows only the nostr close-race name; install is idempotent", () => {
+  const before = process.listenerCount("unhandledRejection");
+  try {
+    assert.equal(handleRejection(Object.assign(new Error("closed"), { name: "SendingOnClosedConnection" })), true);
+    assert.equal(handleRejection(new Error("boom")), false, "unknown errors must be rethrown by the caller");
+    assert.equal(handleRejection(undefined), false);
+    // NEVER emit a real process 'unhandledRejection' here — the installed
+    // listener rethrows unknowns and would fight the node:test runner.
+    installNostrCrashGuard();
+    installNostrCrashGuard();
+    assert.equal(process.listenerCount("unhandledRejection"), before + 1, "double install must register exactly one listener");
+  } finally {
+    uninstallNostrCrashGuard();
+  }
+  assert.equal(process.listenerCount("unhandledRejection"), before, "uninstall must remove the listener");
+});
+
+test("G-F1-4: raw pi-bots subscribe() skips dropped relays, preserves fan-out, leaks no rejection", async () => {
+  const up = makeAsyncThrowRelay({ connected: true });
+  const down = makeAsyncThrowRelay({ connected: false });
+  const relays = new Map([["wss://up.example", up], ["wss://down.example", down]]);
+  const unhandled = [];
+  const onUR = (err) => unhandled.push(err);
+  process.on("unhandledRejection", onUR);
+  try {
+    const subs = subscribe(relays, { kinds: [4] }, () => {});
+    await new Promise((r) => setImmediate(r));
+    assert.equal(unhandled.length, 0, `orphaned rejection escaped raw subscribe: ${unhandled[0]?.name}`);
+    assert.equal(up.subscribeCalls, 1, "connected relay still subscribed (fan-out preserved)");
+    assert.equal(down.subscribeCalls, 0, "dropped relay skipped");
+    assert.equal(subs.length, 1);
+  } finally {
+    process.off("unhandledRejection", onUR);
+  }
+});

--- a/tests/notification-timeouts.test.js
+++ b/tests/notification-timeouts.test.js
@@ -1,0 +1,218 @@
+/**
+ * G-F2-1 — sender-level notification timeouts (2c follow-up pool, spec §F2 C2a).
+ *
+ * The 2c incident class: an apply-path notification fan-out awaiting a
+ * network send with no bound wedges boot or the live apply loop. These
+ * tests point each REAL sender at a hung local socket (a TCP server that
+ * accepts connections and never writes a byte) and assert the send
+ * settles (resolves OR rejects) within a short deadline.
+ *
+ * RED against pre-C2a code: all three senders hang past the deadline
+ * (fetch with no AbortController; webpush.sendNotification with no
+ * timeout option — its TLS handshake against the raw socket never
+ * completes and node applies no default socket timeout).
+ *
+ * Cap injection: the senders read CROW_PUSH_SEND_TIMEOUT_MS at call time
+ * (default 10000 ms); the tests set it to 500 ms for speed. The email
+ * sender hardcodes its Resend URL (no injection surface), so its test
+ * redirects that ONE URL at the global-fetch boundary to the hung server,
+ * passing every option (including the abort signal) through to the real
+ * fetch — the sender's own code path runs unmodified, and nothing escapes
+ * to the real network.
+ *
+ * No DB needed: web-push's sendPushToAll takes db as a parameter — a
+ * stub recording execute() calls is the real injection surface.
+ */
+
+import { test, before, after } from "node:test";
+import assert from "node:assert";
+import net from "node:net";
+import crypto from "node:crypto";
+
+const CAP_MS = 500; // injected sender cap (test speed)
+const DEADLINE_MS = 3000; // must settle well before this with the cap; hangs without it
+
+let server;
+let port;
+const liveSockets = new Set();
+
+before(async () => {
+  // Hung upstream: accepts TCP connections, never responds. Works for
+  // both plain-HTTP fetch (request sent, response never arrives) and
+  // web-push's https.request (TLS handshake never answered).
+  server = net.createServer((socket) => {
+    liveSockets.add(socket);
+    socket.on("close", () => liveSockets.delete(socket));
+    socket.on("error", () => {});
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = server.address().port;
+});
+
+after(async () => {
+  for (const socket of liveSockets) socket.destroy();
+  await new Promise((resolve) => server.close(resolve));
+});
+
+/** Race a sender against a wall clock. "settled" = resolved or rejected in time. */
+function settleWithin(promise, ms) {
+  let timer;
+  const wall = new Promise((resolve) => {
+    timer = setTimeout(() => resolve("hung"), ms);
+  });
+  return Promise.race([
+    promise.then(
+      () => "settled",
+      () => "settled"
+    ),
+    wall,
+  ]).finally(() => clearTimeout(timer));
+}
+
+/** Set env vars for the duration of fn, restoring previous values after. */
+async function withEnv(vars, fn) {
+  const saved = {};
+  for (const [k, v] of Object.entries(vars)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+test("ntfy sender settles within the cap against a hung upstream", async () => {
+  await withEnv(
+    {
+      NTFY_TOPIC: "timeout-test",
+      NTFY_HOST: "127.0.0.1",
+      NTFY_PORT: String(port),
+      NTFY_AUTH_TOKEN: undefined,
+      CROW_PUSH_SEND_TIMEOUT_MS: String(CAP_MS),
+    },
+    async () => {
+      const { sendNtfyNotification } = await import(
+        "../servers/gateway/push/ntfy.js"
+      );
+      const outcome = await settleWithin(
+        sendNtfyNotification({ title: "hang test", body: "hang" }),
+        DEADLINE_MS
+      );
+      assert.strictEqual(
+        outcome,
+        "settled",
+        `ntfy send must settle within ${DEADLINE_MS}ms when the upstream hangs (cap ${CAP_MS}ms)`
+      );
+    }
+  );
+});
+
+test("email sender settles within the cap against a hung upstream", async () => {
+  await withEnv(
+    {
+      RESEND_API_KEY: "re_test_key",
+      MPA_EMAIL_FROM: "crow@test.invalid",
+      MPA_EMAIL_TO: "kevin@test.invalid",
+      NTFY_CLICK_BASE_URL: undefined,
+      CROW_GATEWAY_URL: undefined,
+      CROW_PUSH_SEND_TIMEOUT_MS: String(CAP_MS),
+    },
+    async () => {
+      const { sendEmailNotification } = await import(
+        "../servers/gateway/push/email.js"
+      );
+      // The sender hardcodes https://api.resend.com/emails. Redirect that
+      // one URL to the hung server at the fetch boundary; every option —
+      // including the sender's abort signal — flows to the real fetch.
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = (url, opts) => {
+        if (String(url).startsWith("https://api.resend.com/")) {
+          return realFetch(`http://127.0.0.1:${port}/emails`, opts);
+        }
+        return realFetch(url, opts);
+      };
+      try {
+        // priority=high passes the shouldEmail predicate.
+        const outcome = await settleWithin(
+          sendEmailNotification({ title: "hang test", body: "hang", priority: "high" }),
+          DEADLINE_MS
+        );
+        assert.strictEqual(
+          outcome,
+          "settled",
+          `email send must settle within ${DEADLINE_MS}ms when the upstream hangs (cap ${CAP_MS}ms)`
+        );
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    }
+  );
+});
+
+test("web-push sendPushToAll settles within the cap against a hung endpoint", async () => {
+  const webpush = (await import("web-push")).default;
+  const vapid = webpush.generateVAPIDKeys();
+
+  // Real client-side subscription keys: uncompressed P-256 point + 16-byte
+  // auth secret, base64url — webpush encrypts the payload against these
+  // before dialing, so they must be structurally valid.
+  const ecdh = crypto.createECDH("prime256v1");
+  ecdh.generateKeys();
+  const p256dh = ecdh.getPublicKey().toString("base64url");
+  const auth = crypto.randomBytes(16).toString("base64url");
+
+  await withEnv(
+    {
+      VAPID_PUBLIC_KEY: vapid.publicKey,
+      VAPID_PRIVATE_KEY: vapid.privateKey,
+      VAPID_EMAIL: "mailto:test@test.invalid",
+      CROW_PUSH_SEND_TIMEOUT_MS: String(CAP_MS),
+    },
+    async () => {
+      const { initWebPush, sendPushToAll } = await import(
+        "../servers/gateway/push/web-push.js"
+      );
+      initWebPush();
+
+      const executed = [];
+      const db = {
+        async execute(q) {
+          const sql = typeof q === "string" ? q : q.sql;
+          executed.push(sql);
+          if (sql.startsWith("SELECT")) {
+            return {
+              rows: [
+                {
+                  endpoint: `https://127.0.0.1:${port}/push/hung`,
+                  keys_json: JSON.stringify({ p256dh, auth }),
+                },
+              ],
+            };
+          }
+          return { rows: [] };
+        },
+      };
+
+      const outcome = await settleWithin(
+        sendPushToAll(db, { title: "hang test", body: "hang" }),
+        DEADLINE_MS
+      );
+      assert.strictEqual(
+        outcome,
+        "settled",
+        `web-push fan-out must settle within ${DEADLINE_MS}ms when the endpoint hangs (cap ${CAP_MS}ms)`
+      );
+      // A timed-out send is NOT a 410/404 — the subscription must survive.
+      assert.ok(
+        !executed.some((sql) => sql.startsWith("DELETE")),
+        "timeout must not prune the subscription"
+      );
+    }
+  );
+});

--- a/tests/peer-join-flushed-cap.test.js
+++ b/tests/peer-join-flushed-cap.test.js
@@ -1,0 +1,130 @@
+/**
+ * G-F2-4 (2c follow-ups spec §F2/C2c): peerManager.joinContact must bound its
+ * `await discovery.flushed()` (DHT announce confirmation) with a cap. An
+ * unresponsive DHT must not wedge the boot per-contact join loop
+ * (boot.js:737) or the sync apply chain (wireFullContact,
+ * contact-promote.js:83).
+ *
+ * Vacuity note (spec G-F2-4): the stub boundary is the SWARM, not joinContact.
+ * joinContact's real code (computeTopic, topics.set, swarm.join) executes;
+ * only flushed() hangs. A stubbed joinContact would prove nothing.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// PeerManager computes p2pDisabled from process.env/argv at construction —
+// make the gate deterministic for this test process.
+delete process.env.CROW_DISABLE_INSTANCE_SYNC;
+
+const { PeerManager } = await import("../servers/sharing/peer-manager.js");
+
+test("G-F2-4: joinContact returns within the flushed() cap when DHT confirmation never resolves", async () => {
+  const pm = new PeerManager({
+    ed25519Pubkey: "a".repeat(64),
+    crowId: "crow:test-local",
+  });
+  assert.equal(
+    pm.p2pDisabled,
+    false,
+    "p2p must be enabled or joinContact early-returns and the test is vacuous"
+  );
+
+  // Stub swarm: join() runs for real and returns a discovery whose flushed()
+  // NEVER resolves (no timers — must not keep the event loop alive).
+  const joinCalls = [];
+  pm.swarm = {
+    join(topic, opts) {
+      joinCalls.push({ topic, opts });
+      return { flushed: () => new Promise(() => {}) };
+    },
+  };
+
+  const contact = { crowId: "crow:remote-peer", ed25519Pubkey: "b".repeat(64) };
+
+  // Race deadline: against uncapped (old) code joinContact hangs forever, so
+  // the deadline wins and the assertion below goes red. Against capped code
+  // the small injectable cap (100ms) wins well inside the deadline.
+  const TEST_DEADLINE_MS = 2_000;
+  let deadlineTimer;
+  const deadline = new Promise((resolve) => {
+    deadlineTimer = setTimeout(() => resolve("__test_deadline__"), TEST_DEADLINE_MS);
+  });
+
+  const result = await Promise.race([
+    pm.joinContact(contact, { flushedCapMs: 100 }),
+    deadline,
+  ]);
+  clearTimeout(deadlineTimer);
+
+  assert.notEqual(
+    result,
+    "__test_deadline__",
+    "joinContact hung past the test deadline — flushed() await is uncapped"
+  );
+  assert.ok(Buffer.isBuffer(result), "joinContact must still return the topic buffer");
+  assert.equal(joinCalls.length, 1, "swarm.join must have executed for real");
+  assert.ok(
+    joinCalls[0].topic.equals(result),
+    "the joined topic must be the returned topic"
+  );
+
+  // The announce path completed: topics map contains the contact's topic.
+  const topic = pm.topics.get("crow:remote-peer");
+  assert.ok(topic, "topics map must contain the contact's topic after a capped join");
+  assert.ok(topic.equals(result), "registered topic must match the returned topic");
+});
+
+test("G-F2-4b: joinInstanceSync returns within the flushed() cap when DHT confirmation never resolves", async () => {
+  const pm = new PeerManager({
+    ed25519Pubkey: "a".repeat(64),
+    crowId: "crow:test-local",
+  });
+  assert.equal(
+    pm.p2pDisabled,
+    false,
+    "p2p must be enabled or joinInstanceSync early-returns and the test is vacuous"
+  );
+
+  const joinCalls = [];
+  pm.swarm = {
+    join(topic, opts) {
+      joinCalls.push({ topic, opts });
+      return { flushed: () => new Promise(() => {}) };
+    },
+  };
+
+  const TEST_DEADLINE_MS = 2_000;
+  let deadlineTimer;
+  const deadline = new Promise((resolve) => {
+    deadlineTimer = setTimeout(() => resolve("__test_deadline__"), TEST_DEADLINE_MS);
+  });
+
+  const result = await Promise.race([
+    pm.joinInstanceSync({ flushedCapMs: 100 }),
+    deadline,
+  ]);
+  clearTimeout(deadlineTimer);
+
+  assert.notEqual(
+    result,
+    "__test_deadline__",
+    "joinInstanceSync hung past the test deadline — flushed() await is uncapped"
+  );
+  assert.ok(Buffer.isBuffer(result), "joinInstanceSync must still return the topic buffer");
+  assert.equal(joinCalls.length, 1, "swarm.join must have executed for real");
+  assert.ok(
+    joinCalls[0].topic.equals(result),
+    "the joined topic must be the returned topic"
+  );
+
+  // Registration before the flush: joinInstanceSync sets this.instanceSyncTopic
+  // BEFORE swarm.join / flushed() — assert it survived the capped join.
+  assert.ok(
+    Buffer.isBuffer(pm.instanceSyncTopic),
+    "instanceSyncTopic must be registered after a capped join"
+  );
+  assert.ok(
+    pm.instanceSyncTopic.equals(result),
+    "registered instanceSyncTopic must match the returned topic"
+  );
+});

--- a/tests/pending-emit-gauge.test.js
+++ b/tests/pending-emit-gauge.test.js
@@ -1,0 +1,183 @@
+/**
+ * G-F5-1 (2c follow-up pool, spec §F5 / plan T6): `_pendingPeerEmits` RAM
+ * observability — public `pendingEmitStats()` on InstanceSyncManager plus a
+ * gauge line in tailnet-sync's 60s refresh() loop.
+ *
+ * Contract under test:
+ *   - pendingEmitStats() returns a plain object {peerId: count} for NON-EMPTY
+ *     slots only, and is FULLY SYNCHRONOUS (spec R1-5.2: the map's only
+ *     writers are _chainAppendTask microtasks — a synchronous read cannot
+ *     interleave with a mutation).
+ *   - refresh() logs the gauge AFTER the per-peer loop (R2 Q7: a zero-peer
+ *     refresh still reaches it), ONLY when non-empty, peer ids truncated to
+ *     12 chars, and inside its OWN try/catch (post-C1b the process-level
+ *     nostr crash guard RETHROWS non-nostr errors — an escaped throw here
+ *     would crash the gateway). Optional chaining guards managers that lack
+ *     the method (older/stub managers).
+ *
+ * Harness idiom from tests/backfill-drain-caps.test.js / lamport-reemit.test.js:
+ * per-test mkdtemp CROW_DATA_DIR + real init-db, mgr.dataDir = scratch,
+ * mgr.feedsDisabled = false; entries park via the REAL _appendToPeer path
+ * (peer NOT in outFeeds → parks). Gauge cases drive the exported
+ * __refreshForTest with a stub manager (the feed-rotation.test.js C4 idiom).
+ * NEVER point this file at ~/.crow.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { InstanceSyncManager } from "../servers/sharing/instance-sync.js";
+import { startTailnetSyncClients } from "../servers/sharing/tailnet-sync.js";
+import * as ed from "../node_modules/@noble/ed25519/index.js";
+
+const LOCAL_ID = "inst-eeee-0000-0000-0000-00000000000e";
+const PEER_ID = "peer-ffff-0000-0000-0000-00000000000f";
+const OTHER_ID = "peer-0000-1111-2222-3333-444444444444";
+
+async function makeIdentity() {
+  const priv = Buffer.alloc(32, 0x2c);
+  const pub = Buffer.from(await ed.getPublicKey(priv)).toString("hex");
+  return { ed25519Priv: priv, ed25519Pubkey: pub };
+}
+
+/** Real manager on a scratch DB (backfill-drain-caps idiom). */
+async function makeRig(label) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-f5-gauge-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    // CROW_DB_PATH outranks CROW_DATA_DIR in init-db — blank it, or a shell
+    // exporting it would run the migration against the REAL DB (PR #180).
+    env: { ...process.env, CROW_DATA_DIR: dir, CROW_DB_PATH: "", CROW_DISABLE_NOSTR: "1", CROW_DISABLE_INSTANCE_SYNC: "1" },
+    stdio: "pipe",
+  });
+  const db = createDbClient(join(dir, "crow.db"));
+  const mgr = new InstanceSyncManager(await makeIdentity(), db, LOCAL_ID);
+  mgr.dataDir = join(dir, "instance-sync"); // MUST: keep test feeds out of ~/.crow
+  mgr.feedsDisabled = false;                // MUST: scratch env disables feeds (2c C6)
+  return {
+    dir, db, mgr,
+    cleanup() { rmSync(dir, { recursive: true, force: true }); },
+  };
+}
+
+/** Capture console.warn lines; restore() puts the original back. */
+function captureWarn() {
+  const lines = [];
+  const orig = console.warn;
+  console.warn = (...args) => { lines.push(args.map(String).join(" ")); };
+  return { lines, restore: () => { console.warn = orig; } };
+}
+
+const gaugeLines = (lines) => lines.filter((l) => l.includes("pending emit queues"));
+
+// ── pendingEmitStats unit (real manager, real park path) ────────────────────
+
+test("G-F5-1a: pendingEmitStats counts entries parked via the real _appendToPeer path, non-empty slots only; drain -> {}", async () => {
+  const rig = await makeRig("unit");
+  try {
+    assert.deepEqual(rig.mgr.pendingEmitStats(), {}, "fresh manager: empty plain object");
+
+    // Park via the REAL _appendToPeer path: PEER_ID is NOT in outFeeds → parks.
+    await rig.mgr._appendToPeer(PEER_ID, { table: "memories", op: "insert", row: { id: 990001 } });
+    await rig.mgr._appendToPeer(PEER_ID, { table: "memories", op: "insert", row: { id: 990002 } });
+    await rig.mgr._appendToPeer(PEER_ID, { table: "memories", op: "insert", row: { id: 990003 } });
+    const stats = rig.mgr.pendingEmitStats();
+    assert.deepEqual(stats, { [PEER_ID]: 3 }, "three parked entries counted for the peer");
+    assert.equal(typeof stats.then, "undefined", "synchronous: a plain object, not a promise");
+
+    // Non-empty slots ONLY (mutation target M2): an empty slot in the map is omitted.
+    rig.mgr._pendingPeerEmits.set(OTHER_ID, []);
+    assert.deepEqual(rig.mgr.pendingEmitStats(), { [PEER_ID]: 3 }, "empty slot omitted from stats");
+
+    // Drain onto a now-armed feed → stats back to {} (empty object, not null).
+    const drained = [];
+    rig.mgr.outFeeds.set(PEER_ID, { append: async (e) => drained.push(e) });
+    const n = await rig.mgr._drainPendingEmits(PEER_ID);
+    assert.equal(n, 3, "drain appended all three parked entries");
+    // OTHER_ID's empty slot is still in the map — the include-empty mutant
+    // returns {OTHER_ID: 0} here and goes red.
+    assert.deepEqual(rig.mgr.pendingEmitStats(), {}, "drained -> empty object");
+  } finally {
+    rig.cleanup();
+  }
+});
+
+// ── Gauge through refresh() (stub manager, feed-rotation C4 idiom) ───────────
+
+test("G-F5-1b: refresh() emits ONE gauge line when stats are non-empty -- zero-peer refresh still reaches it; ids truncated to 12 chars", async () => {
+  const stubMgr = {
+    localInstanceId: "me",
+    pendingEmitStats: () => ({ "peer-aaaaaaaabbbbbbbb": 12, "peerB": 256 }),
+  };
+  // ZERO peer rows: the gauge must sit AFTER the per-peer loop (R2 Q7) — an
+  // in-loop placement never runs here and this test goes red.
+  const stubDb = { execute: async () => ({ rows: [] }) };
+  const cap = captureWarn();
+  let clients;
+  try {
+    clients = await startTailnetSyncClients({ db: stubDb, instanceSyncManager: stubMgr, identity: {} });
+    cap.lines.length = 0; // discard the boot refresh; assert the driven one
+    await clients.__refreshForTest();
+    const gauge = gaugeLines(cap.lines);
+    assert.equal(gauge.length, 1, `exactly one gauge line per refresh (got ${JSON.stringify(cap.lines)})`);
+    assert.equal(gauge[0], "[instance-sync] pending emit queues: peer-aaaaaaa=12, peerB=256",
+      "gauge format: [instance-sync] prefix, 12-char-truncated ids, count per peer");
+  } finally {
+    cap.restore();
+    clients?.stop();
+  }
+});
+
+test("G-F5-1c: refresh() emits NO gauge line when stats are empty", async () => {
+  const stubMgr = { localInstanceId: "me", pendingEmitStats: () => ({}) };
+  const stubDb = { execute: async () => ({ rows: [] }) };
+  const cap = captureWarn();
+  let clients;
+  try {
+    clients = await startTailnetSyncClients({ db: stubDb, instanceSyncManager: stubMgr, identity: {} });
+    await clients.__refreshForTest();
+    // Boot refresh AND driven refresh both ran — neither may emit the gauge.
+    assert.deepEqual(gaugeLines(cap.lines), [], "no gauge line for empty stats");
+  } finally {
+    cap.restore();
+    clients?.stop();
+  }
+});
+
+test("G-F5-1d: a manager WITHOUT pendingEmitStats never throws (optional chaining) and emits no gauge", async () => {
+  const stubMgr = { localInstanceId: "me" }; // older/stub manager: no method
+  const stubDb = { execute: async () => ({ rows: [] }) };
+  const cap = captureWarn();
+  let clients;
+  try {
+    clients = await startTailnetSyncClients({ db: stubDb, instanceSyncManager: stubMgr, identity: {} });
+    await clients.__refreshForTest(); // completing without a throw IS the assertion
+    assert.deepEqual(gaugeLines(cap.lines), [], "no gauge line without the method");
+  } finally {
+    cap.restore();
+    clients?.stop();
+  }
+});
+
+test("G-F5-1e: a THROWING pendingEmitStats is contained by the gauge's own try/catch (refresh must not throw)", async () => {
+  const stubMgr = {
+    localInstanceId: "me",
+    pendingEmitStats: () => { throw new Error("boom-gauge"); },
+  };
+  const stubDb = { execute: async () => ({ rows: [] }) };
+  const cap = captureWarn();
+  let clients;
+  try {
+    clients = await startTailnetSyncClients({ db: stubDb, instanceSyncManager: stubMgr, identity: {} });
+    // refresh runs on a bare setInterval in prod and the nostr crash guard
+    // RETHROWS non-nostr errors — an escape here would crash the gateway.
+    // Resolving without a throw IS the assertion.
+    await clients.__refreshForTest();
+    assert.deepEqual(gaugeLines(cap.lines), [], "no gauge line when stats threw");
+  } finally {
+    cap.restore();
+    clients?.stop();
+  }
+});

--- a/tests/resilient-subscribe.test.js
+++ b/tests/resilient-subscribe.test.js
@@ -5,13 +5,12 @@ import { makeDedupeGate } from "../scripts/pi-bots/gateways/nostr-client.mjs";
 
 // Stub nostr-tools Relay. NOTE on fidelity: the real relay.subscribe() does NOT
 // throw on a closed connection — it returns a sub handle and leaks an un-awaited
-// rejected send(). We model "subscribe while down" as a SYNCHRONOUS throw purely
-// for testability (it drives sub=null in the busy-guard test). This is safe
-// because production never calls doSubscribe() while disconnected: at
-// construction the relay is connected, and in ensureHealthy() the synchronous
-// subscribe is gated by `if (!relay.connected) return` with no await between the
-// check and the call. drop() simulates a socket loss: connected=false + fire the
-// live sub's onclose. deliver() pushes an event to the latest live sub.
+// rejected send(). Since 2c-F1 (C1a), doSubscribe() itself guards on
+// `relay.connected` and never reaches relay.subscribe() while disconnected, so
+// this stub's synchronous throw is unreachable belt-and-braces; the async-leak
+// shape is exercised in tests/nostr-crash-guard.test.js. drop() simulates a
+// socket loss: connected=false + fire the live sub's onclose. deliver() pushes
+// an event to the latest live sub.
 function makeStubRelay({ connected = true } = {}) {
   const relay = {
     connected,
@@ -116,7 +115,7 @@ test("close() during an in-flight reconnect prevents a post-close resubscribe", 
   const relay = makeStubRelay({ connected: false });
   let release;
   relay.connect = async () => { relay.connectCalls++; await new Promise((r) => { release = r; }); relay.connected = true; };
-  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {}); // initial subscribe throws (disconnected) → sub=null
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {}); // initial subscribe skipped by the connected guard → sub=null
   assert.equal(relay.subscribeCalls.length, 0);
   const p = h.ensureHealthy(); // enters connect branch, awaits
   h.close();                   // teardown races the in-flight reconnect
@@ -129,7 +128,7 @@ test("overlapping ensureHealthy ticks do not double-subscribe (busy guard)", asy
   const relay = makeStubRelay({ connected: false });
   let release;
   relay.connect = async () => { relay.connectCalls++; await new Promise((r) => { release = r; }); relay.connected = true; };
-  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {}); // initial subscribe throws (disconnected) → sub=null
+  const h = makeResilientSub(relay, { kinds: [4] }, () => {}, {}); // initial subscribe skipped by the connected guard → sub=null
   const p1 = h.ensureHealthy(); // enters, awaits connect → busy
   const p2 = h.ensureHealthy(); // busy → returns immediately
   release();

--- a/tests/sync-conflicts-restore-ui.test.js
+++ b/tests/sync-conflicts-restore-ui.test.js
@@ -1,0 +1,138 @@
+/**
+ * G-F3-1 (2c follow-up F3) — the dashboard Restore button must be disabled
+ * upfront for natural-key tables (contacts, contact_groups, crow_context):
+ * the backend refuses these via NATURAL_KEY_RESTORE_REFUSALS, so rendering a
+ * live button gives the user a click → refused flash instead of an honest
+ * disabled state. A memories (numeric-id) row must still render the button.
+ *
+ * Tested through the section's render() with a real init-db database
+ * (same harness pattern as tests/settings-sync-conflicts-limit.test.js).
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import section from "../servers/gateway/dashboard/settings/sections/sync-conflicts.js";
+
+const dirs = [];
+after(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+function fresh() {
+  const dir = mkdtempSync(join(tmpdir(), "sync-conflicts-restore-ui-"));
+  dirs.push(dir);
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  return createClient({ url: "file:" + join(dir, "crow.db") });
+}
+
+async function seedConflict(db, { table, rowId, op }) {
+  await db.execute({
+    sql: `INSERT INTO sync_conflicts
+            (table_name, row_id, winning_instance_id, losing_instance_id,
+             winning_lamport_ts, losing_lamport_ts, winning_data, losing_data, resolved, op)
+          VALUES (?, ?, 'inst-a', 'inst-b', 2, 1, '{}', '{}', 0, ?)`,
+    args: [table, rowId, op],
+  });
+}
+
+function fakeReq() {
+  return { csrfToken: "test-csrf", query: {} };
+}
+
+/** Extract the rendered <tr> chunk containing the given (unique) row id. */
+function rowChunk(html, rowId) {
+  const chunks = html.split(/<tr[\s>]/);
+  const hits = chunks.filter((c) => c.includes(rowId));
+  assert.equal(hits.length, 1, `exactly one rendered row for ${rowId}`);
+  return hits[0];
+}
+
+const RESTORE_ACTION = 'value="sync_conflicts_restore_other"';
+
+test("G-F3-1: natural-key tables render no Restore form; memories still does", async () => {
+  const db = fresh();
+  try {
+    // Natural-key tables, both ops the backend would refuse.
+    await seedConflict(db, { table: "contacts", rowId: '{"crow_id":"c1"}-u', op: "update" });
+    await seedConflict(db, { table: "contacts", rowId: '{"crow_id":"c2"}-d', op: "delete" });
+    await seedConflict(db, { table: "contact_groups", rowId: '{"group_uid":"g1"}-u', op: "update" });
+    await seedConflict(db, { table: "contact_groups", rowId: '{"group_uid":"g2"}-d', op: "delete" });
+    await seedConflict(db, { table: "crow_context", rowId: '{"section_key":"s1"}-u', op: "update" });
+    // Numeric-id table: Restore must stay available.
+    await seedConflict(db, { table: "memories", rowId: "101-u", op: "update" });
+    await seedConflict(db, { table: "memories", rowId: "102-d", op: "delete" });
+    // op='insert' precedence stays first even on a natural-key table.
+    await seedConflict(db, { table: "contacts", rowId: '{"crow_id":"c3"}-i', op: "insert" });
+
+    const html = await section.render({ req: fakeReq(), db, lang: "en" });
+
+    // contacts / contact_groups: NO restore form (RED today — button renders live).
+    for (const rowId of [
+      '{&quot;crow_id&quot;:&quot;c1&quot;}-u',
+      '{&quot;crow_id&quot;:&quot;c2&quot;}-d',
+      '{&quot;group_uid&quot;:&quot;g1&quot;}-u',
+      '{&quot;group_uid&quot;:&quot;g2&quot;}-d',
+    ]) {
+      const chunk = rowChunk(html, rowId);
+      assert.ok(
+        !chunk.includes(RESTORE_ACTION),
+        `natural-key row ${rowId} must not render a restore_other form`,
+      );
+    }
+
+    // crow_context: no restore form, keeps its composite-key wording.
+    const ctxChunk = rowChunk(html, "{&quot;section_key&quot;:&quot;s1&quot;}-u");
+    assert.ok(!ctxChunk.includes(RESTORE_ACTION), "crow_context row must not render a restore form");
+    assert.match(ctxChunk, /composite key/, "crow_context keeps its composite-key disabled label");
+
+    // memories: restore form present for update AND delete ops.
+    assert.ok(rowChunk(html, "101-u").includes(RESTORE_ACTION), "memories update row keeps the Restore button");
+    assert.ok(rowChunk(html, "102-d").includes(RESTORE_ACTION), "memories delete row keeps the Restore button");
+
+    // op='insert' precedence unchanged: insert wording, not the natural-key label.
+    const insChunk = rowChunk(html, "{&quot;crow_id&quot;:&quot;c3&quot;}-i");
+    assert.ok(!insChunk.includes(RESTORE_ACTION), "insert row has no restore form");
+    assert.match(insChunk, /id collision/, "insert row keeps the insert-specific disabled wording");
+  } finally {
+    await db.close();
+  }
+});
+
+test("NATURAL_KEY_RESTORE_TABLES export is the single source of truth (set ⟺ refusal)", async () => {
+  const mod = await import("../servers/sharing/sync-conflict-resolve.js");
+  const set = mod.NATURAL_KEY_RESTORE_TABLES;
+  assert.ok(set instanceof Set, "NATURAL_KEY_RESTORE_TABLES must be an exported Set");
+  assert.deepEqual(
+    [...set].sort(),
+    ["contact_groups", "contacts", "crow_context"],
+    "set covers exactly the three natural-key tables",
+  );
+
+  // Every member of the set must actually be refused by restoreConflict
+  // (invariant: set membership ⟺ a refusal message exists).
+  const db = fresh();
+  try {
+    let id = 0;
+    for (const table of set) {
+      id += 1;
+      await seedConflict(db, { table, rowId: `nk-${id}`, op: "update" });
+      const { rows } = await db.execute({
+        sql: "SELECT id FROM sync_conflicts WHERE row_id = ?",
+        args: [`nk-${id}`],
+      });
+      const outcome = await mod.restoreConflict(db, rows[0].id, { instanceSync: null });
+      assert.equal(outcome.status, "refused", `${table} restore must be refused`);
+      assert.ok(outcome.message, `${table} refusal carries a per-table message`);
+    }
+  } finally {
+    await db.close();
+  }
+});


### PR DESCRIPTION
Ships the 2c follow-up pool (arc plan §4 Item 2c block), Kevin-approved 2026-07-15. Spec: `docs/superpowers/specs/2026-07-15-2c-followups-design.md` (rev 3, two adversarial review rounds); plan: `docs/superpowers/plans/2026-07-15-2c-followups.md`. No schema bump.

**F1 (urgent-ish)** — uncaught `SendingOnClosedConnection` killed grackle's gateway once during the 2c deploy. nostr-tools' async `send()` rejection escapes every try/catch. Fixed with: `connected` guard in `resilient-subscribe` `doSubscribe()` (the crash path), same guard in the pi-bots raw subscribe, plus a narrow process-level crash guard that swallows only this error class (rate-limited counter) and rethrows everything else. Installed in gateway manager init + pi-bots `connectRelays`.

**F2** — apply-path unbounded network awaits (the 2c boot-wedge class), from a full audit:
- **C2a**: all three notification senders (ntfy, Resend email, web-push) get 10s caps (`CROW_PUSH_SEND_TIMEOUT_MS`); web-push fan-out is now `Promise.allSettled` so N half-open endpoints cost one cap, not N. These were awaited on the live apply chain with no bound.
- **C2b**: the contacts/groups/providers boot backfill pre-drains route through the existing 10s drain cap. Providers (whose re-emit fresh-mints lamports) defers on an incomplete drain (`deferred:n` flag, no emit, retry next boot) with a 3-deferral escape hatch so one slow feed can't block providers backfill forever.
- **C2c**: `joinContact` and `joinInstanceSync` cap their DHT `discovery.flushed()` confirmation awaits (announce fires regardless). `initContact` deliberately NOT capped (an abandoned hypercore ready() would hold the rocksdb dir lock).

**F3** — dashboard Restore button now disabled upfront for natural-key conflict rows (contacts/contact_groups/crow_context), driven by a new exported `NATURAL_KEY_RESTORE_TABLES` set so UI and backend refusal cannot drift. New i18n key (en+es).

**F4** — unreachable-pointer comment on the dead `contact_groups` INSERT-branch tombstone guard (guard kept; becomes load-bearing again if the upstream refusal is ever relaxed).

**F5** — `pendingEmitStats()` + a once-per-60s-tick gauge line (only when non-empty) so parked emit queues are visible before the 256-cap overflow warn.

**Gates**: 20 new tests across 5 files, all RED-first with recorded mutation checks; scratch-env suite **1994 pass / 2 known fails (bundles-validate-install) / 0 skips** (baseline 1974/2/0 + 20 new); check-ports and build-registry green; per-task fresh reviews ×6 + whole-branch review = READY TO MERGE.

(2c-F6, the capstone-tracker ereader `|tojson` fix, was applied to the untracked WIP working tree only and is deliberately NOT in this PR.)