### PR TITLE
feat(db): A3 runtime migration guard — backup, loss classification, quarantine

### DIFF
--- a/docs/developers/db-recovery.md
+++ b/docs/developers/db-recovery.md
@@ -91,3 +91,40 @@ addressed upstream:
   through `createNotification`, which would try to write the corrupt DB first).
   Surfaced in the nest as the `federation-audit` health signal. See
   `servers/shared/cross-host-auth.js`.
+
+## The migration guard (A3)
+
+Every production `init-db` run — auto-update after a pull, the gateway boot
+gate, `scripts/install.sh` upgrades, and `scripts/crow-update.sh` — goes
+through `servers/shared/migration-guard.js` when the run carries migration
+risk (a schema-generation crossing, or a pulled change to
+`scripts/init-db.js`). The guard:
+
+1. Takes a **pre-migration backup** (incremental SQLite backup, safe on a live
+   WAL database) into `<data-dir>/backups/migrations/` (keeps the last 3, plus
+   any pinned by a finding for 30 days).
+2. Runs init-db, then compares per-table row counts, columns, and schema
+   objects against `servers/shared/migration-expectations.js` (the manifest of
+   *expected* drops/prunes/moves/rebuilds — kept honest by a static rot-guard
+   test).
+3. On **high-confidence loss** (an undeclared table vanished, a rebuild lost
+   rows/columns, a large unexplained loss): **restores the backup**, keeps the
+   damaged file as `crow.db.damaged-<ts>` evidence, writes quarantine markers,
+   fires a DB-free ntfy + email alert, and (on the auto-update path) rolls the
+   code back and restarts. Anything less certain **fails open**: the migration
+   stands, and the same loud alert channel explains what looked suspicious.
+
+**Quarantine:** two marker files with one meaning — this migration damaged
+data here, don't re-run it:
+
+- `<repo>/.crow-migration-quarantine.json` (stops every updater sharing the
+  checkout, including the manual "Check for updates now" button)
+- `<data-dir>/migration-quarantine.json` (makes the boot gate skip init-db —
+  the gateway boots on the intact old-schema data; features needing the new
+  schema may error until the fix lands)
+
+The quarantine clears itself when a new commit lands on `main` (up to 3
+automatic retries per generation crossing). To override manually — after
+verifying the verdict was wrong or recovering by hand — delete both marker
+files. `node scripts/guarded-init-db.mjs` is the guarded manual entry point;
+`npm run init-db` remains the bare, unguarded seam for scratch/dev databases.

--- a/scripts/crow-update.sh
+++ b/scripts/crow-update.sh
@@ -43,7 +43,7 @@ npm install 2>&1 | tail -3 | tee -a "$LOG_FILE"
 
 # Run database migrations
 log "Running database migrations..."
-npm run init-db 2>&1 | tee -a "$LOG_FILE"
+node scripts/guarded-init-db.mjs 2>&1 | tee -a "$LOG_FILE"
 
 # Restart gateway if running as systemd service
 if systemctl is-active --quiet crow-gateway 2>/dev/null; then

--- a/scripts/guarded-init-db.mjs
+++ b/scripts/guarded-init-db.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * guarded-init-db.mjs — run init-db through the A3 migration guard.
+ *
+ * The production way to apply migrations by hand: pre-migration backup +
+ * post-migration loss classification + restore-and-quarantine on
+ * high-confidence loss. Used by scripts/install.sh (existing-install branch)
+ * and scripts/crow-update.sh; operators can run it directly.
+ *
+ * `npm run init-db` stays the BARE seam (scratch envs, tests, dev); prefer
+ * this wrapper on any database you care about.
+ *
+ * Exit codes: 0 = pass/fresh/suspect/unreadable (fail open), 2 = loss
+ * (restored + quarantined), 3 = refused (active quarantine marker).
+ */
+
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveDataDir } from "../servers/db.js";
+import {
+  activeMarker, dataMarkerPath, readTreeGeneration, repoMarkerPath,
+  resolveGuardDbPath, runGuardedInitDb,
+} from "../servers/shared/migration-guard.js";
+
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const dbPath = resolveGuardDbPath(resolveDataDir);
+
+const marker = activeMarker(dataMarkerPath(dbPath)) || activeMarker(repoMarkerPath(appRoot));
+if (marker) {
+  console.error(
+    `REFUSED: migration gen ${marker.fromGeneration}->${marker.toGeneration} (sha ${marker.sha}) is quarantined — ` +
+    `it damaged data on a previous run. Delete these files to override:\n  ${dataMarkerPath(dbPath)}\n  ${repoMarkerPath(appRoot)}`
+  );
+  process.exit(3);
+}
+
+let sha = null;
+try {
+  sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: appRoot, timeout: 10000 }).toString().trim();
+} catch {}
+
+const res = await runGuardedInitDb({
+  dbPath,
+  appRoot,
+  sha,
+  newGeneration: readTreeGeneration(appRoot),
+});
+
+console.log(`[guarded-init-db] verdict: ${res.verdict}` + (res.backupPath ? ` (backup: ${res.backupPath})` : ""));
+if (res.report && (res.report.losses.length || res.report.suspects.length)) {
+  for (const l of res.report.losses) console.error(`  LOSS: ${l}`);
+  for (const s of res.report.suspects) console.warn(`  suspect: ${s}`);
+}
+if (res.verdict === "loss") {
+  console.error(`Database restored from backup; migration quarantined. Evidence: ${res.evidence || "n/a"}`);
+  console.error("Restart any Crow-connected processes (gateway, MCP servers, bots) now.");
+  process.exit(2);
+}
+if (res.initDbExit !== 0) {
+  console.error(`init-db exited ${res.initDbExit} — schema may be incomplete; see output above.`);
+  process.exit(res.initDbExit || 1);
+}

--- a/scripts/guarded-init-db.mjs
+++ b/scripts/guarded-init-db.mjs
@@ -53,8 +53,15 @@ if (res.report && (res.report.losses.length || res.report.suspects.length)) {
   for (const s of res.report.suspects) console.warn(`  suspect: ${s}`);
 }
 if (res.verdict === "loss") {
-  console.error(`Database restored from backup; migration quarantined. Evidence: ${res.evidence || "n/a"}`);
-  console.error("Restart any Crow-connected processes (gateway, MCP servers, bots) now.");
+  if (res.restored) {
+    console.error(`Database restored from backup; migration quarantined. Evidence: ${res.evidence}`);
+    console.error("Restart any Crow-connected processes (gateway, MCP servers, bots) now.");
+  } else {
+    console.error("Migration quarantined but automatic restore was NOT possible.");
+    console.error(res.backupPath
+      ? `Restore manually: stop the gateway, then copy ${res.backupPath} over the database.`
+      : "No backup was available — check disk space and docs/developers/db-recovery.md.");
+  }
   process.exit(2);
 }
 if (res.initDbExit !== 0) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,7 +65,7 @@ npm install --silent
 
 # Step 4: Initialize database
 echo "  Initializing database..."
-node scripts/init-db.js
+node scripts/guarded-init-db.mjs
 
 # Step 5: Launch the setup wizard
 echo ""

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -230,6 +230,10 @@ export async function checkForUpdates() {
   }
 }
 
+// Migration-quarantine re-alert cooldown (mirrors the audit-breaker pattern).
+const QUARANTINE_ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
+let _quarantineAlertAt = 0;
+
 /** The mutating sequence; exported ONLY as the test seam for the under-lock
  *  branch re-check (spec D3b — the outer guard would abort a branch fixture
  *  before the lock). */
@@ -247,6 +251,40 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
     await saveSetting("auto_update_last_check", new Date().toISOString());
     await saveSetting("auto_update_last_result", msg);
     return { updated: false, error: msg };
+  }
+
+  // A3 migration quarantine — evaluated UNDER the lock, after the fetch, so
+  // both the 6h tick and the manual "Check now" button (which also lands here)
+  // consult it with origin/main's fresh head sha, and co-hosted gateways
+  // can't race the marker. A quarantined sha is never re-pulled; the marker
+  // auto-clears when main moves (attempts-capped).
+  try {
+    const originHead = await run("git", ["rev-parse", "origin/main"]);
+    const { evaluateQuarantine, resolveGuardDbPath } = await import("../shared/migration-guard.js");
+    const { resolveDataDir } = await import("../db.js");
+    const q = evaluateQuarantine({
+      appRoot: APP_ROOT,
+      dbPath: resolveGuardDbPath(resolveDataDir),
+      originHeadSha: originHead.stdout,
+    });
+    if (q.blocked) {
+      const msg = `Skipped: migration quarantined (gen ${q.marker.fromGeneration}->${q.marker.toGeneration}, attempt ${q.marker.attempts}) — delete the quarantine marker files to override`;
+      log(msg);
+      if (Date.now() - _quarantineAlertAt > QUARANTINE_ALERT_COOLDOWN_MS) {
+        _quarantineAlertAt = Date.now();
+        const { fireMigrationAlert } = await import("../shared/migration-guard.js");
+        await fireMigrationAlert({
+          title: "Crow updates paused: migration quarantined",
+          body: `Auto-update is paused because a migration (schema gen ${q.marker.fromGeneration}->${q.marker.toGeneration}) damaged data and was rolled back. Updates resume automatically when a fix lands on main (attempt ${q.marker.attempts}/3).`,
+        });
+      }
+      await saveSetting("auto_update_last_check", new Date().toISOString());
+      await saveSetting("auto_update_last_result", msg);
+      return { updated: false, skipped: "quarantined", message: msg };
+    }
+    if (q.cleared) log(`Quarantine cleared — main moved past ${q.marker.sha.slice(0, 9)}; retrying the migration under guard`);
+  } catch (err) {
+    log(`quarantine check error (proceeding): ${err?.message}`);
   }
 
   // Check if there are new commits
@@ -300,9 +338,74 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
     }
   }
 
-  // Run init-db for any schema changes
+  // Run init-db for any schema changes — guarded (A3) when the run carries
+  // migration risk: the pulled range crosses a schema generation OR touches
+  // scripts/init-db.js (state-conditional rebuilds fire on DB shape, not
+  // generation). Non-crossing, init-db-unchanged runs keep the bare call.
   log("Running database migrations...");
