### PR TITLE
fix(pi-bots): portable pi-engine resolution — kill the hardcoded nvm paths, honest missing-engine error

### DIFF
--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -22,7 +22,7 @@ import Database from "better-sqlite3";
 import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync, readFileSync, appendFileSync, existsSync, mkdtempSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { countLivePi, LIFECYCLE_DEFAULTS } from "./pi_lifecycle.mjs";
 import { writeBotMcp } from "./mcp_writer.mjs";
 import { validateExtensions, isMultiAgentCapable } from "./pi_extensions_allowlist.mjs";
@@ -30,6 +30,7 @@ import { resolveModel, escalateRequested, stripEscalateToken } from "./model_res
 import { getTrackerContext, kanbanText, cardStatus, resolveTrackerType } from "./tracker.mjs";
 import { resolveSkills, resolveSkill, skillDirs } from "./skill_resolver.mjs";
 import { resolveCrowHome } from "./ext_registry.mjs";
+import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
 import { proposalsDir, selfAuthoringPromptBlock } from "./skill_proposals.mjs";
 import { gatewayHint as resolveGatewayHint } from "./gateways/index.mjs";
 import { runSkillReview } from "./skill_review.mjs";
@@ -43,10 +44,11 @@ import { parsePlanRef, containedRealPath } from "../../servers/gateway/routes/pl
 import { extractPlanFileLine, buildPlanPrompt } from "./plan_dispatch.mjs";
 
 const HOME = process.env.HOME || homedir();
-const NODE = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
 // Package was renamed from @mariozechner/pi-coding-agent to
 // @earendil-works/pi-coding-agent (still 'pi' binary; v0.74.2 verified).
-const PI_CLI = HOME + "/.nvm/versions/node/v20.20.2/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js";
+// node = the process running the bridge; pi cli via the pi_resolver ladder
+// (PIBOT_PI_CLI env → bot-engine bundle → repo dep → running node's global
+// root) — never a hardcoded host layout.
 const CROW_DB = botsDbPath();
 // Skill-file roots are resolved per-instance by skill_resolver (A3):
 // <crowHome>/skills, then ~/.crow/skills, then the repo ~/crow/skills.
