### PR TITLE
fix(rookery): egress tooling follow-ups — systemd unit drops the deployed posture; verify §6 false-fails on the MCP bridge

### DIFF
--- a/bundles/rookery/README.md
+++ b/bundles/rookery/README.md
@@ -153,9 +153,13 @@ Operational notes:
   detects stale rules (drift check).
 - **Reboot persistence**: `--print-systemd-unit` emits a oneshot unit that
   re-runs the script after docker starts (a boot-time re-run is the correct
-  persistence — a saved rules file would go stale). If the model container
-  isn't up in time, the lock installs **drop-only** (fail-closed) and the
-  unit shows failed.
+  persistence — a saved rules file would go stale). Print it with the SAME
+  env the lock is deployed with (e.g. `ALLOW_HOST_TCP_PORTS=3006
+  ./rookery-egress-lock.sh --print-systemd-unit`): every config var set at
+  print time is baked into the unit as an `Environment=` line, so the boot
+  re-run reproduces the deployed posture instead of silently dropping the
+  MCP-bridge allowance. If the model container isn't up in time, the lock
+  installs **drop-only** (fail-closed) and the unit shows failed.
 - **ufw coexistence**: the script never touches `ufw-*` chains or policies;
   `ufw reload`/`enable` rewrite only ufw's own chains, and docker preserves
   `DOCKER-USER` across daemon restarts.

--- a/bundles/rookery/scripts/rookery-egress-lock.sh
+++ b/bundles/rookery/scripts/rookery-egress-lock.sh
@@ -75,6 +75,16 @@
 
 set -euo pipefail
 
+# Record which config vars the CALLER set (before defaulting) so
+# --print-systemd-unit can bake them into the unit — a bare boot-time re-run
+# would otherwise drop the deployed posture (live gap 2026-07-16: the unit
+# reinstalled the lock without ALLOW_HOST_TCP_PORTS=3006, silently killing
+# the MCP bridge after reboot).
+CALLER_SET=()
+for v in MODEL_PUBLISH ALLOW_PUBLISHED_TCP_PORTS ALLOW_HOST_TCP_PORTS ROOKERY_NETWORK; do
+  [[ -n ${!v:-} ]] && CALLER_SET+=("$v")
+done
+
 ROOKERY_NETWORK=${ROOKERY_NETWORK:-rookery_default}
 MODEL_PUBLISH=${MODEL_PUBLISH:-100.118.41.122:8010}
 ALLOW_HOST_TCP_PORTS=${ALLOW_HOST_TCP_PORTS:-}
@@ -288,7 +298,7 @@ Wants=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# --wait rides out slow container starts; on timeout the lock still installs
+$(for v in ${CALLER_SET[@]+"${CALLER_SET[@]}"}; do printf 'Environment="%s=%s"\n' "$v" "${!v}"; done)# --wait rides out slow container starts; on timeout the lock still installs
 # drop-only (fail-closed, no model allow) and exits nonzero so the unit
 # shows failed.
 ExecStart=$script_path --wait 300

--- a/bundles/rookery/scripts/rookery-egress-verify.sh
+++ b/bundles/rookery/scripts/rookery-egress-verify.sh
@@ -18,6 +18,9 @@
 #
 # Exit 0 = all checks passed. Config env mirrors rookery-egress-lock.sh:
 #   ROOKERY_NETWORK, MODEL_PUBLISH, CONTAINER (default crow-rookery),
+#   ALLOW_HOST_TCP_PORTS (same value the lock was installed with — check 6
+#   exempts ESTABLISHED sockets to those ports on the model's host IP, i.e.
+#   the MCP bridge; without it check 6 false-fails once the app connects),
 #   UI_URL (default http://127.0.0.1:3061/),
 #   PROBE_INTERNET (default 1.1.1.1:443), PROBE_TAILNET (default
 #   100.121.254.89:3002), PROBE_PUBLISHED (default 100.118.41.122:8003)
@@ -97,10 +100,16 @@ else
   warn "could not derive bridge gateway — skipping host INPUT probe"
 fi
 
-# 6. vendor ESTAB absent (runbook §6, from the container's own netns)
+# 6. vendor ESTAB absent (runbook §6, from the container's own netns).
+# Sockets the LOCK itself allows are not offenders: the model, plus
+# ALLOW_HOST_TCP_PORTS on the model's host IP (the MCP bridge lives there —
+# without this the check false-fails the moment the app connects its MCPs).
 ESTAB_OUT=$(docker exec "$CONTAINER" node -e '
 const fs = require("fs");
-const [modelIp, modelPort] = process.argv.slice(1);
+const [modelIp, modelPort, allowedCsv] = process.argv.slice(1);
+const allowedHostPorts = new Set(
+  (allowedCsv || "").split(/[\s,]+/).filter(Boolean).map(Number)
+);
 function hex4(ip) { // v4 little-endian hex → dotted
   return ip.match(/../g).reverse().map(h => parseInt(h, 16)).join(".");
 }
@@ -121,6 +130,7 @@ for (const [file, v6] of [["/proc/net/tcp", false], ["/proc/net/tcp6", true]]) {
       rip = hex4(remA);
     }
     if (rip === modelIp && rport === +modelPort) continue;    // the model
+    if (rip === modelIp && allowedHostPorts.has(rport)) continue; // lock-allowed host ports (MCP bridge)
     if (lport === 3061) continue;                             // inbound UI
     if (rip.startsWith("127.") || rip === "v6:" + "0".repeat(32)) continue;
     offenders.push(`${rip}:${rport} (local :${lport})`);
@@ -128,11 +138,11 @@ for (const [file, v6] of [["/proc/net/tcp", false], ["/proc/net/tcp6", true]]) {
 }
 if (offenders.length) { console.log("OFFENDERS " + offenders.join(", ")); process.exit(1); }
 console.log("CLEAN");
-' "${MODEL_PUBLISH%:*}" "${MODEL_PUBLISH##*:}" 2>/dev/null)
+' "${MODEL_PUBLISH%:*}" "${MODEL_PUBLISH##*:}" "${ALLOW_HOST_TCP_PORTS:-}" 2>/dev/null)
 if [[ $ESTAB_OUT == CLEAN ]]; then
   pass "no vendor/foreign ESTABLISHED sockets in the container netns"
 else
-  fail "foreign ESTABLISHED sockets present: ${ESTAB_OUT#OFFENDERS }"
+  fail "foreign ESTABLISHED sockets present: ${ESTAB_OUT#OFFENDERS } (if these are the MCP bridge, re-run with ALLOW_HOST_TCP_PORTS=<ports> matching the installed lock)"
 fi
 
 # 7. rule presence + drift (root only)

--- a/bundles/rookery/tests/test_egress_lock.py
+++ b/bundles/rookery/tests/test_egress_lock.py
@@ -178,3 +178,50 @@ def test_live_derivation_matches_docker():
         timeout=30,
     ).stdout.strip()
     assert f"br-{net_id[:12]}" in proc.stdout
