### PR TITLE
feat(update): A5 CI-gate auto-update — never deploy a red or still-running main

### DIFF
--- a/docs/es/guide/auto-update.md
+++ b/docs/es/guide/auto-update.md
@@ -11,12 +11,18 @@ Crow incluye un actualizador automático integrado que busca nuevas versiones, d
 El actualizador automático se ejecuta como una tarea en segundo plano dentro del proceso del gateway:
 
 1. **Fetch** — ejecuta `git fetch origin main` para buscar nuevos commits
-2. **Stash** — si hay cambios locales (archivos modificados, trabajo sin commitear), los guarda automáticamente en un stash
-3. **Pull** — ejecuta `git pull --ff-only origin main` (solo fast-forward, sin commits de merge)
-4. **Dependencias** — ejecuta `npm install` si `package.json` o `package-lock.json` cambiaron
-5. **Migraciones** — ejecuta `node scripts/init-db.js` para cualquier cambio de esquema
-6. **Restauración** — aplica el stash para restaurar los cambios locales. Si hay conflictos, restaura un estado limpio y registra una advertencia
-7. **Reinicio** — cierra el servidor HTTP de forma ordenada y sale para que systemd reinicie el proceso
+2. **Puerta de CI** — consulta en GitHub los resultados de CI requeridos del commit
+   destino (`suite`, `static-checks`, `audit`). Una compilación en rojo o aún en
+   ejecución pospone la actualización hasta la próxima comprobación; los forks sin
+   esos checks no se ven afectados. Se desactiva con `CROW_UPDATE_CI_GATE=0`.
+3. **Stash** — si hay cambios locales (archivos modificados, trabajo sin commitear), los guarda automáticamente en un stash
+4. **Pull** — ejecuta `git pull --ff-only origin main` (solo fast-forward, sin commits de merge)
+5. **Dependencias** — ejecuta `npm install` si `package.json` o `package-lock.json` cambiaron
+6. **Migraciones** — ejecuta `node scripts/init-db.js` para cualquier cambio de esquema,
+   envuelto en la guarda de migraciones (copia de seguridad automática previa +
+   protección contra pérdida de datos)
+7. **Restauración** — aplica el stash para restaurar los cambios locales. Si hay conflictos, restaura un estado limpio y registra una advertencia
+8. **Reinicio** — cierra el servidor HTTP de forma ordenada y sale para que systemd reinicie el proceso
 
 ## Configuración
 

--- a/docs/guide/auto-update.md
+++ b/docs/guide/auto-update.md
@@ -11,12 +11,18 @@ Crow includes a built-in auto-updater that checks for new versions, pulls change
 The auto-updater runs as a background task inside the gateway process:
 
 1. **Fetch** — runs `git fetch origin main` to check for new commits
