### PR TITLE
feat(extensions): retire the remote crow-addons registry mirror

### DIFF
--- a/servers/gateway/dashboard/panels/extensions/data-queries.js
+++ b/servers/gateway/dashboard/panels/extensions/data-queries.js
@@ -16,7 +16,6 @@ import { loadCollections } from "./collections.js";
 // panel's render path (it already imports ./collections.js, so that knot is real).
 import { needsConfigKeys } from "../../../bundles-config.js";
 
-export const REGISTRY_URL = "https://raw.githubusercontent.com/kh0pper/crow-addons/main/registry.json";
 // Respect the instance's CROW_HOME (matches bundles.js / proxy.js resolveCrowHome).
 // Without this, an alternate instance (CROW_HOME=~/.crow-mpa, ~/.crow-finance) reads
 // the MAIN ~/.crow's installed.json/stores.json instead of its own.
@@ -149,51 +148,37 @@ export async function fetchCommunityStore(storeUrl) {
   }
 }
 
+// A registry entry can itself be a third-party listing (manifest origin:
+// "community" → the generated entry carries official: false) — those get the
+// same Community badge + install-modal caution as community-store add-ons, so
+// _community means "not maintained by Crow", not "came from a community store".
+// An ABSENT official field defaults to first-party: never falsely badge.
+export function withProvenance(addons) {
+  return addons.map((a) => ({ ...a, _community: a.official === false }));
+}
+
 /**
- * Fetch and merge remote + local registry into the available add-ons list.
+ * Load the in-repo registry + community stores into the available add-ons list.
+ * The in-repo registry (registry/add-ons.json) is the sole source of truth —
+ * the remote crow-addons mirror was retired 2026-07-18 (it was listing-only:
+ * installs always need the local checkout, so remote-only entries could only
+ * ever render as phantom, uninstallable cards).
  * Returns { installed, available, collections, registrySource, communityStores }.
  */
 export async function fetchRegistryData() {
   const installed = getInstalled();
 
-  // Load remote registry + merge with local (local entries override/supplement remote)
-  let remoteAddons = [];
   let localAddons = [];
   let registrySource = "none";
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5000);
-    const resp = await fetch(REGISTRY_URL, { signal: controller.signal });
-    clearTimeout(timeout);
-    if (resp.ok) {
-      const remote = await resp.json();
-      remoteAddons = remote["add-ons"] || [];
-      registrySource = "remote";
-    }
-  } catch {}
-
   try {
     if (existsSync(LOCAL_REGISTRY)) {
       const local = JSON.parse(readFileSync(LOCAL_REGISTRY, "utf8"));
       localAddons = local["add-ons"] || [];
-      if (registrySource === "none") registrySource = "local";
-      else registrySource += "+local";
+      registrySource = "local";
     }
   } catch {}
 
-  // Merge: local entries override remote for matching IDs, new local entries are appended
-  const localIds = new Set(localAddons.map((a) => a.id));
-  const mergedAddons = [
-    ...remoteAddons.filter((a) => !localIds.has(a.id)),
-    ...localAddons,
-  ];
-
-  // Merge registry add-ons with community store add-ons. A registry entry can
-  // itself be a third-party listing (manifest origin: "community" → the
-  // generated entry carries official: false) — those get the same Community
-  // badge + install-modal caution as community-store add-ons, so _community
-  // means "not maintained by Crow", not "came from a community store".
-  const officialAddons = mergedAddons.map((a) => ({ ...a, _community: a.official === false }));
+  const officialAddons = withProvenance(localAddons);
   const communityStores = getStores();
   const communityResults = await Promise.all(communityStores.map((s) => fetchCommunityStore(s.url)));
   const communityAddons = communityResults.flatMap((r) => r.addons);

