### PR TITLE
feat(pm-workspace): planner — human-gated calendar-block proposals + planned-events feed

### DIFF
--- a/bundles/pm-workspace/README.md
+++ b/bundles/pm-workspace/README.md
@@ -13,6 +13,14 @@ Personal PM workspace bundle for Crow:
 - **Monday.com sync** — deterministic pull/merge engine: `mirror` boards
   copy into a Bot Board tracker; `twoway` boards three-way merge with
   the kanban tasks DB. Deletions are never propagated (flagged only).
+- **Planner** — human-gated calendar-block proposals. An assistant
+  proposes time blocks (`crow_pm_plan_propose`); a human approves or
+  rejects each one (`crow_pm_plan_decide`, or the dashboard queue);
+  approved blocks are exported as a **planned-events feed** — a JSON
+  file in a Drive folder an external agent (e.g. a Power Automate flow)
+  consumes to create REAL calendar events, stamped with a marker
+  category. The calendar ingest drop closes the loop: exported events
+  seen back with the marker category become `confirmed`.
 
 Boards/kanban UI stays with the existing tasks bundle and Bot Board —
 this bundle deliberately ships **no tracker tables and no board UI**.
@@ -45,11 +53,24 @@ secrets file works as-is.
 | `CROW_GATEWAY_URL` | Used for the digest footer link |
 | `CROW_GATEWAY_ALT_URLS` | Optional comma-separated extra bases (e.g. a public proxy) — the footer links all of them |
 | `CROW_TASKS_DB_PATH` | Kanban tasks DB, default `$CROW_DATA_DIR/tasks.db` |
+| `PLANNER_DRIVE_FOLDER_ID` | Drive folder where approved planned-events feed files are written (enables the planner) |
+| `PLANNER_CATEGORY` | Marker category for planner-created events; reconcile matches on it (default `Crow Plan`) |
+| `PLANNER_CRON` | Planner export/reconcile schedule, default `*/15 * * * *` |
 
 The Outlook summary shape (either source) is
 `{ calendar?: [{start,end,subject,location}], messages?: [{from,subject}], unread_count? }`
 (the HTTP source wraps it as `{ received_at, payload }`). The adapter renders whatever known
 fields are present.
+
+The planned-events feed file (`planned-events-<utc-stamp>.json`) is
+`{ generated_at, generator, category, events: [{ uid, subject, start, end, location, body }] }`
+with `start`/`end` as UTC ISO datetimes. The consuming agent should create
+one calendar event per entry and set `category` on it — that marker is what
+`reconcile` (cron or `crow_pm_plan_reconcile`) matches in the ingest drop
+(subject equal + start within ±5 min) to flip `exported` → `confirmed`.
+Every feed file contains only newly-approved events, so processing a file
+exactly once (e.g. a Drive "when a file is created" trigger) is naturally
+idempotent.
 
 Reserved for later phases (adapters currently stubs): `BOX_CLIENT_ID`,
 `BOX_CLIENT_SECRET`, `BOX_FOLDER_IDS`.

--- a/bundles/pm-workspace/manifest.json
+++ b/bundles/pm-workspace/manifest.json
@@ -32,7 +32,10 @@
       "NTFY_URL",
       "GOOGLE_TOKEN_FILE",
       "CROW_GATEWAY_URL",
-      "CROW_TASKS_DB_PATH"
+      "CROW_TASKS_DB_PATH",
+      "PLANNER_DRIVE_FOLDER_ID",
+      "PLANNER_CATEGORY",
+      "PLANNER_CRON"
     ]
   },
   "panel": "panel/pm-workspace.js",
@@ -63,7 +66,10 @@
     { "name": "NTFY_URL", "description": "Alternate ntfy base URL (default https://ntfy.sh)", "required": false },
     { "name": "GOOGLE_TOKEN_FILE", "description": "Path to a Google OAuth2 authorized_user JSON for calendar/drive digest sections", "required": false },
     { "name": "CROW_GATEWAY_URL", "description": "Public gateway URL used in digest footer links", "required": false },
