### PR TITLE
fix(ci): image-freshness — pinned issue reuse, real image resolution, fresh-install fixes

### DIFF
--- a/.github/workflows/image-freshness.yml
+++ b/.github/workflows/image-freshness.yml
@@ -2,6 +2,10 @@ name: Bundle Image Freshness Check
 
 # Nightly check that every bundle's docker image still pulls.
 # Catches upstream image deletions, repo renames, and tag deprecations.
+#
+# Reporting contract: scheduled failures update ONE pinned issue (found by the
+# bundle-image-stale label) instead of filing a new issue per night; a passing
+# scheduled run closes it. workflow_dispatch runs never touch issues.
 
 on:
   schedule:
@@ -19,17 +23,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Extract bundle images
+        # The script resolves ${VAR:-default} interpolation in image references
+        # and skips locally-built (build:) services — a raw grep here reported
+        # literal `${VLLM_ROCM_IMAGE}` and local build tags as missing images
+        # for months. See the script header for why `docker compose config` is
+        # not used (bundles with required install-time env fail it).
         run: |
           set -e
-          : > /tmp/images.txt
-          for compose in bundles/*/docker-compose.yml; do
-            [ -f "$compose" ] || continue
-            grep -E '^\s*image:\s+' "$compose" | grep -v '^\s*#' | \
-              sed -E 's/^\s*image:\s*//' | tr -d '"' | tr -d "'" >> /tmp/images.txt || true
-          done
-          sort -u /tmp/images.txt -o /tmp/images.txt
-          echo "Found $(wc -l < /tmp/images.txt) unique images:"
+          python3 scripts/extract-bundle-images.py /tmp/images.txt /tmp/parse-failures.txt
+          echo "Images to check:"
           cat /tmp/images.txt
+          if [ -s /tmp/parse-failures.txt ]; then
+            echo "Compose files that failed to parse (their images were NOT checked):"
+            cat /tmp/parse-failures.txt
+          fi
 
       - name: Pull each image
         id: pull
@@ -37,11 +44,21 @@ jobs:
           set +e
           fail=0
           : > /tmp/missing.txt
+          # A compose file that doesn't parse (or an image reference that can't
+          # be resolved) means images silently escaped the check — treat that
+          # as a failure, not a skip. The lines are already self-describing.
+          if [ -s /tmp/parse-failures.txt ]; then
+            cat /tmp/parse-failures.txt >> /tmp/missing.txt
+            fail=1
+          fi
           while IFS= read -r img; do
             [ -z "$img" ] && continue
             echo "::group::Pulling $img"
             if docker pull "$img" >/dev/null 2>&1; then
               echo "OK"
+              # Free the layers immediately — the full set (incl. multi-GB
+              # vLLM/ROCm images) would exhaust runner disk if accumulated.
+              docker rmi "$img" >/dev/null 2>&1 || true
             else
               echo "FAIL"
               echo "$img" >> /tmp/missing.txt
@@ -51,25 +68,84 @@ jobs:
           done < /tmp/images.txt
           exit $fail
 
-      - name: File issue on failure
+      - name: Update the pinned issue on failure
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            let body = "Nightly image-freshness check failed.\n\n";
+            const LABEL = 'bundle-image-stale';
+            const TITLE = 'Bundle image-freshness check failed';
+            let list;
             try {
               const missing = fs.readFileSync('/tmp/missing.txt', 'utf8').trim().split('\n').filter(Boolean);
-              body += "Images that failed to pull:\n";
-              for (const img of missing) body += "- `" + img + "`\n";
+              list = missing.map(m => '- `' + m + '`').join('\n');
             } catch (e) {
-              body += "Could not read missing list — see workflow logs.";
+              list = '_Could not read the missing list — see workflow logs._';
             }
-            body += "\n\nWorkflow run: " + context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo + "/actions/runs/" + context.runId;
-            await github.rest.issues.create({
+            const runUrl = context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId;
+            const body = [
+              'Nightly image-freshness check failed.',
+              '',
+              'Images that failed to pull:',
+              list,
+              '',
+              'Last failing run: ' + runUrl,
+              'Last checked: ' + new Date().toISOString(),
+              '',
+              '_This issue is updated in place by every scheduled failure and auto-closes when the check passes again._',
+            ].join('\n');
+            const open = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "Bundle image-freshness check failed",
-              body,
-              labels: ["bundle-image-stale", "automated"],
+              labels: LABEL,
+              state: 'open',
+              per_page: 100,
             });