--- a/servers/gateway/dashboard/panels/extensions/html.js
+++ b/servers/gateway/dashboard/panels/extensions/html.js
@@ -248,10 +248,6 @@ export function buildExtensionsHTML({
       <input class="ext-search__input" type="text" placeholder="${t("extensions.searchPlaceholder", lang)}" id="ext-search" autocomplete="off">
     </div>`;
 
-  const sourceNote = registrySource === "local"
-    ? `<div class="ext-sourcenote">${t("extensions.localRegistry", lang)}</div>`
-    : "";
-
   // ─── Starter collections ───
   const collectionCard = (c) => `<button type="button" class="ext-collection-card" data-collection-id="${escapeHtml(c.id)}">
         <span class="ext-collection-card__icon">${collectionIcon(c.icon)}</span>
@@ -408,7 +404,6 @@ export function buildExtensionsHTML({
   const viewsHtml = `${dockerBannerHtml}${viewTabsHtml}
     <div class="ext-view" id="ext-view-browse" role="tabpanel">
       ${searchHtml}
-      ${sourceNote}
       ${collectionsHtml}
       ${featuredHtml}
       ${chipsHtml}

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -540,7 +540,6 @@ export const translations = {
   "extensions.communityNotVerified": { en: "Not verified by Crow", es: "No verificado por Crow" },
   "extensions.mcpServers": { en: "MCP Servers", es: "Servidores MCP" },
   "extensions.bundles": { en: "Bundles", es: "Paquetes" },
-  "extensions.localRegistry": { en: "Showing local registry (remote unavailable)", es: "Mostrando registro local (remoto no disponible)" },
   "extensions.dockerUnavailable": { en: "Docker isn't available on this host", es: "Docker no está disponible en este equipo" },
   "extensions.dockerUnavailableDesc": { en: "Extensions that deploy containers can't be installed until Docker is installed and its daemon is running and reachable by this service. On a Crow appliance, re-run the install script (scripts/crow-install.sh) — it installs Docker. Extensions that only connect to existing services still work.", es: "Las extensiones que despliegan contenedores no se pueden instalar hasta que Docker esté instalado y su demonio en ejecución y accesible para este servicio. En un equipo Crow, vuelve a ejecutar el script de instalación (scripts/crow-install.sh), que instala Docker. Las extensiones que solo se conectan a servicios existentes siguen funcionando." },
   "extensions.communityStores": { en: "Community Stores", es: "Tiendas de la comunidad" },

--- a/tests/extensions-data-queries.test.js
+++ b/tests/extensions-data-queries.test.js
@@ -20,7 +20,7 @@ const fixtureInstalled = {
 };
 writeFileSync(join(scratchHome, "installed.json"), JSON.stringify(fixtureInstalled, null, 2));
 
-const { getInstalled, fetchRegistryData, CROW_DIR, INSTALLED_PATH } = await import("../servers/gateway/dashboard/panels/extensions/data-queries.js");
+const { getInstalled, fetchRegistryData, withProvenance, CROW_DIR, INSTALLED_PATH } = await import("../servers/gateway/dashboard/panels/extensions/data-queries.js");
 
 test("getInstalled() resolves CROW_DIR from CROW_HOME, not the operator's real ~/.crow", () => {
   // The module must have derived its paths from the scratch CROW_HOME we set above,
@@ -42,30 +42,31 @@ test("getInstalled() resolves CROW_DIR from CROW_HOME, not the operator's real ~
   }
 });
 
-test("fetchRegistryData derives _community from the entry's own official field (registry provenance)", async () => {
-  // Stub the remote-registry fetch: one third-party entry (official:false, the
-  // build-registry output for manifest origin:"community"), one pre-provenance
-  // entry with official ABSENT (a stale remote mirror) — the conservative
-  // default must treat it as first-party. The repo's local registry entries
-  // (all official:true) merge in and must all stay _community:false.
-  const remote = {
-    "add-ons": [
-      { id: "zz-thirdparty-fixture", name: "ZZ Third Party", description: "d", type: "skill", category: "misc", official: false, origin: "community" },
-      { id: "zz-stale-mirror-fixture", name: "ZZ Stale", description: "d", type: "skill", category: "misc" },
-    ],
-  };
+test("withProvenance derives _community from the entry's own official field (registry provenance)", () => {
+  // A registry entry generated from a manifest with origin:"community" carries
+  // official:false and must badge as Community (badge + install caution). An
+  // entry with official ABSENT (pre-provenance data) must conservatively
+  // default to first-party — never falsely badged.
+  const [third, absent] = withProvenance([
+    { id: "zz-thirdparty-fixture", name: "ZZ Third Party", description: "d", type: "skill", category: "misc", official: false, origin: "community" },
+    { id: "zz-preprovenance-fixture", name: "ZZ Absent", description: "d", type: "skill", category: "misc" },
+  ]);
+  assert.equal(third._community, true, "official:false entry must be _community (Community badge + install caution)");
+  assert.equal(absent._community, false, "official-absent entry must default to first-party, never falsely badged");
+});
+
+test("fetchRegistryData serves the in-repo registry as the sole registry source (remote mirror retired)", async () => {
+  // The remote crow-addons mirror was retired 2026-07-18: no network fetch may
+  // occur, and every available registry entry comes from registry/add-ons.json.
   const realFetch = globalThis.fetch;
-  globalThis.fetch = async () => ({ ok: true, json: async () => remote });
+  let fetched = false;
+  globalThis.fetch = async () => { fetched = true; throw new Error("no network in tests"); };
   try {
-    const { available } = await fetchRegistryData();
-    const third = available.find((a) => a.id === "zz-thirdparty-fixture");
-    const stale = available.find((a) => a.id === "zz-stale-mirror-fixture");
-    assert.ok(third, "stubbed community entry missing from available");
-    assert.equal(third._community, true, "official:false entry must be _community (Community badge + install caution)");
-    assert.equal(stale._community, false, "official-absent entry must default to first-party, never falsely badged");
-    const locals = available.filter((a) => !a.id.startsWith("zz-"));
-    assert.ok(locals.length > 50, "local registry entries should have merged in");
-    for (const a of locals) {
+    const { available, registrySource } = await fetchRegistryData();
+    assert.equal(fetched, false, "fetchRegistryData must not fetch a remote registry");
+    assert.equal(registrySource, "local");
+    assert.ok(available.length > 50, "local registry entries should have loaded");
+    for (const a of available) {
       assert.equal(a._community, false, `local first-party entry '${a.id}' must not be _community`);
     }
   } finally {


### PR DESCRIPTION
Executes the operator's A2-FU decision (made via named-options approval in the Item B session, 2026-07-18): **retire the remote store** rather than automate the mirror.

Why: the remote `kh0pper/crow-addons` `registry.json` was listing-only — installs always require the local checkout — and had drifted to 42 of 91 entries, plus 3 remote-only orphans (crowclaw, google-workspace, tasks) that rendered as phantom, uninstallable store cards on every instance.

What changes:
- `fetchRegistryData()` no longer fetches the remote registry; the in-repo `registry/add-ons.json` (ships with every install) is the sole registry source. Community stores are unchanged and remain the third-party listing path.
- The "Showing local registry (remote unavailable)" caveat note and its i18n key are removed — local is now the normal state, not a degraded one. The `registrySource === "none"` error state (missing/corrupt local registry) is kept.
- Provenance derivation (`official:false` → Community badge, absent → first-party) extracted to an exported `withProvenance()` and unit-tested directly, since the remote-stub vehicle for those assertions is gone. A new test pins that `fetchRegistryData` performs **no network fetch** for registry data.

Suite in worktree: **2067/2067 pass, 0 fail, 0 skip** (baseline 2066 + net 1 new test).

Operator follow-up (not in this PR): archive the `kh0pper/crow-addons` GitHub repo itself.