### PR TITLE
fix(research): timezone-safe citation dates (bare-year publication_date rendered as year − 1)

### DIFF
--- a/servers/research/server.js
+++ b/servers/research/server.js
@@ -30,11 +30,51 @@ const SOURCE_TYPES = [
   "dataset", "other",
 ];
 
-function generateAPA({ authors, title, publication_date, publisher, url, source_type, doi }) {
+// publication_date is free-form TEXT ("1993", "2005-07", "2023-05-14",
+// occasionally prose like "May 14, 2023"). new Date() parses the ISO
+// date-only forms as UTC midnight, and getFullYear()/toLocaleDateString()
+// read them back in the server's LOCAL zone — west of UTC a bare year
+// rendered as year − 1 and a full date as the previous day. Take the
+// fields from the string itself; only non-ISO forms (which Date parses
+// as local time, no shift) fall back to Date.
+const MONTH_NAMES = ["January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"];
+
+function parseDateParts(value) {
+  if (value == null || value === "") return null;
+  const s = String(value).trim();
+  const m = s.match(/^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?(?:[T ].*)?$/);
+  if (m) {
+    const month = m[2] ? Number(m[2]) : null;
+    const day = m[3] ? Number(m[3]) : null;
+    const monthOk = month !== null && month >= 1 && month <= 12;
+    return {
+      year: Number(m[1]),
+      month: monthOk ? month : null,
+      day: monthOk && day !== null && day >= 1 && day <= 31 ? day : null,
+    };
+  }
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return null;
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+}
+
+function citationYear(value) {
+  const p = parseDateParts(value);
+  return p ? String(p.year) : "n.d.";
+}
+
+function citationLongDate(value) {
+  const p = parseDateParts(value);
+  if (!p) return "n.d.";
+  if (!p.month) return String(p.year);
+  const month = MONTH_NAMES[p.month - 1];
+  return p.day ? `${month} ${p.day}, ${p.year}` : `${month} ${p.year}`;
+}
+
+export function generateAPA({ authors, title, publication_date, publisher, url, source_type, doi }) {
   const authorStr = authors || "Unknown Author";
-  const year = publication_date
-    ? `(${new Date(publication_date).getFullYear()})`
-    : "(n.d.)";
+  const year = `(${citationYear(publication_date)})`;
   const titleStr = title || "Untitled";
 
   switch (source_type) {
@@ -57,12 +97,10 @@ function generateAPA({ authors, title, publication_date, publisher, url, source_
   }
 }
 
-function generateMLA({ authors, title, publication_date, publisher, url, source_type }) {
+export function generateMLA({ authors, title, publication_date, publisher, url, source_type }) {
   const authorStr = authors || "Unknown Author";
   const titleStr = title || "Untitled";
-  const pubDate = publication_date
-    ? new Date(publication_date).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
-    : "n.d.";
+  const pubDate = citationLongDate(publication_date);
 
   switch (source_type) {
     case "book":
@@ -84,15 +122,11 @@ function generateMLA({ authors, title, publication_date, publisher, url, source_
   }
 }
 
-function generateChicago({ authors, title, publication_date, publisher, url, source_type, doi }) {
+export function generateChicago({ authors, title, publication_date, publisher, url, source_type, doi }) {
   const authorStr = authors || "Unknown Author";
   const titleStr = title || "Untitled";
-  const pubDate = publication_date
-    ? new Date(publication_date).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
-    : "n.d.";
-  const year = publication_date
-    ? new Date(publication_date).getFullYear()
-    : "n.d.";
+  const pubDate = citationLongDate(publication_date);
+  const year = citationYear(publication_date);
 
   switch (source_type) {
     case "book":

--- a/tests/citation-dates.test.js
+++ b/tests/citation-dates.test.js
@@ -1,0 +1,97 @@
+/**
+ * Citation date rendering must be timezone-safe.
+ *
+ * publication_date is free-form TEXT ("1993", "2005-07", "2023-05-14").
+ * new Date() parses those ISO date-only forms as UTC MIDNIGHT, and
+ * getFullYear()/toLocaleDateString() then read them in the server's local
+ * zone — so west of UTC every bare year rendered as year − 1 ("1993" →
+ * "(1992)") and full dates as the previous day. Found 2026-07-15 by the
+ * rookery Task-6 audit loop: 10/14 bibliography entries wrong, and
+ * crow_get_source's regenerated citations misled a blind audit twice.
+ *
+ * Affected paths all funnel through the generators: crow_add_source
+ * auto-APA, crow_generate_bibliography, crow_get_source citations.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// The bug only shows west of UTC; pin the zone so the test is
+// deterministic on any machine (Node re-reads TZ per Date call on Linux).
+process.env.TZ = "America/Chicago";
+
+const { generateAPA, generateMLA, generateChicago } = await import(
+  "../servers/research/server.js"
+);
+
+const base = {
+  authors: "Cortez, A.",
+  title: "School finance in Texas",
+  publisher: "IDRA",
+  source_type: "academic_paper",
+};
+
+test("APA: bare-year publication_date keeps its year", () => {
+  const apa = generateAPA({ ...base, publication_date: "1993" });
+  assert.match(apa, /\(1993\)/, `got: ${apa}`);
+});
+
+test("APA: full-date publication_date keeps its year", () => {
+  const apa = generateAPA({ ...base, publication_date: "2023-05-14" });
+  assert.match(apa, /\(2023\)/, `got: ${apa}`);
+});
+
+test("APA: missing publication_date renders (n.d.)", () => {
+  const apa = generateAPA({ ...base, publication_date: null });
+  assert.match(apa, /\(n\.d\.\)/, `got: ${apa}`);
+});
+
+test("Chicago: bare-year book keeps its year", () => {
+  const chi = generateChicago({
+    ...base,
+    source_type: "book",
+    publication_date: "1993",
+  });
+  assert.match(chi, /1993/, `got: ${chi}`);
+  assert.doesNotMatch(chi, /1992/, `got: ${chi}`);
+});
+
+test("MLA: full date renders the stored day, not the previous day", () => {
+  const mla = generateMLA({
+    ...base,
+    source_type: "web_article",
+    url: "https://example.org",
+    publication_date: "2023-05-14",
+  });
+  assert.match(mla, /May 14, 2023/, `got: ${mla}`);
+});
+
+test("MLA: bare year renders as the year alone, not December 31 of year − 1", () => {
+  const mla = generateMLA({
+    ...base,
+    source_type: "web_article",
+    url: "https://example.org",
+    publication_date: "1993",
+  });
+  assert.match(mla, /1993/, `got: ${mla}`);
+  assert.doesNotMatch(mla, /December 31, 1992/, `got: ${mla}`);
+});
+
+test("MLA: year-month renders month + year", () => {
+  const mla = generateMLA({
+    ...base,
+    source_type: "web_article",
+    url: "https://example.org",
+    publication_date: "2005-07",
+  });
+  assert.match(mla, /July 2005/, `got: ${mla}`);
+});
+
+test("Chicago: non-ISO date string still renders via Date fallback", () => {
+  const chi = generateChicago({
+    ...base,
+    source_type: "web_article",
+    url: "https://example.org",
+    publication_date: "May 14, 2023",
+  });
+  assert.match(chi, /May 14, 2023/, `got: ${chi}`);
+});


### PR DESCRIPTION
## Bug

`publication_date` is free-form TEXT. `new Date()` parses ISO date-only forms (`"1993"`, `"2023-05-14"`) as **UTC midnight**, and `getFullYear()` / `toLocaleDateString()` read them back in the server's **local zone** — so west of UTC every bare-year source renders as year − 1 (`"1993"` → `(1992)`) and full dates render as the previous day.

All three regenerating paths funnel through the citation generators, so the bug hit:
- `crow_add_source` auto-APA (stored `citation_apa`)
- `crow_generate_bibliography` (regenerates per call)
- `crow_get_source` (regenerated Citations block)

Found 2026-07-15 by the rookery Phase 2 Task-6 audit loop: 10/14 bibliography entries carried the wrong year, and the buggy render misled two blind audits into flagging correct inline years (the audit loop became the bug's best repro).

## Fix

Parse year/month/day from the date **string** itself (`parseDateParts`), never through `Date` + local TZ:
- APA/Chicago year: string-extracted
- MLA/Chicago long date: formatted from parts; a bare year now renders as the year alone instead of "December 31, \<year − 1\>"
- Non-ISO prose dates ("May 14, 2023") fall back to `Date`, which parses them as local time (no shift)
- Unparseable values now render `n.d.` instead of `NaN`

## Tests

TDD: `tests/citation-dates.test.js` (8 cases, TZ pinned to America/Chicago so the repro is deterministic) — watched fail on the old code, green on the fix. `project-spaces-readers/writers` + `tool-manifests` still pass.