+            if (open.data.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.data[0].number,
+                title: TITLE,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: TITLE,
+                body,
+                labels: [LABEL, 'automated'],
+              });
+            }
+
+      - name: Close the pinned issue on success
+        if: success() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'bundle-image-stale';
+            const runUrl = context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId;
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: LABEL,
+              state: 'open',
+              per_page: 100,
+            });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'Image-freshness check passed again: ' + runUrl + ' — closing.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }

--- a/bundles/peertube/docker-compose.yml
+++ b/bundles/peertube/docker-compose.yml
@@ -16,9 +16,10 @@
 # envelope to .env. Without S3 + aggressive pruning, a single active
 # channel can fill a 500 GB disk within months.
 #
-# Image: chocobozzz/peertube:v8.1.5-bookworm (stable line; pin tag to
-# a specific release for production — we use the floating tag for the
-# roll-out, will pin before merge).
+# Image: chocobozzz/peertube:v8.1.5 (pinned release). Debian-suffixed
+# variants (-bookworm) ended at v7.x — v8+ ships plain vN.N.N and
+# vN.N.N-trixie tags only, and upstream retains old version tags, so a
+# plain version pin is durable.
 
 networks:
   crow-federation:
@@ -64,7 +65,7 @@ services:
       retries: 10
 
   peertube:
-    image: chocobozzz/peertube:v8.1.5-bookworm
+    image: chocobozzz/peertube:v8.1.5
     container_name: crow-peertube
     networks:
       - default

--- a/bundles/peertube/manifest.json
+++ b/bundles/peertube/manifest.json
@@ -55,5 +55,5 @@
   ],
   "ports": [],
   "webUI": null,
-  "notes": "Three containers (peertube + postgres + redis). chocobozzz/peertube:production-bookworm image. Expose via caddy_add_federation_site { domain: PEERTUBE_WEBSERVER_HOSTNAME, upstream: 'peertube:9000', profile: 'activitypub-peertube' } — the peertube profile also wires WebSocket upgrade on /socket.io and large request-body limits for video upload chunking. Admin credentials: first-boot logs print a randomly-generated admin password (search `docker logs crow-peertube | grep -A1 \"Username\"`); rotate via `docker exec -it crow-peertube npm run reset-password -- -u root` immediately."
+  "notes": "Three containers (peertube + postgres + redis). chocobozzz/peertube:v8.1.5 image (pinned release; v8+ has no -bookworm variant). Expose via caddy_add_federation_site { domain: PEERTUBE_WEBSERVER_HOSTNAME, upstream: 'peertube:9000', profile: 'activitypub-peertube' } — the peertube profile also wires WebSocket upgrade on /socket.io and large request-body limits for video upload chunking. Admin credentials: first-boot logs print a randomly-generated admin password (search `docker logs crow-peertube | grep -A1 \"Username\"`); rotate via `docker exec -it crow-peertube npm run reset-password -- -u root` immediately."
 }

--- a/bundles/vllm-cuda-embed/docker-compose.yml
+++ b/bundles/vllm-cuda-embed/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-cuda-embed:
-    image: ${VLLM_CUDA_IMAGE}
+    image: ${VLLM_CUDA_IMAGE:-vllm/vllm-openai:v0.11.0}
     container_name: vllm-cuda-embed
     runtime: nvidia
     env_file:

--- a/bundles/vllm-cuda-rerank/docker-compose.yml
+++ b/bundles/vllm-cuda-rerank/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-cuda-rerank:
-    image: ${VLLM_CUDA_IMAGE}
+    image: ${VLLM_CUDA_IMAGE:-vllm/vllm-openai:v0.11.0}
     container_name: vllm-cuda-rerank
     runtime: nvidia
     env_file:

--- a/bundles/vllm-cuda-vision/docker-compose.yml
+++ b/bundles/vllm-cuda-vision/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-cuda-vision:
-    image: ${VLLM_CUDA_IMAGE}
+    image: ${VLLM_CUDA_IMAGE:-vllm/vllm-openai:v0.11.0}
     container_name: vllm-cuda-vision
     runtime: nvidia
     env_file:

--- a/bundles/vllm-rocm-kimi/docker-compose.yml
+++ b/bundles/vllm-rocm-kimi/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-rocm-kimi:
-    image: ${VLLM_ROCM_IMAGE}
+    image: ${VLLM_ROCM_IMAGE:-rocm/vllm-dev:nightly_main_20260413}
     container_name: vllm-rocm-kimi
     devices:
       - /dev/kfd

