### PR TITLE
feat(rookery): B5 — Community badge + rename to Open Science Reviewer

### DIFF
--- a/bundles/rookery/README.md
+++ b/bundles/rookery/README.md
@@ -1,4 +1,4 @@
-# Rookery Reviewer
+# Open Science Reviewer (Rookery)
 
 A self-hosted, one-click extension that turns a Crow deployment into an
 experiment-audit workbench: a Dockerized [OpenScience](https://github.com/synsci/openscience)

--- a/bundles/rookery/manifest.json
+++ b/bundles/rookery/manifest.json
@@ -1,6 +1,7 @@
 {
   "id": "rookery",
-  "name": "Rookery Reviewer",
+  "name": "Open Science Reviewer",
+  "origin": "community",
   "version": "0.1.0",
   "description": "Self-hosted OpenScience reviewer + experiment-audit workspace assembler — audit a report's numeric claims against its registered evidence, on your own local model",
   "type": "bundle",
@@ -31,6 +32,5 @@
     { "name": "ROOKERY_MCP_CROW_TOKEN", "description": "Crow local MCP token for the router endpoint (dashboard → Connect panel → local MCP token; shown once at generation). Required when ROOKERY_MCP_CROW_URL is set; rides the generated config's headers, never a child process env", "required": false, "secret": true }
   ],
   "ports": [3061],
-  "notes": "Self-hosted only — never configure the vendor's Atlas/cloud layer. The reviewer runs entirely on the endpoint you provide. Assembled workspaces contain COPIES of your report + evidence; originals are never modified. NO webUI block on purpose: the app cannot live behind the gateway's /proxy/<id>/ subpath (root-absolute asset paths baked in its binary) — serve 127.0.0.1:3061 at a root origin and set ROOKERY_REVIEWER_URL (see README).",
-  "official": false
+  "notes": "Self-hosted only — never configure the vendor's Atlas/cloud layer. The reviewer runs entirely on the endpoint you provide. Assembled workspaces contain COPIES of your report + evidence; originals are never modified. NO webUI block on purpose: the app cannot live behind the gateway's /proxy/<id>/ subpath (root-absolute asset paths baked in its binary) — serve 127.0.0.1:3061 at a root origin and set ROOKERY_REVIEWER_URL (see README)."
 }

--- a/bundles/rookery/panel/rookery.js
+++ b/bundles/rookery/panel/rookery.js
@@ -1,6 +1,6 @@
 export default {
   id: "rookery",
-  name: "Rookery Reviewer",
+  name: "Open Science Reviewer",
   icon: "search",
   route: "/dashboard/rookery",
   navOrder: 62,
@@ -8,7 +8,7 @@ export default {
   async handler(req, res, { layout }) {
     const content = `
 <div class="panel-page">
-  <h2>Rookery Reviewer</h2>
+  <h2>Open Science Reviewer</h2>
   <p>Assemble an experiment report + its evidence into an audit workspace, then
      open the blind reviewer on it.
      <a id="rk-reviewer-link" href="http://127.0.0.1:3061/" target="_blank" rel="noopener">Open reviewer ↗</a>
@@ -62,6 +62,6 @@ export default {
   refresh();
 })();
 </script>`;
-    res.send(layout({ title: "Rookery Reviewer", content }));
+    res.send(layout({ title: "Open Science Reviewer", content }));
   },
 };

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -5046,7 +5046,8 @@
     },
     {
       "id": "rookery",
-      "name": "Rookery Reviewer",
+      "name": "Open Science Reviewer",
+      "origin": "community",
       "version": "0.1.0",
       "description": "Self-hosted OpenScience reviewer + experiment-audit workspace assembler — audit a report's numeric claims against its registered evidence, on your own local model",
       "type": "bundle",
@@ -5149,7 +5150,7 @@
         3061
       ],
       "notes": "Self-hosted only — never configure the vendor's Atlas/cloud layer. The reviewer runs entirely on the endpoint you provide. Assembled workspaces contain COPIES of your report + evidence; originals are never modified. NO webUI block on purpose: the app cannot live behind the gateway's /proxy/<id>/ subpath (root-absolute asset paths baked in its binary) — serve 127.0.0.1:3061 at a root origin and set ROOKERY_REVIEWER_URL (see README).",
-      "official": true
+      "official": false
     },
     {
       "id": "scratch-offline",

--- a/tests/extensions-data-queries.test.js
+++ b/tests/extensions-data-queries.test.js
@@ -67,7 +67,8 @@ test("fetchRegistryData serves the in-repo registry as the sole registry source 
     assert.equal(registrySource, "local");
     assert.ok(available.length > 50, "local registry entries should have loaded");
     for (const a of available) {
-      assert.equal(a._community, false, `local first-party entry '${a.id}' must not be _community`);
+      assert.equal(a._community, a.official === false,
+        `entry '${a.id}': _community must mirror official===false (badge exactly the declared community entries)`);
     }
   } finally {
     globalThis.fetch = realFetch;


### PR DESCRIPTION
Executes two operator decisions from the Item B session (2026-07-18):

- **Community badge**: the manifest now declares `origin: "community"`, so `build-registry` derives `official: false` and the store renders the Community badge + install-modal caution. The manifest's old `"official": false` was a dead field (build-registry ignores and strips it) — removed.
- **Rename**: display name drops the "Rookery" jargon → **Open Science Reviewer** (manifest, panel, README). Chosen over plain "Open Science" so the name doesn't overclaim — the bundle is specifically a report-audit reviewer — and "for Crow" is redundant inside Crow's own store; one-word follow-up if the operator prefers a different variant. Bundle **id stays `rookery`** (no migration churn); historical planning docs untouched.
- The store-source test's blanket "everything is first-party" assertion is upgraded to the real invariant: `_community` mirrors `official === false` — exactly the declared community entries badge.

`build-registry --check` green; extension store tests green.