@@ -108,8 +110,10 @@ export class PiRpc {
     this.resolved = resolved;
     // Test seam: nodeBin/cliPath let tests drive the exit-surface path with a
     // stub child instead of a real pi (which would wire live MCP servers).
-    const nodeBin = opts.nodeBin || NODE;
-    const cliPath = opts.cliPath || PI_CLI;
+    // Without the seam, requirePiCli throws the honest "bot engine (pi) is
+    // not installed" error instead of spawning a phantom path.
+    const nodeBin = opts.nodeBin || resolveNodeBin();
+    const cliPath = opts.cliPath || requirePiCli().cliPath;
     const args = [cliPath, "--mode", "rpc", "--provider", resolved.provider, "--model", resolved.model,
       "--session-dir", sessionDir + "/sessions"];
     // Phase 3.1 (R9/R11): multi-agent is allowed iff the operator opted in
@@ -150,7 +154,7 @@ export class PiRpc {
         .concat(opts.selfAuthoringDir);
     }
     const env = Object.assign({}, process.env,
-      { PATH: HOME + "/.nvm/versions/node/v20.20.2/bin:" + (process.env.PATH || ""),
+      { PATH: dirname(nodeBin) + ":" + (process.env.PATH || ""),
         PI_PROVIDER: resolved.provider,
         PIBOT_SUBAGENT_DEPTH: "0",
         PI_BOT_PERMISSION_POLICY: JSON.stringify(piPolicy) },

--- a/scripts/pi-bots/bridge_gmail_e2e.mjs
+++ b/scripts/pi-bots/bridge_gmail_e2e.mjs
@@ -11,11 +11,12 @@
  *
  * Run on crow. Pre-seeded thread id passed as argv[2].
  */
+import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
 import { handleInbound, stopSession } from "./bridge.mjs";
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 
-const NODE = "/home/kh0pp/.nvm/versions/node/v20.20.2/bin/node";
+const NODE = resolveNodeBin();
 const GIO = "/home/kh0pp/.s0-spike/gmail_io.mjs";
 const BOT = "research-scout";
 const THREAD = process.argv[2];

--- a/scripts/pi-bots/p3_1_e2e.mjs
+++ b/scripts/pi-bots/p3_1_e2e.mjs
@@ -28,6 +28,8 @@
  * No Gmail; namespaced p31-e2e-* artifacts torn down; production untouched;
  * crow.db busy_timeout-only.
  */
+import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
+import { dirname } from "node:path";
 import Database from "better-sqlite3";
 import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
@@ -35,8 +37,8 @@ import { handleInbound } from "./bridge.mjs";
 import { isMultiAgentCapable } from "./pi_extensions_allowlist.mjs";
 
 const HOME = "/home/kh0pp";
-const NODE = HOME + "/.nvm/versions/node/v20.20.2/bin/node";
-const PI_CLI = HOME + "/.nvm/versions/node/v20.20.2/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js";
+const NODE = resolveNodeBin();
+const PI_CLI = requirePiCli().cliPath;
 const CROW_DB = process.env.CROW_DB_PATH || HOME + "/.crow-mpa/data/crow.db";
 const TASKS_DB = process.env.CROW_TASKS_DB_PATH || HOME + "/.crow-mpa/data/tasks.db";
 const CAPABLE = "alibaba-coding/qwen3.6-plus"; // on MULTI_AGENT_CAPABLE
@@ -115,7 +117,7 @@ const run = async () => {
   console.log("\n=== R10: child-shaped pi inherits per-bot policy + depth (env propagation) ===");
   const childPolicy = JSON.stringify({ bash: "deny", write_paths: [maSdir], multi_agent: true, model_capable: true });
   const childEnv = Object.assign({}, process.env, {
-    PATH: HOME + "/.nvm/versions/node/v20.20.2/bin:" + (process.env.PATH || ""),
+    PATH: dirname(resolveNodeBin()) + ":" + (process.env.PATH || ""),
     PI_PROVIDER: "alibaba-coding",
     PIBOT_SUBAGENT_DEPTH: "1", // subagent/index.ts sets this on every child it spawns
     PI_BOT_PERMISSION_POLICY: childPolicy,

--- a/scripts/pi-bots/pi_resolver.mjs
+++ b/scripts/pi-bots/pi_resolver.mjs
@@ -1,0 +1,76 @@
+/**
+ * pi engine resolution — find the pi CLI and node binary without assuming any
+ * host-specific layout (the old code hardcoded the maintainer's
+ * ~/.nvm/versions/node/v20.20.2 paths, which exist on exactly one machine).
+ *
+ * Ladder (first hit wins):
+ *   1. PIBOT_PI_CLI env — explicit operator override, trusted verbatim (a bad
+ *      path surfaces as an honest spawn error rather than being second-guessed).
+ *   2. <CROW_HOME>/bundles/bot-engine/<pkg>/dist/cli.js — the bot-engine
+ *      extension payload (per-instance, npm-installed at bundle install time).
+ *   3. <repo>/node_modules/<pkg>/dist/cli.js — pi as a declared dependency.
+ *   4. <dirname(execPath)>/../lib/node_modules/<pkg>/dist/cli.js — the global
+ *      npm root of the RUNNING node. Covers nvm (<prefix>/bin/node +
+ *      <prefix>/lib/node_modules), /usr/local, and Debian's /usr layout.
+ *   5. null — callers must surface "bot engine (pi) is not installed", never a
+ *      buried ENOENT/MODULE_NOT_FOUND from a phantom path.
+ */
+import { existsSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const PI_CLI_REL = join(
+  "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js"
+);
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** The node that runs the bridge is the node that runs pi. */
+export function resolveNodeBin() {
+  return process.execPath;
+}
+
+/**
+ * @param {object} [opts]
+ * @param {object} [opts.env]       defaults to process.env
+ * @param {string} [opts.crowHome]  defaults to CROW_HOME || ~/.crow
+ * @param {string} [opts.repoRoot]  defaults to this repo checkout
+ * @param {string} [opts.execPath]  defaults to process.execPath
+ * @returns {{cliPath: string, source: "env"|"bundle"|"repo"|"global"} | null}
+ */
+export function resolvePiCli(opts = {}) {
+  const env = opts.env || process.env;
+  const crowHome = opts.crowHome || env.CROW_HOME || join(homedir(), ".crow");
+  const repoRoot = opts.repoRoot || REPO_ROOT;
+  const execPath = opts.execPath || process.execPath;
+
+  if (env.PIBOT_PI_CLI) return { cliPath: env.PIBOT_PI_CLI, source: "env" };
+
+  const bundle = join(crowHome, "bundles", "bot-engine", PI_CLI_REL);
+  if (existsSync(bundle)) return { cliPath: bundle, source: "bundle" };
+
+  const repo = join(repoRoot, PI_CLI_REL);
+  if (existsSync(repo)) return { cliPath: repo, source: "repo" };
+
+  const global = join(dirname(execPath), "..", "lib", PI_CLI_REL);
+  if (existsSync(global)) return { cliPath: global, source: "global" };
+
+  return null;
+}
+
+/** resolvePiCli or throw the honest missing-engine error (never a phantom path). */
+export function requirePiCli(opts = {}) {
+  const resolved = resolvePiCli(opts);
+  if (!resolved) throw new Error(missingEngineMessage());
+  return resolved;
+}
+
+/** One-line, actionable message for every missing-engine surface. */
+export function missingEngineMessage() {
+  return (
+    "bot engine (pi) is not installed — install the bot-engine extension, " +
+    "run `npm i -g @earendil-works/pi-coding-agent` under the gateway's node, " +
+    "or set PIBOT_PI_CLI to the engine's dist/cli.js"
+  );
+}

--- a/scripts/pi-bots/s0_mcp_probe.mjs
+++ b/scripts/pi-bots/s0_mcp_probe.mjs
@@ -18,6 +18,7 @@
  * Exit 0 + "S0-PROBE OK" on success; non-zero + diagnostic on failure.
  */
 
+import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
 import { spawn } from "node:child_process";
 import { homedir } from "node:os";
 
@@ -50,7 +51,7 @@ if (!t) {
   process.exit(2);
 }
 
-const NODE = `${HOME}/.nvm/versions/node/v20.20.2/bin/node`;
+const NODE = resolveNodeBin();
 
 const child = spawn(NODE, t.args, {
   cwd: t.cwd,

--- a/scripts/pi-bots/s2_rpc_drive.mjs
+++ b/scripts/pi-bots/s2_rpc_drive.mjs
@@ -22,11 +22,13 @@
  * Exit 0 iff all PASS.
  */
 
+import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
+import { dirname } from "node:path";
 import { spawn } from "node:child_process";
 
 const HOME = "/home/kh0pp";
-const NODE = `${HOME}/.nvm/versions/node/v20.20.2/bin/node`;
-const PI_CLI = `${HOME}/.nvm/versions/node/v20.20.2/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js`;
+const NODE = resolveNodeBin();
+const PI_CLI = requirePiCli().cliPath;
 const SPK = `${HOME}/.pi-spike`;
 const PINNED_CWD = `${SPK}/cwd`;
 const SESSION_DIR = `${SPK}/sessions-s2`;
@@ -51,7 +53,7 @@ class PiRpc {
       cwd: cwd || PINNED_CWD,
       env: {
         ...process.env,
-        PATH: `${HOME}/.nvm/versions/node/v20.20.2/bin:${process.env.PATH || ""}`,
+        PATH: `${dirname(resolveNodeBin())}:${process.env.PATH || ""}`,
         PI_CODING_AGENT_DIR: configDir,
         PI_PROVIDER: PROVIDER,
       },

--- a/scripts/pi-bots/s4_regex_schema.mjs
+++ b/scripts/pi-bots/s4_regex_schema.mjs
@@ -16,11 +16,13 @@
  * <function= in assistant text, upstream 500 / "Failed to parse input", an
  * extension_error, or agent_end with NO successful s4 tool_execution_end.
  */
+import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
+import { dirname } from "node:path";
 import { spawn } from "node:child_process";
 
 const HOME = "/home/kh0pp";
-const NODE = `${HOME}/.nvm/versions/node/v20.20.2/bin/node`;
-const PI_CLI = `${HOME}/.nvm/versions/node/v20.20.2/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js`;
+const NODE = resolveNodeBin();
+const PI_CLI = requirePiCli().cliPath;
 const SPK = `${HOME}/.pi-spike`;
 const CWD_S4 = `${SPK}/cwd-s4`;
 const SDIR = `${SPK}/sessions-s4`;
@@ -34,7 +36,7 @@ class PiRpc {
       "--session-dir", SDIR, "--no-session", "--tools", tools];
     this.proc = spawn(NODE, args, {
       cwd: CWD_S4,
-      env: { ...process.env, PATH: `${HOME}/.nvm/versions/node/v20.20.2/bin:${process.env.PATH || ""}`,
+      env: { ...process.env, PATH: `${dirname(resolveNodeBin())}:${process.env.PATH || ""}`,
         PI_CODING_AGENT_DIR: `${SPK}/agent-real`, PI_PROVIDER: provider },
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/tests/pibot-pi-resolver.test.js
+++ b/tests/pibot-pi-resolver.test.js
@@ -1,0 +1,95 @@
+/**
+ * pi engine resolution ladder — the bridge must find the pi CLI without
+ * assuming the maintainer's nvm layout, and must resolve node from the
+ * running process, not a hardcoded version path.
+ *
+ * Ladder (first hit wins):
+ *   1. PIBOT_PI_CLI env (explicit operator override — trusted verbatim)
+ *   2. <CROW_HOME>/bundles/bot-engine/node_modules/@earendil-works/pi-coding-agent/dist/cli.js
+ *      (the future bot-engine extension payload)
+ *   3. <repo>/node_modules/@earendil-works/pi-coding-agent/dist/cli.js
+ *      (pi as a declared dependency, if that packaging is ever chosen)
+ *   4. <dirname(execPath)>/../lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js
+ *      (global npm root of the RUNNING node — covers nvm, /usr/local, and /usr layouts)
+ *   5. null → callers surface an honest "bot engine not installed" error.
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+const PI_REL = "node_modules/@earendil-works/pi-coding-agent/dist/cli.js";
+
+function scratchWith(relPath) {
+  const root = mkdtempSync(join(tmpdir(), "pi-resolve-"));
+  if (relPath) {
+    const p = join(root, relPath);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, "// stub cli\n");
+    return { root, cli: p };
+  }
+  return { root, cli: null };
+}
+
+const { resolvePiCli, resolveNodeBin } = await import("../scripts/pi-bots/pi_resolver.mjs");
+
+test("env override PIBOT_PI_CLI wins verbatim, even if the file is absent", () => {
+  const out = resolvePiCli({
+    env: { PIBOT_PI_CLI: "/explicit/operator/path/cli.js" },
+    crowHome: "/nonexistent-a",
+    repoRoot: "/nonexistent-b",
+    execPath: "/nonexistent-c/bin/node",
+  });
+  assert.deepStrictEqual(out, { cliPath: "/explicit/operator/path/cli.js", source: "env" });
+});
+
+test("bot-engine bundle payload under CROW_HOME is found", () => {
+  const { root, cli } = scratchWith(join("bundles", "bot-engine", PI_REL));
+  const out = resolvePiCli({ env: {}, crowHome: root, repoRoot: "/nonexistent-b", execPath: "/nonexistent-c/bin/node" });
+  assert.deepStrictEqual(out, { cliPath: cli, source: "bundle" });
+});
+
+test("repo node_modules dependency is found when no bundle exists", () => {
+  const { root, cli } = scratchWith(PI_REL);
+  const out = resolvePiCli({ env: {}, crowHome: "/nonexistent-a", repoRoot: root, execPath: "/nonexistent-c/bin/node" });
+  assert.deepStrictEqual(out, { cliPath: cli, source: "repo" });
+});
+
+test("global npm root of the running node is found (nvm/apt/usr-local layouts)", () => {
+  // Simulate <prefix>/bin/node + <prefix>/lib/node_modules/... (the invariant
+  // shared by nvm, /usr/local, and Debian's /usr node).
+  const { root } = scratchWith(null);
+  const cli = join(root, "lib", PI_REL);
+  mkdirSync(dirname(cli), { recursive: true });
+  writeFileSync(cli, "// stub cli\n");
+  const execPath = join(root, "bin", "node");
+  const out = resolvePiCli({ env: {}, crowHome: "/nonexistent-a", repoRoot: "/nonexistent-b", execPath });
+  assert.deepStrictEqual(out, { cliPath: cli, source: "global" });
+});
+
+test("nothing found → null (callers must surface an honest missing-engine error)", () => {
+  const out = resolvePiCli({ env: {}, crowHome: "/nonexistent-a", repoRoot: "/nonexistent-b", execPath: "/nonexistent-c/bin/node" });
+  assert.strictEqual(out, null);
+});
+
+test("resolveNodeBin is the running node, never a hardcoded version path", () => {
+  assert.strictEqual(resolveNodeBin(), process.execPath);
+});
+
+test("requirePiCli throws the honest missing-engine message when nothing resolves", async () => {
+  const { requirePiCli } = await import("../scripts/pi-bots/pi_resolver.mjs");
+  assert.throws(
+    () => requirePiCli({ env: {}, crowHome: "/nonexistent-a", repoRoot: "/nonexistent-b", execPath: "/nonexistent-c/bin/node" }),
+    (e) => {
+      assert.match(e.message, /bot engine \(pi\) is not installed/);
+      assert.match(e.message, /bot-engine extension/);
+      assert.match(e.message, /PIBOT_PI_CLI/);
+      return true;
+    }
+  );
+  // And passes through a successful resolution unchanged.
+  const { root, cli } = scratchWith(join("bundles", "bot-engine", PI_REL));
+  const ok = requirePiCli({ env: {}, crowHome: root, repoRoot: "/nonexistent-b", execPath: "/nonexistent-c/bin/node" });
+  assert.deepStrictEqual(ok, { cliPath: cli, source: "bundle" });
+});


### PR DESCRIPTION
## What

The bot engine (`@earendil-works/pi-coding-agent`) was an **undeclared dependency**: not in `package.json`, never installed by `crow-install.sh`, and spawned from hardcoded `~/.nvm/versions/node/v20.20.2/...` paths that exist on exactly one machine. On a fresh install, Bot Builder's UI works but the first real bot turn dies on a phantom-path spawn; on grackle the hardcode misses the pi that IS installed (under `/usr/lib/node_modules`), so this deploy actively fixes grackle's channel bots.

New `scripts/pi-bots/pi_resolver.mjs`:
- **node** = `process.execPath` (the node running the bridge runs pi — no nvm assumption)
- **pi cli ladder** (first hit wins): `PIBOT_PI_CLI` env (operator override, verbatim) → `CROW_HOME/bundles/bot-engine/node_modules/...` (the approved future bot-engine bundle payload) → repo `node_modules` (if pi ever becomes a declared dep) → the running node's global npm root (`<prefix>/lib/node_modules` — covers nvm, `/usr/local`, and Debian `/usr` layouts) → **`requirePiCli()` throws an honest "bot engine (pi) is not installed" error** naming the three remedies. Never a buried ENOENT.

Wired into `bridge.mjs` (spawn + PATH env prefix; `opts.nodeBin/cliPath` test seam unchanged) and the five dev/E2E harness scripts. Zero nvm hardcodes remain under `scripts/pi-bots/`. `pi_lifecycle`'s `PI_CLI_MARK` cmdline grep matches every ladder outcome (path-suffix based) — no change needed.

`PiRpc` is only constructed inside per-turn functions, so on an engine-less machine the error surfaces per-turn through the existing "(bridge error: …)" relay — imports never throw.

## Context

This is the packaging-neutral core of the Kevin-approved direction (2026-07-17): pi ships as a **bot-engine extension** offered as a directed onboarding step, gating agent channels (Gmail/Discord/Telegram/Slack) — voice channels don't use pi and stay ungated. The bundle, privileged unit install, readiness-checklist row, and theme-collections integration are specced in the 2026-07-17 review doc (Item C4) and land with that arc; every packaging option needs this resolution ladder first.

## Tests (TDD, RED verified)

`tests/pibot-pi-resolver.test.js` — 7 tests: env-override verbatim, bundle rung, repo rung, global-root rung (simulated `<prefix>/bin` + `<prefix>/lib` layout), null-when-absent, `resolveNodeBin === process.execPath`, and `requirePiCli` throwing the actionable message / passing through success. RED runs verified (module absent → ERR_MODULE_NOT_FOUND; then `requirePiCli` missing). Existing `pibot-bridge-exit-surface` test still green (proves the seam is intact).

## Gates

- Full suite, scratch env: **2027 pass / 0 fail / 0 skips** (baseline 2020 + 7)
- `check-port-allocation`: OK · `build-registry --check`: OK

## Post-merge verification plan

Deploy fleet; on crow confirm a real bot turn still works (resolver rung: global via nvm node); on grackle confirm the bridge now resolves `/usr/lib/node_modules/...` (journal shows no phantom-path spawn).