--- a/bundles/vllm-rocm-qwen3-32b/docker-compose.yml
+++ b/bundles/vllm-rocm-qwen3-32b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-rocm-qwen3-32b:
-    image: ${VLLM_ROCM_IMAGE}
+    image: ${VLLM_ROCM_IMAGE:-rocm/vllm-dev:nightly_main_20260413}
     container_name: vllm-rocm-qwen3-32b
     devices:
       - /dev/kfd

--- a/bundles/vllm-rocm-qwen3/docker-compose.yml
+++ b/bundles/vllm-rocm-qwen3/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-rocm-qwen3:
-    image: ${VLLM_ROCM_IMAGE}
+    image: ${VLLM_ROCM_IMAGE:-rocm/vllm-dev:nightly_main_20260413}
     container_name: vllm-rocm-qwen3
     devices:
       - /dev/kfd

--- a/bundles/vllm-rocm-qwen35-27b/docker-compose.yml
+++ b/bundles/vllm-rocm-qwen35-27b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-rocm-qwen35-27b:
-    image: ${VLLM_ROCM_IMAGE}
+    image: ${VLLM_ROCM_IMAGE:-rocm/vllm-dev:nightly_main_20260413}
     container_name: vllm-rocm-qwen35-27b
     devices:
       - /dev/kfd

--- a/bundles/vllm-rocm-qwen35-4b/docker-compose.yml
+++ b/bundles/vllm-rocm-qwen35-4b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm-rocm-qwen35-4b:
-    image: ${VLLM_ROCM_IMAGE}
+    image: ${VLLM_ROCM_IMAGE:-rocm/vllm-dev:nightly_main_20260413}
     container_name: vllm-rocm-qwen35-4b
     devices:
       - /dev/kfd

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4523,7 +4523,7 @@
       ],
       "ports": [],
       "webUI": null,