-  await run("node", ["scripts/init-db.js"]);
+  const guard = await import("../shared/migration-guard.js");
+  const { resolveDataDir: _rdd } = await import("../db.js");
+  const dbPath = guard.resolveGuardDbPath(_rdd);
+  const newGeneration = guard.readTreeGeneration(APP_ROOT);
+  const preState = guard.readSchemaState(dbPath);
+  const armed =
+    (newGeneration != null && preState.readable && preState.userVersion < newGeneration) ||
+    changedFiles.stdout.split("\n").includes("scripts/init-db.js");
+  if (armed) {
+    const headSha = (await run("git", ["rev-parse", "HEAD"])).stdout;
+    const res = await guard.runGuardedInitDb({
+      dbPath, appRoot: APP_ROOT, sha: headSha, newGeneration,
+      log: (m) => log(`[migration-guard] ${m}`),
+    });
+    if (res.verdict === "loss") {
+      // Fail closed: the guard restored the backup and quarantined the sha.
+      // Roll the code back to match the restored schema — but never destroy
+      // local WIP on a possibly-false verdict (quarantined boot handles the
+      // code-newer-than-schema case).
+      const porcelain = await run("git", ["status", "--porcelain"]);
+      const trackedWip = porcelain.stdout.split("\n").filter((l) => l && !l.startsWith("??"));
+      if (trackedWip.length === 0) {
+        await run("git", ["reset", "--hard", currentVersion]);
+        if (changedFiles.stdout.includes("package-lock.json") || changedFiles.stdout.includes("package.json")) {
+          await run("npm", ["install", "--omit=dev"], { timeout: 300000 });
+        }
+        log(`Rolled code back to ${currentVersion} to match the restored database.`);
+      } else {
+        log("Local WIP present — code left at the new sha; next boot is quarantined (old schema, data intact).");
+      }
+      const msg = `Migration quarantined: data loss detected and rolled back (${(res.report?.losses || []).join("; ")})`;
+      await saveSetting("auto_update_last_check", new Date().toISOString());
+      await saveSetting("auto_update_last_result", msg);
+      // The live process's DB handles still pin the pre-restore inode —
+      // restart IMMEDIATELY so the process reopens the restored file.
+      scheduleSupervisedRestart(log, "Restarting to reopen the restored database...");
+      return { updated: false, error: msg, quarantined: true };
+    }
+    if (res.initDbExit !== 0) {
+      const msg = `Migration failed (init-db exit ${res.initDbExit}) — restart withheld, running code unchanged`;
+      log(msg);
+      await guard.fireMigrationAlert({
+        title: "Crow migration failed during auto-update",
+        body: `init-db exited ${res.initDbExit} after pulling an update. The gateway keeps running the previous code; the next restart will retry via the boot gate. Check logs, then run \`node scripts/guarded-init-db.mjs\`.`,
+      });
+      await saveSetting("auto_update_last_check", new Date().toISOString());
+      await saveSetting("auto_update_last_result", msg);
+      return { updated: false, error: msg };
+    }
+  } else {
+    const initRes = await run("node", ["scripts/init-db.js"]);
+    if (initRes.code !== 0) {
+      const msg = `init-db failed (exit ${initRes.code}) — restart withheld, running code unchanged`;
+      log(msg);
+      await guard.fireMigrationAlert({
+        title: "Crow init-db failed during auto-update",
+        body: `init-db exited ${initRes.code} after pulling an update (no migration expected). The gateway keeps running the previous code. Check logs, then run \`node scripts/guarded-init-db.mjs\`.`,
+      });
+      await saveSetting("auto_update_last_check", new Date().toISOString());
+      await saveSetting("auto_update_last_result", msg);
+      return { updated: false, error: msg };
+    }
+  }
 
   const newRef = await run("git", ["rev-parse", "--short", "HEAD"]);
   const newVersion = newRef.stdout;
@@ -317,24 +420,30 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
   // Restart to load the new code when supervised (systemd, launchd
   // KeepAlive, Docker, etc.). Without a supervisor the pulled code only
   // takes effect on the next manual restart.
-  if (isSupervised()) {
-    log("Restarting gateway to apply update...");
-    // Close the HTTP server first to release the port, then exit
-    // so the supervisor's restart doesn't hit EADDRINUSE.
-    // exitCode is preset so that if the loop drains before the inner timer
-    // fires (manual check-now path: crow:shutdown closes the only ref'd
-    // handle), node still exits nonzero — Restart=on-failure needs it.
-    // Both timers are unref'd so a pending restart chain can never hold open
-    // or kill a process whose loop otherwise finished (test runners).
-    process.exitCode = 1;
-    const outer = setTimeout(() => {
-      process.emit("crow:shutdown");
-      setTimeout(() => process.exit(1), 1000).unref();
-    }, 1500);
-    outer.unref();
-  }
+  scheduleSupervisedRestart(log, "Restarting gateway to apply update...");
 
   return { updated: true, from: currentVersion, to: newVersion };
