### PR TITLE
feat(dashboard): B5 — Fediverse Admin panel appears only with a federated bundle installed

### DIFF
--- a/servers/gateway/dashboard/panel-registry.js
+++ b/servers/gateway/dashboard/panel-registry.js
@@ -101,10 +101,22 @@ export function getAllPanels() {
 /**
  * Get visible panels (excludes hidden panels) sorted by navOrder.
  * Used for sidebar nav and dashboard home redirect.
+ * `hidden` may be a boolean or a predicate; a predicate is re-evaluated on
+ * every call so visibility can track runtime state (e.g. the Fediverse Admin
+ * panel appears only once a federated bundle is installed — no restart
+ * needed). Predicates must be synchronous and cheap; a thrown predicate
+ * counts as visible (fail-open: never hide a working panel on a probe bug).
  */
 export function getVisiblePanels() {
   return [...panels.values()]
-    .filter((p) => !p.hidden)
+    .filter((p) => {
+      if (typeof p.hidden !== "function") return !p.hidden;
+      try {
+        return !p.hidden();
+      } catch {
+        return true;
+      }
+    })
     .sort((a, b) => (a.navOrder || 0) - (b.navOrder || 0));
 }
 

--- a/servers/gateway/dashboard/panels/fediverse.js
+++ b/servers/gateway/dashboard/panels/fediverse.js
@@ -14,6 +14,51 @@
  */
 
 import { t } from "../shared/i18n.js";
+import { existsSync, readFileSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+import { fileURLToPath } from "url";
+
+// ─── Visibility gate (B5, 2026-07-18) ───
+//
+// Fediverse features are blind to core: this panel only appears once at least
+// one federated bundle is installed. "Federated" is derived from the in-repo
+// registry (tags include "fediverse"), so new federated bundles gate correctly
+// without touching this file; community-store installs are covered by the
+// installed entry's own tags. The installed.json read happens per nav render
+// (call-time CROW_HOME, matches extensions/data-queries.js) so the panel
+// appears right after an install with no gateway restart.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY_PATH = join(__dirname, "../../../../registry/add-ons.json");
+
+let _federatedIds = null;
+function federatedIds() {
+  if (_federatedIds) return _federatedIds;
+  const ids = new Set();
+  try {
+    const reg = JSON.parse(readFileSync(REGISTRY_PATH, "utf8"));
+    for (const a of reg["add-ons"] || []) {
+      if ((a.tags || []).includes("fediverse")) ids.add(a.id);
+    }
+  } catch {}
+  _federatedIds = ids;
+  return ids;
+}
+
+export function hasFederatedBundleInstalled() {
+  const crowDir = process.env.CROW_HOME || join(homedir(), ".crow");
+  const installedPath = join(crowDir, "installed.json");
+  try {
+    if (!existsSync(installedPath)) return false;
+    const installed = JSON.parse(readFileSync(installedPath, "utf8"));
+    const known = federatedIds();
+    return Object.values(installed).some(
+      (e) => e && (known.has(e.id) || (e.tags || []).includes("fediverse")),
+    );
+  } catch {
+    return false;
+  }
+}
 
 function escapeHtml(s) {
   return String(s ?? "")
@@ -281,6 +326,10 @@ export default {
   route: "/dashboard/fediverse",
   navOrder: 80,
   category: "connections",
+  // Hidden until a federated bundle is installed (see gate above). The route
+  // itself stays mounted — direct navigation on an instance with no federated
+  // bundles just shows empty queues behind auth, which is harmless.
+  hidden: () => !hasFederatedBundleInstalled(),
 
   async handler(req, res, { db, lang, layout }) {
     const tab = (req.query.tab === "crosspost") ? "crosspost" : "moderation";

--- a/tests/fediverse-panel-gate.test.js
+++ b/tests/fediverse-panel-gate.test.js
@@ -1,0 +1,77 @@
+// tests/fediverse-panel-gate.test.js
+//
+// B5 (2026-07-18): fediverse features are blind to core. The Fediverse Admin
+// panel must be absent from the visible panel list on an instance with no
+// federated bundle installed, appear once one is installed (with NO restart —
+// the hidden predicate re-evaluates per getVisiblePanels() call), and the
+// predicate mechanism itself must fail open (a throwing predicate never hides
+// a panel).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// CROW_HOME must be scratch before any dashboard module import (same
+// prod-contamination guard as extensions-data-queries.test.js) — the gate
+// resolves it at call time, but other dashboard modules resolve at load.
+const scratchHome = mkdtempSync(join(tmpdir(), "crow-test-home-"));
+process.env.CROW_HOME = scratchHome;
+
+const { registerPanel, getVisiblePanels } = await import("../servers/gateway/dashboard/panel-registry.js");
+const { default: fediversePanel, hasFederatedBundleInstalled } = await import("../servers/gateway/dashboard/panels/fediverse.js");
+
+registerPanel(fediversePanel);
+
+const visibleIds = () => getVisiblePanels().map((p) => p.id);
+
+test("no installed.json → Fediverse Admin is hidden", () => {
+  assert.equal(hasFederatedBundleInstalled(), false);
+  assert.ok(!visibleIds().includes("fediverse"), "fediverse panel leaked into a fresh install's nav");
+});
+
+test("non-federated installs alone keep the panel hidden", () => {
+  writeFileSync(join(scratchHome, "installed.json"), JSON.stringify({
+    dozzle: { id: "dozzle", name: "Dozzle", installedAt: "2026-07-01T00:00:00.000Z" },
+  }));
+  assert.equal(hasFederatedBundleInstalled(), false);
+  assert.ok(!visibleIds().includes("fediverse"));
+});
+
+test("installing a federated bundle reveals the panel with no restart (registry-tag path)", () => {
+  // peertube is federated via its registry tags — the panel module has NOT
+  // been re-imported since the writes above, proving per-call evaluation.
+  writeFileSync(join(scratchHome, "installed.json"), JSON.stringify({
+    dozzle: { id: "dozzle", name: "Dozzle", installedAt: "2026-07-01T00:00:00.000Z" },
+    peertube: { id: "peertube", name: "PeerTube", installedAt: "2026-07-02T00:00:00.000Z" },
+  }));
+  assert.equal(hasFederatedBundleInstalled(), true);
+  assert.ok(visibleIds().includes("fediverse"), "panel must appear once a federated bundle is installed");
+});
+
+test("a community-store install with its own fediverse tag also reveals the panel", () => {
+  writeFileSync(join(scratchHome, "installed.json"), JSON.stringify({
+    "acme-ap": { id: "acme-ap", name: "Acme AP", tags: ["fediverse"], installedAt: "2026-07-03T00:00:00.000Z" },
+  }));
+  assert.equal(hasFederatedBundleInstalled(), true);
+});
+
+test("corrupt installed.json fails closed for the gate (hidden), never throws", () => {
+  writeFileSync(join(scratchHome, "installed.json"), "{not json");
+  assert.equal(hasFederatedBundleInstalled(), false);
+  assert.ok(!visibleIds().includes("fediverse"));
+});
+
+test("a throwing hidden predicate fails open — the panel stays visible", () => {
+  registerPanel({ id: "zz-throwing-fixture", name: "ZZ", route: "/dashboard/zz", hidden: () => { throw new Error("probe bug"); } });
+  assert.ok(visibleIds().includes("zz-throwing-fixture"), "predicate errors must never hide a panel");
+});
+
+test("boolean hidden still works (design-system stays out of nav)", () => {
+  registerPanel({ id: "zz-bool-hidden", name: "ZZ2", route: "/dashboard/zz2", hidden: true });
+  assert.ok(!visibleIds().includes("zz-bool-hidden"));
+});
+
+test.after(() => {
+  rmSync(scratchHome, { recursive: true, force: true });
+});


### PR DESCRIPTION
Executes the operator's B5 decision (Item B session, 2026-07-18): fediverse features should be blind to core. The Fediverse Admin panel was core code registered unconditionally (`servers/gateway/dashboard/index.js`), so every fresh install showed a fediverse nav item with permanently empty moderation/crosspost queues.

- `getVisiblePanels()` now accepts a **predicate** for `hidden` alongside the existing boolean — re-evaluated on every call, so visibility tracks runtime state; a throwing predicate **fails open** (never hide a working panel on a probe bug).
- The fediverse panel hides until `installed.json` contains a federated bundle. "Federated" is derived from the in-repo registry's `fediverse` tags (funkwhale, gotosocial, lemmy, mastodon, peertube, pixelfed, writefreely — self-maintaining as new ones land), plus the installed entry's own tags for community-store installs.
- Call-time `CROW_HOME` (per-instance correct, matches `extensions/data-queries.js`); the panel appears right after an install with **no gateway restart**. The route stays mounted (auth'd, empty queues) so direct URLs still work.
- 7 new tests: fresh-install hidden, non-federated-only hidden, no-restart appearance, community-tag path, corrupt `installed.json` fails closed for the gate, predicate fail-open, boolean `hidden` regression. Mutation-checked against both the registry filter and the panel's `hidden` key.

Suite in worktree: **2074/2074 pass, 0 fail, 0 skip** (2067 + 7 new).