+
+
+BAKEABLE = ("MODEL_PUBLISH", "ALLOW_PUBLISHED_TCP_PORTS", "ALLOW_HOST_TCP_PORTS", "ROOKERY_NETWORK")
+
+
+def run_unit(extra_env=None):
+    env = {k: v for k, v in os.environ.items() if k not in BAKEABLE}
+    env.update(extra_env or {})
+    return subprocess.run(
+        [str(SCRIPT), "--print-systemd-unit"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_unit_bakes_allow_host_tcp_ports():
+    """The 2026-07-16 live gap: the deployed lock ran with
+    ALLOW_HOST_TCP_PORTS=3006 (MCP bridge), but the printed unit re-ran the
+    script bare at boot — silently killing the bridge after every reboot.
+    The printed unit must reproduce the posture it was printed under."""
+    proc = run_unit({"ALLOW_HOST_TCP_PORTS": "3006"})
+    assert proc.returncode == 0, proc.stderr
+    assert 'Environment="ALLOW_HOST_TCP_PORTS=3006"' in proc.stdout
+    svc = proc.stdout.split("[Service]", 1)[1]
+    assert svc.index('Environment="ALLOW_HOST_TCP_PORTS=3006"') < svc.index("ExecStart=")
+
+
+def test_unit_bakes_every_set_config_var():
+    proc = run_unit({
+        "MODEL_PUBLISH": "10.0.0.5:9000",
+        "ALLOW_PUBLISHED_TCP_PORTS": "8011",
+        "ALLOW_HOST_TCP_PORTS": "3006,3007",
+        "ROOKERY_NETWORK": "other_net",
+    })
+    assert proc.returncode == 0, proc.stderr
+    assert 'Environment="MODEL_PUBLISH=10.0.0.5:9000"' in proc.stdout
+    assert 'Environment="ALLOW_PUBLISHED_TCP_PORTS=8011"' in proc.stdout
+    assert 'Environment="ALLOW_HOST_TCP_PORTS=3006,3007"' in proc.stdout
+    assert 'Environment="ROOKERY_NETWORK=other_net"' in proc.stdout
+
+
+def test_unit_without_config_env_bakes_nothing():
+    proc = run_unit()
+    assert proc.returncode == 0, proc.stderr
+    assert "Environment=" not in proc.stdout


### PR DESCRIPTION
Two operational gaps hit during the real systemd-unit install on 2026-07-16:

## 1. `--print-systemd-unit` emitted a bare `ExecStart`

The deployed lock runs with `ALLOW_HOST_TCP_PORTS=3006` (the crow/research MCP bridge), but the printed unit re-ran the script with no env — so after any reboot the lock reinstalls **without** the bridge allowance and the MCPs die silently (sessions just lack the `crow_*`/`rookery_*` tools; the canary is the only tell).

**Fix:** config vars set at print time (`MODEL_PUBLISH`, `ALLOW_PUBLISHED_TCP_PORTS`, `ALLOW_HOST_TCP_PORTS`, `ROOKERY_NETWORK`) are baked into the unit as quoted `Environment=` lines. Print the unit with the same env the lock is deployed with; README updated.

## 2. verify check 6 false-fails once the app connects its MCPs

§6 flagged the app's own ESTABLISHED sockets to the allowlisted bridge port (`100.118.41.122:3006`) as "foreign" — observed live: verify passes right after `docker restart` (MCPs not yet connected), fails minutes later. **Fix:** §6 exempts `ALLOW_HOST_TCP_PORTS` on the model's host IP, same env contract as the lock. A bare run still flags them (nothing silently exempted by default) and the fail message now says how to pass the allowlist.

## Verification

- TDD: 3 new hermetic tests in `test_egress_lock.py` (watched fail first); bundle suite 59/59.
- Live against the running deployment: `ALLOW_HOST_TCP_PORTS=3006 rookery-egress-verify.sh` → **ALL CHECKS PASSED**; bare run → old FAIL preserved.
- shellcheck clean on both scripts.

Immediate mitigation until this deploys, for the already-installed unit:
```
sudo mkdir -p /etc/systemd/system/rookery-egress-lock.service.d
printf '[Service]\nEnvironment="ALLOW_HOST_TCP_PORTS=3006"\n' | sudo tee /etc/systemd/system/rookery-egress-lock.service.d/allow-ports.conf
sudo systemctl daemon-reload
```