### PR TITLE
docs(C2): cloud-client honesty sweep — blocked-Funnel instructions removed, reachability truth, follow-on posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Local apps, CLIs, and IDEs connect directly to your instance. These work on a st
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | CLI | Desktop app | IDE | IDE | VS Code | CLI | CLI | CLI |
 
-**Cloud web clients** (claude.ai on web/mobile, ChatGPT, Grok, Gemini on the web) are different: their servers have to reach your Crow from the public internet, and a self-hosted Crow deliberately does not expose its MCP endpoints publicly — your instance stays private on your LAN or tailnet. That is a security posture, not a missing feature. If you choose to operate a publicly reachable gateway, the [platform guides](https://maestro.press/software/crow/platforms/) cover the OAuth-based setup each cloud client uses — read [SECURITY.md](SECURITY.md#whats-public-by-default) first.
+**Cloud web clients** (claude.ai on web/mobile, ChatGPT, Grok, Gemini on the web) are different: their servers have to reach your Crow from the public internet, and a self-hosted Crow deliberately does not expose its MCP endpoints publicly — your instance stays private on your LAN or tailnet. That is a security posture, not a missing feature. **Cloud web-client access is planned as a follow-on** after v1, behind a dedicated security review. The [platform guides](https://maestro.press/software/crow/platforms/) explain the current situation per client; if you operate a publicly reachable gateway yourself (unsupported), read [SECURITY.md](SECURITY.md#whats-public-by-default) first.
 
 ## Crow's Nest
 

--- a/docs/platforms/chatgpt.md
+++ b/docs/platforms/chatgpt.md
@@ -1,11 +1,17 @@
 # ChatGPT
 
-Connect Crow to ChatGPT using the SSE transport. ChatGPT supports MCP through its Apps/Connectors feature.
+::: danger Not available for self-hosted Crow (planned as a follow-on)
+ChatGPT connects to MCP servers **from OpenAI's cloud**, so it can only reach a server that is publicly accessible on the internet. A self-hosted Crow is deliberately **not** reachable from the internet — that privacy posture is the product's core promise, not a missing feature. There is currently **no supported way** to connect ChatGPT to a private Crow. Public cloud-client access is **planned as a follow-on** after v1, behind a dedicated security review.
+
+**Use instead:** any of the local MCP clients on the [platforms index](./index) — they run on your machine and reach your private Crow directly.
+:::
+
+The instructions below apply **only** to the unsupported, advanced case where you have made your gateway publicly reachable yourself (your own domain and reverse proxy — read [SECURITY.md](https://github.com/kh0pper/crow/blob/main/SECURITY.md) first). Tailscale Funnel is **not** such a path: Crow's gateway rejects funneled requests to MCP and OAuth routes by design.
 
 ## Prerequisites
 
-- Crow gateway deployed and healthy ([Getting Started guide](../getting-started/))
-- A ChatGPT Plus or Team plan
+- Crow gateway deployed, healthy, **and publicly reachable** (unsupported — see above)
+- A ChatGPT plan with custom MCP access (behind **Developer Mode**; plan/region availability varies)
 
 ## Setup Steps
 
@@ -32,21 +38,13 @@ Repeat for additional servers:
 - **Protocol**: `2024-11-05`
 - **Auth**: OAuth 2.1 (automatic discovery)
 
-::: tip Important
-ChatGPT uses the **SSE** transport, not Streamable HTTP. Use the `/sse` endpoints, not the `/mcp` endpoints.
+::: tip Transport note
+ChatGPT historically required the **SSE** transport; newer ChatGPT releases also accept Streamable HTTP. If a `/sse` endpoint fails to connect, try the matching `/mcp` endpoint.
 :::
 
-## Self-Hosted / Local Setup
+## Self-Hosted Crow
 
-If you're running the Crow gateway on your own machine, you can expose it to ChatGPT using [Tailscale Funnel](../getting-started/tailscale-setup#option-a-tailscale-funnel-personal-hobby-use). Once Funnel is enabled on the machine running the gateway, your SSE endpoint URL will be:
-
-```
-https://<hostname>.<tailnet>.ts.net/memory/sse
-```
-
-Replace `<hostname>` and `<tailnet>` with your Tailscale machine name and tailnet domain. Use the same URL pattern for other servers (`/projects/sse`, `/router/sse`, etc.). The OAuth flow and setup steps are identical to the cloud instructions above — just substitute your Funnel URL for `your-crow-server`.
-
-See the [Tailscale Setup guide](../getting-started/tailscale-setup) for full configuration details.
+A standard self-hosted Crow **cannot** be connected to ChatGPT — see the notice at the top of this page. In particular, **Tailscale Funnel does not work for this**: the gateway rejects funneled requests to every MCP and OAuth route (only the blog and a few public files are Funnel-safe). Earlier versions of this page documented a Funnel-based setup; that flow has never worked on current Crow and the instructions were removed.
 
 ## Verification
 
@@ -64,9 +62,9 @@ If the connector fails to connect or tools don't appear:
 
 - **Leave OAuth fields blank if prompted.** Crow uses Dynamic Client Registration — ChatGPT discovers OAuth endpoints automatically from the `.well-known` metadata.
 - **Verify your gateway's OAuth metadata is reachable.** Visit `https://your-crow-server/.well-known/oauth-authorization-server` in your browser — you should see a JSON response with `authorization_endpoint`, `token_endpoint`, and `registration_endpoint`.
-- **Check `CROW_GATEWAY_URL` in your `.env` file.** This must match your actual public URL exactly (including `https://`). If you're using Tailscale Funnel, it should be `https://<hostname>.<tailnet>.ts.net`.
+- **Check `CROW_GATEWAY_URL` in your `.env` file.** This must match your actual public URL exactly (including `https://`).
 - **Start a new conversation after gateway restarts.** OAuth sessions are tied to the gateway process. When the gateway restarts, existing sessions become invalid.
-- **Use the `/sse` endpoints, not `/mcp`.** ChatGPT uses the SSE transport, not Streamable HTTP.
+- **Try the other transport.** Older ChatGPT builds require `/sse`; newer ones accept `/mcp`. If one fails, try the other.
 
 ## Cross-Platform Context
 

--- a/docs/platforms/claude.md
+++ b/docs/platforms/claude.md
@@ -1,11 +1,17 @@
 # Claude Web & Mobile
 
-Connect Crow to Claude on the web (claude.ai) or the Claude mobile app using Custom Integrations.
+::: danger Not available for self-hosted Crow (planned as a follow-on)
+claude.ai and the Claude mobile app connect to MCP servers **from Anthropic's cloud**, so they can only reach a server that is publicly accessible on the internet. A self-hosted Crow is deliberately **not** reachable from the internet — that privacy posture is the product's core promise, not a missing feature. There is currently **no supported way** to connect claude.ai or the Claude mobile app to a private Crow. Public cloud-client access is **planned as a follow-on** after v1, behind a dedicated security review.
+
+**Use instead:** [Claude Desktop](./claude-desktop) or [Claude Code](./claude-code) — both run on your own machine, reach your private Crow directly, and share the same memories.
+:::
+
+The instructions below apply **only** to the unsupported, advanced case where you have made your gateway publicly reachable yourself (your own domain and reverse proxy — read [SECURITY.md](https://github.com/kh0pper/crow/blob/main/SECURITY.md) first). Tailscale Funnel is **not** such a path: Crow's gateway rejects funneled requests to MCP and OAuth routes by design.
 
 ## Prerequisites
 
-- Crow gateway deployed and healthy ([Getting Started guide](../getting-started/))
-- A Claude Pro, Team, or Enterprise plan (Custom Integrations require a paid plan)
+- Crow gateway deployed, healthy, **and publicly reachable** (unsupported — see above)
+- A Claude plan that supports custom connectors (Free currently includes one connector; paid plans allow more)
 
 ## Setup Steps
 
@@ -38,17 +44,11 @@ Repeat for each server you want to connect:
 - **Protocol**: `2025-03-26`
 - **Auth**: OAuth 2.1 (automatic)
 
-## Self-Hosted / Local Setup
+## Self-Hosted Crow
 
-If you're running the Crow gateway on your own machine (e.g., a Raspberry Pi or home server), you can expose it to Claude using [Tailscale Funnel](../getting-started/tailscale-setup#option-a-tailscale-funnel-personal-hobby-use). Once Funnel is enabled on the machine running the gateway, your MCP endpoint URL will be:
+A standard self-hosted Crow **cannot** be connected to claude.ai — see the notice at the top of this page. In particular, **Tailscale Funnel does not work for this**: the gateway rejects funneled requests to every MCP and OAuth route (only the blog and a few public files are Funnel-safe). Earlier versions of this page documented a Funnel-based setup; that flow has never worked on current Crow and the instructions were removed.
 
-```
-https://<hostname>.<tailnet>.ts.net/memory/mcp
-```
-
-Replace `<hostname>` and `<tailnet>` with your Tailscale machine name and tailnet domain. Use the same URL pattern for other servers (`/projects/mcp`, `/router/mcp`, etc.). The OAuth flow and setup steps are identical to the cloud instructions above — just substitute your Funnel URL for `your-crow-server`.
-
-See the [Tailscale Setup guide](../getting-started/tailscale-setup) for full configuration details.
+Your self-hosted Crow works today with the local clients on the [platforms index](./index) — Claude Desktop and Claude Code give you the same Claude models with full access to your private Crow.
 
 ## Verification
 
@@ -66,7 +66,7 @@ If the connector fails to connect or tools don't appear:
 
 - **Leave OAuth Client ID and Client Secret blank.** Crow uses Dynamic Client Registration (RFC 7591) — Claude discovers the OAuth endpoints automatically from the `.well-known` metadata. No pre-configured credentials needed.
 - **Verify your gateway's OAuth metadata is reachable.** Visit `https://your-crow-server/.well-known/oauth-authorization-server` in your browser — you should see a JSON response with `authorization_endpoint`, `token_endpoint`, and `registration_endpoint`.
-- **Check `CROW_GATEWAY_URL` in your `.env` file.** This must match your actual public URL exactly (including `https://`). If you're using Tailscale Funnel, it should be `https://<hostname>.<tailnet>.ts.net`.
+- **Check `CROW_GATEWAY_URL` in your `.env` file.** This must match your actual public URL exactly (including `https://`).
 - **Start a new conversation after gateway restarts.** OAuth sessions are tied to the gateway process. When the gateway restarts, existing Claude.ai sessions become invalid — start a fresh conversation to re-authenticate.
 - **Check gateway logs for OAuth errors.** If running via systemd: `journalctl -u crow-gateway -f`. Look for errors in the `/register`, `/authorize`, or `/token` endpoints.
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -4,18 +4,22 @@ Crow uses the open [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 ## Compatibility Matrix
 
-| Platform | Transport | Auth | Setup Difficulty | Status |
+::: warning Local clients work today; cloud web clients cannot reach a private Crow
+Clients that run **on your own machine** (desktop apps, CLIs, IDEs) reach your self-hosted Crow directly over LAN/tailnet — they work out of the box. Clients that run **in a vendor's cloud** (claude.ai web/mobile, ChatGPT, Grok on the web) must reach your Crow from the public internet, and a self-hosted Crow is deliberately not exposed there. Cloud web-client access is **planned as a follow-on** after v1, behind a dedicated security review.
+:::
+
+| Platform | Runs | Transport | Auth | Status for a private Crow |
 |---|---|---|---|---|
-| [Claude Web & Mobile](./claude) | Streamable HTTP | OAuth 2.1 | Easy | Fully tested |
-| [Claude Desktop](./claude-desktop) | stdio | N/A (local) | Easy | Fully tested |
-| [Claude Code (CLI)](./claude-code) | stdio / HTTP | OAuth 2.1 | Easy | Fully tested |
-| [ChatGPT](./chatgpt) | SSE | OAuth 2.1 | Easy | Compatible |
-| [Gemini](./gemini) | stdio / HTTP | OAuth 2.1 | Easy | Compatible |
-| [Grok (xAI)](./grok) | Streamable HTTP | Bearer token | Medium | Compatible |
-| [Cursor](./cursor) | stdio / HTTP | Varies | Easy | Compatible |
-| [Windsurf](./windsurf) | stdio / HTTP | Varies | Easy | Compatible |
-| [Cline](./cline) | stdio / HTTP | Varies | Easy | Compatible |
-| [Qwen Code](./qwen-coder) | stdio / HTTP | OAuth 2.1 | Easy | Compatible |
+| [Claude Web & Mobile](./claude) | Vendor cloud | Streamable HTTP | OAuth 2.1 | **Not reachable — planned follow-on** |
+| [Claude Desktop](./claude-desktop) | Your machine | stdio | N/A (local) | Fully tested |
+| [Claude Code (CLI)](./claude-code) | Your machine | stdio / HTTP | OAuth 2.1 | Fully tested |
+| [ChatGPT](./chatgpt) | Vendor cloud | SSE / HTTP | OAuth 2.1 | **Not reachable — planned follow-on** |
+| [Gemini](./gemini) | Your machine (CLI) | stdio / HTTP | OAuth 2.1 | Compatible |
+| [Grok (xAI)](./grok) | Vendor cloud | Streamable HTTP | Bearer token | **Not reachable — planned follow-on** |
+| [Cursor](./cursor) | Your machine | stdio / HTTP | Varies | Compatible |
+| [Windsurf](./windsurf) | Your machine | stdio / HTTP | Varies | Compatible |
+| [Cline](./cline) | Your machine | stdio / HTTP | Varies | Compatible |
+| [Qwen Code](./qwen-coder) | Your machine | stdio / HTTP | OAuth 2.1 | Compatible |
 
 ## Mobile Apps
 


### PR DESCRIPTION
Executes the approved follow-ups 1–4 of the C2 cloud-access decision spike (Gitea `crow-engineering` `specs/2026-07-18-item-c2-cloud-access-decision.md`; decided by the operator 2026-07-18: stay private for v1, cloud web-client access is a committed post-v1 follow-on).

**What was wrong** (verified against `7528c2d3`):
- `docs/platforms/claude.md` and `chatgpt.md` carried "Self-Hosted / Local Setup" sections instructing users to expose `/memory/mcp` (or `/sse`) via **Tailscale Funnel — a flow the gateway deliberately 403s** (`rejectFunneledMiddleware`, `servers/gateway/funnel.js`; the OAuth routes aren't Funnel-safe either). A user following those docs hits a dead end the product built on purpose.
- `docs/platforms/index.md` matrix claimed "Claude Web & Mobile … Easy … Fully tested" and "ChatGPT … Compatible" with no reachability caveat — untrue for every private install and contradicting README's honest posture.
- Stale minors: claude.md paid-plan claim (Free now includes one connector), chatgpt.md SSE-only claim (newer builds accept Streamable HTTP).

**Changes** (docs-only, no code):
- Both cloud-client pages open with an honest status callout: a private Crow is not reachable by cloud web clients **by design**; access is **planned as a follow-on** behind a dedicated security review; local clients are the supported path. The remaining setup steps are explicitly scoped to the unsupported self-exposed-gateway case, with the Funnel non-path called out.
- Platforms matrix: new "Runs" column (vendor cloud vs your machine) and truthful per-client status for a private Crow; warning callout above.
- README Works With: states the follow-on plan explicitly and repoints the platform-guide promise.

Docs build verified locally (`vitepress build`, clean).