-    { "name": "CROW_TASKS_DB_PATH", "description": "Path to the kanban tasks DB (default $CROW_DATA_DIR/tasks.db)", "required": false }
+    { "name": "CROW_TASKS_DB_PATH", "description": "Path to the kanban tasks DB (default $CROW_DATA_DIR/tasks.db)", "required": false },
+    { "name": "PLANNER_DRIVE_FOLDER_ID", "description": "Drive folder where approved planned-events feed files are written for an external agent (e.g. Power Automate) to create real calendar events", "required": false },
+    { "name": "PLANNER_CATEGORY", "description": "Marker category stamped on planner-created calendar events; the reconcile loop-guard matches on it (default: Crow Plan)", "required": false },
+    { "name": "PLANNER_CRON", "description": "Cron expression for planner export/reconcile runs (default: */15 * * * *)", "required": false }
   ],
   "notes": "Notes (markdown + pressure-sensitive drawing with OCR), a daily digest, and deterministic Monday.com sync. Boards/kanban remain the job of the tasks bundle and Bot Board tracker tools — this bundle reads them for the digest and writes them only via the sync engine."
 }

--- a/bundles/pm-workspace/server/config.js
+++ b/bundles/pm-workspace/server/config.js
@@ -72,6 +72,9 @@ const KEYS = [
   "OUTLOOK_INGEST_MAX_AGE_MIN",
   "OUTLOOK_DRIVE_FOLDER_ID",
   "OUTLOOK_TZ",
+  "PLANNER_DRIVE_FOLDER_ID",
+  "PLANNER_CATEGORY",
+  "PLANNER_CRON",
   "CROW_GATEWAY_URL",
   "CROW_GATEWAY_ALT_URLS",
   "CROW_TASKS_DB_PATH",
@@ -101,6 +104,7 @@ export function loadConfig() {
     DIGEST_CRON: merged.DIGEST_CRON || "0 7 * * *",
     SYNC_CRON: merged.SYNC_CRON || "*/15 * * * *",
     SMTP_PORT: merged.SMTP_PORT || "587",
+    PLANNER_CRON: merged.PLANNER_CRON || "*/15 * * * *",
     OCR_VISION_API_KEY: merged.OCR_VISION_API_KEY || "none",
     NTFY_URL: merged.NTFY_URL || "https://ntfy.sh",
   };

--- a/bundles/pm-workspace/server/digest/adapters/outlook.js
+++ b/bundles/pm-workspace/server/digest/adapters/outlook.js
@@ -29,10 +29,10 @@
  * Emitted section items use the renderer's { label, detail? } shape.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { mintGoogleToken, newestFileInFolder, downloadJson } from "../../google-drive.js";
 
 const HTTP_TIMEOUT_MS = 15_000;
-const DRIVE = "https://www.googleapis.com/drive/v3";
 const DEFAULT_TZ = "America/Chicago";
 
 /**
@@ -92,55 +92,16 @@ function fmtMessages(items) {
   }));
 }
 
-/** Mint a Google access token from an authorized_user JSON (in memory). */
-async function mintGoogleToken(tokenFile) {
-  const raw = JSON.parse(readFileSync(tokenFile, "utf8"));
-  if (!raw.refresh_token || !raw.client_id || !raw.client_secret) {
-    if (raw.token) return raw.token;
-    throw new Error("token file missing refresh_token/client_id/client_secret");
-  }
-  const res = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      client_id: raw.client_id,
-      client_secret: raw.client_secret,
-      refresh_token: raw.refresh_token,
-      grant_type: "refresh_token",
-    }),
-    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
-  });
-  if (!res.ok) throw new Error(`token refresh HTTP ${res.status}`);
-  const json = await res.json();
-  if (!json.access_token) throw new Error("refresh grant returned no access_token");
-  return json.access_token;
-}
-
 /**
- * Read the newest file in a Drive folder → { payload, receivedAt }.
- * Returns { empty: true } when the folder has no files yet.
+ * Read the newest file in the ingest Drive folder → { payload, receivedAt }.
+ * Returns { empty: true } when the folder has no files yet. Exported so the
+ * planner can reconcile its exported events against the same drop.
  */