+}
+
+/** Supervised-restart machinery, shared by the normal update path and the
+ *  migration-guard loss path (which must reopen the restored DB file).
+ *  No-op without a supervisor. */
+function scheduleSupervisedRestart(log, message) {
+  if (!isSupervised()) return;
+  log(message);
+  // Close the HTTP server first to release the port, then exit
+  // so the supervisor's restart doesn't hit EADDRINUSE.
+  // exitCode is preset so that if the loop drains before the inner timer
+  // fires (manual check-now path: crow:shutdown closes the only ref'd
+  // handle), node still exits nonzero — Restart=on-failure needs it.
+  // Both timers are unref'd so a pending restart chain can never hold open
+  // or kill a process whose loop otherwise finished (test runners).
+  process.exitCode = 1;
+  const outer = setTimeout(() => {
+    process.emit("crow:shutdown");
+    setTimeout(() => process.exit(1), 1000).unref();
+  }, 1500);
+  outer.unref();
 }
 
 /**

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -358,6 +358,17 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
       log: (m) => log(`[migration-guard] ${m}`),
     });
     if (res.verdict === "loss") {
+      if (!res.restored) {
+        // Restore failed or no backup existed: the (damaged) migrated DB is
+        // what's on disk and the running code matches it. Do NOT roll code
+        // back or restart into a state the alert just told the operator to
+        // repair by hand — keep running, quarantined, loudly.
+        const msg = `Migration quarantined: data loss detected, automatic restore NOT possible — manual recovery required (${(res.report?.losses || []).join("; ")})`;
+        log(msg);
+        await saveSetting("auto_update_last_check", new Date().toISOString());
+        await saveSetting("auto_update_last_result", msg);
+        return { updated: false, error: msg, quarantined: true };
+      }
       // Fail closed: the guard restored the backup and quarantined the sha.
       // Roll the code back to match the restored schema — but never destroy
       // local WIP on a possibly-false verdict (quarantined boot handles the

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -126,7 +126,7 @@ try {
   const { SCHEMA_GENERATION, needsSchemaInit } = await import("../shared/schema-version.js");
   const {
     readSchemaState, runGuardedInitDb, resolveGuardDbPath,
-    activeMarker, dataMarkerPath, repoMarkerPath,
+    activeMarker, dataMarkerPath, repoMarkerPath, backupDir,
   } = await import("../shared/migration-guard.js");
   const { resolveDataDir } = await import("../db.js");
   const { dirname } = await import("node:path");
@@ -160,9 +160,21 @@ try {
       } catch {}
       const res = await runGuardedInitDb({ dbPath, appRoot, sha, newGeneration: SCHEMA_GENERATION });
       if (res.verdict === "loss") {
-        // Fail closed happened inside the guard (restore + quarantine + alert).
-        // Boot continues on the restored, pre-migration DB — data intact.
-        console.warn("[migration-guard] Data loss detected and rolled back — booting on the restored pre-migration database.");
+        if (res.restored) {
+          // Fail closed happened inside the guard (restore + quarantine + alert).
+          // Boot continues on the restored, pre-migration DB — data intact.
+          console.warn("[migration-guard] Data loss detected and rolled back — booting on the restored pre-migration database.");
+        } else if (!res.dbPresent) {
+          // No DB file at all — booting would silently create an empty one.
+          console.error("[migration-guard] FATAL: data loss detected and the database file is missing after a failed restore.");
+          console.error(`  Restore manually from ${res.backupPath || backupDir(dbPath)} before starting the gateway.`);
+          process.exit(1);
+        } else {
+          // Restore unavailable/failed but the (damaged) DB is present: booting
+          // keeps the instance observable; the alert instructs a manual restore
+          // (stop the gateway first). Quarantine prevents repeat damage.
+          console.warn("[migration-guard] Data loss detected and restore was NOT possible — booting on the DAMAGED database. See the alert for manual recovery steps.");
+        }
       } else if (res.initDbExit !== 0) {
         const after = readSchemaState(dbPath);
         if (needsSchemaInit({ coreTableCount: after.coreTableCount, userVersion: after.userVersion, schemaGeneration: SCHEMA_GENERATION })) {

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -109,49 +109,71 @@ if (process.env.CROW_DASHBOARD_PUBLIC === "true") {
   console.warn("   Ensure you have a strong admin password and 2FA enabled. Prefer `tailscale serve` for private remote access.");
 }
 
-// Initialize OAuth tables
-await initOAuthTables();
-
 // Verify core schema exists / is current — auto-initialize if missing (Docker
 // first run) OR if the persisted schema generation is behind the code (an
 // out-of-band `git pull`/rollback/merge-then-restart that added migrations but
 // never re-ran init-db; the 6h auto-updater runs init-db post-pull, this covers
 // the manual path). See servers/shared/schema-version.js.
+//
+// ORDER INVARIANT (A3 / R2-2): this block runs BEFORE the first createDbClient
+// in the process (initOAuthTables below) and its detection read is a raw
+// short-lived better-sqlite3 handle. createDbClient registers a never-closed
+// per-path WAL keeper; if it ran first, a migration-guard restore would swap
+// the DB file under a pinned inode (split-brain). Do not reorder, and do not
+// add DB access above this block. tests/migration-guard.test.js asserts the
+// source ordering.
 try {
   const { SCHEMA_GENERATION, needsSchemaInit } = await import("../shared/schema-version.js");
-  const _schemaDb = createDbClient();
-  const { rows } = await _schemaDb.execute(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('memories', 'dashboard_settings', 'crow_context')"
-  );
-  let userVersion = 0;
-  try {
-    const uvRes = await _schemaDb.execute("PRAGMA user_version");
-    userVersion = Number(uvRes.rows?.[0]?.user_version ?? 0);
-  } catch {
-    userVersion = 0;
-  }
-  _schemaDb.close();
-  const driftOnly = rows.length >= 3 && userVersion < SCHEMA_GENERATION;
-  if (needsSchemaInit({ coreTableCount: rows.length, userVersion, schemaGeneration: SCHEMA_GENERATION })) {
-    if (driftOnly) {
-      console.log(
-        `Schema version drift (db user_version=${userVersion} < code SCHEMA_GENERATION=${SCHEMA_GENERATION}) — running init-db to apply pending migrations...`
+  const {
+    readSchemaState, runGuardedInitDb, resolveGuardDbPath,
+    activeMarker, dataMarkerPath, repoMarkerPath,
+  } = await import("../shared/migration-guard.js");
+  const { resolveDataDir } = await import("../db.js");
+  const { dirname } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const gatewayDir = dirname(fileURLToPath(import.meta.url));
+  const appRoot = dirname(dirname(gatewayDir));
+  const dbPath = resolveGuardDbPath(resolveDataDir);
+  const state = readSchemaState(dbPath);
+  if (needsSchemaInit({ coreTableCount: state.coreTableCount, userVersion: state.userVersion, schemaGeneration: SCHEMA_GENERATION })) {
+    // Quarantine markers (data-dir AND repo level — co-hosted gateways share
+    // one checkout): a known-damaging migration is never knowingly re-run.
+    const marker = activeMarker(dataMarkerPath(dbPath)) || activeMarker(repoMarkerPath(appRoot));
+    if (marker) {
+      console.warn(
+        `[migration-guard] Migration gen ${marker.fromGeneration}->${marker.toGeneration} (sha ${marker.sha}) is QUARANTINED — ` +
+        `booting WITHOUT running init-db. Data is intact; features needing the new schema may error. ` +
+        `Delete ${dataMarkerPath(dbPath)} and ${repoMarkerPath(appRoot)} to override.`
       );
     } else {
-      console.log("Database schema incomplete — running init-db...");
-    }
-    const { execFileSync } = await import("node:child_process");
-    const { dirname } = await import("node:path");
-    const { fileURLToPath } = await import("node:url");
-    const gatewayDir = dirname(fileURLToPath(import.meta.url));
-    const appRoot = dirname(dirname(gatewayDir));
-    try {
-      execFileSync("node", ["scripts/init-db.js"], { cwd: appRoot, stdio: "inherit" });
-      console.log("Database schema initialized successfully.");
-    } catch (initErr) {
-      console.error("ERROR: Failed to auto-initialize database schema:", initErr.message);
-      console.error("  Run 'npm run init-db' manually.");
-      process.exit(1);
+      if (state.coreTableCount >= 3 && state.userVersion < SCHEMA_GENERATION) {
+        console.log(
+          `Schema version drift (db user_version=${state.userVersion} < code SCHEMA_GENERATION=${SCHEMA_GENERATION}) — running guarded init-db...`
+        );
+      } else {
+        console.log("Database schema incomplete — running init-db...");
+      }
+      let sha = null;
+      try {
+        const { execFileSync } = await import("node:child_process");
+        sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: appRoot, timeout: 10000 }).toString().trim();
+      } catch {}
+      const res = await runGuardedInitDb({ dbPath, appRoot, sha, newGeneration: SCHEMA_GENERATION });
+      if (res.verdict === "loss") {
+        // Fail closed happened inside the guard (restore + quarantine + alert).
+        // Boot continues on the restored, pre-migration DB — data intact.
+        console.warn("[migration-guard] Data loss detected and rolled back — booting on the restored pre-migration database.");
+      } else if (res.initDbExit !== 0) {
+        const after = readSchemaState(dbPath);
+        if (needsSchemaInit({ coreTableCount: after.coreTableCount, userVersion: after.userVersion, schemaGeneration: SCHEMA_GENERATION })) {
+          console.error(`ERROR: Failed to auto-initialize database schema (init-db exit ${res.initDbExit}).`);
+          console.error("  Run 'npm run init-db' manually.");
+          process.exit(1);
+        }
+        console.warn(`[migration-guard] init-db exited ${res.initDbExit} but the schema is current — continuing.`);
+      } else {
+        console.log("Database schema initialized successfully.");
+      }
     }
   }
 } catch (e) {
@@ -159,6 +181,9 @@ try {
   console.error("  Run 'npm run init-db' first.");
   process.exit(1);
 }
+
+// Initialize OAuth tables
+await initOAuthTables();
 
 // Clean up old audit log entries (90-day retention)
 try {

--- a/servers/shared/migration-expectations.js
+++ b/servers/shared/migration-expectations.js
@@ -1,0 +1,82 @@
+/**
+ * migration-expectations.js — the expected-changes manifest for the runtime
+ * migration guard (servers/shared/migration-guard.js).
+ *
+ * Every destructive statement in scripts/init-db.js must be declared here, and
+ * every declaration must still exist in init-db — both directions are enforced
+ * by the static rot-guard test (tests/migration-guard.test.js). A destructive
+ * migration cannot merge without declaring itself.
+ *
+ * Spec: crow-engineering specs/2026-07-18-a3-migration-guard-design.md §3.2.
+ */
+
+// Tables init-db may legitimately make DISAPPEAR (guarded drops, no rebuild).
+export const EXPECTED_DROPS = [
+  "research_projects",
+  "orchestrator_events",
+  "orchestrator_role_overrides",
+];
+
+// Prunes init-db itself performs. Each is BOUNDED: the guard evaluates the
+// predicate against snapshot A and excuses at most that many lost rows — a
+// buggy variant that deletes more than its own predicate matches still trips.
+export const EXPECTED_PRUNES = [
+  {
+    table: "schedules",
+    predicate: "task LIKE 'pipeline:%' AND task NOT LIKE 'pipeline:botcron:%'",
+  },
+  {
+    table: "project_spaces",
+    predicate: "type = 'learner_profile' AND archived_at IS NOT NULL",
+  },
+];
+
+// Row MOVES: a decrease in `from` is excused up to the observed increase in
+// `to` (the dashboard_settings PK-restore migration relocates instance-scoped
+// rows into dashboard_settings_overrides).
+export const EXPECTED_MOVES = [
+  { from: "dashboard_settings", to: "dashboard_settings_overrides" },
+];
+
+// High-churn queue/cache tables where routine runtime activity (retention
+// prunes, queue drains, fetch-and-delete stores, session sweeps) legitimately
+// drains rows — including to zero — while a guarded run is in flight. Their
+// losses alert (SUSPECT) but never fail closed.
+export const VOLATILE_TABLES = [
+  "cross_host_calls",
+  "notifications",
+  "message_retry_queue",
+  "bot_message_seen",
+  "relay_blobs",
+  "mcp_sessions",
+  "crowdsec_decisions_cache",
+];
+
+// Rebuild sources (DROP TABLE + recreate + copy) with per-table loss policy:
+//   "strict"         → any unexcused loss on a FIRED rebuild = high-confidence loss
+//   "dedup-tolerant" → the rebuild dedups by design (INSERT OR IGNORE); loss on
+//                      a fired rebuild classifies SUSPECT, not loss
+// dashboard_settings is strict but its loss is excusable via its EXPECTED_MOVE.
+export const REBUILD_TABLES = {
+  // generic TABLE_SPECS rebuilds (rebuildMainFKsToProjectSpaces):
+  research_sources: "strict",
+  research_notes: "strict",
+  data_backends: "strict",
+  // standalone state-conditional rebuilds:
+  shared_items: "strict",
+  crow_context: "dedup-tolerant",
+  dashboard_settings: "strict",
+};
+
+// sqlite_master objects init-db removes WITHOUT recreating (legacy trigger and
+// index cleanup). Glob patterns on the object name. Objects belonging to an
+// excused table drop/rebuild are excused automatically by the guard.
+export const EXPECTED_OBJECT_REMOVALS = [
+  "tr_rp_to_ps_*", // legacy research_projects mirror triggers
+  "idx_dashboard_settings_*", // dropped by the dashboard_settings PK restore
+  "idx_crow_context_*", // dropped/replaced by the scope-index migration
+];
+
+// Classification thresholds (env-overridable for emergencies only).
+export const LOSS_FLOOR = Number(process.env.CROW_MIGRATION_LOSS_FLOOR || 10);
+export const LOSS_FRACTION = Number(process.env.CROW_MIGRATION_LOSS_FRACTION || 0.5);