-      "notes": "Three containers (peertube + postgres + redis). chocobozzz/peertube:production-bookworm image. Expose via caddy_add_federation_site { domain: PEERTUBE_WEBSERVER_HOSTNAME, upstream: 'peertube:9000', profile: 'activitypub-peertube' } — the peertube profile also wires WebSocket upgrade on /socket.io and large request-body limits for video upload chunking. Admin credentials: first-boot logs print a randomly-generated admin password (search `docker logs crow-peertube | grep -A1 \"Username\"`); rotate via `docker exec -it crow-peertube npm run reset-password -- -u root` immediately.",
+      "notes": "Three containers (peertube + postgres + redis). chocobozzz/peertube:v8.1.5 image (pinned release; v8+ has no -bookworm variant). Expose via caddy_add_federation_site { domain: PEERTUBE_WEBSERVER_HOSTNAME, upstream: 'peertube:9000', profile: 'activitypub-peertube' } — the peertube profile also wires WebSocket upgrade on /socket.io and large request-body limits for video upload chunking. Admin credentials: first-boot logs print a randomly-generated admin password (search `docker logs crow-peertube | grep -A1 \"Username\"`); rotate via `docker exec -it crow-peertube npm run reset-password -- -u root` immediately.",
       "official": true
     },
     {

--- a/scripts/extract-bundle-images.py
+++ b/scripts/extract-bundle-images.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Extract the pullable docker images referenced by bundle compose files.
+
+Used by .github/workflows/image-freshness.yml. Walks bundles/*/docker-compose.yml,
+skips services with a build: section (their image: is a local tag, never pullable),
+and resolves ${VAR} / ${VAR:-default} interpolation in image references against the
+bundle's own .env file. A full `docker compose config` is deliberately NOT used:
+many bundles require install-time env (${VAR:?} passwords, media paths) and fail
+strict interpolation, but only the image field matters here.
+
+Interpolation values come from the bundle's .env (local/operator runs) with
+.env.example as fallback (the only one present in CI — bundles/*/.env is
+gitignored), then inline ${VAR:-default} defaults. An image reference that
+still contains an unresolvable variable is reported as a failure, NOT
+silently dropped — a silent drop would hide exactly the untracked-default
+misconfiguration this checker exists to catch.
+
+Usage: extract-bundle-images.py <images-out> <failures-out>
+  images-out    one image reference per line, sorted, de-duplicated
+  failures-out  compose files that could not be parsed or whose image
+                reference could not be resolved (those images are unchecked)
+"""
+
+import glob
+import os
+import re
+import sys
+
+import yaml
+
+INTERP = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?])([^}]*))?\}")
+
+
+def load_env(path):
+    env = {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                env[key.strip()] = value.strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return env
+
+
+def resolve(image, env):
+    unresolved = []
+
+    def sub(match):
+        name, op, default = match.group(1), match.group(2), match.group(3)
+        value = env.get(name, "")
+        if not value and op in (":-", "-"):
+            value = default or ""
+        if not value:
+            unresolved.append(name)
+        return value
+
+    resolved = INTERP.sub(sub, image).strip()
+    return resolved, unresolved
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: extract-bundle-images.py <images-out> <failures-out>")
+    images, failures = set(), []
+    for compose in sorted(glob.glob("bundles/*/docker-compose.yml")):
+        bundle_dir = os.path.dirname(compose)
+        env = load_env(os.path.join(bundle_dir, ".env.example"))
+        env.update(load_env(os.path.join(bundle_dir, ".env")))
+        try:
+            with open(compose, encoding="utf-8") as f:
+                doc = yaml.safe_load(f)
+            services = doc.get("services") or {}
+            for service in services.values():
+                if not isinstance(service, dict) or "build" in service:
+                    continue
+                image = service.get("image")
+                if isinstance(image, str):
+                    resolved, unresolved = resolve(image, env)
+                    if unresolved:
+                        failures.append(
+                            f"{compose} (unresolvable image {image!r}: "
+                            f"no value or default for {', '.join(unresolved)})"
+                        )
+                    elif resolved:
+                        images.add(resolved)
+        except Exception:
+            failures.append(f"{compose} (compose parse failure)")
+    with open(sys.argv[1], "w", encoding="utf-8") as f:
+        f.writelines(img + "\n" for img in sorted(images))
+    with open(sys.argv[2], "w", encoding="utf-8") as f:
+        f.writelines(path + "\n" for path in failures)
+    print(f"{len(images)} unique pullable images, {len(failures)} parse failures")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Item A2 — image-freshness ops-noise + fresh-install reliability triage

### Reporter (ops noise)
The nightly image-freshness workflow filed an **unconditional new issue per scheduled failure** — 97 open bot issues accumulated since April. Now:
- Scheduled failures **update one pinned issue** (found by the `bundle-image-stale` label; created only if absent).
- A **passing scheduled run auto-closes** any open labeled issue.
- `workflow_dispatch` runs never touch issues.

### Signal (checker correctness)
5 of the 6 recurring "failures" were checker false positives. Extraction moves from a raw `grep image:` to `scripts/extract-bundle-images.py`:
- Skips `build:` services (`crow-companion`, `crow-scratch-offline`, `crow-sdxl` are local tags — never pullable).
- Resolves `${VAR:-default}` interpolation (`.env` → `.env.example` → inline default). The literal strings `${VLLM_ROCM_IMAGE}`/`${VLLM_CUDA_IMAGE}` had been reported as "missing images" for months.
- **Unresolvable image references and unparseable compose files are reported failures, not silent drops** (adversarial-review finding: a silent drop would hide exactly the untracked-default class this checker exists to catch).
- `docker rmi` after each pull bounds runner disk — the multi-GB vLLM/ROCm images are now genuinely in scope.
- `docker compose config` was evaluated and rejected: 27 bundles legitimately require install-time env (`${VAR:?}` secrets/paths) and fail strict interpolation.

### Real fresh-install breakage found and fixed
- **peertube**: pinned `v8.1.5-bookworm` never existed (`-bookworm` variants ended at v7.x) → `v8.1.5` (verified on Docker Hub; upstream retains old version tags, so the pin is durable). Manifest note corrected; registry regenerated (`build-registry --check` green).
- **All 8 vllm-\* bundles**: `image: ${VLLM_ROCM_IMAGE}` / `${VLLM_CUDA_IMAGE}` had no tracked default anywhere (no `.env.example`, empty manifest `env_vars`) — a fresh install interpolated a blank image and `compose up` failed. Inline defaults added (`rocm/vllm-dev:nightly_main_20260413`, `vllm/vllm-openai:v0.11.0`, both verified to exist).

### Verification
- Full sweep: **all 71 unique images across the 75 compose files exist upstream** (Docker Hub tags API; the only mid-sweep "failures" were anonymous rate-limiting, re-verified individually).
- Extractor probes: bare `${VAR}` and `${VAR:?}` forms are reported, not dropped; output image set identical pre/post the review fix.
- Suite in the worktree: **2033/2033 pass / 0 fail / 0 skip** (exact baseline).
- Adversarial review: one Important finding (silent-drop of unresolvable images in CI, where `bundles/*/.env` never exists) — fixed with `.env.example` fallback + report-as-failure.