-async function readDriveDrop(config) {
+export async function readDriveDrop(config) {
   const token = await mintGoogleToken(config.GOOGLE_TOKEN_FILE);
-  const auth = { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) };
-  const folderId = config.OUTLOOK_DRIVE_FOLDER_ID;
-  const q = encodeURIComponent(`'${folderId}' in parents and trashed = false`);
-  const listUrl = `${DRIVE}/files?q=${q}&orderBy=modifiedTime desc&pageSize=1&fields=files(id,name,modifiedTime)`;
-  const listRes = await fetch(listUrl, auth);
-  if (!listRes.ok) throw new Error(`Drive list HTTP ${listRes.status}`);
-  const { files } = await listRes.json();
-  if (!files || files.length === 0) return { empty: true };
-
-  const file = files[0];
-  const getRes = await fetch(`${DRIVE}/files/${file.id}?alt=media`, auth);
-  if (!getRes.ok) throw new Error(`Drive download HTTP ${getRes.status}`);
-  const text = await getRes.text();
-  let payload;
-  try {
-    payload = JSON.parse(text);
-  } catch {
-    throw new Error("drop file is not valid JSON");
-  }
+  const file = await newestFileInFolder(token, config.OUTLOOK_DRIVE_FOLDER_ID);
+  if (!file) return { empty: true };
+  let payload = await downloadJson(token, file.id);
   // The flow may write the summary bare, or wrapped as { payload }.
   if (payload && typeof payload === "object" && payload.payload) payload = payload.payload;
   return { payload, receivedAt: file.modifiedTime || null };

--- a/bundles/pm-workspace/server/digest/cron.js
+++ b/bundles/pm-workspace/server/digest/cron.js
@@ -17,6 +17,7 @@
 import parser from "cron-parser";
 import { runDigest, localDate } from "./index.js";
 import { runSync } from "../sync/monday.js";
+import { exportApproved, reconcile, plannerConfigured } from "../planner.js";
 
 const TICK_MS = 60_000;
 
@@ -33,8 +34,10 @@ function prevOccurrence(expr, now = new Date()) {
 export function startCrons(db, loadConfig) {
   const state = {
     lastSyncRun: null, // Date
+    lastPlannerRun: null, // Date
     digestRunning: false,
     syncRunning: false,
+    plannerRunning: false,
     timer: null,
   };
 
@@ -90,6 +93,28 @@ export function startCrons(db, loadConfig) {
           console.error(`[pm-workspace cron] sync failed: ${err.message}`);
         } finally {
           state.syncRunning = false;
+        }
+      }
+    }
+    // ── Planner (export approved → feed file, reconcile confirmations) ──
+    if (!state.plannerRunning && plannerConfigured(config)) {
+      const prev = prevOccurrence(config.PLANNER_CRON, now);
+      if (prev && (!state.lastPlannerRun || prev > state.lastPlannerRun)) {
+        state.plannerRunning = true;
+        state.lastPlannerRun = now;
+        try {
+          const exported = await exportApproved(db, config);
+          if (exported.exported > 0) {
+            console.log(`[pm-workspace cron] planner exported ${exported.exported} → ${exported.file}`);
+          }
+          const rec = await reconcile(db, config);
+          if (rec.confirmed > 0) {
+            console.log(`[pm-workspace cron] planner confirmed ${rec.confirmed} event(s)`);
+          }
+        } catch (err) {
+          console.error(`[pm-workspace cron] planner failed: ${err.message}`);
+        } finally {
+          state.plannerRunning = false;
         }
       }
     }

--- a/bundles/pm-workspace/server/digest/index.js
+++ b/bundles/pm-workspace/server/digest/index.js
@@ -14,6 +14,7 @@ import { googleSections } from "./adapters/google.js";
 import { mondayLocalSection } from "./adapters/monday-local.js";
 import { boxSection } from "./adapters/box.js";
 import { outlookSections } from "./adapters/outlook.js";
+import { plannerSection } from "../planner.js";
 import { renderDigest } from "./render.js";
 import { send as sendMail, smtpConfigured } from "../mailer.js";
 
@@ -50,6 +51,7 @@ export async function assembleDigest(db, config) {
   push(await guarded(() => googleSections(config), "Google"));
   push(await guarded(() => boxSection(config), "Box"));
   push(await guarded(() => outlookSections(config), "Outlook"));
+  push(await guarded(() => plannerSection(db), "Planner"));
 
   return { date: localDate(), sections };
 }

--- a/bundles/pm-workspace/server/google-drive.js
+++ b/bundles/pm-workspace/server/google-drive.js
@@ -1,0 +1,91 @@
+/**
+ * PM Workspace — minimal Google Drive REST helpers.
+ *
+ * Shared by the Outlook ingest adapter (read the newest drop file) and the
+ * planner feed (write approved planned-events JSON for an external agent —
+ * e.g. a Power Automate flow — to consume).
+ *
+ * Auth: a Google `authorized_user` JSON file (GOOGLE_TOKEN_FILE) whose
+ * refresh token is exchanged for a short-lived access token per call burst.
+ * No SDK dependency — plain fetch against the Drive v3 REST API.
+ */
+
+import { readFileSync } from "node:fs";
+
+const DRIVE = "https://www.googleapis.com/drive/v3";
+const UPLOAD = "https://www.googleapis.com/upload/drive/v3";
+const HTTP_TIMEOUT_MS = 15_000;
+
+/** Mint a Google access token from an authorized_user JSON (in memory). */
+export async function mintGoogleToken(tokenFile) {
+  const raw = JSON.parse(readFileSync(tokenFile, "utf8"));
+  if (!raw.refresh_token || !raw.client_id || !raw.client_secret) {
+    if (raw.token) return raw.token;
+    throw new Error("token file missing refresh_token/client_id/client_secret");
+  }
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: raw.client_id,
+      client_secret: raw.client_secret,
+      refresh_token: raw.refresh_token,
+      grant_type: "refresh_token",
+    }),
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`token refresh HTTP ${res.status}`);
+  const json = await res.json();
+  if (!json.access_token) throw new Error("refresh grant returned no access_token");
+  return json.access_token;
+}
+
+function authHeaders(token) {
+  return { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) };
+}
+
+/** Newest non-trashed file in a folder → { id, name, modifiedTime } or null. */
+export async function newestFileInFolder(token, folderId) {
+  const q = encodeURIComponent(`'${folderId}' in parents and trashed = false`);
+  const url = `${DRIVE}/files?q=${q}&orderBy=modifiedTime desc&pageSize=1&fields=files(id,name,modifiedTime)`;
+  const res = await fetch(url, authHeaders(token));
+  if (!res.ok) throw new Error(`Drive list HTTP ${res.status}`);
+  const { files } = await res.json();
+  return files && files.length > 0 ? files[0] : null;
+}
+
+/** Download a file's content and parse it as JSON. */
+export async function downloadJson(token, fileId) {
+  const res = await fetch(`${DRIVE}/files/${fileId}?alt=media`, authHeaders(token));
+  if (!res.ok) throw new Error(`Drive download HTTP ${res.status}`);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error("file is not valid JSON");
+  }
+}
+
+/**
+ * Create a JSON file in a folder (multipart upload).
+ * Returns the created file's { id, name }.
+ */
+export async function uploadJson(token, folderId, name, obj) {
+  const boundary = "pmws" + Math.random().toString(36).slice(2);
+  const metadata = JSON.stringify({ name, parents: [folderId], mimeType: "application/json" });
+  const content = JSON.stringify(obj, null, 2);
+  const body =
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n` +
+    `--${boundary}\r\nContent-Type: application/json\r\n\r\n${content}\r\n--${boundary}--`;
+  const res = await fetch(`${UPLOAD}/files?uploadType=multipart&fields=id,name`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+    },
+    body,
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`Drive upload HTTP ${res.status}`);
+  return res.json();
+}

--- a/bundles/pm-workspace/server/init-tables.js
+++ b/bundles/pm-workspace/server/init-tables.js
@@ -93,6 +93,31 @@ export async function initPmTables(db) {
     CREATE INDEX IF NOT EXISTS idx_pm_sync_state_local ON pm_sync_state(local_kind, local_id);
   `);
 