-2. **Stash** — if there are local changes (modified files, uncommitted work), stashes them automatically
-3. **Pull** — runs `git pull --ff-only origin main` (fast-forward only, no merge commits)
-4. **Dependencies** — runs `npm install` if `package.json` or `package-lock.json` changed
-5. **Migrations** — runs `node scripts/init-db.js` for any schema changes
-6. **Restore** — pops the stash to restore local changes. If there are conflicts, restores a clean state and logs a warning
-7. **Restart** — gracefully closes the HTTP server and exits so systemd restarts the process
+2. **CI gate** — checks the target commit's required CI results on GitHub
+   (`suite`, `static-checks`, `audit`). A red or still-running build skips the
+   update until the next check; forks without those CI checks are unaffected.
+   Disable with `CROW_UPDATE_CI_GATE=0`.
+3. **Stash** — if there are local changes (modified files, uncommitted work), stashes them automatically
+4. **Pull** — runs `git pull --ff-only origin main` (fast-forward only, no merge commits)
+5. **Dependencies** — runs `npm install` if `package.json` or `package-lock.json` changed
+6. **Migrations** — runs `node scripts/init-db.js` for any schema changes, wrapped in
+   the migration guard (automatic pre-migration backup + data-loss protection — see
+   the [database recovery guide](../developers/db-recovery.md))
+7. **Restore** — pops the stash to restore local changes. If there are conflicts, restores a clean state and logs a warning
+8. **Restart** — gracefully closes the HTTP server and exits so systemd restarts the process
 
 ## Configuration
 

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -234,6 +234,59 @@ export async function checkForUpdates() {
 const QUARANTINE_ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 let _quarantineAlertAt = 0;
 
+// ---------------------------------------------------------------------------
+// A5: CI gate — never pull a commit whose required CI is red or still running.
+// Q6 gates merges; this gates DEPLOYS (a direct admin push to main previously
+// reached every instance within 6h regardless of CI state).
+// ---------------------------------------------------------------------------
+
+// The three branch-protection context names (the A1 contract). Other runs
+// (deploy-docs, build, image-freshness) never block updates.
+const CI_GATE_CONTEXTS = ["suite", "static-checks", "audit"];
+
+/**
+ * Pure classification of a GitHub check-runs payload for the target sha.
+ * "unknown" (no named runs — a fork without our CI, or an API oddity) FAILS
+ * OPEN: strangers' forks and non-GitHub deployments must still update; the
+ * gate only defends against a KNOWABLY red main.
+ */
+export function classifyCheckRuns(payload) {
+  const runs = (payload?.check_runs || []).filter((r) => CI_GATE_CONTEXTS.includes(r?.name));
+  if (runs.length === 0) return "unknown";
+  if (runs.some((r) => r.status !== "completed")) return "pending";
+  const ok = ["success", "neutral", "skipped"];
+  return runs.every((r) => ok.includes(r.conclusion)) ? "green" : "red";
+}
+
+let _ciVerdictOverride = null;
+/** Test hook: force the CI-gate verdict (fixture repos have non-GitHub
+ *  remotes, so the real fetch path naturally skips). */
+export function _setCiVerdictForTest(v) { _ciVerdictOverride = v; }
+
+/**
+ * Resolve the CI verdict for the sha the pull would land on. Fail-open
+ * ("unknown") on: non-GitHub origin, network failure, non-200, bad JSON.
+ * One unauthenticated call per update tick — far under the anonymous limit.
+ */
+async function resolveCiVerdict(remoteUrl, sha) {
+  if (_ciVerdictOverride) return _ciVerdictOverride;
+  const m = /github\.com[:/]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/.exec(remoteUrl || "");
+  if (!m) return "unknown";
+  try {
+    const resp = await fetch(
+      `https://api.github.com/repos/${m[1]}/${m[2]}/commits/${sha}/check-runs`,
+      {
+        headers: { Accept: "application/vnd.github+json", "User-Agent": "crow-auto-update" },
+        signal: AbortSignal.timeout(15000),
+      },
+    );
+    if (!resp.ok) return "unknown";
+    return classifyCheckRuns(await resp.json());
+  } catch {
+    return "unknown";
+  }
+}
+
 /** The mutating sequence; exported ONLY as the test seam for the under-lock
  *  branch re-check (spec D3b — the outer guard would abort a branch fixture
  *  before the lock). */
@@ -302,6 +355,24 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
   }
 
   log(`${behindCount} new commit(s) available. Updating...`);
+
+  // A5: consult the target sha's required check-runs before pulling. Red or
+  // still-running CI skips this tick (self-heals when main is fixed or CI
+  // completes); unknown fails open. CROW_UPDATE_CI_GATE=0 disables.
+  if (process.env.CROW_UPDATE_CI_GATE !== "0") {
+    const remote = await run("git", ["remote", "get-url", "origin"]);
+    const targetSha = (await run("git", ["rev-parse", "origin/main"])).stdout;
+    const ci = await resolveCiVerdict(remote.stdout, targetSha);
+    if (ci === "red" || ci === "pending") {
+      const msg = ci === "red"
+        ? `Skipped: CI is RED on origin/main (${targetSha.slice(0, 9)}) — not deploying a failing build; will retry next tick`
+        : `Skipped: CI still running on origin/main (${targetSha.slice(0, 9)}) — will retry next tick`;
+      log(msg);
+      await saveSetting("auto_update_last_check", new Date().toISOString());
+      await saveSetting("auto_update_last_result", msg);
+      return { updated: false, skipped: ci === "red" ? "ci-red" : "ci-pending", message: msg };
+    }
+  }
 
   // D3b: re-check the branch UNDER the lock, immediately before the pull —
   // a parallel session's raw `git checkout` races the outer guard across the

