### PR TITLE
fix(bundles): install .env fallback ladder + secret inference + suite fully green (both standing test fails retired)

### DIFF
--- a/servers/gateway/dashboard/panels/extensions/client.js
+++ b/servers/gateway/dashboard/panels/extensions/client.js
@@ -498,12 +498,12 @@ export function extensionsClientJS(lang) {
             (addon.env_vars || []).forEach(function(ev) { metaByName[ev.name] = ev; });
             var scopedEnvVars = keys.map(function(key) {
               // Undeclared key (installed-but-unregistered bundle): the registry
-              // can't tell us `secret`, so infer it from the name — otherwise a
-              // credential renders as a visible type=text input.
+              // can't tell us the secret flag, so infer it from the name — otherwise
+              // a credential renders as a visible type=text input.
               return metaByName[key] || {
                 name: key,
                 required: true,
-                secret: /(KEY|TOKEN|SECRET|PASS|CREDENTIAL)/i.test(key),
+                secret: /(KEY|TOKEN|SECRET|PASS|CREDENTIAL|JWT|HASH)/i.test(key),
               };
             });
 

--- a/servers/gateway/dashboard/panels/extensions/client.js
+++ b/servers/gateway/dashboard/panels/extensions/client.js
@@ -497,7 +497,14 @@ export function extensionsClientJS(lang) {
             var metaByName = {};
             (addon.env_vars || []).forEach(function(ev) { metaByName[ev.name] = ev; });
             var scopedEnvVars = keys.map(function(key) {
-              return metaByName[key] || { name: key, required: true };
+              // Undeclared key (installed-but-unregistered bundle): the registry
+              // can't tell us `secret`, so infer it from the name — otherwise a
+              // credential renders as a visible type=text input.
+              return metaByName[key] || {
+                name: key,
+                required: true,
+                secret: /(KEY|TOKEN|SECRET|PASS|CREDENTIAL)/i.test(key),
+              };
             });
 
             showInstallModal(

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -1239,6 +1239,50 @@ export async function validateInstall(bundleId, { envVars = {}, consentToken = n
  * @param {object} opts.manifest          the on-disk manifest
  * @returns {Promise<{ok:true, needsRestart:boolean}|{ok:false, reason:string}>}
  */
+/**
+ * Write the bundle's .env at install time. Ladder:
+ *   1. Provided non-empty values → written verbatim.
+ *   2. Zero usable values → copy .env.example if present (this fallback was
+ *      previously dead for UI installs: the install modal always sends an
+ *      env_vars OBJECT, and the old `else if` only ran for non-objects).
+ *   3. Still nothing, but the manifest declares env vars → a comment-only
+ *      placeholder .env. Without ANY .env the needs-setup badge fails closed
+ *      (resolveEffectiveEnv managed:false — bundles-config.js) and a bundle
+ *      whose required key has no default can NEVER badge (frigate was the
+ *      live case). Comment-only on purpose: `KEY=` lines would set empty-string
+ *      env vars in the container, which is not the same as unset.
+ * Never clobbers an existing .env via the fallback paths.
+ *
+ * @param {string} destDir           installed bundle dir (~/.crow/bundles/<id>)
+ * @param {object|null} envVars      values from the install modal / CLI
+ * @param {object|null} manifest     the bundle manifest (for env_vars)
+ * @param {(msg:string)=>void} [log] install-job logger
+ */
+export function writeInstallEnv(destDir, envVars, manifest, log = () => {}) {
+  const envPath = join(destDir, ".env");
+  const examplePath = join(destDir, ".env.example");
+  const envLines = (envVars && typeof envVars === "object")
+    ? Object.entries(envVars)
+        .filter(([, v]) => v !== undefined && v !== "")
+        .map(([k, v]) => `${k}=${v}`)
+    : [];
+  if (envLines.length > 0) {
+    writeFileSync(envPath, envLines.join("\n") + "\n");
+    log(`Wrote ${envLines.length} env vars`);
+    return;
+  }
+  if (existsSync(envPath)) return;
+  if (existsSync(examplePath)) {
+    cpSync(examplePath, envPath);
+    log("Created .env from .env.example");
+    return;
+  }
+  if ((manifest?.env_vars || []).length > 0) {
+    writeFileSync(envPath, "# Managed by Crow — no values provided at install; configure via the dashboard Extensions panel.\n");
+    log("Wrote placeholder .env (no values provided — configure via Extensions)");
+  }
+}
+
 export async function runInstallJob(bundleId, envVars, { job, installedSnapshot, consentVerified, manifest }) {
   let needsRestart = false;
   try {
@@ -1275,19 +1319,9 @@ export async function runInstallJob(bundleId, envVars, { job, installedSnapshot,
       }
     }
 
-    // 2. Write env vars if provided
-    if (envVars && typeof envVars === "object") {
-      const envLines = Object.entries(envVars)
-        .filter(([, v]) => v !== undefined && v !== "")
-        .map(([k, v]) => `${k}=${v}`);
-      if (envLines.length > 0) {
-        writeFileSync(join(destDir, ".env"), envLines.join("\n") + "\n");
-        appendLog(job, `Wrote ${envLines.length} env vars`);
-      }
-    } else if (existsSync(join(destDir, ".env.example")) && !existsSync(join(destDir, ".env"))) {
-      cpSync(join(destDir, ".env.example"), join(destDir, ".env"));
-      appendLog(job, "Created .env from .env.example");
-    }
+    // 2. Write env vars (provided values → .env.example fallback → manifest
+    // placeholder). Extracted so the fallback ladder is unit-testable.
+    writeInstallEnv(destDir, envVars, manifest, (msg) => appendLog(job, msg));
 
     // 2.5 Inject shared-storage vars if bundle declares a translator.
     // Gateway owns the translation in-process (configure-storage.mjs is not

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -1248,9 +1248,11 @@ export async function validateInstall(bundleId, { envVars = {}, consentToken = n
  *   3. Still nothing, but the manifest declares env vars → a comment-only
  *      placeholder .env. Without ANY .env the needs-setup badge fails closed
  *      (resolveEffectiveEnv managed:false — bundles-config.js) and a bundle
- *      whose required key has no default can NEVER badge (frigate was the
- *      live case). Comment-only on purpose: `KEY=` lines would set empty-string
- *      env vars in the container, which is not the same as unset.
+ *      whose required key has no default AND no .env.example can NEVER badge
+ *      (vaultwarden, gitea, immich, adguard-home, … — roughly twenty such
+ *      bundles ship today; NOT frigate, whose .env.example takes rung 2).
+ *      Comment-only on purpose: `KEY=` lines would set empty-string env vars
+ *      in the container, which is not the same as unset.
  * Never clobbers an existing .env via the fallback paths.
  *
  * @param {string} destDir           installed bundle dir (~/.crow/bundles/<id>)

--- a/tests/bundles-install-env.test.js
+++ b/tests/bundles-install-env.test.js
@@ -30,9 +30,10 @@ test("UI install with zero usable values falls back to .env.example (the dead-fa
   assert.equal(readFileSync(join(dest, ".env"), "utf8"), "REQ_KEY=\n# fill me in\n");
 });
 
-test("frigate shape: zero values, NO .env.example, manifest declares env vars → placeholder .env (managed evidence)", () => {
+test("vaultwarden shape: zero values, NO .env.example, manifest declares env vars → placeholder .env (managed evidence)", () => {
   // Without ANY .env the needs-setup badge fails closed (resolveEffectiveEnv
-  // managed:false) and the bundle can never badge — frigate was the live case.
+  // managed:false) and the bundle can never badge — ~20 shipped bundles have a
+  // required-no-default key and no .env.example (vaultwarden, gitea, immich, …).
   const dest = scratchDest();
   writeInstallEnv(dest, {}, { env_vars: [{ name: "MQTT_HOST", required: true }] });
   assert.ok(existsSync(join(dest, ".env")), "placeholder .env must be written so the bundle can badge");

--- a/tests/bundles-install-env.test.js
+++ b/tests/bundles-install-env.test.js
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Same isolation rule as bundles-install-job.test.js: bundles.js resolves its
+// paths from CROW_HOME at module load — point it at a scratch dir BEFORE import.
+process.env.CROW_HOME = mkdtempSync(join(tmpdir(), "crow-test-home-"));
+const { writeInstallEnv } = await import("../servers/gateway/routes/bundles.js");
+
+const scratchDest = () => mkdtempSync(join(tmpdir(), "crow-env-dest-"));
+
+test("provided non-empty values are written to .env; empty/undefined values dropped", () => {
+  const dest = scratchDest();
+  writeInstallEnv(dest, { A_KEY: "v1", EMPTY: "", GONE: undefined, B_KEY: "v2" }, null);
+  const content = readFileSync(join(dest, ".env"), "utf8");
+  assert.equal(content, "A_KEY=v1\nB_KEY=v2\n");
+});
+
+test("UI install with zero usable values falls back to .env.example (the dead-fallback bug)", () => {
+  // The old code only consulted .env.example when envVars was NOT an object —
+  // but the install modal ALWAYS sends an object, so the fallback was dead for
+  // every UI install. A required-keys-left-blank UI install must still get the
+  // example copied.
+  const dest = scratchDest();
+  writeFileSync(join(dest, ".env.example"), "REQ_KEY=\n# fill me in\n");
+  writeInstallEnv(dest, { REQ_KEY: "" }, { env_vars: [{ name: "REQ_KEY", required: true }] });
+  assert.ok(existsSync(join(dest, ".env")), ".env.example fallback must fire for a zero-value UI install");
+  assert.equal(readFileSync(join(dest, ".env"), "utf8"), "REQ_KEY=\n# fill me in\n");
+});
+
+test("frigate shape: zero values, NO .env.example, manifest declares env vars → placeholder .env (managed evidence)", () => {
+  // Without ANY .env the needs-setup badge fails closed (resolveEffectiveEnv
+  // managed:false) and the bundle can never badge — frigate was the live case.
+  const dest = scratchDest();
+  writeInstallEnv(dest, {}, { env_vars: [{ name: "MQTT_HOST", required: true }] });
+  assert.ok(existsSync(join(dest, ".env")), "placeholder .env must be written so the bundle can badge");
+  const content = readFileSync(join(dest, ".env"), "utf8");
+  assert.ok(content.startsWith("#"), "placeholder must be comment-only (no KEY= lines — empty-string env vars change container semantics)");
+  assert.ok(!/^[A-Z_]+=/m.test(content), "placeholder must not set any variable");
+});
+
+test("zero values, no example, manifest with NO env vars → no .env littered", () => {
+  const dest = scratchDest();
+  writeInstallEnv(dest, {}, { env_vars: [] });
+  assert.ok(!existsSync(join(dest, ".env")));
+  writeInstallEnv(dest, {}, null);
+  assert.ok(!existsSync(join(dest, ".env")));
+});
+
+test("an existing .env is never clobbered by the fallback paths", () => {
+  const dest = scratchDest();
+  writeFileSync(join(dest, ".env"), "KEEP=1\n");
+  writeFileSync(join(dest, ".env.example"), "KEEP=example\n");
+  writeInstallEnv(dest, {}, { env_vars: [{ name: "KEEP", required: true }] });
+  assert.equal(readFileSync(join(dest, ".env"), "utf8"), "KEEP=1\n");
+});
+
+test("non-object envVars keeps the original example-copy behavior", () => {
+  const dest = scratchDest();
+  writeFileSync(join(dest, ".env.example"), "X=1\n");
+  writeInstallEnv(dest, null, null);
+  assert.equal(readFileSync(join(dest, ".env"), "utf8"), "X=1\n");
+});

--- a/tests/bundles-validate-install.test.js
+++ b/tests/bundles-validate-install.test.js
@@ -1,11 +1,16 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { validateInstall } from "../servers/gateway/routes/bundles.js";
+import { createDbClient } from "../servers/db.js";
 
-const INSTALLED_PATH = join(homedir(), ".crow", "installed.json");
+// Honor CROW_HOME like the code under test does (routes/bundles.js resolves its
+// paths from it) — under the scratch suite env this points at the throwaway dir,
+// NOT the operator's real ~/.crow.
+const CROW_HOME = process.env.CROW_HOME || join(homedir(), ".crow");
+const INSTALLED_PATH = join(CROW_HOME, "installed.json");
 
 test("invalid bundle id → 400 invalid_id", async () => {
   const r = await validateInstall("../../etc/passwd");
@@ -37,6 +42,31 @@ test("consent bundle with an invalid/bogus token → 403 consent_invalid", async
   // 'caddy' again, but this time with a token that cannot possibly match a
   // row in install_consents — never minted, so validateConsentToken's
   // UPDATE...RETURNING finds nothing and consentVerified stays false.
+  //
+  // validateInstall opens its own createDbClient() for the consent check. On a
+  // scratch CROW_DATA_DIR that DB is table-less (init-db never ran), so the
+  // UPDATE used to throw instead of returning consent_invalid — this test was
+  // one of the suite's standing "known fails" under the scratch env. Create
+  // the one table the path touches (same DDL as scripts/init-db.js; IF NOT
+  // EXISTS makes it a no-op on a fully-initialized host DB). better-sqlite3
+  // won't mkdir, so provision the scratch data dir first (real hosts have it).
+  if (process.env.CROW_DATA_DIR) mkdirSync(process.env.CROW_DATA_DIR, { recursive: true });
+  const db = createDbClient();
+  try {
+    await db.execute({
+      sql: `CREATE TABLE IF NOT EXISTS install_consents (
+              token TEXT PRIMARY KEY,
+              bundle_id TEXT NOT NULL,
+              schema_version INTEGER NOT NULL DEFAULT 1,
+              created_at INTEGER NOT NULL,
+              expires_at INTEGER NOT NULL,
+              consumed INTEGER NOT NULL DEFAULT 0
+            )`,
+      args: [],
+    });
+  } finally {
+    try { db.close(); } catch {}
+  }
   const r = await validateInstall("caddy", {
     forceInstall: true,
     consentToken: "not-a-real-token",
@@ -91,26 +121,42 @@ test("bundle with a missing required dependency bundle → 400 missing_dependenc
   assert.ok(r.extra.missing_dependencies.includes("caddy"));
 });
 
-test("a bundle already present in ~/.crow/installed.json → 409 already_installed", async () => {
-  // Reads the REAL, live installed.json to pick an id that's genuinely
-  // installed on this host — does not write to it. If nothing usable is
-  // installed (fresh host), skip honestly rather than faking a fixture.
+test("a bundle already present in installed.json → 409 already_installed", async () => {
+  // On the operator's host: reads the REAL installed.json to pick an id that's
+  // genuinely installed — never writes it. Under a scratch CROW_HOME (the suite
+  // env) installed.json doesn't exist, and this test used to skip on prod /
+  // fail closed on scratch (the candidate came from prod state the code under
+  // test couldn't see). Scratch is disposable, so seed the fixture there and
+  // make the 409 deterministic; remove it after so parallel test files see the
+  // same empty scratch they started with.
+  let seeded = false;
   if (!existsSync(INSTALLED_PATH)) {
-    console.log("  (skipped: no ~/.crow/installed.json on this host)");
-    return;
+    if (!process.env.CROW_HOME) {
+      // Real ~/.crow without an installed.json (fresh host): never write there.
+      console.log("  (skipped: no installed.json and no scratch CROW_HOME to seed)");
+      return;
+    }
+    writeFileSync(INSTALLED_PATH, JSON.stringify([
+      { id: "uptime-kuma", installed_at: "2026-01-01T00:00:00Z" },
+    ]));
+    seeded = true;
   }
-  const installed = JSON.parse(readFileSync(INSTALLED_PATH, "utf8"));
-  const candidate = (Array.isArray(installed) ? installed : [])
-    .map((i) => i.id)
-    .find((id) => existsSync(join(process.cwd(), "bundles", id)));
-  if (!candidate) {
-    console.log("  (skipped: no installed bundle also present in the bundles/ registry)");
-    return;
+  try {
+    const installed = JSON.parse(readFileSync(INSTALLED_PATH, "utf8"));
+    const candidate = (Array.isArray(installed) ? installed : [])
+      .map((i) => i.id)
+      .find((id) => existsSync(join(process.cwd(), "bundles", id)));
+    if (!candidate) {
+      console.log("  (skipped: no installed bundle also present in the bundles/ registry)");
+      return;
+    }
+    const r = await validateInstall(candidate, { forceInstall: true });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 409);
+    assert.equal(r.code, "already_installed");
+  } finally {
+    if (seeded) rmSync(INSTALLED_PATH, { force: true });
   }
-  const r = await validateInstall(candidate, { forceInstall: true });
-  assert.equal(r.ok, false);
-  assert.equal(r.status, 409);
-  assert.equal(r.code, "already_installed");
 });
 
 test("a plain, non-consent, non-GPU bundle passes and returns its manifest + installed snapshot", async () => {


### PR DESCRIPTION
The three Item-3 filed follow-ups, Kevin-approved 2026-07-16.

**1. `writeInstallEnv()` fallback ladder** (extracted from `runInstallJob`, unit-tested): provided values → `.env.example` copy → comment-only placeholder `.env` when the manifest declares env vars. The `.env.example` fallback was DEAD for every UI install (the modal always sends an `env_vars` object; the old `else if` only ran for non-objects). The placeholder gives managed-evidence so the ~20 required-no-default no-example bundles (vaultwarden, gitea, immich, adguard-home, …) can finally show the "Needs setup" badge — without it `resolveEffectiveEnv` fails closed on `managed:false`. Comment-only on purpose: `KEY=` lines would set empty-string container env vars, which is not the same as unset. **Review corrections:** frigate (the originally-cited case) actually ships `.env.example` and its default suppresses the badge — rung 2, not rung 3. Behavior note: the revived rung 2 means blank UI installs of ~29 `.env.example` bundles now get the example's defaults applied (alignment with the CLI installer's existing behavior).

**2. Secret inference for undeclared keys** (extensions client): the installed-but-unregistered configure fallback now renders keys matching `KEY|TOKEN|SECRET|PASS|CREDENTIAL|JWT|HASH` as password inputs instead of visible text. Build war story: the first version's code comment used backticks — that region of `client.js` lives inside a template literal, so the backtick terminated it and broke the entire dashboard graph. The dashboard-mounted canary test caught it (the targeted test files did not).

**3. Both standing "known fails" retired — the suite on scratch env is now FULLY GREEN (2017/2017/0/0).** `consent_invalid` provisions the scratch data dir + `install_consents` table (IF-NOT-EXISTS, DDL matching init-db; no-op on real hosts); `already_installed` honors `CROW_HOME` and seeds/removes a scratch fixture instead of reading the operator's prod `installed.json`. **From this PR on, ANY suite failure is news** — the "2 known fails" carve-out is retired alongside the check-ports one.

**Gates:** RED-first tests + 3 mutation checks (each flips named tests); full suite scratch 2017/2017/0/0; check-ports green; build-registry green; adversarial Opus review READY TO MERGE (5 minors, 3 folded: frigate rationale, JWT/HASH regex, behavior-change disclosure).