+  await initTable(db, "pm_planned_events", `
+    CREATE TABLE IF NOT EXISTS pm_planned_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      uid TEXT UNIQUE,
+      title TEXT NOT NULL,
+      start_utc TEXT NOT NULL,
+      end_utc TEXT NOT NULL,
+      location TEXT,
+      body TEXT,
+      source TEXT,
+      source_ref TEXT,
+      status TEXT DEFAULT 'proposed'
+        CHECK(status IN ('proposed','approved','rejected','exported','confirmed','cancelled')),
+      decided_at TEXT,
+      decided_via TEXT,
+      exported_at TEXT,
+      feed_file TEXT,
+      confirmed_at TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pm_planned_events_status ON pm_planned_events(status, start_utc);
+  `);
+
   await initTable(db, "pm_sync_log", `
     CREATE TABLE IF NOT EXISTS pm_sync_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/bundles/pm-workspace/server/planner.js
+++ b/bundles/pm-workspace/server/planner.js
@@ -1,0 +1,241 @@
+/**
+ * PM Workspace — planner: human-gated calendar-block proposals and the
+ * planned-events feed.
+ *
+ * Flow: a proposal (typically drafted from board/task due dates by an
+ * assistant) is stored as `proposed`. A human approves or rejects it —
+ * either via the dashboard queue or via the MCP tools (chat). Approved
+ * events are exported as a JSON feed file into a Drive folder
+ * (PLANNER_DRIVE_FOLDER_ID) where an external agent — e.g. a Power
+ * Automate flow — picks them up and creates REAL calendar events, tagged
+ * with a marker category (PLANNER_CATEGORY, default "Crow Plan").
+ *
+ * Loop guard: the calendar ingest drop (see digest/adapters/outlook.js)
+ * carries each event's categories. reconcile() matches exported events
+ * against the newest drop by marker category + subject + start time and
+ * promotes them to `confirmed` — so the system recognizes its own events
+ * and never re-proposes them.
+ *
+ * Status lifecycle:
+ *   proposed → approved → exported → confirmed
+ *            ↘ rejected            (terminal)
+ *   any non-exported status → cancelled (terminal)
+ *
+ * Each event is exported at most once (status flips to `exported` only
+ * after the feed file upload succeeds; the export query only ever selects
+ * `approved` rows).
+ */
+
+import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mintGoogleToken, uploadJson } from "./google-drive.js";
+import { readDriveDrop } from "./digest/adapters/outlook.js";
+
+const DEFAULT_CATEGORY = "Crow Plan";
+const STATUSES = ["proposed", "approved", "rejected", "exported", "confirmed", "cancelled"];
+
+export function plannerConfigured(config) {
+  return Boolean(
+    config.PLANNER_DRIVE_FOLDER_ID && config.GOOGLE_TOKEN_FILE && existsSync(config.GOOGLE_TOKEN_FILE)
+  );
+}
+
+/** Parse an ISO datetime; throws with the field name on garbage. */
+function parseIso(value, field) {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) {
+    throw new Error(`${field} must be an ISO datetime (got ${JSON.stringify(value)})`);
+  }
+  let iso = value.replace(/\.\d+/, "");
+  if (!/(Z|[+-]\d{2}:\d{2})$/.test(iso)) iso += "Z"; // bare datetime → UTC
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) throw new Error(`${field} is not a valid datetime: ${value}`);
+  return d;
+}
+
+/** Normalize any accepted datetime input to a UTC ISO string (second precision). */
+function toUtcIso(value, field) {
+  return parseIso(value, field).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/** Create a proposal (status `proposed`). Returns the stored row. */
+export async function propose(db, { title, start, end, location, body, source, source_ref }) {
+  if (!title || !String(title).trim()) throw new Error("title is required");
+  const startUtc = toUtcIso(start, "start");
+  const endUtc = toUtcIso(end, "end");
+  if (endUtc <= startUtc) throw new Error("end must be after start");
+  const uid = "pe-" + randomBytes(6).toString("hex");
+  await db.execute({
+    sql: `INSERT INTO pm_planned_events (uid, title, start_utc, end_utc, location, body, source, source_ref)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [uid, String(title).trim(), startUtc, endUtc, location || null, body || null, source || null, source_ref || null],
+  });
+  return getByUid(db, uid);
+}
+
+export async function getByUid(db, uid) {
+  const { rows } = await db.execute({
+    sql: "SELECT * FROM pm_planned_events WHERE uid = ?",
+    args: [uid],
+  });
+  return rows[0] || null;
+}
+
+/** List planned events, optionally filtered by status. Newest first. */
+export async function list(db, { status, limit = 50 } = {}) {
+  if (status && !STATUSES.includes(status)) throw new Error(`unknown status: ${status}`);
+  const { rows } = await db.execute({
+    sql: status
+      ? "SELECT * FROM pm_planned_events WHERE status = ? ORDER BY start_utc ASC LIMIT ?"
+      : "SELECT * FROM pm_planned_events ORDER BY id DESC LIMIT ?",
+    args: status ? [status, limit] : [limit],
+  });
+  return rows;
+}
+
+/**
+ * Decide a proposal: decision `approved` | `rejected` | `cancelled`.
+ * `via` records the gate surface ("dashboard" | "chat" | ...).
+ * Only `proposed` rows can be approved/rejected; `cancelled` additionally
+ * applies to `approved` rows not yet exported. Exported rows are immutable
+ * here (the external agent may already have created the event).
+ */
+export async function decide(db, { uid, decision, via }) {
+  const row = await getByUid(db, uid);
+  if (!row) throw new Error(`no planned event with uid ${uid}`);
+  const allowedFrom = decision === "cancelled" ? ["proposed", "approved"] : ["proposed"];
+  if (!["approved", "rejected", "cancelled"].includes(decision)) {
+    throw new Error(`decision must be approved, rejected, or cancelled (got ${decision})`);
+  }
+  if (!allowedFrom.includes(row.status)) {
+    throw new Error(`cannot mark ${row.status} event ${uid} as ${decision}`);
+  }
+  await db.execute({
+    sql: `UPDATE pm_planned_events
+          SET status = ?, decided_at = datetime('now'), decided_via = ?, updated_at = datetime('now')
+          WHERE uid = ?`,
+    args: [decision, via || "chat", uid],
+  });
+  return getByUid(db, uid);
+}
+
+/**
+ * Export all `approved` events as one feed file in PLANNER_DRIVE_FOLDER_ID.
+ * No-op ({ exported: 0 }) when nothing is approved. Rows flip to `exported`
+ * only after the upload succeeds.
+ */
+export async function exportApproved(db, config) {
+  if (!plannerConfigured(config)) {
+    throw new Error("planner not configured (set PLANNER_DRIVE_FOLDER_ID + GOOGLE_TOKEN_FILE)");
+  }
+  const approved = await list(db, { status: "approved", limit: 100 });
+  if (approved.length === 0) return { exported: 0 };
+
+  const category = config.PLANNER_CATEGORY || DEFAULT_CATEGORY;
+  const generatedAt = new Date().toISOString();
+  const feed = {
+    generated_at: generatedAt,
+    generator: "crow-pm-workspace",
+    category,
+    events: approved.map((e) => ({
+      uid: e.uid,
+      subject: e.title,
+      start: e.start_utc,
+      end: e.end_utc,
+      location: e.location || "",
+      body: e.body || "",
+    })),
+  };
+  const stamp = generatedAt.replace(/[-:]/g, "").replace(/\..*$/, "").replace("T", "-");
+  const name = `planned-events-${stamp}.json`;
+
+  const token = await mintGoogleToken(config.GOOGLE_TOKEN_FILE);
+  const file = await uploadJson(token, config.PLANNER_DRIVE_FOLDER_ID, name, feed);
+
+  for (const e of approved) {
+    await db.execute({
+      sql: `UPDATE pm_planned_events
+            SET status = 'exported', exported_at = datetime('now'), feed_file = ?, updated_at = datetime('now')
+            WHERE uid = ? AND status = 'approved'`,
+      args: [file.name || name, e.uid],
+    });
+  }
+  return { exported: approved.length, file: file.name || name, file_id: file.id || null };
+}
+
+/** Epoch millis for an ingest-drop datetime (bare datetimes are UTC). */
+function dropTimeMs(value) {
+  if (typeof value !== "string") return NaN;
+  let iso = value.replace(/\.\d+/, "");
+  if (!/(Z|[+-]\d{2}:\d{2})$/.test(iso)) iso += "Z";
+  return Date.parse(iso);
+}
+
+/**
+ * Reconcile `exported` events against the newest calendar ingest drop:
+ * an exported event whose subject + start (±5 min) match a drop event
+ * carrying the marker category becomes `confirmed`.
+ */
+export async function reconcile(db, config) {
+  const exported = await list(db, { status: "exported", limit: 100 });
+  if (exported.length === 0) return { checked: 0, confirmed: 0 };
+
+  if (!config.OUTLOOK_DRIVE_FOLDER_ID || !config.GOOGLE_TOKEN_FILE) {
+    return { checked: exported.length, confirmed: 0, reason: "calendar ingest not configured (OUTLOOK_DRIVE_FOLDER_ID)" };
+  }
+  const drop = await readDriveDrop(config);
+  if (drop.empty || !Array.isArray(drop.payload?.calendar)) {
+    return { checked: exported.length, confirmed: 0, reason: "no calendar data in ingest drop" };
+  }
+  const category = config.PLANNER_CATEGORY || DEFAULT_CATEGORY;
+  const marked = drop.payload.calendar.filter(
+    (e) => Array.isArray(e.categories) && e.categories.includes(category)
+  );
+
+  let confirmed = 0;
+  for (const ev of exported) {
+    const evStart = Date.parse(ev.start_utc);
+    const hit = marked.find(
+      (m) =>
+        String(m.subject || "").trim() === String(ev.title).trim() &&
+        Math.abs(dropTimeMs(m.start) - evStart) <= 5 * 60 * 1000
+    );
+    if (hit) {
+      await db.execute({
+        sql: `UPDATE pm_planned_events
+              SET status = 'confirmed', confirmed_at = datetime('now'), updated_at = datetime('now')
+              WHERE uid = ? AND status = 'exported'`,
+        args: [ev.uid],
+      });
+      confirmed += 1;
+    }
+  }
+  return { checked: exported.length, confirmed };
+}
+
+/** Digest section: pending gate decisions + exports awaiting confirmation. */
+export async function plannerSection(db) {
+  const section = { title: "Planner", available: false, items: [] };
+  try {
+    const proposed = await list(db, { status: "proposed", limit: 10 });
+    const exported = await list(db, { status: "exported", limit: 10 });
+    section.available = true;
+    for (const e of proposed) {
+      section.items.push({
+        label: e.title,
+        detail: `PROPOSED ${e.start_utc}–${e.end_utc}` + (e.source ? ` · from ${e.source}` : ""),
+        urgent: true,
+      });
+    }
+    for (const e of exported) {
+      section.items.push({
+        label: e.title,
+        detail: `exported ${e.exported_at || ""} — awaiting calendar confirmation`,
+      });
+    }
+    if (section.items.length === 0) section.note = "No pending proposals or unconfirmed exports.";
+  } catch (err) {
+    section.available = false;
+    section.reason = `planner unavailable: ${err.message}`;
+  }
+  return section;
+}