--- a/servers/shared/migration-guard.js
+++ b/servers/shared/migration-guard.js
@@ -235,7 +235,14 @@ export function backupDir(dbPath) {
 
 async function takeBackup(dbPath, fromGen, toGen, performBackupFn) {
   const dir = backupDir(dbPath);
-  mkdirSync(dir, { recursive: true });
+  // A backup-infrastructure failure (unwritable data dir, ENOSPC — the most
+  // likely trigger for a BACKUP feature) must degrade to the fail-open
+  // "no safety backup" path, never throw out of the never-throws guard.
+  try {
+    mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    return { ok: false, reason: `cannot create backup dir: ${err?.message}` };
+  }
   // Free-space precheck: ≥1.2× DB size on the anchor filesystem.
   try {
     const { statfsSync } = await import("node:fs");
@@ -300,15 +307,31 @@ export function pinBackup(path) {
 /* ----------------------------------------------------------------- restore */
 
 /** Move damaged db (+wal/+shm) aside as evidence, copy the backup in. The
- *  caller guarantees this process holds no handles on dbPath. */
+ *  caller guarantees this process holds no handles on dbPath.
+ *
+ *  Self-healing on partial failure: if the copy-in fails after the rename,
+ *  the damaged file (and its WAL siblings) are renamed BACK so dbPath is
+ *  never left missing — a missing DB file would be silently re-created empty
+ *  by the next better-sqlite3 open, which is worse than the damaged state. */
 export function restoreBackup(dbPath, backupPath) {
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
   const evidence = `${dbPath}.damaged-${ts}`;
   renameSync(dbPath, evidence);
+  const movedSuffixes = [];
   for (const suffix of ["-wal", "-shm"]) {
-    try { renameSync(dbPath + suffix, evidence + suffix); } catch {}
+    try { renameSync(dbPath + suffix, evidence + suffix); movedSuffixes.push(suffix); } catch {}
   }
-  copyFileSync(backupPath, dbPath);
+  try {
+    copyFileSync(backupPath, dbPath);
+  } catch (err) {
+    try {
+      renameSync(evidence, dbPath);
+      for (const suffix of movedSuffixes) {
+        try { renameSync(evidence + suffix, dbPath + suffix); } catch {}
+      }
+    } catch {}
+    throw new Error(`restore copy failed (damaged file moved back): ${err?.message}`);
+  }
   return { evidence };
 }
 
@@ -518,11 +541,20 @@ export async function runGuardedInitDb({
         (evidence
           ? `The database was RESTORED from the pre-migration backup; the damaged file is kept at ${evidence}. Restart any Crow-connected processes (MCP servers, bots) now.`
           : backup.ok
-            ? `Automatic restore failed — restore manually from ${backup.path}.`
+            ? `Automatic restore FAILED — stop the gateway and restore manually from ${backup.path}.`
             : `No backup was available (disk) — the loss is NOT recoverable from the guard; check ${backupDir(dbPath)}.`) +
         ` This migration is quarantined (attempt ${marker.attempts}/${QUARANTINE_MAX_ATTEMPTS}); delete ${dataMarkerPath(dbPath)} and ${repoMarkerPath(appRoot)} to override.`,
     });
-    return { verdict: "loss", backupPath: backup.path, evidence, report: result.report, initDbExit: r.code, marker };
+    return {
+      verdict: "loss",
+      backupPath: backup.path,
+      evidence,
+      restored: !!evidence,
+      dbPresent: existsSync(dbPath),
+      report: result.report,
+      initDbExit: r.code,
+      marker,
+    };
   }
 
   if (result.verdict === "suspect") {

--- a/servers/shared/migration-guard.js
+++ b/servers/shared/migration-guard.js
@@ -1,0 +1,540 @@
+/**
+ * migration-guard.js — runtime migration guard (Item A3).
+ *
+ * Wraps production init-db runs (auto-update post-pull, gateway boot gate,
+ * guarded-init-db CLI) with: pre-migration backup, post-migration row-count /
+ * column / schema-object classification, and the Q9 policy — fail closed ONLY
+ * on high-confidence loss (restore + quarantine), fail open with a loud
+ * DB-free alert on everything else.
+ *
+ * HARD RULE: every DB access in this module uses raw short-lived
+ * better-sqlite3 connections, explicitly closed before any restore — NEVER
+ * createDbClient (its per-path keeper handle is never closed and would pin
+ * the pre-restore inode for process lifetime; see servers/db.js keeper docs).
+ * On the boot path this module's readSchemaState() IS the gate's detection
+ * read, so createDbClient first touches the DB only after the gate concludes.
+ *
+ * Spec + review record: crow-engineering
+ * specs/2026-07-18-a3-migration-guard-design.md (rev 3; R1 4C/7M/6M, R2 2C/3M/5M).
+ */
+
+import Database from "better-sqlite3";
+import {
+  copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync,
+  statSync, unlinkSync, writeFileSync,
+} from "node:fs";
+import { execFile } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import {
+  EXPECTED_DROPS, EXPECTED_MOVES, EXPECTED_OBJECT_REMOVALS, EXPECTED_PRUNES,
+  LOSS_FLOOR, LOSS_FRACTION, REBUILD_TABLES, VOLATILE_TABLES,
+} from "./migration-expectations.js";
+
+const BACKUP_KEEP = 3;
+const BACKUP_MAX_MB = Number(process.env.CROW_MIGRATION_BACKUP_MAX_MB || 2048);
+const PIN_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // pinned backups exempt 30 days
+const DAMAGED_KEEP = 2;
+const QUARANTINE_MAX_ATTEMPTS = 3;
+const REPO_MARKER = ".crow-migration-quarantine.json";
+const DATA_MARKER = "migration-quarantine.json";
+
+/* ------------------------------------------------------------------ paths */
+
+/** The DB path exactly as init-db resolves it. */
+export function resolveGuardDbPath(dataDirResolver) {
+  if (process.env.CROW_DB_PATH) return resolve(process.env.CROW_DB_PATH);
+  return join(dataDirResolver(), "crow.db");
+}
+
+/** Backups + marker anchor: the DB's own directory (CROW_DB_PATH may diverge
+ *  from resolveDataDir — grackle's F2 incident). */
+export function guardAnchor(dbPath) {
+  return dirname(resolve(dbPath));
+}
+
+/* -------------------------------------------------------------- snapshots */
+
+/** Raw, short-lived, readonly snapshot of everything classification needs. */
+export function snapshotDb(dbPath) {
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const tables = {};
+    const tableRows = db
+      .prepare("SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+      .all();
+    for (const { name, sql } of tableRows) {
+      let count = null;
+      try {
+        count = db.prepare(`SELECT COUNT(*) AS n FROM "${name.replace(/"/g, '""')}"`).get().n;
+      } catch {
+        count = null; // unreadable table — classification treats null as unknown
+      }
+      let columns = [];
+      try {
+        columns = db.prepare(`PRAGMA table_info("${name.replace(/"/g, '""')}")`).all().map((c) => c.name);
+      } catch {}
+      tables[name] = { count, columns, sql: sql || "" };
+    }
+    const objects = db
+      .prepare("SELECT type||':'||name AS o, tbl_name FROM sqlite_master WHERE type IN ('index','trigger','view') AND name NOT LIKE 'sqlite_%'")
+      .all();
+    const userVersion = db.pragma("user_version", { simple: true });
+    const pruneCounts = {};
+    for (const { table, predicate } of EXPECTED_PRUNES) {
+      try {
+        pruneCounts[table] = db
+          .prepare(`SELECT COUNT(*) AS n FROM "${table.replace(/"/g, '""')}" WHERE ${predicate}`)
+          .get().n;
+      } catch {
+        pruneCounts[table] = 0;
+      }
+    }
+    return { tables, objects, userVersion, pruneCounts };
+  } finally {
+    try { db.close(); } catch {}
+  }
+}
+
+/** Boot-gate detection read — raw, never createDbClient. */
+export function readSchemaState(dbPath) {
+  if (!existsSync(dbPath)) return { exists: false, coreTableCount: 0, userVersion: 0, readable: false };
+  let db;
+  try {
+    db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    const coreTableCount = db
+      .prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE type='table' AND name IN ('memories','dashboard_settings','crow_context')")
+      .get().n;
+    let userVersion = 0;
+    try { userVersion = db.pragma("user_version", { simple: true }); } catch {}
+    return { exists: true, coreTableCount, userVersion, readable: true };
+  } catch {
+    return { exists: true, coreTableCount: 0, userVersion: 0, readable: false };
+  } finally {
+    try { db?.close(); } catch {}
+  }
+}
+
+/* ----------------------------------------------------------- classification */
+
+function globToRe(glob) {
+  return new RegExp("^" + glob.split("*").map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(".*") + "$");
+}
+
+const OBJECT_REMOVAL_RES = EXPECTED_OBJECT_REMOVALS.map(globToRe);
+
+/**
+ * Pure classification of snapshot A → B. Returns { verdict, report } where
+ * verdict ∈ pass|suspect|loss (init-db exit handling is the caller's job —
+ * a nonzero exit can only worsen pass → suspect).
+ */
+export function classify(snapA, snapB) {
+  const losses = [];
+  const suspects = [];
+  const excused = [];
+  const moveGains = {};
+  for (const { from, to } of EXPECTED_MOVES) {
+    const a = snapA.tables[to]?.count ?? 0;
+    const b = snapB.tables[to]?.count ?? 0;
+    moveGains[from] = Math.max(0, (b ?? 0) - (a ?? 0));
+  }
+
+  for (const [name, aInfo] of Object.entries(snapA.tables)) {
+    const bInfo = snapB.tables[name];
+    // Disappeared tables
+    if (!bInfo) {
+      if (EXPECTED_DROPS.includes(name)) { excused.push(`${name}: expected drop`); continue; }
+      losses.push(`table ${name} disappeared (${aInfo.count} rows)`);
+      continue;
+    }
+    if (aInfo.count == null || bInfo.count == null) {
+      suspects.push(`${name}: count unreadable (A=${aInfo.count} B=${bInfo.count})`);
+      continue;
+    }
+    let lost = aInfo.count - bInfo.count;
+    if (lost <= 0) continue; // increases always pass
+
+    // Excusals, in spec order: prunes (bounded), moves (bounded)
+    const prune = EXPECTED_PRUNES.find((p) => p.table === name);
+    if (prune) {
+      const bound = snapA.pruneCounts[name] ?? 0;
+      const used = Math.min(lost, bound);
+      if (used > 0) excused.push(`${name}: ${used} rows via expected prune`);
+      lost -= used;
+    }
+    if (lost > 0 && moveGains[name] > 0) {
+      const used = Math.min(lost, moveGains[name]);
+      excused.push(`${name}: ${used} rows moved to ${EXPECTED_MOVES.find((m) => m.from === name).to}`);
+      lost -= used;
+    }
+    if (lost <= 0) continue;
+
+    const rebuildPolicy = REBUILD_TABLES[name];
+    const rebuildFired = rebuildPolicy && aInfo.sql !== bInfo.sql;
+    if (rebuildFired) {
+      const msg = `rebuilt table ${name} lost ${lost} rows (${aInfo.count} -> ${bInfo.count})`;
+      if (rebuildPolicy === "strict") losses.push(msg);
+      else suspects.push(`${msg} [dedup-tolerant rebuild]`);
+      continue;
+    }
+    if (VOLATILE_TABLES.includes(name)) {
+      suspects.push(`volatile ${name}: ${aInfo.count} -> ${bInfo.count}`);
+      continue;
+    }
+    const toZero = bInfo.count === 0 && aInfo.count >= LOSS_FLOOR;
+    const bigLoss = lost >= LOSS_FLOOR && lost / aInfo.count > LOSS_FRACTION;
+    if (toZero || bigLoss) {
+      losses.push(`table ${name}: ${aInfo.count} -> ${bInfo.count} unexplained`);
+    } else {
+      suspects.push(`${name}: ${aInfo.count} -> ${bInfo.count} (noise band)`);
+    }
+  }
+
+  // Column loss on FIRED rebuilds (identical counts, narrower table)
+  for (const [name, policy] of Object.entries(REBUILD_TABLES)) {
+    const aInfo = snapA.tables[name];
+    const bInfo = snapB.tables[name];
+    if (!aInfo || !bInfo || aInfo.sql === bInfo.sql) continue;
+    const lostCols = aInfo.columns.filter((c) => !bInfo.columns.includes(c));
+    if (lostCols.length) {
+      const msg = `rebuilt table ${name} lost column(s): ${lostCols.join(", ")}`;
+      if (policy === "strict") losses.push(msg);
+      else suspects.push(msg);
+    }
+  }
+
+  // sqlite_master object removals (indexes/triggers/views) — SUSPECT band
+  const bObjects = new Set(snapB.objects.map((o) => o.o));
+  for (const { o, tbl_name } of snapA.objects) {
+    if (bObjects.has(o)) continue;
+    const name = o.split(":")[1];
+    const tableExcused =
+      EXPECTED_DROPS.includes(tbl_name) ||
+      (REBUILD_TABLES[tbl_name] && snapA.tables[tbl_name]?.sql !== snapB.tables[tbl_name]?.sql) ||
+      !snapB.tables[tbl_name];
+    if (tableExcused && snapB.tables[tbl_name]) {
+      // rebuild fired: object loss on a rebuilt table is still worth an alert
+      // unless explicitly expected — FTS trigger loss broke search before.
+      if (OBJECT_REMOVAL_RES.some((re) => re.test(name))) { excused.push(`object ${o}: expected removal`); continue; }
+      suspects.push(`object ${o} removed by ${tbl_name} rebuild without recreation`);
+      continue;
+    }
+    if (tableExcused) { excused.push(`object ${o}: table excused`); continue; }
+    if (OBJECT_REMOVAL_RES.some((re) => re.test(name))) { excused.push(`object ${o}: expected removal`); continue; }
+    suspects.push(`object ${o} removed`);
+  }
+
+  const verdict = losses.length ? "loss" : suspects.length ? "suspect" : "pass";
+  return { verdict, report: { losses, suspects, excused } };
+}
+
+/* ------------------------------------------------------------------ backup */
+
+export function backupDir(dbPath) {
+  return join(guardAnchor(dbPath), "backups", "migrations");
+}
+
+async function takeBackup(dbPath, fromGen, toGen, performBackupFn) {
+  const dir = backupDir(dbPath);
+  mkdirSync(dir, { recursive: true });
+  // Free-space precheck: ≥1.2× DB size on the anchor filesystem.
+  try {
+    const { statfsSync } = await import("node:fs");
+    const dbSize = statSync(dbPath).size;
+    const st = statfsSync(dir);
+    if (st.bavail * st.bsize < dbSize * 1.2) {
+      return { ok: false, reason: `insufficient disk (need ${Math.ceil((dbSize * 1.2) / 1e6)}MB free)` };
+    }
+  } catch {} // statfs unsupported → attempt the backup anyway
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const dest = join(dir, `crow-pre-g${fromGen}-to-g${toGen}-${ts}.db`);
+  try {
+    await performBackupFn(dbPath, dest);
+    return { ok: true, path: dest };
+  } catch (err) {
+    try { unlinkSync(dest); } catch {}
+    return { ok: false, reason: err?.message || String(err) };
+  }
+}
+
+/** Retention: keep last BACKUP_KEEP + size cap; pinned exempt 30 days.
+ *  Also caps damaged-evidence sets at DAMAGED_KEEP. */
+export function sweepRetention(dbPath) {
+  const dir = backupDir(dbPath);
+  let entries = [];
+  try {
+    entries = readdirSync(dir)
+      .filter((f) => f.startsWith("crow-pre-") && f.endsWith(".db"))
+      .map((f) => ({ f, full: join(dir, f), mtime: statSync(join(dir, f)).mtimeMs, size: statSync(join(dir, f)).size }))
+      .sort((a, b) => b.mtime - a.mtime);
+  } catch { return; }
+  const now = Date.now();
+  const pinned = (e) => existsSync(e.full + ".pin") && now - e.mtime < PIN_EXPIRY_MS;
+  let kept = 0, bytes = 0;
+  for (const e of entries) {
+    if (pinned(e)) continue;
+    kept += 1;
+    bytes += e.size;
+    if (kept > BACKUP_KEEP || bytes > BACKUP_MAX_MB * 1e6) {
+      try { unlinkSync(e.full); unlinkSync(e.full + ".pin"); } catch {}
+    }
+  }
+  // Damaged-evidence cap (crow.db.damaged-<ts>[-wal|-shm]) in the anchor dir.
+  try {
+    const anchor = guardAnchor(dbPath);
+    const damaged = readdirSync(anchor)
+      .filter((f) => /\.damaged-[^/]*$/.test(f) && !/-wal$|-shm$/.test(f))
+      .map((f) => ({ f, mtime: statSync(join(anchor, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+    for (const e of damaged.slice(DAMAGED_KEEP)) {
+      for (const suffix of ["", "-wal", "-shm"]) {
+        try { unlinkSync(join(anchor, e.f + suffix)); } catch {}
+      }
+    }
+  } catch {}
+}
+
+export function pinBackup(path) {
+  try { writeFileSync(path + ".pin", new Date().toISOString()); } catch {}
+}
+
+/* ----------------------------------------------------------------- restore */
+
+/** Move damaged db (+wal/+shm) aside as evidence, copy the backup in. The
+ *  caller guarantees this process holds no handles on dbPath. */
+export function restoreBackup(dbPath, backupPath) {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const evidence = `${dbPath}.damaged-${ts}`;
+  renameSync(dbPath, evidence);
+  for (const suffix of ["-wal", "-shm"]) {
+    try { renameSync(dbPath + suffix, evidence + suffix); } catch {}
+  }
+  copyFileSync(backupPath, dbPath);
+  return { evidence };
+}
+
+/* ---------------------------------------------------------------- markers */
+
+export function repoMarkerPath(appRoot) { return join(appRoot, REPO_MARKER); }
+export function dataMarkerPath(dbPath) { return join(guardAnchor(dbPath), DATA_MARKER); }
+
+export function readMarker(path) {
+  try { return JSON.parse(readFileSync(path, "utf8")); } catch { return null; }
+}
+
+/** Active = present and not auto-cleared. */
+export function activeMarker(path) {
+  const m = readMarker(path);
+  return m && !m.cleared ? m : null;
+}
+
+export function writeQuarantine({ appRoot, dbPath, sha, fromGeneration, toGeneration, report }) {
+  // attempts is keyed by the (from,to) generation pair: a prior marker for the
+  // SAME crossing (cleared or not) carries its attempts forward.
+  let attempts = 1;
+  for (const p of [repoMarkerPath(appRoot), dataMarkerPath(dbPath)]) {
+    const prev = readMarker(p);
+    if (prev && prev.fromGeneration === fromGeneration && prev.toGeneration === toGeneration) {
+      attempts = Math.max(attempts, (prev.attempts || 0) + 1);
+    }
+  }
+  const marker = { sha, fromGeneration, toGeneration, at: new Date().toISOString(), attempts, report };
+  for (const p of [repoMarkerPath(appRoot), dataMarkerPath(dbPath)]) {
+    try { writeFileSync(p, JSON.stringify(marker, null, 2)); } catch {}
+  }
+  return marker;
+}
+
+/**
+ * Under-lock evaluation for the updater: given origin/main's fresh head sha,
+ * decide { blocked, marker, cleared }. Clears (marks cleared:true, preserving
+ * attempts for the pair) when the head moved AND attempts < cap.
+ */
+export function evaluateQuarantine({ appRoot, dbPath, originHeadSha }) {
+  const paths = [repoMarkerPath(appRoot), dataMarkerPath(dbPath)];
+  const markers = paths.map((p) => ({ p, m: readMarker(p) })).filter((x) => x.m && !x.m.cleared);
+  if (!markers.length) return { blocked: false };
+  const m = markers[0].m;
+  if (originHeadSha && originHeadSha !== m.sha && (m.attempts || 1) < QUARANTINE_MAX_ATTEMPTS) {
+    for (const { p, m: mm } of markers) {
+      try { writeFileSync(p, JSON.stringify({ ...mm, cleared: true, clearedAt: new Date().toISOString() }, null, 2)); } catch {}
+    }
+    return { blocked: false, cleared: true, marker: m };
+  }
+  return { blocked: true, marker: m };
+}
+
+/* ---------------------------------------------------------------- alerting */
+
+let _alertChannels = null;
+/** Test hook. */
+export function _setAlertChannelsForTest(ch) { _alertChannels = ch; }
+
+async function loadAlertChannels() {
+  if (_alertChannels) return _alertChannels;
+  const [ntfy, email] = await Promise.all([
+    import("../gateway/push/ntfy.js"),
+    import("../gateway/push/email.js"),
+  ]);
+  return { sendNtfyNotification: ntfy.sendNtfyNotification, sendEmailNotification: email.sendEmailNotification };
+}
+
+/** DB-free loud alert (PR #124 pattern) — never throws. */
+export async function fireMigrationAlert({ title, body }) {
+  try {
+    const ch = await loadAlertChannels();
+    const payload = { title, body, url: "/dashboard/nest", priority: "high", type: "system" };
+    await ch.sendNtfyNotification(payload);
+    await ch.sendEmailNotification(payload);
+  } catch (err) {
+    console.warn(`[migration-guard] alert failed: ${err?.message}`);
+  }
+}
+
+/* -------------------------------------------------------------- generation */
+
+/** Parse SCHEMA_GENERATION from a checked-out tree (the running process's
+ *  import may be stale after a pull). */
+export function readTreeGeneration(appRoot) {
+  try {
+    const src = readFileSync(join(appRoot, "servers", "shared", "schema-version.js"), "utf8");
+    const m = src.match(/SCHEMA_GENERATION\s*=\s*(\d+)/);
+    return m ? Number(m[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/* ------------------------------------------------------------ orchestration */
+
+function defaultRunInitDb(appRoot) {
+  return new Promise((res) => {
+    execFile("node", ["scripts/init-db.js"], { cwd: appRoot, timeout: 600000 }, (err, stdout, stderr) => {
+      res({ code: err ? err.code || 1 : 0, stdout: String(stdout || ""), stderr: String(stderr || "") });
+    });
+  });
+}
+
+/**
+ * The guarded init-db run (spec §3.1). Never throws; never runs init-db twice.
+ * The caller decides what to do with the verdict (restart, exit, proceed).
+ *
+ * @returns {Promise<{verdict:string, backupPath?:string, evidence?:string,
+ *   report?:object, initDbExit?:number, marker?:object}>}
+ */
+export async function runGuardedInitDb({
+  dbPath,
+  appRoot,
+  sha = null,
+  newGeneration = null,
+  log = (m) => console.log(`[migration-guard] ${m}`),
+  runInitDb = defaultRunInitDb,
+  performBackupFn = null,
+  restore = true, // callers that must not restore (unsupervised contexts) pass false-only via policy — default per spec
+}) {
+  const doBackup = performBackupFn || (await import("../db.js")).performBackup;
+
+  // Pre-flight
+  const state = readSchemaState(dbPath);
+  if (!state.exists) {
+    const r = await runInitDb(appRoot);
+    return { verdict: "fresh", initDbExit: r.code };
+  }
+  if (!state.readable) {
+    // Unreadable ≠ empty: preserve evidence file-copies, alert, run unguarded.
+    const dir = backupDir(dbPath);
+    try {
+      mkdirSync(dir, { recursive: true });
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      for (const suffix of ["", "-wal", "-shm"]) {
+        if (existsSync(dbPath + suffix)) copyFileSync(dbPath + suffix, join(dir, `unreadable-${ts}${suffix || ".db"}`));
+      }
+    } catch {}
+    await fireMigrationAlert({
+      title: "Crow DB unreadable before migration",
+      body: `The database at ${dbPath} could not be read before a migration run. File copies were saved to ${dir}. If the migration fails, run \`npm run recover-db\`.`,
+    });
+    const r = await runInitDb(appRoot);
+    return { verdict: "unreadable", initDbExit: r.code };
+  }
+  if (state.coreTableCount < 3) {
+    const r = await runInitDb(appRoot);
+    return { verdict: "fresh", initDbExit: r.code };
+  }
+
+  // Snapshot A + backup
+  let snapA;
+  try {
+    snapA = snapshotDb(dbPath);
+  } catch (err) {
+    log(`snapshot failed (${err?.message}) — running unguarded`);
+    const r = await runInitDb(appRoot);
+    return { verdict: "unreadable", initDbExit: r.code };
+  }
+  const fromGen = snapA.userVersion;
+  const toGen = newGeneration ?? fromGen;
+  const backup = await takeBackup(dbPath, fromGen, toGen, doBackup);
+  if (!backup.ok) {
+    log(`backup failed: ${backup.reason} — proceeding WITHOUT a safety backup (fail open)`);
+    await fireMigrationAlert({
+      title: "Crow migration running without a safety backup",
+      body: `Pre-migration backup failed (${backup.reason}) for ${dbPath}. The migration will proceed; free disk space to restore protection. Backups live in ${backupDir(dbPath)}.`,
+    });
+  }
+
+  // The migration
+  const r = await runInitDb(appRoot);
+
+  // Snapshot B + classify
+  let result;
+  try {
+    const snapB = snapshotDb(dbPath);
+    result = classify(snapA, snapB);
+  } catch (err) {
+    result = { verdict: "suspect", report: { losses: [], suspects: [`post-migration snapshot failed: ${err?.message}`], excused: [] } };
+  }
+  if (r.code !== 0 && result.verdict === "pass") {
+    result = { verdict: "suspect", report: { ...result.report, suspects: [...result.report.suspects, `init-db exited ${r.code}`] } };
+  }
+
+  const summary = [...result.report.losses, ...result.report.suspects].join("; ") || "clean";
+
+  if (result.verdict === "loss") {
+    let evidence = null;
+    if (backup.ok && restore) {
+      try {
+        ({ evidence } = restoreBackup(dbPath, backup.path));
+        pinBackup(backup.path);
+        log(`HIGH-CONFIDENCE LOSS — restored ${dbPath} from ${backup.path}; damaged file kept at ${evidence}`);
+      } catch (err) {
+        log(`restore FAILED: ${err?.message}`);
+        evidence = null;
+      }
+    }
+    const marker = writeQuarantine({ appRoot, dbPath, sha, fromGeneration: fromGen, toGeneration: toGen, report: result.report });
+    await fireMigrationAlert({
+      title: "Crow migration guard: data loss detected — migration quarantined",
+      body:
+        `A migration on ${dbPath} destroyed data (${summary}). ` +
+        (evidence
+          ? `The database was RESTORED from the pre-migration backup; the damaged file is kept at ${evidence}. Restart any Crow-connected processes (MCP servers, bots) now.`
+          : backup.ok
+            ? `Automatic restore failed — restore manually from ${backup.path}.`
+            : `No backup was available (disk) — the loss is NOT recoverable from the guard; check ${backupDir(dbPath)}.`) +
+        ` This migration is quarantined (attempt ${marker.attempts}/${QUARANTINE_MAX_ATTEMPTS}); delete ${dataMarkerPath(dbPath)} and ${repoMarkerPath(appRoot)} to override.`,
+    });
+    return { verdict: "loss", backupPath: backup.path, evidence, report: result.report, initDbExit: r.code, marker };
+  }
+
+  if (result.verdict === "suspect") {
+    if (backup.ok) pinBackup(backup.path);
+    await fireMigrationAlert({
+      title: "Crow migration guard: suspicious changes (proceeding)",
+      body: `A migration on ${dbPath} produced unexplained changes (${summary}). The system proceeded (fail open). Pre-migration backup: ${backup.ok ? backup.path : "NONE (disk)"} — kept pinned for 30 days.`,
+    });
+  }
+
+  sweepRetention(dbPath);
+  return { verdict: result.verdict, backupPath: backup.ok ? backup.path : undefined, report: result.report, initDbExit: r.code };
+}
+
+export const _testables = { takeBackup, defaultRunInitDb, QUARANTINE_MAX_ATTEMPTS };

--- a/tests/auto-update-hardening.test.js
+++ b/tests/auto-update-hardening.test.js
@@ -13,6 +13,7 @@
 import { execFileSync } from "node:child_process";
 import {
   mkdtempSync,
+  mkdirSync,
   rmSync,
   writeFileSync,
   readFileSync,
@@ -59,7 +60,11 @@ function fixture() {
   g(work, "config", "user.email", "t@t");
   g(work, "config", "user.name", "t");
   writeFileSync(join(work, "a.txt"), "one\n");
-  g(work, "add", "a.txt");
+  // A runnable no-op init-db: since A3 the updater CHECKS its exit code
+  // (a failure now withholds the restart), so fixture updates need one.
+  mkdirSync(join(work, "scripts"), { recursive: true });
+  writeFileSync(join(work, "scripts", "init-db.js"), "process.exit(0);\n");
+  g(work, "add", "a.txt", "scripts/init-db.js");
   g(work, "commit", "-m", "c1");
   g(work, "push", "origin", "main");
   return { root, origin, work, cleanup: () => rmSync(root, { recursive: true, force: true }) };

--- a/tests/migration-guard.test.js
+++ b/tests/migration-guard.test.js
@@ -384,3 +384,54 @@ test("retention: keeps last 3, pinned exempt, damaged capped at 2", (t) => {
   const damagedLeft = readdirSync(dir).filter((f) => f.includes(".damaged-"));
   assert.equal(damagedLeft.length, 2);
 });
+
+/* ------------------------------------------- final-review regression fixes */
+
+test("takeBackup: unwritable backup dir fails OPEN (no throw, no-backup alert), never crashes the guard", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-nobk-"));
+  t.after(() => { _setAlertChannelsForTest(null); rmSync(dir, { recursive: true, force: true }); });
+  const dbPath = join(dir, "data", "crow.db");
+  makeFixtureDb(dbPath);
+  // A regular FILE where the backups dir must go → mkdirSync throws ENOTDIR.
+  writeFileSync(join(dir, "data", "backups"), "not a directory");
+  const alerts = stubAlerts();
+  const res = await runGuardedInitDb({
+    dbPath, appRoot: dir, newGeneration: 9, log: () => {},
+    runInitDb: async () => ({ code: 0 }), performBackupFn: copyBackup,
+  });
+  assert.equal(res.verdict, "pass");
+  assert.ok(alerts.some(([, p]) => /without a safety backup/.test(p.title)), "no-backup alert fired");
+});
+
+test("restoreBackup: failed copy self-heals — damaged file renamed back, dbPath never missing", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-heal-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const dbPath = join(dir, "crow.db");
+  writeFileSync(dbPath, "damaged-content");
+  assert.throws(() => restoreBackup(dbPath, join(dir, "no-such-backup.db")), /restore copy failed/);
+  assert.ok(existsSync(dbPath), "dbPath must not be left missing");
+  assert.equal(readFileSync(dbPath, "utf8"), "damaged-content");
+});
+
+test("loss without a usable backup reports restored:false and dbPresent:true", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-lossnb-"));
+  t.after(() => { _setAlertChannelsForTest(null); rmSync(dir, { recursive: true, force: true }); });
+  const dbPath = join(dir, "data", "crow.db");
+  makeFixtureDb(dbPath);
+  writeFileSync(join(dir, "data", "backups"), "not a directory"); // backup impossible
+  stubAlerts();
+  const res = await runGuardedInitDb({
+    dbPath, appRoot: dir, sha: "bad", newGeneration: 9, log: () => {},
+    runInitDb: async () => {
+      const db = new Database(dbPath);
+      db.exec("DROP TABLE test_data");
+      db.close();
+      return { code: 0 };
+    },
+    performBackupFn: copyBackup,
+  });
+  assert.equal(res.verdict, "loss");
+  assert.equal(res.restored, false);
+  assert.equal(res.dbPresent, true);
+  assert.ok(activeMarker(dataMarkerPath(dbPath)), "still quarantined");
+});

--- a/tests/migration-guard.test.js
+++ b/tests/migration-guard.test.js
@@ -1,0 +1,386 @@
+// Tests for the A3 runtime migration guard (servers/shared/migration-guard.js)
+// and its expected-changes manifest. Includes the static rot-guards that keep
+// the manifest honest against scripts/init-db.js and keep the boot-order
+// invariant (guard before the first createDbClient) from regressing.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, mkdirSync, rmSync, readdirSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import Database from "better-sqlite3";
+
+import {
+  classify, readSchemaState, snapshotDb, runGuardedInitDb, restoreBackup,
+  writeQuarantine, evaluateQuarantine, activeMarker, readMarker,
+  repoMarkerPath, dataMarkerPath, readTreeGeneration, resolveGuardDbPath,
+  sweepRetention, backupDir, pinBackup, _setAlertChannelsForTest, _testables,
+} from "../servers/shared/migration-guard.js";
+import {
+  EXPECTED_DROPS, EXPECTED_PRUNES, EXPECTED_MOVES, REBUILD_TABLES,
+  VOLATILE_TABLES,
+} from "../servers/shared/migration-expectations.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+function snap(tables, { objects = [], userVersion = 8, pruneCounts = {} } = {}) {
+  const t = {};
+  for (const [name, v] of Object.entries(tables)) {
+    t[name] = { count: v.count, columns: v.columns || ["id"], sql: v.sql || `CREATE TABLE ${name} (id)` };
+  }
+  return { tables: t, objects, userVersion, pruneCounts };
+}
+
+/* ------------------------------------------------------- classification */
+
+test("classify: increases and unchanged counts pass", () => {
+  const a = snap({ foo: { count: 5 }, bar: { count: 0 } });
+  const b = snap({ foo: { count: 9 }, bar: { count: 0 } });
+  assert.equal(classify(a, b).verdict, "pass");
+});
+
+test("classify: undeclared disappeared table is loss; declared drop is excused", () => {
+  const a = snap({ foo: { count: 5 }, research_projects: { count: 3 } });
+  const b = snap({});
+  const r = classify(a, b);
+  assert.equal(r.verdict, "loss");
+  assert.ok(r.report.losses.some((l) => l.includes("foo")));
+  assert.ok(r.report.excused.some((e) => e.includes("research_projects")));
+});
+
+test("classify: to-zero above floor is loss; small noise is suspect", () => {
+  const a = snap({ big: { count: 50 }, small: { count: 9 } });
+  const b = snap({ big: { count: 0 }, small: { count: 7 } });
+  const r = classify(a, b);
+  assert.equal(r.verdict, "loss");
+  assert.ok(r.report.losses.some((l) => l.includes("big")));
+  assert.ok(r.report.suspects.some((s) => s.includes("small")));
+});
+
+test("classify: >50% and >=floor loss is loss; below either threshold is suspect", () => {
+  const a = snap({ t1: { count: 100 }, t2: { count: 100 } });
+  const b = snap({ t1: { count: 40 }, t2: { count: 60 } }); // t1 -60 (>50%), t2 -40 (<50%)
+  const r = classify(a, b);
+  assert.ok(r.report.losses.some((l) => l.includes("t1")));
+  assert.ok(r.report.suspects.some((s) => s.includes("t2")));
+});
+
+test("classify: volatile tables never fail closed", () => {
+  const a = snap({ cross_host_calls: { count: 500 } });
+  const b = snap({ cross_host_calls: { count: 0 } });
+  const r = classify(a, b);
+  assert.equal(r.verdict, "suspect");
+});
+
+test("classify: prunes are bounded by the snapshot-A predicate count", () => {
+  const a = snap({ schedules: { count: 30 } }, { pruneCounts: { schedules: 10 } });
+  const ok = classify(a, snap({ schedules: { count: 20 } }, { pruneCounts: {} }));
+  assert.equal(ok.verdict, "pass"); // exactly the predicate count
+  const over = classify(a, snap({ schedules: { count: 4 } }, { pruneCounts: {} }));
+  assert.equal(over.verdict, "loss"); // 26 lost, only 10 excusable → 16 unexplained > floor + >50%
+});
+
+test("classify: moves excuse the source up to the destination gain", () => {
+  const a = snap({ dashboard_settings: { count: 40 }, dashboard_settings_overrides: { count: 0 } });
+  const moved = snap({ dashboard_settings: { count: 10 }, dashboard_settings_overrides: { count: 30 } });
+  assert.equal(classify(a, moved).verdict, "pass");
+  const lostToo = snap({ dashboard_settings: { count: 5 }, dashboard_settings_overrides: { count: 30 } });
+  // 35 lost, 30 moved → 5 unexplained; dashboard_settings rebuild NOT fired (same sql) → noise band (5 < floor)
+  assert.equal(classify(a, lostToo).verdict, "suspect");
+});
+
+test("classify: fired strict rebuild losing rows is loss even below thresholds", () => {
+  const a = snap({ research_sources: { count: 100, sql: "CREATE TABLE research_sources (old)" } });
+  const b = snap({ research_sources: { count: 97, sql: "CREATE TABLE research_sources (new)" } });
+  const r = classify(a, b);
+  assert.equal(r.verdict, "loss");
+});
+
+test("classify: fired dedup-tolerant rebuild losing rows is suspect", () => {
+  const a = snap({ crow_context: { count: 100, sql: "CREATE TABLE crow_context (old)" } });
+  const b = snap({ crow_context: { count: 97, sql: "CREATE TABLE crow_context (new)" } });
+  assert.equal(classify(a, b).verdict, "suspect");
+});
+
+test("classify: unfired rebuild-table decrease is concurrent noise, not loss", () => {
+  const a = snap({ research_sources: { count: 100, sql: "CREATE TABLE research_sources (x)" } });
+  const b = snap({ research_sources: { count: 97, sql: "CREATE TABLE research_sources (x)" } });
+  assert.equal(classify(a, b).verdict, "suspect");
+});
+
+test("classify: fired rebuild losing a column is loss", () => {
+  const a = snap({ research_sources: { count: 10, columns: ["id", "title", "doi"], sql: "v1" } });
+  const b = snap({ research_sources: { count: 10, columns: ["id", "title"], sql: "v2" } });
+  const r = classify(a, b);
+  assert.equal(r.verdict, "loss");
+  assert.ok(r.report.losses.some((l) => l.includes("doi")));
+});
+
+test("classify: expected object removals excused, others suspect", () => {
+  const a = snap({ t: { count: 1 } }, {
+    objects: [
+      { o: "trigger:tr_rp_to_ps_ins", tbl_name: "research_projects" },
+      { o: "index:idx_something_else", tbl_name: "t" },
+    ],
+  });
+  const b = snap({ t: { count: 1 } }, { objects: [] });
+  const r = classify(a, b);
+  assert.equal(r.verdict, "suspect");
+  assert.ok(r.report.excused.some((e) => e.includes("tr_rp_to_ps_ins")));
+  assert.ok(r.report.suspects.some((s) => s.includes("idx_something_else")));
+});
+
+/* ------------------------------------------------------------- markers */
+
+test("quarantine: attempts key on the generation pair and cap at 3", () => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-marker-"));
+  const dbPath = join(dir, "data", "crow.db");
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const args = { appRoot: dir, dbPath, sha: "aaa", fromGeneration: 8, toGeneration: 9, report: {} };
+
+  const m1 = writeQuarantine(args);
+  assert.equal(m1.attempts, 1);
+  // blocked while head == quarantined sha
+  assert.equal(evaluateQuarantine({ appRoot: dir, dbPath, originHeadSha: "aaa" }).blocked, true);
+  // head moved → cleared
+  const ev = evaluateQuarantine({ appRoot: dir, dbPath, originHeadSha: "bbb" });
+  assert.equal(ev.blocked, false);
+  assert.equal(ev.cleared, true);
+  assert.equal(activeMarker(repoMarkerPath(dir)), null); // cleared ≠ active
+
+  // same pair re-quarantines with attempts carried forward
+  const m2 = writeQuarantine({ ...args, sha: "bbb" });
+  assert.equal(m2.attempts, 2);
+  const m3attempts = writeQuarantine({ ...args, sha: "ccc" }).attempts;
+  assert.equal(m3attempts, 3);
+  // at the cap, a moved head no longer clears
+  const blockedAtCap = evaluateQuarantine({ appRoot: dir, dbPath, originHeadSha: "ddd" });
+  assert.equal(blockedAtCap.blocked, true);
+
+  // a DIFFERENT crossing starts fresh
+  const other = writeQuarantine({ ...args, fromGeneration: 9, toGeneration: 10, sha: "eee" });
+  assert.equal(other.attempts, 1);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/* ---------------------------------------------------- static rot-guards */
+
+test("rot-guard: every destructive statement in init-db is declared in the manifest (and vice versa)", () => {
+  const src = readFileSync(join(REPO_ROOT, "scripts", "init-db.js"), "utf8");
+
+  // Literal DROP TABLEs (name must be terminated by ; or a quote — skips the
+  // template-literal generic rebuild and prose in comments).
+  const dropNames = [...src.matchAll(/DROP TABLE (?:IF EXISTS )?([a-zA-Z_][a-zA-Z0-9_]*)\s*[;"'`]/g)].map((m) => m[1]);
+  assert.ok(dropNames.length >= 6, `expected ≥6 literal drops, saw ${dropNames}`);
+  const declared = new Set([...EXPECTED_DROPS, ...Object.keys(REBUILD_TABLES)]);
+  for (const n of dropNames) {
+    assert.ok(declared.has(n), `init-db drops table '${n}' but the manifest does not declare it — add it to migration-expectations.js`);
+  }
+
+  // Generic rebuild: every TABLE_SPECS key must be declared as a rebuild table.
+  const specsBlock = src.match(/const TABLE_SPECS = \{([\s\S]*?)\n {2}\};/);
+  assert.ok(specsBlock, "TABLE_SPECS block not found in init-db.js — update the rot-guard scanner");
+  const specKeys = [...specsBlock[1].matchAll(/^ {4}([a-zA-Z_][a-zA-Z0-9_]*): \{/gm)].map((m) => m[1]);
+  assert.ok(specKeys.length >= 3, `expected ≥3 TABLE_SPECS keys, saw ${specKeys}`);
+  for (const k of specKeys) {
+    assert.ok(REBUILD_TABLES[k], `TABLE_SPECS rebuild '${k}' is not declared in REBUILD_TABLES`);
+  }
+
+  // DELETE FROMs must be declared prunes, with predicates that still match.
+  const deleteNames = [...src.matchAll(/DELETE FROM ([a-zA-Z_][a-zA-Z0-9_]*)/g)].map((m) => m[1]);
+  const pruneTables = EXPECTED_PRUNES.map((p) => p.table);
+  for (const n of deleteNames) {
+    assert.ok(pruneTables.includes(n), `init-db deletes from '${n}' but EXPECTED_PRUNES does not declare it`);
+  }
+  for (const p of EXPECTED_PRUNES) {
+    assert.ok(deleteNames.includes(p.table), `EXPECTED_PRUNES declares '${p.table}' but init-db no longer deletes from it — remove the stale entry`);
+    assert.ok(src.includes(p.predicate), `EXPECTED_PRUNES predicate for '${p.table}' no longer matches init-db source — keep them in sync`);
+  }
+
+  // Reverse: stale drop declarations.
+  for (const n of EXPECTED_DROPS) {
+    assert.ok(dropNames.includes(n), `EXPECTED_DROPS declares '${n}' but init-db no longer drops it — remove the stale entry`);
+  }
+  for (const k of Object.keys(REBUILD_TABLES)) {
+    assert.ok(dropNames.includes(k) || specKeys.includes(k), `REBUILD_TABLES declares '${k}' but init-db has no rebuild for it`);
+  }
+  // Moves: destination table must exist in init-db DDL.
+  for (const m of EXPECTED_MOVES) {
+    assert.ok(src.includes(m.to), `EXPECTED_MOVES destination '${m.to}' not found in init-db`);
+  }
+  // Volatile list mentions only real tables.
+  for (const v of VOLATILE_TABLES) {
+    assert.ok(src.includes(v), `VOLATILE_TABLES entry '${v}' not found in init-db — is the table name right?`);
+  }
+});
+
+test("rot-guard: readTreeGeneration parses the real schema-version.js", () => {
+  const gen = readTreeGeneration(REPO_ROOT);
+  assert.ok(Number.isInteger(gen) && gen >= 8, `parsed generation ${gen}`);
+});
+
+test("rot-guard: boot gate precedes the first createDbClient call in index.js", () => {
+  const src = readFileSync(join(REPO_ROOT, "servers", "gateway", "index.js"), "utf8");
+  const gate = src.indexOf("runGuardedInitDb");
+  const oauth = src.indexOf("await initOAuthTables()");
+  const firstClient = src.indexOf("createDbClient()");
+  assert.ok(gate > 0 && oauth > 0 && firstClient > 0);
+  assert.ok(gate < oauth, "schema gate must run before initOAuthTables (R2-2: keeper pins the pre-restore inode)");
+  assert.ok(gate < firstClient, "schema gate must run before the first createDbClient()");
+});
+
+/* --------------------------------------------------------- integration */
+
+function makeFixtureDb(dbPath, { victimRows = 20 } = {}) {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE memories (id INTEGER PRIMARY KEY, content TEXT);
+    CREATE TABLE dashboard_settings (key TEXT PRIMARY KEY, value TEXT);
+    CREATE TABLE crow_context (id INTEGER PRIMARY KEY, section TEXT);
+    CREATE TABLE test_data (id INTEGER PRIMARY KEY, payload TEXT);
+  `);
+  const ins = db.prepare("INSERT INTO test_data (payload) VALUES (?)");
+  for (let i = 0; i < victimRows; i++) ins.run(`row-${i}`);
+  db.pragma("user_version = 8");
+  db.close();
+}
+
+function stubAlerts() {
+  const calls = [];
+  _setAlertChannelsForTest({
+    sendNtfyNotification: async (p) => calls.push(["ntfy", p]),
+    sendEmailNotification: async (p) => calls.push(["email", p]),
+  });
+  return calls;
+}
+
+const copyBackup = async (src, dest) => {
+  const db = new Database(src, { readonly: true });
+  try { await db.backup(dest); } finally { db.close(); }
+};
+
+test("integration: destructive migration → backup, restore, quarantine, alert", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-int-"));
+  t.after(() => { _setAlertChannelsForTest(null); rmSync(dir, { recursive: true, force: true }); });
+  const dbPath = join(dir, "data", "crow.db");
+  makeFixtureDb(dbPath);
+  const alerts = stubAlerts();
+
+  const destructive = async () => {
+    const db = new Database(dbPath);
+    db.exec("DROP TABLE test_data");
+    db.pragma("user_version = 9");
+    db.close();
+    return { code: 0 };
+  };
+
+  const res = await runGuardedInitDb({
+    dbPath, appRoot: dir, sha: "badsha", newGeneration: 9,
+    log: () => {}, runInitDb: destructive, performBackupFn: copyBackup,
+  });
+
+  assert.equal(res.verdict, "loss");
+  assert.ok(existsSync(res.backupPath), "backup file exists");
+  assert.ok(existsSync(res.backupPath + ".pin"), "backup pinned");
+  assert.ok(res.evidence && existsSync(res.evidence), "damaged evidence kept");
+  // Restored DB has the victim table back, full row count, old generation.
+  const db = new Database(dbPath, { readonly: true });
+  assert.equal(db.prepare("SELECT COUNT(*) AS n FROM test_data").get().n, 20);
+  assert.equal(db.pragma("user_version", { simple: true }), 8);
+  db.close();
+  // Markers at both levels, attempts=1.
+  const marker = activeMarker(dataMarkerPath(dbPath));
+  assert.ok(marker && marker.sha === "badsha" && marker.attempts === 1);
+  assert.ok(activeMarker(repoMarkerPath(dir)));
+  // Loud alert went through both DB-free channels.
+  assert.ok(alerts.some(([ch, p]) => ch === "ntfy" && /quarantined/.test(p.title)));
+  assert.ok(alerts.some(([ch]) => ch === "email"));
+  // The updater refuses this sha.
+  assert.equal(evaluateQuarantine({ appRoot: dir, dbPath, originHeadSha: "badsha" }).blocked, true);
+});
+
+test("integration: legitimate additive migration passes with zero findings", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-add-"));
+  t.after(() => { _setAlertChannelsForTest(null); rmSync(dir, { recursive: true, force: true }); });
+  const dbPath = join(dir, "data", "crow.db");
+  makeFixtureDb(dbPath);
+  const alerts = stubAlerts();
+
+  const additive = async () => {
+    const db = new Database(dbPath);
+    db.exec("CREATE TABLE new_feature (id INTEGER PRIMARY KEY); ALTER TABLE test_data ADD COLUMN extra TEXT");
+    db.pragma("user_version = 9");
+    db.close();
+    return { code: 0 };
+  };
+
+  const res = await runGuardedInitDb({
+    dbPath, appRoot: dir, sha: "goodsha", newGeneration: 9,
+    log: () => {}, runInitDb: additive, performBackupFn: copyBackup,
+  });
+  assert.equal(res.verdict, "pass");
+  assert.equal(alerts.length, 0, "no alerts on a clean migration");
+  assert.equal(activeMarker(dataMarkerPath(dbPath)), null);
+  // DB kept the migrated state (no restore).
+  const db = new Database(dbPath, { readonly: true });
+  assert.equal(db.pragma("user_version", { simple: true }), 9);
+  assert.ok(db.prepare("SELECT name FROM sqlite_master WHERE name='new_feature'").get());
+  db.close();
+});
+
+test("integration: fresh and missing DBs run unguarded", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-fresh-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const dbPath = join(dir, "data", "crow.db");
+  let ran = 0;
+  const res = await runGuardedInitDb({
+    dbPath, appRoot: dir, newGeneration: 9, log: () => {},
+    runInitDb: async () => { ran += 1; return { code: 0 }; },
+    performBackupFn: copyBackup,
+  });
+  assert.equal(res.verdict, "fresh");
+  assert.equal(ran, 1);
+});
+
+test("readSchemaState: raw detection matches fixture", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-state-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const dbPath = join(dir, "crow.db");
+  makeFixtureDb(dbPath);
+  const s = readSchemaState(dbPath);
+  assert.deepEqual(
+    { exists: s.exists, coreTableCount: s.coreTableCount, userVersion: s.userVersion, readable: s.readable },
+    { exists: true, coreTableCount: 3, userVersion: 8, readable: true },
+  );
+  assert.equal(readSchemaState(join(dir, "nope.db")).exists, false);
+});
+
+test("retention: keeps last 3, pinned exempt, damaged capped at 2", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "mg-ret-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const dbPath = join(dir, "crow.db");
+  writeFileSync(dbPath, "x");
+  const bdir = backupDir(dbPath);
+  mkdirSync(bdir, { recursive: true });
+  const now = Date.now();
+  for (let i = 0; i < 6; i++) {
+    const f = join(bdir, `crow-pre-g8-to-g9-t${i}.db`);
+    writeFileSync(f, "backup");
+    utimesSync(f, new Date(now - i * 1000), new Date(now - i * 1000));
+  }
+  pinBackup(join(bdir, "crow-pre-g8-to-g9-t5.db")); // oldest, pinned
+  for (let i = 0; i < 4; i++) {
+    const f = join(dir, `crow.db.damaged-t${i}`);
+    writeFileSync(f, "damaged");
+    utimesSync(f, new Date(now - i * 1000), new Date(now - i * 1000));
+  }
+  sweepRetention(dbPath);
+  const left = readdirSync(bdir).filter((f) => f.endsWith(".db"));
+  assert.equal(left.length, 4, `3 recent + 1 pinned, saw ${left}`); // t0,t1,t2 + pinned t5
+  assert.ok(left.includes("crow-pre-g8-to-g9-t5.db"));
+  const damagedLeft = readdirSync(dir).filter((f) => f.includes(".damaged-"));
+  assert.equal(damagedLeft.length, 2);
+});


### PR DESCRIPTION
## Item A3 — productize the migration rail

Every external instance now gets what the fleet gets by runbook: automatic protection around every production `init-db` run.

### What it does
When a run carries migration risk (schema-generation crossing, **or** the pulled range touches `scripts/init-db.js` — init-db contains state-conditional destructive rebuilds that fire on DB shape, not generation), the guard (`servers/shared/migration-guard.js`):

1. Takes a **pre-migration backup** (incremental better-sqlite3 `.backup()`, live-WAL-safe) with free-space precheck and retention (last 3 + size cap; finding-pinned backups exempt 30 days).
2. Runs init-db, then classifies per-table row counts, columns, and sqlite_master objects against the **expected-changes manifest** (`servers/shared/migration-expectations.js`) — declared drops, predicate-**bounded** prunes, row moves, volatile queue/cache tables, per-table rebuild policies. A static rot-guard test forces any future destructive migration to declare itself.
3. **Q9 policy:** high-confidence loss (undeclared table gone, fired rebuild lost rows/columns, large unexplained loss) fails **closed** — restore the backup, keep the damaged file (+WAL) as evidence, quarantine the migration (repo-level + data-dir markers; attempts-capped auto-clear when main moves; the manual "Check now" button can't bypass it), loud **DB-free** ntfy+email alert, conditional code rollback (never over local WIP) + immediate supervised restart. Anything less certain fails **open** with the same loud alert.

Covered paths: auto-update post-pull, gateway boot gate, `scripts/install.sh` (its existing-install branch is an upgrade path), `scripts/crow-update.sh`, and the new `scripts/guarded-init-db.mjs` CLI. `npm run init-db` stays the bare scratch/dev seam (documented).

### Key invariants
- **Boot order (R2-2):** the schema gate now runs *before* the first `createDbClient` with a raw short-lived detection read — a restore never swaps the DB file under the process's never-closed WAL keeper. Enforced by a source-order regression test.
- init-db's exit code is now **checked** on the update path (was silently discarded); failure withholds the restart and alerts.
- The guard never throws and never runs init-db twice; every internal failure maps to a fail-open verdict.

### Rigor record
- Spec (3 revisions) + full review record: crow-engineering `specs/2026-07-18-a3-migration-guard-design.md`. Adversarial rounds: R1 4 CRIT / 7 MAJ / 6 MIN; R2 2 CRIT / 3 MAJ / 5 MIN; final whole-branch review 2 blocking implementation bugs (unguarded backup-dir `mkdirSync` could crash boot; non-atomic restore could leave the DB file missing while callers claimed success) — all fixed with regression tests.
- **Live-proven** on a scratch gateway: fresh boot; armed drift boot against the *real* init-db (backup `crow-pre-g7-to-g8-*.db` taken, classification pass, gen 7→8); quarantined boot (gen-7 DB serving under gen-8 code, marker warning, no init-db run).
- Suite: **2057 / 2057 / 0 / 0** (baseline 2033 + 24 guard tests; 2 auto-update fixtures adapted to carry a runnable init-db).

No schema bump (no `SCHEMA_GENERATION` change; the manual dry-run rail is untouched and remains the pre-merge gate for bumps). A5 (CI-gating auto-update + the Q10 `enforce_admins` flip) is deliberately **not** in this PR.