### PR TITLE
fix(dashboard): Connect-panel token forms opt out of Turbo (one-time reveal silently dropped)

### DIFF
--- a/servers/gateway/dashboard/panels/connect.js
+++ b/servers/gateway/dashboard/panels/connect.js
@@ -51,7 +51,10 @@ function tokenConfig(endpoint, token) {
 }
 
 function tokenForm(action, label, variant, csrf) {
-  return `<form method="POST" action="/dashboard/connect" style="display:inline-block;margin:0">`
+  // data-turbo="false": Turbo 8 intercepts form submissions and silently
+  // drops a non-redirect 200 response — the token rotates server-side but
+  // the one-time reveal page never renders. Full navigation shows it.
+  return `<form method="POST" action="/dashboard/connect" data-turbo="false" style="display:inline-block;margin:0">`
     + `<input type="hidden" name="_csrf" value="${escapeHtml(csrf || "")}">`
     + `<input type="hidden" name="action" value="${escapeHtml(action)}">`
     + button(label, { variant, type: "submit" })

--- a/tests/connect.test.js
+++ b/tests/connect.test.js
@@ -115,3 +115,16 @@ test("Connections section points at the connect wizard", async () => {
   assert.ok(html.includes("/dashboard/connect"), "links to the connect wizard");
   assert.ok(html.includes(i18n.t("connect.openWizard", "en")), "uses the wizard link label");
 });
+
+test("token forms opt out of Turbo (one-time reveal must not be dropped)", async () => {
+  // Turbo 8 intercepts form submissions and silently discards a non-redirect
+  // 200 response, so the POST "succeeded" (token rotated!) but the one-time
+  // reveal never rendered. data-turbo="false" makes the browser do a full
+  // navigation and show the response page.
+  const html = await render();
+  const forms = html.match(/<form\b[^>]*method="POST"[^>]*>/g) || [];
+  assert.ok(forms.length > 0, "connect panel renders at least one POST form");
+  for (const form of forms) {
+    assert.match(form, /data-turbo="false"/, `form missing data-turbo="false": ${form}`);
+  }
+});


### PR DESCRIPTION
## Bug

The Connect panel's Generate / Rotate / Revoke token buttons are plain POST forms that respond with a 200 page render (the one-time token reveal). Turbo 8 intercepts form submissions and **silently discards non-redirect responses** — so the POST succeeds server-side (a token is minted or rotated!) but the reveal page never renders. The token is lost the only time it is ever shown, and a confused retry rotates it again.

Reported by Kevin 2026-07-14 during rookery Phase 2 (the token had to be pulled via sqlite as a workaround).

## Fix

`data-turbo="false"` on `tokenForm()` — the browser does a full navigation and displays the response page. Minimal, per the follow-up note; redirect-after-POST with a flash reveal remains a possible later refactor.

## Tests

TDD: new test in `tests/connect.test.js` asserts every POST form the panel renders carries `data-turbo="false"` — watched it fail before the fix. `connect.test.js` + `connect-token.test.js`: 36/36 pass.