--- a/bundles/pm-workspace/server/server.js
+++ b/bundles/pm-workspace/server/server.js
@@ -19,6 +19,7 @@ import { smtpConfigured } from "./mailer.js";
 import { preview, runDigest } from "./digest/index.js";
 import { runSync } from "./sync/monday.js";
 import { loadSyncConfig } from "./sync/mapping.js";
+import * as planner from "./planner.js";
 
 function text(t) {
   return { content: [{ type: "text", text: t }] };
@@ -199,6 +200,91 @@ export function createPmWorkspaceServer(db, options = {}) {
     }
   );
 
+  // ── Planner (calendar-block proposals + planned-events feed) ──
+
+  server.tool(
+    "crow_pm_plan_propose",
+    "Propose a calendar time block (status 'proposed'). Nothing reaches the feed until a human approves it via crow_pm_plan_decide or the dashboard queue. Datetimes are ISO; bare datetimes are treated as UTC.",
+    {
+      title: z.string().min(1).max(300).describe("Event subject (kept clean — the marker is a category, not a title tag)"),
+      start: z.string().describe("Start datetime, ISO (UTC if no offset)"),
+      end: z.string().describe("End datetime, ISO (UTC if no offset)"),
+      location: z.string().max(300).optional().describe("Location"),
+      body: z.string().max(5000).optional().describe("Event body/description"),
+      source: z.string().max(100).optional().describe("Where the proposal came from, e.g. 'monday:12345678' or 'chat'"),
+      source_ref: z.string().max(500).optional().describe("Optional URL or reference for the source item"),
+    },
+    async (input) => {
+      try {
+        const row = await planner.propose(db, input);
+        return text(JSON.stringify(row, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
+  server.tool(
+    "crow_pm_plan_list",
+    "List planned events, optionally by status (proposed | approved | rejected | exported | confirmed | cancelled).",
+    {
+      status: z.enum(["proposed", "approved", "rejected", "exported", "confirmed", "cancelled"]).optional(),
+      limit: z.number().int().min(1).max(200).default(50),
+    },
+    async ({ status, limit }) => {
+      const rows = await planner.list(db, { status, limit });
+      return text(JSON.stringify(rows, null, 2));
+    }
+  );
+
+  server.tool(
+    "crow_pm_plan_decide",
+    "Record a human decision on a proposal: approved | rejected | cancelled. This is the chat gate — only call it when the human has explicitly decided. Approved events are exported to the feed on the next planner cron tick (or crow_pm_plan_export).",
+    {
+      uid: z.string().describe("Planned-event uid (pe-…)"),
+      decision: z.enum(["approved", "rejected", "cancelled"]),
+      via: z.string().max(50).default("chat").describe("Gate surface recorded on the row"),
+    },
+    async ({ uid, decision, via }) => {
+      try {
+        const row = await planner.decide(db, { uid, decision, via });
+        return text(JSON.stringify(row, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
+  server.tool(
+    "crow_pm_plan_export",
+    "Export all approved events NOW as one planned-events feed file in the configured Drive folder (instead of waiting for the planner cron). Each event is exported exactly once.",
+    {},
+    async () => {
+      try {
+        const config = loadConfig();
+        const result = await planner.exportApproved(db, config);
+        return text(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
+  server.tool(
+    "crow_pm_plan_reconcile",
+    "Match exported events against the newest calendar ingest drop (marker category + subject + start ±5 min) and mark hits 'confirmed'. Also runs automatically on the planner cron.",
+    {},
+    async () => {
+      try {
+        const config = loadConfig();
+        const result = await planner.reconcile(db, config);
+        return text(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
   // ── Status ──
 
   server.tool(
@@ -223,6 +309,7 @@ export function createPmWorkspaceServer(db, options = {}) {
           enabled: config.PM_RUN_CRON === "1",
           digest_cron: config.DIGEST_CRON,
           sync_cron: config.SYNC_CRON,
+          planner_cron: config.PLANNER_CRON,
         },
         adapters: {
           smtp: smtpConfigured(config),
@@ -230,6 +317,7 @@ export function createPmWorkspaceServer(db, options = {}) {
           google: Boolean(config.GOOGLE_TOKEN_FILE && existsSync(config.GOOGLE_TOKEN_FILE)),
           box: false,
           outlook: false,
+          planner: planner.plannerConfigured(config),
         },
         ocr: {
           configured: Boolean(config.OCR_VISION_URL && config.OCR_VISION_MODEL),

--- a/bundles/pm-workspace/skills/pm-workspace.md
+++ b/bundles/pm-workspace/skills/pm-workspace.md
@@ -13,6 +13,10 @@ triggers:
   - sync monday
   - pm workspace
   - project notes
+  - plan a block
+  - calendar block
+  - planned events
+  - approve proposal
 tools:
   - crow-pm-workspace
 ---
@@ -39,6 +43,11 @@ tools:
 | Run a Monday sync pass | `crow_pm_sync_run` |
 | Check sync health / conflicts | `crow_pm_sync_status` |
 | What's configured? | `crow_pm_status` (adapters, endpoints, cron state, DB paths) |
+| Propose a calendar block | `crow_pm_plan_propose` (status `proposed`; goes nowhere without a human decision) |
+| List proposals / feed state | `crow_pm_plan_list` |
+| Record the human's approve/reject | `crow_pm_plan_decide` (ONLY after an explicit human decision) |
+| Push approved blocks to the feed now | `crow_pm_plan_export` (otherwise the planner cron does it) |
+| Check which exports became real events | `crow_pm_plan_reconcile` |
 
 ## Boundaries — important
 - **Boards and kanban are NOT this server's job.** Task/board CRUD is done
@@ -51,6 +60,11 @@ tools:
 - Drawing notes need a saved PNG snapshot before OCR works; if
   `crow_pm_ocr_note` says there is no snapshot, the user should open the
   note in the panel editor and let it autosave first.
+- **The planner gate is a human gate.** Never call `crow_pm_plan_decide`
+  with `approved` unless the human explicitly approved that specific
+  block (in chat, or they used the dashboard queue). Proposals are cheap;
+  approvals are not yours to make. Keep event titles clean — the marker
+  is a calendar category, not a title tag.
 
 ## Workflow notes
 - After OCR, the transcription is FTS-searchable immediately and is also


### PR DESCRIPTION
## What

Adds a **planner** to the pm-workspace bundle: human-gated calendar-block proposals that flow into a **planned-events feed** an external agent (e.g. a Power Automate flow) consumes to create real calendar events.

**Lifecycle:** `proposed → approved → exported → confirmed` (plus terminal `rejected` / `cancelled`).

- An assistant proposes time blocks (`crow_pm_plan_propose`). Proposals go nowhere on their own.
- A human approves/rejects (`crow_pm_plan_decide`, `decided_via` recorded; dashboard queue panel comes in a follow-up PR — until then chat is the gate).
- Approved blocks are exported **exactly once** as `planned-events-<utc-stamp>.json` into `PLANNER_DRIVE_FOLDER_ID` (status flips only after the upload succeeds; each feed file contains only newly-approved events, so a "when a file is created" trigger is naturally idempotent).
- The consuming agent creates the events and stamps them with the marker category (`PLANNER_CATEGORY`, default `Crow Plan`).
- **Loop guard:** `reconcile` matches exported events against the newest calendar ingest drop (marker category + subject + start ±5 min) and promotes them to `confirmed`, so the system recognizes its own events and never re-proposes them.

## Changes

- New `pm_planned_events` table (idempotent init)
- New `server/planner.js` (propose/list/decide/export/reconcile + digest section)
- New `server/google-drive.js` — shared minimal Drive REST helpers (token mint, newest-in-folder, download JSON, multipart upload); the Outlook adapter is refactored onto them and its drop reader is now exported
- Planner cron (`PLANNER_CRON`, default `*/15 * * * *`): auto-export approved + reconcile, only when `PM_RUN_CRON=1` and the planner is configured
- Digest gains a **Planner** section (pending gate decisions + unconfirmed exports)
- 5 new MCP tools; `crow_pm_status` reports planner config/cron
- Bundle skill doc marks approval as strictly human ("approvals are not yours to make")

## Testing

- 21-assertion functional test of the full lifecycle against a scratch DB with Drive fetch stubbed: validation, gate transitions (including illegal ones), export-exactly-once, feed shape, reconcile matching (category/subject/time-window), digest section
- MCP server construction smoke test (all tools register)
- `node --check` on all touched modules; manifest JSON validated