### PR TITLE
fix(rookery): unit Environment= lines were glued to the following comment (regression from #201)

### DIFF
--- a/bundles/rookery/scripts/rookery-egress-lock.sh
+++ b/bundles/rookery/scripts/rookery-egress-lock.sh
@@ -298,7 +298,8 @@ Wants=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-$(for v in ${CALLER_SET[@]+"${CALLER_SET[@]}"}; do printf 'Environment="%s=%s"\n' "$v" "${!v}"; done)# --wait rides out slow container starts; on timeout the lock still installs
+$(for v in ${CALLER_SET[@]+"${CALLER_SET[@]}"}; do printf 'Environment="%s=%s"\n' "$v" "${!v}"; done)
+# --wait rides out slow container starts; on timeout the lock still installs
 # drop-only (fail-closed, no model allow) and exits nonzero so the unit
 # shows failed.
 ExecStart=$script_path --wait 300

--- a/bundles/rookery/tests/test_egress_lock.py
+++ b/bundles/rookery/tests/test_egress_lock.py
@@ -225,3 +225,14 @@ def test_unit_without_config_env_bakes_nothing():
     proc = run_unit()
     assert proc.returncode == 0, proc.stderr
     assert "Environment=" not in proc.stdout
+
+
+def test_unit_environment_lines_are_whole_lines():
+    """Regression: the $(...) emitting Environment= lines swallowed its
+    trailing newline, gluing the last Environment= line to the '# --wait'
+    comment — systemd misparses 'Environment="..."# comment'. Every
+    Environment= line must be a whole line of its own."""
+    proc = run_unit({"ALLOW_HOST_TCP_PORTS": "3006"})
+    lines = proc.stdout.splitlines()
+    assert 'Environment="ALLOW_HOST_TCP_PORTS=3006"' in lines
+    assert not any("Environment=" in l and "#" in l for l in lines)


### PR DESCRIPTION
Fix-forward for a regression I introduced in #201: the `$(...)` block emitting baked `Environment=` lines swallows its trailing newline, so the last `Environment=` line concatenated with the `# --wait` comment — `Environment="ALLOW_HOST_TCP_PORTS=3006"# --wait rides out...` — which systemd misparses.

Caught in the real-emission preview **before** any unit was installed from the fixed script (the currently-installed unit predates #201 and is protected by the drop-in). The #201 tests asserted substring presence and ordering but not line integrity.

Fix: the comment moves to its own literal line (the env-less print now carries one harmless blank line). New regression test pins whole-line emission. Suite 16/16, shellcheck clean; verified both emissions by running the script.