### PR TITLE
fix(dashboard): co-hosted instances resolve CROW_HOME, not homedir (nest grid, skills, add-on settings, companion target)

### DIFF
--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4796,7 +4796,10 @@
           "NTFY_URL",
           "GOOGLE_TOKEN_FILE",
           "CROW_GATEWAY_URL",
-          "CROW_TASKS_DB_PATH"
+          "CROW_TASKS_DB_PATH",
+          "PLANNER_DRIVE_FOLDER_ID",
+          "PLANNER_CATEGORY",
+          "PLANNER_CRON"
         ]
       },
       "panel": "panel/pm-workspace.js",
@@ -4915,6 +4918,21 @@
         {
           "name": "CROW_TASKS_DB_PATH",
           "description": "Path to the kanban tasks DB (default $CROW_DATA_DIR/tasks.db)",
+          "required": false
+        },
+        {
+          "name": "PLANNER_DRIVE_FOLDER_ID",
+          "description": "Drive folder where approved planned-events feed files are written for an external agent (e.g. Power Automate) to create real calendar events",
+          "required": false
+        },
+        {
+          "name": "PLANNER_CATEGORY",
+          "description": "Marker category stamped on planner-created calendar events; the reconcile loop-guard matches on it (default: Crow Plan)",
+          "required": false
+        },
+        {
+          "name": "PLANNER_CRON",
+          "description": "Cron expression for planner export/reconcile runs (default: */15 * * * *)",
           "required": false
         }
       ],

