### PR TITLE
Item D — residual minors batch: global i18n parity gate, docsUrl sweep, $-safe interpolation, de-jargon

### DIFF
--- a/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
+++ b/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
@@ -16,7 +16,7 @@ import { handleDeleteConfirm } from "./delete-bot.js";
 import { readSetting, writeSetting } from "../../settings/registry.js";
 import { regenerateBotMcp } from "../bot-mcp-regen.js";
 import { normalizeSkillName } from "../../../../../scripts/pi-bots/skill_proposals.mjs";
-import { t, SUPPORTED_LANGS } from "../../shared/i18n.js";
+import { t, fill, SUPPORTED_LANGS } from "../../shared/i18n.js";
 import { parseCookies } from "../../auth.js";
 
 // Same crow_lang-cookie resolution the dashboard router uses (index.js);
@@ -64,7 +64,7 @@ export async function handleBotBuilderPost(req, res, { db }) {
       const existing = (await db.execute({ sql: "SELECT 1 FROM pi_bot_defs WHERE bot_id=?", args: [botId] })).rows[0];
       if (existing) {
         return res.redirectAfterPost(
-          "/dashboard/bot-builder?error=" + encodeURIComponent(t("botbuilder.createExists", reqLang(req)).replace("{id}", botId))
+          "/dashboard/bot-builder?error=" + encodeURIComponent(fill(t("botbuilder.createExists", reqLang(req)), { id: botId }))
         );
       }
       await db.execute({

--- a/servers/gateway/dashboard/panels/bot-builder/checklist.js
+++ b/servers/gateway/dashboard/panels/bot-builder/checklist.js
@@ -16,7 +16,7 @@
  */
 
 import { escapeHtml } from "../../shared/components.js";
-import { t } from "../../shared/i18n.js";
+import { t, fill } from "../../shared/i18n.js";
 import { loadModelOptions } from "./data-queries.js";
 import { missingGatewayFields } from "./gateway-fields.js";
 
@@ -56,7 +56,7 @@ export async function renderReadiness(db, bot, def, lang) {
     modelReady
       ? `<code>${escapeHtml(configured)}</code>`
       : (configured
-          ? t("botbuilder.checkModelUnavailable", lang).replace("{key}", escapeHtml(configured))
+          ? fill(t("botbuilder.checkModelUnavailable", lang), { key: escapeHtml(configured) })
           : t("botbuilder.checkModelNone", lang)),
     tabHref("ai"), fixLabel));
 
@@ -70,15 +70,15 @@ export async function renderReadiness(db, bot, def, lang) {
     if (missing.length) {
       rows.push(row(WARN, t("botbuilder.checkChannel", lang),
         `${escapeHtml(gw.type)} — ` +
-        t("botbuilder.checkChannelIncomplete", lang).replace("{fields}", escapeHtml(missing.join(", "))),
+        fill(t("botbuilder.checkChannelIncomplete", lang), { fields: escapeHtml(missing.join(", ")) }),
         tabHref("gateways"), fixLabel));
     } else {
       let detail = escapeHtml(gw.type);
       if (gw.type === "gmail") {
         detail += ` — ${escapeHtml(gw.address || "")}, ` +
-          t("botbuilder.checkChannelAllowed", lang).replace("{n}", String((gw.allowlist || []).length));
+          fill(t("botbuilder.checkChannelAllowed", lang), { n: (gw.allowlist || []).length });
       } else if (gw.device_id) {
-        detail += ` — ${t("botbuilder.checkChannelDevice", lang).replace("{id}", escapeHtml(String(gw.device_id)))}`;
+        detail += ` — ${fill(t("botbuilder.checkChannelDevice", lang), { id: escapeHtml(String(gw.device_id)) })}`;
       }
       rows.push(row(OK, t("botbuilder.checkChannel", lang), detail, tabHref("gateways"), fixLabel));
     }
@@ -89,14 +89,14 @@ export async function renderReadiness(db, bot, def, lang) {
   const nMcp = (tools.crow_mcp || []).length;
   const nBuiltin = (tools.pi_builtin || []).length;
   rows.push(row(OK, t("botbuilder.checkTools", lang),
-    t("botbuilder.checkToolsDetail", lang).replace("{mcp}", String(nMcp)).replace("{builtin}", String(nBuiltin)),
+    fill(t("botbuilder.checkToolsDetail", lang), { mcp: nMcp, builtin: nBuiltin }),
     tabHref("tools"), fixLabel));
 
   // ---- Skills & prompt ----
   const nSkills = (def.skills || []).length;
   const hasPrompt = !!(def.system_prompt || "").trim();
   rows.push(row(hasPrompt ? OK : WARN, t("botbuilder.checkSkills", lang),
-    t("botbuilder.checkSkillsDetail", lang).replace("{n}", String(nSkills)) +
+    fill(t("botbuilder.checkSkillsDetail", lang), { n: nSkills }) +
     (hasPrompt ? ` · ${t("botbuilder.checkPromptSet", lang)}` : ` · ${t("botbuilder.checkPromptMissing", lang)}`),
     tabHref("skills"), fixLabel));
 

--- a/servers/gateway/dashboard/panels/bot-builder/delete-bot.js
+++ b/servers/gateway/dashboard/panels/bot-builder/delete-bot.js
@@ -32,7 +32,7 @@
 
 import { escapeHtml, section, callout } from "../../shared/components.js";
 import { csrfInput } from "../../shared/csrf.js";
-import { t } from "../../shared/i18n.js";
+import { t, fill } from "../../shared/i18n.js";
 import { readSetting, writeSetting } from "../../settings/registry.js";
 
 async function count(db, sql, args) {
@@ -89,28 +89,27 @@ export async function renderDeleteConfirm(req, res, { db, layout, lang, PAGE_CSS
 
   const li = (txt) => `<li>${txt}</li>`;
   const items = [
-    li(t("botbuilder.delRadiusSessions", lang).replace("{n}", String(br.sessions))),
-    gwType ? li(t("botbuilder.delRadiusGateway", lang).replace("{type}", escapeHtml(gwType))) : "",
+    li(fill(t("botbuilder.delRadiusSessions", lang), { n: br.sessions })),
+    gwType ? li(fill(t("botbuilder.delRadiusGateway", lang), { type: escapeHtml(gwType) })) : "",
     (br.acl || br.invites)
-      ? li(t("botbuilder.delRadiusMessaging", lang).replace("{acl}", String(br.acl)).replace("{inv}", String(br.invites)))
+      ? li(fill(t("botbuilder.delRadiusMessaging", lang), { acl: br.acl, inv: br.invites }))
       : "",
     br.boundDevices.length
-      ? li(t("botbuilder.delRadiusDevices", lang).replace("{names}",
-          escapeHtml(br.boundDevices.map((d) => d.name || d.id).join(", "))))
+      ? li(fill(t("botbuilder.delRadiusDevices", lang), {
+          names: escapeHtml(br.boundDevices.map((d) => d.name || d.id).join(", ")) }))
       : "",
     (br.messages || br.groupMemberships)
-      ? li(t("botbuilder.delRadiusConversation", lang)
-          .replace("{n}", String(br.messages)).replace("{g}", String(br.groupMemberships)))
+      ? li(fill(t("botbuilder.delRadiusConversation", lang), { n: br.messages, g: br.groupMemberships }))
       : "",
     li(t("botbuilder.delRadiusWorkspaceKept", lang)),
   ].filter(Boolean).join("");
 
   const liveWarn = br.liveSessions
-    ? callout(escapeHtml(t("botbuilder.delLiveSessionsWarn", lang).replace("{n}", String(br.liveSessions))), "warning")
+    ? callout(escapeHtml(fill(t("botbuilder.delLiveSessionsWarn", lang), { n: br.liveSessions })), "warning")
     : "";
 
   const body =
-    `<p>${t("botbuilder.delIntro", lang).replace("{name}", `<b>${escapeHtml(bot.display_name || botId)}</b>`)}</p>` +
+    `<p>${fill(t("botbuilder.delIntro", lang), { name: `<b>${escapeHtml(bot.display_name || botId)}</b>` })}</p>` +
     `<ul class="btb-del-radius">${items}</ul>` +
     liveWarn +
     callout(escapeHtml(t("botbuilder.delPermanent", lang)), "error") +

--- a/servers/gateway/dashboard/panels/bot-builder/editor.js
+++ b/servers/gateway/dashboard/panels/bot-builder/editor.js
@@ -7,7 +7,7 @@
  */
 import { escapeHtml, section, badge, formField, actionBar } from "../../shared/components.js";
 import { csrfInput } from "../../shared/csrf.js";
-import { t, tJs } from "../../shared/i18n.js";
+import { t, tJs, fill } from "../../shared/i18n.js";
 import { createDbClient } from "../../../../db.js";
 import { serversForBot } from "../../../../../scripts/pi-bots/mcp_writer.mjs";
 import {
@@ -188,7 +188,7 @@ export async function renderBotEditor(req, res, { db, layout, lang, PAGE_CSS, bo
     // bot's resolved model is MULTI_AGENT_CAPABLE AND Permissions →
     // Multi-agent is on.
     const subWarn = PI_EXT_ALLOWLIST.includes("subagent")
-      ? `<p class="btb-warn">&#9888; ${t("botbuilder.warnSubagent", lang).replace("{models}", `<code>${escapeHtml(MULTI_AGENT_CAPABLE.join(", "))}</code>`)}</p>`
+      ? `<p class="btb-warn">&#9888; ${fill(t("botbuilder.warnSubagent", lang), { models: `<code>${escapeHtml(MULTI_AGENT_CAPABLE.join(", "))}</code>` })}</p>`
       : "";
     const peerTools = await gatherPeerTools(db);
     const remoteOn = await remoteInvocationOn(db);
@@ -308,7 +308,7 @@ export async function renderBotEditor(req, res, { db, layout, lang, PAGE_CSS, bo
         const unavailable = voiceUnavailableSelections(def);
         if (unavailable.length) {
           noVoiceWarn =
-            `<p class="btb-notice-warn">${t("botbuilder.warnNoVoiceTools", lang).replace("{tools}", `<code>${unavailable.map(escapeHtml).join("</code>, <code>")}</code>`)}</p>`;
+            `<p class="btb-notice-warn">${fill(t("botbuilder.warnNoVoiceTools", lang), { tools: `<code>${unavailable.map(escapeHtml).join("</code>, <code>")}</code>` })}</p>`;
         }
       } catch { /* tool-executor unavailable: skip the warning */ }
 
@@ -460,7 +460,7 @@ export async function renderBotEditor(req, res, { db, layout, lang, PAGE_CSS, bo
         (botCrowId ? `<p class="btb-hint">${escapeHtml(t("botbuilder.cmRawAddress", lang))}: <code>${escapeHtml(botCrowId)}</code></p>` : "") +
         `<form method="POST">${actInputs("gw_advanced_add")}` +
         `<div class="btb-group"><label>${escapeHtml(t("botbuilder.cmManualPubkey", lang))}</label>` +
-        `<input type="text" name="sender_pubkey" class="btb-input" placeholder="secp256k1 hex (64 or 66)"></div>` +
+        `<input type="text" name="sender_pubkey" class="btb-input" placeholder="${escapeHtml(t("botbuilder.cmPubkeyPlaceholder", lang))}"></div>` +
         `<div class="btb-group"><label>${escapeHtml(t("botbuilder.cmManualName", lang))}</label>` +
         `<input type="text" name="display_name" class="btb-input"></div>` +
         `<button type="submit" class="btb-btn">${escapeHtml(t("botbuilder.cmManualAdd", lang))}</button></form>` +

--- a/servers/gateway/dashboard/shared/components.js
+++ b/servers/gateway/dashboard/shared/components.js
@@ -45,12 +45,10 @@ export function dataTable(headers, rows) {
  * Form field.
  */
 /**
- * Public docs-site URL for a docs path (Item 5 PR4, spec §D7). New dashboard
- * links to the docs site should use this one exported base. (Pre-existing
- * per-integration doc URLs in integrations.js still carry absolutes — a
- * recorded follow-up, not this helper's claim.) The canonical public docs
- * host is maestro.press (VitePress base '/software/crow/' is only the path
- * prefix).
+ * Public docs-site URL for a docs path (Item 5 PR4, spec §D7). All dashboard
+ * and integration-registry links to the docs site route through this one
+ * exported base. The canonical public docs host is maestro.press (VitePress
+ * base '/software/crow/' is only the path prefix).
  * @param {string} path - docs path without leading slash, e.g. "guide/bot-builder-tutorial"
  */
 export const DOCS_BASE = "https://maestro.press/software/crow/";

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -827,6 +827,7 @@ export const translations = {
   "botbuilder.cmAdvanced": { en: "Advanced", es: "Avanzado" },
   "botbuilder.cmRawAddress": { en: "Bot address", es: "Dirección del bot" },
   "botbuilder.cmManualPubkey": { en: "Add by public key", es: "Añadir por clave pública" },
+  "botbuilder.cmPubkeyPlaceholder": { en: "Public key (64 or 66 hex characters)", es: "Clave pública (64 o 66 caracteres hexadecimales)" },
   "botbuilder.cmManualName": { en: "Name (optional)", es: "Nombre (opcional)" },
   "botbuilder.cmManualAdd": { en: "Add", es: "Añadir" },
   "botbuilder.cmTaglineLabel": { en: "Directory tagline (optional)", es: "Lema del directorio (opcional)" },
@@ -1695,4 +1696,27 @@ export function tJs(key, lang = "en") {
     .replace(/'/g, "\\'")
     .replace(/`/g, "\\`")
     .replace(/\$\{/g, "\\${");
+}
+
+/**
+ * Interpolate {name} placeholders with literal values.
+ *
+ * Use this instead of chained String.replace("{x}", value) whenever a value
+ * can carry user-controlled text: a replacement STRING treats $&, $', $`,
+ * $$ and $<n> specially, so a bot id or device name containing "$&" would
+ * render mangled. split/join inserts the value verbatim.
+ *
+ * Values are NOT HTML-escaped here — callers escape per context (some sites
+ * deliberately interpolate pre-built HTML such as <code> lists).
+ *
+ * @param {string} str - template containing {name} placeholders
+ * @param {Record<string, string|number>} params - placeholder → literal value
+ * @returns {string}
+ */
+export function fill(str, params) {
+  let out = String(str);
+  for (const [k, v] of Object.entries(params || {})) {
+    out = out.split(`{${k}}`).join(String(v));
+  }
+  return out;
 }

--- a/servers/gateway/integrations.js
+++ b/servers/gateway/integrations.js
@@ -5,6 +5,8 @@
  * Each entry maps to a server in .mcp.json but adds metadata for the UI.
  */
 
+import { docsUrl } from "./dashboard/shared/components.js";
+
 export const INTEGRATIONS = [
   {
     id: "trello",
@@ -15,7 +17,7 @@ export const INTEGRATIONS = [
     envVars: ["TRELLO_API_KEY", "TRELLO_TOKEN"],
     keyUrl: "https://trello.com/power-ups/admin",
     keyInstructions: "Copy your API Key, then visit the authorization link on that page to generate a Token.",
-    docsUrl: "https://maestro.press/software/crow/integrations/trello",
+    docsUrl: docsUrl("integrations/trello"),
     category: "productivity",
   },
   {
@@ -27,7 +29,7 @@ export const INTEGRATIONS = [
     envVars: ["CANVAS_API_TOKEN", "CANVAS_BASE_URL"],
     keyUrl: "https://community.canvaslms.com/t5/Admin-Guide/How-do-I-manage-API-access-tokens/ta-p/89",
     keyInstructions: "In Canvas: Account → Settings → New Access Token. Also set your Canvas URL (e.g. https://your-school.instructure.com).",
-    docsUrl: "https://maestro.press/software/crow/integrations/canvas-lms",
+    docsUrl: docsUrl("integrations/canvas-lms"),
     category: "productivity",
   },
   {
@@ -39,7 +41,7 @@ export const INTEGRATIONS = [
     envVars: ["GITHUB_PERSONAL_ACCESS_TOKEN"],
     keyUrl: "https://github.com/settings/tokens",
     keyInstructions: "Generate new token (classic) → select scopes: repo, read:org, read:user → copy the token.",
-    docsUrl: "https://maestro.press/software/crow/integrations/github",
+    docsUrl: docsUrl("integrations/github"),
     category: "development",
   },
   {
@@ -51,7 +53,7 @@ export const INTEGRATIONS = [
     envVars: ["BRAVE_API_KEY"],
     keyUrl: "https://brave.com/search/api/",
     keyInstructions: "Sign up for a free API key and copy it from the Brave developer dashboard.",
-    docsUrl: "https://maestro.press/software/crow/integrations/brave-search",
+    docsUrl: docsUrl("integrations/brave-search"),
     category: "development",
   },
   {
@@ -63,7 +65,7 @@ export const INTEGRATIONS = [
     envVars: ["SLACK_BOT_TOKEN"],
     keyUrl: "https://api.slack.com/apps",
     keyInstructions: "Create New App → OAuth & Permissions → add scopes (channels:history, channels:read, chat:write, users:read) → Install to Workspace → copy Bot Token (xoxb-...).",
-    docsUrl: "https://maestro.press/software/crow/integrations/slack",
+    docsUrl: docsUrl("integrations/slack"),
     category: "communication",
   },
   {
@@ -81,7 +83,7 @@ export const INTEGRATIONS = [
     }),
     keyUrl: "https://www.notion.so/my-integrations",
     keyInstructions: "Create new integration → copy the Internal Integration Secret (ntn_...) → then share your Notion pages with the integration.",
-    docsUrl: "https://maestro.press/software/crow/integrations/notion",
+    docsUrl: docsUrl("integrations/notion"),
     category: "productivity",
   },
   {
@@ -93,7 +95,7 @@ export const INTEGRATIONS = [
     envVars: ["DISCORD_BOT_TOKEN"],
     keyUrl: "https://discord.com/developers/applications",
     keyInstructions: "New Application → Bot tab → Reset Token → copy it. Enable Message Content Intent under Bot settings.",
-    docsUrl: "https://maestro.press/software/crow/integrations/discord",
+    docsUrl: docsUrl("integrations/discord"),
     category: "communication",
   },
   {
@@ -105,7 +107,7 @@ export const INTEGRATIONS = [
     envVars: ["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],
     keyUrl: "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps",
     keyInstructions: "Register an app in Azure AD → add Graph permissions (Chat.Read, ChannelMessage.Read.All, ChannelMessage.Send) → create a client secret.",
-    docsUrl: "https://maestro.press/software/crow/integrations/microsoft-teams",
+    docsUrl: docsUrl("integrations/microsoft-teams"),
     category: "communication",
   },
   {
@@ -117,7 +119,7 @@ export const INTEGRATIONS = [
     envVars: ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
     keyUrl: "https://console.cloud.google.com/apis/credentials",
     keyInstructions: "Create OAuth 2.0 Client ID (Desktop App type). Enable Gmail, Calendar, Sheets, Docs, and Slides APIs.",
-    docsUrl: "https://maestro.press/software/crow/integrations/google-workspace",
+    docsUrl: docsUrl("integrations/google-workspace"),
     category: "productivity",
     requires: ["uvx"],
   },
@@ -130,7 +132,7 @@ export const INTEGRATIONS = [
     envVars: ["ZOTERO_API_KEY", "ZOTERO_USER_ID"],
     keyUrl: "https://www.zotero.org/settings/keys",
     keyInstructions: "Create new private key → check 'Allow library access' → copy the API key and your User ID (shown at top of page).",
-    docsUrl: "https://maestro.press/software/crow/integrations/zotero",
+    docsUrl: docsUrl("integrations/zotero"),
     category: "productivity",
     requires: ["uvx"],
   },
@@ -143,7 +145,7 @@ export const INTEGRATIONS = [
     envVars: ["CROW_ENABLE_ARXIV"], // No API key needed, but requires explicit opt-in
     keyUrl: null,
     keyInstructions: "No API key required. Set CROW_ENABLE_ARXIV=1 to enable.",
-    docsUrl: "https://maestro.press/software/crow/integrations/arxiv",
+    docsUrl: docsUrl("integrations/arxiv"),
     category: "productivity",
     requires: ["uvx"],
   },
@@ -157,7 +159,7 @@ export const INTEGRATIONS = [
     envVars: ["RENDER_API_KEY"],
     keyUrl: "https://dashboard.render.com/account/api-keys",
     keyInstructions: "Go to Account Settings → API Keys → Create API Key → copy it.",
-    docsUrl: "https://maestro.press/software/crow/integrations/render",
+    docsUrl: docsUrl("integrations/render"),
     category: "development",
   },
   {
@@ -182,7 +184,7 @@ export const INTEGRATIONS = [
     envVars: ["HA_URL", "HA_TOKEN"],
     keyUrl: "https://www.home-assistant.io/docs/authentication/",
     keyInstructions: "Profile → Security → Long-lived access tokens → Create Token. Also set your Home Assistant URL.",
-    docsUrl: "https://maestro.press/software/crow/integrations/home-assistant",
+    docsUrl: docsUrl("integrations/home-assistant"),
     category: "productivity",
   },
   {
@@ -194,7 +196,7 @@ export const INTEGRATIONS = [
     envVars: ["OBSIDIAN_VAULT_PATH"],
     keyUrl: null,
     keyInstructions: "Set the path to your Obsidian vault directory.",
-    docsUrl: "https://maestro.press/software/crow/integrations/obsidian",
+    docsUrl: docsUrl("integrations/obsidian"),
     category: "productivity",
   },
 ];

--- a/tests/i18n-global-parity.test.js
+++ b/tests/i18n-global-parity.test.js
@@ -1,0 +1,151 @@
+/**
+ * Global EN/ES parity gate over EVERY key in the dashboard i18n table
+ * (Item D minors batch; extends the per-panel guards in
+ * bot-builder-i18n-parity.test.js / settings-i18n-section-labels.test.js
+ * to the whole ~1,400-key surface).
+ *
+ * What it enforces, for ALL keys:
+ *   1. en and es are both present, non-empty strings.
+ *   2. es !== en — because t() falls back to en, an identical es is an
+ *      INVISIBLE missing translation — except for the named exceptions
+ *      below (strings that are legitimately the same word in Spanish:
+ *      "Error", "RAM", "URL", product names, hex/enum labels…).
+ *   3. Anti-rot: every exception key must still exist AND still be
+ *      identical. If someone later translates one, the stale exception
+ *      fails the suite so the list can't accumulate dead entries.
+ *   4. {placeholder} sets match between en and es.
+ *   5. No language variants beyond SUPPORTED_LANGS sneak into an entry.
+ *
+ * Also covers fill(), the $-safe interpolation helper added alongside this
+ * gate: String.replace("{x}", value) treats $&, $', $`, $$ specially in the
+ * replacement string, so user-controlled values (bot ids, device names)
+ * could render mangled. fill() must insert them verbatim.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { translations, SUPPORTED_LANGS, fill } from "../servers/gateway/dashboard/shared/i18n.js";
+
+// Keys whose en and es are legitimately identical (reviewed 2026-07-18 —
+// language-neutral terms, product/protocol names, numerals, enum labels).
+const IDENTICAL_OK = new Set([
+  "nav.blog",
+  "login.2faPlaceholder", // "000000"
+  "common.error", // "Error" is Spanish too
+  "notif.ram",
+  "notif.cpus",
+  "health.cpu",
+  "health.ram",
+  "health.docker",
+  "messages.info",
+  "messages.error",
+  "messages.tokens",
+  "messages.botTag", // "bot"
+  "blog.pageTitle",
+  "blog.total",
+  "blog.rss",
+  "blog.atom",
+  "blog.tableSlug", // "Slug" — technical term
+  "files.general",
+  "files.blogBadge",
+  "files.docCategory", // "Doc"
+  "extensions.categorySocial",
+  "botbuilder.labelBash",
+  "botbuilder.labelExternalSend", // raw tool id, deliberately untranslated
+  "botbuilder.thId", // "ID"
+  "botbuilder.skillsGroupGeneral",
+  "botbuilder.wizGw_gmail", // channel product names
+  "botbuilder.wizGw_discord",
+  "botbuilder.wizGw_telegram",
+  "botbuilder.wizGw_slack",
+  "botbuilder.monThId",
+  "botbuilder.monThBot",
+  "botbuilder.monThEsc", // column abbreviation
+  "botbuilder.monThControl", // "control" is Spanish too
+  "botboard.jsLeasePrefix", // prefixes a raw English enum value — translating only the prefix buys nothing
+  "botboard.labelBotSwitcher", // "Bot"
+  "botboard.colBot",
+  "settings.ed25519", // key-algorithm name
+  "settings.serif",
+  "settings.local",
+  "settings.tailnetLan", // "Tailnet / LAN"
+  "settings.url",
+  "settings.group.general",
+  "syncConflicts.colOp", // "Op" — abbreviation of operación
+  "contacts.typeManual", // "Manual" is Spanish too
+  "contacts.fieldCrowId", // "Crow ID" — product term
+  "contacts.manual",
+  "contacts.groupColor", // "Color" is Spanish too
+  "connect.localStdioHeading", // "Local (stdio)"
+]);
+
+const keys = Object.keys(translations);
+
+test("every key has non-empty en and es", () => {
+  for (const k of keys) {
+    const v = translations[k];
+    for (const lang of SUPPORTED_LANGS) {
+      assert.equal(typeof v[lang], "string", `${k} missing ${lang}`);
+      assert.ok(v[lang].length > 0, `${k} has empty ${lang}`);
+    }
+  }
+});
+
+test("es differs from en except for the named exceptions", () => {
+  const offenders = keys.filter(
+    (k) => translations[k].es === translations[k].en && !IDENTICAL_OK.has(k),
+  );
+  assert.deepEqual(
+    offenders,
+    [],
+    `untranslated keys (es === en): ${offenders.join(", ")} — translate them ` +
+      "or, if the string is legitimately identical in Spanish, add the key " +
+      "to IDENTICAL_OK with a reason",
+  );
+});
+
+test("anti-rot: every exception key still exists and is still identical", () => {
+  for (const k of IDENTICAL_OK) {
+    assert.ok(translations[k], `IDENTICAL_OK entry ${k} no longer exists — remove it`);
+    assert.equal(
+      translations[k].es,
+      translations[k].en,
+      `IDENTICAL_OK entry ${k} is no longer identical (it was translated) — remove the stale exception`,
+    );
+  }
+});
+
+test("{placeholder} sets match between en and es for every key", () => {
+  const ph = (s) => (s.match(/\{[a-zA-Z0-9_]+\}/g) || []).sort().join(",");
+  for (const k of keys) {
+    assert.equal(
+      ph(translations[k].en),
+      ph(translations[k].es),
+      `${k}: placeholder mismatch between en ("${translations[k].en}") and es ("${translations[k].es}")`,
+    );
+  }
+});
+
+test("entries carry only supported language codes", () => {
+  const allowed = new Set(SUPPORTED_LANGS);
+  for (const k of keys) {
+    for (const lang of Object.keys(translations[k])) {
+      assert.ok(allowed.has(lang), `${k} carries unsupported language "${lang}"`);
+    }
+  }
+});
+
+// ---- fill() — $-safe interpolation ----
+
+test("fill inserts $-laden user values verbatim", () => {
+  assert.equal(fill("Bot {id} exists", { id: "a$&b" }), "Bot a$&b exists");
+  assert.equal(fill("Device {name}", { name: "x$'y$`z" }), "Device x$'y$`z");
+  assert.equal(fill("Cost {n}", { n: "$$5" }), "Cost $$5");
+  assert.equal(fill("{a} and {b}", { a: "$1", b: "$<x>" }), "$1 and $<x>");
+});
+
+test("fill replaces every occurrence and handles numbers and missing params", () => {
+  assert.equal(fill("{n} of {n}", { n: 3 }), "3 of 3");
+  assert.equal(fill("no params here", {}), "no params here");
+  assert.equal(fill("keep {unknown}", { other: "x" }), "keep {unknown}");
+  assert.equal(fill("keep {unknown}", undefined), "keep {unknown}");
+});


### PR DESCRIPTION
v1 Proving Arc **Item D** (residual minors, single PR, triage-first per the Item-3 precedent). Six pooled candidates from the master doc were re-verified against current code before building; two had rotted and were dropped.

## Shipped

**Global EN/ES i18n parity gate** — `tests/i18n-global-parity.test.js` covers **all 1,394 keys** in `servers/gateway/dashboard/shared/i18n.js` (previous guards covered only bot-builder + settings-section labels):
- `en`/`es` both present and non-empty; `es !== en` (an identical `es` is an invisible missing translation because `t()` falls back to `en`), with **48 reviewed language-neutral exceptions** ("Error", "RAM", "URL", channel product names, hex/enum labels — each value inspected before listing);
- anti-rot: a stale exception (key removed, or later translated) fails the suite;
- `{placeholder}` sets match between languages for every key; entries carry only supported language codes.
- Mutation-tested: an untranslated key, a stale exception, and a placeholder drift each turn the gate red (1 failure per mutation, verified).

**docsUrl sweep** — the 14 absolute `https://maestro.press/...` docs URLs route through `docsUrl()`; the stale "recorded follow-up" note in `components.js` is resolved. Location correction vs the master doc: the URLs live in `servers/gateway/integrations.js` (the registry), not the settings section — the section only renders `item.docsUrl`. Generated URLs verified byte-identical; `mcp-research`'s pre-existing `docsUrl: null` untouched.

**$-safe interpolation (`fill()`)** — `String.replace("{x}", value)` treats `$&` `$'` `` $` `` `$$` specially in the replacement string, so user-controlled values (bot ids, device names, model keys) could render mangled. New `fill()` helper in `i18n.js` (split/join, inserts verbatim; values deliberately NOT HTML-escaped — some call sites interpolate pre-built `<code>` HTML, callers escape per context). All 16 `t().replace("{x}", …)` sites in the bot-builder panel converted; unit tests cover every `$` pattern.

**secp256k1 placeholder de-jargon** — the `crow-messages` Advanced disclosure's raw `secp256k1 hex (64 or 66)` input placeholder replaced with keyed plain-language copy EN+ES (`botbuilder.cmPubkeyPlaceholder`).

**BH-6 CDP recipe allowlist** (ops-side, not in this diff — the recipes live in git-ignored `~/.crow/p4/`): the fresh-tab meta-glasses probe 404 (×2 per tab session by design, bounded since PR #170) is now an expected-findings allowlist entry in the round template, reported INFO instead of FAIL.

## Dropped at triage (and why)

- **Room fan-out publish stall bound** — already shipped: PR #202 (`f5642d9e`, 2026-07-16 minor pool ×3) added the 10s cap + `Promise.allSettled` to `fanOut()`; verified in current `servers/sharing/room-fanout.js`, and `room-inbound.js`'s only other awaits are local DB calls. The master-doc bullet (2026-07-17) was stale on arrival.
- **Conflict-resolve dead-branch comment** — already present: `sync-conflict-resolve.js:333` carries the "NOTE (2c-F4): currently UNREACHABLE" pointer the bullet asked for.
- **`stripComments` edge case** (bot-builder parity test helper) — dropped with rationale: the line-comment heuristic's failure mode is confined to the guard test itself (worst case a missed/false forbidden-string hit in source scanning, never product behavior), the guard has caught real issues as-is, and a robust fix means writing a JS lexer — disproportionate for a test helper. Recorded here so it isn't silently omitted.

## Verification

- Full suite in the worktree: **2081 pass / 0 fail / 0 skipped** — exactly the 2074 baseline + this PR's 7 new tests.
- Parity gate mutation-tested red→green (three defect classes).
- `INTEGRATIONS` docsUrl output diffed against pre-change values: identical.
- No schema, port, or registry changes.