### PR TITLE
feat(models): Item G PR G-A — curated model catalog, CI validator, hardware probe (foundations)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
         run: node scripts/check-port-allocation.js
       - name: Registry build check
         run: node scripts/build-registry.mjs --check
+      - run: npm run validate-model-catalog
 
   audit:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check": "node scripts/check.js",
     "sync-skills": "node scripts/sync-skills.js",
     "build-registry": "node scripts/build-registry.mjs",
+    "validate-model-catalog": "node scripts/validate-model-catalog.js",
     "test:bundle-contract": "node --test tests/bundle-contract.test.js",
     "backup": "bash scripts/backup.sh",
     "restore": "bash scripts/restore.sh",

--- a/registry/model-catalog.json
+++ b/registry/model-catalog.json
@@ -1,0 +1,198 @@
+{
+  "version": 1,
+  "runtime": {
+    "name": "llama.cpp",
+    "release": "b10068",
+    "assets": {
+      "linux-x64-vulkan": {
+        "file": "llama-b10068-bin-ubuntu-vulkan-x64.tar.gz",
+        "sha256": "713641920dce6c8efb953ebc9ffa309977e200cec5e182e6ad0e8b086203cdc3",
+        "min_glibc": "2.34"
+      },
+      "linux-x64-cpu": {
+        "file": "llama-b10068-bin-ubuntu-x64.tar.gz",
+        "sha256": "6bf3d20de562e4df230f1a7c54fb7a06a80c7ff40f5311c953e8255744be4eb2",
+        "min_glibc": "2.34"
+      },
+      "darwin-arm64": {
+        "file": "llama-b10068-bin-macos-arm64.tar.gz",
+        "sha256": "13aa2d40c76ad1dcb8ebeec5f0d2814bf3b2f84a66935c7d4dc6f7cca8e38d68"
+      },
+      "darwin-x64": {
+        "file": "llama-b10068-bin-macos-x64.tar.gz",
+        "sha256": "73a63a0fdcfd8d0625fe20aa8f2af62e3d6437c6380b46129ca1a9abacbde0d5"
+      }
+    }
+  },
+  "models": [
+    {
+      "id": "qwen3-4b",
+      "family": "qwen3",
+      "lab": "Qwen",
+      "hf_repo": "Qwen/Qwen3-4B-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "first_run_default": true,
+      "tags": ["chat", "small", "cpu-capable"],
+      "notes": "Small class default. Runs on CPU alone (min_vram_mb: 0) on an 8 GB RAM machine; this is the first model Crow offers on a fresh install.",
+      "quants": [
+        {
+          "file": "Qwen3-4B-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 2497.28,
+          "min_ram_mb": 6030,
+          "min_vram_mb": 0,
+          "sha256": "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5"
+        }
+      ]
+    },
+    {
+      "id": "phi-4-mini-instruct",
+      "family": "phi4",
+      "lab": "Microsoft",
+      "hf_repo": "unsloth/Phi-4-mini-instruct-GGUF",
+      "license": "mit",
+      "gated": false,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "tags": ["chat", "small", "cpu-capable"],
+      "notes": "GGUF requantized by unsloth from Microsoft's Phi-4-mini-instruct (3.8B). CPU-capable second small-class option alongside the Qwen default.",
+      "quants": [
+        {
+          "file": "Phi-4-mini-instruct-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 2491.87,
+          "min_ram_mb": 6226,
+          "min_vram_mb": 0,
+          "sha256": "88c00229914083cd112853aab84ed51b87bdf6b9ce42f532d8c85c7c63b1730a"
+        }
+      ]
+    },
+    {
+      "id": "llama-3.1-8b-instruct",
+      "family": "llama3.1",
+      "lab": "Meta",
+      "hf_repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+      "license": "llama3.1",
+      "gated": false,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "tags": ["chat", "mid"],
+      "notes": "Community GGUF requantization by bartowski (275k+ downloads) — Meta does not publish official GGUF files for Llama 3.1. min_vram_mb is an engineering estimate (quant size rounded up + ~1 GiB headroom for KV/activations at this entry's context_len), not a vendor-published figure.",
+      "quants": [
+        {
+          "file": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 4920.74,
+          "min_ram_mb": 9728,
+          "min_vram_mb": 6144,
+          "sha256": "7b064f5842bf9532c91456deda288a1b672397a54fa729aa665952863033557c"
+        }
+      ]
+    },
+    {
+      "id": "ministral-8b-instruct",
+      "family": "ministral",
+      "lab": "Mistral AI",
+      "hf_repo": "bartowski/Ministral-8B-Instruct-2410-GGUF",
+      "license": "mrl",
+      "gated": false,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "tags": ["chat", "mid"],
+      "notes": "Mistral Research License (MRL) — non-commercial use only, not permissive; documented here so the catalog card shows it honestly. min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology).",
+      "quants": [
+        {
+          "file": "Ministral-8B-Instruct-2410-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 4911.5,
+          "min_ram_mb": 10256,
+          "min_vram_mb": 6144,
+          "sha256": "bbe8d91c196491b1802b20aba121d2ef38945a8e6c6c6a8710bfd2ef393fe73f"
+        }
+      ]
+    },
+    {
+      "id": "qwen3-14b",
+      "family": "qwen3",
+      "lab": "Qwen",
+      "hf_repo": "Qwen/Qwen3-14B-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "tags": ["chat", "mid"],
+      "notes": "Official Qwen GGUF. min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology).",
+      "quants": [
+        {
+          "file": "Qwen3-14B-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 9001.75,
+          "min_ram_mb": 16225,
+          "min_vram_mb": 10240,
+          "sha256": "500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0"
+        }
+      ]
+    },
+    {
+      "id": "deepseek-r1-distill-qwen-32b",
+      "family": "deepseek-r1-distill",
+      "lab": "DeepSeek",
+      "hf_repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+      "license": "mit",
+      "gated": false,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "tags": ["chat", "large", "reasoning"],
+      "notes": "DeepSeek-R1 reasoning distilled onto a Qwen2.5-32B base, released by DeepSeek under MIT; GGUF requantized by bartowski. Large class — needs a real GPU or a lot of RAM to be usable; min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology).",
+      "quants": [
+        {
+          "file": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 19851.34,
+          "min_ram_mb": 31101,
+          "min_vram_mb": 21504,
+          "sha256": "bed9b0f551f5b95bf9da5888a48f0f87c37ad6b72519c4cbd775f54ac0b9fc62"
+        }
+      ]
+    },
+    {
+      "id": "gemma-3-27b-it",
+      "family": "gemma3",
+      "lab": "Google",
+      "hf_repo": "google/gemma-3-27b-it-qat-q4_0-gguf",
+      "license": "gemma",
+      "gated": true,
+      "task": "chat",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_0",
+      "tags": ["chat", "large", "gated"],
+      "notes": "Official Google QAT (quantization-aware training) GGUF, gated on Hugging Face (gated: \"manual\" — requires an HF account that has clicked accept on the Gemma license before download works, even with a valid token). Exercises the catalog's three-state gated-download flow. This repo's blobs=true metadata endpoint happened to still expose a real sha256 for the quant file despite the gate (only the actual file download at /resolve/ enforces it) — verified independently against the HF tree API's file-size field, which matches exactly. Large class — needs a real GPU or a lot of RAM to be usable; min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology). The repo also ships a multimodal mmproj file that is NOT included here — this entry is text-chat only.",
+      "quants": [
+        {
+          "file": "gemma-3-27b-it-q4_0.gguf",
+          "quant": "Q4_0",
+          "size_mb": 17229.63,
+          "min_ram_mb": 28664,
+          "min_vram_mb": 18432,
+          "sha256": "7b131f721b95bd06ef4066e18ed2febed15ad6620f61c6eaf37832837ca109fe"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/dev/hf-catalog-entry.mjs
+++ b/scripts/dev/hf-catalog-entry.mjs
@@ -216,9 +216,13 @@ async function main() {
   const argv = process.argv.slice(2);
   const { values, positionals } = parseCliArgs(argv);
 
-  if (values.help || argv.length === 0) {
+  if (values.help) {
     process.stdout.write(HELP);
     process.exit(0);
+  }
+
+  if (argv.length === 0) {
+    fail("usage: <hf_repo> <filename> [options] (--help for details)", 1);
   }
 
   const [repo, filename] = positionals;

--- a/scripts/dev/hf-catalog-entry.mjs
+++ b/scripts/dev/hf-catalog-entry.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Dev-only helper: given a Hugging Face GGUF repo + filename, fetch the REAL
+ * size and sha256 (git-LFS oid) for that file and emit a `quants[]` entry
+ * shaped for `registry/model-catalog.json`.
+ *
+ * NOT shipped in any runtime path — this is a build-time tool a developer
+ * runs by hand when curating the catalog. Nothing under servers/ imports it.
+ *
+ * RAM-fit formula (baseline KV-cache estimate; see spec's RAM-fit section,
+ * Gitea crow-engineering specs/2026-07-18-item-g-model-catalog-design.md):
+ *
+ *   kv_estimate_mb = KV_STREAMS * n_layer * n_embd * BYTES_PER_ELEM * context_len / 1e6
+ *   min_ram_mb     = ceil(size_mb + kv_estimate_mb + overhead_mb)
+ *
+ * KV_STREAMS = 2 (one K cache + one V cache per layer).
+ * BYTES_PER_ELEM = 2 (fp16 KV cache, llama.cpp's default `--cache-type-k/v f16`).
+ * overhead_mb = 512 by default (fixed runtime/allocator overhead), overridable.
+ *
+ * This is a BASELINE estimate, not exact: it uses n_embd (full hidden size)
+ * rather than num_key_value_heads * head_dim, so it does NOT account for
+ * grouped-query attention (GQA) shrinking the KV cache on modern models — the
+ * result is deliberately conservative (an over-estimate) on any GQA model,
+ * which is the honest direction to be wrong in for a RAM-fit gate. If a future
+ * revision wants the exact GQA-aware term, pass --n-kv-heads and --head-dim;
+ * today's formula does not consume them (documented no-op, kept for
+ * forward compatibility / model-card record-keeping only).
+ *
+ * Usage:
+ *   node scripts/dev/hf-catalog-entry.mjs <hf_repo> <filename> \
+ *     --n-layer <int> --n-embd <int> [--context-len 8192] \
+ *     [--quant Q4_K_M] [--min-vram-mb 0] [--overhead-mb 512] \
+ *     [--kv-bytes-per-elem 2] [--n-kv-heads <int>] [--head-dim <int>] \
+ *     [--hf-token <token>]
+ *
+ * Example:
+ *   node scripts/dev/hf-catalog-entry.mjs Qwen/Qwen3-4B-GGUF Qwen3-4B-Q4_K_M.gguf \
+ *     --n-layer 36 --n-embd 2560 --context-len 8192 --quant Q4_K_M --min-vram-mb 0
+ *
+ * Gated repos: the HF API hides `blobs` (size + sha256) for gated repos
+ * unless the request is authenticated AND the account has accepted the
+ * license. This script falls back to the unauthenticated `/tree/main` API,
+ * which (as observed 2026-07-18 against google/gemma-3-27b-it-qat-q4_0-gguf)
+ * DOES expose the real file `size` even for a gated repo, but the LFS `oid`
+ * (sha256) itself is redacted. In that case the emitted quant has a REAL
+ * `size_mb` and `sha256: null`, with a warning on stderr. The catalog
+ * validator (Task 2) only accepts a null sha256 when the model entry is
+ * `gated: true` — never invent a hash.
+ */
+
+import { parseArgs } from "node:util";
+
+const HELP = `hf-catalog-entry.mjs — fetch a real HF GGUF file size + sha256 and emit a catalog quant entry
+
+Usage:
+  node scripts/dev/hf-catalog-entry.mjs <hf_repo> <filename> [options]
+
+Positional:
+  <hf_repo>            Hugging Face repo id, e.g. "Qwen/Qwen3-4B-GGUF"
+  <filename>            GGUF filename inside that repo, e.g. "Qwen3-4B-Q4_K_M.gguf"
+                        (path form "subdir/file.gguf" is allowed for multi-file repos)
+
+Required options:
+  --n-layer <int>       Number of transformer layers (num_hidden_layers in the
+                        base model's config.json). Feeds the KV-cache estimate.
+  --n-embd <int>        Hidden size / embedding dim (hidden_size in config.json).
+                        Feeds the KV-cache estimate.
+
+Options:
+  --context-len <int>   Context length to size the KV cache at. Default 8192.
+                        Use an honest deployment default, NOT the model's max
+                        context (a 128K max context would wildly overstate
+                        actual RAM need for a typical chat session).
+  --quant <string>      Quant label to stamp on the entry (e.g. "Q4_K_M").
+                        Default: inferred from <filename> (last _TOKEN before
+                        ".gguf", uppercased) — override if inference is wrong.
+  --min-vram-mb <int>   min_vram_mb to stamp on the entry. Default 0 (CPU-ok).
+  --overhead-mb <int>   Fixed runtime/allocator overhead added on top of the
+                        KV estimate. Default 512.
+  --kv-bytes-per-elem <int>
+                        Bytes per KV cache element. Default 2 (fp16 KV cache,
+                        llama.cpp's default). Documented override for a future
+                        quantized-KV-cache catalog revision.
+  --n-kv-heads <int>    Informational only (GQA key/value head count) — NOT
+                        consumed by today's baseline formula. Recorded so a
+                        future GQA-aware revision doesn't have to re-derive it.
+  --head-dim <int>      Informational only (attention head dimension) — same
+                        no-op/record-keeping status as --n-kv-heads.
+  --hf-token <token>    Bearer token for the HF API (gated repos you have
+                        accepted the license for). Never logged. Prefer the
+                        HF_TOKEN env var over passing this on the command line.
+  --help, -h            Show this help and exit.
+
+Output:
+  A single JSON object on stdout, shaped for registry/model-catalog.json's
+  quants[] array: { file, quant, size_mb, min_ram_mb, min_vram_mb, sha256 }.
+  Diagnostics (including the gated-repo fallback warning) go to stderr, never
+  stdout, so this script composes with "> entry.json" or piping into jq.
+
+Exit codes: 0 success, 1 usage error, 2 HF API / network error, 3 file not
+found in the repo's file listing.
+`;
+
+function fail(msg, code) {
+  process.stderr.write(`hf-catalog-entry: ${msg}\n`);
+  process.exit(code);
+}
+
+function parseCliArgs(argv) {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        help: { type: "boolean", short: "h", default: false },
+        "n-layer": { type: "string" },
+        "n-embd": { type: "string" },
+        "context-len": { type: "string", default: "8192" },
+        quant: { type: "string" },
+        "min-vram-mb": { type: "string", default: "0" },
+        "overhead-mb": { type: "string", default: "512" },
+        "kv-bytes-per-elem": { type: "string", default: "2" },
+        "n-kv-heads": { type: "string" },
+        "head-dim": { type: "string" },
+        "hf-token": { type: "string" },
+      },
+    });
+  } catch (err) {
+    fail(`bad arguments: ${err.message}`, 1);
+  }
+  return parsed;
+}
+
+/** Baseline KV-cache estimate in MB. See the module doc comment for the formula's provenance and known GQA over-estimate direction. */
+export function kvEstimateMb({ nLayer, nEmbd, contextLen, bytesPerElem = 2 }) {
+  const KV_STREAMS = 2; // one K cache + one V cache per layer
+  return (KV_STREAMS * nLayer * nEmbd * bytesPerElem * contextLen) / 1e6;
+}
+
+/** min_ram_mb = ceil(size_mb + kv_estimate_mb + overhead_mb). */
+export function computeMinRamMb({ sizeMb, nLayer, nEmbd, contextLen, bytesPerElem = 2, overheadMb = 512 }) {
+  const kv = kvEstimateMb({ nLayer, nEmbd, contextLen, bytesPerElem });
+  return Math.ceil(sizeMb + kv + overheadMb);
+}
+
+/** Infer a quant label like "Q4_K_M" from a GGUF filename. Best-effort; callers should pass --quant if this guesses wrong. */
+export function inferQuantFromFilename(filename) {
+  const base = filename.replace(/\.gguf$/i, "");
+  const m = base.match(/([A-Za-z]?[Qq][0-9]+(?:_[A-Za-z0-9]+)*|F16|F32|BF16)$/);
+  return m ? m[1].toUpperCase() : base.toUpperCase();
+}
+
+async function hfFetchJson(url, token) {
+  const headers = { Accept: "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(url, { headers });
+  return { res, body: res.ok ? await res.json() : null, status: res.status };
+}
+
+/**
+ * Resolve size_mb + sha256 for a file in an HF repo.
+ * Tries the blobs=true model API first (gives both size and LFS sha256 for
+ * ungated repos, or any repo with a valid authenticated+accepted token).
+ * Falls back to the unauthenticated /tree/main API, which HF has been
+ * observed to still expose real `size` for on a gated repo (sha256/oid is
+ * redacted there) — see module doc comment.
+ */
+export async function resolveFileMeta({ repo, filename, token, fetchImpl = fetch }) {
+  const blobsUrl = `https://huggingface.co/api/models/${repo}?blobs=true`;
+  const headers = { Accept: "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const blobsRes = await fetchImpl(blobsUrl, { headers });
+  if (blobsRes.ok) {
+    const data = await blobsRes.json();
+    const sib = (data.siblings || []).find((s) => s.rfilename === filename);
+    if (!sib) return { found: false, gatedFallback: false };
+    // The blobs=true LFS metadata has been observed keyed as either
+    // `lfs.sha256` or `lfs.oid` depending on HF API version — accept either,
+    // never invent one.
+    const lfsSha = sib.lfs && (sib.lfs.sha256 || sib.lfs.oid);
+    if (sib.size != null && lfsSha) {
+      return { found: true, gatedFallback: false, sizeBytes: sib.size, sha256: lfsSha };
+    }
+    if (sib.size != null) {
+      // Present but not an LFS pointer (small non-LFS file, unusual for a
+      // GGUF) — no sha256 available from this endpoint either way.
+      return { found: true, gatedFallback: false, sizeBytes: sib.size, sha256: null };
+    }
+    return { found: false, gatedFallback: false };
+  }
+
+  if (blobsRes.status !== 401 && blobsRes.status !== 403) {
+    throw new Error(`HF API ${blobsUrl} -> HTTP ${blobsRes.status}`);
+  }
+
+  // Gated-repo fallback: unauthenticated /tree/main has been observed to
+  // still return real `size` (sha256/oid redacted) for a gated repo.
+  process.stderr.write(
+    `hf-catalog-entry: WARNING ${repo} blobs API returned ${blobsRes.status} (gated or private) — falling back to /tree/main; sha256 will be null.\n`
+  );
+  const treeUrl = `https://huggingface.co/api/models/${repo}/tree/main`;
+  const treeRes = await fetchImpl(treeUrl, { headers });
+  if (!treeRes.ok) {
+    throw new Error(`HF API ${treeUrl} -> HTTP ${treeRes.status} (gated-repo fallback also failed)`);
+  }
+  const entries = await treeRes.json();
+  const entry = entries.find((e) => e.path === filename);
+  if (!entry) return { found: false, gatedFallback: true };
+  const sizeBytes = entry.lfs?.size ?? entry.size;
+  return { found: true, gatedFallback: true, sizeBytes, sha256: null };
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const { values, positionals } = parseCliArgs(argv);
+
+  if (values.help || argv.length === 0) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+
+  const [repo, filename] = positionals;
+  if (!repo || !filename) fail("usage: <hf_repo> <filename> [options] (--help for details)", 1);
+  if (!values["n-layer"] || !values["n-embd"]) fail("--n-layer and --n-embd are required", 1);
+
+  const nLayer = Number(values["n-layer"]);
+  const nEmbd = Number(values["n-embd"]);
+  const contextLen = Number(values["context-len"]);
+  const overheadMb = Number(values["overhead-mb"]);
+  const bytesPerElem = Number(values["kv-bytes-per-elem"]);
+  const minVramMb = Number(values["min-vram-mb"]);
+  const token = values["hf-token"] || process.env.HF_TOKEN || undefined;
+
+  for (const [name, val] of [
+    ["--n-layer", nLayer],
+    ["--n-embd", nEmbd],
+    ["--context-len", contextLen],
+    ["--overhead-mb", overheadMb],
+    ["--kv-bytes-per-elem", bytesPerElem],
+    ["--min-vram-mb", minVramMb],
+  ]) {
+    if (!Number.isFinite(val) || val < 0) fail(`${name} must be a non-negative number, got ${val}`, 1);
+  }
+
+  let meta;
+  try {
+    meta = await resolveFileMeta({ repo, filename, token });
+  } catch (err) {
+    fail(`HF API request failed: ${err.message}`, 2);
+    return;
+  }
+
+  if (!meta.found) {
+    fail(`file "${filename}" not found in ${repo}'s file listing`, 3);
+    return;
+  }
+
+  const sizeMb = meta.sizeBytes / 1e6;
+  const minRamMb = computeMinRamMb({ sizeMb, nLayer, nEmbd, contextLen, bytesPerElem, overheadMb });
+  const quant = values.quant || inferQuantFromFilename(filename);
+
+  if (meta.gatedFallback) {
+    process.stderr.write(
+      `hf-catalog-entry: NOTE sha256 is null (gated repo, API hides the LFS oid without an accepted-license token). size_mb is real (from /tree/main). Set the model entry's "gated": true so the validator accepts a null sha256.\n`
+    );
+  }
+
+  const entry = {
+    file: filename,
+    quant,
+    size_mb: Math.round(sizeMb * 100) / 100,
+    min_ram_mb: minRamMb,
+    min_vram_mb: minVramMb,
+    sha256: meta.sha256,
+  };
+
+  process.stdout.write(JSON.stringify(entry, null, 2) + "\n");
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => fail(`unexpected error: ${err.stack || err.message}`, 2));
+}

--- a/scripts/validate-model-catalog.js
+++ b/scripts/validate-model-catalog.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Validates registry/model-catalog.json (Item G model-catalog theme).
+ *
+ * Exports a pure function `validateCatalog(catalogObj) -> { ok, errors }`
+ * for tests and other tooling, plus a CLI main that loads the real catalog
+ * file and exits 1 on any error (wired into CI's static-checks job as
+ * `npm run validate-model-catalog`).
+ *
+ * Checks:
+ *   - runtime.assets keys are drawn from a known set; linux-* keys require
+ *     min_glibc.
+ *   - model ids are unique.
+ *   - every quant has a sha256 UNLESS the owning model is gated:true (a
+ *     gated HF repo can hide the LFS blob's sha256 even when size is known
+ *     — see scripts/dev/hf-catalog-entry.mjs's doc comment). A non-gated
+ *     model must always carry a real sha256.
+ *   - min_ram_mb is never less than the quant's own size_mb (a RAM-math
+ *     sanity floor: whatever else is estimated, the model has to fit in RAM
+ *     at all before KV-cache/overhead are even added).
+ *   - min_runtime_version (a llama.cpp "b<build>" tag) must not exceed
+ *     runtime.release's build number.
+ *   - exactly one model has first_run_default:true, and that model must be
+ *     ungated with at least one quant carrying min_vram_mb:0 (CPU-capable) —
+ *     first_run_default is the model Crow offers as the default first
+ *     install on a machine with no GPU.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CATALOG_PATH = join(REPO_ROOT, "registry/model-catalog.json");
+
+const KNOWN_RUNTIME_ASSET_KEYS = new Set([
+  "linux-x64-vulkan",
+  "linux-x64-cpu",
+  "darwin-arm64",
+  "darwin-x64",
+]);
+
+const SHA256_RE = /^[0-9a-f]{64}$/i;
+
+/** Parse a llama.cpp release tag "b<number>" into its numeric build. Returns NaN on malformed input. */
+function parseBuildNumber(tag) {
+  if (typeof tag !== "string") return NaN;
+  const m = tag.match(/^b(\d+)$/);
+  return m ? Number(m[1]) : NaN;
+}
+
+export function validateCatalog(catalog) {
+  const errors = [];
+
+  if (!catalog || typeof catalog !== "object") {
+    return { ok: false, errors: ["catalog must be an object"] };
+  }
+
+  const runtime = catalog.runtime;
+  if (!runtime || typeof runtime !== "object") {
+    errors.push("runtime is required");
+  } else {
+    const releaseBuild = parseBuildNumber(runtime.release);
+    if (Number.isNaN(releaseBuild)) {
+      errors.push(`runtime.release must be a "b<number>" tag, got ${JSON.stringify(runtime.release)}`);
+    }
+
+    const assets = runtime.assets;
+    if (!assets || typeof assets !== "object") {
+      errors.push("runtime.assets is required");
+    } else {
+      for (const [key, asset] of Object.entries(assets)) {
+        if (!KNOWN_RUNTIME_ASSET_KEYS.has(key)) {
+          errors.push(`unknown runtime asset key "${key}"`);
+        }
+        if (key.startsWith("linux-") && (!asset || !asset.min_glibc)) {
+          errors.push(`runtime asset "${key}" is a linux asset and must declare min_glibc`);
+        }
+        if (!asset || !asset.file) {
+          errors.push(`runtime asset "${key}" is missing file`);
+        }
+        if (!asset || !SHA256_RE.test(asset.sha256 || "")) {
+          errors.push(`runtime asset "${key}" has an invalid or missing sha256`);
+        }
+      }
+    }
+  }
+
+  const models = Array.isArray(catalog.models) ? catalog.models : null;
+  if (!models) {
+    errors.push("models must be an array");
+    return { ok: errors.length === 0, errors };
+  }
+
+  const seenIds = new Set();
+  const firstRunDefaults = [];
+  const releaseBuild = runtime && typeof runtime === "object" ? parseBuildNumber(runtime.release) : NaN;
+
+  models.forEach((model, idx) => {
+    const label = model && model.id ? `model "${model.id}"` : `models[${idx}]`;
+
+    if (!model || typeof model !== "object") {
+      errors.push(`${label}: entry must be an object`);
+      return;
+    }
+
+    if (!model.id) {
+      errors.push(`${label}: missing id`);
+    } else if (seenIds.has(model.id)) {
+      errors.push(`duplicate model id "${model.id}"`);
+    } else {
+      seenIds.add(model.id);
+    }
+
+    if (model.first_run_default === true) {
+      firstRunDefaults.push(model);
+    }
+
+    if (!Number.isNaN(releaseBuild) && model.min_runtime_version != null) {
+      const modelBuild = parseBuildNumber(model.min_runtime_version);
+      if (Number.isNaN(modelBuild)) {
+        errors.push(`${label}: min_runtime_version must be a "b<number>" tag, got ${JSON.stringify(model.min_runtime_version)}`);
+      } else if (modelBuild > releaseBuild) {
+        errors.push(
+          `${label}: min_runtime_version ${model.min_runtime_version} is greater than runtime.release ${runtime.release}`
+        );
+      }
+    }
+
+    const quants = Array.isArray(model.quants) ? model.quants : [];
+    if (quants.length === 0) {
+      errors.push(`${label}: must have at least one quant`);
+    }
+
+    quants.forEach((quant, qidx) => {
+      const qlabel = `${label} quant[${qidx}]${quant && quant.quant ? ` (${quant.quant})` : ""}`;
+
+      if (!quant || typeof quant !== "object") {
+        errors.push(`${qlabel}: entry must be an object`);
+        return;
+      }
+
+      // sha256: required for every quant, UNLESS the owning model is
+      // gated:true — a gated HF repo can hide the LFS blob's sha256 even
+      // when the file's size is independently known.
+      const gated = model.gated === true;
+      if (quant.sha256 == null) {
+        if (!gated) {
+          errors.push(`${qlabel}: missing quant sha256 (only allowed when the model is gated:true)`);
+        }
+      } else if (!SHA256_RE.test(quant.sha256)) {
+        errors.push(`${qlabel}: sha256 is not a valid 64-char hex string`);
+      }
+
+      if (typeof quant.size_mb !== "number" || !(quant.size_mb > 0)) {
+        errors.push(`${qlabel}: size_mb must be a positive number`);
+      }
+      if (typeof quant.min_ram_mb !== "number") {
+        errors.push(`${qlabel}: min_ram_mb must be a number`);
+      } else if (typeof quant.size_mb === "number" && quant.min_ram_mb < quant.size_mb) {
+        errors.push(`${qlabel}: min_ram_mb (${quant.min_ram_mb}) is less than quant size_mb (${quant.size_mb})`);
+      }
+      if (typeof quant.min_vram_mb !== "number") {
+        errors.push(`${qlabel}: min_vram_mb must be a number`);
+      }
+    });
+  });
+
+  if (firstRunDefaults.length === 0) {
+    errors.push("exactly one model must have first_run_default:true, found 0");
+  } else if (firstRunDefaults.length > 1) {
+    errors.push(
+      `exactly one model must have first_run_default:true, found ${firstRunDefaults.length} (${firstRunDefaults
+        .map((m) => m.id)
+        .join(", ")})`
+    );
+  } else {
+    const def = firstRunDefaults[0];
+    if (def.gated === true) {
+      errors.push(`first_run_default model "${def.id}" must not be gated:true`);
+    }
+    const quants = Array.isArray(def.quants) ? def.quants : [];
+    const hasCpuCapable = quants.some((q) => q && q.min_vram_mb === 0);
+    if (!hasCpuCapable) {
+      errors.push(`first_run_default model "${def.id}" must have at least one quant with min_vram_mb:0`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+function main() {
+  let catalog;
+  try {
+    catalog = JSON.parse(readFileSync(CATALOG_PATH, "utf8"));
+  } catch (err) {
+    console.error(`ERROR: failed to read/parse ${CATALOG_PATH}: ${err.message}`);
+    process.exit(1);
+  }
+
+  const { ok, errors } = validateCatalog(catalog);
+  if (!ok) {
+    console.error(`ERROR: ${errors.length} model-catalog validation issue(s):`);
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  console.log(`OK: ${catalog.models.length} model(s) in ${CATALOG_PATH} validate cleanly.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/servers/gateway/models/probe.js
+++ b/servers/gateway/models/probe.js
@@ -1,0 +1,452 @@
+/**
+ * Hardware probe for the model catalog (Item G).
+ *
+ * Detects what a host can actually run a model on — accelerator kind, GPU
+ * name/VRAM, available RAM, and free disk — for the catalog's panel fit
+ * badges and runtime asset selection (later tasks). Genuinely new detection
+ * code: it does NOT extend or import `gpu-arch.js` or `hardware-gate.js`.
+ * Their behaviors were CONSULTED for parsing patterns (rocminfo agent/pool
+ * state machine, nvidia-smi CSV, /proc/meminfo `Key:  N kB` lines,
+ * `fs.statfsSync` disk math) but are explicitly wrong to reuse here:
+ *
+ *   - gpu-arch.js's `detectGpuVramGb` FAILS OPEN (null VRAM => install not
+ *     blocked). A fit badge must fail CLOSED: unknown data never renders as
+ *     "fits".
+ *   - hardware-gate.js's `computeEffectiveRam` counts SwapFree (half-weight,
+ *     SSD/zram only) toward available RAM. Fit badges must NEVER count swap
+ *     — a model that only "fits" by swapping is a bad user experience, not
+ *     a fit.
+ *   - Neither file covers Vulkan (the actual acceleration path for AMD
+ *     consumer GPUs without ROCm installed) or WSL2 (which needs a hard
+ *     override, not a probe result).
+ *
+ * Detection order (linux): WSLInterop file / kernel string -> wsl2 flag
+ * (forces accel "cpu", v1 rule: no CUDA asset exists for linux under WSL2,
+ * and we don't attempt GPU passthrough detection there). Otherwise:
+ * vulkaninfo (deviceName + VRAM from the DEVICE_LOCAL memory heap) -> accel
+ * "vulkan"; else nvidia-smi -> accel "cuda"; else rocminfo (AMD family,
+ * still reported as "vulkan" since the Probe.accel enum has no separate
+ * "rocm" value — v1 always ships the Vulkan/Mesa asset for AMD). darwin ->
+ * accel "metal" always (deterministic), RAM from `sysctl -n hw.memsize`
+ * (this is total physical memory, not "available" — macOS has no direct
+ * MemAvailable equivalent exposed via a single documented command; treating
+ * total-as-available is a deliberate v1 simplification, not a detection
+ * bug — see task-3-report.md).
+ *
+ * Anything genuinely undetectable leaves its Probe field(s) null AND pushes
+ * a short name ("gpu" | "ram" | "disk") into `unknown`. A deliberate,
+ * confident non-detection (WSL2's forced cpu, darwin's forced metal) is NOT
+ * "unknown" and does not get pushed.
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import * as nodeFs from "node:fs";
+import * as nodeOs from "node:os";
+
+const WSL_INTEROP_PATH = "/proc/sys/fs/binfmt_misc/WSLInterop";
+const MEMINFO_PATH = "/proc/meminfo";
+
+// ---------------------------------------------------------------------------
+// execFile helper — always resolves (never throws/rejects); a command that
+// errors or is missing resolves to null so callers can treat every
+// detection path uniformly as "did this signal come back or not".
+// ---------------------------------------------------------------------------
+
+function run(execFile, cmd, args) {
+  return new Promise((resolve) => {
+    try {
+      execFile(cmd, args, { encoding: "utf8", timeout: 5000 }, (err, stdout) => {
+        if (err) resolve(null);
+        else resolve(typeof stdout === "string" ? stdout : String(stdout ?? ""));
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsers — exported for direct unit testing / reuse.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `vulkaninfo` (plain, no args — the default --text mode) output.
+ * `--summary` mode does NOT include memory heap data on any vulkan-tools
+ * build checked for this task, so the probe must invoke plain `vulkaninfo`
+ * to get the DEVICE_LOCAL heap size the spec asks for (see task-3-report.md
+ * for the verification). Skips PHYSICAL_DEVICE_TYPE_CPU devices (software
+ * rasterizers like llvmpipe) and picks the device with the largest
+ * DEVICE_LOCAL heap when more than one real GPU is present.
+ * Returns { name, vramMb } or null if no GPU with a DEVICE_LOCAL heap found.
+ */
+export function parseVulkaninfo(text) {
+  if (!text) return null;
+  const lines = text.split("\n");
+  const candidates = [];
+
+  let currentType = null;
+  let currentName = null;
+  let inMemProps = false;
+  let heapSize = 0;
+  let maxHeapBytes = 0;
+
+  const flushDevice = () => {
+    if (currentName && currentType !== "PHYSICAL_DEVICE_TYPE_CPU" && maxHeapBytes > 0) {
+      candidates.push({ name: currentName, vramMb: Math.round(maxHeapBytes / 1024 / 1024) });
+    }
+    currentType = null;
+    currentName = null;
+    inMemProps = false;
+    heapSize = 0;
+    maxHeapBytes = 0;
+  };
+
+  for (const line of lines) {
+    if (/^GPU\d+:/.test(line)) {
+      flushDevice();
+      continue;
+    }
+    const typeM = line.match(/deviceType\s*=\s*(\S+)/);
+    if (typeM) {
+      currentType = typeM[1];
+      continue;
+    }
+    const nameM = line.match(/deviceName\s*=\s*(.+)/);
+    if (nameM) {
+      currentName = nameM[1].trim();
+      continue;
+    }
+    if (/VkPhysicalDeviceMemoryProperties:/.test(line)) {
+      inMemProps = true;
+      continue;
+    }
+    if (!inMemProps) continue;
+    if (/memoryTypes:/.test(line)) {
+      inMemProps = false;
+      continue;
+    }
+    const sizeM = line.match(/^\s*size\s*=\s*(\d+)/);
+    if (sizeM) {
+      heapSize = parseInt(sizeM[1], 10);
+      continue;
+    }
+    if (/MEMORY_HEAP_DEVICE_LOCAL_BIT/.test(line)) {
+      if (heapSize > maxHeapBytes) maxHeapBytes = heapSize;
+      continue;
+    }
+  }
+  flushDevice(); // last device in the file never hits a following "GPUn:" line
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.vramMb - a.vramMb);
+  return candidates[0];
+}
+
+/**
+ * Parse `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`
+ * output (one "name, memMiB" line per GPU). Returns the first valid GPU
+ * line as { name, vramMb } (memory.total in MiB, treated as MB), or null.
+ */
+export function parseNvidiaSmi(text) {
+  if (!text) return null;
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split(",").map((p) => p.trim());
+    if (parts.length < 2) continue;
+    const name = parts[0];
+    const mem = parseInt(parts[1], 10);
+    if (name && Number.isFinite(mem) && mem > 0) {
+      return { name, vramMb: mem };
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse `rocminfo` output. Consulted (per the task brief) as the AMD
+ * fallback when vulkaninfo itself is missing but ROCm is installed. Mirrors
+ * gpu-arch.js's Agent/Pool state-machine parsing pattern (Name: gfxNNNN
+ * marks a GPU agent unambiguously; CPU agents never carry a gfx token) but
+ * is a fresh, standalone implementation that additionally captures
+ * "Marketing Name:" for a human-readable GPU name and reports VRAM in MB
+ * (not GB — fit-badge math needs MB precision).
+ * Returns { name, vramMb } for the largest GPU agent's GLOBAL pool, or null.
+ */
+export function parseRocminfo(text) {
+  if (!text) return null;
+  const lines = text.split("\n");
+  const candidates = [];
+
+  let inAgent = false;
+  let isGpu = false;
+  let marketingName = null;
+  let inGlobalSegment = false;
+  let maxKb = 0;
+
+  const flushAgent = () => {
+    if (isGpu && maxKb > 0) {
+      candidates.push({ name: marketingName || "AMD GPU", vramMb: Math.round(maxKb / 1024) });
+    }
+    isGpu = false;
+    marketingName = null;
+    inGlobalSegment = false;
+    maxKb = 0;
+  };
+
+  for (const line of lines) {
+    if (/^\s*Agent\s+\d+/.test(line)) {
+      flushAgent();
+      inAgent = true;
+      continue;
+    }
+    if (!inAgent) continue;
+    if (/^\s*Name:\s*gfx[0-9a-f]+\s*$/.test(line)) {
+      isGpu = true;
+      continue;
+    }
+    const mn = line.match(/^\s*Marketing Name:\s*(.+?)\s*$/);
+    if (mn) {
+      marketingName = mn[1];
+      continue;
+    }
+    if (!isGpu) continue;
+    if (/^\s*Segment:\s*GLOBAL/.test(line)) {
+      inGlobalSegment = true;
+      continue;
+    }
+    if (/^\s*Segment:/.test(line)) {
+      inGlobalSegment = false;
+      continue;
+    }
+    if (inGlobalSegment) {
+      const m = line.match(/^\s*Size:\s*(\d+)\b.*KB/);
+      if (m) maxKb = Math.max(maxKb, parseInt(m[1], 10));
+    }
+  }
+  flushAgent(); // last agent in the file never hits a following "Agent N" line
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => b.vramMb - a.vramMb);
+  return candidates[0];
+}
+
+/** Parse the `MemAvailable:  N kB` line from /proc/meminfo text. MB, rounded. */
+export function parseMemAvailableMb(text) {
+  if (!text) return null;
+  for (const line of text.split("\n")) {
+    const m = line.match(/^MemAvailable:\s+(\d+)\s+kB/);
+    if (m) return Math.round(Number(m[1]) / 1024);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers (impure — call out to execFile/fs)
+// ---------------------------------------------------------------------------
+
+function detectWsl2(fs, release) {
+  if (fs.existsSync(WSL_INTEROP_PATH)) return true;
+  if (typeof release === "string" && /microsoft/i.test(release)) return true;
+  return false;
+}
+
+async function readMemAvailable(fs) {
+  try {
+    const raw = fs.readFileSync(MEMINFO_PATH, "utf8");
+    return parseMemAvailableMb(raw);
+  } catch {
+    return null;
+  }
+}
+
+function readDiskFreeMb(fs, dir) {
+  if (!dir) return null;
+  try {
+    const s = fs.statfsSync(dir);
+    return Math.round((Number(s.bavail) * Number(s.bsize)) / (1024 * 1024));
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// probeHardware
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} Probe
+ * @property {"linux"|"darwin"} platform
+ * @property {boolean} wsl2
+ * @property {"vulkan"|"cuda"|"metal"|"cpu"} accel
+ * @property {string|null} gpuName
+ * @property {number|null} vramMb
+ * @property {number|null} ramAvailableMb
+ * @property {number|null} diskFreeMb
+ * @property {string[]} unknown
+ */
+
+/**
+ * Probe this host's hardware. Every external call is injected (execFile,
+ * fs) so every path is fixture-testable without the real binaries/files.
+ * `platform`/`release` are also injectable (defaulting to process.platform
+ * / os.release()) — needed to exercise the darwin and WSL2 branches from
+ * fixtures without a real machine of that kind. `modelsDir`, if given, is
+ * the directory `fs.statfsSync` is called against for `diskFreeMb`; if
+ * omitted, diskFreeMb stays null and "disk" is pushed to `unknown`.
+ *
+ * @param {{execFile?: Function, fs?: Object, platform?: string, release?: string, modelsDir?: string|null}} [opts]
+ * @returns {Promise<Probe>}
+ */
+export async function probeHardware(opts = {}) {
+  const {
+    execFile = execFileCb,
+    fs = nodeFs,
+    platform = process.platform,
+    release = nodeOs.release(),
+    modelsDir = null,
+  } = opts;
+
+  const unknown = [];
+  const probe = {
+    platform: platform === "darwin" ? "darwin" : "linux",
+    wsl2: false,
+    accel: "cpu",
+    gpuName: null,
+    vramMb: null,
+    ramAvailableMb: null,
+    diskFreeMb: null,
+    unknown,
+  };
+
+  if (probe.platform === "darwin") {
+    probe.accel = "metal";
+    const out = await run(execFile, "sysctl", ["-n", "hw.memsize"]);
+    const bytes = out ? parseInt(out.trim(), 10) : NaN;
+    if (Number.isFinite(bytes) && bytes > 0) {
+      probe.ramAvailableMb = Math.round(bytes / 1024 / 1024);
+    } else {
+      unknown.push("ram");
+    }
+    // No spec'd way to detect GPU name/VRAM on darwin (unified memory,
+    // metal is deterministic from platform alone) — left null + unknown.
+    unknown.push("gpu");
+  } else {
+    probe.wsl2 = detectWsl2(fs, release);
+
+    if (probe.wsl2) {
+      // v1 rule: force cpu, no GPU passthrough detection attempted. This is
+      // a deliberate policy decision, not a failed detection, so nothing is
+      // pushed to `unknown` for it.
+      probe.accel = "cpu";
+    } else {
+      const vkOut = await run(execFile, "vulkaninfo", []);
+      const vk = parseVulkaninfo(vkOut);
+      if (vk) {
+        probe.accel = "vulkan";
+        probe.gpuName = vk.name;
+        probe.vramMb = vk.vramMb;
+      } else {
+        const nvOut = await run(execFile, "nvidia-smi", [
+          "--query-gpu=name,memory.total",
+          "--format=csv,noheader,nounits",
+        ]);
+        const nv = parseNvidiaSmi(nvOut);
+        if (nv) {
+          probe.accel = "cuda";
+          probe.gpuName = nv.name;
+          probe.vramMb = nv.vramMb;
+        } else {
+          const rcOut = await run(execFile, "rocminfo", []);
+          const rc = parseRocminfo(rcOut);
+          if (rc) {
+            // Probe.accel has no separate "rocm" value; AMD family is
+            // reported as "vulkan" (v1 only ships the Vulkan/Mesa asset).
+            probe.accel = "vulkan";
+            probe.gpuName = rc.name;
+            probe.vramMb = rc.vramMb;
+          } else {
+            probe.accel = "cpu";
+            unknown.push("gpu");
+          }
+        }
+      }
+    }
+
+    const memAvail = await readMemAvailable(fs);
+    if (memAvail != null) {
+      probe.ramAvailableMb = memAvail;
+    } else {
+      unknown.push("ram");
+    }
+  }
+
+  const diskFreeMb = readDiskFreeMb(fs, modelsDir);
+  if (diskFreeMb != null) {
+    probe.diskFreeMb = diskFreeMb;
+  } else {
+    unknown.push("disk");
+  }
+
+  return probe;
+}
+
+// ---------------------------------------------------------------------------
+// fitBadge
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether `quant` fits on the given `probe`.
+ *
+ * Fail-closed: missing RAM info (`probe.ramAvailableMb == null`) NEVER
+ * returns "fits" — it returns "unknown". Swap is never part of `probe`, so
+ * it can never leak in here either.
+ *
+ * effective RAM = probe.ramAvailableMb
+ *   + (probe.vramMb, only when quant.min_vram_mb > 0 AND
+ *      probe.vramMb >= quant.min_vram_mb — i.e. the GPU can actually hold
+ *      the offloaded layers; VRAM below the quant's own floor doesn't count
+ *      at all, and a CPU-capable quant with min_vram_mb: 0 never adds VRAM
+ *      even if a GPU is present, since it wasn't asked to be used).
+ *
+ * Thresholds (exact-integer comparison, no floating-point boundary noise):
+ *   min_ram_mb <= effective                    -> "fits"
+ *   min_ram_mb <= effective * 1.10 (inclusive)  -> "tight"
+ *   otherwise                                   -> "wont_fit"
+ *
+ * @param {Probe|null|undefined} probe
+ * @param {{min_ram_mb?: number, min_vram_mb?: number}} quant
+ * @returns {"fits"|"tight"|"wont_fit"|"unknown"}
+ */
+export function fitBadge(probe, quant) {
+  if (!probe || probe.ramAvailableMb == null) return "unknown";
+  const minRam = quant?.min_ram_mb;
+  if (typeof minRam !== "number" || !Number.isFinite(minRam)) return "unknown";
+
+  const minVram = typeof quant?.min_vram_mb === "number" ? quant.min_vram_mb : 0;
+  let effective = probe.ramAvailableMb;
+  if (minVram > 0 && typeof probe.vramMb === "number" && probe.vramMb >= minVram) {
+    effective += probe.vramMb;
+  }
+
+  if (minRam <= effective) return "fits";
+  if (10 * minRam <= 11 * effective) return "tight"; // minRam / effective <= 1.10, integer-exact
+  return "wont_fit";
+}
+
+// ---------------------------------------------------------------------------
+// Module-level cache
+// ---------------------------------------------------------------------------
+
+let cachedProbe = null;
+
+/** Returns the last probe stored by `reprobe()`, or null if never probed. */
+export function getCachedProbe() {
+  return cachedProbe;
+}
+
+/** Forces a fresh `probeHardware()` call, stores it as the cache, and returns it. */
+export async function reprobe(opts = {}) {
+  const probe = await probeHardware(opts);
+  cachedProbe = probe;
+  return probe;
+}

--- a/tests/model-catalog-validate.test.js
+++ b/tests/model-catalog-validate.test.js
@@ -1,0 +1,143 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { validateCatalog } from "../scripts/validate-model-catalog.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const SEED_PATH = join(REPO_ROOT, "registry/model-catalog.json");
+
+function loadSeed() {
+  return JSON.parse(readFileSync(SEED_PATH, "utf8"));
+}
+
+// Deep clone helper so each test mutates its own copy of the seed.
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function firstModel(catalog, id) {
+  return catalog.models.find((m) => m.id === id);
+}
+
+test("valid seed catalog passes", () => {
+  const catalog = loadSeed();
+  const result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+});
+
+test("duplicate model id fails", () => {
+  const catalog = loadSeed();
+  const dup = clone(firstModel(catalog, "phi-4-mini-instruct"));
+  dup.id = "qwen3-4b"; // collide with the existing first_run_default entry
+  catalog.models.push(dup);
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /duplicate model id/i.test(e)));
+});
+
+test("missing quant sha256 fails on an ungated entry", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "phi-4-mini-instruct");
+  assert.equal(model.gated, false);
+  model.quants[0].sha256 = null;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /sha256/i.test(e)));
+});
+
+test("min_ram_mb below quant size_mb fails (RAM-math floor)", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "phi-4-mini-instruct");
+  model.quants[0].min_ram_mb = Math.floor(model.quants[0].size_mb) - 1;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /min_ram_mb/i.test(e)));
+});
+
+test("min_runtime_version greater than runtime.release fails", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "phi-4-mini-instruct");
+  // runtime.release is "b10068" in the seed.
+  model.min_runtime_version = "b10069";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /min_runtime_version/i.test(e)));
+});
+
+test("zero first_run_default entries fails", () => {
+  const catalog = loadSeed();
+  for (const m of catalog.models) delete m.first_run_default;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /first_run_default/i.test(e)));
+});
+
+test("two first_run_default entries fails", () => {
+  const catalog = loadSeed();
+  firstModel(catalog, "phi-4-mini-instruct").first_run_default = true;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /first_run_default/i.test(e)));
+});
+
+test("first_run_default entry that is gated:true fails", () => {
+  const catalog = loadSeed();
+  const current = firstModel(catalog, "qwen3-4b");
+  delete current.first_run_default;
+  const gated = firstModel(catalog, "gemma-3-27b-it");
+  gated.first_run_default = true;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /first_run_default/i.test(e) && /gated/i.test(e)));
+});
+
+test("first_run_default entry with no min_vram_mb:0 quant fails", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "qwen3-4b");
+  model.quants[0].min_vram_mb = 4096;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /first_run_default/i.test(e) && /min_vram_mb/i.test(e)));
+});
+
+test("unknown runtime asset key fails", () => {
+  const catalog = loadSeed();
+  catalog.runtime.assets["windows-x64"] = { file: "llama-b10068-bin-win-x64.zip", sha256: "a".repeat(64) };
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /unknown runtime asset key/i.test(e) || /windows-x64/i.test(e)));
+});
+
+test("missing min_glibc on a linux asset fails", () => {
+  const catalog = loadSeed();
+  delete catalog.runtime.assets["linux-x64-cpu"].min_glibc;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /min_glibc/i.test(e)));
+});
+
+// --- Orchestrator-decided deviation: null sha256 is valid iff gated:true ---
+
+test("null quant sha256 is valid when the model entry is gated:true", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "gemma-3-27b-it");
+  assert.equal(model.gated, true);
+  model.quants[0].sha256 = null;
+  const result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+});
+
+test("null quant sha256 is rejected when the model entry is gated:false", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "qwen3-14b");
+  assert.equal(model.gated, false);
+  model.quants[0].sha256 = null;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /sha256/i.test(e)));
+});

--- a/tests/models-probe.test.js
+++ b/tests/models-probe.test.js
@@ -1,0 +1,417 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  probeHardware,
+  fitBadge,
+  getCachedProbe,
+  reprobe,
+} from "../servers/gateway/models/probe.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures — provenance noted per block. See task-3-report.md for full detail.
+// ---------------------------------------------------------------------------
+
+// Captured verbatim (structure) from `vulkaninfo` (no args — the default
+// --text mode) run on host crow, an AMD Ryzen AI Max+ 395 (RADV GFX1151,
+// Mesa 25.2.8-0ubuntu0.24.04.1). Byte sizes for the DEVICE_LOCAL heap were
+// swapped from crow's real 83 GiB unified-memory figure (not representative
+// of a discrete card) to 17179869184 bytes = exactly 16 GiB, matching a
+// typical discrete "AMD consumer GPU" (e.g. RX 7800 XT 16GB) fit-badge
+// scenario. GPU1 (llvmpipe software rasterizer, deviceType
+// PHYSICAL_DEVICE_TYPE_CPU) is real output shape too, kept to prove the
+// parser skips CPU-type devices.
+const VULKANINFO_AMD_NO_ROCM = `
+==========
+VULKANINFO
+==========
+
+Vulkan Instance Version: 1.3.275
+
+Devices:
+========
+GPU0:
+	apiVersion         = 1.4.318
+	driverVersion      = 25.2.8
+	vendorID           = 0x1002
+	deviceID           = 0x1586
+	deviceType         = PHYSICAL_DEVICE_TYPE_DISCRETE_GPU
+	deviceName         = AMD Radeon RX 7800 XT (RADV NAVI32)
+	driverID           = DRIVER_ID_MESA_RADV
+	driverName         = radv
+	driverInfo         = Mesa 25.2.8-0ubuntu0.24.04.1
+	conformanceVersion = 1.4.0.0
+
+VkPhysicalDeviceMemoryProperties:
+=================================
+memoryHeaps: count = 2
+	memoryHeaps[0]:
+		size   = 17179869184 (0x400000000) (16.00 GiB)
+		budget = 15461330944 (0x399994000) (14.40 GiB)
+		usage  = 0 (0x00000000) (0.00 B)
+		flags: count = 1
+			MEMORY_HEAP_DEVICE_LOCAL_BIT
+	memoryHeaps[1]:
+		size   = 8589934592 (0x200000000) (8.00 GiB)
+		budget = 8589934592 (0x200000000) (8.00 GiB)
+		usage  = 0 (0x00000000) (0.00 B)
+		flags:
+			None
+memoryTypes: count = 4
+	memoryTypes[0]:
+		heapIndex     = 0
+		propertyFlags = 0x0001: count = 1
+			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+
+GPU1:
+	apiVersion         = 1.4.318
+	driverVersion      = 25.2.8
+	vendorID           = 0x10005
+	deviceID           = 0x0000
+	deviceType         = PHYSICAL_DEVICE_TYPE_CPU
+	deviceName         = llvmpipe (LLVM 20.1.2, 256 bits)
+	driverID           = DRIVER_ID_MESA_LLVMPIPE
+	driverName         = llvmpipe
+	driverInfo         = Mesa 25.2.8-0ubuntu0.24.04.1 (LLVM 20.1.2)
+	conformanceVersion = 1.3.1.1
+
+VkPhysicalDeviceMemoryProperties:
+=================================
+memoryHeaps: count = 1
+	memoryHeaps[0]:
+		size   = 134155722752 (0x1f3c4de000) (124.94 GiB)
+		budget = 134155722752 (0x1f3c4de000) (124.94 GiB)
+		usage  = 133521686528 (0x1f16834000) (124.35 GiB)
+		flags: count = 1
+			MEMORY_HEAP_DEVICE_LOCAL_BIT
+memoryTypes: count = 1
+	memoryTypes[0]:
+		heapIndex     = 0
+		propertyFlags = 0x000f: count = 4
+			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
+`;
+
+// Real /proc/meminfo captured on host crow (field set + line format:
+// `Key:  N kB`), values edited so MemAvailable is modest and SwapFree is
+// deliberately huge — this is the fixture that proves swap is NEVER
+// counted toward available RAM.
+const MEMINFO_HUGE_SWAP = `MemTotal:       131011448 kB
+MemFree:          610000 kB
+MemAvailable:     512000 kB
+Buffers:           18892 kB
+Cached:           559944 kB
+SwapCached:        86216 kB
+Active:         17137232 kB
+Inactive:       22296108 kB
+SwapTotal:      20000000 kB
+SwapFree:       19500000 kB
+Dirty:              1352 kB
+Writeback:              0 kB
+`;
+
+// Same real field shape, but no MemAvailable line at all — proves the
+// "missing RAM info" fail-closed path (probe.ramAvailableMb === null).
+const MEMINFO_NO_MEMAVAILABLE = `MemTotal:       131011448 kB
+MemFree:          610000 kB
+Buffers:           18892 kB
+Cached:           559944 kB
+SwapTotal:      20000000 kB
+SwapFree:       19500000 kB
+`;
+
+// Documented `nvidia-smi --query-gpu=name,memory.total
+// --format=csv,noheader,nounits` output shape (no NVIDIA GPU present on
+// crow to capture directly — this is the well-known scripting invocation
+// format used throughout NVIDIA's own docs and countless tooling).
+const NVIDIA_SMI_CSV = `NVIDIA GeForce RTX 3080, 10240
+`;
+
+// Real rocminfo output captured on host crow (ROCm 7.2.1), trimmed to the
+// CPU agent (Agent 1) + GPU agent (Agent 2, gfx1151) blocks, keeping the
+// real field labels/ordering: Name, Marketing Name, Segment/Size pool
+// lines under "Pool Info".
+const ROCMINFO_AGENT_BLOCK = `ROCk module is loaded
+=====================
+HSA System Attributes
+=====================
+Runtime Version:         1.18
+
+==========
+HSA Agents
+==========
+*******
+Agent 1
+*******
+  Name:                    AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Marketing Name:          AMD RYZEN AI MAX+ 395 w/ Radeon 8060S
+  Vendor Name:             CPU
+  Device Type:             CPU
+  Pool Info:
+    Pool 1
+      Segment:                 GLOBAL; FLAGS: FINE GRAINED
+      Size:                    131011448(0x7cf1378) KB
+      Allocatable:             TRUE
+*******
+Agent 2
+*******
+  Name:                    gfx1151
+  Marketing Name:          AMD Radeon Graphics
+  Vendor Name:             AMD
+  Device Type:             GPU
+  Pool Info:
+    Pool 1
+      Segment:                 GLOBAL; FLAGS: COARSE GRAINED
+      Size:                    130023424(0x7c00000) KB
+      Allocatable:             TRUE
+`;
+
+function fakeFs({ existsFiles = [], readFiles = {}, statfs = null } = {}) {
+  return {
+    existsSync(path) {
+      return existsFiles.includes(path);
+    },
+    readFileSync(path, enc) {
+      if (path in readFiles) return readFiles[path];
+      const err = new Error(`ENOENT: ${path}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+    statfsSync(path) {
+      if (statfs === null) {
+        const err = new Error(`ENOENT: ${path}`);
+        err.code = "ENOENT";
+        throw err;
+      }
+      if (typeof statfs === "function") return statfs(path);
+      return statfs;
+    },
+  };
+}
+
+/**
+ * Fake execFile matching node:child_process's callback signature:
+ * execFile(file, args, options, callback).
+ * `handlers` maps command name -> stdout string (success) or `null` (error).
+ */
+function fakeExecFile(handlers) {
+  return (cmd, args, options, callback) => {
+    const cb = typeof options === "function" ? options : callback;
+    if (!(cmd in handlers) || handlers[cmd] === null) {
+      cb(new Error(`${cmd}: command not found`));
+      return;
+    }
+    cb(null, handlers[cmd], "");
+  };
+}
+
+const ALL_FAIL_EXEC = fakeExecFile({});
+
+// ---------------------------------------------------------------------------
+// probeHardware — accelerator + VRAM detection
+// ---------------------------------------------------------------------------
+
+test("AMD host without ROCm: vulkaninfo succeeds -> accel vulkan, VRAM from DEVICE_LOCAL heap", async () => {
+  const execFile = fakeExecFile({ vulkaninfo: VULKANINFO_AMD_NO_ROCM });
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+
+  assert.equal(probe.platform, "linux");
+  assert.equal(probe.wsl2, false);
+  assert.equal(probe.accel, "vulkan");
+  assert.equal(probe.gpuName, "AMD Radeon RX 7800 XT (RADV NAVI32)");
+  assert.equal(probe.vramMb, 16384); // 17179869184 bytes / 1024 / 1024
+});
+
+test("WSL2 + nvidia-smi present -> accel forced cpu (v1 rule, no CUDA asset for linux)", async () => {
+  const execFile = fakeExecFile({
+    "nvidia-smi": NVIDIA_SMI_CSV,
+    vulkaninfo: VULKANINFO_AMD_NO_ROCM,
+  });
+  const fs = fakeFs({
+    existsFiles: ["/proc/sys/fs/binfmt_misc/WSLInterop"],
+    readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP },
+  });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "5.15.0-microsoft-standard-WSL2" });
+
+  assert.equal(probe.wsl2, true);
+  assert.equal(probe.accel, "cpu");
+  assert.equal(probe.gpuName, null);
+  assert.equal(probe.vramMb, null);
+});
+
+test("WSL2 detected via kernel release string fallback when WSLInterop file absent", async () => {
+  const execFile = ALL_FAIL_EXEC;
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "5.15.0-microsoft-standard-WSL2" });
+
+  assert.equal(probe.wsl2, true);
+  assert.equal(probe.accel, "cpu");
+});
+
+test("nothing detectable at all -> null fields + names pushed to unknown", async () => {
+  const execFile = ALL_FAIL_EXEC;
+  const fs = fakeFs({}); // no WSLInterop, no /proc/meminfo, no statfs
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+
+  assert.equal(probe.wsl2, false);
+  assert.equal(probe.accel, "cpu");
+  assert.equal(probe.gpuName, null);
+  assert.equal(probe.vramMb, null);
+  assert.equal(probe.ramAvailableMb, null);
+  assert.equal(probe.diskFreeMb, null);
+  assert.ok(probe.unknown.includes("gpu"));
+  assert.ok(probe.unknown.includes("ram"));
+  assert.ok(probe.unknown.includes("disk"));
+});
+
+test("swap is never counted toward ramAvailableMb, even when swap is huge", async () => {
+  const execFile = ALL_FAIL_EXEC;
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+
+  // MemAvailable: 512000 kB -> 500 MB. SwapFree: 19500000 kB (~19 GB) must
+  // NOT be added in, even though it dwarfs MemAvailable.
+  assert.equal(probe.ramAvailableMb, 500);
+});
+
+test("missing MemAvailable line -> ramAvailableMb null + pushed to unknown (fail-closed)", async () => {
+  const execFile = ALL_FAIL_EXEC;
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_NO_MEMAVAILABLE } });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+
+  assert.equal(probe.ramAvailableMb, null);
+  assert.ok(probe.unknown.includes("ram"));
+});
+
+test("nvidia-smi path used when vulkaninfo fails -> accel cuda", async () => {
+  const execFile = fakeExecFile({ "nvidia-smi": NVIDIA_SMI_CSV });
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+
+  assert.equal(probe.accel, "cuda");
+  assert.equal(probe.gpuName, "NVIDIA GeForce RTX 3080");
+  assert.equal(probe.vramMb, 10240);
+});
+
+test("rocminfo consulted when vulkaninfo and nvidia-smi both fail -> accel vulkan (AMD family)", async () => {
+  const execFile = fakeExecFile({ rocminfo: ROCMINFO_AGENT_BLOCK });
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+
+  assert.equal(probe.accel, "vulkan");
+  assert.equal(probe.gpuName, "AMD Radeon Graphics");
+  assert.equal(probe.vramMb, 126976); // 130023424 KB / 1024
+});
+
+test("darwin: accel metal, RAM from sysctl hw.memsize", async () => {
+  const execFile = fakeExecFile({ sysctl: "34359738368\n" }); // 32 GiB
+  const fs = fakeFs({});
+  const probe = await probeHardware({ execFile, fs, platform: "darwin", release: "23.0.0" });
+
+  assert.equal(probe.platform, "darwin");
+  assert.equal(probe.accel, "metal");
+  assert.equal(probe.ramAvailableMb, 32768);
+});
+
+test("disk free reported via fs.statfsSync when modelsDir given", async () => {
+  const execFile = ALL_FAIL_EXEC;
+  const fs = fakeFs({
+    readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP },
+    statfs: { bavail: 1000000, bsize: 4096 },
+  });
+  const probe = await probeHardware({ execFile, fs, platform: "linux", release: "6.8.0-generic", modelsDir: "/home/kh0pp/.crow/models" });
+
+  assert.equal(probe.diskFreeMb, Math.round((1000000 * 4096) / (1024 * 1024)));
+  assert.ok(!probe.unknown.includes("disk"));
+});
+
+// ---------------------------------------------------------------------------
+// fitBadge
+// ---------------------------------------------------------------------------
+
+test("fitBadge: available RAM meets min_ram_mb exactly -> fits", () => {
+  const probe = { ramAvailableMb: 8000, vramMb: null };
+  assert.equal(fitBadge(probe, { min_ram_mb: 8000, min_vram_mb: 0 }), "fits");
+});
+
+test("fitBadge: available RAM comfortably above min_ram_mb -> fits", () => {
+  const probe = { ramAvailableMb: 16000, vramMb: null };
+  assert.equal(fitBadge(probe, { min_ram_mb: 8000, min_vram_mb: 0 }), "fits");
+});
+
+test("fitBadge: exactly 10% over -> tight (boundary inclusive)", () => {
+  const probe = { ramAvailableMb: 8000, vramMb: null };
+  // minRam 8800 = effective 8000 * 1.10 exactly.
+  assert.equal(fitBadge(probe, { min_ram_mb: 8800, min_vram_mb: 0 }), "tight");
+});
+
+test("fitBadge: just over the 10% edge -> wont_fit", () => {
+  const probe = { ramAvailableMb: 8000, vramMb: null };
+  assert.equal(fitBadge(probe, { min_ram_mb: 8801, min_vram_mb: 0 }), "wont_fit");
+});
+
+test("fitBadge: far over -> wont_fit", () => {
+  const probe = { ramAvailableMb: 4000, vramMb: null };
+  assert.equal(fitBadge(probe, { min_ram_mb: 16000, min_vram_mb: 0 }), "wont_fit");
+});
+
+test("fitBadge: ramAvailableMb null -> unknown, NEVER fits (fail-closed)", () => {
+  const probe = { ramAvailableMb: null, vramMb: null };
+  assert.equal(fitBadge(probe, { min_ram_mb: 1, min_vram_mb: 0 }), "unknown");
+});
+
+test("fitBadge: probe itself null/undefined -> unknown", () => {
+  assert.equal(fitBadge(null, { min_ram_mb: 1000, min_vram_mb: 0 }), "unknown");
+  assert.equal(fitBadge(undefined, { min_ram_mb: 1000, min_vram_mb: 0 }), "unknown");
+});
+
+test("fitBadge: sufficient VRAM counts toward the fit when min_vram_mb > 0", () => {
+  // RAM alone falls short, but detected VRAM covers min_vram_mb and pushes
+  // the effective total over min_ram_mb.
+  const probe = { ramAvailableMb: 6000, vramMb: 12000 };
+  const quant = { min_ram_mb: 16000, min_vram_mb: 8000 };
+  // effective = 6000 + 12000 = 18000 >= 16000 -> fits
+  assert.equal(fitBadge(probe, quant), "fits");
+});
+
+test("fitBadge: VRAM below min_vram_mb does NOT count toward the fit", () => {
+  const probe = { ramAvailableMb: 6000, vramMb: 4000 }; // vramMb < min_vram_mb
+  const quant = { min_ram_mb: 16000, min_vram_mb: 8000 };
+  // effective stays 6000 (vram excluded) -> far short -> wont_fit
+  assert.equal(fitBadge(probe, quant), "wont_fit");
+});
+
+test("fitBadge: min_vram_mb 0 (CPU-capable quant) never adds VRAM even if present", () => {
+  const probe = { ramAvailableMb: 8000, vramMb: 24000 };
+  const quant = { min_ram_mb: 8000, min_vram_mb: 0 };
+  assert.equal(fitBadge(probe, quant), "fits"); // RAM alone already fits
+});
+
+// ---------------------------------------------------------------------------
+// module-level cache: getCachedProbe / reprobe
+// ---------------------------------------------------------------------------
+
+test("getCachedProbe returns null before any reprobe in a fresh module state, then reprobe populates it", async () => {
+  // This test must run before any other test in this file calls reprobe();
+  // it is registered first among the cache tests and node:test executes a
+  // single file's top-level tests in declaration order by default.
+  assert.equal(getCachedProbe(), null);
+
+  const execFile = fakeExecFile({ vulkaninfo: VULKANINFO_AMD_NO_ROCM });
+  const fs = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+
+  const fresh = await reprobe({ execFile, fs, platform: "linux", release: "6.8.0-generic" });
+  assert.equal(fresh.accel, "vulkan");
+  assert.strictEqual(getCachedProbe(), fresh);
+});
+
+test("reprobe forces a fresh probe even when hardware inputs changed", async () => {
+  const fsA = fakeFs({ readFiles: { "/proc/meminfo": MEMINFO_HUGE_SWAP } });
+  await reprobe({ execFile: ALL_FAIL_EXEC, fs: fsA, platform: "linux", release: "6.8.0-generic" });
+  assert.equal(getCachedProbe().accel, "cpu");
+
+  const execFile2 = fakeExecFile({ vulkaninfo: VULKANINFO_AMD_NO_ROCM });
+  const fresh2 = await reprobe({ execFile: execFile2, fs: fsA, platform: "linux", release: "6.8.0-generic" });
+  assert.equal(fresh2.accel, "vulkan");
+  assert.strictEqual(getCachedProbe(), fresh2);
+});


### PR DESCRIPTION
First of five Item G PRs (spec: Gitea `crow-engineering` `specs/2026-07-18-item-g-model-catalog-design.md`, SIGNED OFF r3 after a 2-round adversarial review; plan: `plans/2026-07-18-item-g-implementation.md`). **No behavior change to running systems** — this PR is pure foundations: data, a validator, and an unwired module.

**What's in it:**
- `registry/model-catalog.json` — curated 7-model seed (Qwen/Phi/Llama/Ministral/DeepSeek/Gemma, small/mid/large classes) + llama.cpp runtime block pinned to release b10068 (4 assets: linux-x64 vulkan/cpu, darwin arm64/x64; per-asset sha256 + min_glibc). **Every hash fetched live and independently re-verified in review** (one runtime asset was re-downloaded and re-hashed; HF LFS oids spot-checked). Exactly one `first_run_default` (Qwen3-4B, CPU-capable, apache-2.0) for C1's wizard; one `gated:true` entry (Google's official Gemma-3-27B QAT GGUF) to exercise the gated flow.
- `scripts/dev/hf-catalog-entry.mjs` — dev helper that builds catalog entries from the HF API with real sizes/shas and the documented KV-cache RAM formula.
- `scripts/validate-model-catalog.js` + 13 tests — schema, unique ids, sha rules (null only on gated), RAM-math floor, numeric `b<build>` version comparison (mutation-verified non-lexical), exactly-one-first_run_default, asset-key allowlist, min_glibc. Wired as a step inside the existing `static-checks` job (no job renames).
- `servers/gateway/models/probe.js` + 22 tests — NEW hardware detection (vulkan heaps, WSL2, MemAvailable-only RAM, statfs disk) with **fail-closed fit badges** (unknown data never reads "fits"; swap never counts; WSL2 forces CPU). Fully dependency-injected; fixtures from real captured output. Mutation-tested in review on the two safety-critical behaviors; live-verified on this host (RADV GFX1151, 83 GiB heap detected). Deliberate deviation from the plan: plain `vulkaninfo` instead of `--summary` — the summary mode omits `memoryHeaps` entirely (verified empirically; documented in the module).

**Suite:** 2116/2116 pass, 0 fail, 0 skip (baseline 2081 + 35 new).

Each task was implemented by a fresh implementer and gated by an independent reviewer (spec + quality verdicts, adversarial mutations); review records in the session ledger.