--- a/servers/gateway/dashboard/companion-target.js
+++ b/servers/gateway/dashboard/companion-target.js
@@ -38,7 +38,9 @@ import { getPeerOverview } from "./overview-cache.js";
 
 function isLocalCompanionRunning() {
   try {
-    const installedPath = resolve(homedir(), ".crow", "installed.json");
+    // Resolved via CROW_HOME — a co-hosted instance must not report the
+    // PRIMARY instance's companion as its own local companion.
+    const installedPath = resolve(process.env.CROW_HOME || resolve(homedir(), ".crow"), "installed.json");
     if (!existsSync(installedPath)) return false;
     const installed = JSON.parse(readFileSync(installedPath, "utf-8"));
     const list = Array.isArray(installed) ? installed : Object.values(installed);

--- a/servers/gateway/dashboard/panels/nest/data-queries.js
+++ b/servers/gateway/dashboard/panels/nest/data-queries.js
@@ -54,9 +54,11 @@ export async function getNestData(db, lang, opts = {}) {
     pinnedItems = rows[0]?.value ? JSON.parse(rows[0].value) : [];
   } catch {}
 
-  // Installed bundles
+  // Installed bundles — resolved via CROW_HOME so co-hosted instances (MPA,
+  // alternate workspaces) render their OWN installed.json, not the primary's.
   let bundles = [];
-  const installedPath = join(homedir(), ".crow", "installed.json");
+  const crowHome = process.env.CROW_HOME || join(homedir(), ".crow");
+  const installedPath = join(crowHome, "installed.json");
   if (existsSync(installedPath)) {
     try {
       let installed = JSON.parse(readFileSync(installedPath, "utf-8"));
@@ -73,9 +75,9 @@ export async function getNestData(db, lang, opts = {}) {
         let icon = null;
         let category = null;
         const installedAt = meta.installedAt || null;
-        // Try to load manifest from ~/.crow/bundles/ or repo bundles/
+        // Try to load manifest from <CROW_HOME>/bundles/ or repo bundles/
         const manifestPaths = [
-          join(homedir(), ".crow", "bundles", id, "manifest.json"),
+          join(crowHome, "bundles", id, "manifest.json"),
           join(import.meta.dirname, "../../../../../bundles", id, "manifest.json"),
         ];
         for (const mp of manifestPaths) {

--- a/servers/gateway/dashboard/panels/skills.js
+++ b/servers/gateway/dashboard/panels/skills.js
@@ -18,7 +18,9 @@ import { getInstanceSyncManager } from "../../../sharing/server.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_SKILLS_DIR = join(__dirname, "../../../../skills");
-const USER_SKILLS_DIR = join(homedir(), ".crow", "skills");
+// Resolved via CROW_HOME so co-hosted instances (MPA, alternate workspaces)
+// read and write their OWN user skills, not the primary instance's.
+const USER_SKILLS_DIR = join(process.env.CROW_HOME || join(homedir(), ".crow"), "skills");
 
 function listSkillFiles(dir) {
   try {

--- a/servers/gateway/dashboard/settings/registry.js
+++ b/servers/gateway/dashboard/settings/registry.js
@@ -86,7 +86,9 @@ export async function dispatchAction(sectionsList, { req, res, db, action }) {
  * Load add-on settings sections from ~/.crow/bundles/<id>/settings-section.js
  */
 export async function loadAddonSettings() {
-  const crowDir = join(homedir(), ".crow");
+  // Resolved via CROW_HOME so co-hosted instances load their OWN add-on
+  // settings sections, not the primary instance's.
+  const crowDir = process.env.CROW_HOME || join(homedir(), ".crow");
   const installedPath = join(crowDir, "installed.json");
 
   if (!existsSync(installedPath)) return;

--- a/tests/nest-crow-home.test.js
+++ b/tests/nest-crow-home.test.js
@@ -1,0 +1,91 @@
+/**
+ * Nest home grid must render THIS instance's installed bundles — resolved via
+ * CROW_HOME — never the primary instance's ~/.crow/installed.json.
+ *
+ * Regression: co-hosted gateways (MPA, R4) rendered the primary instance's
+ * personal bundle tiles because data-queries.js hardcoded homedir()/.crow.
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Scratch CROW_HOME set BEFORE the dynamic import (repo pattern, commit 71ad6104).
+const scratch = mkdtempSync(join(tmpdir(), "nest-crowhome-"));
+process.env.CROW_HOME = scratch;
+process.env.CROW_DATA_DIR = join(scratch, "data");
+mkdirSync(join(scratch, "data"), { recursive: true });
+
+test("nest home grid reads installed bundles from CROW_HOME, not homedir", async () => {
+  writeFileSync(
+    join(scratch, "installed.json"),
+    JSON.stringify([{ id: "scratch-bundle", type: "bundle", installedAt: "2026-07-17T00:00:00Z" }])
+  );
+  mkdirSync(join(scratch, "bundles", "scratch-bundle"), { recursive: true });
+  writeFileSync(
+    join(scratch, "bundles", "scratch-bundle", "manifest.json"),
+    JSON.stringify({ name: "Scratch Bundle", icon: "database", category: "test" })
+  );
+
+  const { getNestData } = await import("../servers/gateway/dashboard/panels/nest/data-queries.js");
+  const db = { execute: async () => ({ rows: [] }) };
+  const data = await getNestData(db, "en");
+
+  const ids = data.bundles.map((b) => b.id);
+  // Leak guard: every rendered bundle tile must come from THIS instance's
+  // installed.json — on a host whose real ~/.crow/installed.json has bundles,
+  // the pre-fix code returns those instead.
+  assert.deepStrictEqual(ids, ["scratch-bundle"], `bundle tiles leaked from outside CROW_HOME: ${JSON.stringify(ids)}`);
+  // Manifest metadata must resolve from CROW_HOME/bundles/<id>/ as well.
+  const sb = data.bundles.find((b) => b.id === "scratch-bundle");
+  assert.strictEqual(sb.name, "Scratch Bundle");
+});
+
+test("skills panel lists user skills from CROW_HOME, not homedir", async () => {
+  mkdirSync(join(scratch, "skills"), { recursive: true });
+  writeFileSync(
+    join(scratch, "skills", "scratch-only-skill.md"),
+    "---\ntitle: Scratch Only Skill\n---\nbody\n"
+  );
+
+  const { default: skillsPanel } = await import("../servers/gateway/dashboard/panels/skills.js");
+  const req = { method: "GET", query: {} };
+  const res = { redirect: () => {} };
+  const html = await skillsPanel.handler(req, res, {
+    db: { execute: async () => ({ rows: [] }) },
+    layout: ({ content }) => content,
+    lang: "en",
+  });
+
+  assert.ok(
+    String(html).includes("scratch-only-skill"),
+    "user skill in CROW_HOME/skills must appear in the skills list"
+  );
+});
+
+test("add-on settings sections load from CROW_HOME, not homedir", async () => {
+  // Extend the scratch installed.json with an add-on that ships a settings section.
+  writeFileSync(
+    join(scratch, "installed.json"),
+    JSON.stringify([
+      { id: "scratch-bundle", type: "bundle", installedAt: "2026-07-17T00:00:00Z" },
+      { id: "scratch-addon", type: "bundle", installedAt: "2026-07-17T00:00:00Z" },
+    ])
+  );
+  mkdirSync(join(scratch, "bundles", "scratch-addon"), { recursive: true });
+  writeFileSync(
+    join(scratch, "bundles", "scratch-addon", "settings-section.js"),
+    "export default { id: 'scratch-addon-section', label: 'Scratch Addon', render: () => '' };\n"
+  );
+
+  const { loadAddonSettings, getSettingsSection } = await import(
+    "../servers/gateway/dashboard/settings/registry.js"
+  );
+  await loadAddonSettings();
+
+  assert.ok(
+    getSettingsSection("scratch-addon-section"),
+    "settings-section.js under CROW_HOME/bundles must register for this instance"
+  );
+});


### PR DESCRIPTION
## What

Four dashboard sites hardcoded `~/.crow`, so a co-hosted gateway (MPA, or the new R4 work workspace) rendered or acted on the **primary** instance's state instead of its own:

| Site | Leak |
|---|---|
| `panels/nest/data-queries.js:59,:78` | Home-grid bundle tiles came from the primary's `installed.json` — observed live: a fresh work instance showed the operator's personal model/NVR/companion bundles, with live docker status dots (shared daemon) |
| `panels/skills.js:21` | Skills panel listed/wrote user skills under the primary's `~/.crow/skills` |
| `settings/registry.js` `loadAddonSettings()` | Add-on settings sections loaded from the primary's bundles dir |
| `companion-target.js:41` | A co-hosted instance reported the primary's running companion as its own local companion (verified live: `crow-companion` Up ⇒ the R4 instance resolved a "local" companion it doesn't have) |

All four now resolve via `CROW_HOME` with the existing `homedir()` fallback — the same pattern as `extensions/data-queries.js` `CROW_DIR` and `peer-credentials.js`.

## Tests (TDD, RED verified pre-fix)

`tests/nest-crow-home.test.js` — scratch `CROW_HOME` set before dynamic import (repo pattern `71ad6104`):
1. **nest grid**: bundle tiles must equal exactly the scratch instance's `installed.json` (pre-fix RED: returned the real host's 8 personal bundles); manifest metadata must resolve from `CROW_HOME/bundles/`
2. **skills panel**: a user skill in `CROW_HOME/skills` appears in the rendered list (pre-fix RED)
3. **add-on settings**: a `settings-section.js` under `CROW_HOME/bundles/<id>/` registers (pre-fix RED)

The pre-fix RED runs are the mutation evidence for each guard. **`companion-target.js` ships without a dedicated test**: a deterministic test needs a docker seam (without it, the test is vacuous on any host not running `crow-companion`) — flagged rather than papered over; the fix is the same one-line class as the tested three.

## Also carried: registry regen (main drift)

`build-registry --check` was RED on main: the pm-workspace planner PRs added `PLANNER_DRIVE_FOLDER_ID` / `PLANNER_CATEGORY` / `PLANNER_CRON` to the manifest without regenerating `registry/add-ons.json`. Mechanical regen committed separately (same class as the rookery regen carried by #202).

## Gates

- Full suite, scratch env: **2020 pass / 0 fail / 0 skips** (baseline 2017 + 3 new; the single pre-regen fail was the registry drift above)
- `check-port-allocation`: OK, zero error lines
- `build-registry --check`: OK after regen

## Post-merge live verification plan

Deploy fleet, then reload the R4 (`:8449`) and MPA dashboards: the primary's personal bundle tiles must be gone from their home grids (R4 should show only its own 5 installed bundles' tiles).