--- a/tests/auto-update-ci-gate.test.js
+++ b/tests/auto-update-ci-gate.test.js
@@ -61,7 +61,7 @@ test("classifyCheckRuns: no named runs (fork without our CI) is unknown", () => 
 
 const g = (cwd, ...args) => execFileSync("git", args, { cwd, stdio: "pipe" }).toString().trim();
 
-function fixture() {
+function fixture({ behind = true } = {}) {
   const root = mkdtempSync(join(tmpdir(), "au-cigate-"));
   const origin = join(root, "origin.git");
   const work = join(root, "work");
@@ -75,6 +75,7 @@ function fixture() {
   g(work, "add", "a.txt", "scripts/init-db.js");
   g(work, "commit", "-m", "c1");
   g(work, "push", "origin", "main");
+  if (!behind) return { root, work, cleanup: () => rmSync(root, { recursive: true, force: true }) };
   // A new commit on origin (via a second clone) so the update has work to do.
   const pusher = mkdtempSync(join(root, "pusher-"));
   execFileSync("git", ["clone", origin, pusher], { stdio: "pipe" });
@@ -145,6 +146,23 @@ test("local (non-GitHub) remotes fail open without the test hook", async () => {
     const res = await runLockedUpdate(() => {});
     assert.equal(res.updated, true, "unknown verdict (local remote) proceeds");
   } finally {
+    _setDbForTest(null);
+    _setAppRootForTest(join(import.meta.dirname, ".."));
+    fx.cleanup();
+  }
+});
+
+test("placement: an up-to-date repo short-circuits BEFORE the CI gate (red verdict never consulted)", async () => {
+  const fx = fixture({ behind: false });
+  try {
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    _setCiVerdictForTest("red");
+    const res = await runLockedUpdate(() => {});
+    assert.equal(res.updated, false);
+    assert.equal(res.skipped, undefined, "behind=0 must return plain up-to-date, not a CI skip");
+  } finally {
+    _setCiVerdictForTest(null);
     _setDbForTest(null);
     _setAppRootForTest(join(import.meta.dirname, ".."));
     fx.cleanup();

--- a/tests/auto-update-ci-gate.test.js
+++ b/tests/auto-update-ci-gate.test.js
@@ -1,0 +1,152 @@
+// A5: CI-gate on auto-update — classifyCheckRuns (pure) and the wired skip in
+// runLockedUpdate (via the verdict test hook; fixture remotes are local paths,
+// so the real fetch path naturally fails open as "unknown").
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  classifyCheckRuns, runLockedUpdate,
+  _setAppRootForTest, _setDbForTest, _setCiVerdictForTest,
+} from "../servers/gateway/auto-update.js";
+
+delete process.env.INVOCATION_ID;
+delete process.env.CROW_SUPERVISED;
+
+const run = (name, status, conclusion) => ({ name, status, conclusion });
+
+test("classifyCheckRuns: all three green (extra runs ignored)", () => {
+  assert.equal(classifyCheckRuns({ check_runs: [
+    run("suite", "completed", "success"),
+    run("static-checks", "completed", "success"),
+    run("audit", "completed", "success"),
+    run("deploy-docs", "completed", "failure"), // never blocks
+  ] }), "green");
+});
+
+test("classifyCheckRuns: any named failure is red", () => {
+  assert.equal(classifyCheckRuns({ check_runs: [
+    run("suite", "completed", "failure"),
+    run("static-checks", "completed", "success"),
+  ] }), "red");
+  assert.equal(classifyCheckRuns({ check_runs: [run("audit", "completed", "cancelled")] }), "red");
+});
+
+test("classifyCheckRuns: incomplete named run is pending", () => {
+  assert.equal(classifyCheckRuns({ check_runs: [
+    run("suite", "in_progress", null),
+    run("audit", "completed", "success"),
+  ] }), "pending");
+});
+
+test("classifyCheckRuns: neutral/skipped conclusions count as green", () => {
+  assert.equal(classifyCheckRuns({ check_runs: [
+    run("suite", "completed", "success"),
+    run("audit", "completed", "skipped"),
+  ] }), "green");
+});
+
+test("classifyCheckRuns: no named runs (fork without our CI) is unknown", () => {
+  assert.equal(classifyCheckRuns({ check_runs: [] }), "unknown");
+  assert.equal(classifyCheckRuns({ check_runs: [run("other-ci", "completed", "failure")] }), "unknown");
+  assert.equal(classifyCheckRuns(null), "unknown");
+  assert.equal(classifyCheckRuns({}), "unknown");
+});
+
+// --------------------------------------------------------- wired behavior
+
+const g = (cwd, ...args) => execFileSync("git", args, { cwd, stdio: "pipe" }).toString().trim();
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "au-cigate-"));
+  const origin = join(root, "origin.git");
+  const work = join(root, "work");
+  execFileSync("git", ["init", "--bare", "-b", "main", origin], { stdio: "pipe" });
+  execFileSync("git", ["clone", origin, work], { stdio: "pipe" });
+  g(work, "config", "user.email", "t@t");
+  g(work, "config", "user.name", "t");
+  writeFileSync(join(work, "a.txt"), "one\n");
+  mkdirSync(join(work, "scripts"), { recursive: true });
+  writeFileSync(join(work, "scripts", "init-db.js"), "process.exit(0);\n");
+  g(work, "add", "a.txt", "scripts/init-db.js");
+  g(work, "commit", "-m", "c1");
+  g(work, "push", "origin", "main");
+  // A new commit on origin (via a second clone) so the update has work to do.
+  const pusher = mkdtempSync(join(root, "pusher-"));
+  execFileSync("git", ["clone", origin, pusher], { stdio: "pipe" });
+  g(pusher, "config", "user.email", "t@t");
+  g(pusher, "config", "user.name", "t");
+  writeFileSync(join(pusher, "b.txt"), "two\n");
+  g(pusher, "add", "b.txt");
+  g(pusher, "commit", "-m", "c2");
+  g(pusher, "push", "origin", "main");
+  return { root, work, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+const stubDb = () => ({ execute: async () => ({ rows: [] }) });
+
+test("ci-red verdict skips the pull; HEAD unchanged; self-heals when green", async () => {
+  const fx = fixture();
+  try {
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const before = g(fx.work, "rev-parse", "HEAD");
+
+    _setCiVerdictForTest("red");
+    const red = await runLockedUpdate(() => {});
+    assert.equal(red.updated, false);
+    assert.equal(red.skipped, "ci-red");
+    assert.equal(g(fx.work, "rev-parse", "HEAD"), before, "red CI must not pull");
+
+    _setCiVerdictForTest("pending");
+    const pending = await runLockedUpdate(() => {});
+    assert.equal(pending.skipped, "ci-pending");
+    assert.equal(g(fx.work, "rev-parse", "HEAD"), before, "pending CI must not pull");
+
+    _setCiVerdictForTest("green");
+    const ok = await runLockedUpdate(() => {});
+    assert.equal(ok.updated, true, "green CI proceeds");
+    assert.notEqual(g(fx.work, "rev-parse", "HEAD"), before);
+  } finally {
+    _setCiVerdictForTest(null);
+    _setDbForTest(null);
+    _setAppRootForTest(join(import.meta.dirname, ".."));
+    fx.cleanup();
+  }
+});
+
+test("CROW_UPDATE_CI_GATE=0 disables the gate even on red", async () => {
+  const fx = fixture();
+  try {
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    _setCiVerdictForTest("red");
+    process.env.CROW_UPDATE_CI_GATE = "0";
+    const res = await runLockedUpdate(() => {});
+    assert.equal(res.updated, true, "gate disabled → red is ignored");
+  } finally {
+    delete process.env.CROW_UPDATE_CI_GATE;
+    _setCiVerdictForTest(null);
+    _setDbForTest(null);
+    _setAppRootForTest(join(import.meta.dirname, ".."));
+    fx.cleanup();
+  }
+});
+
+test("local (non-GitHub) remotes fail open without the test hook", async () => {
+  const fx = fixture();
+  try {
+    _setAppRootForTest(fx.work);
+    _setDbForTest(stubDb());
+    const res = await runLockedUpdate(() => {});
+    assert.equal(res.updated, true, "unknown verdict (local remote) proceeds");
+  } finally {
+    _setDbForTest(null);
+    _setAppRootForTest(join(import.meta.dirname, ".."));
+    fx.cleanup();
+  }
+});


### PR DESCRIPTION
## Item A5 — CI-gate the fleet's auto-update

Q6 gates merges; nothing gated **deploys** — a direct admin push to main previously reached every instance within 6h regardless of CI state. `runLockedUpdate` now consults the target sha's check-runs (one unauthenticated GitHub API call per tick, only when there's actually something to pull) before pulling:

- Gates **only** on the three branch-protection contexts (`suite`, `static-checks`, `audit`); other runs (deploy-docs, build, image-freshness) never block updates.
- `red` → skip this tick (self-heals when main is fixed or reverted); `pending` → skip (a push mid-CI waits one tick); `green` → proceed.
- `unknown` **fails open**: forks without our CI, non-GitHub remotes, and API failures must never brick updates for the self-hosted audience.
- Escape hatch `CROW_UPDATE_CI_GATE=0` (documented EN + ES).

The manual "Check for updates now" button goes through the same gate. `classifyCheckRuns` is pure and unit-tested (incl. `action_required`, re-run dedup via the API's `filter=latest` default, extra-runs ignored); the wired behavior is proven against fixture repos via a verdict test hook, including the placement regression the review demanded (an up-to-date repo short-circuits **before** the gate — no wasted API call, no misleading "CI red" status).

Spec: crow-engineering `specs/2026-07-18-a5-ci-gate-autoupdate.md` (adversarial review round: one Important finding — the placement-regression test gap — fixed).

Suite: **2066 / 2066 / 0 / 0** (2057 baseline + 9 gate tests).

**Q10 acceptance step (post-merge):** flip branch protection `enforce_admins` → **true**, closing the admin direct-push hotfix path now that both the merge gate (A1), the runtime DB net (A3), and the deploy gate (this PR) are in place.