### PR TITLE
fix(sharing): minor pool x3 — heal-warn rate-limit, room fan-out cap, dead feed-key-announce removal

### DIFF
--- a/docs/superpowers/specs/2026-07-16-minor-pool-3-design.md
+++ b/docs/superpowers/specs/2026-07-16-minor-pool-3-design.md
@@ -1,0 +1,108 @@
+# Minor pool ×3 — heal-log rate-limit, room fan-out cap, dead feed-key-announce path
+
+**Date:** 2026-07-16 · **Scope:** the three items left unshipped by the 2c follow-up pool
+(PR #198; recorded in the pool-complete ledger block and memory). All three are small and
+mechanical; per the arc plan §2 this spec is brief and the hard gate is the adversarial
+diff review.
+
+## Item 1 — tailnet refresh heal-failure log rate-limit (2d T8 note)
+
+**Defect.** `startTailnetSyncClients → refresh()` (`servers/sharing/tailnet-sync.js:543`)
+warns `[tailnet-sync] refresh heal for <id>…: <msg>` on EVERY 60s rescan for a
+persistently failing `initInstance` — one log line per minute per wedged peer, forever.
+Same class as the pre-#144 silent-retry problem inverted: not silent, but unbounded spam
+that buries real signal (the known-benign log classes list keeps growing because of
+exactly this shape).
+
+**Fix.** Per-peer failure counter in the `startTailnetSyncClients` closure (Map
+`peerId → count`), same observability contract as the F1 crash guard
+(`nostr-crash-guard.js`): log at counts 1, 10, 100, 1000… (`Number.isInteger(Math.log10(n))`),
+message carries `#n`. On a SUCCESSFUL heal for a peer with a non-zero counter, log one
+`recovered after n failures` line and reset the counter — so a new failure episode logs
+immediately again and the episode boundary is visible. Counter entries are deleted in the
+existing out-of-scope cleanup loop (where dialers are stopped) so the Map cannot grow
+unboundedly across re-pairs.
+
+**Tests** (harness = the existing `__refreshForTest` handle; stub `db.execute` returning
+one peer row without `gateway_url` so no PeerDialer spawns; stub manager whose
+`initInstance` throws):
+- T1a RED: 12 consecutive failing refreshes → exactly 2 heal-warn lines (#1, #10). Old
+  code emits 12 → red.
+- T1b: fail ×3 → succeed once → `recovered after 3` logged; fail again → immediate `#1`.
+- Mutation: comment out the log10 gate → T1a red; comment out the reset-on-success →
+  T1b red.
+
+## Item 2 — onSocialMessage room fan-out publish stall (2c spec §F2 adjacent gap, R1 item 10)
+
+**Defect.** `fanOut()` (`servers/sharing/room-fanout.js`) serially awaits
+`nostrManager.sendControl(c, envelope)` per member with NO time bound. The call chain is
+`nostr.js subscribeToIncoming → await onSocialMessage → room-inbound
+handleRoomMessageInbound → await fanOut` — i.e. it runs INSIDE the relay's inbound
+message loop. `sendControl → _sendControlEvent → safeRelayPublish → relay.publish()`
+waits for the relay's OK frame; a half-open socket stalls it indefinitely, and the
+serial loop compounds it per member. One wedged relay send freezes inbound message
+processing for that subscription. (Recorded as deliberately out of scope in 2c §F2 —
+"candidate for a future pool" — this is that pool.)
+
+**Fix.** Same sender-bounding pattern as 2c C2a/C2b, applied inside `fanOut`:
+- Per-member cap: `Promise.race([sendControl(...), capTimer])`, default `capMs = 10_000`,
+  injectable via a new `capMs` option (tests use small values). Timer cleared in
+  `finally`. A capped member counts as `failed` and logs through the existing `log`
+  callback. Post-cap rejections of the abandoned `sendControl` are absorbed by the race
+  (reaction attached at race time — the empirically proven #198 fact); they can never
+  reach the process crash guard.
+- Fan-out shape: serial `for` loop → `Promise.allSettled` over the non-excluded members,
+  so N wedged members cost ≈ one cap, not N× (the R1-2.3 bound-the-fan-out-not-just-the-
+  send rule; push precedent `servers/gateway/push/web-push.js:57`).
+- Preserved semantics: `excludeContactId` skip, best-effort per member, `{sent, failed}`
+  return shape, per-failure `log` line. Rooms have no cross-member ordering semantics
+  (mirror of push). `sent`/`failed` become completion-ordered — the one existing consumer
+  (`room-inbound.js:113`) ignores the result, and the existing test already sorts.
+
+**Tests** (existing direct-import harness in `tests/room-fanout.test.js`):
+- T2a RED: one member's `sendControl` never settles (`capMs: 50`) → old fanOut never
+  resolves (asserted via an outer timer race) → red; new: resolves, hung member in
+  `failed`, healthy member in `sent`.
+- T2b: three hanging members, `capMs: 100` → total wall-clock < 2×capMs (parallel bound;
+  guards regression to a serial capped loop).
+- T2c: existing exclusion/sent/failed test keeps passing unchanged.
+- Mutation: drop the cap → T2a red; revert to serial loop → T2b red.
+
+## Item 3 — peer-manager `feed-key-announce` dead path
+
+**Defect.** `_handleMessage case "feed-key-announce"` (`servers/sharing/peer-manager.js:342`)
+is doubly broken: (1) NOTHING in the codebase ever sends that message type (grep: the
+case statement is the sole occurrence) — feed keys ride the challenge /
+challenge-response piggyback, and rotation rides tailnet-sync's in-band exchange (2d);
+(2) if it EVER fired it would call `onInstanceKeyReceived(state.remoteCrowId, …)` —
+passing a crow_id where the handler (boot.js:850) requires an INSTANCE id. crow_id is
+shared fleet-wide, so it can never key a `crow_instances` row: the write would silently
+no-op at best, and a future refactor of `onInstanceKeyReceived` could turn it into a
+cross-instance key mis-write. The challenge-response path three cases above documents
+this exact requirement ("Must include the peer's instance_id … crow_id is shared across
+all paired instances").
+
+**Fix.** Delete the case; leave a short comment at the site recording why (never sent +
+wrong-keyed since birth), so it isn't re-added naively. Deleting beats "fixing" it:
+a correct announce would need a new message shape (instance_id field) AND a sender —
+design work for whichever future item actually needs an announce, not this one.
+
+**Tests:** regression pin — drive `_handleMessage` directly (constructed `PeerManager`
+with a stub identity, authenticated state) with a `feed-key-announce` message and assert
+`onInstanceKeyReceived` is NOT invoked. Red on the old code (it IS invoked, mis-keyed) →
+green after deletion.
+
+## Non-goals
+
+- No env knob for the fan-out cap (push's `CROW_PUSH_SEND_TIMEOUT_MS` is push-scoped;
+  a knob here is speculative — the option param covers tests).
+- No announce-message redesign (item 3 is a deletion, not a feature).
+- No change to `safeRelayPublish` itself — its connect/publish waits are what the cap
+  bounds; unwrapping them individually would re-litigate 2c C2a for no added bound.
+
+## Ship gates
+
+Suite on scratch env (baseline 1994 pass / 2 known bundles-validate-install fails /
+0 skips — any 3rd failure is new); check-ports (exactly one error line: `Port 8090
+(capstone-tracker)`); build-registry `--check`; adversarial diff review (fresh
+subagent, READY-TO-MERGE verdict required); mutation checks above run and recorded.

--- a/docs/superpowers/specs/2026-07-16-minor-pool-3-design.md
+++ b/docs/superpowers/specs/2026-07-16-minor-pool-3-design.md
@@ -37,12 +37,15 @@ one peer row without `gateway_url` so no PeerDialer spawns; stub manager whose
 **Defect.** `fanOut()` (`servers/sharing/room-fanout.js`) serially awaits
 `nostrManager.sendControl(c, envelope)` per member with NO time bound. The call chain is
 `nostr.js subscribeToIncoming → await onSocialMessage → room-inbound
-handleRoomMessageInbound → await fanOut` — i.e. it runs INSIDE the relay's inbound
-message loop. `sendControl → _sendControlEvent → safeRelayPublish → relay.publish()`
-waits for the relay's OK frame; a half-open socket stalls it indefinitely, and the
-serial loop compounds it per member. One wedged relay send freezes inbound message
-processing for that subscription. (Recorded as deliberately out of scope in 2c §F2 —
-"candidate for a future pool" — this is that pool.)
+handleRoomMessageInbound → await fanOut`. `sendControl → _sendControlEvent →
+safeRelayPublish → relay.publish()` waits for the relay's OK frame; a half-open socket
+stalls it indefinitely, and the serial loop compounds it per member. **Review
+correction (R1 finding 1):** nostr-tools dispatches `onevent` WITHOUT awaiting it
+(abstract-relay.js:423), so a wedged fan-out never froze the whole subscription — the
+real damage is that ONE message's handling wedges forever with N× serial compounding,
+plus a leaked pending promise per member. Still worth bounding; the "freezes the
+subscription" framing in earlier drafts was wrong. (Recorded as deliberately out of
+scope in 2c §F2 — "candidate for a future pool" — this is that pool.)
 
 **Fix.** Same sender-bounding pattern as 2c C2a/C2b, applied inside `fanOut`:
 - Per-member cap: `Promise.race([sendControl(...), capTimer])`, default `capMs = 10_000`,
@@ -56,8 +59,10 @@ processing for that subscription. (Recorded as deliberately out of scope in 2c �
   send rule; push precedent `servers/gateway/push/web-push.js:57`).
 - Preserved semantics: `excludeContactId` skip, best-effort per member, `{sent, failed}`
   return shape, per-failure `log` line. Rooms have no cross-member ordering semantics
-  (mirror of push). `sent`/`failed` become completion-ordered — the one existing consumer
-  (`room-inbound.js:113`) ignores the result, and the existing test already sorts.
+  (mirror of push). `sent`/`failed` become completion-ordered — all four call sites
+  (`room-inbound.js:113`, `room-send.js:26` and `:30`,
+  `dashboard/panels/messages/api-handlers.js:310`) ignore the result, and the existing
+  test already sorts (R1 finding 5 corrected the earlier "one consumer" claim).
 
 **Tests** (existing direct-import harness in `tests/room-fanout.test.js`):
 - T2a RED: one member's `sendControl` never settles (`capMs: 50`) → old fanOut never

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4882,7 +4882,8 @@
         "envKeys": [
           "ROOKERY_WORKSPACES_DIR",
           "ROOKERY_REVIEWER_URL",
-          "UV_NO_CACHE"
+          "UV_NO_CACHE",
+          "ROOKERY_OPENALEX_MAILTO"
         ]
       },
       "panel": "panel/rookery.js",
@@ -4897,7 +4898,7 @@
       "env_vars": [
         {
           "name": "ROOKERY_MODEL_BASE_URL",
-          "description": "OpenAI-compatible endpoint for the reviewer model (e.g. a local llama.cpp/vLLM server; find your configured endpoint in Crow's AI settings). For a server on the Docker host use http://host.docker.internal:<port>/v1",
+          "description": "OpenAI-compatible endpoint for the reviewer model (e.g. a local llama.cpp/vLLM server; find your configured endpoint in Crow's AI settings). If the host service binds a SPECIFIC IP (e.g. a Tailscale address), use that IP directly: http://<host-ip>:<port>/v1 — host.docker.internal only reaches services listening on 0.0.0.0 or the Docker bridge, and times out otherwise (verified 2026-07-14)",
           "required": true
         },
         {
@@ -4934,6 +4935,27 @@
           "description": "Disable uv's download cache for the host MCP process (prevents multi-GB cache growth)",
           "default": "1",
           "required": false
+        },
+        {
+          "name": "ROOKERY_MCP_CROW_URL",
+          "description": "Optional: crow gateway PROJECTS MCP mount, registered in-app as a remote MCP so the reviewer can file sources/bibliographies into crow projects. Use the least-privilege /projects/mcp mount, NOT /router/mcp (the router's crow_tools category exposes every connected integration). Use an IP the CONTAINER can route to the host (e.g. http://<host-tailscale-ip>:3006/projects/mcp — NOT localhost, that's the container itself). With the egress lock installed, re-run it with ALLOW_HOST_TCP_PORTS=<port> to open this one path",
+          "required": false
+        },
+        {
+          "name": "ROOKERY_MCP_RESEARCH_URL",
+          "description": "Optional: the gateway's FILTERED tools mount for this bundle (http://<host-ip>:<port>/tools-rookery/mcp — requires a clients.json entry {\"rookery\":{\"allowSources\":[\"rookery\"]}} and a gateway restart). Exposes only this bundle's host tools: rookery_assemble_exp + rookery_search_openalex. Shares ROOKERY_MCP_CROW_TOKEN",
+          "required": false
+        },
+        {
+          "name": "ROOKERY_OPENALEX_MAILTO",
+          "description": "Optional email for OpenAlex's polite pool (faster rate limits for rookery_search_openalex). Host-side only",
+          "required": false
+        },
+        {
+          "name": "ROOKERY_MCP_CROW_TOKEN",
+          "description": "Crow local MCP token for the router endpoint (dashboard → Connect panel → local MCP token; shown once at generation). Required when ROOKERY_MCP_CROW_URL is set; rides the generated config's headers, never a child process env",
+          "required": false,
+          "secret": true
         }
       ],
       "ports": [

--- a/servers/sharing/peer-manager.js
+++ b/servers/sharing/peer-manager.js
@@ -339,15 +339,14 @@ export class PeerManager {
         break;
       }
 
-      case "feed-key-announce": {
-        // Peer advertises the Hypercore feed key they use to write to us.
-        // We persist it so future gateway starts can open the inbound feed
-        // without waiting for a fresh Hyperswarm handshake.
-        if (state.authenticated && state.remoteCrowId && this.onInstanceKeyReceived && msg.feed_key_hex) {
-          this.onInstanceKeyReceived(state.remoteCrowId, msg.feed_key_hex);
-        }
-        break;
-      }
+      // NOTE: a "feed-key-announce" case lived here until 2026-07. Nothing in
+      // the codebase ever SENT that message type (feed keys ride the
+      // challenge/challenge-response piggyback above; rotation rides
+      // tailnet-sync's in-band exchange, 2d), and the handler passed
+      // state.remoteCrowId where onInstanceKeyReceived requires an INSTANCE
+      // id — crow_id is shared fleet-wide and can never key a crow_instances
+      // row. If an announce message is ever actually needed, it must carry
+      // the sender's instance_id (see the challenge-response case).
     }
   }
 

--- a/servers/sharing/room-fanout.js
+++ b/servers/sharing/room-fanout.js
@@ -32,9 +32,11 @@ export function buildRoomJoinEnvelope({ roomUid, roomName, hostCrowId, members =
  *
  * Every send is capped at `capMs` and the members run in parallel
  * (Promise.allSettled), so N wedged sends cost ~one cap, not N×. This runs
- * INSIDE the relay's inbound message loop (nostr.js subscribeToIncoming →
- * onSocialMessage → room-inbound → fanOut): an unbounded relay.publish() on a
- * half-open socket used to freeze inbound processing for that subscription.
+ * inside a relay message's handler chain (nostr.js subscribeToIncoming →
+ * onSocialMessage → room-inbound → fanOut). nostr-tools dispatches onevent
+ * WITHOUT awaiting it, so a wedged send never froze the whole subscription —
+ * but it did wedge THAT message's handling forever (serial per-member
+ * compounding) and leaked a pending promise per member. The cap bounds both.
  * A capped member counts as failed; the abandoned sendControl's eventual
  * rejection is absorbed by the race (reaction attached at race time — it can
  * never reach the process crash guard). sent/failed are completion-ordered.

--- a/servers/sharing/room-fanout.js
+++ b/servers/sharing/room-fanout.js
@@ -29,13 +29,37 @@ export function buildRoomJoinEnvelope({ roomUid, roomName, hostCrowId, members =
  * one failed recipient never aborts the rest. Returns { sent:[ids], failed:[ids] }.
  * Uses nostrManager.sendControl — publish-only, so control envelopes are NOT cached
  * into the 1:1 `messages` table (sendMessage WOULD cache them).
+ *
+ * Every send is capped at `capMs` and the members run in parallel
+ * (Promise.allSettled), so N wedged sends cost ~one cap, not N×. This runs
+ * INSIDE the relay's inbound message loop (nostr.js subscribeToIncoming →
+ * onSocialMessage → room-inbound → fanOut): an unbounded relay.publish() on a
+ * half-open socket used to freeze inbound processing for that subscription.
+ * A capped member counts as failed; the abandoned sendControl's eventual
+ * rejection is absorbed by the race (reaction attached at race time — it can
+ * never reach the process crash guard). sent/failed are completion-ordered.
  */
-export async function fanOut({ nostrManager, members, envelope, excludeContactId = null, log = () => {} }) {
+export async function fanOut({ nostrManager, members, envelope, excludeContactId = null, log = () => {}, capMs = 10_000 }) {
   const sent = [], failed = [];
-  for (const c of members) {
-    if (excludeContactId != null && Number(c.id) === Number(excludeContactId)) continue;
-    try { await nostrManager.sendControl(c, envelope); sent.push(c.id); }
-    catch (e) { failed.push(c.id); log("room fanout fail contact=" + c.id + ": " + (e && e.message)); }
-  }
+  const targets = members.filter((c) => !(excludeContactId != null && Number(c.id) === Number(excludeContactId)));
+  await Promise.allSettled(targets.map(async (c) => {
+    let timer;
+    // Deliberately NOT unref'd: with a hung sendControl this timer can be the
+    // only thing left on the loop — unref'd, the loop drains and the cap never
+    // fires (the exact instance-sync.js:493 node:test trap). The fast path
+    // clears it in finally, so it never outlives a healthy send.
+    const cap = new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`sendControl exceeded ${capMs}ms`)), capMs);
+    });
+    try {
+      await Promise.race([nostrManager.sendControl(c, envelope), cap]);
+      sent.push(c.id);
+    } catch (e) {
+      failed.push(c.id);
+      log("room fanout fail contact=" + c.id + ": " + (e && e.message));
+    } finally {
+      clearTimeout(timer);
+    }
+  }));
   return { sent, failed };
 }

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -549,7 +549,9 @@ export async function startTailnetSyncClients(ctx) {
         await instanceSyncManager.initInstance(peer.id, keyBuf);
         const failures = healFailures.get(peer.id);
         if (failures) {
-          console.warn(`[tailnet-sync] refresh heal for ${peer.id.slice(0,12)}… recovered after ${failures} failure(s)`);
+          // Distinct wording on purpose: greps/alerts keyed on the failure
+          // class "refresh heal for" must not also match recoveries.
+          console.warn(`[tailnet-sync] heal recovered for ${peer.id.slice(0,12)}… after ${failures} failure(s)`);
           healFailures.delete(peer.id);
         }
       } catch (err) {

--- a/servers/sharing/tailnet-sync.js
+++ b/servers/sharing/tailnet-sync.js
@@ -509,6 +509,14 @@ export class PeerDialer {
 export async function startTailnetSyncClients(ctx) {
   const { db, instanceSyncManager } = ctx;
   const dialers = new Map();
+  // Per-peer heal-failure counters (peerId → consecutive failure count). A
+  // wedged initInstance (e.g. a held rocksdb dir lock) used to warn on EVERY
+  // 60s rescan — one line per minute per peer, forever. Same observability
+  // contract as the nostr crash guard: log at #1, #10, #100, …, plus one
+  // "recovered" line when a failing peer heals (episode boundary visible,
+  // next episode logs #1 immediately). Entries are dropped alongside the
+  // peer's dialer when it leaves scope, so re-pair churn cannot grow the Map.
+  const healFailures = new Map();
 
   async function refresh() {
     let rows;
@@ -539,8 +547,17 @@ export async function startTailnetSyncClients(ctx) {
       try {
         const keyBuf = peer.sync_url ? instanceSyncManager.validateIncomingFeedKey?.(peer.id, peer.sync_url) ?? null : null;
         await instanceSyncManager.initInstance(peer.id, keyBuf);
+        const failures = healFailures.get(peer.id);
+        if (failures) {
+          console.warn(`[tailnet-sync] refresh heal for ${peer.id.slice(0,12)}… recovered after ${failures} failure(s)`);
+          healFailures.delete(peer.id);
+        }
       } catch (err) {
-        console.warn(`[tailnet-sync] refresh heal for ${peer.id.slice(0,12)}…: ${err.message}`);
+        const n = (healFailures.get(peer.id) || 0) + 1;
+        healFailures.set(peer.id, n);
+        if (Number.isInteger(Math.log10(n))) {
+          console.warn(`[tailnet-sync] refresh heal for ${peer.id.slice(0,12)}…: ${err.message} (#${n})`);
+        }
       }
       if (!peer.gateway_url) continue;
       if (dialers.has(peer.id)) {
@@ -558,6 +575,9 @@ export async function startTailnetSyncClients(ctx) {
     // Stop dialers for peers no longer in scope (revoked, etc.)
     for (const [id, dialer] of dialers) {
       if (!seenIds.has(id)) { dialer.stop(); dialers.delete(id); }
+    }
+    for (const id of healFailures.keys()) {
+      if (!seenIds.has(id)) healFailures.delete(id);
     }
     // F5 gauge: parked emit-queue sizes ({peerId: count}), visible BEFORE the
     // 256-cap overflow warn drops entries. Placed AFTER the per-peer loop so a

--- a/tests/peer-manager-feed-key-announce.test.js
+++ b/tests/peer-manager-feed-key-announce.test.js
@@ -1,0 +1,26 @@
+/**
+ * Minor-pool item 3 (2026-07-16 spec): regression pin for the removed
+ * "feed-key-announce" dead path. Nothing in the codebase ever SENT that
+ * message type, and the handler passed state.remoteCrowId where
+ * onInstanceKeyReceived (boot.js) requires an INSTANCE id — crow_id is shared
+ * fleet-wide and can never key a crow_instances row. This pin fails if anyone
+ * re-adds the wrong-keyed handler.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PeerManager } from "../servers/sharing/peer-manager.js";
+
+test("feed-key-announce messages do NOT invoke onInstanceKeyReceived (dead path stays dead)", () => {
+  const pm = new PeerManager({ crowId: "crow:test", ed25519Pubkey: "00".repeat(32), ed25519Priv: "00".repeat(32) });
+  let called = null;
+  pm.onInstanceKeyReceived = (id, key) => { called = [id, key]; };
+  const conn = { write() {}, destroy() {} };
+  pm._handleMessage(
+    conn,
+    { type: "feed-key-announce", feed_key_hex: "ab".repeat(32) },
+    Buffer.alloc(32),
+    { authenticated: true, remoteCrowId: "crow:test", isInstanceConn: true },
+    () => {},
+  );
+  assert.equal(called, null, `feed-key-announce must be ignored; got onInstanceKeyReceived(${called?.[0]}) — a crow_id, not an instance id`);
+});

--- a/tests/room-fanout.test.js
+++ b/tests/room-fanout.test.js
@@ -30,3 +30,33 @@ test("fanOut sends to every member except the excluded origin; returns sent/fail
   assert.deepEqual(res.sent.sort(), [1, 2]);
   assert.deepEqual(res.failed, [3]);
 });
+
+// Minor-pool item 2 (2026-07-16 spec): fanOut runs INSIDE the relay's inbound
+// message loop (nostr.js subscribeToIncoming → onSocialMessage → room-inbound →
+// fanOut); an unbounded sendControl (half-open relay socket mid-publish) used to
+// stall inbound processing indefinitely, compounded serially per member.
+test("a hung sendControl is capped: fanOut resolves, hung member fails, healthy member sends", async () => {
+  const nostrManager = { sendControl(contact) {
+    if (contact.id === 1) return new Promise(() => {}); // half-open socket: never settles
+    return Promise.resolve({ eventId: "e", relays: ["wss://x"] });
+  } };
+  const fails = [];
+  const res = await Promise.race([
+    fanOut({ nostrManager, members: [{ id: 1 }, { id: 2 }], envelope: "{}", log: (m) => fails.push(m), capMs: 50 }),
+    new Promise((resolve) => { const t = setTimeout(() => resolve("__hung__"), 2_000); t.unref?.(); }),
+  ]);
+  assert.notEqual(res, "__hung__", "fanOut must resolve despite a never-settling sendControl");
+  assert.deepEqual(res.sent, [2]);
+  assert.deepEqual(res.failed, [1]);
+  assert.ok(fails.some((m) => m.includes("contact=1")), "capped member must be logged through the log callback");
+});
+
+test("N hung members cost ~one cap, not N× (parallel fan-out, not a serial capped loop)", async () => {
+  const nostrManager = { sendControl: () => new Promise(() => {}) };
+  const start = performance.now();
+  const res = await fanOut({ nostrManager, members: [{ id: 1 }, { id: 2 }, { id: 3 }], envelope: "{}", capMs: 100 });
+  const elapsed = performance.now() - start;
+  assert.deepEqual(res.sent, []);
+  assert.deepEqual(res.failed.sort(), [1, 2, 3]);
+  assert.ok(elapsed < 250, `3 hung members should cost ~1 cap (100ms), took ${Math.round(elapsed)}ms`);
+});

--- a/tests/room-fanout.test.js
+++ b/tests/room-fanout.test.js
@@ -53,10 +53,11 @@ test("a hung sendControl is capped: fanOut resolves, hung member fails, healthy 
 
 test("N hung members cost ~one cap, not N× (parallel fan-out, not a serial capped loop)", async () => {
   const nostrManager = { sendControl: () => new Promise(() => {}) };
+  const capMs = 200; // serial would take >= 3*capMs (600ms); parallel ~1 cap.
   const start = performance.now();
-  const res = await fanOut({ nostrManager, members: [{ id: 1 }, { id: 2 }, { id: 3 }], envelope: "{}", capMs: 100 });
+  const res = await fanOut({ nostrManager, members: [{ id: 1 }, { id: 2 }, { id: 3 }], envelope: "{}", capMs });
   const elapsed = performance.now() - start;
   assert.deepEqual(res.sent, []);
   assert.deepEqual(res.failed.sort(), [1, 2, 3]);
-  assert.ok(elapsed < 250, `3 hung members should cost ~1 cap (100ms), took ${Math.round(elapsed)}ms`);
+  assert.ok(elapsed < 2.5 * capMs, `3 hung members should cost ~1 cap (${capMs}ms), took ${Math.round(elapsed)}ms`);
 });

--- a/tests/tailnet-sync-heal-ratelimit.test.js
+++ b/tests/tailnet-sync-heal-ratelimit.test.js
@@ -1,0 +1,104 @@
+/**
+ * Minor-pool item 1 (2026-07-16 spec): the 60s rescan's per-peer heal failure
+ * warn must be rate-limited (log at #1, #10, #100, …) with a reset-on-recovery
+ * line, instead of one warn per minute per wedged peer forever.
+ *
+ * Harness: startTailnetSyncClients exposes __refreshForTest; the stub peer row
+ * carries no gateway_url so no PeerDialer is spawned, and the stub manager's
+ * initInstance is the heal call the warn wraps.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { startTailnetSyncClients } from "../servers/sharing/tailnet-sync.js";
+
+function makeCtx({ initInstance }) {
+  const db = {
+    execute: async () => ({
+      rows: [{ id: "peer1234567890abcdef", gateway_url: null, tailscale_ip: null, sync_url: null, status: "active" }],
+    }),
+  };
+  const instanceSyncManager = {
+    localInstanceId: "self1234567890abcdef",
+    initInstance,
+    pendingEmitStats: () => ({}),
+  };
+  return { db, instanceSyncManager };
+}
+
+function captureWarns() {
+  const lines = [];
+  const orig = console.warn;
+  console.warn = (...args) => { lines.push(args.join(" ")); };
+  return { lines, restore: () => { console.warn = orig; } };
+}
+
+const healLines = (lines) => lines.filter((l) => l.includes("refresh heal for") && !l.includes("recovered"));
+const recoveryLines = (lines) => lines.filter((l) => l.includes("recovered after"));
+
+test("persistently failing heal logs at #1 and #10 only across 12 refreshes", async () => {
+  const ctx = makeCtx({ initInstance: async () => { throw new Error("rocksdb lock held"); } });
+  const cap = captureWarns();
+  let handle;
+  try {
+    handle = await startTailnetSyncClients(ctx); // refresh #1 runs inline
+    for (let i = 0; i < 11; i++) await handle.__refreshForTest();
+    const heals = healLines(cap.lines);
+    assert.equal(heals.length, 2, `expected 2 rate-limited heal warns, got ${heals.length}:\n${heals.join("\n")}`);
+    assert.ok(heals[0].includes("#1"), `first warn should carry #1: ${heals[0]}`);
+    assert.ok(heals[1].includes("#10"), `second warn should carry #10: ${heals[1]}`);
+  } finally {
+    cap.restore();
+    handle?.stop();
+  }
+});
+
+test("recovery resets the counter: recovered line once, then a fresh episode logs #1 again", async () => {
+  let fail = true;
+  const ctx = makeCtx({ initInstance: async () => { if (fail) throw new Error("still locked"); } });
+  const cap = captureWarns();
+  let handle;
+  try {
+    handle = await startTailnetSyncClients(ctx); // fail #1
+    await handle.__refreshForTest(); // fail #2
+    await handle.__refreshForTest(); // fail #3
+    fail = false;
+    await handle.__refreshForTest(); // success → recovery line + reset
+    const recs = recoveryLines(cap.lines);
+    assert.equal(recs.length, 1, `expected one recovery line, got:\n${cap.lines.join("\n")}`);
+    assert.ok(recs[0].includes("3"), `recovery line should carry the failure count 3: ${recs[0]}`);
+    await handle.__refreshForTest(); // success again → NO second recovery line
+    assert.equal(recoveryLines(cap.lines).length, 1, "recovery must log once per episode, not on every success");
+    fail = true;
+    await handle.__refreshForTest(); // new episode → immediate #1
+    const heals = healLines(cap.lines);
+    assert.ok(heals[heals.length - 1].includes("#1"), `fresh episode should log #1 immediately: ${heals[heals.length - 1]}`);
+  } finally {
+    cap.restore();
+    handle?.stop();
+  }
+});
+
+test("out-of-scope peer's counter entry is dropped (no unbounded growth across re-pairs)", async () => {
+  let rows = [{ id: "peer1234567890abcdef", gateway_url: null, tailscale_ip: null, sync_url: null, status: "active" }];
+  const db = { execute: async () => ({ rows }) };
+  const instanceSyncManager = {
+    localInstanceId: "self1234567890abcdef",
+    initInstance: async () => { throw new Error("locked"); },
+    pendingEmitStats: () => ({}),
+  };
+  const cap = captureWarns();
+  let handle;
+  try {
+    handle = await startTailnetSyncClients({ db, instanceSyncManager }); // fail #1 → warn
+    rows = []; // peer revoked / out of scope
+    await handle.__refreshForTest(); // cleanup pass
+    rows = [{ id: "peer1234567890abcdef", gateway_url: null, tailscale_ip: null, sync_url: null, status: "active" }];
+    await handle.__refreshForTest(); // peer re-paired: fresh episode → #1 again (counter was dropped, not resumed at #2)
+    const heals = healLines(cap.lines);
+    assert.equal(heals.length, 2, `expected #1 twice (fresh episodes), got:\n${heals.join("\n")}`);
+    assert.ok(heals[1].includes("#1"), `re-paired peer should restart at #1: ${heals[1]}`);
+  } finally {
+    cap.restore();
+    handle?.stop();
+  }
+});

--- a/tests/tailnet-sync-heal-ratelimit.test.js
+++ b/tests/tailnet-sync-heal-ratelimit.test.js
@@ -32,8 +32,10 @@ function captureWarns() {
   return { lines, restore: () => { console.warn = orig; } };
 }
 
-const healLines = (lines) => lines.filter((l) => l.includes("refresh heal for") && !l.includes("recovered"));
-const recoveryLines = (lines) => lines.filter((l) => l.includes("recovered after"));
+// The recovery line deliberately does NOT contain the failure-class string
+// "refresh heal for" (grep/alert de-collision — see tailnet-sync.js comment).
+const healLines = (lines) => lines.filter((l) => l.includes("refresh heal for"));
+const recoveryLines = (lines) => lines.filter((l) => l.includes("heal recovered for"));
 
 test("persistently failing heal logs at #1 and #10 only across 12 refreshes", async () => {
   const ctx = makeCtx({ initInstance: async () => { throw new Error("rocksdb lock held"); } });


### PR DESCRIPTION
The three items left unshipped by the 2c follow-up pool (#198). Spec: `docs/superpowers/specs/2026-07-16-minor-pool-3-design.md` (includes the R1 review corrections).

**1. tailnet-sync heal-warn rate-limit (2d T8 note).** The 60s rescan warned on EVERY failed per-peer `initInstance` heal — one line per minute per wedged peer, forever. Now a per-peer counter logs at #1/#10/#100… (same contract as the nostr crash guard) plus one `heal recovered for … after N failure(s)` line per episode (distinct wording so greps keyed on the failure class `refresh heal for` can't match recoveries). Counter entries drop with out-of-scope peers.

**2. room fan-out publish cap (2c spec §F2 adjacent gap, R1 item 10).** `fanOut()` serially awaited `sendControl` per member with no bound; `relay.publish()` on a half-open socket stalls indefinitely, wedging that message's handling forever with N× serial compounding (review-corrected framing: nostr-tools dispatches `onevent` un-awaited, so the whole subscription never froze — one message's chain did). Now: per-send 10s cap (`Promise.race`, timer cleared in `finally`, deliberately not unref'd — the instance-sync.js:493 loop-drain trap) + `Promise.allSettled` across members so N wedged sends cost ~one cap. All four call sites ignore the result; semantics otherwise preserved.

**3. peer-manager `feed-key-announce` dead path deleted.** Zero senders exist codebase-wide, and the handler passed `remoteCrowId` where `onInstanceKeyReceived` requires an INSTANCE id (crow_id is shared fleet-wide — it can never key a `crow_instances` row). Regression pin keeps it dead; feed keys ride the challenge-response piggyback + tailnet-sync's in-band exchange (2d).

Plus a mechanical `npm run build-registry` regen — the rookery Phase 2 merge (e6f59fe2) updated the bundle manifest without regenerating `registry/add-ons.json`, leaving `build-registry --check` red on main.

**Gates:** all REDs verified against old code; 5 mutation checks each flip a named test; full suite on scratch env 2009 pass / 2 known fails (bundles-validate-install pair) / 0 skips; check-ports green (single known capstone-tracker line); build-registry --check green after the regen. Adversarial review (fresh Opus subagent): READY TO MERGE, 6 minor/nit findings, 4 folded (stall framing, recovery-log wording, timing margin, spec caller count).