### PR TITLE
feat(models): Item G PR G-B — native llama.cpp runtime core (downloads, provider registration, orchestrator native branch, chat path)

### DIFF
--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -357,6 +357,10 @@ export const translations = {
   "messages.acceptRequest": { en: "Accept", es: "Aceptar" },
   "messages.declineRequest": { en: "Decline", es: "Rechazar" },
 
+  // ─── Chat — native model runtime (Item G, Task 10) ───
+  "chat.native_model_loading": { en: "Loading local model \"{provider}\" — this can take a few minutes for larger models.", es: "Cargando el modelo local \"{provider}\" — esto puede tardar varios minutos en modelos más grandes." },
+  "chat.native_model_load_failed": { en: "The local model \"{provider}\" didn't load in time. Check the gateway logs for details.", es: "El modelo local \"{provider}\" no cargó a tiempo. Consulta los registros del gateway para más detalles." },
+
   // ─── Peer invite share (Messages Phase 2 PR1) ───
   "invite.shareLabel": { en: "Share this link", es: "Comparte este enlace" },
   "invite.shareHint": {

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -76,7 +76,7 @@ import {
 import { resolveDataDir } from "../db.js";
 import { loadState } from "./models/state.js";
 import { acquireHostLock } from "./models/native-lock.js";
-import { identityProbe, startModel, stopModel, ensureRuntime } from "./models/runtime.js";
+import { identityProbe, startModel, stopModel, ensureRuntime, nativeReadinessTimeoutMs } from "./models/runtime.js";
 import { getCachedProbe } from "./models/probe.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -409,6 +409,18 @@ export async function maybeAcquireLocalProvider(providerName, opts = {}) {
 }
 
 /**
+ * Is `providerName` a native (llama.cpp/gateway-supervised) runtime — as
+ * opposed to a Docker-bundle provider or a cloud/peer provider? PURE,
+ * no I/O. Callers (chat.js) use this ONLY to pick user-facing copy for a
+ * `maybeAcquireLocalProvider` failure — never to gate whether to acquire at
+ * all (that decision belongs to `acquireProvider`/`maybeAcquireLocalProvider`
+ * themselves). Unknown provider name -> false (never throws).
+ */
+export function isNativeRuntimeProvider(providerName, cfg = loadProviders()) {
+  return isNativeRuntime(getProvider(providerName, cfg));
+}
+
+/**
  * Map a provider NAME to the bundle-backed provider that should be warmed for it.
  * PURE (takes the loaded providers cfg). Some providers are bundle-less raw-endpoint
  * aliases that share a baseUrl with a bundled provider — e.g. pi resolves to
@@ -531,6 +543,19 @@ async function waitForNativeReady(baseUrl, alias, {
  * and isn't queued behind `_swapInFlight`, so there's nothing to protect
  * it from). `opts.onTerminal`, if given, is forwarded verbatim to
  * `startModelFn` — see `runtime.js`'s `startModel` doc.
+ *
+ * Readiness timeout (Item G, Task 10): `opts.readinessTimeoutMs`, if given,
+ * wins outright (tests use this to keep the timeout window short). Absent
+ * that, the timeout is SCALED to the model's actual size via
+ * `runtime.js`'s `nativeReadinessTimeoutMs(regEntry.sizeMb, opts.storageClass)`
+ * — a multi-GB quant honestly gets longer to become ready than the old flat
+ * `READINESS_TIMEOUT_MS` gave every native model regardless of size. An
+ * older registry entry with no recorded `sizeMb` (registered before this
+ * field existed) degrades to that function's `120_000`ms floor, not a
+ * crash. `opts.storageClass` defaults to `"ssd"` — see `runtime.js`'s doc
+ * for why this is an honest injectable override, not real detection.
+ * `opts.nativeReadinessTimeoutMsFn` overrides the formula function itself
+ * (test seam only).
  */
 async function startNativeAndAwaitReady(providerName, p, opts = {}) {
   const {
@@ -542,9 +567,11 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
     spawnFn,
     onTerminal,
     binPath: preResolvedBinPath,
-    readinessTimeoutMs = READINESS_TIMEOUT_MS,
+    readinessTimeoutMs: readinessTimeoutMsOverride,
     readinessPollMs = READINESS_POLL_MS,
     readinessInitialDelayMs = READINESS_INITIAL_DELAY_MS,
+    storageClass = "ssd",
+    nativeReadinessTimeoutMsFn = nativeReadinessTimeoutMs,
   } = opts;
 
   const alias = nativeAlias(p);
@@ -560,9 +587,13 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
   }
   const ggufPath = join(dir, "models", "blobs", regEntry.file);
 
+  const readinessTimeoutMs = readinessTimeoutMsOverride != null
+    ? readinessTimeoutMsOverride
+    : nativeReadinessTimeoutMsFn(regEntry.sizeMb, storageClass);
+
   const binPath = preResolvedBinPath || await resolveNativeBinPath(p, opts);
 
-  console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port})`);
+  console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port}, readinessTimeoutMs=${readinessTimeoutMs})`);
   const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal });
   _nativeHandles.set(providerName, handle);
 

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -39,7 +39,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname, resolve } from "node:path";
 import { loadProviders as loadCachedProviders } from "../shared/providers.js";
@@ -48,9 +48,23 @@ import {
   setResidencyInitialized, recordResidency, releaseResidency,
   pruneResidency, getProviderHealth,
 } from "./provider-health.js";
+import { resolveDataDir } from "../db.js";
+import { loadState } from "./models/state.js";
+import { acquireHostLock } from "./models/native-lock.js";
+import { identityProbe, startModel, stopModel, ensureRuntime } from "./models/runtime.js";
+import { getCachedProbe } from "./models/probe.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const BUNDLES_DIR = resolve(dirname(__filename), "..", "..", "bundles");
+const MODEL_CATALOG_PATH = resolve(dirname(__filename), "..", "..", "registry", "model-catalog.json");
+
+/** Default `loadCatalogFn` for the native start path — reads the curated
+ * catalog's `runtime` block (llama.cpp version pin + per-platform assets)
+ * that `ensureRuntime` needs. Injectable so tests never touch the real
+ * repo-tracked catalog file. */
+function defaultLoadCatalog() {
+  return JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+}
 
 function loadProviders() {
   return loadCachedProviders();
@@ -66,6 +80,38 @@ const READINESS_POLL_MS = 2_000;
 const READINESS_INITIAL_DELAY_MS = 1_000;
 const PROBE_TIMEOUT_MS = 2_000;
 
+// -----------------------------------------------------------------------
+// Native runtime — typed errors (Item G, Task 9)
+// -----------------------------------------------------------------------
+
+/** Thrown when a native provider's port is answering, but NOT as the model
+ * we expect (`identityProbe` returned "conflict") — either on the fast
+ * path (already-something-else resident) or after a fresh start that bound
+ * a port already claimed by an unrelated process. NEVER treated as
+ * resident, NEVER routed traffic — see `identityProbe`'s doc for why. */
+export class NativePortConflictError extends Error {
+  constructor(providerName, baseUrl) {
+    super(`native provider "${providerName}" (${baseUrl}) is serving a different model than expected — refusing to route traffic`);
+    this.name = "NativePortConflictError";
+    this.code = "NATIVE_PORT_CONFLICT";
+    this.providerName = providerName;
+    this.baseUrl = baseUrl;
+  }
+}
+
+/** Thrown when `acquireHostLock` returns null for a native provider's mutex
+ * group — some other Crow instance (a different gateway process on this
+ * same host) currently holds the GPU/RAM for that group. Honest, typed —
+ * never silently swallowed into a generic false/null. */
+export class NativeHostLockHeldError extends Error {
+  constructor(mutexGroup) {
+    super(`another Crow instance on this host is using the GPU/RAM (native runtime lock held for "${mutexGroup}")`);
+    this.name = "NativeHostLockHeldError";
+    this.code = "NATIVE_HOST_LOCK_HELD";
+    this.mutexGroup = mutexGroup;
+  }
+}
+
 const IDLE_REVERT_MS = Number(process.env.GPU_IDLE_REVERT_MS ?? 20 * 60 * 1000);
 const IDLE_CHECK_INTERVAL_MS = Number(process.env.GPU_IDLE_CHECK_INTERVAL_MS ?? 2 * 60 * 1000);
 const RESIDENCY_POLL_MS = Number(process.env.CROW_PROVIDER_RESIDENCY_POLL_MS ?? 120_000);
@@ -77,6 +123,21 @@ let _residencyTimer = null;
 let _residencyInFlight = false;
 let _residencyPollFailing = false; // edge-trigger for the poll's failure warn
 const _lastUsedAt = new Map(); // providerName -> epoch ms of last acquireProvider success
+
+// Live `startModel()` handles for native-runtime providers this process has
+// started, keyed by provider name. Purely in-memory — reset on gateway
+// restart, which is exactly the "simulated restart" case the re-warm path
+// (identityProbe against the OS-level port, not this map) must still handle
+// correctly: a missing entry here means "we don't have a handle", NOT
+// "nothing is listening on that port".
+const _nativeHandles = new Map();
+
+/** Test seam — seed/clear a fake native handle without going through a real
+ * `startModel()` spawn. Mirrors `_setDeferredResidentsForTest`. */
+export function _setNativeHandleForTest(name, handle) {
+  if (handle === null || handle === undefined) _nativeHandles.delete(name);
+  else _nativeHandles.set(name, handle);
+}
 
 // -----------------------------------------------------------------------
 // Bundle control
@@ -169,8 +230,7 @@ async function waitForReady(baseUrl, { totalTimeoutMs = READINESS_TIMEOUT_MS } =
 // Provider/mutex resolution
 // -----------------------------------------------------------------------
 
-function getProvider(name) {
-  const cfg = loadProviders();
+function getProvider(name, cfg = loadProviders()) {
   return cfg.providers?.[name] || null;
 }
 
@@ -179,11 +239,35 @@ function mutexGroupOf(provider) {
   return provider.gpuPolicy?.mutexGroup ?? provider.mutexGroup ?? provider.models?.[0]?.mutexGroup ?? null;
 }
 
-function getMutexSiblings(name) {
-  const p = getProvider(name);
+/** A provider is native iff its gpu_policy JSON declares `runtime: "native"`
+ * (see `manager.js`'s `registerModel` — the ONLY writer of this field). */
+function isNativeRuntime(provider) {
+  return provider?.gpuPolicy?.runtime === "native";
+}
+
+/** The llama-server `--alias` this provider serves — its own `models[0].id`,
+ * per `registerModel`'s row shape (verbatim from the task brief). */
+function nativeAlias(provider) {
+  return provider?.models?.[0]?.id ?? null;
+}
+
+/** Parse the port out of a native provider's `baseUrl`
+ * (`http://127.0.0.1:<port>/v1`). Never re-derived/re-allocated elsewhere —
+ * a re-warm after restart MUST bind the exact port the DB row already
+ * advertises, not a fresh one from the port pool. */
+function portFromBaseUrl(baseUrl) {
+  try {
+    const port = Number(new URL(baseUrl).port);
+    return Number.isFinite(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+function getMutexSiblings(name, cfg = loadProviders()) {
+  const p = getProvider(name, cfg);
   const group = mutexGroupOf(p);
   if (!group) return [];
-  const cfg = loadProviders();
   return Object.entries(cfg.providers || {})
     .filter(([n, v]) => n !== name && mutexGroupOf(v) === group)
     .map(([n]) => n);
@@ -257,16 +341,20 @@ export async function isProviderReady(providerName) {
  *   - `false`  if readiness timed out.
  *
  * Never throws — caller should fall through to the adapter on error.
+ *
+ * `opts.cfg` overrides the provider config this resolves `providerName`
+ * from (tests only; forwarded to `acquireProvider` too — see its doc).
  */
-export async function maybeAcquireLocalProvider(providerName) {
+export async function maybeAcquireLocalProvider(providerName, opts = {}) {
   if (!providerName) return null;
-  const p = getProvider(providerName);
-  if (!p?.bundleId) return null;
+  const cfg = opts.cfg || loadProviders();
+  const p = getProvider(providerName, cfg);
+  if (!p?.bundleId && !isNativeRuntime(p)) return null;
   // host unset defaults to local (matches resolveFromModelsJson).
   if (p.host && p.host !== "local") return null;
   if (!isLocallyOrchestratable(p)) return null; // F-INSTALL-10: not this machine's bundle
   try {
-    return await acquireProvider(providerName);
+    return await acquireProvider(providerName, opts);
   } catch (err) {
     console.warn(`[gpu-orchestrator] maybeAcquireLocalProvider(${providerName}) failed: ${err.message}`);
     return false;
@@ -286,7 +374,7 @@ export function resolveWarmableProviderName(cfg, name, ownAddrs = getOwnAddresse
   const provs = (cfg && cfg.providers) || {};
   const direct = provs[name];
   if (!direct) return null;
-  if (direct.bundleId) {
+  if (direct.bundleId || isNativeRuntime(direct)) {
     if (!isLocallyOrchestratable(direct, ownAddrs)) return null; // F-INSTALL-10
     return name;
   }
@@ -317,6 +405,174 @@ export async function warmProviderByName(name) {
 // Test/introspection helpers — exported for smoke scripts.
 export const _internals = { getProvider, getMutexSiblings, getMutexGroups, mutexGroupOf };
 
+// -----------------------------------------------------------------------
+// Native runtime — acquire path (Item G, Task 9)
+// -----------------------------------------------------------------------
+
+/** Poll `identityProbe` until it reports "resident" or "conflict", or the
+ * timeout elapses (-> "down"). Mirrors `waitForReady`'s shape for the
+ * Docker path, but native readiness is identity-based (is THIS the model
+ * we asked for), not just a bare 200. */
+async function waitForNativeReady(baseUrl, alias, {
+  totalTimeoutMs, pollMs, initialDelayMs, identityProbeFn, fetchImpl,
+}) {
+  await new Promise((r) => setTimeout(r, initialDelayMs));
+  const deadline = Date.now() + totalTimeoutMs;
+  while (Date.now() < deadline) {
+    const status = await identityProbeFn(baseUrl, alias, fetchImpl);
+    if (status === "resident" || status === "conflict") return status;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return "down";
+}
+
+/**
+ * Start a native provider's llama-server process and wait for it to report
+ * itself resident. No locking, no sibling swap — those are the acquire
+ * path's job (`acquireNativeSwap`) and `ensureResident`'s native branch
+ * deliberately skips them too, mirroring the Docker `ensureResident`'s
+ * parity (alwaysResident providers don't swap siblings at boot).
+ *
+ * Binds the EXACT port already encoded in `p.baseUrl` — NEVER re-allocates
+ * a fresh one from the port pool. A bind failure (the process never
+ * reports resident within the timeout) is an honest thrown error, never a
+ * silent fallback to a different port.
+ */
+async function startNativeAndAwaitReady(providerName, p, opts = {}) {
+  const {
+    identityProbeFn = identityProbe,
+    startModelFn = startModel,
+    ensureRuntimeFn = ensureRuntime,
+    loadStateFn = loadState,
+    resolveDataDirFn = resolveDataDir,
+    loadCatalogFn = defaultLoadCatalog,
+    getCachedProbeFn = getCachedProbe,
+    fetchImpl,
+    spawnFn,
+    readinessTimeoutMs = READINESS_TIMEOUT_MS,
+    readinessPollMs = READINESS_POLL_MS,
+    readinessInitialDelayMs = READINESS_INITIAL_DELAY_MS,
+  } = opts;
+
+  const alias = nativeAlias(p);
+  if (!alias) throw new Error(`orchestrator: native provider "${providerName}" has no model alias (models[0].id)`);
+  const port = portFromBaseUrl(p.baseUrl);
+  if (!port) throw new Error(`orchestrator: native provider "${providerName}" has an unparseable baseUrl port (${p.baseUrl})`);
+
+  const dir = resolveDataDirFn();
+  const state = loadStateFn(dir);
+  const regEntry = state.registry?.[providerName];
+  if (!regEntry?.file) {
+    throw new Error(`orchestrator: no model registry entry for native provider "${providerName}" — was it registered?`);
+  }
+  const ggufPath = join(dir, "models", "blobs", regEntry.file);
+
+  const catalog = loadCatalogFn();
+  const probe = getCachedProbeFn();
+  const binPath = await ensureRuntimeFn(dir, catalog.runtime, probe);
+
+  console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port})`);
+  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn });
+  _nativeHandles.set(providerName, handle);
+
+  const result = await waitForNativeReady(p.baseUrl, alias, {
+    totalTimeoutMs: readinessTimeoutMs,
+    pollMs: readinessPollMs,
+    initialDelayMs: readinessInitialDelayMs,
+    identityProbeFn,
+    fetchImpl,
+  });
+
+  if (result === "resident") {
+    console.log(`[gpu-orchestrator] ${providerName} ready`);
+    _lastUsedAt.set(providerName, Date.now());
+    return true;
+  }
+  if (result === "conflict") {
+    throw new NativePortConflictError(providerName, p.baseUrl);
+  }
+  // "down" — the process never reported itself resident within the
+  // timeout. Never silently rebind on a different port; surface it.
+  throw new Error(`orchestrator: native provider "${providerName}" failed to bind port ${port} within ${readinessTimeoutMs}ms — refusing to rebind on a different port`);
+}
+
+/**
+ * Native branch of `acquireProvider`'s swap transaction (runs inside the
+ * same `_swapInFlight` single-flight as the Docker branch). Order:
+ *   1. `identityProbe` fast path — resident -> done; conflict -> typed
+ *      error, no lock ever taken, no traffic routed.
+ *   2. `acquireHostLock(mutexGroup)` — null -> typed "another Crow
+ *      instance..." error.
+ *   3. Sibling swap: Docker sibling via `bundleStop`, native sibling via
+ *      its handle's `stop()` — mirrors the Docker branch's sibling loop.
+ *   4. `startNativeAndAwaitReady`.
+ * The lock is released in `finally` once this swap transaction settles —
+ * it protects the START critical section against a second gateway process
+ * on this host racing to start a sibling; ongoing residency truth is
+ * `identityProbe`/the OS-level bind test, not this lock (see
+ * `native-lock.js`'s module doc).
+ */
+async function acquireNativeSwap(providerName, p, cfg, opts = {}) {
+  const {
+    acquireHostLockFn = acquireHostLock,
+    identityProbeFn = identityProbe,
+    stopModelFn = stopModel,
+    bundleStopFn = bundleStop,
+    probeReadyFn = probeReady,
+    fetchImpl,
+  } = opts;
+
+  const alias = nativeAlias(p);
+  if (alias) {
+    const fastStatus = await identityProbeFn(p.baseUrl, alias, fetchImpl);
+    if (fastStatus === "resident") {
+      _lastUsedAt.set(providerName, Date.now());
+      return true;
+    }
+    if (fastStatus === "conflict") {
+      throw new NativePortConflictError(providerName, p.baseUrl);
+    }
+    // "down" — fall through to lock + start.
+  }
+
+  const mutexGroup = mutexGroupOf(p) || providerName;
+  const release = acquireHostLockFn(mutexGroup);
+  if (!release) {
+    throw new NativeHostLockHeldError(mutexGroup);
+  }
+
+  try {
+    const siblings = getMutexSiblings(providerName, cfg);
+    for (const sibName of siblings) {
+      const sib = getProvider(sibName, cfg);
+      if (!sib || !isLocallyOrchestratable(sib)) continue;
+      if (isNativeRuntime(sib)) {
+        const sibHandle = _nativeHandles.get(sibName);
+        if (sibHandle && sibHandle.live) {
+          console.log(`[gpu-orchestrator] swapping out native ${sibName} for ${providerName}`);
+          await stopModelFn(sibHandle).catch((err) =>
+            console.warn(`[gpu-orchestrator] stop native ${sibName} failed: ${err.message}`)
+          );
+          _nativeHandles.delete(sibName);
+        }
+        _lastUsedAt.delete(sibName);
+      } else if (sib.bundleId) {
+        if (await probeReadyFn(sib.baseUrl)) {
+          console.log(`[gpu-orchestrator] swapping out ${sibName} (bundleId=${sib.bundleId}) for ${providerName}`);
+          await bundleStopFn(sib.bundleId).catch((err) =>
+            console.warn(`[gpu-orchestrator] stop ${sib.bundleId} failed: ${err.message}`)
+          );
+          _lastUsedAt.delete(sibName);
+        }
+      }
+    }
+
+    return await startNativeAndAwaitReady(providerName, p, opts);
+  } finally {
+    release();
+  }
+}
+
 /**
  * Ensure `providerName` is resident and responsive. Stops mutex siblings
  * first (if any). Waits up to READINESS_TIMEOUT_MS for warmup.
@@ -325,10 +581,29 @@ export const _internals = { getProvider, getMutexSiblings, getMutexGroups, mutex
  * for the same or different providers queue cleanly.
  *
  * Returns true on success, false on timeout. Throws on docker errors.
+ *
+ * `opts` (native-only; ignored by the Docker branch) forwards injectable
+ * seams to the native start path — see `startNativeAndAwaitReady`'s doc.
+ * `opts.cfg` overrides the provider config the native branch resolves the
+ * target/siblings from (tests only — production always omits it, so
+ * `getProvider`/`getMutexSiblings` fall back to the real `loadProviders()`).
+ * No existing caller passes `opts`, so Docker-path behavior is unaffected.
  */
-export async function acquireProvider(providerName) {
-  const p = getProvider(providerName);
+export async function acquireProvider(providerName, opts = {}) {
+  const cfg = opts.cfg || loadProviders();
+  const p = getProvider(providerName, cfg);
   if (!p) throw new Error(`orchestrator: unknown provider "${providerName}"`);
+
+  if (isNativeRuntime(p)) {
+    if (!isLocallyOrchestratable(p)) {
+      console.warn(`[gpu-orchestrator] refusing to orchestrate ${providerName} — its baseUrl is not on this machine`);
+      return null;
+    }
+    const nativeSwap = _swapInFlight.then(() => acquireNativeSwap(providerName, p, cfg, opts));
+    _swapInFlight = nativeSwap.catch(() => {});
+    return nativeSwap;
+  }
+
   if (!p.bundleId) throw new Error(`orchestrator: provider "${providerName}" has no bundleId`);
   if (!isLocallyOrchestratable(p)) {
     console.warn(`[gpu-orchestrator] refusing to orchestrate ${providerName} — its baseUrl is not on this machine`);
@@ -455,12 +730,39 @@ export function _setDeferredResidentsForTest(names) {
   _deferredResidents = new Set(names);
 }
 
+/** Native branch of `ensureResident`: "resident" = process alive (we hold a
+ * live handle) AND `identityProbe` confirms it's actually serving our
+ * alias (per the task brief's exact definition) — a live process alone
+ * isn't enough, matching `identityProbe`'s "never trust a port without
+ * confirming what it's serving" stance. Not resident -> start it (no
+ * lock/sibling-swap, mirroring the Docker branch's boot-time parity). */
+async function ensureNativeResident(name, p, opts = {}) {
+  const { identityProbeFn = identityProbe, fetchImpl } = opts;
+  const handle = _nativeHandles.get(name);
+  const alias = nativeAlias(p);
+  if (handle && handle.live && alias) {
+    const status = await identityProbeFn(p.baseUrl, alias, fetchImpl);
+    if (status === "resident") {
+      console.log(`[gpu-orchestrator] ${name} already resident`);
+      return false;
+    }
+  }
+  await startNativeAndAwaitReady(name, p, opts);
+  return providerHasEmbedModel(p);
+}
+
 /** Ensure ONE alwaysResident provider: probe → bundleUp → waitForReady.
  *  Returns true iff it warmed an embed-capable provider (caller may
- *  trigger the embedding backfill). Never throws. */
-async function ensureResident(name, cfg = loadProviders()) {
+ *  trigger the embedding backfill). Never throws.
+ *
+ *  `opts` (native-only) forwards injectable seams to
+ *  `ensureNativeResident` — see its doc; ignored by the Docker branch. */
+export async function ensureResident(name, cfg = loadProviders(), opts = {}) {
   try {
     const p = (cfg.providers || {})[name];
+    if (p && isNativeRuntime(p)) {
+      return await ensureNativeResident(name, p, opts);
+    }
     if (!p?.bundleId) {
       console.warn(`[gpu-orchestrator] ${name} has no bundleId — skipping`);
       return false;
@@ -544,10 +846,15 @@ export async function pollResidency(opts = {}) {
 
       // SSRF / path-traversal gate: only providers this machine can actually
       // orchestrate (a safe bundleId whose compose file exists) are probed.
-      if (!p.bundleId || !isSafeBundleId(p.bundleId)) { releaseResidency(name); continue; }
-      let exists = false;
-      try { exists = composeExists(p.bundleId); } catch { exists = false; }
-      if (!exists) { releaseResidency(name); continue; }
+      // Per-runtime: native providers have no bundleId/compose file at all
+      // (their control plane is startModel/stopModel, not docker compose)
+      // and must NEVER be releaseResidency()'d for lacking one.
+      if (!isNativeRuntime(p)) {
+        if (!p.bundleId || !isSafeBundleId(p.bundleId)) { releaseResidency(name); continue; }
+        let exists = false;
+        try { exists = composeExists(p.bundleId); } catch { exists = false; }
+        if (!exists) { releaseResidency(name); continue; }
+      }
 
       let prev = health.providers[name];
       // Operator repointed the provider — release and re-evaluate ownership

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -73,11 +73,13 @@ import {
   setResidencyInitialized, recordResidency, releaseResidency,
   pruneResidency, getProviderHealth,
 } from "./provider-health.js";
-import { resolveDataDir } from "../db.js";
-import { loadState } from "./models/state.js";
+import { resolveDataDir, createDbClient } from "../db.js";
+import { loadState, saveState, reconcileOnBoot } from "./models/state.js";
 import { acquireHostLock } from "./models/native-lock.js";
 import { identityProbe, startModel, stopModel, ensureRuntime, nativeReadinessTimeoutMs } from "./models/runtime.js";
-import { getCachedProbe } from "./models/probe.js";
+import { getCachedProbe, reprobe } from "./models/probe.js";
+import { enqueueDownload } from "./models/manager.js";
+import { listProvidersAll } from "../shared/providers-db.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const BUNDLES_DIR = resolve(dirname(__filename), "..", "..", "bundles");
@@ -498,10 +500,20 @@ async function resolveNativeBinPath(p, opts = {}) {
     resolveDataDirFn = resolveDataDir,
     loadCatalogFn = defaultLoadCatalog,
     getCachedProbeFn = getCachedProbe,
+    reprobeFn = reprobe,
   } = opts;
   const dir = resolveDataDirFn();
   const catalog = loadCatalogFn();
-  const probe = getCachedProbeFn();
+  // Fix 1 (final-review fix wave, CRITICAL): the cache is null until
+  // reprobe() runs, and nothing on the production boot path ever calls it
+  // — every native acquire threw UNSUPPORTED_PLATFORM(null) forever. Warm
+  // it here, once, on a cache miss; reprobe() also populates probe.js's own
+  // module cache, so subsequent calls' getCachedProbeFn() sees it warm and
+  // never re-probes.
+  let probe = getCachedProbeFn();
+  if (!probe) {
+    probe = await reprobeFn();
+  }
   const key = (catalog && catalog.runtime && catalog.runtime.release) || "default";
   if (_runtimeEnsureInFlight.has(key)) return _runtimeEnsureInFlight.get(key);
   const inFlight = Promise.resolve()
@@ -610,6 +622,26 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
     _lastUsedAt.set(providerName, Date.now());
     return true;
   }
+
+  // Fix 5 (final-review fix wave, IMPORTANT): a FRESH start that ends in
+  // "down" (readiness timeout) or "conflict" (bound the port but isn't
+  // serving OUR alias) must not leave the process it just spawned running,
+  // untracked, behind an about-to-be-released lock. Without this,
+  // `acquireOrStartNative`'s `finally` still releases the mutex-group lock
+  // (this throw means `success` never became `true`), while the loading/
+  // misbehaving process kept running with its `_nativeHandles` entry still
+  // intact — free lock, live orphan process, exactly the hazard this fix
+  // closes. `handle.stop()` fires the handle's own `onTerminal("stopped")`,
+  // which (per `acquireOrStartNative`) is ALSO wired to release this same
+  // lock — but `release()` is idempotent (see `native-lock.js`), so that
+  // and the `finally`'s own release below never double-free anything.
+  try {
+    await handle.stop();
+  } catch (err) {
+    console.warn(`[gpu-orchestrator] stop native ${providerName} after readiness failure failed: ${err.message}`);
+  }
+  if (_nativeHandles.get(providerName) === handle) _nativeHandles.delete(providerName);
+
   if (result === "conflict") {
     throw new NativePortConflictError(providerName, p.baseUrl);
   }
@@ -679,6 +711,14 @@ async function acquireOrStartNative(providerName, p, cfg, opts = {}) {
     const fastStatus = await identityProbeFn(p.baseUrl, alias, fetchImpl);
     if (fastStatus === "resident") {
       _lastUsedAt.set(providerName, Date.now());
+      // Fix 2 (final-review fix wave, CRITICAL): handle.touch() resets
+      // runtime.js's idle-stop timer — until this call it had ZERO
+      // callers, so a resident native model under continuous active load
+      // still got killed by its own idle timer (default 30 min) the
+      // instant that timer's initial window elapsed, since nothing ever
+      // reset it. This IS the traffic signal that should keep it warm.
+      const liveHandle = _nativeHandles.get(providerName);
+      if (liveHandle?.live) liveHandle.touch();
       return { freshStart: false };
     }
     if (fastStatus === "conflict") {
@@ -1152,6 +1192,126 @@ export function _stopResidencyMonitor() {
   _residencyPollFailing = false;
 }
 
+/** True if a process with this pid appears to be alive on this host — same
+ * rule as `native-lock.js`'s (unexported) `defaultIsProcessAlive`: a
+ * `kill(pid, 0)` that succeeds, or fails EPERM (exists, owned by someone
+ * else), both count as "alive"; only ESRCH means it's genuinely gone.
+ * Duplicated locally (4 lines) rather than importing a private helper from
+ * `native-lock.js` — this module's only real coupling to that file stays
+ * the one function (`acquireHostLock`) the acquire path already needs. */
+function defaultIsProcessAlive(pid) {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === "EPERM";
+  }
+}
+
+/**
+ * Boot-time native-model reconciliation (final-review fix wave, Fix 3 —
+ * IMPORTANT). `state.js`'s `reconcileOnBoot` is a pure function that was
+ * never actually invoked from any production boot path — a killed gateway
+ * left stale port reservations, unexplained provider-row orphans, and
+ * abandoned in-progress GGUF downloads forever. This function is the
+ * missing caller: loadState -> reconcileOnBoot (against the live
+ * `providers` table, shaped to `{modelId}` for native rows, and a real
+ * pid-liveness check) -> saveState (persists freed reservations) -> log
+ * `orphanRows` honestly -> re-enqueue every still-journaled download via
+ * `manager.js`'s `enqueueDownload`.
+ *
+ * Re-enqueue caveat (honest limitation, not silently papered over):
+ * `state.journal` entries (see `state.js`'s doc) do not record which QUANT
+ * a download was for — only `url`/`dest`/`bytesDone`/`expectedSha`.
+ * `enqueueDownload` -> `downloadModel` re-derives `url`/`dest` from
+ * `resolveEntry(catalog, modelId, quant)`, defaulting `quant` to the
+ * model's `default_quant` when omitted (as it is here). A download that
+ * was for the default quant (the common case) resumes correctly — its
+ * freshly re-derived `url`/`dest` match the journaled ones, so
+ * `downloadModel`'s own resume-match check picks up `bytesDone` where it
+ * left off. A download for a NON-default quant re-derives a DIFFERENT
+ * `url`/`dest`, fails that match, and restarts from scratch instead of
+ * truly resuming — a safe degrade (no corruption, no crash), just not a
+ * true resume; fixing it would require the journal to record `quant` too,
+ * out of scope for this fix.
+ *
+ * Never throws — every failure mode (provider-row read, the reconcile call
+ * itself, an individual re-enqueue) is independently caught and warned, so
+ * a broken model-runtime state on one instance can never block gateway
+ * boot for anyone. `db`, if omitted, degrades to "no provider rows" (still
+ * frees reservations by liveness alone) — needed for callers/tests that
+ * don't have a DB handle yet.
+ *
+ * @returns {Promise<{freedReservations:Array, orphanRows:Array, resumableDownloads:Array}>}
+ */
+const EMPTY_RECONCILE_PLAN = Object.freeze({ freedReservations: [], orphanRows: [], resumableDownloads: [] });
+
+export async function initNativeModels({
+  dir = resolveDataDir(),
+  db,
+  loadStateFn = loadState,
+  saveStateFn = saveState,
+  listProvidersAllFn = listProvidersAll,
+  isProcessAliveFn = defaultIsProcessAlive,
+  reconcileOnBootFn = reconcileOnBoot,
+  enqueueDownloadFn = enqueueDownload,
+  loadCatalogFn = defaultLoadCatalog,
+} = {}) {
+  // Whole body wrapped: `reconcileOnBootFn` is an injected seam (a caller's
+  // stub, or a future state.js change) just as capable of throwing as the
+  // I/O around it — every step here is "convenience/cleanup", never
+  // boot-critical, so ANY failure degrades to the empty plan rather than
+  // propagating (this function's own promise must never reject).
+  try {
+    const state = loadStateFn(dir);
+
+    let nativeRows = [];
+    if (db) {
+      try {
+        const rows = await listProvidersAllFn(db);
+        nativeRows = rows
+          .filter((r) => !r.disabled && r.gpuPolicy?.runtime === "native")
+          .map((r) => ({ modelId: r.id }));
+      } catch (err) {
+        console.warn(`[gpu-orchestrator] native model reconcile: failed to read provider rows: ${err.message}`);
+      }
+    }
+
+    const plan = reconcileOnBootFn({
+      state,
+      listProviderRows: () => nativeRows,
+      isProcessAlive: isProcessAliveFn,
+    });
+
+    if (plan.freedReservations.length) {
+      console.log(`[gpu-orchestrator] native model reconcile: freed ${plan.freedReservations.length} stale port reservation(s): ${plan.freedReservations.map((r) => r.modelId).join(", ")}`);
+      saveStateFn(dir, state);
+    }
+
+    if (plan.orphanRows.length) {
+      console.warn(`[gpu-orchestrator] native model reconcile: ${plan.orphanRows.length} provider row(s) with no matching port reservation: ${plan.orphanRows.map((r) => r.modelId).join(", ")}`);
+    }
+
+    for (const dl of plan.resumableDownloads) {
+      try {
+        const catalog = loadCatalogFn();
+        console.log(`[gpu-orchestrator] native model reconcile: resuming interrupted download for ${dl.modelId} (${dl.bytesDone || 0} bytes so far)`);
+        Promise.resolve(enqueueDownloadFn({ modelId: dl.modelId, dir, catalog })).catch((err) => {
+          console.warn(`[gpu-orchestrator] native model reconcile: resume of ${dl.modelId} failed: ${err.message}`);
+        });
+      } catch (err) {
+        console.warn(`[gpu-orchestrator] native model reconcile: could not re-enqueue ${dl.modelId}: ${err.message}`);
+      }
+    }
+
+    return plan;
+  } catch (err) {
+    console.warn(`[gpu-orchestrator] native model reconcile failed: ${err.message}`);
+    return EMPTY_RECONCILE_PLAN;
+  }
+}
+
 /**
  * Startup — ensure all alwaysResident providers are up.
  * Non-fatal: logs and continues on error. Call from gateway init.
@@ -1169,6 +1329,22 @@ export async function initOrchestrator() {
   // failure class this feature exists to eliminate).
   setResidencyInitialized();
   startResidencyMonitor();
+
+  // Native-model boot reconciliation (final-review fix wave, Fix 3) — its
+  // own dedicated try/catch, deliberately separate from the alwaysResident
+  // loop below, so a reconcile failure can never prevent alwaysResident
+  // bundles from coming up (and vice versa).
+  try {
+    const db = createDbClient();
+    try {
+      await initNativeModels({ db });
+    } finally {
+      try { db.close(); } catch { /* best effort */ }
+    }
+  } catch (err) {
+    console.warn(`[gpu-orchestrator] native model reconcile failed: ${err.message}`);
+  }
+
   try {
     const cfg = loadProviders();
     const ownAddrs = getOwnAddresses();

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -36,10 +36,35 @@
  *
  * Keep `defaultMember: true` on exactly one provider per group if you
  * want idle auto-revert to restore it after a specialist times out.
+ *
+ * --- Native runtime providers (Item G, Task 9) ---
+ *
+ * A provider is native iff `gpuPolicy.runtime === "native"` (only
+ * `manager.js`'s `registerModel` writes this). Control plane: spawn/kill a
+ * local `llama-server` process via `models/runtime.js`'s `startModel`/
+ * `stopModel`, not docker compose. Cross-GATEWAY-PROCESS contention for a
+ * native model's mutexGroup is arbitrated by an advisory host-wide lock
+ * (`models/native-lock.js`'s `acquireHostLock`) that is held for the LIFE
+ * of the model's residency — acquired right before a successful start,
+ * released exactly once when that process reaches a terminal state
+ * (explicit stop, idle-timeout self-stop, or restarts-exhausted), via
+ * `startModel`'s `onTerminal` callback. See `acquireOrStartNative`'s doc
+ * for the full ordering.
+ *
+ * KNOWN v1 LIMITATION: this lock arbitrates native-vs-native ONLY. Nothing
+ * in the Docker control plane reads it, so a Docker bundle acquired on one
+ * gateway process and a native model acquired on ANOTHER gateway process,
+ * contending for the same physical GPU/RAM but declared in different
+ * mutexGroups, are NOT mutually excluded by anything in this file.
+ * Same-PROCESS eviction between the two control planes IS covered in both
+ * directions (a native acquire stops a Docker sibling via `bundleStop`; a
+ * Docker acquire stops a native sibling via its handle's `stop()`) — only
+ * the cross-process case is an open gap, left for a future revision if
+ * multi-gateway hosts ever need a unified VRAM ledger.
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname, resolve } from "node:path";
 import { loadProviders as loadCachedProviders } from "../shared/providers.js";
@@ -58,12 +83,34 @@ const __filename = fileURLToPath(import.meta.url);
 const BUNDLES_DIR = resolve(dirname(__filename), "..", "..", "bundles");
 const MODEL_CATALOG_PATH = resolve(dirname(__filename), "..", "..", "registry", "model-catalog.json");
 
+// mtime-checked cache — `defaultLoadCatalog` runs on every native acquire
+// (potentially every chat turn once a native model is warm), so a bare
+// readFileSync+JSON.parse per call is wasted work for a file that changes
+// only on deploy. Re-reads only when the file's mtime actually moves (an
+// `npm run deploy`/git-pull picking up a catalog update), never silently
+// staying stale across a long-running gateway process.
+let _catalogCache = null;
+let _catalogCacheMtimeMs = null;
+
 /** Default `loadCatalogFn` for the native start path — reads the curated
  * catalog's `runtime` block (llama.cpp version pin + per-platform assets)
  * that `ensureRuntime` needs. Injectable so tests never touch the real
- * repo-tracked catalog file. */
+ * repo-tracked catalog file (and never see cross-test cache pollution —
+ * each test supplies its own `loadCatalogFn`, bypassing this cache
+ * entirely). */
 function defaultLoadCatalog() {
-  return JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+  let mtimeMs;
+  try {
+    mtimeMs = statSync(MODEL_CATALOG_PATH).mtimeMs;
+  } catch {
+    mtimeMs = null;
+  }
+  if (_catalogCache && mtimeMs !== null && mtimeMs === _catalogCacheMtimeMs) {
+    return _catalogCache;
+  }
+  _catalogCache = JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+  _catalogCacheMtimeMs = mtimeMs;
+  return _catalogCache;
 }
 
 function loadProviders() {
@@ -406,8 +453,53 @@ export async function warmProviderByName(name) {
 export const _internals = { getProvider, getMutexSiblings, getMutexGroups, mutexGroupOf };
 
 // -----------------------------------------------------------------------
-// Native runtime — acquire path (Item G, Task 9)
+// Native runtime — acquire path (Item G, Task 9; lock-lifetime + download-
+// isolation fixed in review round 1)
 // -----------------------------------------------------------------------
+
+// `ensureRuntime` in-flight dedupe, keyed by catalog release — a first
+// install's download can take a while; if two callers ask for the same
+// release concurrently (e.g. two providers on the same llama.cpp pin,
+// acquired at the same moment by two chat turns), the second must await
+// the first's already-running install rather than starting a redundant
+// second download. `ensureRuntime` is itself idempotent (its manifest
+// check + atomic staging-dir rename), so this is a performance/network
+// courtesy, not a correctness requirement — but it's cheap to provide.
+const _runtimeEnsureInFlight = new Map(); // release key -> Promise<binPath>
+
+/**
+ * Resolve the llama-server `binPath` for a native provider. Deliberately
+ * called from `acquireProvider`'s native branch BEFORE the `_swapInFlight`
+ * chain is ever touched (Task 9 review round 1, finding 2): a first-install
+ * download can take minutes, and it must never occupy the single-flight
+ * queue that unrelated Docker/native swaps for OTHER providers are waiting
+ * behind — only the actual spawn+sibling-swap belongs in that critical
+ * section. `ensureRuntime`'s own manifest check makes a repeat call for an
+ * already-installed release cheap (no network I/O), so resolving it
+ * unconditionally on every acquire — even one that turns out to hit the
+ * `identityProbe` fast path and never needs to start anything — is an
+ * acceptable, small, constant cost.
+ */
+async function resolveNativeBinPath(p, opts = {}) {
+  const {
+    ensureRuntimeFn = ensureRuntime,
+    resolveDataDirFn = resolveDataDir,
+    loadCatalogFn = defaultLoadCatalog,
+    getCachedProbeFn = getCachedProbe,
+  } = opts;
+  const dir = resolveDataDirFn();
+  const catalog = loadCatalogFn();
+  const probe = getCachedProbeFn();
+  const key = (catalog && catalog.runtime && catalog.runtime.release) || "default";
+  if (_runtimeEnsureInFlight.has(key)) return _runtimeEnsureInFlight.get(key);
+  const inFlight = Promise.resolve()
+    .then(() => ensureRuntimeFn(dir, catalog.runtime, probe))
+    .finally(() => {
+      if (_runtimeEnsureInFlight.get(key) === inFlight) _runtimeEnsureInFlight.delete(key);
+    });
+  _runtimeEnsureInFlight.set(key, inFlight);
+  return inFlight;
+}
 
 /** Poll `identityProbe` until it reports "resident" or "conflict", or the
  * timeout elapses (-> "down"). Mirrors `waitForReady`'s shape for the
@@ -428,27 +520,28 @@ async function waitForNativeReady(baseUrl, alias, {
 
 /**
  * Start a native provider's llama-server process and wait for it to report
- * itself resident. No locking, no sibling swap — those are the acquire
- * path's job (`acquireNativeSwap`) and `ensureResident`'s native branch
- * deliberately skips them too, mirroring the Docker `ensureResident`'s
- * parity (alwaysResident providers don't swap siblings at boot).
+ * itself resident. Binds the EXACT port already encoded in `p.baseUrl` —
+ * NEVER re-allocates a fresh one from the port pool. A bind failure (the
+ * process never reports resident within the timeout) is an honest thrown
+ * error, never a silent fallback to a different port.
  *
- * Binds the EXACT port already encoded in `p.baseUrl` — NEVER re-allocates
- * a fresh one from the port pool. A bind failure (the process never
- * reports resident within the timeout) is an honest thrown error, never a
- * silent fallback to a different port.
+ * `opts.binPath`, if given, is used as-is (the caller already resolved it
+ * via `resolveNativeBinPath` outside the single-flight); otherwise it's
+ * resolved inline here (the `ensureResident` boot path calls this directly
+ * and isn't queued behind `_swapInFlight`, so there's nothing to protect
+ * it from). `opts.onTerminal`, if given, is forwarded verbatim to
+ * `startModelFn` — see `runtime.js`'s `startModel` doc.
  */
 async function startNativeAndAwaitReady(providerName, p, opts = {}) {
   const {
     identityProbeFn = identityProbe,
     startModelFn = startModel,
-    ensureRuntimeFn = ensureRuntime,
     loadStateFn = loadState,
     resolveDataDirFn = resolveDataDir,
-    loadCatalogFn = defaultLoadCatalog,
-    getCachedProbeFn = getCachedProbe,
     fetchImpl,
     spawnFn,
+    onTerminal,
+    binPath: preResolvedBinPath,
     readinessTimeoutMs = READINESS_TIMEOUT_MS,
     readinessPollMs = READINESS_POLL_MS,
     readinessInitialDelayMs = READINESS_INITIAL_DELAY_MS,
@@ -467,12 +560,10 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
   }
   const ggufPath = join(dir, "models", "blobs", regEntry.file);
 
-  const catalog = loadCatalogFn();
-  const probe = getCachedProbeFn();
-  const binPath = await ensureRuntimeFn(dir, catalog.runtime, probe);
+  const binPath = preResolvedBinPath || await resolveNativeBinPath(p, opts);
 
   console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port})`);
-  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn });
+  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal });
   _nativeHandles.set(providerName, handle);
 
   const result = await waitForNativeReady(p.baseUrl, alias, {
@@ -497,22 +588,52 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
 }
 
 /**
- * Native branch of `acquireProvider`'s swap transaction (runs inside the
- * same `_swapInFlight` single-flight as the Docker branch). Order:
- *   1. `identityProbe` fast path — resident -> done; conflict -> typed
- *      error, no lock ever taken, no traffic routed.
- *   2. `acquireHostLock(mutexGroup)` — null -> typed "another Crow
+ * Core native acquire, shared by `acquireProvider`'s native branch AND
+ * `ensureResident`'s native branch (Task 9 review round 1: both paths can
+ * start a process and therefore both need identical lock discipline).
+ * Order (binding — see finding 1 of the review):
+ *   1. `identityProbe` fast path — resident -> done, lock never touched
+ *      (an already-resident model's lock is already held from ITS start,
+ *      by definition below — re-touching it here would open a window
+ *      where the lock is briefly free while the model is still up);
+ *      conflict -> typed error, no lock ever taken, no traffic routed.
+ *   2. Sibling swap — BEFORE taking the lock. A same-mutexGroup sibling
+ *      may currently be the one holding this group's lock (locks now
+ *      live for the life of a resident native model, not just its
+ *      startup); stopping it releases that lock as a side effect of its
+ *      own `onTerminal`, so the lock is free for us by the time step 3
+ *      asks for it — UNLESS something outside this group's own siblings
+ *      holds it, which is a genuine conflict, correctly surfaced by step 3.
+ *   3. `acquireHostLock(mutexGroup)` — null -> typed "another Crow
  *      instance..." error.
- *   3. Sibling swap: Docker sibling via `bundleStop`, native sibling via
- *      its handle's `stop()` — mirrors the Docker branch's sibling loop.
- *   4. `startNativeAndAwaitReady`.
- * The lock is released in `finally` once this swap transaction settles —
- * it protects the START critical section against a second gateway process
- * on this host racing to start a sibling; ongoing residency truth is
- * `identityProbe`/the OS-level bind test, not this lock (see
- * `native-lock.js`'s module doc).
+ *   4. `startNativeAndAwaitReady`, with an `onTerminal` callback wired to
+ *      release the lock taken in step 3. On a FAILED start (never became
+ *      resident, or a post-start identity conflict), `finally` releases
+ *      the lock immediately — ownership was never successfully handed
+ *      off. On a SUCCESSFUL start, `finally` does NOT release it: the
+ *      lock is now owned by the running process and is released exactly
+ *      once, whenever it reaches a terminal state (explicit stop —
+ *      including a future sibling swap-out or unregister — idle-timeout
+ *      self-stop, or maxRestarts-exhausted unhealthy give-up), per
+ *      `runtime.js`'s `startModel` `onTerminal` contract. A gateway
+ *      crash mid-residency is covered separately, by `native-lock.js`'s
+ *      stale-pid steal on the NEXT acquire.
+ *
+ * Cross-process Docker-vs-native is a known v1 gap: this lock arbitrates
+ * native-vs-native only. A Docker bundle on another gateway process has no
+ * way to observe or wait on this lock (nothing in the Docker control plane
+ * reads it), so a Docker acquire on one gateway and a native acquire on
+ * another, racing for the same physical GPU/RAM but in DIFFERENT
+ * mutexGroups, are not mutually excluded by anything in this file. Only
+ * same-PROCESS eviction (below, and its Docker-branch mirror in
+ * `acquireProvider`) is guaranteed today.
+ *
+ * @returns {Promise<{freshStart: boolean}>} `freshStart` is `false` when
+ *   the fast path found it already resident (nothing new happened —
+ *   `ensureResident` uses this to decide whether to report embed
+ *   recovery), `true` when this call actually started it.
  */
-async function acquireNativeSwap(providerName, p, cfg, opts = {}) {
+async function acquireOrStartNative(providerName, p, cfg, opts = {}) {
   const {
     acquireHostLockFn = acquireHostLock,
     identityProbeFn = identityProbe,
@@ -527,12 +648,37 @@ async function acquireNativeSwap(providerName, p, cfg, opts = {}) {
     const fastStatus = await identityProbeFn(p.baseUrl, alias, fetchImpl);
     if (fastStatus === "resident") {
       _lastUsedAt.set(providerName, Date.now());
-      return true;
+      return { freshStart: false };
     }
     if (fastStatus === "conflict") {
       throw new NativePortConflictError(providerName, p.baseUrl);
     }
-    // "down" — fall through to lock + start.
+    // "down" — fall through to sibling swap + lock + start.
+  }
+
+  const siblings = getMutexSiblings(providerName, cfg);
+  for (const sibName of siblings) {
+    const sib = getProvider(sibName, cfg);
+    if (!sib || !isLocallyOrchestratable(sib)) continue;
+    if (isNativeRuntime(sib)) {
+      const sibHandle = _nativeHandles.get(sibName);
+      if (sibHandle && sibHandle.live) {
+        console.log(`[gpu-orchestrator] swapping out native ${sibName} for ${providerName}`);
+        await stopModelFn(sibHandle).catch((err) =>
+          console.warn(`[gpu-orchestrator] stop native ${sibName} failed: ${err.message}`)
+        );
+        _nativeHandles.delete(sibName);
+      }
+      _lastUsedAt.delete(sibName);
+    } else if (sib.bundleId) {
+      if (await probeReadyFn(sib.baseUrl)) {
+        console.log(`[gpu-orchestrator] swapping out ${sibName} (bundleId=${sib.bundleId}) for ${providerName}`);
+        await bundleStopFn(sib.bundleId).catch((err) =>
+          console.warn(`[gpu-orchestrator] stop ${sib.bundleId} failed: ${err.message}`)
+        );
+        _lastUsedAt.delete(sibName);
+      }
+    }
   }
 
   const mutexGroup = mutexGroupOf(p) || providerName;
@@ -541,36 +687,31 @@ async function acquireNativeSwap(providerName, p, cfg, opts = {}) {
     throw new NativeHostLockHeldError(mutexGroup);
   }
 
+  let success = false;
   try {
-    const siblings = getMutexSiblings(providerName, cfg);
-    for (const sibName of siblings) {
-      const sib = getProvider(sibName, cfg);
-      if (!sib || !isLocallyOrchestratable(sib)) continue;
-      if (isNativeRuntime(sib)) {
-        const sibHandle = _nativeHandles.get(sibName);
-        if (sibHandle && sibHandle.live) {
-          console.log(`[gpu-orchestrator] swapping out native ${sibName} for ${providerName}`);
-          await stopModelFn(sibHandle).catch((err) =>
-            console.warn(`[gpu-orchestrator] stop native ${sibName} failed: ${err.message}`)
-          );
-          _nativeHandles.delete(sibName);
-        }
-        _lastUsedAt.delete(sibName);
-      } else if (sib.bundleId) {
-        if (await probeReadyFn(sib.baseUrl)) {
-          console.log(`[gpu-orchestrator] swapping out ${sibName} (bundleId=${sib.bundleId}) for ${providerName}`);
-          await bundleStopFn(sib.bundleId).catch((err) =>
-            console.warn(`[gpu-orchestrator] stop ${sib.bundleId} failed: ${err.message}`)
-          );
-          _lastUsedAt.delete(sibName);
-        }
-      }
-    }
-
-    return await startNativeAndAwaitReady(providerName, p, opts);
+    const onTerminal = (reason) => {
+      console.log(`[gpu-orchestrator] native ${providerName} lock released (terminal: ${reason})`);
+      release();
+    };
+    await startNativeAndAwaitReady(providerName, p, { ...opts, onTerminal });
+    success = true;
+    return { freshStart: true };
   } finally {
-    release();
+    // A successful start hands lock ownership off to `onTerminal` above —
+    // releasing here too would free it while the model is still resident
+    // (finding 1). Only a FAILED start (never reached `success = true`)
+    // releases here.
+    if (!success) release();
   }
+}
+
+/** Thin `acquireProvider`-shaped wrapper — see `acquireOrStartNative`'s
+ * doc for the actual logic. `acquireProvider`'s contract is "true on
+ * success, throw on failure", so `freshStart` is not surfaced here (only
+ * `ensureResident`'s native branch cares about that distinction). */
+async function acquireNativeSwap(providerName, p, cfg, opts = {}) {
+  await acquireOrStartNative(providerName, p, cfg, opts);
+  return true;
 }
 
 /**
@@ -599,7 +740,15 @@ export async function acquireProvider(providerName, opts = {}) {
       console.warn(`[gpu-orchestrator] refusing to orchestrate ${providerName} — its baseUrl is not on this machine`);
       return null;
     }
-    const nativeSwap = _swapInFlight.then(() => acquireNativeSwap(providerName, p, cfg, opts));
+    // Resolve the runtime binary BEFORE touching _swapInFlight (Task 9
+    // review round 1, finding 2): a first-install download can take
+    // minutes and must never occupy the single-flight queue that an
+    // unrelated provider's swap is waiting behind. Only the actual
+    // spawn+sibling-swap (acquireNativeSwap, via startNativeAndAwaitReady)
+    // runs inside the single-flight below.
+    const binPath = await resolveNativeBinPath(p, opts);
+    const nativeOpts = { ...opts, binPath };
+    const nativeSwap = _swapInFlight.then(() => acquireNativeSwap(providerName, p, cfg, nativeOpts));
     _swapInFlight = nativeSwap.catch(() => {});
     return nativeSwap;
   }
@@ -611,20 +760,55 @@ export async function acquireProvider(providerName, opts = {}) {
   }
 
   const swap = _swapInFlight.then(async () => {
+    // Injectable purely so `acquireProvider ... a Docker provider evicts a
+    // resident native sibling` is unit-testable without a real `docker`
+    // binary (Task 9 review round 1, finding 3) — every default is the
+    // exact real function, so no existing caller's behavior changes.
+    const {
+      probeReadyFn = probeReady,
+      bundleUpFn = bundleUp,
+      bundleStopFn = bundleStop,
+      stopModelFn = stopModel,
+      waitForReadyFn = waitForReady,
+    } = opts;
+
     // Fast path: already resident.
-    if (await probeReady(p.baseUrl)) {
+    if (await probeReadyFn(p.baseUrl)) {
       _lastUsedAt.set(providerName, Date.now());
       return true;
     }
 
-    // Stop mutex siblings first.
-    const siblings = getMutexSiblings(providerName);
+    // Stop mutex siblings first. A sibling can be native (Task 9 review
+    // round 1, finding 3: same-PROCESS symmetric eviction — a native
+    // sibling with a live handle in _nativeHandles is stopped via that
+    // handle, same as the native branch's own sibling loop; its
+    // `onTerminal` releases the native host lock as a side effect, same as
+    // there). Cross-PROCESS Docker-vs-native is NOT covered — see the
+    // module doc and `acquireOrStartNative`'s doc for why: the native
+    // host lock has no Docker-side reader, so a Docker acquire on one
+    // gateway and a native acquire on ANOTHER, contending for the same
+    // physical GPU/RAM in different mutexGroups, are not mutually
+    // excluded by anything in this file. Only this same-process case is.
+    const siblings = getMutexSiblings(providerName, cfg);
     for (const sibName of siblings) {
-      const sib = getProvider(sibName);
-      if (!sib?.bundleId || !isLocallyOrchestratable(sib)) continue;
-      if (await probeReady(sib.baseUrl)) {
+      const sib = getProvider(sibName, cfg);
+      if (!sib || !isLocallyOrchestratable(sib)) continue;
+      if (isNativeRuntime(sib)) {
+        const sibHandle = _nativeHandles.get(sibName);
+        if (sibHandle && sibHandle.live) {
+          console.log(`[gpu-orchestrator] swapping out native ${sibName} for ${providerName}`);
+          await stopModelFn(sibHandle).catch((err) =>
+            console.warn(`[gpu-orchestrator] stop native ${sibName} failed: ${err.message}`)
+          );
+          _nativeHandles.delete(sibName);
+        }
+        _lastUsedAt.delete(sibName);
+        continue;
+      }
+      if (!sib.bundleId) continue;
+      if (await probeReadyFn(sib.baseUrl)) {
         console.log(`[gpu-orchestrator] swapping out ${sibName} (bundleId=${sib.bundleId}) for ${providerName}`);
-        await bundleStop(sib.bundleId).catch((err) =>
+        await bundleStopFn(sib.bundleId).catch((err) =>
           console.warn(`[gpu-orchestrator] stop ${sib.bundleId} failed: ${err.message}`)
         );
         _lastUsedAt.delete(sibName);
@@ -633,8 +817,8 @@ export async function acquireProvider(providerName, opts = {}) {
 
     // Start target.
     console.log(`[gpu-orchestrator] starting ${providerName} (bundleId=${p.bundleId})`);
-    await bundleUp(p.bundleId);
-    const ready = await waitForReady(p.baseUrl);
+    await bundleUpFn(p.bundleId);
+    const ready = await waitForReadyFn(p.baseUrl);
     if (ready) {
       console.log(`[gpu-orchestrator] ${providerName} ready`);
       _lastUsedAt.set(providerName, Date.now());
@@ -736,18 +920,18 @@ export function _setDeferredResidentsForTest(names) {
  * isn't enough, matching `identityProbe`'s "never trust a port without
  * confirming what it's serving" stance. Not resident -> start it (no
  * lock/sibling-swap, mirroring the Docker branch's boot-time parity). */
-async function ensureNativeResident(name, p, opts = {}) {
-  const { identityProbeFn = identityProbe, fetchImpl } = opts;
-  const handle = _nativeHandles.get(name);
-  const alias = nativeAlias(p);
-  if (handle && handle.live && alias) {
-    const status = await identityProbeFn(p.baseUrl, alias, fetchImpl);
-    if (status === "resident") {
-      console.log(`[gpu-orchestrator] ${name} already resident`);
-      return false;
-    }
+async function ensureNativeResident(name, p, cfg, opts = {}) {
+  // Delegates to the SAME core acquireProvider's native branch uses (Task
+  // 9 review round 1, finding 1): both paths can start a process and
+  // therefore both need identical lock discipline — a boot-time ensure
+  // that started a model without taking/holding its mutexGroup's host
+  // lock would leave that lock free for a DIFFERENT gateway process to
+  // walk right past while this model is genuinely resident.
+  const result = await acquireOrStartNative(name, p, cfg, opts);
+  if (!result.freshStart) {
+    console.log(`[gpu-orchestrator] ${name} already resident`);
+    return false;
   }
-  await startNativeAndAwaitReady(name, p, opts);
   return providerHasEmbedModel(p);
 }
 
@@ -761,7 +945,7 @@ export async function ensureResident(name, cfg = loadProviders(), opts = {}) {
   try {
     const p = (cfg.providers || {})[name];
     if (p && isNativeRuntime(p)) {
-      return await ensureNativeResident(name, p, opts);
+      return await ensureNativeResident(name, p, cfg, opts);
     }
     if (!p?.bundleId) {
       console.warn(`[gpu-orchestrator] ${name} has no bundleId — skipping`);

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -15,7 +15,10 @@
  *     buffered whole in memory), hashes incrementally with a single
  *     `crypto.createHash("sha256")` fed from the same chunks as they're
  *     written, follows redirects manually (checking the host allowlist on
- *     EVERY hop, not just the first), and re-hashes an on-disk prefix from
+ *     EVERY hop, not just the first, and rejecting any non-https hop outside an
+ *     explicit test-only escape — a bare hostname check alone would still
+ *     let a plain `http:` URL through, or let a redirect silently downgrade
+ *     an https request to http), and re-hashes an on-disk prefix from
  *     scratch when resuming (a streaming hash object has no way to "resume"
  *     — the only way to get a correct final digest after a partial file is
  *     to re-feed the bytes already on disk into a fresh hash before
@@ -34,7 +37,9 @@
  * `CROW_MODEL_DL_CONCURRENCY` — GGUF downloads are multi-gigabyte and this
  * host's disk/network don't benefit from more parallelism than that, and
  * unbounded concurrency would let a chatty panel starve every download of
- * bandwidth at once.
+ * bandwidth at once. It is also idempotent per `modelId`: a second enqueue
+ * for a model already queued/downloading returns the SAME promise rather
+ * than starting a second writer on the same destination file.
  *
  * `dir` is always injected by the caller (same convention as `state.js`:
  * production passes `resolveDataDir()`, tests pass an `fs.mkdtempSync`
@@ -108,6 +113,19 @@ export class UnsafeDestinationError extends Error {
     super(message);
     this.name = "UnsafeDestinationError";
     this.code = "UNSAFE_DESTINATION";
+  }
+}
+
+/** Shared typed error for redirect-handling protocol violations: a
+ * non-https URL at a hop that isn't explicitly test-escaped (see
+ * `insecureHttpHosts`), a redirect response with no Location header, or
+ * exceeding `maxRedirects`. `code` distinguishes the three cases so
+ * callers can tell them apart without string-matching `message`. */
+export class DownloadProtocolError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = "DownloadProtocolError";
+    this.code = code;
   }
 }
 
@@ -210,20 +228,37 @@ function requestOnce(urlStr, { headers, lookup }) {
   });
 }
 
-/** Follow redirects manually, re-checking the host allowlist on every hop
- * (including the first) before connecting. Returns the final 200/206
- * response. `maxRedirects` bounds the number of redirect hops (not
- * counting the initial request). */
-async function openStream({ url, headers, lookup, maxRedirects }) {
+/** Follow redirects manually, re-checking the host allowlist AND the
+ * https-only protocol requirement on every hop (including the first)
+ * before connecting. Returns the final 200/206 response. `maxRedirects`
+ * bounds the number of redirect hops (not counting the initial request).
+ *
+ * `insecureHttpHosts` is a test-only escape (default `[]`, i.e. https is
+ * required everywhere in production): a hop whose URL is `http:` is only
+ * allowed through when its hostname is literally in this list. Without
+ * this, a plain `http:` URL to an allowlisted host would download fine,
+ * and — worse — a redirect could silently downgrade an https request to
+ * http on any later hop; checking protocol independently on every hop
+ * (not just validating the initial URL) closes both holes. */
+async function openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts = [] }) {
   let currentUrl = url;
   // eslint-disable-next-line no-await-in-loop -- redirect hops are
   // inherently sequential: each hop's Location header depends on the
-  // previous response, and each hop must be allowlist-checked before the
-  // NEXT connection is made — parallelizing would defeat the check.
+  // previous response, and each hop must be allowlist/protocol-checked
+  // before the NEXT connection is made — parallelizing would defeat that.
   for (let hop = 0; hop <= maxRedirects; hop++) {
     const urlObj = new URL(currentUrl);
     if (!isAllowedHost(urlObj.hostname)) {
       throw new HostNotAllowedError(urlObj.hostname);
+    }
+    if (urlObj.protocol !== "https:") {
+      const escaped = urlObj.protocol === "http:" && insecureHttpHosts.includes(urlObj.hostname);
+      if (!escaped) {
+        throw new DownloadProtocolError(
+          `Refusing non-https URL (${urlObj.protocol}) for host ${urlObj.hostname} — pass insecureHttpHosts to explicitly allow this host (tests only; never set in production)`,
+          "INSECURE_PROTOCOL",
+        );
+      }
     }
     // eslint-disable-next-line no-await-in-loop
     const { res } = await requestOnce(currentUrl, { headers, lookup });
@@ -231,7 +266,10 @@ async function openStream({ url, headers, lookup, maxRedirects }) {
       res.resume(); // discard redirect body
       const location = res.headers.location;
       if (!location) {
-        throw new Error(`Redirect response (${res.statusCode}) with no Location header from ${currentUrl}`);
+        throw new DownloadProtocolError(
+          `Redirect response (${res.statusCode}) with no Location header from ${currentUrl}`,
+          "REDIRECT_NO_LOCATION",
+        );
       }
       currentUrl = new URL(location, currentUrl).toString();
       continue;
@@ -242,7 +280,7 @@ async function openStream({ url, headers, lookup, maxRedirects }) {
     }
     return { res, finalUrl: currentUrl };
   }
-  throw new Error(`Too many redirects (> ${maxRedirects}) downloading ${url}`);
+  throw new DownloadProtocolError(`Too many redirects (> ${maxRedirects}) downloading ${url}`, "TOO_MANY_REDIRECTS");
 }
 
 /** Re-hash the on-disk prefix `[0, resumeFrom)` of `dest` into `hash`
@@ -325,12 +363,17 @@ function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream 
  *   - `createWriteStream`: injected write-stream factory, defaults to
  *     `fs.createWriteStream` — tests override it to force an ENOSPC error
  *     deterministically instead of actually filling the disk.
+ *   - `insecureHttpHosts`: test-only escape from the https-only
+ *     requirement (default `[]` — https is mandatory everywhere in
+ *     production). See `openStream` doc for why every hop is checked
+ *     independently.
  *
  * Returns `{ path, sha256, bytesDone }`. Throws `HostNotAllowedError`,
- * `ChecksumError` (dest already deleted), or `DiskFullError` (dest KEPT
- * for resume) as documented above; any other stream error is rethrown
- * as-is with a `.bytesDone` property attached so callers can journal
- * progress before propagating.
+ * `DownloadProtocolError` (insecure protocol / bad redirect), `ChecksumError`
+ * (dest already deleted), or `DiskFullError` (dest KEPT for resume) as
+ * documented above; any other stream error is rethrown as-is with a
+ * `.bytesDone` property attached so callers can journal progress before
+ * propagating.
  */
 export async function fetchModelBlob({
   url,
@@ -341,6 +384,7 @@ export async function fetchModelBlob({
   lookup,
   maxRedirects = 5,
   createWriteStream = fsCreateWriteStream,
+  insecureHttpHosts = [],
 }) {
   assertNotSymlink(dest);
 
@@ -355,7 +399,7 @@ export async function fetchModelBlob({
   const headers = {};
   if (effectiveResumeFrom > 0) headers.Range = `bytes=${effectiveResumeFrom}-`;
 
-  const { res } = await openStream({ url, headers, lookup, maxRedirects });
+  const { res } = await openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts });
   const totalBytes = parseTotalBytes(res.headers, effectiveResumeFrom);
 
   let bytesDone;
@@ -397,8 +441,9 @@ function modelsBlobDir(dir) {
  * killed/restarted process can resume. See module doc for the full
  * contract; `dir` is the injected CROW_HOME/data dir (never guessed).
  *
- * `baseUrl` and `lookup` exist purely for tests — production never sets
- * them (real huggingface.co, real DNS).
+ * `baseUrl`, `lookup`, and `insecureHttpHosts` exist purely for tests —
+ * production never sets them (real huggingface.co, real DNS, https
+ * required everywhere).
  */
 export async function downloadModel({
   modelId,
@@ -411,6 +456,7 @@ export async function downloadModel({
   maxRedirects = 5,
   createWriteStream,
   journalIntervalMs = 1000,
+  insecureHttpHosts,
 }) {
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
   const blobDir = modelsBlobDir(dir);
@@ -462,6 +508,7 @@ export async function downloadModel({
       lookup,
       maxRedirects,
       createWriteStream,
+      insecureHttpHosts,
       onProgress: wrappedOnProgress,
     });
     const s = loadState(dir);
@@ -521,6 +568,7 @@ export function deleteModel({ modelId, quant, dir, catalog }) {
 
 const downloadQueue = [];
 let activeDownloads = 0;
+const inFlightByModelId = new Map();
 
 /** Concurrency for `enqueueDownload`: `CROW_MODEL_DL_CONCURRENCY`, clamped
  * to [1, 2]. Non-numeric/missing/less-than-1 falls back to 1. */
@@ -554,10 +602,31 @@ function pumpDownloadQueue() {
  * With the default concurrency of 1, two enqueued downloads never overlap
  * — the second's HTTP request is not opened until the first has fully
  * settled (resolved or rejected).
+ *
+ * Idempotent per `modelId`: calling this again for a `modelId` that
+ * already has a job queued or running returns the SAME promise instead of
+ * enqueueing a second job. Without this, `CROW_MODEL_DL_CONCURRENCY=2`
+ * (or even concurrency 1 with two rapid calls before the first is
+ * dequeued) could run two downloads for the same model concurrently —
+ * two writers racing on the same `dest` file. The dedup entry is cleared
+ * once the job settles, so a later call (after completion) starts a
+ * genuinely fresh job.
  */
 export function enqueueDownload(params) {
-  return new Promise((resolvePromise, reject) => {
+  const key = params && params.modelId;
+  if (key && inFlightByModelId.has(key)) {
+    return inFlightByModelId.get(key);
+  }
+  const promise = new Promise((resolvePromise, reject) => {
     downloadQueue.push({ params, resolve: resolvePromise, reject });
     pumpDownloadQueue();
   });
+  if (key) {
+    const tracked = promise.finally(() => {
+      if (inFlightByModelId.get(key) === tracked) inFlightByModelId.delete(key);
+    });
+    inFlightByModelId.set(key, tracked);
+    return tracked;
+  }
+  return promise;
 }

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -746,10 +746,14 @@ export function pickChatMutexGroup(existingRows) {
  * refetches a still-mid-write row.
  *
  * The `dir`-scoped `state.registry[modelId]` entry this writes (`file`,
- * `quant`, `catalogId`, `registeredAt`) is what lets `unregisterModel` find
- * the on-disk blob to delete without needing a `catalog` argument of its
- * own — the registry entry IS the durable record of which file this
- * modelId's row corresponds to.
+ * `quant`, `catalogId`, `registeredAt`, `sizeMb`) is what lets
+ * `unregisterModel` find the on-disk blob to delete without needing a
+ * `catalog` argument of its own — the registry entry IS the durable record
+ * of which file this modelId's row corresponds to. `sizeMb` (the quant's
+ * catalog `size_mb`, MB, may be a float) is read back by
+ * `gpu-orchestrator.js`'s native acquire path to scale the readiness
+ * timeout to the model's actual size (Item G, Task 10) — it is NOT used by
+ * `unregisterModel` or anything else in this file.
  *
  * Injectable seams (`allocatePortFn`/`listProvidersAllFn`/`upsertProviderFn`/
  * `invalidateCacheFn`) default to the real implementations; tests use them
@@ -812,6 +816,7 @@ export async function registerModel({
     quant: quantEntry.quant,
     catalogId: model.id,
     registeredAt: new Date().toISOString(),
+    sizeMb: Number.isFinite(quantEntry.size_mb) ? quantEntry.size_mb : null,
   };
   saveState(dir, state);
 

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -132,6 +132,39 @@ export class DownloadProtocolError extends Error {
   }
 }
 
+/** Thrown when a GGUF download's underlying socket sits idle (no bytes
+ * sent or received) for longer than `timeoutMs` — final-review fix wave,
+ * Fix 4 (IMPORTANT). Mirrors `runtime.js`'s `RuntimeDownloadTimeoutError`
+ * as its own distinct type (not a `DownloadProtocolError` — a stalled
+ * connection is not a protocol violation, it's a liveness failure) so
+ * callers can tell the two apart without string-matching `message`. Two
+ * phases are covered independently: a connect/header-wait stall (before
+ * any response arrives — Node's own per-request socket `timeout` option,
+ * `requestOnce`'s `req.on("timeout", ...)`) and a stalled body mid-stream
+ * (after headers, `streamToFile`'s own JS-level idle timer, reset on every
+ * `res` `"data"` event — deliberately NOT reusing Node's socket-timeout
+ * event for this phase, since that event stays armed for the socket's
+ * whole lifetime and racing it against a second, independent watchdog
+ * would make which typed error wins nondeterministic; see `requestOnce`'s
+ * `req.setTimeout(0)` call once headers arrive). Like `DiskFullError` (and
+ * unlike `ChecksumError`), the partial file is deliberately KEPT on disk —
+ * `downloadModel`'s journal already makes a timeout resumable, exactly
+ * like any other mid-download failure. */
+export class DownloadTimeoutError extends Error {
+  constructor(url, timeoutMs) {
+    super(`Download stalled (no socket activity for ${timeoutMs}ms): ${url}`);
+    this.name = "DownloadTimeoutError";
+    this.code = "DOWNLOAD_TIMEOUT";
+    this.url = url;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/** Default socket-idle timeout for a GGUF download hop (~120s, matching
+ * `runtime.js`'s `DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS`). Injectable end to
+ * end via `fetchModelBlob({ timeoutMs })` / `downloadModel({ timeoutMs })`. */
+export const DEFAULT_DOWNLOAD_TIMEOUT_MS = 120_000;
+
 /** Thrown by `registerModel` when a provider row already exists at the
  * target id and was NOT registered by this native runtime for this catalog
  * model — e.g. a user's cloud/bundle provider that happens to share the
@@ -234,13 +267,27 @@ function parseTotalBytes(headers, resumeFrom) {
 // Layer 1: raw download engine
 // ---------------------------------------------------------------------------
 
-function requestOnce(urlStr, { headers, lookup }) {
+/**
+ * `timeoutMs`, if given, arms Node's per-request socket-idle timer for the
+ * connect/header-wait phase ONLY: once headers arrive (the response
+ * callback fires), `req.setTimeout(0)` disarms it immediately — body-phase
+ * stalls are watched independently by `streamToFile`'s own JS-level idle
+ * timer (see `DownloadTimeoutError`'s doc for why two independent
+ * mechanisms, not one shared across both phases).
+ */
+function requestOnce(urlStr, { headers, lookup, timeoutMs }) {
   return new Promise((resolvePromise, reject) => {
     const urlObj = new URL(urlStr);
     const transport = urlObj.protocol === "https:" ? https : http;
-    const req = transport.request(urlObj, { method: "GET", headers, lookup }, (res) => {
+    const req = transport.request(urlObj, { method: "GET", headers, lookup, timeout: timeoutMs }, (res) => {
+      req.setTimeout(0);
       resolvePromise({ req, res });
     });
+    if (timeoutMs) {
+      req.once("timeout", () => {
+        req.destroy(new DownloadTimeoutError(urlStr, timeoutMs));
+      });
+    }
     req.on("error", reject);
     req.end();
   });
@@ -258,7 +305,7 @@ function requestOnce(urlStr, { headers, lookup }) {
  * and — worse — a redirect could silently downgrade an https request to
  * http on any later hop; checking protocol independently on every hop
  * (not just validating the initial URL) closes both holes. */
-async function openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts = [] }) {
+async function openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts = [], timeoutMs }) {
   let currentUrl = url;
   // eslint-disable-next-line no-await-in-loop -- redirect hops are
   // inherently sequential: each hop's Location header depends on the
@@ -279,7 +326,7 @@ async function openStream({ url, headers, lookup, maxRedirects, insecureHttpHost
       }
     }
     // eslint-disable-next-line no-await-in-loop
-    const { res } = await requestOnce(currentUrl, { headers, lookup });
+    const { res } = await requestOnce(currentUrl, { headers, lookup, timeoutMs });
     if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
       res.resume(); // discard redirect body
       const location = res.headers.location;
@@ -316,7 +363,16 @@ function rehashPrefix(dest, resumeFrom, hash) {
   });
 }
 
-function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream }) {
+/**
+ * `timeoutMs`, if given, arms an idle watchdog (Fix 4, final-review fix
+ * wave) that resets on every `res` `"data"` event: if `timeoutMs` elapses
+ * with no bytes received, `fail()`s with a `DownloadTimeoutError` — the
+ * body-phase half of the two-phase mechanism `requestOnce`'s doc describes
+ * (this half is a plain JS timer, deliberately independent of Node's own
+ * socket-timeout event, which `requestOnce` disarms once headers arrive).
+ * `url` is passed through only for the error message.
+ */
+function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream, timeoutMs, url }) {
   return new Promise((resolvePromise, reject) => {
     const writeStream = createWriteStream(dest, {
       flags: resumeFrom > 0 ? "r+" : "w",
@@ -324,18 +380,35 @@ function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream 
     });
     let bytesDone = resumeFrom;
     let settled = false;
+    let idleTimer = null;
+
+    const clearIdleTimer = () => {
+      if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = null;
+      }
+    };
 
     const fail = (err) => {
       if (settled) return;
       settled = true;
+      clearIdleTimer();
       err.bytesDone = bytesDone;
       try { res.destroy(); } catch { /* already gone */ }
       try { writeStream.destroy(); } catch { /* already gone */ }
       reject(err);
     };
 
+    const resetIdleTimer = () => {
+      if (!timeoutMs) return;
+      clearIdleTimer();
+      idleTimer = setTimeout(() => fail(new DownloadTimeoutError(url, timeoutMs)), timeoutMs);
+    };
+    resetIdleTimer(); // start the clock immediately — a body that never sends a first byte is also a stall
+
     res.on("data", (chunk) => {
       if (settled) return;
+      resetIdleTimer();
       hash.update(chunk);
       bytesDone += chunk.length;
       const ok = writeStream.write(chunk);
@@ -361,6 +434,7 @@ function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream 
     res.on("end", () => {
       if (settled) return;
       settled = true;
+      clearIdleTimer();
       writeStream.end(() => resolvePromise({ bytesDone }));
     });
   });
@@ -385,13 +459,20 @@ function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream 
  *     requirement (default `[]` — https is mandatory everywhere in
  *     production). See `openStream` doc for why every hop is checked
  *     independently.
+ *   - `timeoutMs`: socket-idle timeout (final-review fix wave, Fix 4),
+ *     default `DEFAULT_DOWNLOAD_TIMEOUT_MS` (120s) — covers both a
+ *     connect/header-wait stall and a stalled body mid-stream (see
+ *     `DownloadTimeoutError`'s doc for the two-phase mechanism). Without
+ *     this, a dropped/black-holed TCP connection left the download's
+ *     promise (and everything awaiting it, including `enqueueDownload`'s
+ *     serial queue) unsettled forever.
  *
  * Returns `{ path, sha256, bytesDone }`. Throws `HostNotAllowedError`,
  * `DownloadProtocolError` (insecure protocol / bad redirect), `ChecksumError`
- * (dest already deleted), or `DiskFullError` (dest KEPT for resume) as
- * documented above; any other stream error is rethrown as-is with a
- * `.bytesDone` property attached so callers can journal progress before
- * propagating.
+ * (dest already deleted), `DiskFullError`, or `DownloadTimeoutError` (both
+ * dest KEPT for resume) as documented above; any other stream error is
+ * rethrown as-is with a `.bytesDone` property attached so callers can
+ * journal progress before propagating.
  */
 export async function fetchModelBlob({
   url,
@@ -403,6 +484,7 @@ export async function fetchModelBlob({
   maxRedirects = 5,
   createWriteStream = fsCreateWriteStream,
   insecureHttpHosts = [],
+  timeoutMs = DEFAULT_DOWNLOAD_TIMEOUT_MS,
 }) {
   assertNotSymlink(dest);
 
@@ -417,7 +499,7 @@ export async function fetchModelBlob({
   const headers = {};
   if (effectiveResumeFrom > 0) headers.Range = `bytes=${effectiveResumeFrom}-`;
 
-  const { res } = await openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts });
+  const { res } = await openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts, timeoutMs });
   const totalBytes = parseTotalBytes(res.headers, effectiveResumeFrom);
 
   let bytesDone;
@@ -428,6 +510,8 @@ export async function fetchModelBlob({
       resumeFrom: effectiveResumeFrom,
       hash,
       createWriteStream,
+      timeoutMs,
+      url,
       onBytes: (n) => {
         bytesDone = n;
         if (typeof onProgress === "function") onProgress({ bytesDone: n, totalBytes });
@@ -461,7 +545,9 @@ function modelsBlobDir(dir) {
  *
  * `baseUrl`, `lookup`, and `insecureHttpHosts` exist purely for tests —
  * production never sets them (real huggingface.co, real DNS, https
- * required everywhere).
+ * required everywhere). `timeoutMs` (Fix 4) passes through to
+ * `fetchModelBlob`'s socket-idle timeout — default `DEFAULT_DOWNLOAD_TIMEOUT_MS`
+ * unless overridden.
  */
 export async function downloadModel({
   modelId,
@@ -475,6 +561,7 @@ export async function downloadModel({
   createWriteStream,
   journalIntervalMs = 1000,
   insecureHttpHosts,
+  timeoutMs,
 }) {
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
   const blobDir = modelsBlobDir(dir);
@@ -527,6 +614,7 @@ export async function downloadModel({
       maxRedirects,
       createWriteStream,
       insecureHttpHosts,
+      timeoutMs,
       onProgress: wrappedOnProgress,
     });
     const s = loadState(dir);

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -132,6 +132,21 @@ export class DownloadProtocolError extends Error {
   }
 }
 
+/** Thrown by `registerModel` when a provider row already exists at the
+ * target id and was NOT registered by this native runtime for this catalog
+ * model — e.g. a user's cloud/bundle provider that happens to share the
+ * catalog's model id. Registration refuses to overwrite it: no upsert is
+ * attempted and no port reservation is left behind (the port is allocated
+ * AFTER this check passes, never before). */
+export class ProviderIdConflictError extends Error {
+  constructor(modelId) {
+    super(`A provider with id "${modelId}" already exists and was not registered by this native runtime for this model — refusing to overwrite it.`);
+    this.name = "ProviderIdConflictError";
+    this.code = "PROVIDER_ID_CONFLICT";
+    this.modelId = modelId;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Host allowlist
 // ---------------------------------------------------------------------------
@@ -740,6 +755,24 @@ export function pickChatMutexGroup(existingRows) {
  * `invalidateCacheFn`) default to the real implementations; tests use them
  * to observe call order without needing to intercept module internals.
  *
+ * Provider-id collision guard: `modelId` doubles as the provider row's `id`
+ * (see the section header comment), which means a user's own cloud/bundle
+ * provider could already occupy that id by coincidence — an unrelated row
+ * that this call must never clobber. BEFORE anything else (before even
+ * allocating a port, so a rejected call never leaks a reservation), any
+ * existing row at this id is checked for ownership: it's "ours" only if its
+ * `gpu_policy.runtime === "native"` AND its own `models[]` array already
+ * carries an entry for this catalog model's id (i.e. it's a row THIS
+ * registration path wrote, for THIS model — the row itself is the durable
+ * record, deliberately NOT the local, ephemeral `state.registry` map,
+ * which `unregisterModel` clears on every teardown; ownership must survive
+ * a register→unregister→re-register cycle on the same instance). Anything
+ * else (a foreign provider, or a native-tagged row for a different model)
+ * throws `ProviderIdConflictError` with the existing row completely
+ * untouched.
+ *
+ * @throws {ProviderIdConflictError} if a provider already exists at this id
+ *   and isn't a prior registration of this same model by this runtime.
  * @returns {Promise<object>} the registered provider row shape:
  *   `{ id, baseUrl, port, apiKey, host, bundleId, description, models,
  *      gpuPolicy, disabled, lamport_ts }`
@@ -758,6 +791,21 @@ export async function registerModel({
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
 
   const state = loadState(dir);
+
+  // Collision guard — read-only, runs BEFORE any state/DB mutation (in
+  // particular before allocatePortFn, so a rejected call leaves no
+  // reservation behind to clean up).
+  const existingRows = await listProvidersAllFn(db);
+  const existingRow = existingRows.find((r) => r.id === modelId);
+  if (existingRow) {
+    const isOurs = existingRow.gpuPolicy?.runtime === NATIVE_RUNTIME
+      && Array.isArray(existingRow.models)
+      && existingRow.models.some((m) => m && m.id === model.id);
+    if (!isOurs) {
+      throw new ProviderIdConflictError(modelId);
+    }
+  }
+
   const port = await allocatePortFn(state, modelId, { crowHome: dir, pid: process.pid });
   state.registry[modelId] = {
     file: sanitizeFilename(quantEntry.file),
@@ -769,8 +817,10 @@ export async function registerModel({
 
   const gpuPolicy = { runtime: NATIVE_RUNTIME };
   if (model.task === "chat") {
-    const existingRows = await listProvidersAllFn(db);
-    gpuPolicy.mutexGroup = pickChatMutexGroup(existingRows);
+    // Exclude this model's own (pre-existing, legitimate-re-register) row
+    // from the mutex-group count — it must never vote for its own group.
+    const otherRows = existingRows.filter((r) => r.id !== modelId);
+    gpuPolicy.mutexGroup = pickChatMutexGroup(otherRows);
   }
   // embed-class (and any other non-chat task): no mutexGroup key at all —
   // embedding servers don't contend for the chat mutex group.

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -1,0 +1,563 @@
+/**
+ * GGUF model download pipeline (Item G, native model runtime, Task 6).
+ *
+ * This is the first half of the "manager" module — downloads only. Task 7
+ * extends this same file with provider registration (turning a downloaded
+ * blob into a running llama.cpp provider row); the seam is deliberately
+ * kept clean: everything above `// --- provider registration (Task 7) ---`
+ * (not present yet) only ever touches the filesystem + `state.js`'s
+ * `journal` map, never the DB.
+ *
+ * Two layers:
+ *
+ *   - `fetchModelBlob()` — the raw download engine. Given a ready URL and a
+ *     destination path, it streams the response straight to disk (NEVER
+ *     buffered whole in memory), hashes incrementally with a single
+ *     `crypto.createHash("sha256")` fed from the same chunks as they're
+ *     written, follows redirects manually (checking the host allowlist on
+ *     EVERY hop, not just the first), and re-hashes an on-disk prefix from
+ *     scratch when resuming (a streaming hash object has no way to "resume"
+ *     — the only way to get a correct final digest after a partial file is
+ *     to re-feed the bytes already on disk into a fresh hash before
+ *     appending the rest). Knows nothing about `state.js` or catalogs.
+ *
+ *   - `downloadModel()` — the orchestrator. Resolves a catalog entry to a
+ *     URL + a sanitized on-disk destination, consults the journal (from
+ *     `state.js`) to decide whether this is a fresh download or a resume,
+ *     and journals progress (throttled) back through `loadState`/
+ *     `saveState` so a killed process can pick up where it left off. This
+ *     is the layer real callers (the model panel, Task 7's provider
+ *     registration) use.
+ *
+ * `enqueueDownload()` is a module-level serial queue over `downloadModel`:
+ * concurrency defaults to 1 and is honored up to a max of 2 via
+ * `CROW_MODEL_DL_CONCURRENCY` — GGUF downloads are multi-gigabyte and this
+ * host's disk/network don't benefit from more parallelism than that, and
+ * unbounded concurrency would let a chatty panel starve every download of
+ * bandwidth at once.
+ *
+ * `dir` is always injected by the caller (same convention as `state.js`:
+ * production passes `resolveDataDir()`, tests pass an `fs.mkdtempSync`
+ * scratch dir) — this module never guesses a path itself.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  createReadStream,
+  createWriteStream as fsCreateWriteStream,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  statSync,
+  truncateSync,
+  unlinkSync,
+} from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { basename, join } from "node:path";
+
+import { loadState, saveState } from "./state.js";
+
+// ---------------------------------------------------------------------------
+// Typed errors
+// ---------------------------------------------------------------------------
+
+/** Thrown when a URL (initial or any redirect hop) resolves to a host
+ * outside the allowlist — see `isAllowedHost`. */
+export class HostNotAllowedError extends Error {
+  constructor(hostname) {
+    super(`Host not allowed for model download: ${hostname}`);
+    this.name = "HostNotAllowedError";
+    this.code = "HOST_NOT_ALLOWED";
+    this.hostname = hostname;
+  }
+}
+
+/** Thrown when the completed download's sha256 does not match the
+ * catalog's `expectedSha`. The partial/completed file is deleted before
+ * this is thrown — a mismatched blob is never left on disk to be
+ * mistaken for a good one. */
+export class ChecksumError extends Error {
+  constructor(expectedSha, actualSha) {
+    super(`Checksum mismatch: expected ${expectedSha}, got ${actualSha}`);
+    this.name = "ChecksumError";
+    this.code = "CHECKSUM_MISMATCH";
+    this.expectedSha = expectedSha;
+    this.actualSha = actualSha;
+  }
+}
+
+/** Thrown when the write stream fails with ENOSPC. Unlike ChecksumError,
+ * the partial file is deliberately KEPT on disk so a later call can
+ * resume once space is freed. */
+export class DiskFullError extends Error {
+  constructor(cause) {
+    super("No space left on device while writing model file");
+    this.name = "DiskFullError";
+    this.code = "DISK_FULL";
+    if (cause) this.cause = cause;
+  }
+}
+
+/** Thrown when the resolved destination path already exists as a symlink
+ * (refuse to write/append through it — could point anywhere on the host),
+ * or when a catalog filename would resolve outside the injected models
+ * directory. */
+export class UnsafeDestinationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UnsafeDestinationError";
+    this.code = "UNSAFE_DESTINATION";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Host allowlist
+// ---------------------------------------------------------------------------
+
+const ALLOWED_HOST_EXACT = new Set(["huggingface.co"]);
+const ALLOWED_HOST_SUFFIXES = [".huggingface.co", ".hf.co"];
+
+/**
+ * True iff `hostname` is exactly "huggingface.co", a subdomain of
+ * huggingface.co, or a subdomain of hf.co. Suffix match requires a
+ * literal "." boundary — `String.endsWith(".huggingface.co")` — so
+ * "evilhuggingface.co" (no dot before the label) correctly fails; a bare
+ * "hf.co" apex also fails (only ".hf.co" is in the suffix list, "hf.co"
+ * itself is not in the exact set — intentional, matches the spec's
+ * allowlist literally).
+ */
+export function isAllowedHost(hostname) {
+  if (typeof hostname !== "string" || hostname.length === 0) return false;
+  const host = hostname.toLowerCase();
+  if (ALLOWED_HOST_EXACT.has(host)) return true;
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Hugging Face "resolve" download URL. `baseUrl` defaults to the
+ * real huggingface.co origin and is only ever overridden by tests (to
+ * point at a local fixture server while keeping the hostname text — and
+ * therefore the allowlist check — realistic). */
+export function buildDownloadUrl(hfRepo, file, baseUrl = "https://huggingface.co") {
+  return `${baseUrl}/${hfRepo}/resolve/main/${file}`;
+}
+
+/** Reduce a catalog filename to a safe, flat basename: no directories, no
+ * traversal. Catalog files are curated (Task 2's validator already gates
+ * them), but this is defense in depth — a destination path is always
+ * `<modelsDir>/<sanitizeFilename(file)>`, never anything the filename
+ * string itself could redirect elsewhere. */
+export function sanitizeFilename(name) {
+  const base = basename(String(name ?? ""));
+  if (!base || base === "." || base === "..") {
+    throw new UnsafeDestinationError(`Unsafe model filename: ${JSON.stringify(name)}`);
+  }
+  return base;
+}
+
+/** Look up a model + quant entry in a parsed model-catalog.json object.
+ * `quant` defaults to the model's `default_quant`. */
+export function resolveEntry(catalog, modelId, quant) {
+  const model = (catalog?.models || []).find((m) => m.id === modelId);
+  if (!model) throw new Error(`Unknown model id in catalog: ${modelId}`);
+  const quantId = quant || model.default_quant;
+  const quantEntry = (model.quants || []).find((q) => q.quant === quantId);
+  if (!quantEntry) throw new Error(`Unknown quant "${quantId}" for model ${modelId}`);
+  return { model, quantEntry };
+}
+
+function assertNotSymlink(dest) {
+  let st;
+  try {
+    st = lstatSync(dest);
+  } catch (err) {
+    if (err && err.code === "ENOENT") return;
+    throw err;
+  }
+  if (st.isSymbolicLink()) {
+    throw new UnsafeDestinationError(`Refusing to write through symlink at destination: ${dest}`);
+  }
+}
+
+function parseTotalBytes(headers, resumeFrom) {
+  const contentRange = headers["content-range"];
+  if (contentRange) {
+    const m = /\/(\d+)\s*$/.exec(String(contentRange));
+    if (m) return Number(m[1]);
+  }
+  const contentLength = headers["content-length"];
+  if (contentLength != null) return resumeFrom + Number(contentLength);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1: raw download engine
+// ---------------------------------------------------------------------------
+
+function requestOnce(urlStr, { headers, lookup }) {
+  return new Promise((resolvePromise, reject) => {
+    const urlObj = new URL(urlStr);
+    const transport = urlObj.protocol === "https:" ? https : http;
+    const req = transport.request(urlObj, { method: "GET", headers, lookup }, (res) => {
+      resolvePromise({ req, res });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/** Follow redirects manually, re-checking the host allowlist on every hop
+ * (including the first) before connecting. Returns the final 200/206
+ * response. `maxRedirects` bounds the number of redirect hops (not
+ * counting the initial request). */
+async function openStream({ url, headers, lookup, maxRedirects }) {
+  let currentUrl = url;
+  // eslint-disable-next-line no-await-in-loop -- redirect hops are
+  // inherently sequential: each hop's Location header depends on the
+  // previous response, and each hop must be allowlist-checked before the
+  // NEXT connection is made — parallelizing would defeat the check.
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const urlObj = new URL(currentUrl);
+    if (!isAllowedHost(urlObj.hostname)) {
+      throw new HostNotAllowedError(urlObj.hostname);
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const { res } = await requestOnce(currentUrl, { headers, lookup });
+    if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
+      res.resume(); // discard redirect body
+      const location = res.headers.location;
+      if (!location) {
+        throw new Error(`Redirect response (${res.statusCode}) with no Location header from ${currentUrl}`);
+      }
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+    if (res.statusCode !== 200 && res.statusCode !== 206) {
+      res.resume();
+      throw new Error(`Unexpected HTTP status ${res.statusCode} downloading ${currentUrl}`);
+    }
+    return { res, finalUrl: currentUrl };
+  }
+  throw new Error(`Too many redirects (> ${maxRedirects}) downloading ${url}`);
+}
+
+/** Re-hash the on-disk prefix `[0, resumeFrom)` of `dest` into `hash`
+ * (streamed, not buffered whole). Must run BEFORE any new bytes are
+ * appended — a streaming hash object has no "seek", so the only way to
+ * get a correct final digest is to replay the existing prefix through a
+ * fresh hash first. */
+function rehashPrefix(dest, resumeFrom, hash) {
+  if (resumeFrom <= 0) return Promise.resolve();
+  return new Promise((resolvePromise, reject) => {
+    const rs = createReadStream(dest, { start: 0, end: resumeFrom - 1 });
+    rs.on("data", (chunk) => hash.update(chunk));
+    rs.on("end", resolvePromise);
+    rs.on("error", reject);
+  });
+}
+
+function streamToFile({ res, dest, resumeFrom, hash, onBytes, createWriteStream }) {
+  return new Promise((resolvePromise, reject) => {
+    const writeStream = createWriteStream(dest, {
+      flags: resumeFrom > 0 ? "r+" : "w",
+      start: resumeFrom,
+    });
+    let bytesDone = resumeFrom;
+    let settled = false;
+
+    const fail = (err) => {
+      if (settled) return;
+      settled = true;
+      err.bytesDone = bytesDone;
+      try { res.destroy(); } catch { /* already gone */ }
+      try { writeStream.destroy(); } catch { /* already gone */ }
+      reject(err);
+    };
+
+    res.on("data", (chunk) => {
+      if (settled) return;
+      hash.update(chunk);
+      bytesDone += chunk.length;
+      const ok = writeStream.write(chunk);
+      onBytes(bytesDone);
+      if (!ok) {
+        res.pause();
+        writeStream.once("drain", () => res.resume());
+      }
+    });
+    res.on("error", fail);
+    res.on("aborted", () => fail(new Error("Download aborted by remote server")));
+    res.on("close", () => {
+      if (!settled && res.complete === false) {
+        fail(new Error("Connection closed before response completed"));
+      }
+    });
+
+    writeStream.on("error", (err) => {
+      if (err && err.code === "ENOSPC") fail(new DiskFullError(err));
+      else fail(err);
+    });
+
+    res.on("end", () => {
+      if (settled) return;
+      settled = true;
+      writeStream.end(() => resolvePromise({ bytesDone }));
+    });
+  });
+}
+
+/**
+ * Raw download engine: stream `url` to `dest`, hashing incrementally,
+ * honoring the host allowlist on every hop, resuming from `resumeFrom`
+ * bytes (re-hashing the on-disk prefix first) when given a nonzero
+ * `resumeFrom`. Never buffers the whole file in memory.
+ *
+ * Options:
+ *   - `lookup`: injected DNS resolver (Node's standard http/https request
+ *     option) — production leaves it unset (real DNS); tests pass one that
+ *     forces every hostname to 127.0.0.1 so allowlist tests can use real
+ *     hostnames (huggingface.co, evil.example.com, ...) against a local
+ *     fixture server with zero real network traffic.
+ *   - `createWriteStream`: injected write-stream factory, defaults to
+ *     `fs.createWriteStream` — tests override it to force an ENOSPC error
+ *     deterministically instead of actually filling the disk.
+ *
+ * Returns `{ path, sha256, bytesDone }`. Throws `HostNotAllowedError`,
+ * `ChecksumError` (dest already deleted), or `DiskFullError` (dest KEPT
+ * for resume) as documented above; any other stream error is rethrown
+ * as-is with a `.bytesDone` property attached so callers can journal
+ * progress before propagating.
+ */
+export async function fetchModelBlob({
+  url,
+  dest,
+  resumeFrom = 0,
+  expectedSha,
+  onProgress,
+  lookup,
+  maxRedirects = 5,
+  createWriteStream = fsCreateWriteStream,
+}) {
+  assertNotSymlink(dest);
+
+  const hash = createHash("sha256");
+  const onDiskSize = existsSync(dest) ? statSync(dest).size : 0;
+  const effectiveResumeFrom = Math.min(resumeFrom, onDiskSize);
+  if (effectiveResumeFrom > 0) {
+    truncateSync(dest, effectiveResumeFrom);
+    await rehashPrefix(dest, effectiveResumeFrom, hash);
+  }
+
+  const headers = {};
+  if (effectiveResumeFrom > 0) headers.Range = `bytes=${effectiveResumeFrom}-`;
+
+  const { res } = await openStream({ url, headers, lookup, maxRedirects });
+  const totalBytes = parseTotalBytes(res.headers, effectiveResumeFrom);
+
+  let bytesDone;
+  try {
+    ({ bytesDone } = await streamToFile({
+      res,
+      dest,
+      resumeFrom: effectiveResumeFrom,
+      hash,
+      createWriteStream,
+      onBytes: (n) => {
+        bytesDone = n;
+        if (typeof onProgress === "function") onProgress({ bytesDone: n, totalBytes });
+      },
+    }));
+  } catch (err) {
+    if (typeof err.bytesDone !== "number") err.bytesDone = bytesDone ?? effectiveResumeFrom;
+    throw err;
+  }
+
+  const sha256 = hash.digest("hex");
+  if (expectedSha && sha256.toLowerCase() !== String(expectedSha).toLowerCase()) {
+    try { unlinkSync(dest); } catch { /* best effort */ }
+    throw new ChecksumError(expectedSha, sha256);
+  }
+  return { path: dest, sha256, bytesDone };
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: catalog + journal orchestration
+// ---------------------------------------------------------------------------
+
+function modelsBlobDir(dir) {
+  return join(dir, "models", "blobs");
+}
+
+/**
+ * Download a model's quant file, journaling progress to `state.js` so a
+ * killed/restarted process can resume. See module doc for the full
+ * contract; `dir` is the injected CROW_HOME/data dir (never guessed).
+ *
+ * `baseUrl` and `lookup` exist purely for tests — production never sets
+ * them (real huggingface.co, real DNS).
+ */
+export async function downloadModel({
+  modelId,
+  quant,
+  dir,
+  catalog,
+  onProgress,
+  lookup,
+  baseUrl,
+  maxRedirects = 5,
+  createWriteStream,
+  journalIntervalMs = 1000,
+}) {
+  const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
+  const blobDir = modelsBlobDir(dir);
+  mkdirSync(blobDir, { recursive: true });
+  const dest = join(blobDir, sanitizeFilename(quantEntry.file));
+  assertNotSymlink(dest);
+
+  const url = baseUrl ? buildDownloadUrl(model.hf_repo, quantEntry.file, baseUrl) : buildDownloadUrl(model.hf_repo, quantEntry.file);
+  const expectedSha = quantEntry.sha256 || null;
+
+  const initialState = loadState(dir);
+  const existingEntry = initialState.journal[modelId];
+  const resumeFrom = existingEntry && existingEntry.url === url && existingEntry.dest === dest ? existingEntry.bytesDone || 0 : 0;
+  const startedAt = (existingEntry && existingEntry.url === url && existingEntry.dest === dest && existingEntry.startedAt) || new Date().toISOString();
+
+  // Seed/refresh the journal entry immediately, before any network I/O, so
+  // even an interruption in the first instant leaves a resumable record.
+  initialState.journal[modelId] = { url, dest, bytesDone: resumeFrom, expectedSha, startedAt };
+  saveState(dir, initialState);
+
+  // Persisting reloads state fresh each time (rather than reusing one
+  // in-memory object across the whole download) to minimize — though not
+  // fully eliminate — clobbering a concurrent download's journal entry
+  // when CROW_MODEL_DL_CONCURRENCY=2. state.json has no real locking; this
+  // is a known, accepted v1 limitation (matches state.js's own
+  // documented tradeoffs), not something this task solves.
+  const persistJournal = (bytesDone) => {
+    const s = loadState(dir);
+    s.journal[modelId] = { url, dest, bytesDone, expectedSha, startedAt };
+    saveState(dir, s);
+  };
+
+  let lastSave = Date.now();
+  const wrappedOnProgress = ({ bytesDone, totalBytes }) => {
+    if (typeof onProgress === "function") onProgress({ bytesDone, totalBytes });
+    const now = Date.now();
+    if (now - lastSave >= journalIntervalMs) {
+      lastSave = now;
+      persistJournal(bytesDone);
+    }
+  };
+
+  try {
+    const result = await fetchModelBlob({
+      url,
+      dest,
+      resumeFrom,
+      expectedSha,
+      lookup,
+      maxRedirects,
+      createWriteStream,
+      onProgress: wrappedOnProgress,
+    });
+    const s = loadState(dir);
+    delete s.journal[modelId];
+    saveState(dir, s);
+    return { path: result.path, sha256: result.sha256 };
+  } catch (err) {
+    if (err instanceof ChecksumError) {
+      // fetchModelBlob already deleted the bad file — the journal entry
+      // for it is equally stale, drop it rather than offering a "resume"
+      // that would just re-download from scratch anyway.
+      const s = loadState(dir);
+      delete s.journal[modelId];
+      saveState(dir, s);
+      throw err;
+    }
+    // Any other failure (host refused, interrupted connection, disk full,
+    // ...): flush the latest known bytesDone unconditionally, bypassing
+    // the throttle, so a subsequent call always resumes from an accurate
+    // point rather than losing up to journalIntervalMs of progress.
+    const bytesDone = typeof err.bytesDone === "number" ? err.bytesDone : resumeFrom;
+    persistJournal(bytesDone);
+    throw err;
+  }
+}
+
+/**
+ * Remove a downloaded model's blob (and its journal entry, if any) from
+ * `dir`. Task 7 extends this to also unregister the corresponding
+ * provider row; this task's version only ever touches the filesystem +
+ * `state.js`.
+ */
+export function deleteModel({ modelId, quant, dir, catalog }) {
+  const { quantEntry } = resolveEntry(catalog, modelId, quant);
+  const dest = join(modelsBlobDir(dir), sanitizeFilename(quantEntry.file));
+
+  let deleted = false;
+  try {
+    unlinkSync(dest);
+    deleted = true;
+  } catch (err) {
+    if (err && err.code !== "ENOENT") throw err;
+  }
+
+  const state = loadState(dir);
+  if (state.journal[modelId]) {
+    delete state.journal[modelId];
+    saveState(dir, state);
+  }
+
+  return { path: dest, deleted };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level serial download queue
+// ---------------------------------------------------------------------------
+
+const downloadQueue = [];
+let activeDownloads = 0;
+
+/** Concurrency for `enqueueDownload`: `CROW_MODEL_DL_CONCURRENCY`, clamped
+ * to [1, 2]. Non-numeric/missing/less-than-1 falls back to 1. */
+export function getDownloadConcurrency() {
+  const raw = Number.parseInt(process.env.CROW_MODEL_DL_CONCURRENCY, 10);
+  if (!Number.isFinite(raw) || raw < 1) return 1;
+  return Math.min(raw, 2);
+}
+
+function pumpDownloadQueue() {
+  while (activeDownloads < getDownloadConcurrency() && downloadQueue.length > 0) {
+    const job = downloadQueue.shift();
+    activeDownloads++;
+    downloadModel(job.params).then(
+      (result) => {
+        activeDownloads--;
+        job.resolve(result);
+        pumpDownloadQueue();
+      },
+      (err) => {
+        activeDownloads--;
+        job.reject(err);
+        pumpDownloadQueue();
+      },
+    );
+  }
+}
+
+/**
+ * Enqueue a `downloadModel(params)` call on the module-level serial queue.
+ * With the default concurrency of 1, two enqueued downloads never overlap
+ * — the second's HTTP request is not opened until the first has fully
+ * settled (resolved or rejected).
+ */
+export function enqueueDownload(params) {
+  return new Promise((resolvePromise, reject) => {
+    downloadQueue.push({ params, resolve: resolvePromise, reject });
+    pumpDownloadQueue();
+  });
+}

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -1,14 +1,15 @@
 /**
- * GGUF model download pipeline (Item G, native model runtime, Task 6).
+ * GGUF model download + registration pipeline (Item G, native model
+ * runtime, Tasks 6-7).
  *
- * This is the first half of the "manager" module — downloads only. Task 7
- * extends this same file with provider registration (turning a downloaded
- * blob into a running llama.cpp provider row); the seam is deliberately
- * kept clean: everything above `// --- provider registration (Task 7) ---`
- * (not present yet) only ever touches the filesystem + `state.js`'s
- * `journal` map, never the DB.
+ * Everything above `// --- provider registration (Task 7) ---` is the
+ * download engine (Task 6) — it only ever touches the filesystem +
+ * `state.js`'s `journal` map, never the DB. Below that marker, Task 7 turns
+ * a downloaded blob into a running llama.cpp provider row (`registerModel`),
+ * tears one down (`unregisterModel`), and answers "what points at this
+ * provider" for the delete-confirmation dialog (`providerBindings`).
  *
- * Two layers:
+ * Two layers (Task 6, downloads):
  *
  *   - `fetchModelBlob()` — the raw download engine. Given a ready URL and a
  *     destination path, it streams the response straight to disk (NEVER
@@ -61,7 +62,9 @@ import http from "node:http";
 import https from "node:https";
 import { basename, join } from "node:path";
 
-import { loadState, saveState } from "./state.js";
+import { allocatePort, loadState, releasePort, saveState } from "./state.js";
+import { disableProvider, listProvidersAll, upsertProvider } from "../../shared/providers-db.js";
+import { invalidateProvidersCache } from "../../shared/providers.js";
 
 // ---------------------------------------------------------------------------
 // Typed errors
@@ -629,4 +632,289 @@ export function enqueueDownload(params) {
     return tracked;
   }
   return promise;
+}
+
+// ---------------------------------------------------------------------------
+// --- provider registration (Task 7) ---
+// ---------------------------------------------------------------------------
+//
+// This section turns a downloaded GGUF into a running provider row and
+// tears it back down. Real-schema facts this code was written against
+// (`scripts/init-db.js`, `servers/shared/providers-db.js` — read those
+// files before changing any of this):
+//
+//   - `providers` has NO hard-delete helper — only `disableProvider(db, id)`
+//     (soft-delete: `disabled = 1`, preserves history for instance-sync).
+//     `unregisterModel`'s "delete provider row" step is therefore a soft
+//     delete, matching every other provider-removal path in this codebase
+//     (`unregisterProvidersByBundle`) rather than inventing a hard DELETE.
+//   - `providers.gpu_policy` is a TEXT column added by a later migration
+//     (`addColumnIfMissing`, not the original CREATE TABLE) holding a JSON
+//     blob — there is no dedicated "runtime" or "mutex_group" column, so
+//     "native" marking and the mutex group both ride inside that JSON, per
+//     the task spec's "no schema changes" constraint.
+//   - There is no `ai_profiles` or `bots` TABLE. AI chat profiles are a
+//     JSON array stored at `dashboard_settings.value` under
+//     `key = 'ai_profiles'` (see `servers/gateway/dashboard/settings/
+//     sections/llm/ai-profiles.js`); a pointer-mode profile carries
+//     `provider_id` (+ `model_id`) directly. Bots are rows in
+//     `pi_bot_defs(bot_id, display_name, definition, ...)` where
+//     `definition` is a JSON blob whose `models.default` / `models.escalation`
+//     / `fast_voice_model` fields hold `"<providerId>/<modelId>"` strings
+//     (see `servers/gateway/dashboard/panels/bot-builder/data-queries.js`
+//     `loadModelOptions` — it builds exactly that key shape). `providerBindings`
+//     below reads both real locations directly; there was no queryable
+//     `provider_id` column to join against for bots.
+//
+// A registered model's provider `id` is the catalog `modelId` itself (e.g.
+// "qwen3-4b") — stable, already namespaced by the curated catalog, and the
+// natural key `state.js`'s `registry` map and `reconcileOnBoot`'s
+// `listProviderRows().modelId` shaping both key off of.
+
+/** Runtime marker + provider id → catalog model id, unused elsewhere. */
+const NATIVE_RUNTIME = "native";
+
+/** Default mutex group for a chat-class native model when no existing
+ * enabled provider row (native or otherwise) already claims a chat-class
+ * mutex group to join. */
+const DEFAULT_CHAT_MUTEX_GROUP = "local-llm";
+
+/**
+ * A provider row (as returned by `listProvidersAll`) counts as a
+ * "chat-class member" of its mutex group when at least one of its `models[]`
+ * entries carries `task === "chat"`. Rows without a mutex group, disabled
+ * rows, and rows with no chat-tagged model entries are not counted.
+ */
+function isChatClassRow(row) {
+  return Array.isArray(row.models) && row.models.some((m) => m && m.task === "chat");
+}
+
+/**
+ * mutexGroup rule for a newly-registering chat-class model (spec verbatim):
+ * join the existing group with the most chat-class members; if no enabled
+ * provider row has any chat-class member in a group, fall back to
+ * `DEFAULT_CHAT_MUTEX_GROUP`. Ties keep the first group encountered in
+ * `existingRows` order (stable — `listProvidersAll` orders by
+ * `disabled ASC, id`, so ties resolve alphabetically by provider id).
+ * Pure function of the rows already in the registry — the row being
+ * registered is never included (call this BEFORE inserting it).
+ */
+export function pickChatMutexGroup(existingRows) {
+  const counts = new Map();
+  for (const row of existingRows) {
+    if (row.disabled) continue;
+    const group = row.gpuPolicy?.mutexGroup;
+    if (!group) continue;
+    if (!isChatClassRow(row)) continue;
+    counts.set(group, (counts.get(group) || 0) + 1);
+  }
+  let best = null;
+  let bestCount = 0;
+  for (const [group, count] of counts) {
+    if (count > bestCount) {
+      best = group;
+      bestCount = count;
+    }
+  }
+  return best || DEFAULT_CHAT_MUTEX_GROUP;
+}
+
+/**
+ * Register a downloaded model as a native-runtime provider row.
+ *
+ * Order (binding — later tasks' process supervisor depends on this exact
+ * sequence): allocate + bind-test the port → persist the reservation +
+ * registry entry to state.json → insert the provider row with its FINAL
+ * `base_url` (the port never changes after this point — no placeholder,
+ * no later "update base_url once the process is up") → invalidate the
+ * providers cache LAST, so no reader can observe a cache miss that
+ * refetches a still-mid-write row.
+ *
+ * The `dir`-scoped `state.registry[modelId]` entry this writes (`file`,
+ * `quant`, `catalogId`, `registeredAt`) is what lets `unregisterModel` find
+ * the on-disk blob to delete without needing a `catalog` argument of its
+ * own — the registry entry IS the durable record of which file this
+ * modelId's row corresponds to.
+ *
+ * Injectable seams (`allocatePortFn`/`listProvidersAllFn`/`upsertProviderFn`/
+ * `invalidateCacheFn`) default to the real implementations; tests use them
+ * to observe call order without needing to intercept module internals.
+ *
+ * @returns {Promise<object>} the registered provider row shape:
+ *   `{ id, baseUrl, port, apiKey, host, bundleId, description, models,
+ *      gpuPolicy, disabled, lamport_ts }`
+ */
+export async function registerModel({
+  modelId,
+  quant,
+  catalog,
+  db,
+  dir,
+  allocatePortFn = allocatePort,
+  listProvidersAllFn = listProvidersAll,
+  upsertProviderFn = upsertProvider,
+  invalidateCacheFn = invalidateProvidersCache,
+}) {
+  const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
+
+  const state = loadState(dir);
+  const port = await allocatePortFn(state, modelId, { crowHome: dir, pid: process.pid });
+  state.registry[modelId] = {
+    file: sanitizeFilename(quantEntry.file),
+    quant: quantEntry.quant,
+    catalogId: model.id,
+    registeredAt: new Date().toISOString(),
+  };
+  saveState(dir, state);
+
+  const gpuPolicy = { runtime: NATIVE_RUNTIME };
+  if (model.task === "chat") {
+    const existingRows = await listProvidersAllFn(db);
+    gpuPolicy.mutexGroup = pickChatMutexGroup(existingRows);
+  }
+  // embed-class (and any other non-chat task): no mutexGroup key at all —
+  // embedding servers don't contend for the chat mutex group.
+
+  const baseUrl = `http://127.0.0.1:${port}/v1`;
+  const models = [{ id: model.id, task: model.task, contextLen: model.context_len }];
+  const description = `${model.family} ${quantEntry.quant} (native)`;
+
+  const upserted = await upsertProviderFn(db, {
+    id: modelId,
+    baseUrl,
+    apiKey: null,
+    host: "local",
+    bundleId: null,
+    description,
+    models,
+    disabled: false,
+    providerType: "openai-compat",
+    gpuPolicy,
+  });
+
+  await invalidateCacheFn();
+
+  return {
+    id: modelId,
+    baseUrl,
+    port,
+    apiKey: null,
+    host: "local",
+    bundleId: null,
+    description,
+    models,
+    gpuPolicy,
+    disabled: false,
+    lamport_ts: upserted.lamport_ts,
+  };
+}
+
+/**
+ * Tear down a registered native model: stop its process (if a live runtime
+ * handle is given — no process supervisor exists yet as of Task 7, this is
+ * a forward-looking seam for the task that adds one), free its port
+ * reservation, delete its blob, soft-delete its provider row, and
+ * invalidate the providers cache. Order is binding (asserted via injected
+ * spies in tests) — each step only starts once the previous one has
+ * settled.
+ *
+ * `runtimeHandle`, if given, is duck-typed as `{ live: boolean, stop():
+ * Promise<void> }` — `stop()` is only called when `live` is truthy.
+ *
+ * Injectable seams mirror `registerModel`'s pattern.
+ *
+ * @returns {Promise<{ modelId, deleted: boolean, disabled: boolean }>}
+ */
+export async function unregisterModel({
+  modelId,
+  db,
+  dir,
+  runtimeHandle,
+  releasePortFn = releasePort,
+  unlinkFn = unlinkSync,
+  disableProviderFn = disableProvider,
+  invalidateCacheFn = invalidateProvidersCache,
+}) {
+  if (runtimeHandle && runtimeHandle.live) {
+    await runtimeHandle.stop();
+  }
+
+  const state = loadState(dir);
+  releasePortFn(state, modelId);
+  const regEntry = state.registry[modelId];
+  delete state.registry[modelId];
+  saveState(dir, state);
+
+  let deleted = false;
+  if (regEntry?.file) {
+    const dest = join(modelsBlobDir(dir), regEntry.file);
+    try {
+      unlinkFn(dest);
+      deleted = true;
+    } catch (err) {
+      if (err && err.code !== "ENOENT") throw err;
+    }
+  }
+
+  const result = await disableProviderFn(db, modelId);
+  await invalidateCacheFn();
+
+  return { modelId, deleted, disabled: !!result?.ok };
+}
+
+/**
+ * What currently points at provider `providerId`, for the delete
+ * confirmation ("this will break N profiles and M bots") dialog.
+ *
+ * Reads the two REAL locations that reference a provider id (see the
+ * section header comment above for why there is no `provider_id` column to
+ * query directly):
+ *   - `dashboard_settings` row keyed `'ai_profiles'` (JSON array; pointer-mode
+ *     entries carry `provider_id`).
+ *   - `pi_bot_defs.definition` (JSON per row; `models.default`,
+ *     `models.escalation`, `fast_voice_model` carry `"<providerId>/<modelId>"`).
+ *
+ * Missing table/row/malformed JSON in either location resolves to an empty
+ * list for that half rather than throwing — a fresh install with no
+ * `pi_bot_defs` table (MPA-only, per `bot-board/data-queries.js`) must still
+ * answer this query.
+ *
+ * @returns {Promise<{ profiles: Array<object>, bots: Array<{bot_id,display_name}> }>}
+ */
+export async function providerBindings(db, providerId) {
+  const profiles = [];
+  try {
+    const { rows } = await db.execute({
+      sql: "SELECT value FROM dashboard_settings WHERE key = 'ai_profiles'",
+      args: [],
+    });
+    const parsed = JSON.parse(rows[0]?.value || "[]");
+    if (Array.isArray(parsed)) {
+      for (const p of parsed) {
+        if (p && p.provider_id === providerId) profiles.push(p);
+      }
+    }
+  } catch {
+    /* no dashboard_settings row, or corrupt JSON -> no profile bindings found */
+  }
+
+  const bots = [];
+  try {
+    const { rows } = await db.execute({
+      sql: "SELECT bot_id, display_name, definition FROM pi_bot_defs",
+      args: [],
+    });
+    const prefix = `${providerId}/`;
+    for (const row of rows) {
+      let def;
+      try { def = JSON.parse(row.definition || "{}"); } catch { def = {}; }
+      const keys = [def?.models?.default, def?.models?.escalation, def?.fast_voice_model];
+      const bound = keys.some((k) => typeof k === "string" && k.startsWith(prefix));
+      if (bound) bots.push({ bot_id: row.bot_id, display_name: row.display_name });
+    }
+  } catch {
+    /* pi_bot_defs missing on this instance (primary gateway) -> no bot bindings */
+  }
+
+  return { profiles, bots };
 }

--- a/servers/gateway/models/native-lock.js
+++ b/servers/gateway/models/native-lock.js
@@ -1,0 +1,150 @@
+/**
+ * Advisory host-wide mutex for native llama.cpp runtime processes (Item G,
+ * Task 8). Two native models in the same `mutexGroup` (see
+ * `manager.js`'s `pickChatMutexGroup`) must never both hold the GPU at
+ * once; `acquireHostLock(mutexGroup)` is the primitive the process
+ * supervisor (`runtime.js`) and Task 9's gpu-orchestrator wiring use to
+ * serialize that.
+ *
+ * Design choice, documented honestly: Node has no built-in `flock(2)`
+ * binding, and this task adds no new npm dependency. Two ways to get an
+ * advisory lock without one:
+ *
+ *   1. Spawn the external `flock` CLI (util-linux) around the whole
+ *      critical section.
+ *   2. A PID lockfile created with the `wx` ("open, fail if it exists")
+ *      flag — the same `O_CREAT|O_EXCL` atomicity `flock(2)` itself is
+ *      built on, just addressed through the filesystem namespace instead
+ *      of a kernel lock table entry.
+ *
+ * (1) is Linux-only in practice — `flock` ships with util-linux, which is
+ * not present on macOS by default (a v1 target platform per the runtime
+ * catalog's darwin-arm64/darwin-x64 assets) — and it also only lets a
+ * *whole external command* hold the lock for its lifetime, which doesn't
+ * fit this module's "acquire now, release later from arbitrary code"
+ * shape (the caller starts a long-lived llama-server child in between).
+ * (2) works identically on every POSIX platform Node runs on with zero
+ * new dependencies, so that's what this module implements.
+ *
+ * Same caveat as `flock(2)` itself applies: this is *advisory* — nothing
+ * stops another process from deleting or ignoring the lockfile. It only
+ * protects cooperating callers (every native-runtime caller in this
+ * codebase goes through `acquireHostLock`).
+ *
+ * Path: `$XDG_RUNTIME_DIR/crow-native-llm-<mutexGroup>.lock`, falling back
+ * to the OS tmpdir when `XDG_RUNTIME_DIR` is unset (headless/systemd
+ * services, some containers). Never `~/.crow/...` — this lock is a
+ * host-level resource, not per-instance state.
+ */
+
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+/** True if a process with this pid appears to be alive on this host. A
+ * `kill(pid, 0)` that succeeds, or fails with EPERM (exists but owned by
+ * someone else), both count as "alive" — only ESRCH ("no such process")
+ * means it's genuinely gone and the lock it left behind is stale. */
+function defaultIsProcessAlive(pid) {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === "EPERM";
+  }
+}
+
+/** Directory the lockfile lives in: `opts.runtimeDir`, else
+ * `$XDG_RUNTIME_DIR`, else the OS tmpdir. Exported so callers/tests can
+ * predict the path without duplicating the fallback rule. */
+export function lockDirFor(opts = {}) {
+  return opts.runtimeDir || process.env.XDG_RUNTIME_DIR || tmpdir();
+}
+
+/** Full path to `mutexGroup`'s lockfile under `lockDirFor(opts)`. */
+export function lockPathFor(mutexGroup, opts = {}) {
+  return join(lockDirFor(opts), `crow-native-llm-${mutexGroup}.lock`);
+}
+
+function readLockPid(fs, path) {
+  try {
+    const raw = fs.readFileSync(path, "utf8");
+    const pid = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attempt to acquire the advisory host lock for `mutexGroup`.
+ *
+ * Returns a `release()` function on success, or `null` if the lock is
+ * currently held elsewhere by a live owner (never blocks — this is a
+ * non-blocking `flock(LOCK_EX | LOCK_NB)` equivalent). A lockfile left
+ * behind by a dead owner (pid no longer alive, or unreadable/corrupt
+ * content — either way its liveness can't be confirmed) is treated as
+ * stale and stolen rather than honored forever.
+ *
+ * @param {string} mutexGroup
+ * @param {{runtimeDir?: string, pid?: number, isProcessAlive?: (pid:number)=>boolean, fs?: object}} [opts]
+ *   `fs`/`pid`/`isProcessAlive` are injectable for tests; production uses
+ *   the real `node:fs`, `process.pid`, and a real liveness check.
+ * @returns {(() => void) | null}
+ */
+export function acquireHostLock(mutexGroup, opts = {}) {
+  const {
+    fs = { existsSync, mkdirSync, openSync, closeSync, writeSync, readFileSync, unlinkSync },
+    pid = process.pid,
+    isProcessAlive = defaultIsProcessAlive,
+  } = opts;
+  const lockPath = lockPathFor(mutexGroup, opts);
+  fs.mkdirSync(dirname(lockPath), { recursive: true });
+
+  const tryCreate = () => {
+    let fd;
+    try {
+      fd = fs.openSync(lockPath, "wx");
+    } catch (err) {
+      if (err && err.code === "EEXIST") return false;
+      throw err;
+    }
+    try {
+      fs.writeSync(fd, String(pid));
+    } finally {
+      fs.closeSync(fd);
+    }
+    return true;
+  };
+
+  let created = tryCreate();
+  if (!created) {
+    const existingPid = readLockPid(fs, lockPath);
+    if (existingPid != null && isProcessAlive(existingPid)) {
+      return null; // held elsewhere by a live owner
+    }
+    // Stale (dead owner, or unreadable/corrupt content) — steal it.
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      /* already gone */
+    }
+    created = tryCreate();
+    if (!created) return null; // lost a race with another stealer
+  }
+
+  let released = false;
+  return function release() {
+    if (released) return;
+    released = true;
+    // Only remove the file if it still identifies us — a defensive check
+    // against removing a lock some other steal race already replaced.
+    try {
+      const currentPid = readLockPid(fs, lockPath);
+      if (currentPid === pid) fs.unlinkSync(lockPath);
+    } catch {
+      /* already gone */
+    }
+  };
+}

--- a/servers/gateway/models/native-lock.js
+++ b/servers/gateway/models/native-lock.js
@@ -29,7 +29,19 @@
  * Same caveat as `flock(2)` itself applies: this is *advisory* — nothing
  * stops another process from deleting or ignoring the lockfile. It only
  * protects cooperating callers (every native-runtime caller in this
- * codebase goes through `acquireHostLock`).
+ * codebase goes through `acquireHostLock`). The stale-lock steal (see
+ * `stealStaleLock` below) is rename-atomic — see its doc for the TOCTOU
+ * this guards against — but a lock is still just a cooperative signal:
+ * two uncoordinated processes that both bypass `acquireHostLock` entirely
+ * (or a lock whose file was manually deleted from outside this module)
+ * are not prevented from colliding by anything in this file. The REAL
+ * backstops against two llama-server processes actually fighting over
+ * the same GPU/port are one layer up in `runtime.js`: `identityProbe`
+ * (never trusts a port as "ours" without confirming what it's actually
+ * serving) and `state.js`'s `allocatePort` bind-test (never trusts a
+ * port reservation without confirming the OS will actually let it bind).
+ * This lock is a fast-path optimization to avoid contending for those in
+ * the common case, not the sole correctness mechanism.
  *
  * Path: `$XDG_RUNTIME_DIR/crow-native-llm-<mutexGroup>.lock`, falling back
  * to the OS tmpdir when `XDG_RUNTIME_DIR` is unset (headless/systemd
@@ -37,7 +49,7 @@
  * host-level resource, not per-instance state.
  */
 
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -77,6 +89,85 @@ function readLockPid(fs, path) {
   }
 }
 
+function randomSuffix() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Discard a stale lockfile at `lockPath`, rename-atomic — this is the fix
+ * for a real two-process TOCTOU a reviewer reproduced against an earlier
+ * version of this module that did a bare, unconditional `unlinkSync`:
+ *
+ *   1. Racers A and B both find the SAME lock stale (dead owner pid) and
+ *      both decide to steal it.
+ *   2. A unlinks the stale file, then (successfully, via its own
+ *      O_CREAT|O_EXCL `tryCreate`) writes its OWN fresh lock at the same
+ *      path.
+ *   3. B — still mid-steal, unaware A already finished — unlinks
+ *      `lockPath` AGAIN. `unlinkSync` doesn't check *whose* file is
+ *      there; it just removes whatever currently exists. B has just
+ *      destroyed A's live lock without A knowing.
+ *   4. B creates its own fresh lock. Now BOTH A and B believe they hold
+ *      the mutex.
+ *
+ * The fix: instead of blindly unlinking, atomically CLAIM the file via
+ * `renameSync(lockPath, <private staging path>)`. `rename(2)` on the same
+ * source path can only succeed for exactly one caller — every other
+ * concurrent renamer targeting that same source gets `ENOENT` once the
+ * winner's rename has completed, and simply gives up (falls through to
+ * `acquireHostLock`'s own subsequent `tryCreate()`, which will correctly
+ * fail if the winner has since created their new lock, or correctly
+ * succeed into a genuinely free slot if the winner's own steal is what
+ * emptied it).
+ *
+ * The winner still isn't done: `rename` is atomic but content-blind — if
+ * some OTHER process had already recreated a live, unrelated lock at
+ * `lockPath` between this caller's earlier staleness read and this
+ * rename call, the winner would have just yanked THAT away by accident.
+ * So after winning the rename, re-read the staged copy and compare its
+ * pid against `existingPid` (the pid this caller observed as stale
+ * earlier, passed in). A match confirms it's genuinely the same stale
+ * file — discard it. A mismatch means this caller almost stole a live
+ * lock out from under its legitimate new owner — rename it straight back
+ * rather than destroy it, and let the subsequent `tryCreate()` correctly
+ * fail against that restored, legitimate lock.
+ *
+ * Exported for direct testing of this specific race (see
+ * `tests/models-runtime.test.js`) — the interleaving above can't be
+ * reliably forced through the public `acquireHostLock` entry point alone
+ * since a real re-read there always reflects "whatever is on disk right
+ * now", not "what a racer believed a moment ago".
+ */
+export function stealStaleLock({ fs, lockPath, existingPid }) {
+  const stagingPath = `${lockPath}.steal.${randomSuffix()}`;
+  try {
+    fs.renameSync(lockPath, stagingPath);
+  } catch (err) {
+    if (err && err.code === "ENOENT") return; // another racer already claimed/cleared it
+    throw err;
+  }
+  const stagedPid = readLockPid(fs, stagingPath);
+  if (stagedPid === existingPid) {
+    // Genuinely the same stale file we decided to steal from — discard it,
+    // freeing lockPath for a fresh O_CREAT|O_EXCL create.
+    try {
+      fs.unlinkSync(stagingPath);
+    } catch {
+      /* already gone */
+    }
+  } else {
+    // We accidentally captured a DIFFERENT (fresh/live) lock that was
+    // (re)created between our staleness read and this rename — put it
+    // back rather than clobber its legitimate owner.
+    try {
+      fs.renameSync(stagingPath, lockPath);
+    } catch {
+      /* best-effort restore; if this also fails there's nothing more we
+       * can safely do from here without risking a second collision */
+    }
+  }
+}
+
 /**
  * Attempt to acquire the advisory host lock for `mutexGroup`.
  *
@@ -85,7 +176,8 @@ function readLockPid(fs, path) {
  * non-blocking `flock(LOCK_EX | LOCK_NB)` equivalent). A lockfile left
  * behind by a dead owner (pid no longer alive, or unreadable/corrupt
  * content — either way its liveness can't be confirmed) is treated as
- * stale and stolen rather than honored forever.
+ * stale and stolen (via `stealStaleLock`, rename-atomic — see its doc)
+ * rather than honored forever.
  *
  * @param {string} mutexGroup
  * @param {{runtimeDir?: string, pid?: number, isProcessAlive?: (pid:number)=>boolean, fs?: object}} [opts]
@@ -95,7 +187,7 @@ function readLockPid(fs, path) {
  */
 export function acquireHostLock(mutexGroup, opts = {}) {
   const {
-    fs = { existsSync, mkdirSync, openSync, closeSync, writeSync, readFileSync, unlinkSync },
+    fs = { existsSync, mkdirSync, openSync, closeSync, writeSync, readFileSync, unlinkSync, renameSync },
     pid = process.pid,
     isProcessAlive = defaultIsProcessAlive,
   } = opts;
@@ -124,14 +216,14 @@ export function acquireHostLock(mutexGroup, opts = {}) {
     if (existingPid != null && isProcessAlive(existingPid)) {
       return null; // held elsewhere by a live owner
     }
-    // Stale (dead owner, or unreadable/corrupt content) — steal it.
-    try {
-      fs.unlinkSync(lockPath);
-    } catch {
-      /* already gone */
-    }
+    // Stale (dead owner, or unreadable/corrupt content) — steal it, then
+    // race a fresh create the same way the very first attempt did. The
+    // final tryCreate() is itself O_CREAT|O_EXCL-atomic, so no matter how
+    // stealStaleLock resolved (won/lost/aborted-and-restored), at most one
+    // concurrent caller ever ends up holding the lock.
+    stealStaleLock({ fs, lockPath, existingPid });
     created = tryCreate();
-    if (!created) return null; // lost a race with another stealer
+    if (!created) return null; // someone else's create won the re-race
   }
 
   let released = false;

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -1,0 +1,793 @@
+/**
+ * llama.cpp binary asset management + llama-server child supervision
+ * (Item G, native model runtime, Task 8).
+ *
+ * Two layers:
+ *
+ *   - Asset layer (`resolveAsset`, `ensureRuntime`): turns a hardware probe
+ *     (`servers/gateway/models/probe.js` shapes) plus the catalog's
+ *     `runtime` block (`registry/model-catalog.json`) into a downloaded,
+ *     checksum-verified, executable `llama-server` binary on disk under
+ *     `<dir>/runtimes/llamacpp/<release>/`. Runtime binaries ship from
+ *     github.com/ggml-org/llama.cpp releases — a DIFFERENT host allowlist
+ *     from `manager.js`'s huggingface.co-only GGUF allowlist, so this
+ *     module owns its own (`isAllowedRuntimeHost`) rather than importing
+ *     `manager.js`'s (which is hardcoded to HF and not injectable). The
+ *     redirect-following / streaming-hash / typed-error PATTERN mirrors
+ *     `manager.js`'s `fetchModelBlob` deliberately, minus resume support:
+ *     runtime archives are tens of MB (not the multi-GB GGUF files
+ *     `manager.js` handles), so a killed download just restarts rather
+ *     than resuming.
+ *
+ *   - Process layer (`startModel`, `stopModel`, `identityProbe`): spawns
+ *     and supervises the `llama-server` child (own process group, restart
+ *     with backoff, idle-timeout auto-stop, status snapshot for the
+ *     panel), and answers "is the model this port is *actually* serving
+ *     the one we think it is" for boot-time reconciliation.
+ *
+ * `dir` is always caller-injected (same convention as `state.js` and
+ * `manager.js`) — never a hardcoded `~/.crow/...`.
+ */
+
+import { createHash } from "node:crypto";
+import { execFileSync as execFileSyncNode, spawn as spawnCb } from "node:child_process";
+import {
+  chmodSync,
+  createWriteStream as fsCreateWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Typed errors
+// ---------------------------------------------------------------------------
+
+/** Thrown by `resolveAsset` (wrapped in its `{ error }` return, never
+ * thrown directly by that function — see its doc) for every "can't
+ * honestly pick an asset" case: unsupported platform/arch, no catalog
+ * entry for the resolved key, or glibc too old for every candidate.
+ * `code` is one of UNSUPPORTED_PLATFORM | NO_ASSET | GLIBC_TOO_OLD. */
+export class RuntimeAssetError extends Error {
+  constructor(message, code, details = {}) {
+    super(message);
+    this.name = "RuntimeAssetError";
+    this.code = code;
+    Object.assign(this, details);
+  }
+}
+
+/** Thrown when a runtime-asset URL (initial or any redirect hop) resolves
+ * to a host outside {@link isAllowedRuntimeHost}. */
+export class RuntimeHostNotAllowedError extends Error {
+  constructor(hostname) {
+    super(`Host not allowed for runtime asset download: ${hostname}`);
+    this.name = "RuntimeHostNotAllowedError";
+    this.code = "HOST_NOT_ALLOWED";
+    this.hostname = hostname;
+  }
+}
+
+/** Thrown when a downloaded archive's sha256 does not match the catalog's
+ * declared value. The partial file is deleted before this is thrown — a
+ * mismatched archive is never left on disk, never extracted, and never
+ * chmod+x'd. */
+export class RuntimeChecksumError extends Error {
+  constructor(expectedSha, actualSha) {
+    super(`Runtime asset checksum mismatch: expected ${expectedSha}, got ${actualSha}`);
+    this.name = "RuntimeChecksumError";
+    this.code = "CHECKSUM_MISMATCH";
+    this.expectedSha = expectedSha;
+    this.actualSha = actualSha;
+  }
+}
+
+/** Mirrors `manager.js`'s `DownloadProtocolError`: a non-https hop that
+ * isn't explicitly test-escaped, a redirect with no Location header, or
+ * exceeding the redirect cap. */
+export class RuntimeDownloadProtocolError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = "RuntimeDownloadProtocolError";
+    this.code = code;
+  }
+}
+
+/** Thrown when extraction completed but no file named `binaryName` was
+ * found anywhere under the release directory — a corrupt/unexpected
+ * archive layout. */
+export class RuntimeExtractionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "RuntimeExtractionError";
+    this.code = "EXTRACTION_FAILED";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// glibc parsing (pure — mirrors probe.js's exported-pure-parser convention)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the glibc version out of `ldd --version` output. Both the vanilla
+ * GNU output ("ldd (GNU libc) 2.35") and Debian/Ubuntu's patched form
+ * ("ldd (Ubuntu GLIBC 2.35-0ubuntu3.8) 2.35") end their first line with
+ * the bare "MAJOR.MINOR" — the regex anchors on that trailing token
+ * rather than the first number seen, since the parenthetical package
+ * string can itself contain a version-shaped number before it.
+ * Returns `{ major, minor }` or `null` if unparseable/empty.
+ */
+export function parseGlibcVersion(lddOutput) {
+  if (!lddOutput) return null;
+  const firstLine = String(lddOutput).split("\n")[0] || "";
+  const m = /(\d+)\.(\d+)\s*$/.exec(firstLine.trim());
+  if (!m) return null;
+  return { major: Number.parseInt(m[1], 10), minor: Number.parseInt(m[2], 10) };
+}
+
+/** True iff `actual` ({major,minor}, possibly null) satisfies `required`
+ * (a "MAJOR.MINOR" string from the catalog, e.g. "2.34"). Missing/
+ * unparseable `actual` never satisfies anything — undetectable is not
+ * "assume it's fine", matching `probe.js`'s fail-closed fit-badge stance. */
+export function glibcAtLeast(actual, required) {
+  if (!actual || !required) return false;
+  const parts = String(required).split(".").map((n) => Number.parseInt(n, 10));
+  const reqMajor = parts[0];
+  const reqMinor = parts[1] || 0;
+  if (actual.major !== reqMajor) return actual.major > reqMajor;
+  return actual.minor >= reqMinor;
+}
+
+// ---------------------------------------------------------------------------
+// resolveAsset
+// ---------------------------------------------------------------------------
+
+const LINUX_VULKAN_KEY = "linux-x64-vulkan";
+const LINUX_CPU_KEY = "linux-x64-cpu";
+const DEFAULT_RUNTIME_BASE_URL = "https://github.com/ggml-org/llama.cpp";
+
+/** Build a GitHub release-asset download URL. `baseUrl` defaults to the
+ * real llama.cpp repo origin; tests override it to point at a local
+ * fixture server while keeping the literal "github.com" hostname (and
+ * therefore the allowlist check) realistic — see `manager.js`'s
+ * `buildDownloadUrl` for the identical pattern. */
+export function buildRuntimeDownloadUrl(release, file, baseUrl = DEFAULT_RUNTIME_BASE_URL) {
+  return `${baseUrl}/releases/download/${release}/${file}`;
+}
+
+/**
+ * Pick which catalog `runtime.assets` entry to install for this host,
+ * honestly — never a guess. Pure/synchronous: every external fact
+ * (`ldd --version` output, CPU architecture) is passed in via `opts`
+ * rather than probed here, so this is unit-testable without a real host.
+ *
+ * Rules (spec verbatim):
+ *   - `probe.platform` outside {"linux","darwin"} -> `UNSUPPORTED_PLATFORM`.
+ *   - darwin: arch (from `opts.arch`, else `probe.arch`, else
+ *     `process.arch` — `Probe` itself carries no arch field, hardware
+ *     probing doesn't need one since it's a build-time host fact, not
+ *     something requiring detection) picks darwin-arm64/darwin-x64; an
+ *     arch that's neither -> `UNSUPPORTED_PLATFORM`.
+ *   - linux + `probe.wsl2 === true` -> forces the cpu asset REGARDLESS of
+ *     `probe.accel` — defense in depth on top of `probe.js` already
+ *     forcing `accel:"cpu"` under WSL2 (this function never trusts accel
+ *     alone for the wsl2 case, in case a probe object reaches here from
+ *     somewhere that didn't apply that rule).
+ *   - linux, not wsl2, `accel` in {"vulkan","cuda"}: try the vulkan asset
+ *     (the only GPU-accelerated linux build the catalog ships — llama.cpp's
+ *     Vulkan backend also runs on NVIDIA hardware, so a "cuda" probe result
+ *     still resolves to the vulkan asset). Requires
+ *     `glibcAtLeast(parseGlibcVersion(opts.lddOutput), asset.min_glibc)`;
+ *     if that fails (too old, OR undetectable — unparseable/missing
+ *     `opts.lddOutput` is treated the same as "too old" here: an unproven
+ *     minimum is never assumed met), falls through to the cpu asset below
+ *     rather than failing outright.
+ *   - cpu asset: also glibc-gated (the catalog declares `min_glibc` on
+ *     the cpu asset too). If the host doesn't meet even the cpu asset's
+ *     requirement, that's `GLIBC_TOO_OLD` — an honest error, never a guess.
+ *
+ * @returns {{key:string,url:string,sha256:string}|{error:RuntimeAssetError}}
+ */
+export function resolveAsset(probe, runtimeBlock, opts = {}) {
+  const assets = (runtimeBlock && runtimeBlock.assets) || {};
+  const release = runtimeBlock && runtimeBlock.release;
+  const { lddOutput, arch, baseUrl } = opts;
+
+  if (!probe || (probe.platform !== "linux" && probe.platform !== "darwin")) {
+    return {
+      error: new RuntimeAssetError(
+        `Unsupported platform for native runtime: ${probe && probe.platform}`,
+        "UNSUPPORTED_PLATFORM",
+        { platform: probe && probe.platform },
+      ),
+    };
+  }
+
+  if (probe.platform === "darwin") {
+    const effectiveArch = arch || probe.arch || process.arch;
+    const key = effectiveArch === "arm64" ? "darwin-arm64" : effectiveArch === "x64" ? "darwin-x64" : null;
+    if (!key) {
+      return {
+        error: new RuntimeAssetError(
+          `Unsupported darwin architecture: ${effectiveArch}`,
+          "UNSUPPORTED_PLATFORM",
+          { platform: "darwin", arch: effectiveArch },
+        ),
+      };
+    }
+    const asset = assets[key];
+    if (!asset) {
+      return { error: new RuntimeAssetError(`No runtime asset for "${key}" in catalog`, "NO_ASSET", { key }) };
+    }
+    return { key, url: buildRuntimeDownloadUrl(release, asset.file, baseUrl), sha256: asset.sha256 };
+  }
+
+  // linux
+  const forceCpu = probe.wsl2 === true;
+  const wantsGpu = !forceCpu && (probe.accel === "vulkan" || probe.accel === "cuda");
+
+  if (wantsGpu) {
+    const vkAsset = assets[LINUX_VULKAN_KEY];
+    if (!vkAsset) {
+      return { error: new RuntimeAssetError(`No runtime asset for "${LINUX_VULKAN_KEY}" in catalog`, "NO_ASSET", { key: LINUX_VULKAN_KEY }) };
+    }
+    if (glibcAtLeast(parseGlibcVersion(lddOutput), vkAsset.min_glibc)) {
+      return { key: LINUX_VULKAN_KEY, url: buildRuntimeDownloadUrl(release, vkAsset.file, baseUrl), sha256: vkAsset.sha256 };
+    }
+    // Too old (or undetectable) for the GPU build — fall through to cpu.
+  }
+
+  const cpuAsset = assets[LINUX_CPU_KEY];
+  if (!cpuAsset) {
+    return { error: new RuntimeAssetError(`No runtime asset for "${LINUX_CPU_KEY}" in catalog`, "NO_ASSET", { key: LINUX_CPU_KEY }) };
+  }
+  if (cpuAsset.min_glibc && !glibcAtLeast(parseGlibcVersion(lddOutput), cpuAsset.min_glibc)) {
+    return {
+      error: new RuntimeAssetError(
+        `glibc too old for any linux runtime asset (need >= ${cpuAsset.min_glibc})`,
+        "GLIBC_TOO_OLD",
+        { required: cpuAsset.min_glibc, detected: parseGlibcVersion(lddOutput) },
+      ),
+    };
+  }
+  return { key: LINUX_CPU_KEY, url: buildRuntimeDownloadUrl(release, cpuAsset.file, baseUrl), sha256: cpuAsset.sha256 };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime asset download (own allowlist — see module doc)
+// ---------------------------------------------------------------------------
+
+const RUNTIME_ALLOWED_HOSTS = new Set(["github.com", "objects.githubusercontent.com"]);
+
+/** True iff `hostname` is exactly "github.com" or "objects.githubusercontent.com"
+ * (GitHub's release-asset redirect target). No subdomain wildcarding —
+ * these are the two literal hosts a llama.cpp release download hits. */
+export function isAllowedRuntimeHost(hostname) {
+  if (typeof hostname !== "string" || hostname.length === 0) return false;
+  return RUNTIME_ALLOWED_HOSTS.has(hostname.toLowerCase());
+}
+
+function requestOnce(urlStr, { lookup }) {
+  return new Promise((resolvePromise, reject) => {
+    const urlObj = new URL(urlStr);
+    const transport = urlObj.protocol === "https:" ? https : http;
+    const req = transport.request(urlObj, { method: "GET", lookup }, (res) => resolvePromise({ res }));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/** Follow redirects manually, re-checking the host allowlist AND the
+ * https-only requirement on every hop (see `manager.js`'s `openStream`
+ * for why every hop, not just the first). `insecureHttpHosts` is the
+ * same test-only escape as `manager.js` (default `[]` — https required
+ * everywhere in production). */
+async function openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts = [] }) {
+  let currentUrl = url;
+  // eslint-disable-next-line no-await-in-loop -- sequential by nature, see manager.js's identical loop.
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    const urlObj = new URL(currentUrl);
+    if (!isAllowedRuntimeHost(urlObj.hostname)) {
+      throw new RuntimeHostNotAllowedError(urlObj.hostname);
+    }
+    if (urlObj.protocol !== "https:") {
+      const escaped = urlObj.protocol === "http:" && insecureHttpHosts.includes(urlObj.hostname);
+      if (!escaped) {
+        throw new RuntimeDownloadProtocolError(
+          `Refusing non-https URL (${urlObj.protocol}) for host ${urlObj.hostname} — pass insecureHttpHosts to explicitly allow this host (tests only; never set in production)`,
+          "INSECURE_PROTOCOL",
+        );
+      }
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const { res } = await requestOnce(currentUrl, { lookup });
+    if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
+      res.resume();
+      const location = res.headers.location;
+      if (!location) {
+        throw new RuntimeDownloadProtocolError(`Redirect response (${res.statusCode}) with no Location header from ${currentUrl}`, "REDIRECT_NO_LOCATION");
+      }
+      currentUrl = new URL(location, currentUrl).toString();
+      continue;
+    }
+    if (res.statusCode !== 200) {
+      res.resume();
+      throw new Error(`Unexpected HTTP status ${res.statusCode} downloading ${currentUrl}`);
+    }
+    return res;
+  }
+  throw new RuntimeDownloadProtocolError(`Too many redirects (> ${maxRedirects}) downloading ${url}`, "TOO_MANY_REDIRECTS");
+}
+
+/**
+ * Download a runtime asset archive to `dest`, hashing incrementally
+ * (never buffered whole in memory) and verifying against `expectedSha`
+ * BEFORE returning. On mismatch, the partial/completed file is deleted
+ * and `RuntimeChecksumError` is thrown — never left on disk to be
+ * mistaken for a good one, and never reaches `ensureRuntime`'s
+ * extract/chmod steps. No resume support (see module doc for why).
+ */
+export async function downloadRuntimeAsset({
+  url,
+  dest,
+  expectedSha,
+  lookup,
+  maxRedirects = 5,
+  createWriteStream = fsCreateWriteStream,
+  insecureHttpHosts = [],
+}) {
+  const res = await openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts });
+  const hash = createHash("sha256");
+  await new Promise((resolvePromise, reject) => {
+    const ws = createWriteStream(dest);
+    let settled = false;
+    const fail = (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+    res.on("data", (chunk) => hash.update(chunk));
+    res.on("error", fail);
+    ws.on("error", fail);
+    res.pipe(ws);
+    ws.on("finish", () => {
+      if (settled) return;
+      settled = true;
+      resolvePromise();
+    });
+  });
+
+  const sha256 = hash.digest("hex");
+  if (expectedSha && sha256.toLowerCase() !== String(expectedSha).toLowerCase()) {
+    try {
+      unlinkSync(dest);
+    } catch {
+      /* best effort */
+    }
+    throw new RuntimeChecksumError(expectedSha, sha256);
+  }
+  return { path: dest, sha256 };
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/** Extract a `.tar.gz` runtime archive with the system `tar` binary (no
+ * new npm dependency — Node has no built-in tar reader). Injectable via
+ * `ensureRuntime`'s `extract` option so tests never depend on a real
+ * downloaded archive's internal layout; production always uses this. */
+function defaultExtractTarGz({ archivePath, destDir, execFileSyncImpl = execFileSyncNode }) {
+  mkdirSync(destDir, { recursive: true });
+  execFileSyncImpl("tar", ["-xzf", archivePath, "-C", destDir], { stdio: "ignore" });
+}
+
+function findBinaryRecursive(fsMod, dir, name) {
+  let entries;
+  try {
+    entries = fsMod.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const found = findBinaryRecursive(fsMod, full, name);
+      if (found) return found;
+    } else if (entry.name === name) {
+      return full;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// ensureRuntime
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a working `llama-server` binary exists under
+ * `<dir>/runtimes/llamacpp/<runtimeBlock.release>/` for this host, and
+ * return its path. Idempotent: a prior successful install for the exact
+ * same resolved asset (key + sha256) is detected via a small manifest
+ * file and reused without re-downloading.
+ *
+ * Binding order — an unverified binary is NEVER made executable, let
+ * alone spawned:
+ *   1. `resolveAsset` (throws its wrapped error on failure — see below).
+ *   2. Download the archive; `downloadRuntimeAsset` verifies its sha256
+ *      BEFORE this function proceeds (a mismatch throws
+ *      `RuntimeChecksumError` and the bad file is already gone).
+ *   3. Extract (`tar`).
+ *   4. Locate the `binaryName` file (default `"llama-server"`) anywhere
+ *      under the release directory.
+ *   5. `chmodFn(binPath, 0o755)` — the ONLY point in this function that
+ *      makes anything executable, and it only runs after steps 2-4 have
+ *      all succeeded.
+ *
+ * `resolveAsset` itself returns `{ error }` rather than throwing (see its
+ * doc); this function is the one that turns that into an actual throw,
+ * since `ensureRuntime` is the point where an action was actually
+ * attempted, matching this codebase's convention of throwing typed
+ * errors at the point of a real mutation (see `manager.js`).
+ *
+ * @returns {Promise<string>} the executable binary's path.
+ */
+export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
+  const {
+    lddOutput,
+    arch,
+    lookup,
+    maxRedirects = 5,
+    createWriteStream = fsCreateWriteStream,
+    insecureHttpHosts = [],
+    baseUrl,
+    download = downloadRuntimeAsset,
+    extract = defaultExtractTarGz,
+    binaryName = "llama-server",
+    chmodFn = chmodSync,
+    fs = { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync },
+  } = opts;
+
+  const resolved = resolveAsset(probe, runtimeBlock, { lddOutput, arch, baseUrl });
+  if (resolved.error) throw resolved.error;
+
+  const releaseDir = join(dir, "runtimes", "llamacpp", runtimeBlock.release);
+  const manifestPath = join(releaseDir, ".crow-runtime-installed.json");
+
+  if (fs.existsSync(manifestPath)) {
+    try {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      if (
+        manifest
+        && manifest.key === resolved.key
+        && manifest.sha256 === resolved.sha256
+        && manifest.binPath
+        && fs.existsSync(manifest.binPath)
+      ) {
+        return manifest.binPath; // already installed for this exact asset
+      }
+    } catch {
+      /* corrupt manifest — fall through and reinstall */
+    }
+  }
+
+  fs.mkdirSync(releaseDir, { recursive: true });
+  const archivePath = join(releaseDir, `.download-${resolved.key}.tmp`);
+
+  // Step 2: download + verify. Throws before anything below runs on a
+  // checksum mismatch, host-not-allowed, or protocol violation.
+  await download({
+    url: resolved.url,
+    dest: archivePath,
+    expectedSha: resolved.sha256,
+    lookup,
+    maxRedirects,
+    createWriteStream,
+    insecureHttpHosts,
+  });
+
+  // Step 3: extract.
+  extract({ archivePath, destDir: releaseDir });
+  try {
+    fs.unlinkSync(archivePath);
+  } catch {
+    /* best-effort cleanup of the staging archive */
+  }
+
+  // Step 4: locate.
+  const binPath = findBinaryRecursive(fs, releaseDir, binaryName);
+  if (!binPath) {
+    throw new RuntimeExtractionError(`Extracted ${resolved.key} but found no "${binaryName}" binary under ${releaseDir}`);
+  }
+
+  // Step 5: the ONLY chmod+x in this function, only after 2-4 succeeded.
+  chmodFn(binPath, 0o755);
+
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({ key: resolved.key, sha256: resolved.sha256, binPath, installedAt: new Date().toISOString() }, null, 2),
+  );
+
+  return binPath;
+}
+
+// ---------------------------------------------------------------------------
+// setpriv availability probe
+// ---------------------------------------------------------------------------
+
+let _setprivCache;
+
+/** Probe whether the `setpriv` binary (util-linux) is available on this
+ * host, once — result is cached module-wide after the first real call
+ * (production never re-execs it per model start). `force:true` bypasses
+ * the cache (test-only, so a suite can exercise both outcomes in the
+ * same process); `execFileSyncImpl` is injectable so tests never invoke
+ * a real binary. */
+export function probeSetprivAvailable(opts = {}) {
+  const { execFileSyncImpl = execFileSyncNode, force = false } = opts;
+  if (!force && _setprivCache !== undefined) return _setprivCache;
+  try {
+    execFileSyncImpl("setpriv", ["--version"], { stdio: "ignore" });
+    _setprivCache = true;
+  } catch {
+    _setprivCache = false;
+  }
+  return _setprivCache;
+}
+
+/** Test-only: clear the module-wide setpriv-probe cache. */
+export function __resetSetprivProbeCacheForTest() {
+  _setprivCache = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Process supervision
+// ---------------------------------------------------------------------------
+
+/** Default per-model idle timeout, minutes: `CROW_MODEL_IDLE_MIN` env var
+ * (positive integer), else 30. */
+export function defaultIdleMinutes() {
+  const raw = Number.parseInt(process.env.CROW_MODEL_IDLE_MIN, 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : 30;
+}
+
+/** Build the llama-server CLI args. MUST (per spec) include
+ * `--alias <alias> --port <port> --host <host>`; also includes
+ * `--model <ggufPath>` (the actual model-to-serve flag — implied by
+ * `ggufPath` being a required `startModel` input, not separately called
+ * out in the spec's "MUST include" list because that list is about the
+ * identity/networking flags a caller can verify without knowing
+ * llama-server's full CLI surface). */
+export function buildLlamaServerArgs({ ggufPath, alias, port, host = "127.0.0.1", extraArgs = [] }) {
+  return ["--model", ggufPath, "--alias", alias, "--port", String(port), "--host", host, ...extraArgs];
+}
+
+// Status snapshot registry for the panel (Task 9 wires this into
+// gpu-orchestrator). Keyed by alias — `startModel` registers on start,
+// `stop()` deregisters once the process has actually stopped.
+const activeHandles = new Map();
+
+/** Every currently-tracked model's `status()` snapshot, for the panel. */
+export function getStatusSnapshot() {
+  return Array.from(activeHandles.values()).map((h) => h.status());
+}
+
+/**
+ * Spawn and supervise a llama-server child process.
+ *
+ * Returns a handle satisfying `{ live: boolean, stop(): Promise<void> }`
+ * (the seam `manager.js`'s `unregisterModel({ runtimeHandle })` expects,
+ * per Task 7) plus `status()` (snapshot for the panel) and `touch()`
+ * (reset the idle timer on observed activity — callers wire this to
+ * request traffic; Task 8 itself never calls it).
+ *
+ * Supervision:
+ *   - Own process group (`detached: true`, mirroring `scripts/pi-bots/
+ *     bridge.mjs`'s pi-supervision pattern) so `stop()` can
+ *     `process.kill(-pid, "SIGTERM")` the whole tree, falling back to a
+ *     direct child kill if the pgroup is already gone.
+ *   - Wrapped in `setpriv --pdeathsig=SIGTERM <binPath> ...` IFF setpriv
+ *     is available (probed via `probeSetprivAvailable()`, injectable via
+ *     `setprivAvailable`) — belt-and-braces process-group supervision:
+ *     if crow's own gateway process dies uncleanly (no chance to run its
+ *     `stop()`/SIGTERM-the-group path), `--pdeathsig` still gets the
+ *     child a SIGTERM directly from the kernel.
+ *   - Restart-with-backoff on an unexpected exit: up to `maxRestarts`
+ *     (default 3) restarts, each waiting `backoffMs(attemptIndex)`
+ *     (default exponential, capped at 30s) before respawning. On the
+ *     `maxRestarts`-th unexpected exit, gives up: `state` becomes
+ *     `"unhealthy"`, `lastError` retained, no further respawn.
+ *   - Idle timer: stops the process after `idleMinutes` (default
+ *     `defaultIdleMinutes()`) of no `touch()` calls, UNLESS `keepWarm` or
+ *     `alwaysResident` is set (idle timer never scheduled at all in that
+ *     case) or `idleMinutes <= 0`.
+ *
+ * `spawn`/`setTimeoutFn`/`clearTimeoutFn`/`setprivAvailable` are all
+ * injectable so tests never touch a real process or a real clock.
+ */
+export function startModel({
+  binPath,
+  ggufPath,
+  alias,
+  port,
+  host = "127.0.0.1",
+  extraArgs = [],
+  spawn = spawnCb,
+  keepWarm = false,
+  alwaysResident = false,
+  idleMinutes = defaultIdleMinutes(),
+  setprivAvailable = probeSetprivAvailable(),
+  maxRestarts = 3,
+  backoffMs = (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+}) {
+  const idleDisabled = !!keepWarm || !!alwaysResident || !(idleMinutes > 0);
+
+  const handle = {
+    alias,
+    port,
+    live: false,
+    state: "starting",
+    restartCount: 0,
+    lastError: null,
+    startedAt: null,
+    child: null,
+    _idleTimer: null,
+    _restartTimer: null,
+    _stopped: false,
+  };
+
+  function resetIdleTimer() {
+    if (idleDisabled) return;
+    if (handle._idleTimer) clearTimeoutFn(handle._idleTimer);
+    handle._idleTimer = setTimeoutFn(() => handle.stop(), idleMinutes * 60 * 1000);
+  }
+
+  function spawnChild() {
+    const args = buildLlamaServerArgs({ ggufPath, alias, port, host, extraArgs });
+    const [cmd, cmdArgs] = setprivAvailable
+      ? ["setpriv", ["--pdeathsig=SIGTERM", binPath, ...args]]
+      : [binPath, args];
+    const child = spawn(cmd, cmdArgs, { detached: true, stdio: ["ignore", "pipe", "pipe"] });
+    handle.child = child;
+    handle.live = true;
+    handle.state = "running";
+    handle.startedAt = new Date().toISOString();
+
+    child.on("error", (err) => {
+      handle.lastError = err && err.message;
+    });
+    child.on("exit", (code, signal) => {
+      handle.live = false;
+      handle.child = null;
+      if (handle._stopped) {
+        handle.state = "stopped";
+        activeHandles.delete(alias);
+        return;
+      }
+      handle.lastError = `exited (code=${code}, signal=${signal})`;
+      if (handle.restartCount >= maxRestarts) {
+        handle.state = "unhealthy";
+        return;
+      }
+      handle.restartCount += 1;
+      handle.state = "restarting";
+      const delay = backoffMs(handle.restartCount - 1);
+      handle._restartTimer = setTimeoutFn(() => {
+        if (!handle._stopped) spawnChild();
+      }, delay);
+    });
+
+    resetIdleTimer();
+  }
+
+  handle.status = function status() {
+    return {
+      alias,
+      port,
+      state: handle.state,
+      live: handle.live,
+      restartCount: handle.restartCount,
+      lastError: handle.lastError,
+      startedAt: handle.startedAt,
+      pid: handle.child ? handle.child.pid : null,
+    };
+  };
+
+  handle.touch = function touch() {
+    resetIdleTimer();
+  };
+
+  handle.stop = function stop() {
+    handle._stopped = true;
+    if (handle._idleTimer) clearTimeoutFn(handle._idleTimer);
+    if (handle._restartTimer) clearTimeoutFn(handle._restartTimer);
+    activeHandles.delete(alias);
+    if (!handle.child) {
+      handle.state = "stopped";
+      handle.live = false;
+      return Promise.resolve();
+    }
+    const child = handle.child;
+    const pid = child.pid;
+    const exited = new Promise((resolvePromise) => child.once("exit", resolvePromise));
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    }
+    return exited.then(() => {
+      handle.state = "stopped";
+      handle.live = false;
+    });
+  };
+
+  activeHandles.set(alias, handle);
+  spawnChild();
+  return handle;
+}
+
+/** Thin wrapper matching the spec's named export; identical to
+ * `handle.stop()`. */
+export function stopModel(handle) {
+  return handle.stop();
+}
+
+// ---------------------------------------------------------------------------
+// identityProbe
+// ---------------------------------------------------------------------------
+
+/**
+ * Ask a (supposedly) running llama-server "who are you actually serving"
+ * and compare against `alias`. Used at boot / before trusting a port
+ * reservation: a process IS listening, but is it OUR model?
+ *
+ * `${baseUrl}/models` (brief-literal path) — a real llama-server exposes
+ * this at `/v1/models`, so a production `baseUrl` already carries the
+ * `/v1` suffix (matching the provider `base_url` shape `manager.js`
+ * writes, `http://127.0.0.1:<port>/v1`); this function itself is
+ * path-agnostic, it just appends "/models" to whatever it's given.
+ *
+ * - Connection refused / fetch throws -> `"down"`.
+ * - Non-2xx status, or a body that isn't parseable JSON -> `"down"`
+ *   (something's listening but isn't answering like a model server).
+ * - `data.data[0].id === alias` -> `"resident"`.
+ * - Anything else that DID respond successfully (including an empty
+ *   `data` array, or a present-but-different id) -> `"conflict"`.
+ *   **Deliberately never `"resident"` for this branch** — a live server
+ *   that isn't provably serving `alias` must never be reported as if it
+ *   were; a caller that trusted a false "resident" here could hand off
+ *   requests to a completely different model without knowing it.
+ *
+ * @returns {Promise<"resident"|"conflict"|"down">}
+ */
+export async function identityProbe(baseUrl, alias, fetchImpl = fetch) {
+  let res;
+  try {
+    res = await fetchImpl(`${baseUrl}/models`);
+  } catch {
+    return "down";
+  }
+  if (!res || !res.ok) return "down";
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    return "down";
+  }
+  const servedId = data && Array.isArray(data.data) && data.data[0] && data.data[0].id;
+  if (servedId === alias) return "resident";
+  return "conflict";
+}

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -38,12 +38,14 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
 import http from "node:http";
 import https from "node:https";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Typed errors
@@ -328,10 +330,14 @@ async function openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts 
 /**
  * Download a runtime asset archive to `dest`, hashing incrementally
  * (never buffered whole in memory) and verifying against `expectedSha`
- * BEFORE returning. On mismatch, the partial/completed file is deleted
- * and `RuntimeChecksumError` is thrown — never left on disk to be
- * mistaken for a good one, and never reaches `ensureRuntime`'s
- * extract/chmod steps. No resume support (see module doc for why).
+ * BEFORE returning. On checksum mismatch, or on any stream/network error
+ * mid-download (connection drop, ENOSPC, ...), the partial file is
+ * deleted before the error propagates — never left on disk to be
+ * mistaken for a good (or resumable) one. Unlike `manager.js`'s GGUF
+ * downloads, there is no journal here to resume against: runtime
+ * archives are tens of MB, so a caller that wants to retry just calls
+ * this again from scratch (see module doc for why resume isn't worth
+ * the complexity here).
  */
 export async function downloadRuntimeAsset({
   url,
@@ -344,24 +350,48 @@ export async function downloadRuntimeAsset({
 }) {
   const res = await openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts });
   const hash = createHash("sha256");
-  await new Promise((resolvePromise, reject) => {
-    const ws = createWriteStream(dest);
-    let settled = false;
-    const fail = (err) => {
-      if (settled) return;
-      settled = true;
-      reject(err);
-    };
-    res.on("data", (chunk) => hash.update(chunk));
-    res.on("error", fail);
-    ws.on("error", fail);
-    res.pipe(ws);
-    ws.on("finish", () => {
-      if (settled) return;
-      settled = true;
-      resolvePromise();
+  try {
+    await new Promise((resolvePromise, reject) => {
+      const ws = createWriteStream(dest);
+      let settled = false;
+      const fail = (err) => {
+        if (settled) return;
+        settled = true;
+        try {
+          res.destroy();
+        } catch {
+          /* already gone */
+        }
+        try {
+          ws.destroy();
+        } catch {
+          /* already gone */
+        }
+        reject(err);
+      };
+      res.on("data", (chunk) => hash.update(chunk));
+      res.on("error", fail);
+      res.on("aborted", () => fail(new Error("Download aborted by remote server")));
+      ws.on("error", fail);
+      res.pipe(ws);
+      ws.on("finish", () => {
+        if (settled) return;
+        settled = true;
+        resolvePromise();
+      });
     });
-  });
+  } catch (err) {
+    // Stream/network failure mid-download (not a checksum mismatch — that
+    // case is handled below, after a successful stream completion). The
+    // partial file is never left behind for a later caller to mistake
+    // for a complete or resumable download.
+    try {
+      unlinkSync(dest);
+    } catch {
+      /* already gone, or never created */
+    }
+    throw err;
+  }
 
   const sha256 = hash.digest("hex");
   if (expectedSha && sha256.toLowerCase() !== String(expectedSha).toLowerCase()) {
@@ -419,17 +449,32 @@ function findBinaryRecursive(fsMod, dir, name) {
  * file and reused without re-downloading.
  *
  * Binding order — an unverified binary is NEVER made executable, let
- * alone spawned:
+ * alone spawned, AND the final `releaseDir` never observably contains a
+ * partial install:
  *   1. `resolveAsset` (throws its wrapped error on failure — see below).
- *   2. Download the archive; `downloadRuntimeAsset` verifies its sha256
- *      BEFORE this function proceeds (a mismatch throws
- *      `RuntimeChecksumError` and the bad file is already gone).
- *   3. Extract (`tar`).
+ *   2. Download the archive to a scratch file next to (not inside)
+ *      `releaseDir`; `downloadRuntimeAsset` verifies its sha256 AND
+ *      cleans up after itself on any failure (mismatch or mid-stream
+ *      error) before this function proceeds.
+ *   3. Extract (`tar`) into a STAGING directory
+ *      (`<parent>/.extract-<key>-<release>.tmp`), never directly into
+ *      `releaseDir`. A disk-full or killed process mid-tar leaves only a
+ *      stray staging directory next to `releaseDir` — `releaseDir`
+ *      itself is untouched, so a later run can never mistake a
+ *      half-extracted archive for a complete install.
  *   4. Locate the `binaryName` file (default `"llama-server"`) anywhere
- *      under the release directory.
- *   5. `chmodFn(binPath, 0o755)` — the ONLY point in this function that
- *      makes anything executable, and it only runs after steps 2-4 have
- *      all succeeded.
+ *      under the staging directory.
+ *   5. `chmodFn(stagedBinPath, 0o755)` — the ONLY point in this function
+ *      that makes anything executable, and it only runs after steps
+ *      2-4 have all succeeded. The manifest is ALSO written into the
+ *      staging directory at this point (not into `releaseDir` yet) so it
+ *      finalizes together with the binary in the next step — a reader
+ *      can never observe a `releaseDir` with a binary but no manifest,
+ *      or a manifest with no binary.
+ *   6. Finalize with a single `renameSync(stagingDir, releaseDir)` — an
+ *      atomic swap on the same filesystem. Any stale `releaseDir` left
+ *      by an old/corrupt manifest is cleared first (POSIX `rename` onto
+ *      a non-empty directory fails with `ENOTEMPTY`).
  *
  * `resolveAsset` itself returns `{ error }` rather than throwing (see its
  * doc); this function is the one that turns that into an actual throw,
@@ -452,37 +497,42 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     extract = defaultExtractTarGz,
     binaryName = "llama-server",
     chmodFn = chmodSync,
-    fs = { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync },
+    fs = { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync, rmSync, renameSync },
   } = opts;
 
   const resolved = resolveAsset(probe, runtimeBlock, { lddOutput, arch, baseUrl });
   if (resolved.error) throw resolved.error;
 
-  const releaseDir = join(dir, "runtimes", "llamacpp", runtimeBlock.release);
+  const runtimesDir = join(dir, "runtimes", "llamacpp");
+  const releaseDir = join(runtimesDir, runtimeBlock.release);
   const manifestPath = join(releaseDir, ".crow-runtime-installed.json");
 
   if (fs.existsSync(manifestPath)) {
     try {
       const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      const candidateBinPath = manifest && manifest.relBinPath ? join(releaseDir, manifest.relBinPath) : null;
       if (
         manifest
         && manifest.key === resolved.key
         && manifest.sha256 === resolved.sha256
-        && manifest.binPath
-        && fs.existsSync(manifest.binPath)
+        && candidateBinPath
+        && fs.existsSync(candidateBinPath)
       ) {
-        return manifest.binPath; // already installed for this exact asset
+        return candidateBinPath; // already installed for this exact asset
       }
     } catch {
       /* corrupt manifest — fall through and reinstall */
     }
   }
 
-  fs.mkdirSync(releaseDir, { recursive: true });
-  const archivePath = join(releaseDir, `.download-${resolved.key}.tmp`);
+  fs.mkdirSync(runtimesDir, { recursive: true });
+  const archivePath = join(runtimesDir, `.download-${resolved.key}-${runtimeBlock.release}.tmp`);
+  const stagingDir = join(runtimesDir, `.extract-${resolved.key}-${runtimeBlock.release}.tmp`);
 
   // Step 2: download + verify. Throws before anything below runs on a
-  // checksum mismatch, host-not-allowed, or protocol violation.
+  // checksum mismatch, host-not-allowed, protocol violation, or
+  // mid-stream failure (and never leaves the partial archive behind
+  // either — see `downloadRuntimeAsset`).
   await download({
     url: resolved.url,
     dest: archivePath,
@@ -493,29 +543,55 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     insecureHttpHosts,
   });
 
-  // Step 3: extract.
-  extract({ archivePath, destDir: releaseDir });
+  // Only now (download verified) do we touch the staging extract dir —
+  // clear any leftover from a previous crashed/killed attempt first.
+  try {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+  fs.mkdirSync(stagingDir, { recursive: true });
+
+  // Step 3: extract into staging, never into releaseDir.
+  extract({ archivePath, destDir: stagingDir });
   try {
     fs.unlinkSync(archivePath);
   } catch {
     /* best-effort cleanup of the staging archive */
   }
 
-  // Step 4: locate.
-  const binPath = findBinaryRecursive(fs, releaseDir, binaryName);
-  if (!binPath) {
-    throw new RuntimeExtractionError(`Extracted ${resolved.key} but found no "${binaryName}" binary under ${releaseDir}`);
+  // Step 4: locate, within staging.
+  const stagedBinPath = findBinaryRecursive(fs, stagingDir, binaryName);
+  if (!stagedBinPath) {
+    try {
+      fs.rmSync(stagingDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+    throw new RuntimeExtractionError(`Extracted ${resolved.key} but found no "${binaryName}" binary under ${stagingDir}`);
   }
 
   // Step 5: the ONLY chmod+x in this function, only after 2-4 succeeded.
-  chmodFn(binPath, 0o755);
+  chmodFn(stagedBinPath, 0o755);
 
+  const relBinPath = relative(stagingDir, stagedBinPath);
   fs.writeFileSync(
-    manifestPath,
-    JSON.stringify({ key: resolved.key, sha256: resolved.sha256, binPath, installedAt: new Date().toISOString() }, null, 2),
+    join(stagingDir, ".crow-runtime-installed.json"),
+    JSON.stringify({ key: resolved.key, sha256: resolved.sha256, relBinPath, installedAt: new Date().toISOString() }, null, 2),
   );
 
-  return binPath;
+  // Step 6: atomic(-ish) finalize — a single rename swaps the
+  // fully-populated staging dir into place. Clear any stale releaseDir
+  // first (POSIX rename onto an existing non-empty directory fails with
+  // ENOTEMPTY).
+  try {
+    fs.rmSync(releaseDir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+  fs.renameSync(stagingDir, releaseDir);
+
+  return join(releaseDir, relBinPath);
 }
 
 // ---------------------------------------------------------------------------

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -112,6 +112,23 @@ export class RuntimeExtractionError extends Error {
   }
 }
 
+/** Thrown when a runtime-asset download's underlying socket sits idle
+ * (no bytes sent or received — connect-hang, stalled headers, OR a
+ * stalled body mid-stream, since the timeout is a single socket-idle
+ * timer that resets on any I/O and is never cleared for the socket's
+ * lifetime) for longer than `timeoutMs`. Without this, a dropped/black-
+ * holed TCP connection left `requestOnce`'s promise (and everything
+ * awaiting it) unsettled forever — see Task 9 review round 1. */
+export class RuntimeDownloadTimeoutError extends Error {
+  constructor(url, timeoutMs) {
+    super(`Runtime asset download stalled (no socket activity for ${timeoutMs}ms): ${url}`);
+    this.name = "RuntimeDownloadTimeoutError";
+    this.code = "DOWNLOAD_TIMEOUT";
+    this.url = url;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // glibc parsing (pure — mirrors probe.js's exported-pure-parser convention)
 // ---------------------------------------------------------------------------
@@ -267,6 +284,12 @@ export function resolveAsset(probe, runtimeBlock, opts = {}) {
 
 const RUNTIME_ALLOWED_HOSTS = new Set(["github.com", "objects.githubusercontent.com"]);
 
+/** Default socket-idle timeout for a runtime-asset download hop
+ * (~120s, per Task 9 review round 1: "no promise may hang forever on a
+ * stalled TCP connection"). Injectable end to end via
+ * `downloadRuntimeAsset({ timeoutMs })` / `ensureRuntime(..., { timeoutMs })`. */
+export const DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS = 120_000;
+
 /** True iff `hostname` is exactly "github.com" or "objects.githubusercontent.com"
  * (GitHub's release-asset redirect target). No subdomain wildcarding —
  * these are the two literal hosts a llama.cpp release download hits. */
@@ -275,11 +298,19 @@ export function isAllowedRuntimeHost(hostname) {
   return RUNTIME_ALLOWED_HOSTS.has(hostname.toLowerCase());
 }
 
-function requestOnce(urlStr, { lookup }) {
+function requestOnce(urlStr, { lookup, timeoutMs = DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS }) {
   return new Promise((resolvePromise, reject) => {
     const urlObj = new URL(urlStr);
     const transport = urlObj.protocol === "https:" ? https : http;
-    const req = transport.request(urlObj, { method: "GET", lookup }, (res) => resolvePromise({ res }));
+    // `timeout` sets a single idle timer on the underlying socket that
+    // resets on ANY I/O and is never cleared for the socket's lifetime —
+    // it therefore covers both a connect/header-wait hang AND a stalled
+    // body mid-download (the socket `res` streams from is the same one
+    // `req` is bound to), not just the initial connect.
+    const req = transport.request(urlObj, { method: "GET", lookup, timeout: timeoutMs }, (res) => resolvePromise({ res }));
+    req.on("timeout", () => {
+      req.destroy(new RuntimeDownloadTimeoutError(urlStr, timeoutMs));
+    });
     req.on("error", reject);
     req.end();
   });
@@ -290,7 +321,7 @@ function requestOnce(urlStr, { lookup }) {
  * for why every hop, not just the first). `insecureHttpHosts` is the
  * same test-only escape as `manager.js` (default `[]` — https required
  * everywhere in production). */
-async function openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts = [] }) {
+async function openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts = [], timeoutMs }) {
   let currentUrl = url;
   // eslint-disable-next-line no-await-in-loop -- sequential by nature, see manager.js's identical loop.
   for (let hop = 0; hop <= maxRedirects; hop++) {
@@ -308,7 +339,7 @@ async function openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts 
       }
     }
     // eslint-disable-next-line no-await-in-loop
-    const { res } = await requestOnce(currentUrl, { lookup });
+    const { res } = await requestOnce(currentUrl, { lookup, timeoutMs });
     if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
       res.resume();
       const location = res.headers.location;
@@ -347,8 +378,9 @@ export async function downloadRuntimeAsset({
   maxRedirects = 5,
   createWriteStream = fsCreateWriteStream,
   insecureHttpHosts = [],
+  timeoutMs = DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS,
 }) {
-  const res = await openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts });
+  const res = await openRuntimeStream({ url, lookup, maxRedirects, insecureHttpHosts, timeoutMs });
   const hash = createHash("sha256");
   try {
     await new Promise((resolvePromise, reject) => {
@@ -498,6 +530,7 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     binaryName = "llama-server",
     chmodFn = chmodSync,
     fs = { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync, rmSync, renameSync },
+    timeoutMs = DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS,
   } = opts;
 
   const resolved = resolveAsset(probe, runtimeBlock, { lddOutput, arch, baseUrl });
@@ -541,6 +574,7 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     maxRedirects,
     createWriteStream,
     insecureHttpHosts,
+    timeoutMs,
   });
 
   // Only now (download verified) do we touch the staging extract dir —
@@ -684,9 +718,20 @@ export function getStatusSnapshot() {
  *     `defaultIdleMinutes()`) of no `touch()` calls, UNLESS `keepWarm` or
  *     `alwaysResident` is set (idle timer never scheduled at all in that
  *     case) or `idleMinutes <= 0`.
+ *   - `onTerminal(reason)` (Task 9 review round 1): fires EXACTLY ONCE,
+ *     the first time this handle reaches a state it will never leave —
+ *     `"stopped"` (via `stop()`, called explicitly, from a sibling
+ *     swap-out, or by the idle timer above) or `"unhealthy"` (the
+ *     `maxRestarts`-th unexpected exit). A restart that still has budget
+ *     left is NOT terminal — `onTerminal` does not fire for it. Exists so
+ *     a caller that hands out a host-wide resource tied to this process's
+ *     lifetime (gpu-orchestrator's native mutex-group lock) can release it
+ *     exactly when the process can no longer be considered to hold that
+ *     resource, without polling `status()`. Never throws into the
+ *     supervisor even if the callback itself throws.
  *
- * `spawn`/`setTimeoutFn`/`clearTimeoutFn`/`setprivAvailable` are all
- * injectable so tests never touch a real process or a real clock.
+ * `spawn`/`setTimeoutFn`/`clearTimeoutFn`/`setprivAvailable`/`onTerminal`
+ * are all injectable so tests never touch a real process or a real clock.
  */
 export function startModel({
   binPath,
@@ -704,6 +749,7 @@ export function startModel({
   backoffMs = (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
   setTimeoutFn = setTimeout,
   clearTimeoutFn = clearTimeout,
+  onTerminal = () => {},
 }) {
   const idleDisabled = !!keepWarm || !!alwaysResident || !(idleMinutes > 0);
 
@@ -720,6 +766,17 @@ export function startModel({
     _restartTimer: null,
     _stopped: false,
   };
+
+  let terminalFired = false;
+  function fireTerminal(reason) {
+    if (terminalFired) return;
+    terminalFired = true;
+    try {
+      onTerminal(reason);
+    } catch {
+      /* a caller's terminal hook must never break process supervision */
+    }
+  }
 
   function resetIdleTimer() {
     if (idleDisabled) return;
@@ -747,11 +804,13 @@ export function startModel({
       if (handle._stopped) {
         handle.state = "stopped";
         activeHandles.delete(alias);
+        fireTerminal("stopped");
         return;
       }
       handle.lastError = `exited (code=${code}, signal=${signal})`;
       if (handle.restartCount >= maxRestarts) {
         handle.state = "unhealthy";
+        fireTerminal("unhealthy");
         return;
       }
       handle.restartCount += 1;
@@ -790,6 +849,7 @@ export function startModel({
     if (!handle.child) {
       handle.state = "stopped";
       handle.live = false;
+      fireTerminal("stopped");
       return Promise.resolve();
     }
     const child = handle.child;
@@ -807,6 +867,10 @@ export function startModel({
     return exited.then(() => {
       handle.state = "stopped";
       handle.live = false;
+      // fireTerminal("stopped") already ran inside spawnChild's own "exit"
+      // listener above (registered before this once()-listener, so it
+      // always runs first) — idempotent via terminalFired, not repeated
+      // here.
     });
   };
 

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -661,6 +661,43 @@ export function __resetSetprivProbeCacheForTest() {
 // Process supervision
 // ---------------------------------------------------------------------------
 
+/** Base readiness-timeout floor (ms) `nativeReadinessTimeoutMs` scales up
+ * from. Matches the flat default a bare llama-server process cold-start
+ * (weights already on disk, just mmap + warm-up) needs on modest hardware. */
+export const NATIVE_READINESS_BASE_MS = 120_000;
+
+/** Per-megabyte readiness allowance (ms), by storage class the model's
+ * GGUF blob is read from — an HDD's sequential read is roughly 5x slower
+ * than an SSD's for the mmap-driven load llama-server does on start, so a
+ * multi-GB model takes proportionally longer to become ready. */
+const NATIVE_READINESS_MS_PER_MB = { ssd: 8, hdd: 40 };
+
+/**
+ * How long to wait for a native (llama.cpp) model to report itself
+ * resident, scaled by how much has to be read off disk: `120_000 +
+ * quantSizeMb * (storageClass === "hdd" ? 40 : 8)`. A 2.5 GB quant on SSD
+ * gets ~140s; the same quant on HDD gets ~220s; a 17 GB quant on HDD gets
+ * ~800s.
+ *
+ * `storageClass` is NOT auto-detected — `models/probe.js`'s `diskFreeMb`
+ * only reports free space, not the underlying device's rotational-vs-flash
+ * class, and building that detection is out of scope here. v1 honestly
+ * assumes `"ssd"` (the common case for the fast NVMe/SSD boxes this native
+ * runtime targets) unless a caller passes an explicit override — see
+ * `gpu-orchestrator.js`'s `startNativeAndAwaitReady`, which forwards
+ * `opts.storageClass` through for exactly that purpose.
+ *
+ * A non-finite/zero/negative `quantSizeMb` (e.g. an older registry entry
+ * written before this field existed) degrades to the bare `120_000` floor
+ * rather than throwing — an honest "we don't know the size" default, not a
+ * crash.
+ */
+export function nativeReadinessTimeoutMs(quantSizeMb, storageClass = "ssd") {
+  const sizeMb = Number.isFinite(quantSizeMb) && quantSizeMb > 0 ? quantSizeMb : 0;
+  const msPerMb = NATIVE_READINESS_MS_PER_MB[storageClass] ?? NATIVE_READINESS_MS_PER_MB.ssd;
+  return NATIVE_READINESS_BASE_MS + sizeMb * msPerMb;
+}
+
 /** Default per-model idle timeout, minutes: `CROW_MODEL_IDLE_MIN` env var
  * (positive integer), else 30. */
 export function defaultIdleMinutes() {

--- a/servers/gateway/models/state.js
+++ b/servers/gateway/models/state.js
@@ -1,0 +1,187 @@
+/**
+ * Models state store + port allocator (Item G, native model runtime).
+ *
+ * One JSON state file per CROW_HOME (`<dir>/models/state.json`) holding
+ * three independent maps keyed by modelId:
+ *
+ *   - reservations: ephemeral port claims for a locally-spawned model
+ *     runtime process (18100-18199), each with an owner {crowHome, pid}
+ *     and createdAt so a later boot can tell a live claim from a stale one.
+ *   - journal: in-progress model downloads (url/dest/bytesDone/expectedSha/
+ *     startedAt) so a killed download can resume instead of restarting.
+ *   - registry: models this CROW_HOME has actually installed (file/quant/
+ *     catalogId/registeredAt), independent of whether a runtime is
+ *     currently running for them.
+ *
+ * `dir` is always injected by the caller — this module never guesses a
+ * path itself. Production callers pass `resolveDataDir()` (the same
+ * data-dir helper `servers/gateway/index.js` uses, from `servers/db.js`);
+ * tests pass an `fs.mkdtempSync` scratch dir. This host runs multiple
+ * gateways (primary, MPA, ...) with distinct CROW_HOMEs — a hardcoded
+ * `~/.crow/...` here would cross-contaminate their model runtimes.
+ *
+ * `reconcileOnBoot` is a pure function over its three injected callbacks
+ * (`state`, `listProviderRows()`, `isProcessAlive(pid)`) — it never opens
+ * the real DB or touches `process` itself, so it's testable without a live
+ * gateway.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import net from "node:net";
+
+import { resolveDataDir } from "../../db.js";
+
+export const PORT_RANGE_START = 18100;
+export const PORT_RANGE_END = 18199; // inclusive
+
+/**
+ * Thrown by allocatePort when every port in the range is reserved or
+ * actually bound by something else on the host.
+ */
+export class PortRangeExhaustedError extends Error {
+  constructor(message = `No free port in ${PORT_RANGE_START}-${PORT_RANGE_END}`) {
+    super(message);
+    this.name = "PortRangeExhaustedError";
+    this.code = "PORT_RANGE_EXHAUSTED";
+  }
+}
+
+function emptyState() {
+  return { reservations: {}, journal: {}, registry: {} };
+}
+
+/** Path to the state file for a given (injected) CROW_HOME/data dir. */
+export function statePath(dir) {
+  return join(dir, "models", "state.json");
+}
+
+/**
+ * Load state from `<dir>/models/state.json`. Missing file or unparsable
+ * JSON both resolve to a fresh empty state rather than throwing — a
+ * corrupt/absent state file must never block boot.
+ */
+export function loadState(dir) {
+  const path = statePath(dir);
+  if (!existsSync(path)) return emptyState();
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw);
+    return {
+      reservations: (parsed && typeof parsed.reservations === "object" && parsed.reservations) || {},
+      journal: (parsed && typeof parsed.journal === "object" && parsed.journal) || {},
+      registry: (parsed && typeof parsed.registry === "object" && parsed.registry) || {},
+    };
+  } catch {
+    return emptyState();
+  }
+}
+
+/**
+ * Atomically persist state to `<dir>/models/state.json`: write to a
+ * pid+timestamp-suffixed tmp file in the same directory, then rename over
+ * the target. Rename is atomic on the same filesystem, so a reader never
+ * observes a half-written file.
+ */
+export function saveState(dir, state) {
+  const path = statePath(dir);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = join(dirname(path), `.state.json.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  writeFileSync(tmpPath, JSON.stringify(state, null, 2), "utf8");
+  renameSync(tmpPath, path);
+}
+
+/**
+ * Bind-test a port on 127.0.0.1: resolves true if a listener could be
+ * opened (and immediately closes it), false if the bind failed (in use by
+ * something on the host, reserved or not).
+ */
+function canBind(port) {
+  return new Promise((resolvePromise) => {
+    const server = net.createServer();
+    server.once("error", () => {
+      resolvePromise(false);
+    });
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolvePromise(true));
+    });
+  });
+}
+
+/**
+ * Reserve the lowest free port in 18100-18199 for `modelId`. "Free" means
+ * both: not already recorded in `state.reservations`, and actually
+ * bindable on 127.0.0.1 right now (a stale reservation could otherwise
+ * shadow a port something else on the host is legitimately using, or vice
+ * versa a live OS-level bind could go unnoticed by a reservations-only
+ * check). Mutates `state.reservations` in place and returns the port.
+ *
+ * `owner.crowHome` defaults to `resolveDataDir()` (call-time, not a
+ * module-load constant, so it reflects whichever CROW_HOME this process
+ * is actually running under) and can be overridden for tests.
+ */
+export async function allocatePort(state, modelId, { crowHome = resolveDataDir(), pid = process.pid } = {}) {
+  const reservedPorts = new Set(Object.values(state.reservations).map((r) => r.port));
+  for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
+    if (reservedPorts.has(port)) continue;
+    // eslint-disable-next-line no-await-in-loop -- ports must be probed in
+    // ascending order, one at a time; parallelizing would race binds.
+    const free = await canBind(port);
+    if (!free) continue;
+    state.reservations[modelId] = {
+      port,
+      owner: { crowHome, pid },
+      createdAt: new Date().toISOString(),
+    };
+    return port;
+  }
+  throw new PortRangeExhaustedError();
+}
+
+/** Free modelId's port reservation, if any. No-op if it has none. */
+export function releasePort(state, modelId) {
+  delete state.reservations[modelId];
+}
+
+/**
+ * Boot-time reconciliation over injected state + callbacks. Pure: takes
+ * every fact it needs as an argument and returns a plan; it does not
+ * mutate the DB, spawn/kill processes, or touch the filesystem itself.
+ * The caller applies the plan (and should saveState after freeing).
+ *
+ *  - freedReservations: reservations whose owner pid is no longer alive
+ *    AND which have no corresponding provider row (a live provider row
+ *    means the runtime is still legitimately using that port even though
+ *    the reserving pid is gone, e.g. after a re-exec). Freed from
+ *    `state.reservations` in place.
+ *  - orphanRows: provider rows that reference a modelId with no matching
+ *    port reservation — the DB thinks a local runtime is registered but
+ *    this CROW_HOME's state has no record of holding a port for it.
+ *  - resumableDownloads: every journal entry, since presence in the
+ *    journal always means "not yet completed" (a finished download is
+ *    removed from the journal by the downloader, not left behind).
+ */
+export function reconcileOnBoot({ state, listProviderRows, isProcessAlive }) {
+  const providerRows = listProviderRows() || [];
+  const providerModelIds = new Set(providerRows.map((row) => row.modelId));
+
+  const freedReservations = [];
+  for (const [modelId, reservation] of Object.entries(state.reservations)) {
+    const ownerAlive = isProcessAlive(reservation.owner?.pid);
+    const hasProviderRow = providerModelIds.has(modelId);
+    if (!ownerAlive && !hasProviderRow) {
+      freedReservations.push({ modelId, ...reservation });
+      delete state.reservations[modelId];
+    }
+  }
+
+  const reservedModelIds = new Set(Object.keys(state.reservations));
+  const orphanRows = providerRows.filter((row) => !reservedModelIds.has(row.modelId));
+
+  const resumableDownloads = Object.entries(state.journal).map(([modelId, entry]) => ({
+    modelId,
+    ...entry,
+  }));
+
+  return { freedReservations, orphanRows, resumableDownloads };
+}

--- a/servers/gateway/routes/chat.js
+++ b/servers/gateway/routes/chat.js
@@ -29,6 +29,8 @@ import { chooseProvider as smartRoute, stripSlashCommand, SmartChatDisabled } fr
 import { fixedWindowLimit } from "../middleware/rate-limit.js";
 import { recordUsageEvent } from "../../shared/metering.js";
 import { resolveTenantId } from "../../shared/tenancy.js";
+import { parseCookies } from "../dashboard/auth.js";
+import { t, fill, SUPPORTED_LANGS } from "../dashboard/shared/i18n.js";
 
 /** Sliding window: max messages to send to AI */
 const CONTEXT_WINDOW = 20;
@@ -38,6 +40,46 @@ const activeGenerations = new Map();
 
 /** Rate limiter: 10 messages / 60s, keyed by req.ip (legacy key name: sessionToken) */
 const messageRateLimit = fixedWindowLimit({ max: 10, windowMs: 60 * 1000 });
+
+/**
+ * `provider_warming` SSE payload for a warm attempt (Item G, Task 10).
+ * Pure — exported so the native-vs-Docker copy split is unit-testable
+ * without standing up the whole SSE route (DB, adapter resolution, etc.).
+ * Docker/cloud path is UNCHANGED — no `message` field, exactly as before
+ * this task (the Docker warm is normally fast enough that the UI never
+ * needed narration). Native gets a translated `message` because a
+ * first-time native warm reads a multi-GB GGUF off disk and can take
+ * minutes — long enough that a bare "warming" pill with no explanation
+ * reads as a hang.
+ */
+export function nativeWarmingEvent(providerName, isNative, lang) {
+  if (!isNative) return { provider_id: providerName };
+  return {
+    provider_id: providerName,
+    message: fill(t("chat.native_model_loading", lang), { provider: providerName }),
+  };
+}
+
+/**
+ * `error` SSE payload when `maybeAcquireLocalProvider` reports a timeout
+ * (`warmed === false`). Pure — same testability rationale as
+ * `nativeWarmingEvent`. The Docker-bundle hint ("docker compose logs") is
+ * UNCHANGED for non-native providers; a native provider has no compose
+ * file, so it must NEVER see that hint — it gets the new, real-i18n
+ * `chat.native_model_load_failed` copy and a distinct `code` instead.
+ */
+export function providerNotReadyError(providerName, isNative, lang) {
+  if (isNative) {
+    return {
+      message: fill(t("chat.native_model_load_failed", lang), { provider: providerName }),
+      code: "native_provider_not_ready",
+    };
+  }
+  return {
+    message: `Local provider "${providerName}" did not become ready in time. Check "docker compose logs" for its bundle.`,
+    code: "provider_not_ready",
+  };
+}
 
 export default function chatRouter(dashboardAuth) {
   const router = Router();
@@ -408,6 +450,15 @@ export default function chatRouter(dashboardAuth) {
       return res.status(429).json({ error: "Rate limited — max 10 messages per minute" });
     }
 
+    // Dashboard's language cookie — same convention `dashboard/index.js`
+    // uses for every server-rendered/translated string (see its many
+    // `SUPPORTED_LANGS.includes(cookies.crow_lang)` call sites). Used below
+    // ONLY for the native-runtime warming/failure copy (Item G, Task 10) —
+    // every other message on this route predates i18n and stays plain
+    // English, unchanged.
+    const cookies = parseCookies(req);
+    const lang = SUPPORTED_LANGS.includes(cookies.crow_lang) ? cookies.crow_lang : "en";
+
     const db = createDbClient();
     const toolExecutor = createToolExecutor();
 
@@ -592,18 +643,17 @@ export default function chatRouter(dashboardAuth) {
         return;
       }
 
-      // Warm up on-demand local bundles (vLLM / llama.cpp swap groups).
-      // Fast path if already resident; returns null for cloud + peer-hosted
-      // providers (no-op). Swap-siblings on the same port are stopped first.
+      // Warm up on-demand local bundles (vLLM / llama.cpp swap groups) OR a
+      // native (llama.cpp, gateway-supervised) model process. Fast path if
+      // already resident; returns null for cloud + peer-hosted providers
+      // (no-op). Swap-siblings on the same port are stopped first.
       try {
-        const { maybeAcquireLocalProvider } = await import("../gpu-orchestrator.js");
-        sendEvent("provider_warming", { provider_id: effectiveProvider });
+        const { maybeAcquireLocalProvider, isNativeRuntimeProvider } = await import("../gpu-orchestrator.js");
+        const isNative = isNativeRuntimeProvider(effectiveProvider);
+        sendEvent("provider_warming", nativeWarmingEvent(effectiveProvider, isNative, lang));
         const warmed = await maybeAcquireLocalProvider(effectiveProvider);
         if (warmed === false) {
-          sendEvent("error", {
-            message: `Local provider "${effectiveProvider}" did not become ready in time. Check "docker compose logs" for its bundle.`,
-            code: "provider_not_ready",
-          });
+          sendEvent("error", providerNotReadyError(effectiveProvider, isNative, lang));
           closeStream();
           return;
         }

--- a/servers/gateway/routes/llm-router.js
+++ b/servers/gateway/routes/llm-router.js
@@ -203,7 +203,18 @@ async function handleChat(req, res) {
 
   // Warm before forward (N3): bring up a cold / swapped-out local provider (e.g.
   // the on-demand 35B) before forwarding. No-op for non-local / no-bundle
-  // providers; never throws.
+  // providers; never throws. Native (llama.cpp, gateway-supervised) providers
+  // warm through this EXACT SAME call as chat.js's SSE route — Item G, Task 10
+  // needed no change here: `maybeAcquireLocalProvider` already branches into
+  // the native acquire path (proven by
+  // tests/gpu-orchestrator-native.test.js's "maybeAcquireLocalProvider does
+  // not early-out on a native provider's null bundleId"). What this route
+  // does NOT have is chat.js's `provider_warming`/`error` SSE events — this
+  // is a raw OpenAI-compat proxy for the companion/glasses LLM loop, which
+  // forwards the upstream body verbatim and never authors its own SSE
+  // frames, so there is no event channel to put a "warming" notice on. The
+  // companion sees a warm-up simply as this await taking longer, same as
+  // before this task.
   const [providerId] = splitKey(key);
   await maybeAcquireLocalProvider(providerId);
 

--- a/tests/chat-native-copy.test.js
+++ b/tests/chat-native-copy.test.js
@@ -1,0 +1,90 @@
+/**
+ * chat.js's native-vs-Docker warming/failure copy (Item G, Task 10).
+ *
+ * `nativeWarmingEvent`/`providerNotReadyError` are pure helpers exported
+ * from `servers/gateway/routes/chat.js` specifically so this split is
+ * unit-testable without standing up the full SSE route (DB, conversation
+ * row, provider adapter resolution, etc. — none of that is relevant to
+ * "which copy gets picked"). The route itself (`chat.js` around its
+ * `maybeAcquireLocalProvider` call site) just calls these two functions and
+ * forwards their output verbatim to `sendEvent`.
+ *
+ * What's asserted:
+ *   - Docker/cloud path (isNative=false) is BYTE-IDENTICAL to the
+ *     pre-Task-10 behavior: `provider_warming` carries no `message`, and a
+ *     timeout error keeps the exact `docker compose logs` hint + the
+ *     `provider_not_ready` code.
+ *   - Native path (isNative=true) NEVER surfaces the Docker hint, uses the
+ *     new `chat.native_model_loading` / `chat.native_model_load_failed` i18n
+ *     keys (real EN + ES, via the same `t()`/`fill()` the rest of the
+ *     dashboard uses), and a distinct `native_provider_not_ready` code.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { nativeWarmingEvent, providerNotReadyError } from "../servers/gateway/routes/chat.js";
+import { t, fill } from "../servers/gateway/dashboard/shared/i18n.js";
+
+// --- Docker/cloud path: unchanged from pre-Task-10 behavior ----------------
+
+test("nativeWarmingEvent: Docker/cloud provider gets provider_id only, no message field", () => {
+  const evt = nativeWarmingEvent("crow-chat", false, "en");
+  assert.deepEqual(evt, { provider_id: "crow-chat" });
+});
+
+test("providerNotReadyError: Docker/cloud provider keeps the exact docker-compose hint + provider_not_ready code", () => {
+  const err = providerNotReadyError("crow-chat", false, "en");
+  assert.equal(err.code, "provider_not_ready");
+  assert.equal(
+    err.message,
+    'Local provider "crow-chat" did not become ready in time. Check "docker compose logs" for its bundle.',
+  );
+});
+
+test("providerNotReadyError: Docker/cloud copy is unaffected by lang (never localized — matches its pre-Task-10 behavior)", () => {
+  const en = providerNotReadyError("crow-chat", false, "en");
+  const es = providerNotReadyError("crow-chat", false, "es");
+  assert.equal(en.message, es.message);
+});
+
+// --- Native path: new i18n keys, never the Docker hint ----------------------
+
+test("nativeWarmingEvent: native provider gets a translated message (EN)", () => {
+  const evt = nativeWarmingEvent("qwen3-4b", true, "en");
+  assert.equal(evt.provider_id, "qwen3-4b");
+  assert.equal(evt.message, fill(t("chat.native_model_loading", "en"), { provider: "qwen3-4b" }));
+  assert.match(evt.message, /qwen3-4b/, "the provider name is interpolated into the message");
+});
+
+test("nativeWarmingEvent: native provider gets a translated message (ES), distinct from EN", () => {
+  const en = nativeWarmingEvent("qwen3-4b", true, "en").message;
+  const es = nativeWarmingEvent("qwen3-4b", true, "es").message;
+  assert.notEqual(en, es, "EN and ES copy must actually differ (real translation, not a stub)");
+  assert.equal(es, fill(t("chat.native_model_loading", "es"), { provider: "qwen3-4b" }));
+});
+
+test("providerNotReadyError: native failure NEVER contains the docker-compose hint, in either language", () => {
+  const en = providerNotReadyError("qwen3-4b", true, "en");
+  const es = providerNotReadyError("qwen3-4b", true, "es");
+  assert.equal(en.code, "native_provider_not_ready");
+  assert.equal(es.code, "native_provider_not_ready");
+  for (const err of [en, es]) {
+    assert.doesNotMatch(err.message.toLowerCase(), /docker/, "native failure copy must never mention docker");
+    assert.doesNotMatch(err.message.toLowerCase(), /compose/, "native failure copy must never mention compose");
+  }
+});
+
+test("providerNotReadyError: native failure copy uses the chat.native_model_load_failed key (EN + real ES)", () => {
+  const en = providerNotReadyError("qwen3-4b", true, "en");
+  const es = providerNotReadyError("qwen3-4b", true, "es");
+  assert.equal(en.message, fill(t("chat.native_model_load_failed", "en"), { provider: "qwen3-4b" }));
+  assert.equal(es.message, fill(t("chat.native_model_load_failed", "es"), { provider: "qwen3-4b" }));
+  assert.notEqual(en.message, es.message, "EN and ES copy must actually differ (real translation, not a stub)");
+  assert.match(en.message, /qwen3-4b/);
+  assert.match(es.message, /qwen3-4b/);
+});
+
+test("providerNotReadyError: an unsupported lang falls back to English (t()'s own fallback, not special-cased here)", () => {
+  const fr = providerNotReadyError("qwen3-4b", true, "fr");
+  const en = providerNotReadyError("qwen3-4b", true, "en");
+  assert.equal(fr.message, en.message);
+});

--- a/tests/fixtures/stub-llama-server.mjs
+++ b/tests/fixtures/stub-llama-server.mjs
@@ -1,0 +1,64 @@
+/**
+ * Minimal stand-in for llama-server's OpenAI-compatible "list models"
+ * endpoint (Item G Task 8, `tests/models-runtime.test.js`). This is what
+ * `identityProbe()` is tested against — never a real llama-server binary,
+ * never real (non-loopback) network.
+ *
+ * `identityProbe(baseUrl, alias, fetchImpl)` fetches `${baseUrl}/models`
+ * (brief-literal path). A real llama-server exposes this at `/v1/models`,
+ * so a production caller passes a `baseUrl` that already ends in `/v1`
+ * (matching the provider `base_url` shape `manager.js` writes,
+ * `http://127.0.0.1:<port>/v1`) — this fixture itself only ever needs to
+ * answer whatever path its caller requests, so it serves plain `/models`
+ * and tests build `baseUrl` without a `/v1` suffix.
+ *
+ * Usable two ways:
+ *   - Imported in-process (the pattern `tests/models-manager.test.js`
+ *     already uses for its HF download fixture): `startStubLlamaServer({
+ *     modelId }) -> Promise<{ server, port, baseUrl, close() }>`.
+ *   - Run standalone (`node tests/fixtures/stub-llama-server.mjs <modelId>
+ *     [port]`) for manual poking; prints `PORT <n>` on its first stdout
+ *     line once listening.
+ */
+import http from "node:http";
+
+/**
+ * Start the stub server. `modelId` is the id it reports at `data[0].id`
+ * (the "what does this server think it's serving" the conflict-detection
+ * test flips). `port` defaults to 0 (OS-assigned, avoids collisions
+ * between parallel test files).
+ */
+export function startStubLlamaServer({ modelId, port = 0, host = "127.0.0.1" } = {}) {
+  return new Promise((resolvePromise, reject) => {
+    const server = http.createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/models") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ object: "list", data: [{ id: modelId, object: "model" }] }));
+        return;
+      }
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      const actualPort = server.address().port;
+      resolvePromise({
+        server,
+        port: actualPort,
+        baseUrl: `http://${host}:${actualPort}`,
+        close: () => new Promise((res) => server.close(res)),
+      });
+    });
+  });
+}
+
+// Standalone entry point — not exercised by the test suite, kept for
+// manual/ops use (e.g. poking identityProbe by hand against a real port).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const modelId = process.argv[2] || "stub-model";
+  const port = Number(process.argv[3] || 0);
+  startStubLlamaServer({ modelId, port }).then(({ port: p }) => {
+    process.stdout.write(`PORT ${p}\n`);
+  });
+  process.on("SIGTERM", () => process.exit(0));
+}

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -29,6 +29,7 @@ import {
   resolveWarmableProviderName,
   ensureResident,
   isNativeRuntimeProvider,
+  initNativeModels,
   NativePortConflictError,
   NativeHostLockHeldError,
   _setNativeHandleForTest,
@@ -491,4 +492,306 @@ test("isNativeRuntimeProvider: true for a native provider, false for a Docker pr
   assert.equal(isNativeRuntimeProvider("native-target", cfg), true);
   assert.equal(isNativeRuntimeProvider("docker-target", cfg), false);
   assert.equal(isNativeRuntimeProvider("does-not-exist", cfg), false);
+});
+
+// ---------------------------------------------------------------------------
+// Final-review fix wave — Fix 1: probe cache never populated in production
+// ---------------------------------------------------------------------------
+
+test("Fix 1: acquire native with a null initial probe cache awaits reprobeFn exactly once; a second acquire makes zero additional calls", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18116, "qwen3-4b") } };
+  const fakeProbe = { platform: "linux", accel: "cpu" };
+  let cachedProbe = null; // mirrors probe.js's real cache: null until reprobe() warms it
+  let reprobeCalls = 0;
+  const getCachedProbeFn = () => cachedProbe;
+  const reprobeFn = async () => {
+    reprobeCalls += 1;
+    cachedProbe = fakeProbe; // reprobe() also populates the cache it's read from — same as production
+    return fakeProbe;
+  };
+
+  const ensureRuntimeCalls = [];
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    // Per acquire: 1st call is the fast-path check (nothing running yet ->
+    // "down"), 2nd+ is the post-start readiness wait -> "resident". `probeCalls`
+    // is reset to 0 before the second acquire below so this pattern repeats.
+    return probeCalls === 1 ? "down" : "resident";
+  };
+
+  const opts = {
+    cfg,
+    identityProbeFn,
+    acquireHostLockFn: () => () => {},
+    startModelFn: () => fakeHandle(),
+    ensureRuntimeFn: async (dir, runtimeBlock, probe) => {
+      ensureRuntimeCalls.push(probe);
+      return "/fake/runtimes/llamacpp/b1/llama-server";
+    },
+    loadStateFn: () => ({ registry: { "native-target": { file: "model.gguf" } } }),
+    resolveDataDirFn: () => "/fake/crow-home",
+    loadCatalogFn: () => ({ runtime: { release: "b1", assets: {} } }),
+    getCachedProbeFn,
+    reprobeFn,
+    readinessTimeoutMs: 200,
+    readinessPollMs: 5,
+    readinessInitialDelayMs: 0,
+  };
+
+  const first = await acquireProvider("native-target", opts);
+  assert.equal(first, true);
+  assert.equal(reprobeCalls, 1, "reprobeFn was awaited exactly once on the null-cache miss");
+  assert.deepEqual(ensureRuntimeCalls[0], fakeProbe, "the reprobe()'d probe (not null) was threaded into ensureRuntimeFn");
+
+  // Second acquire: a fresh down->resident cycle (same shape as the first —
+  // resolveNativeBinPath runs unconditionally on every acquireProvider call,
+  // per its own doc, regardless of which path the swap itself takes).
+  probeCalls = 0;
+  await acquireProvider("native-target", opts);
+  assert.equal(reprobeCalls, 1, "second acquire: zero additional reprobeFn calls — the cache is warm");
+});
+
+// ---------------------------------------------------------------------------
+// Final-review fix wave — Fix 2: handle.touch() had zero callers
+// ---------------------------------------------------------------------------
+
+test("Fix 2: the resident fast path touches the live native handle, resetting its idle timer", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18117, "qwen3-4b") } };
+  let touchCalls = 0;
+  const handle = fakeHandle({ touch: () => { touchCalls += 1; } });
+  _setNativeHandleForTest("native-target", handle);
+
+  // resolveNativeBinPath runs unconditionally on every acquireProvider call
+  // (before the fast path is even checked — see its own doc), so this test
+  // needs the full stub bag even though it never reaches a real start.
+  const result = await acquireProvider(
+    "native-target",
+    startCapableOpts({ cfg, identityProbeFn: async () => "resident" }), // fast path — already resident
+  );
+
+  assert.equal(result, true);
+  assert.equal(touchCalls, 1, "handle.touch() was called on the resident fast path");
+});
+
+test("Fix 2: the resident fast path does not call touch() when there is no live handle in-memory (simulated-restart re-warm case)", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18118, "qwen3-4b") } };
+  // No _setNativeHandleForTest call — beforeEach already cleared it. This
+  // is the "simulated restart" shape: identityProbe reports resident (the
+  // real OS-level port is up) but this process holds no in-memory handle.
+  const result = await acquireProvider(
+    "native-target",
+    startCapableOpts({ cfg, identityProbeFn: async () => "resident" }),
+  );
+  assert.equal(result, true, "still reports resident even with no live handle to touch — touch() is best-effort, not required for correctness");
+});
+
+test("Fix 2: touch() is not called on a dead (non-live) cached handle", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18119, "qwen3-4b") } };
+  let touchCalls = 0;
+  const handle = fakeHandle({ live: false, touch: () => { touchCalls += 1; } });
+  _setNativeHandleForTest("native-target", handle);
+
+  await acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn: async () => "resident" }));
+
+  assert.equal(touchCalls, 0, "a non-live handle is never touched — matches the sibling-eviction gate's live check elsewhere in this file");
+});
+
+// ---------------------------------------------------------------------------
+// Final-review fix wave — Fix 5: readiness-timeout orphans a loading process
+// ---------------------------------------------------------------------------
+
+test("Fix 5: a readiness timeout (\"down\") stops the orphaned handle and clears it from _nativeHandles before throwing; both release paths fire safely", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18121, "qwen3-4b") } };
+
+  // A handle that mirrors runtime.js's real behavior more faithfully than
+  // the bare `fakeHandle()` helper: its stop() actually fires the captured
+  // onTerminal callback (exactly once), same as the real startModel's
+  // handle does — needed so this test can observe BOTH release paths Fix
+  // 5's doc describes (onTerminal's, and acquireOrStartNative's own
+  // finally block) actually firing, not just one of them.
+  let live = true;
+  let stopCalls = 0;
+  let capturedOnTerminal = null;
+  const handle = {
+    get live() { return live; },
+    async stop() {
+      stopCalls += 1;
+      live = false;
+      if (capturedOnTerminal) capturedOnTerminal("stopped");
+    },
+    status() { return { live }; },
+  };
+  const startModelFn = (params) => {
+    capturedOnTerminal = params.onTerminal;
+    return handle;
+  };
+  const identityProbeFn = async () => "down"; // never becomes resident — the timeout path
+
+  // Idempotent, like native-lock.js's real release() closure (guarded by a
+  // `released` flag) — a raw (non-guarded) counter alongside it proves BOTH
+  // call sites actually invoke it, while the guarded flag proves that,
+  // exactly as Fix 5's doc claims, this is safe: no crash, no double-free.
+  let rawReleaseCalls = 0;
+  let released = false;
+  const release = () => {
+    rawReleaseCalls += 1;
+    if (released) return;
+    released = true;
+  };
+
+  await assert.rejects(
+    () => acquireProvider("native-target", {
+      ...startCapableOpts({ cfg, identityProbeFn, startModelFn }),
+      acquireHostLockFn: () => release,
+    }),
+    /failed to bind port 18121|refusing to rebind/,
+  );
+
+  assert.equal(stopCalls, 1, "the orphaned handle was stopped before the readiness-timeout error was thrown");
+  assert.equal(live, false);
+  assert.equal(rawReleaseCalls, 2, "release() was invoked from BOTH call sites — onTerminal (via handle.stop()) and acquireOrStartNative's finally block");
+  assert.equal(released, true, "and it settled safely — no throw from the second (idempotent-no-op) call");
+});
+
+test("Fix 5: a post-start identity conflict also stops the orphaned handle and clears it from _nativeHandles before throwing", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18122, "qwen3-4b") } };
+  const handle = fakeHandle();
+  const startModelFn = () => handle;
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    // 1st call: fast-path check (nothing running yet -> "down"). 2nd+:
+    // post-start readiness wait — the process bound the port but is
+    // serving something else.
+    return probeCalls === 1 ? "down" : "conflict";
+  };
+
+  let caught = null;
+  try {
+    await acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn, startModelFn }));
+  } catch (err) {
+    caught = err;
+  }
+
+  assert.ok(caught instanceof NativePortConflictError, `expected NativePortConflictError, got ${caught}`);
+  assert.equal(handle.stopCalls, 1, "the orphaned (conflicting) handle was stopped before the conflict error was thrown");
+  assert.equal(handle.live, false);
+});
+
+// ---------------------------------------------------------------------------
+// Final-review fix wave — Fix 3: reconcileOnBoot never invoked
+// ---------------------------------------------------------------------------
+
+test("Fix 3: initNativeModels invokes reconcileOnBootFn exactly once, shaping native provider rows to {modelId}", async () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  let reconcileCalls = 0;
+  let capturedListProviderRows = null;
+  const reconcileOnBootFn = (args) => {
+    reconcileCalls += 1;
+    capturedListProviderRows = args.listProviderRows;
+    assert.equal(args.state, state);
+    assert.equal(typeof args.isProcessAlive, "function");
+    return { freedReservations: [], orphanRows: [], resumableDownloads: [] };
+  };
+
+  const rows = [
+    { id: "native-a", disabled: false, gpuPolicy: { runtime: "native" } },
+    { id: "docker-b", disabled: false, gpuPolicy: null }, // not native — must be excluded
+    { id: "native-disabled", disabled: true, gpuPolicy: { runtime: "native" } }, // disabled — excluded
+  ];
+
+  const plan = await initNativeModels({
+    dir: "/fake/crow-home",
+    db: {}, // truthy — enables the provider-row read branch
+    loadStateFn: () => state,
+    saveStateFn: () => {},
+    listProvidersAllFn: async () => rows,
+    reconcileOnBootFn,
+  });
+
+  assert.equal(reconcileCalls, 1, "reconcileOnBoot was invoked exactly once");
+  assert.deepEqual(capturedListProviderRows(), [{ modelId: "native-a" }], "only the enabled native row was shaped in — Docker and disabled rows excluded");
+  assert.deepEqual(plan, { freedReservations: [], orphanRows: [], resumableDownloads: [] });
+});
+
+test("Fix 3: a journaled (interrupted) download is re-enqueued via enqueueDownloadFn", async () => {
+  const state = {
+    reservations: {},
+    journal: {
+      "native-partial": { url: "https://huggingface.co/x/resolve/main/y.gguf", dest: "/fake/blobs/y.gguf", bytesDone: 1024, expectedSha: "deadbeef", startedAt: "2026-07-18T00:00:00.000Z" },
+    },
+    registry: {},
+  };
+  const enqueueCalls = [];
+  const catalog = { models: [] };
+
+  await initNativeModels({
+    dir: "/fake/crow-home",
+    db: null, // no DB — reservations/journal reconciliation still runs
+    loadStateFn: () => state,
+    saveStateFn: () => {},
+    loadCatalogFn: () => catalog,
+    enqueueDownloadFn: (params) => {
+      enqueueCalls.push(params);
+      return Promise.resolve({ path: "/fake/blobs/y.gguf", sha256: "deadbeef" });
+    },
+  });
+
+  assert.equal(enqueueCalls.length, 1, "the one journaled download was re-enqueued");
+  assert.equal(enqueueCalls[0].modelId, "native-partial");
+  assert.equal(enqueueCalls[0].dir, "/fake/crow-home");
+  assert.equal(enqueueCalls[0].catalog, catalog);
+});
+
+test("Fix 3: a reconcileOnBootFn throw does not propagate out of initNativeModels", async () => {
+  await assert.doesNotReject(() => initNativeModels({
+    dir: "/fake/crow-home",
+    db: null,
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: {} }),
+    reconcileOnBootFn: () => {
+      throw new Error("boom");
+    },
+  }));
+});
+
+test("Fix 3: a provider-row read failure (bad db) does not propagate — reconciliation degrades to reservations-only", async () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  let reconcileCalls = 0;
+  const plan = await initNativeModels({
+    dir: "/fake/crow-home",
+    db: {},
+    loadStateFn: () => state,
+    listProvidersAllFn: async () => {
+      throw new Error("db read failed");
+    },
+    reconcileOnBootFn: (args) => {
+      reconcileCalls += 1;
+      assert.deepEqual(args.listProviderRows(), [], "provider rows degrade to empty on a read failure, never throw");
+      return { freedReservations: [], orphanRows: [], resumableDownloads: [] };
+    },
+  });
+  assert.equal(reconcileCalls, 1);
+  assert.deepEqual(plan, { freedReservations: [], orphanRows: [], resumableDownloads: [] });
+});
+
+test("Fix 3: freed reservations are persisted via saveStateFn", async () => {
+  const state = { reservations: { "model-dead": { port: 18100 } }, journal: {}, registry: {} };
+  let saveCalls = 0;
+  await initNativeModels({
+    dir: "/fake/crow-home",
+    db: null,
+    loadStateFn: () => state,
+    saveStateFn: (dir, s) => {
+      saveCalls += 1;
+      assert.equal(dir, "/fake/crow-home");
+      assert.equal(s, state);
+    },
+    reconcileOnBootFn: () => ({
+      freedReservations: [{ modelId: "model-dead", port: 18100 }],
+      orphanRows: [],
+      resumableDownloads: [],
+    }),
+  });
+  assert.equal(saveCalls, 1, "saveState was called because a reservation was freed");
 });

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -168,15 +168,10 @@ test("acquire native: identity conflict on the fast path throws before taking th
   let caught = null;
   try {
     await acquireProvider("native-target", {
-      cfg,
-      identityProbeFn: async () => "conflict",
+      ...startCapableOpts({ cfg, identityProbeFn: async () => "conflict", startCalls }),
       acquireHostLockFn: () => {
         lockCalls += 1;
         return () => {};
-      },
-      startModelFn: (p) => {
-        startCalls.push(p);
-        return fakeHandle();
       },
     });
   } catch (err) {
@@ -195,13 +190,8 @@ test("acquire native: host lock held elsewhere surfaces an honest error, no star
   let caught = null;
   try {
     await acquireProvider("native-target", {
-      cfg,
-      identityProbeFn: async () => "down",
+      ...startCapableOpts({ cfg, identityProbeFn: async () => "down", startCalls }),
       acquireHostLockFn: () => null, // held elsewhere
-      startModelFn: (p) => {
-        startCalls.push(p);
-        return fakeHandle();
-      },
     });
   } catch (err) {
     caught = err;
@@ -271,14 +261,84 @@ test("acquire native: a native sibling in the same mutexGroup is stopped via its
   assert.equal(sibHandle.live, false);
 });
 
+// --- fix round 1, finding 1: lock held for the LIFE of residency ----------
+
+test("acquire native: the host lock is held for the life of residency — release fires only on the handle's terminal transition, never right after a successful start", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18112, "qwen3-4b") } };
+  let releaseCalls = 0;
+  const release = () => {
+    releaseCalls += 1;
+  };
+  let capturedOnTerminal = null;
+  const startModelFn = (params) => {
+    capturedOnTerminal = params.onTerminal;
+    assert.equal(typeof capturedOnTerminal, "function", "startModel is given an onTerminal callback to wire up");
+    return fakeHandle();
+  };
+
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return probeCalls === 1 ? "down" : "resident"; // fast-path down, then resident once "started"
+  };
+
+  const result = await acquireProvider("native-target", {
+    ...startCapableOpts({ cfg, identityProbeFn, startModelFn }),
+    acquireHostLockFn: () => release,
+  });
+
+  assert.equal(result, true);
+  assert.equal(releaseCalls, 0, "the lock must NOT be released immediately after a successful start");
+
+  // Simulate the process later reaching a terminal state (runtime.js's
+  // own onTerminal-firing correctness — idle-stop, restarts-exhausted,
+  // explicit stop — is covered separately in tests/models-runtime.test.js;
+  // this test only proves gpu-orchestrator wires release() to fire when
+  // that callback IS invoked, and not before).
+  capturedOnTerminal("stopped");
+  assert.equal(releaseCalls, 1, "release fires when the handle reaches a terminal state");
+});
+
+// --- fix round 1, finding 3: Docker acquire evicts a native sibling -------
+
+test("Docker acquire evicts a resident native sibling in the same mutexGroup (handle.stop spy)", async () => {
+  const cfg = {
+    providers: {
+      "docker-target": dockerProv("http://127.0.0.1:8003/v1", "vllm-rocm-qwen35-4b", { gpuPolicy: { mutexGroup: "local-llm" } }),
+      "native-sib": nativeProv(18120, "qwen3-4b", { gpuPolicy: { runtime: "native", mutexGroup: "local-llm" } }),
+    },
+  };
+  const sibHandle = fakeHandle();
+  _setNativeHandleForTest("native-sib", sibHandle);
+
+  const bundleUpCalls = [];
+  const result = await acquireProvider("docker-target", {
+    cfg,
+    probeReadyFn: async () => false, // never "already resident" via the fast path — force the full swap+start
+    bundleUpFn: async (bundleId) => {
+      bundleUpCalls.push(bundleId);
+    },
+    waitForReadyFn: async () => true, // stub past the real polling loop
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(bundleUpCalls, ["vllm-rocm-qwen35-4b"]);
+  assert.equal(sibHandle.stopCalls, 1, "the native sibling's handle.stop() was called to admit the Docker target");
+  assert.equal(sibHandle.live, false);
+});
+
 // --- touch point 2: maybeAcquireLocalProvider ------------------------------
 
 test("maybeAcquireLocalProvider does not early-out on a native provider's null bundleId", async () => {
   const cfg = { providers: { "native-target": nativeProv(18108, "qwen3-4b") } };
-  const result = await maybeAcquireLocalProvider("native-target", {
-    cfg,
-    identityProbeFn: async () => "resident", // fast path — already warm
-  });
+  // Fast path (already resident) — resolveNativeBinPath still runs before
+  // the single-flight per the acquireProvider contract, so the full
+  // start-capable opts bag is supplied even though nothing will actually
+  // start.
+  const result = await maybeAcquireLocalProvider(
+    "native-target",
+    startCapableOpts({ cfg, identityProbeFn: async () => "resident" }),
+  );
   assert.equal(result, true, "must not return null just because the native provider has no bundleId");
 });
 
@@ -318,7 +378,10 @@ test("ensureResident native: no live handle -> starts it and reports embed capab
   let probeCalls = 0;
   const identityProbeFn = async () => {
     probeCalls += 1;
-    return "resident"; // once started, immediately reports resident
+    // First call is the fast-path check (nothing running yet -> "down");
+    // subsequent calls are the post-start readiness wait, which reports
+    // resident immediately once the (stubbed) process is "up".
+    return probeCalls === 1 ? "down" : "resident";
   };
 
   const result = await ensureResident("native-target", cfg, {

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -28,11 +28,13 @@ import {
   maybeAcquireLocalProvider,
   resolveWarmableProviderName,
   ensureResident,
+  isNativeRuntimeProvider,
   NativePortConflictError,
   NativeHostLockHeldError,
   _setNativeHandleForTest,
 } from "../servers/gateway/gpu-orchestrator.js";
 import { _resetProviderHealth, getProviderHealth } from "../servers/gateway/provider-health.js";
+import { nativeReadinessTimeoutMs } from "../servers/gateway/models/runtime.js";
 
 // --- fixtures ------------------------------------------------------------
 
@@ -400,4 +402,93 @@ test("ensureResident native: no live handle -> starts it and reports embed capab
 
   assert.equal(result, true, "started fresh AND is embed-capable -> caller should trigger backfill");
   assert.ok(probeCalls >= 1);
+});
+
+// --- Item G, Task 10: size-scaled readiness timeout -------------------------
+
+test("nativeReadinessTimeoutMs: boundaries — 0 MB floors at 120s, 2500 MB SSD is 140s, 17000 MB HDD is 800s", () => {
+  assert.equal(nativeReadinessTimeoutMs(0), 120_000, "0 MB (or unknown size) never goes below the base floor");
+  assert.equal(nativeReadinessTimeoutMs(2500, "ssd"), 140_000, "120_000 + 2500*8 = 140_000");
+  assert.equal(nativeReadinessTimeoutMs(17000, "hdd"), 800_000, "120_000 + 17000*40 = 800_000");
+});
+
+test("nativeReadinessTimeoutMs: defaults to ssd's per-MB rate when storageClass is omitted", () => {
+  assert.equal(nativeReadinessTimeoutMs(2500), nativeReadinessTimeoutMs(2500, "ssd"));
+});
+
+test("nativeReadinessTimeoutMs: a non-finite/negative size degrades to the bare floor, never throws or goes negative", () => {
+  assert.equal(nativeReadinessTimeoutMs(undefined), 120_000);
+  assert.equal(nativeReadinessTimeoutMs(null), 120_000);
+  assert.equal(nativeReadinessTimeoutMs(NaN), 120_000);
+  assert.equal(nativeReadinessTimeoutMs(-500), 120_000);
+});
+
+test("acquire native: with no readinessTimeoutMs override, the timeout is computed from the registry entry's sizeMb via nativeReadinessTimeoutMs — not the old flat default", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18113, "qwen3-4b") } };
+  const calls = [];
+  // Tiny stand-in formula so the test doesn't actually wait real minutes —
+  // proves WHAT gets passed in (sizeMb, storageClass), not the real
+  // production timeout value (that's covered by the boundary tests above).
+  const nativeReadinessTimeoutMsFn = (sizeMb, storageClass) => {
+    calls.push({ sizeMb, storageClass });
+    return 200; // ms — plenty for the stubbed identity-probe below
+  };
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    // 1st call: acquireOrStartNative's fast-path check (nothing running
+    // yet). 2nd+: the post-start readiness wait — "resident" immediately.
+    return probeCalls === 1 ? "down" : "resident";
+  };
+
+  const result = await acquireProvider("native-target", {
+    ...startCapableOpts({ cfg, identityProbeFn }),
+    // Override the fixture's flat `readinessTimeoutMs: 200` from
+    // startCapableOpts — this test is specifically about what happens when
+    // NO override is supplied, so the formula path is exercised instead.
+    readinessTimeoutMs: undefined,
+    nativeReadinessTimeoutMsFn,
+    loadStateFn: () => ({ registry: { "native-target": { file: "model.gguf", sizeMb: 4321 } } }),
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, [{ sizeMb: 4321, storageClass: "ssd" }], "the registry entry's sizeMb and the default ssd storageClass were threaded into the formula");
+});
+
+test("acquire native: an explicit readinessTimeoutMs override still wins outright (existing test fixtures keep working)", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18114, "qwen3-4b") } };
+  let formulaCalls = 0;
+  const nativeReadinessTimeoutMsFn = () => {
+    formulaCalls += 1;
+    return 999_999;
+  };
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return probeCalls === 1 ? "down" : "resident";
+  };
+
+  const result = await acquireProvider("native-target", {
+    ...startCapableOpts({ cfg, identityProbeFn }),
+    nativeReadinessTimeoutMsFn,
+    // startCapableOpts already sets readinessTimeoutMs: 200 — an explicit
+    // override — so the formula must never even be called.
+  });
+
+  assert.equal(result, true);
+  assert.equal(formulaCalls, 0, "an explicit readinessTimeoutMs override bypasses the formula entirely");
+});
+
+// --- Item G, Task 10: isNativeRuntimeProvider (chat.js copy-selection seam) -
+
+test("isNativeRuntimeProvider: true for a native provider, false for a Docker provider, false for an unknown name", () => {
+  const cfg = {
+    providers: {
+      "native-target": nativeProv(18115, "qwen3-4b"),
+      "docker-target": dockerProv("http://127.0.0.1:8003/v1", "vllm-rocm-qwen35-4b"),
+    },
+  };
+  assert.equal(isNativeRuntimeProvider("native-target", cfg), true);
+  assert.equal(isNativeRuntimeProvider("docker-target", cfg), false);
+  assert.equal(isNativeRuntimeProvider("does-not-exist", cfg), false);
 });

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -1,0 +1,340 @@
+/**
+ * gpu-orchestrator native-runtime branch (Item G, Task 9).
+ *
+ * A provider is native iff `provider.gpuPolicy?.runtime === "native"`
+ * (the ONLY writer of that field is `manager.js`'s `registerModel` — see
+ * its doc for the exact row shape this file's fixtures mirror: `bundleId:
+ * null`, `host: "local"`, `baseUrl: "http://127.0.0.1:<port>/v1"`,
+ * `models: [{ id: <alias>, task, contextLen }]`).
+ *
+ * Every native-path test stubs `spawn`/`fetch`-adjacent seams
+ * (`identityProbeFn`, `startModelFn`, `stopModelFn`, `acquireHostLockFn`,
+ * `bundleStopFn`, `probeReadyFn`, `ensureRuntimeFn`, `loadStateFn`,
+ * `resolveDataDirFn`, `loadCatalogFn`, `getCachedProbeFn`) via the
+ * `opts` bag `acquireProvider`/`maybeAcquireLocalProvider`/`ensureResident`
+ * now accept — no real llama-server, no real filesystem/network touched.
+ * `opts.cfg` overrides the provider config the native branch resolves
+ * targets/siblings from, following the same "cfg passed explicitly"
+ * pattern `tests/gpu-orchestrator-host-gate.test.js` and
+ * `tests/gpu-orchestrator-residency-poll.test.js` already use for the
+ * PURE helpers in this module.
+ */
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  pollResidency,
+  acquireProvider,
+  maybeAcquireLocalProvider,
+  resolveWarmableProviderName,
+  ensureResident,
+  NativePortConflictError,
+  NativeHostLockHeldError,
+  _setNativeHandleForTest,
+} from "../servers/gateway/gpu-orchestrator.js";
+import { _resetProviderHealth, getProviderHealth } from "../servers/gateway/provider-health.js";
+
+// --- fixtures ------------------------------------------------------------
+
+const OWN = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/** A native provider row shaped exactly like `manager.js`'s `registerModel`
+ * output: `bundleId: null`, `host: "local"`, loopback baseUrl,
+ * `models[0].id` doubling as the llama-server `--alias`. */
+function nativeProv(port, alias, extra = {}) {
+  const { gpuPolicy, ...rest } = extra;
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    host: "local",
+    bundleId: null,
+    models: [{ id: alias, task: "chat" }],
+    gpuPolicy: { runtime: "native", ...gpuPolicy },
+    ...rest,
+  };
+}
+
+/** A Docker-backed provider row (the pre-existing, unmodified control
+ * plane) — used to prove the native branch doesn't weaken the Docker
+ * gates it sits beside. */
+function dockerProv(baseUrl, bundleId, extra = {}) {
+  return { baseUrl, bundleId, host: "local", models: [{ id: "docker-model", task: "chat" }], ...extra };
+}
+
+/** A stub `startModel()` handle — `{ live, stop(), status() }`. */
+function fakeHandle(overrides = {}) {
+  const h = {
+    live: true,
+    stopCalls: 0,
+    async stop() {
+      h.stopCalls += 1;
+      h.live = false;
+    },
+    status() {
+      return { live: h.live };
+    },
+    ...overrides,
+  };
+  return h;
+}
+
+/** Injectable seams that get a fresh native provider all the way to
+ * "started and ready" without touching a real binary/download/process. */
+function startCapableOpts({ cfg, identityProbeFn, startCalls = [], startModelFn }) {
+  return {
+    cfg,
+    identityProbeFn,
+    acquireHostLockFn: () => () => {},
+    startModelFn: startModelFn || ((params) => {
+      startCalls.push(params);
+      return fakeHandle();
+    }),
+    ensureRuntimeFn: async () => "/fake/runtimes/llamacpp/b1/llama-server",
+    loadStateFn: () => ({ registry: { "native-target": { file: "model.gguf" } } }),
+    resolveDataDirFn: () => "/fake/crow-home",
+    loadCatalogFn: () => ({ runtime: { release: "b1", assets: {} } }),
+    getCachedProbeFn: () => ({ platform: "linux", accel: "cpu" }),
+    readinessTimeoutMs: 200,
+    readinessPollMs: 5,
+    readinessInitialDelayMs: 0,
+  };
+}
+
+beforeEach(() => {
+  _resetProviderHealth();
+  _setNativeHandleForTest("native-target", null);
+  _setNativeHandleForTest("native-sib", null);
+});
+
+// --- touch point 5: pollResidency compose-file gate (named blocker) -----
+
+test("pollResidency never releases a native provider's residency for lacking a compose file", async () => {
+  const cfg = {
+    providers: {
+      "native-embed": nativeProv(18107, "qwen3-embed", { gpuPolicy: { alwaysResident: true, runtime: "native" } }),
+      "docker-embed": dockerProv("http://127.0.0.1:9100/v1", "safe-bundle", { gpuPolicy: { alwaysResident: true } }),
+    },
+  };
+  const probe = async () => true;
+  const composeExistsCalls = [];
+  // ALWAYS false — this is exactly the condition that used to trip the
+  // gate for anything with a bundleId. A native provider must never even
+  // ask composeExists in the first place.
+  const composeExists = (id) => {
+    composeExistsCalls.push(id);
+    return false;
+  };
+
+  const probed = await pollResidency({ cfg, ownAddrs: OWN, probe, now: () => 1000, composeExists });
+
+  assert.deepEqual(probed.sort(), ["native-embed"], "only the native provider was probed this tick");
+  assert.deepEqual(composeExistsCalls, ["safe-bundle"], "composeExists is never called for a native provider");
+  const health = getProviderHealth().providers;
+  assert.ok(health["native-embed"], "native provider's residency entry was NOT released for lacking a compose file");
+  assert.equal(health["docker-embed"], undefined, "Docker provider still correctly released — the per-runtime gate didn't weaken the Docker path");
+});
+
+// --- touch point 1: acquireProvider re-warm / bind-failure (named blocker) --
+
+test("after simulated restart, re-warm binds the exact port from base_url; bind failure surfaces an error, never a silent rebind", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18106, "qwen3-4b") } };
+  // Simulated restart: _nativeHandles has NOTHING for "native-target" (the
+  // in-memory map reset with the gateway process) — beforeEach already
+  // ensures this. The real llama-server process either died or never came
+  // back; identityProbe never reports "resident" for the whole window,
+  // simulating a bind failure (e.g. EADDRINUSE causing an immediate exit).
+  const startCalls = [];
+  const startModelFn = (params) => {
+    startCalls.push(params);
+    return fakeHandle();
+  };
+  const identityProbeFn = async () => "down";
+
+  await assert.rejects(
+    () => acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn, startCalls, startModelFn })),
+    /failed to bind port 18106|refusing to rebind/,
+  );
+
+  assert.equal(startCalls.length, 1, "started exactly once — no retry attempt on a different port");
+  assert.equal(startCalls[0].port, 18106, "bound the EXACT port encoded in base_url, never re-allocated");
+});
+
+// --- touch point 1: identity-conflict / lock-held --------------------------
+
+test("acquire native: identity conflict on the fast path throws before taking the lock or starting anything", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18105, "qwen3-4b") } };
+  let lockCalls = 0;
+  const startCalls = [];
+
+  let caught = null;
+  try {
+    await acquireProvider("native-target", {
+      cfg,
+      identityProbeFn: async () => "conflict",
+      acquireHostLockFn: () => {
+        lockCalls += 1;
+        return () => {};
+      },
+      startModelFn: (p) => {
+        startCalls.push(p);
+        return fakeHandle();
+      },
+    });
+  } catch (err) {
+    caught = err;
+  }
+
+  assert.ok(caught instanceof NativePortConflictError, `expected NativePortConflictError, got ${caught}`);
+  assert.equal(lockCalls, 0, "the host lock is never taken on a conflict");
+  assert.equal(startCalls.length, 0, "never started — no traffic routed to a conflicting port");
+});
+
+test("acquire native: host lock held elsewhere surfaces an honest error, no start attempted", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18104, "qwen3-4b") } };
+  const startCalls = [];
+
+  let caught = null;
+  try {
+    await acquireProvider("native-target", {
+      cfg,
+      identityProbeFn: async () => "down",
+      acquireHostLockFn: () => null, // held elsewhere
+      startModelFn: (p) => {
+        startCalls.push(p);
+        return fakeHandle();
+      },
+    });
+  } catch (err) {
+    caught = err;
+  }
+
+  assert.ok(caught instanceof NativeHostLockHeldError, `expected NativeHostLockHeldError, got ${caught}`);
+  assert.match(caught.message, /another Crow instance on this host is using the GPU\/RAM/);
+  assert.equal(startCalls.length, 0, "never started while the lock is held elsewhere");
+});
+
+// --- touch point 1: sibling swap inside the single-flight -----------------
+
+test("acquire native: a Docker sibling in the same mutexGroup is stopped via bundleStop to admit it", async () => {
+  const cfg = {
+    providers: {
+      "native-target": nativeProv(18101, "qwen3-4b", { gpuPolicy: { runtime: "native", mutexGroup: "local-llm" } }),
+      "docker-sib": dockerProv("http://127.0.0.1:8003/v1", "vllm-rocm-qwen35-4b", { gpuPolicy: { mutexGroup: "local-llm" } }),
+    },
+  };
+
+  let targetProbeCalls = 0;
+  const identityProbeFn = async (baseUrl) => {
+    if (baseUrl.includes(":18101")) {
+      targetProbeCalls += 1;
+      return targetProbeCalls === 1 ? "down" : "resident";
+    }
+    return "down";
+  };
+  const bundleStopCalls = [];
+  const bundleStopFn = async (bundleId) => {
+    bundleStopCalls.push(bundleId);
+  };
+  const probeReadyFn = async (baseUrl) => baseUrl.includes(":8003"); // Docker sibling is currently up
+
+  const result = await acquireProvider(
+    "native-target",
+    { ...startCapableOpts({ cfg, identityProbeFn }), bundleStopFn, probeReadyFn },
+  );
+
+  assert.equal(result, true);
+  assert.deepEqual(bundleStopCalls, ["vllm-rocm-qwen35-4b"], "the Docker sibling was stopped via bundleStop");
+});
+
+test("acquire native: a native sibling in the same mutexGroup is stopped via its handle's stop()", async () => {
+  const cfg = {
+    providers: {
+      "native-target": nativeProv(18102, "qwen3-8b", { gpuPolicy: { runtime: "native", mutexGroup: "local-llm" } }),
+      "native-sib": nativeProv(18103, "qwen3-4b", { gpuPolicy: { runtime: "native", mutexGroup: "local-llm" } }),
+    },
+  };
+  const sibHandle = fakeHandle();
+  _setNativeHandleForTest("native-sib", sibHandle);
+
+  let targetProbeCalls = 0;
+  const identityProbeFn = async (baseUrl) => {
+    if (baseUrl.includes(":18102")) {
+      targetProbeCalls += 1;
+      return targetProbeCalls === 1 ? "down" : "resident";
+    }
+    return "down";
+  };
+
+  const result = await acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn }));
+
+  assert.equal(result, true);
+  assert.equal(sibHandle.stopCalls, 1, "the native sibling's handle.stop() was called exactly once");
+  assert.equal(sibHandle.live, false);
+});
+
+// --- touch point 2: maybeAcquireLocalProvider ------------------------------
+
+test("maybeAcquireLocalProvider does not early-out on a native provider's null bundleId", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18108, "qwen3-4b") } };
+  const result = await maybeAcquireLocalProvider("native-target", {
+    cfg,
+    identityProbeFn: async () => "resident", // fast path — already warm
+  });
+  assert.equal(result, true, "must not return null just because the native provider has no bundleId");
+});
+
+// --- touch point 3: resolveWarmableProviderName ----------------------------
+
+test("resolveWarmableProviderName treats a native provider (bundleId null, runtime native) as warmable", () => {
+  const cfg = { providers: { "native-target": nativeProv(18109, "qwen3-4b") } };
+  assert.equal(resolveWarmableProviderName(cfg, "native-target", OWN), "native-target");
+});
+
+// --- touch point 4: ensureResident -----------------------------------------
+
+test("ensureResident native: process alive + identityProbe resident -> already resident, never restarts", async () => {
+  const p = nativeProv(18110, "qwen3-embed", { gpuPolicy: { alwaysResident: true, runtime: "native" } });
+  const cfg = { providers: { "native-target": p } };
+  _setNativeHandleForTest("native-target", fakeHandle({ live: true }));
+
+  const startCalls = [];
+  const result = await ensureResident("native-target", cfg, {
+    identityProbeFn: async () => "resident",
+    startModelFn: (params) => {
+      startCalls.push(params);
+      return fakeHandle();
+    },
+  });
+
+  assert.equal(result, false, "already resident -> no NEW embed warmup to report");
+  assert.equal(startCalls.length, 0, "never restarted an already-resident process");
+});
+
+test("ensureResident native: no live handle -> starts it and reports embed capability", async () => {
+  const p = nativeProv(18111, "qwen3-embed", { gpuPolicy: { alwaysResident: true, runtime: "native" } });
+  p.models = [{ id: "qwen3-embed", task: "embed" }];
+  const cfg = { providers: { "native-target": p } };
+  // beforeEach already cleared any handle for "native-target".
+
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return "resident"; // once started, immediately reports resident
+  };
+
+  const result = await ensureResident("native-target", cfg, {
+    identityProbeFn,
+    acquireHostLockFn: () => () => {},
+    startModelFn: () => fakeHandle(),
+    ensureRuntimeFn: async () => "/fake/runtimes/llamacpp/b1/llama-server",
+    loadStateFn: () => ({ registry: { "native-target": { file: "model.gguf" } } }),
+    resolveDataDirFn: () => "/fake/crow-home",
+    loadCatalogFn: () => ({ runtime: { release: "b1", assets: {} } }),
+    getCachedProbeFn: () => ({ platform: "linux", accel: "cpu" }),
+    readinessTimeoutMs: 200,
+    readinessPollMs: 5,
+    readinessInitialDelayMs: 0,
+  });
+
+  assert.equal(result, true, "started fresh AND is embed-capable -> caller should trigger backfill");
+  assert.ok(probeCalls >= 1);
+});

--- a/tests/models-manager.test.js
+++ b/tests/models-manager.test.js
@@ -1,0 +1,639 @@
+/**
+ * Tests for servers/gateway/models/manager.js — the GGUF download pipeline
+ * (Item G, Task 6).
+ *
+ * Every test runs against a LOCAL node:http fixture server (listen on
+ * 127.0.0.1, OS-assigned or explicitly reused ports) — no real network
+ * traffic ever leaves this process. Host-allowlist tests use a real
+ * huggingface.co-family hostname in the download URL together with an
+ * injected `lookup` (Node's standard http/https request option) that
+ * forces DNS resolution straight to 127.0.0.1, so the allowlist check runs
+ * against the actual literal hostnames named in the spec while every
+ * socket still talks to the local fixture server.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  symlinkSync,
+  createWriteStream as fsCreateWriteStream,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  downloadModel,
+  deleteModel,
+  enqueueDownload,
+  getDownloadConcurrency,
+  isAllowedHost,
+  buildDownloadUrl,
+  sanitizeFilename,
+  resolveEntry,
+  HostNotAllowedError,
+  ChecksumError,
+  DiskFullError,
+  UnsafeDestinationError,
+} from "../servers/gateway/models/manager.js";
+import { loadState } from "../servers/gateway/models/state.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeBlob(size) {
+  const buf = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) buf[i] = i % 256;
+  return buf;
+}
+
+const BLOB = makeBlob(300_000);
+const BLOB_SHA256 = createHash("sha256").update(BLOB).digest("hex");
+
+function scratchDir(tag) {
+  return mkdtempSync(join(tmpdir(), `models-manager-${tag}-`));
+}
+
+function startServer(handler) {
+  return new Promise((resolvePromise, reject) => {
+    const srv = http.createServer(handler);
+    srv.listen(0, "127.0.0.1", () => resolvePromise({ srv, port: srv.address().port }));
+    srv.on("error", reject);
+  });
+}
+
+function startServerOnPort(port, handler) {
+  return new Promise((resolvePromise, reject) => {
+    const srv = http.createServer(handler);
+    srv.listen(port, "127.0.0.1", () => resolvePromise({ srv, port }));
+    srv.on("error", reject);
+  });
+}
+
+function getFreePort() {
+  return new Promise((resolvePromise, reject) => {
+    const probe = net.createServer();
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address();
+      probe.close(() => resolvePromise(port));
+    });
+    probe.on("error", reject);
+  });
+}
+
+function stopServer(srv) {
+  return new Promise((resolvePromise) => srv.close(() => resolvePromise()));
+}
+
+/** Forces every hostname to 127.0.0.1 — lets tests use real huggingface.co
+ * / hf.co-family / disallowed hostnames in URLs with zero real DNS or
+ * network traffic. Handles both the classic single-address callback shape
+ * and the `{ all: true }` shape Node's happy-eyeballs multi-address connect
+ * path (net's `lookupAndConnectMultiple`) requests. */
+function lookupToLocalhost(_hostname, options, callback) {
+  if (options && options.all) {
+    callback(null, [{ address: "127.0.0.1", family: 4 }]);
+  } else {
+    callback(null, "127.0.0.1", 4);
+  }
+}
+
+function rangeAwareHandler(blob) {
+  return (req, res) => {
+    const range = req.headers.range;
+    if (range) {
+      const m = /bytes=(\d+)-/.exec(range);
+      const start = m ? Number.parseInt(m[1], 10) : 0;
+      res.writeHead(206, {
+        "Content-Range": `bytes ${start}-${blob.length - 1}/${blob.length}`,
+        "Content-Length": String(blob.length - start),
+      });
+      res.end(blob.subarray(start));
+    } else {
+      res.writeHead(200, { "Content-Length": String(blob.length) });
+      res.end(blob);
+    }
+  };
+}
+
+function killAtHalfHandler(blob) {
+  return (req, res) => {
+    res.writeHead(200, { "Content-Length": String(blob.length) });
+    const half = Math.floor(blob.length / 2);
+    res.write(blob.subarray(0, half));
+    setTimeout(() => res.destroy(), 15);
+  };
+}
+
+function makeCatalog({ hfRepo = "test/repo", file = "blob.gguf", sha256 = BLOB_SHA256, quant = "Q4_K_M" } = {}) {
+  return {
+    version: 1,
+    models: [
+      {
+        id: "test-model",
+        hf_repo: hfRepo,
+        default_quant: quant,
+        quants: [{ file, quant, sha256 }],
+      },
+    ],
+  };
+}
+
+function makeEnospcWriteStream(thresholdBytes) {
+  return (dest, opts) => {
+    const real = fsCreateWriteStream(dest, opts);
+    let written = 0;
+    const originalWrite = real.write.bind(real);
+    real.write = (chunk, ...rest) => {
+      written += chunk.length;
+      if (written > thresholdBytes) {
+        setImmediate(() => {
+          real.emit("error", Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" }));
+        });
+        return false;
+      }
+      return originalWrite(chunk, ...rest);
+    };
+    return real;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — no network, no filesystem
+// ---------------------------------------------------------------------------
+
+test("isAllowedHost allows huggingface.co and its subdomains, case-insensitively", () => {
+  assert.equal(isAllowedHost("huggingface.co"), true);
+  assert.equal(isAllowedHost("cdn-lfs.huggingface.co"), true);
+  assert.equal(isAllowedHost("HuggingFace.CO"), true);
+});
+
+test("isAllowedHost allows hf.co subdomains but NOT the bare hf.co apex", () => {
+  assert.equal(isAllowedHost("sub.hf.co"), true);
+  assert.equal(isAllowedHost("cdn.lfs.hf.co"), true);
+  assert.equal(isAllowedHost("hf.co"), false);
+});
+
+test("isAllowedHost rejects lookalike and unrelated hosts", () => {
+  assert.equal(isAllowedHost("evilhuggingface.co"), false);
+  assert.equal(isAllowedHost("evil.example.com"), false);
+  assert.equal(isAllowedHost("huggingface.co.evil.com"), false);
+  assert.equal(isAllowedHost(""), false);
+  assert.equal(isAllowedHost(undefined), false);
+});
+
+test("buildDownloadUrl builds the real huggingface.co resolve URL by default", () => {
+  assert.equal(
+    buildDownloadUrl("Qwen/Qwen3-4B-GGUF", "Qwen3-4B-Q4_K_M.gguf"),
+    "https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf",
+  );
+});
+
+test("sanitizeFilename strips directories and rejects . / ..", () => {
+  assert.equal(sanitizeFilename("blob.gguf"), "blob.gguf");
+  assert.equal(sanitizeFilename("../../etc/passwd"), "passwd");
+  assert.throws(() => sanitizeFilename(".."), UnsafeDestinationError);
+  assert.throws(() => sanitizeFilename("."), UnsafeDestinationError);
+});
+
+test("resolveEntry finds the model + default quant, and rejects unknown ids", () => {
+  const catalog = makeCatalog();
+  const { model, quantEntry } = resolveEntry(catalog, "test-model");
+  assert.equal(model.id, "test-model");
+  assert.equal(quantEntry.quant, "Q4_K_M");
+  assert.throws(() => resolveEntry(catalog, "nope"));
+});
+
+test("getDownloadConcurrency clamps CROW_MODEL_DL_CONCURRENCY to [1,2]", () => {
+  const prev = process.env.CROW_MODEL_DL_CONCURRENCY;
+  try {
+    delete process.env.CROW_MODEL_DL_CONCURRENCY;
+    assert.equal(getDownloadConcurrency(), 1);
+    process.env.CROW_MODEL_DL_CONCURRENCY = "2";
+    assert.equal(getDownloadConcurrency(), 2);
+    process.env.CROW_MODEL_DL_CONCURRENCY = "5";
+    assert.equal(getDownloadConcurrency(), 2);
+    process.env.CROW_MODEL_DL_CONCURRENCY = "0";
+    assert.equal(getDownloadConcurrency(), 1);
+    process.env.CROW_MODEL_DL_CONCURRENCY = "not-a-number";
+    assert.equal(getDownloadConcurrency(), 1);
+  } finally {
+    if (prev === undefined) delete process.env.CROW_MODEL_DL_CONCURRENCY;
+    else process.env.CROW_MODEL_DL_CONCURRENCY = prev;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// downloadModel — full happy path
+// ---------------------------------------------------------------------------
+
+test("downloadModel streams the full blob to disk and verifies sha256 incrementally", async () => {
+  const { srv, port } = await startServer(rangeAwareHandler(BLOB));
+  try {
+    const dir = scratchDir("full");
+    try {
+      const catalog = makeCatalog();
+      const progressCalls = [];
+      const result = await downloadModel({
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+        onProgress: (p) => progressCalls.push(p),
+      });
+      assert.equal(result.sha256, BLOB_SHA256);
+      assert.deepEqual(readFileSync(result.path), BLOB);
+      assert.ok(progressCalls.length > 0, "expected at least one progress callback");
+      assert.equal(progressCalls.at(-1).bytesDone, BLOB.length);
+
+      const state = loadState(dir);
+      assert.equal(state.journal["test-model"], undefined, "journal entry should be cleared on success");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Checksum mismatch
+// ---------------------------------------------------------------------------
+
+test("wrong sha256 deletes the file and throws a typed ChecksumError", async () => {
+  const { srv, port } = await startServer(rangeAwareHandler(BLOB));
+  try {
+    const dir = scratchDir("badsha");
+    try {
+      const catalog = makeCatalog({ sha256: "0".repeat(64) });
+      await assert.rejects(
+        () =>
+          downloadModel({
+            modelId: "test-model",
+            dir,
+            catalog,
+            lookup: lookupToLocalhost,
+            baseUrl: `http://huggingface.co:${port}`,
+          }),
+        (err) => {
+          assert.ok(err instanceof ChecksumError, `expected ChecksumError, got ${err}`);
+          assert.equal(err.expectedSha, "0".repeat(64));
+          return true;
+        },
+      );
+      const dest = join(dir, "models", "blobs", "blob.gguf");
+      assert.equal(existsSync(dest), false, "bad blob must be deleted");
+
+      const state = loadState(dir);
+      assert.equal(state.journal["test-model"], undefined, "no journal entry left for a checksum-mismatched blob");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Interrupted download journals progress
+// ---------------------------------------------------------------------------
+
+test("interrupted download (socket killed mid-stream) journals bytesDone", async () => {
+  const { srv, port } = await startServer(killAtHalfHandler(BLOB));
+  try {
+    const dir = scratchDir("interrupt");
+    try {
+      const catalog = makeCatalog();
+      await assert.rejects(() =>
+        downloadModel({
+          modelId: "test-model",
+          dir,
+          catalog,
+          lookup: lookupToLocalhost,
+          baseUrl: `http://huggingface.co:${port}`,
+        }),
+      );
+      const state = loadState(dir);
+      const entry = state.journal["test-model"];
+      assert.ok(entry, "expected a journal entry after interruption");
+      assert.ok(
+        entry.bytesDone > 0 && entry.bytesDone < BLOB.length,
+        `expected partial bytesDone, got ${entry.bytesDone}`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Resume: Range from journal, re-hash on-disk prefix, final sha matches
+// ---------------------------------------------------------------------------
+
+test("resume issues Range from journal bytesDone, re-hashes the prefix, and completes with a matching sha256", async () => {
+  const port = await getFreePort();
+  const dir = scratchDir("resume");
+  try {
+    const catalog = makeCatalog();
+
+    // Phase 1: interrupted at ~50%.
+    const phase1 = await startServerOnPort(port, killAtHalfHandler(BLOB));
+    await assert.rejects(() =>
+      downloadModel({
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+      }),
+    );
+    await stopServer(phase1.srv);
+
+    const journaled = loadState(dir).journal["test-model"];
+    assert.ok(journaled, "expected a journal entry after phase 1");
+    const bytesAfterInterrupt = journaled.bytesDone;
+    assert.ok(bytesAfterInterrupt > 0 && bytesAfterInterrupt < BLOB.length);
+
+    // Phase 2: same URL (same port) resumes; assert the Range header sent
+    // matches the journaled offset exactly.
+    let seenRange;
+    const phase2 = await startServerOnPort(port, (req, res) => {
+      seenRange = req.headers.range || null;
+      rangeAwareHandler(BLOB)(req, res);
+    });
+    try {
+      const result = await downloadModel({
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+      });
+      assert.equal(seenRange, `bytes=${bytesAfterInterrupt}-`);
+      assert.equal(result.sha256, BLOB_SHA256);
+      assert.deepEqual(readFileSync(result.path), BLOB);
+
+      const state = loadState(dir);
+      assert.equal(state.journal["test-model"], undefined);
+    } finally {
+      await stopServer(phase2.srv);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ENOSPC -> DiskFullError, partial kept
+// ---------------------------------------------------------------------------
+
+test("write-stream ENOSPC error becomes a typed DiskFullError and keeps the partial file", async () => {
+  const { srv, port } = await startServer(rangeAwareHandler(BLOB));
+  try {
+    const dir = scratchDir("enospc");
+    try {
+      const catalog = makeCatalog();
+      await assert.rejects(
+        () =>
+          downloadModel({
+            modelId: "test-model",
+            dir,
+            catalog,
+            lookup: lookupToLocalhost,
+            baseUrl: `http://huggingface.co:${port}`,
+            createWriteStream: makeEnospcWriteStream(50_000),
+          }),
+        (err) => {
+          assert.ok(err instanceof DiskFullError, `expected DiskFullError, got ${err}`);
+          return true;
+        },
+      );
+      const dest = join(dir, "models", "blobs", "blob.gguf");
+      assert.ok(existsSync(dest), "partial file must be kept for resume");
+
+      const state = loadState(dir);
+      assert.ok(state.journal["test-model"], "journal entry must remain so a later call can resume");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Host allowlist
+// ---------------------------------------------------------------------------
+
+test("redirect to a disallowed host is refused with a typed HostNotAllowedError", async () => {
+  const port = await getFreePort();
+  const { srv } = await startServerOnPort(
+    port,
+    (req, res) => {
+      res.writeHead(302, { Location: `http://evil.example.com:${port}/x` });
+      res.end();
+    },
+  );
+  try {
+    const dir = scratchDir("evilhost");
+    try {
+      const catalog = makeCatalog();
+      await assert.rejects(
+        () =>
+          downloadModel({
+            modelId: "test-model",
+            dir,
+            catalog,
+            lookup: lookupToLocalhost,
+            baseUrl: `http://huggingface.co:${port}`,
+          }),
+        (err) => {
+          assert.ok(err instanceof HostNotAllowedError, `expected HostNotAllowedError, got ${err}`);
+          assert.equal(err.hostname, "evil.example.com");
+          return true;
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("redirect to an allowed hf.co-family host is followed to a successful completion", async () => {
+  const port = await getFreePort();
+  const location = `http://cdn-lfs.huggingface.co:${port}/cdn-path/blob.gguf`;
+  const { srv } = await startServerOnPort(port, (req, res) => {
+    if (req.url.includes("/resolve/main/")) {
+      res.writeHead(302, { Location: location });
+      res.end();
+      return;
+    }
+    rangeAwareHandler(BLOB)(req, res);
+  });
+  try {
+    const dir = scratchDir("redirectok");
+    try {
+      const catalog = makeCatalog();
+      const result = await downloadModel({
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+      });
+      assert.equal(result.sha256, BLOB_SHA256);
+      assert.deepEqual(readFileSync(result.path), BLOB);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Symlink-at-destination refusal
+// ---------------------------------------------------------------------------
+
+test("an existing symlink at the destination path is refused before any network activity", async () => {
+  const dir = scratchDir("symlink");
+  try {
+    const blobDir = join(dir, "models", "blobs");
+    mkdirSync(blobDir, { recursive: true });
+    const dest = join(blobDir, "blob.gguf");
+    const target = join(dir, "elsewhere.txt");
+    writeFileSync(target, "not a model file");
+    symlinkSync(target, dest);
+
+    const catalog = makeCatalog();
+    await assert.rejects(
+      () => downloadModel({ modelId: "test-model", dir, catalog }),
+      (err) => {
+        assert.ok(err instanceof UnsafeDestinationError, `expected UnsafeDestinationError, got ${err}`);
+        return true;
+      },
+    );
+    // The symlink target must be untouched.
+    assert.equal(readFileSync(target, "utf8"), "not a model file");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// deleteModel
+// ---------------------------------------------------------------------------
+
+test("deleteModel removes the downloaded blob and any journal entry", async () => {
+  const { srv, port } = await startServer(rangeAwareHandler(BLOB));
+  try {
+    const dir = scratchDir("delete");
+    try {
+      const catalog = makeCatalog();
+      const result = await downloadModel({
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+      });
+      assert.ok(existsSync(result.path));
+
+      const del = deleteModel({ modelId: "test-model", dir, catalog });
+      assert.equal(del.deleted, true);
+      assert.equal(existsSync(result.path), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("deleteModel is a no-op (deleted:false) when nothing is on disk", () => {
+  const dir = scratchDir("delete-noop");
+  try {
+    const catalog = makeCatalog();
+    const del = deleteModel({ modelId: "test-model", dir, catalog });
+    assert.equal(del.deleted, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Queue: concurrency-1 serialization
+// ---------------------------------------------------------------------------
+
+test("enqueueDownload runs two downloads serially under the default concurrency of 1", async () => {
+  const prevConcurrency = process.env.CROW_MODEL_DL_CONCURRENCY;
+  delete process.env.CROW_MODEL_DL_CONCURRENCY;
+  const port = await getFreePort();
+  const timestamps = {};
+  const { srv } = await startServerOnPort(port, (req, res) => {
+    const key = req.url.includes("blob-a") ? "a" : "b";
+    timestamps[`${key}Start`] = Date.now();
+    setTimeout(() => {
+      res.writeHead(200, { "Content-Length": String(BLOB.length) });
+      res.end(BLOB);
+      timestamps[`${key}End`] = Date.now();
+    }, 60);
+  });
+  try {
+    const dir = scratchDir("queue");
+    try {
+      const catalog = {
+        version: 1,
+        models: [
+          {
+            id: "model-a",
+            hf_repo: "test/repo",
+            default_quant: "Q4_K_M",
+            quants: [{ file: "blob-a.gguf", quant: "Q4_K_M", sha256: BLOB_SHA256 }],
+          },
+          {
+            id: "model-b",
+            hf_repo: "test/repo",
+            default_quant: "Q4_K_M",
+            quants: [{ file: "blob-b.gguf", quant: "Q4_K_M", sha256: BLOB_SHA256 }],
+          },
+        ],
+      };
+      const common = { dir, catalog, lookup: lookupToLocalhost, baseUrl: `http://huggingface.co:${port}` };
+
+      const [ra, rb] = await Promise.all([
+        enqueueDownload({ modelId: "model-a", ...common }),
+        enqueueDownload({ modelId: "model-b", ...common }),
+      ]);
+      assert.equal(ra.sha256, BLOB_SHA256);
+      assert.equal(rb.sha256, BLOB_SHA256);
+
+      assert.ok(timestamps.aStart && timestamps.aEnd && timestamps.bStart && timestamps.bEnd);
+      const firstEnd = Math.min(timestamps.aEnd, timestamps.bEnd);
+      const secondStart = timestamps.aEnd < timestamps.bEnd ? timestamps.bStart : timestamps.aStart;
+      assert.ok(
+        secondStart >= firstEnd,
+        `expected serial (non-overlapping) execution, got firstEnd=${firstEnd} secondStart=${secondStart}`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+    if (prevConcurrency === undefined) delete process.env.CROW_MODEL_DL_CONCURRENCY;
+    else process.env.CROW_MODEL_DL_CONCURRENCY = prevConcurrency;
+  }
+});

--- a/tests/models-manager.test.js
+++ b/tests/models-manager.test.js
@@ -54,6 +54,8 @@ import {
   DiskFullError,
   UnsafeDestinationError,
   DownloadProtocolError,
+  DownloadTimeoutError,
+  fetchModelBlob,
 } from "../servers/gateway/models/manager.js";
 import { loadState } from "../servers/gateway/models/state.js";
 
@@ -150,6 +152,19 @@ function killAtHalfHandler(blob) {
     const half = Math.floor(blob.length / 2);
     res.write(blob.subarray(0, half));
     setTimeout(() => res.destroy(), 15);
+  };
+}
+
+/** Headers + a partial body, then genuine silence — never destroys the
+ * connection, never ends the response. Distinct from `killAtHalfHandler`
+ * (which actively severs the connection): this simulates a black-holed/
+ * hung peer, exactly what Fix 4's socket-idle timeout exists to detect. */
+function stallAfterHalfHandler(blob) {
+  return (req, res) => {
+    res.writeHead(200, { "Content-Length": String(blob.length) });
+    const half = Math.floor(blob.length / 2);
+    res.write(blob.subarray(0, half));
+    // deliberately never res.end() / res.destroy() — a real stall
   };
 }
 
@@ -356,6 +371,129 @@ test("interrupted download (socket killed mid-stream) journals bytesDone", async
       rmSync(dir, { recursive: true, force: true });
     }
   } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Final-review fix wave — Fix 4: GGUF downloads had no socket timeout
+// ---------------------------------------------------------------------------
+
+test("Fix 4: a connection that never sends headers rejects with a typed DownloadTimeoutError instead of hanging forever", async () => {
+  // Accepts the connection but never writes a byte and never ends the
+  // response — the connect/header-wait phase, handled by requestOnce's own
+  // Node socket-timeout option (mirrors runtime.js's identical test for
+  // downloadRuntimeAsset).
+  const { srv, port } = await startServer(() => {});
+  const dir = scratchDir("dl-connect-stall");
+  try {
+    const dest = join(dir, "connect-stall.gguf");
+    await assert.rejects(
+      () => fetchModelBlob({
+        url: `http://huggingface.co:${port}/x/resolve/main/y.gguf`,
+        dest,
+        lookup: lookupToLocalhost,
+        insecureHttpHosts: INSECURE_HF,
+        timeoutMs: 50, // tiny for a fast test — production default is 120s
+      }),
+      (err) => {
+        assert.ok(err instanceof DownloadTimeoutError, `expected DownloadTimeoutError, got ${err}`);
+        assert.equal(err.code, "DOWNLOAD_TIMEOUT");
+        assert.equal(err.timeoutMs, 50);
+        return true;
+      },
+    );
+    assert.equal(existsSync(dest), false, "no partial file — the stall was never past the connect/header phase");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    await stopServer(srv);
+  }
+});
+
+test("Fix 4: a connection that sends headers + partial body then stalls rejects with a typed DownloadTimeoutError within the injected timeout; partial file is kept, not deleted", async () => {
+  const { srv, port } = await startServer(stallAfterHalfHandler(BLOB));
+  try {
+    const dir = scratchDir("dl-body-stall");
+    try {
+      const dest = join(dir, "body-stall.gguf");
+      await assert.rejects(
+        () => fetchModelBlob({
+          url: `http://huggingface.co:${port}/x/resolve/main/y.gguf`,
+          dest,
+          lookup: lookupToLocalhost,
+          insecureHttpHosts: INSECURE_HF,
+          timeoutMs: 50,
+        }),
+        (err) => {
+          assert.ok(err instanceof DownloadTimeoutError, `expected DownloadTimeoutError, got ${err}`);
+          assert.equal(err.code, "DOWNLOAD_TIMEOUT");
+          assert.ok(err.bytesDone > 0 && err.bytesDone < BLOB.length, `expected partial bytesDone on the error, got ${err.bytesDone}`);
+          return true;
+        },
+      );
+      assert.equal(existsSync(dest), true, "the partial file is KEPT on disk (like DiskFullError), not deleted (unlike ChecksumError)");
+      const onDisk = readFileSync(dest);
+      assert.ok(onDisk.length > 0 && onDisk.length < BLOB.length);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("Fix 4: downloadModel journals bytesDone on a body stall, so a subsequent call resumes rather than restarting", async () => {
+  const { srv, port } = await startServer(stallAfterHalfHandler(BLOB));
+  try {
+    const dir = scratchDir("dl-model-stall");
+    try {
+      const catalog = makeCatalog();
+      await assert.rejects(
+        () => downloadModel({
+          modelId: "test-model",
+          dir,
+          catalog,
+          lookup: lookupToLocalhost,
+          baseUrl: `http://huggingface.co:${port}`,
+          insecureHttpHosts: INSECURE_HF,
+          timeoutMs: 50,
+        }),
+        (err) => {
+          assert.ok(err instanceof DownloadTimeoutError, `expected DownloadTimeoutError, got ${err}`);
+          return true;
+        },
+      );
+      const state = loadState(dir);
+      const entry = state.journal["test-model"];
+      assert.ok(entry, "expected a journal entry after the stall");
+      assert.ok(entry.bytesDone > 0 && entry.bytesDone < BLOB.length, `expected partial bytesDone, got ${entry.bytesDone}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("Fix 4: fetchModelBlob without an explicit timeoutMs defaults to DEFAULT_DOWNLOAD_TIMEOUT_MS and does not spuriously time out a normal fast download", async () => {
+  const { srv, port } = await startServer((req, res) => {
+    res.writeHead(200, { "Content-Length": String(BLOB.length) });
+    res.end(BLOB);
+  });
+  const dir = scratchDir("dl-default-timeout");
+  try {
+    const dest = join(dir, "fast.gguf");
+    const result = await fetchModelBlob({
+      url: `http://huggingface.co:${port}/x/resolve/main/y.gguf`,
+      dest,
+      lookup: lookupToLocalhost,
+      insecureHttpHosts: INSECURE_HF,
+      // timeoutMs omitted — the default (120s) must not fire for a fast,
+      // successful download.
+    });
+    assert.equal(result.sha256, BLOB_SHA256);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
     await stopServer(srv);
   }
 });

--- a/tests/models-manager.test.js
+++ b/tests/models-manager.test.js
@@ -10,6 +10,14 @@
  * forces DNS resolution straight to 127.0.0.1, so the allowlist check runs
  * against the actual literal hostnames named in the spec while every
  * socket still talks to the local fixture server.
+ *
+ * The manager also requires https on every hop by default (see
+ * `DownloadProtocolError`, code INSECURE_PROTOCOL). Since every fixture
+ * server here is plain http, tests pass the test-only `insecureHttpHosts`
+ * escape (`INSECURE_HF` / `INSECURE_HF_AND_CDN` below) naming exactly the
+ * hostnames they dial — production never sets this option. Two dedicated
+ * tests ("plain http ... is rejected" and "an https-to-http downgrade
+ * redirect is rejected") prove what happens WITHOUT the escape.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -24,6 +32,9 @@ import {
   writeFileSync,
   mkdirSync,
   symlinkSync,
+  openSync,
+  writeSync,
+  closeSync,
   createWriteStream as fsCreateWriteStream,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -42,8 +53,17 @@ import {
   ChecksumError,
   DiskFullError,
   UnsafeDestinationError,
+  DownloadProtocolError,
 } from "../servers/gateway/models/manager.js";
 import { loadState } from "../servers/gateway/models/state.js";
+
+// Every fixture server in this file is plain http (no TLS) — this is the
+// explicit test-only escape from the manager's https-only enforcement.
+// Production NEVER sets insecureHttpHosts; see the two dedicated tests
+// below ("http to an allowlisted host is rejected" and "downgrade redirect
+// is rejected") for what happens WITHOUT it.
+const INSECURE_HF = ["huggingface.co"];
+const INSECURE_HF_AND_CDN = ["huggingface.co", "cdn-lfs.huggingface.co"];
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -248,6 +268,7 @@ test("downloadModel streams the full blob to disk and verifies sha256 incrementa
         catalog,
         lookup: lookupToLocalhost,
         baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
         onProgress: (p) => progressCalls.push(p),
       });
       assert.equal(result.sha256, BLOB_SHA256);
@@ -283,6 +304,7 @@ test("wrong sha256 deletes the file and throws a typed ChecksumError", async () 
             catalog,
             lookup: lookupToLocalhost,
             baseUrl: `http://huggingface.co:${port}`,
+            insecureHttpHosts: INSECURE_HF,
           }),
         (err) => {
           assert.ok(err instanceof ChecksumError, `expected ChecksumError, got ${err}`);
@@ -320,6 +342,7 @@ test("interrupted download (socket killed mid-stream) journals bytesDone", async
           catalog,
           lookup: lookupToLocalhost,
           baseUrl: `http://huggingface.co:${port}`,
+          insecureHttpHosts: INSECURE_HF,
         }),
       );
       const state = loadState(dir);
@@ -356,6 +379,7 @@ test("resume issues Range from journal bytesDone, re-hashes the prefix, and comp
         catalog,
         lookup: lookupToLocalhost,
         baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
       }),
     );
     await stopServer(phase1.srv);
@@ -379,6 +403,7 @@ test("resume issues Range from journal bytesDone, re-hashes the prefix, and comp
         catalog,
         lookup: lookupToLocalhost,
         baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
       });
       assert.equal(seenRange, `bytes=${bytesAfterInterrupt}-`);
       assert.equal(result.sha256, BLOB_SHA256);
@@ -386,6 +411,71 @@ test("resume issues Range from journal bytesDone, re-hashes the prefix, and comp
 
       const state = loadState(dir);
       assert.equal(state.journal["test-model"], undefined);
+    } finally {
+      await stopServer(phase2.srv);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resuming over a corrupted on-disk prefix produces a ChecksumError", async () => {
+  const port = await getFreePort();
+  const dir = scratchDir("corrupt-resume");
+  try {
+    const catalog = makeCatalog();
+
+    // Phase 1: interrupted partway through, same as the resume test above.
+    const phase1 = await startServerOnPort(port, killAtHalfHandler(BLOB));
+    await assert.rejects(() =>
+      downloadModel({
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
+      }),
+    );
+    await stopServer(phase1.srv);
+
+    const journaled = loadState(dir).journal["test-model"];
+    assert.ok(journaled, "expected a journal entry after phase 1");
+    assert.ok(journaled.bytesDone > 0 && journaled.bytesDone < BLOB.length);
+
+    // Corrupt a byte inside the already-written prefix, BEFORE resuming —
+    // the resume path re-hashes exactly this on-disk range from scratch, so
+    // a flipped byte here must surface as a final checksum mismatch even
+    // though the rest of the download completes normally.
+    const dest = join(dir, "models", "blobs", "blob.gguf");
+    const flipOffset = Math.floor(journaled.bytesDone / 2);
+    const fd = openSync(dest, "r+");
+    try {
+      writeSync(fd, Buffer.from([BLOB[flipOffset] ^ 0xff]), 0, 1, flipOffset);
+    } finally {
+      closeSync(fd);
+    }
+
+    const phase2 = await startServerOnPort(port, rangeAwareHandler(BLOB));
+    try {
+      await assert.rejects(
+        () =>
+          downloadModel({
+            modelId: "test-model",
+            dir,
+            catalog,
+            lookup: lookupToLocalhost,
+            baseUrl: `http://huggingface.co:${port}`,
+            insecureHttpHosts: INSECURE_HF,
+          }),
+        (err) => {
+          assert.ok(err instanceof ChecksumError, `expected ChecksumError, got ${err}`);
+          return true;
+        },
+      );
+      // The corrupted (now known-bad) blob must be deleted, same as any
+      // other checksum mismatch.
+      assert.equal(existsSync(dest), false);
     } finally {
       await stopServer(phase2.srv);
     }
@@ -412,6 +502,7 @@ test("write-stream ENOSPC error becomes a typed DiskFullError and keeps the part
             catalog,
             lookup: lookupToLocalhost,
             baseUrl: `http://huggingface.co:${port}`,
+            insecureHttpHosts: INSECURE_HF,
             createWriteStream: makeEnospcWriteStream(50_000),
           }),
         (err) => {
@@ -457,6 +548,7 @@ test("redirect to a disallowed host is refused with a typed HostNotAllowedError"
             catalog,
             lookup: lookupToLocalhost,
             baseUrl: `http://huggingface.co:${port}`,
+            insecureHttpHosts: INSECURE_HF,
           }),
         (err) => {
           assert.ok(err instanceof HostNotAllowedError, `expected HostNotAllowedError, got ${err}`);
@@ -493,9 +585,94 @@ test("redirect to an allowed hf.co-family host is followed to a successful compl
         catalog,
         lookup: lookupToLocalhost,
         baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF_AND_CDN,
       });
       assert.equal(result.sha256, BLOB_SHA256);
       assert.deepEqual(readFileSync(result.path), BLOB);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// HTTPS enforcement
+// ---------------------------------------------------------------------------
+
+test("plain http to an allowlisted host is rejected without the insecureHttpHosts escape", async () => {
+  const { srv, port } = await startServer(rangeAwareHandler(BLOB));
+  try {
+    const dir = scratchDir("http-rejected");
+    try {
+      const catalog = makeCatalog();
+      let requestsReceived = 0;
+      srv.on("request", () => { requestsReceived++; });
+      await assert.rejects(
+        () =>
+          downloadModel({
+            modelId: "test-model",
+            dir,
+            catalog,
+            lookup: lookupToLocalhost,
+            baseUrl: `http://huggingface.co:${port}`,
+            // no insecureHttpHosts — https is required by default
+          }),
+        (err) => {
+          assert.ok(err instanceof DownloadProtocolError, `expected DownloadProtocolError, got ${err}`);
+          assert.equal(err.code, "INSECURE_PROTOCOL");
+          return true;
+        },
+      );
+      assert.equal(requestsReceived, 0, "must be refused before ever connecting");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("an https-to-http downgrade redirect is rejected even to an otherwise-allowed host", async () => {
+  // Models the real hazard: buildDownloadUrl's production output is always
+  // https, but a compromised/misconfigured redirect could point somewhere
+  // that downgrades to http. The initial hop is explicitly escaped
+  // (INSECURE_HF, standing in for "we already validated this connection");
+  // the redirect target is a DIFFERENT allowed-by-hostname host that is
+  // deliberately NOT in the escape list, proving each hop's protocol is
+  // checked independently rather than only the first URL.
+  const port = await getFreePort();
+  const downgradeLocation = `http://cdn-lfs.huggingface.co:${port}/downgraded/blob.gguf`;
+  const { srv } = await startServerOnPort(port, (req, res) => {
+    if (req.url.includes("/resolve/main/")) {
+      res.writeHead(302, { Location: downgradeLocation });
+      res.end();
+      return;
+    }
+    // Should never be reached — the downgrade must be refused before this.
+    rangeAwareHandler(BLOB)(req, res);
+  });
+  try {
+    const dir = scratchDir("downgrade");
+    try {
+      const catalog = makeCatalog();
+      await assert.rejects(
+        () =>
+          downloadModel({
+            modelId: "test-model",
+            dir,
+            catalog,
+            lookup: lookupToLocalhost,
+            baseUrl: `http://huggingface.co:${port}`,
+            insecureHttpHosts: INSECURE_HF, // cdn-lfs.huggingface.co is deliberately NOT escaped
+          }),
+        (err) => {
+          assert.ok(err instanceof DownloadProtocolError, `expected DownloadProtocolError, got ${err}`);
+          assert.equal(err.code, "INSECURE_PROTOCOL");
+          return true;
+        },
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -549,6 +726,7 @@ test("deleteModel removes the downloaded blob and any journal entry", async () =
         catalog,
         lookup: lookupToLocalhost,
         baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
       });
       assert.ok(existsSync(result.path));
 
@@ -612,7 +790,13 @@ test("enqueueDownload runs two downloads serially under the default concurrency 
           },
         ],
       };
-      const common = { dir, catalog, lookup: lookupToLocalhost, baseUrl: `http://huggingface.co:${port}` };
+      const common = {
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
+      };
 
       const [ra, rb] = await Promise.all([
         enqueueDownload({ modelId: "model-a", ...common }),
@@ -635,5 +819,50 @@ test("enqueueDownload runs two downloads serially under the default concurrency 
     await stopServer(srv);
     if (prevConcurrency === undefined) delete process.env.CROW_MODEL_DL_CONCURRENCY;
     else process.env.CROW_MODEL_DL_CONCURRENCY = prevConcurrency;
+  }
+});
+
+test("enqueueDownload is idempotent per modelId: a second enqueue while one is in flight returns the same job", async () => {
+  let requestCount = 0;
+  const { srv, port } = await startServer((req, res) => {
+    requestCount++;
+    // Small delay so both enqueue calls land while the first request is
+    // still in flight, giving the dedup a real window to matter.
+    setTimeout(() => rangeAwareHandler(BLOB)(req, res), 30);
+  });
+  try {
+    const dir = scratchDir("dedup");
+    try {
+      const catalog = makeCatalog();
+      const opts = {
+        modelId: "test-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
+      };
+
+      const p1 = enqueueDownload(opts);
+      const p2 = enqueueDownload(opts);
+      assert.equal(p1, p2, "a second enqueue while the first is in flight must return the SAME promise");
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      assert.equal(r1.sha256, BLOB_SHA256);
+      assert.equal(r2.sha256, BLOB_SHA256);
+      assert.equal(requestCount, 1, "the underlying download must only run once — no second writer on the same dest");
+
+      // Once settled, the dedup entry is cleared: a later enqueue for the
+      // same modelId is a genuinely fresh job, not the stale cached one.
+      const p3 = enqueueDownload(opts);
+      assert.notEqual(p3, p1);
+      const r3 = await p3;
+      assert.equal(r3.sha256, BLOB_SHA256);
+      assert.equal(requestCount, 2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
   }
 });

--- a/tests/models-registration.test.js
+++ b/tests/models-registration.test.js
@@ -1,0 +1,492 @@
+/**
+ * Tests for the provider registration + delete flow half of
+ * servers/gateway/models/manager.js (Item G, Task 7).
+ *
+ * Harness: freshLibsql() — the same pattern as tests/providers-upsert-noop.test.js
+ * and tests/providers-reconcile-gate.test.js: `scripts/init-db.js` run against a
+ * per-test tmp dir (real providers/dashboard_settings/pi_bot_defs schema, never
+ * the real ~/.crow), CROW_DATA_DIR pointed at that dir so
+ * getOrCreateLocalInstanceId() (called deep inside upsertProvider) writes its
+ * instance-id file there too.
+ *
+ * The SAME tmp dir doubles as the `dir` argument to registerModel/unregisterModel
+ * (state.json + the model blobs directory) — matching production, where both the
+ * DB and models/state.json live under one CROW_HOME.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  registerModel,
+  unregisterModel,
+  providerBindings,
+  pickChatMutexGroup,
+  sanitizeFilename,
+} from "../servers/gateway/models/manager.js";
+import { loadState, saveState } from "../servers/gateway/models/state.js";
+import { upsertProvider, setProviderSyncManager } from "../servers/shared/providers-db.js";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "models-registration-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return {
+    dir, db,
+    cleanup() {
+      setProviderSyncManager(null);
+      if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+      else process.env.CROW_DATA_DIR = prevDataDir;
+      try { db.close(); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function dbRow(db, id) {
+  const { rows } = await db.execute({ sql: "SELECT * FROM providers WHERE id = ?", args: [id] });
+  return rows[0];
+}
+
+function makeCatalog() {
+  return {
+    version: 1,
+    runtime: { name: "llama.cpp", release: "b10068", assets: {} },
+    models: [
+      {
+        id: "chat-test-model",
+        family: "TestFamily",
+        lab: "TestLab",
+        hf_repo: "test/chat-test-model-GGUF",
+        license: "apache-2.0",
+        gated: false,
+        task: "chat",
+        context_len: 8192,
+        min_runtime_version: "b10068",
+        default_quant: "Q4_K_M",
+        tags: ["chat"],
+        notes: "test fixture",
+        quants: [
+          { file: "chat-test-model-Q4_K_M.gguf", quant: "Q4_K_M", size_mb: 1, min_ram_mb: 1, min_vram_mb: 0, sha256: "abc" },
+        ],
+      },
+      {
+        id: "embed-test-model",
+        family: "TestEmbedFamily",
+        lab: "TestLab",
+        hf_repo: "test/embed-test-model-GGUF",
+        license: "apache-2.0",
+        gated: false,
+        task: "embed",
+        context_len: 512,
+        min_runtime_version: "b10068",
+        default_quant: "Q4_K_M",
+        tags: ["embed"],
+        notes: "test fixture",
+        quants: [
+          { file: "embed-test-model-Q4_K_M.gguf", quant: "Q4_K_M", size_mb: 1, min_ram_mb: 1, min_vram_mb: 0, sha256: "def" },
+        ],
+      },
+    ],
+  };
+}
+
+/** Insert a fake existing provider row directly (bypassing registerModel) to
+ * build mutexGroup-rule fixtures. `models` entries carry `task` the same way
+ * registerModel writes them. */
+function seedExistingProvider(db, { id, mutexGroup, task, disabled = false }) {
+  return upsertProvider(db, {
+    id,
+    baseUrl: `http://127.0.0.1:19999/v1`,
+    apiKey: null,
+    host: "local",
+    bundleId: null,
+    description: "fixture",
+    models: [{ id: `${id}-model`, task, contextLen: 4096 }],
+    disabled,
+    providerType: "openai-compat",
+    gpuPolicy: mutexGroup ? { runtime: "native", mutexGroup } : { runtime: "native" },
+  });
+}
+
+function blobPathFor(dir, file) {
+  return join(dir, "models", "blobs", sanitizeFilename(file));
+}
+
+// ---------------------------------------------------------------------------
+// registerModel — row shape + ordering
+// ---------------------------------------------------------------------------
+
+test("registerModel: writes a provider row with the FINAL base_url, models[], and native gpu_policy", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const result = await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+
+    assert.equal(result.id, "chat-test-model");
+    assert.match(result.baseUrl, /^http:\/\/127\.0\.0\.1:\d+\/v1$/);
+    assert.equal(result.baseUrl, `http://127.0.0.1:${result.port}/v1`);
+
+    const row = await dbRow(db, "chat-test-model");
+    assert.ok(row, "provider row exists");
+    assert.equal(row.base_url, result.baseUrl, "row's base_url is already the FINAL url, not a placeholder");
+    assert.equal(row.disabled, 0);
+
+    const models = JSON.parse(row.models);
+    assert.deepEqual(models, [{ id: "chat-test-model", task: "chat", contextLen: 8192 }]);
+
+    const gpuPolicy = JSON.parse(row.gpu_policy);
+    assert.equal(gpuPolicy.runtime, "native");
+    assert.equal(gpuPolicy.mutexGroup, "local-llm", "sole chat model with no existing groups falls back to local-llm");
+  } finally { cleanup(); }
+});
+
+test("registerModel: allocates a port already recorded in state.json reservations before returning", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const result = await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+    const state = loadState(dir);
+    assert.ok(state.reservations["chat-test-model"], "port reservation persisted");
+    assert.equal(state.reservations["chat-test-model"].port, result.port);
+    assert.ok(state.registry["chat-test-model"], "registry entry persisted for later unregister");
+    assert.equal(state.registry["chat-test-model"].file, "chat-test-model-Q4_K_M.gguf");
+    assert.equal(state.registry["chat-test-model"].quant, "Q4_K_M");
+  } finally { cleanup(); }
+});
+
+test("registerModel: invalidates the providers cache exactly once, AFTER the row is durably written", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const order = [];
+    let sawRowAtInvalidateTime = null;
+    await registerModel({
+      modelId: "chat-test-model",
+      catalog: makeCatalog(),
+      db,
+      dir,
+      upsertProviderFn: async (...args) => {
+        order.push("upsert");
+        const { upsertProvider } = await import("../servers/shared/providers-db.js");
+        return upsertProvider(...args);
+      },
+      invalidateCacheFn: async () => {
+        order.push("invalidate");
+        sawRowAtInvalidateTime = await dbRow(db, "chat-test-model");
+      },
+    });
+    assert.deepEqual(order, ["upsert", "invalidate"], "cache invalidation happens after the DB write, not before");
+    assert.ok(sawRowAtInvalidateTime, "the row was already visible to a DB read at invalidate-time");
+  } finally { cleanup(); }
+});
+
+test("registerModel: allocates the port BEFORE inserting the provider row", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const order = [];
+    const { allocatePort } = await import("../servers/gateway/models/state.js");
+    await registerModel({
+      modelId: "chat-test-model",
+      catalog: makeCatalog(),
+      db,
+      dir,
+      allocatePortFn: async (...args) => {
+        order.push("allocatePort");
+        return allocatePort(...args);
+      },
+      upsertProviderFn: async (...args) => {
+        order.push("upsertRow");
+        const { upsertProvider } = await import("../servers/shared/providers-db.js");
+        return upsertProvider(...args);
+      },
+    });
+    assert.deepEqual(order, ["allocatePort", "upsertRow"]);
+  } finally { cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// registerModel — mutexGroup rule
+// ---------------------------------------------------------------------------
+
+test("registerModel: chat-class model joins the existing group with the MOST chat-class members", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    // group "vram-a": 1 chat-class member
+    await seedExistingProvider(db, { id: "existing-a", mutexGroup: "vram-a", task: "chat" });
+    // group "vram-b": 2 chat-class members
+    await seedExistingProvider(db, { id: "existing-b1", mutexGroup: "vram-b", task: "chat" });
+    await seedExistingProvider(db, { id: "existing-b2", mutexGroup: "vram-b", task: "chat" });
+    // a disabled row in vram-b's would-be-bigger group must NOT count
+    await seedExistingProvider(db, { id: "existing-b3-disabled", mutexGroup: "vram-b", task: "chat", disabled: true });
+    // a non-chat (embed) row in a third group must NOT count as chat-class
+    await seedExistingProvider(db, { id: "existing-c", mutexGroup: "vram-c", task: "embed" });
+
+    const result = await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+    const gpuPolicy = JSON.parse((await dbRow(db, "chat-test-model")).gpu_policy);
+    assert.equal(gpuPolicy.mutexGroup, "vram-b");
+    assert.equal(result.gpuPolicy.mutexGroup, "vram-b");
+  } finally { cleanup(); }
+});
+
+test("registerModel: chat-class model falls back to local-llm when no group has any chat-class member", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    // A group exists, but its only member is embed-class -> doesn't count.
+    await seedExistingProvider(db, { id: "existing-embed", mutexGroup: "vram-a", task: "embed" });
+
+    await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+    const gpuPolicy = JSON.parse((await dbRow(db, "chat-test-model")).gpu_policy);
+    assert.equal(gpuPolicy.mutexGroup, "local-llm");
+  } finally { cleanup(); }
+});
+
+test("registerModel: embed-class model gets NO mutexGroup key at all", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    // Even with an existing chat group present, embed models never join it.
+    await seedExistingProvider(db, { id: "existing-a", mutexGroup: "vram-a", task: "chat" });
+
+    const result = await registerModel({ modelId: "embed-test-model", catalog: makeCatalog(), db, dir });
+    const row = await dbRow(db, "embed-test-model");
+    const gpuPolicy = JSON.parse(row.gpu_policy);
+    assert.equal(gpuPolicy.runtime, "native");
+    assert.ok(!("mutexGroup" in gpuPolicy), "embed-class rows carry no mutexGroup property");
+    assert.ok(!("mutexGroup" in result.gpuPolicy));
+  } finally { cleanup(); }
+});
+
+test("pickChatMutexGroup: pure function, exhaustive over the rule (unit-level, no DB)", () => {
+  assert.equal(pickChatMutexGroup([]), "local-llm");
+  assert.equal(
+    pickChatMutexGroup([{ disabled: false, gpuPolicy: { mutexGroup: "g1" }, models: [{ task: "chat" }] }]),
+    "g1",
+  );
+  assert.equal(
+    pickChatMutexGroup([
+      { disabled: false, gpuPolicy: { mutexGroup: "g1" }, models: [{ task: "chat" }] },
+      { disabled: false, gpuPolicy: { mutexGroup: "g2" }, models: [{ task: "chat" }] },
+      { disabled: false, gpuPolicy: { mutexGroup: "g2" }, models: [{ task: "chat" }] },
+    ]),
+    "g2",
+    "the group with more chat-class members wins",
+  );
+  assert.equal(
+    pickChatMutexGroup([{ disabled: false, gpuPolicy: { mutexGroup: "g1" }, models: [{ task: "embed" }] }]),
+    "local-llm",
+    "a group whose only member is embed-class doesn't count",
+  );
+  assert.equal(
+    pickChatMutexGroup([{ disabled: true, gpuPolicy: { mutexGroup: "g1" }, models: [{ task: "chat" }] }]),
+    "local-llm",
+    "disabled rows don't count",
+  );
+  assert.equal(
+    pickChatMutexGroup([{ disabled: false, gpuPolicy: {}, models: [{ task: "chat" }] }]),
+    "local-llm",
+    "a row with no mutexGroup at all doesn't count",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// unregisterModel — order + effects
+// ---------------------------------------------------------------------------
+
+async function registerAndDownload(db, dir, modelId = "chat-test-model") {
+  const result = await registerModel({ modelId, catalog: makeCatalog(), db, dir });
+  const dest = blobPathFor(dir, "chat-test-model-Q4_K_M.gguf");
+  mkdirSync(join(dir, "models", "blobs"), { recursive: true });
+  writeFileSync(dest, "fake gguf bytes");
+  return { result, dest };
+}
+
+test("unregisterModel: order is stop -> releasePort -> deleteFile -> deleteRow -> invalidateCache", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    await registerAndDownload(db, dir);
+    const order = [];
+    const { releasePort } = await import("../servers/gateway/models/state.js");
+    const { disableProvider } = await import("../servers/shared/providers-db.js");
+
+    await unregisterModel({
+      modelId: "chat-test-model",
+      db,
+      dir,
+      runtimeHandle: { live: true, stop: async () => { order.push("stop"); } },
+      releasePortFn: (...args) => { order.push("releasePort"); return releasePort(...args); },
+      unlinkFn: (...args) => {
+        order.push("deleteFile");
+        return unlinkSync(...args);
+      },
+      disableProviderFn: (...args) => { order.push("deleteRow"); return disableProvider(...args); },
+      invalidateCacheFn: () => { order.push("invalidateCache"); },
+    });
+
+    assert.deepEqual(order, ["stop", "releasePort", "deleteFile", "deleteRow", "invalidateCache"]);
+  } finally { cleanup(); }
+});
+
+test("unregisterModel: skips stop() when no runtimeHandle is given (or it isn't live)", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    await registerAndDownload(db, dir);
+    const order = [];
+    await unregisterModel({
+      modelId: "chat-test-model",
+      db,
+      dir,
+      releasePortFn: (state, id) => { order.push("releasePort"); state.reservations && delete state.reservations[id]; },
+      unlinkFn: () => { order.push("deleteFile"); },
+      disableProviderFn: async () => { order.push("deleteRow"); return { ok: true }; },
+      invalidateCacheFn: () => { order.push("invalidateCache"); },
+    });
+    assert.deepEqual(order, ["releasePort", "deleteFile", "deleteRow", "invalidateCache"]);
+
+    const order2 = [];
+    await registerAndDownload(db, dir, "chat-test-model");
+    await unregisterModel({
+      modelId: "chat-test-model",
+      db,
+      dir,
+      runtimeHandle: { live: false, stop: async () => { order2.push("stop"); } },
+      releasePortFn: (state, id) => { order2.push("releasePort"); state.reservations && delete state.reservations[id]; },
+      unlinkFn: () => { order2.push("deleteFile"); },
+      disableProviderFn: async () => { order2.push("deleteRow"); return { ok: true }; },
+      invalidateCacheFn: () => { order2.push("invalidateCache"); },
+    });
+    assert.deepEqual(order2, ["releasePort", "deleteFile", "deleteRow", "invalidateCache"], "live:false never calls stop()");
+  } finally { cleanup(); }
+});
+
+test("unregisterModel: real effects — releases the port, deletes the blob, soft-deletes the row", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const { dest } = await registerAndDownload(db, dir);
+    assert.ok(existsSync(dest), "fixture: blob exists before unregister");
+
+    const outcome = await unregisterModel({ modelId: "chat-test-model", db, dir });
+    assert.equal(outcome.deleted, true);
+    assert.equal(outcome.disabled, true);
+
+    assert.ok(!existsSync(dest), "blob deleted from disk");
+
+    const state = loadState(dir);
+    assert.equal(state.reservations["chat-test-model"], undefined, "port reservation released");
+    assert.equal(state.registry["chat-test-model"], undefined, "registry entry cleared");
+
+    const row = await dbRow(db, "chat-test-model");
+    assert.equal(Number(row.disabled), 1, "provider row soft-deleted (disabled=1), not hard-deleted");
+  } finally { cleanup(); }
+});
+
+test("unregisterModel: missing blob (already deleted) is not an error", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const { result } = await (async () => ({ result: await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir }) }))();
+    void result;
+    // No file ever written to disk for this model.
+    const outcome = await unregisterModel({ modelId: "chat-test-model", db, dir });
+    assert.equal(outcome.deleted, false);
+    assert.equal(outcome.disabled, true);
+  } finally { cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// providerBindings
+// ---------------------------------------------------------------------------
+
+async function seedAiProfiles(db, profiles) {
+  await db.execute({
+    sql: "INSERT INTO dashboard_settings (key, value) VALUES ('ai_profiles', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    args: [JSON.stringify(profiles)],
+  });
+}
+
+async function seedBot(db, { botId, definition }) {
+  await db.execute({
+    sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition) VALUES (?, ?, ?)",
+    args: [botId, botId, JSON.stringify(definition)],
+  });
+}
+
+test("providerBindings: finds a pointer-mode ai_profiles entry bound to the provider id", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await seedAiProfiles(db, [
+      { id: "p1", kind: "chat", name: "Bound Profile", provider_id: "chat-test-model", model_id: "chat-test-model" },
+      { id: "p2", kind: "chat", name: "Other Profile", provider_id: "some-other-provider", model_id: "x" },
+      { id: "p3", kind: "auto", name: "Auto Profile" },
+    ]);
+    const { profiles, bots } = await providerBindings(db, "chat-test-model");
+    assert.equal(profiles.length, 1);
+    assert.equal(profiles[0].id, "p1");
+    assert.deepEqual(bots, []);
+  } finally { cleanup(); }
+});
+
+test("providerBindings: finds a bot bound via models.default / models.escalation / fast_voice_model", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await seedBot(db, {
+      botId: "bot-default",
+      definition: { models: { default: "chat-test-model/chat-test-model" } },
+    });
+    await seedBot(db, {
+      botId: "bot-escalation",
+      definition: { models: { default: "other-provider/x", escalation: "chat-test-model/chat-test-model" } },
+    });
+    await seedBot(db, {
+      botId: "bot-fast-voice",
+      definition: { models: { default: "other-provider/x" }, fast_voice_model: "chat-test-model/chat-test-model" },
+    });
+    await seedBot(db, {
+      botId: "bot-unbound",
+      definition: { models: { default: "other-provider/x" } },
+    });
+
+    const { profiles, bots } = await providerBindings(db, "chat-test-model");
+    assert.deepEqual(profiles, []);
+    const ids = bots.map((b) => b.bot_id).sort();
+    assert.deepEqual(ids, ["bot-default", "bot-escalation", "bot-fast-voice"]);
+  } finally { cleanup(); }
+});
+
+test("providerBindings: a provider id prefix must not false-match a different provider (e.g. 'chat-test' vs 'chat-test-model')", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await seedBot(db, { botId: "bot-a", definition: { models: { default: "chat-test/some-model" } } });
+    const { bots } = await providerBindings(db, "chat-test-model");
+    assert.deepEqual(bots, [], "prefix match requires the '/' boundary, not a bare string prefix");
+  } finally { cleanup(); }
+});
+
+test("providerBindings: empty case — a provider with no profile or bot bindings returns both empty", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    await seedAiProfiles(db, [{ id: "p1", kind: "chat", name: "Unrelated", provider_id: "unrelated-provider" }]);
+    await seedBot(db, { botId: "bot-a", definition: { models: { default: "unrelated-provider/x" } } });
+
+    const { profiles, bots } = await providerBindings(db, "chat-test-model");
+    assert.deepEqual(profiles, []);
+    assert.deepEqual(bots, []);
+  } finally { cleanup(); }
+});
+
+test("providerBindings: no ai_profiles row / no pi_bot_defs rows at all -> both empty, no throw", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const { profiles, bots } = await providerBindings(db, "chat-test-model");
+    assert.deepEqual(profiles, []);
+    assert.deepEqual(bots, []);
+  } finally { cleanup(); }
+});

--- a/tests/models-registration.test.js
+++ b/tests/models-registration.test.js
@@ -27,6 +27,7 @@ import {
   providerBindings,
   pickChatMutexGroup,
   sanitizeFilename,
+  ProviderIdConflictError,
 } from "../servers/gateway/models/manager.js";
 import { loadState, saveState } from "../servers/gateway/models/state.js";
 import { upsertProvider, setProviderSyncManager } from "../servers/shared/providers-db.js";
@@ -299,6 +300,83 @@ test("pickChatMutexGroup: pure function, exhaustive over the rule (unit-level, n
 });
 
 // ---------------------------------------------------------------------------
+// registerModel — provider-id collision guard (fix round 1)
+// ---------------------------------------------------------------------------
+
+test("registerModel: refuses to clobber a foreign existing provider row at the same id", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    // A user's own unrelated cloud provider happens to share the catalog's
+    // model id (coincidence, e.g. hand-configured before the catalog
+    // existed). NOT native-tagged, NOT ours.
+    const foreign = {
+      id: "chat-test-model",
+      baseUrl: "https://api.example.com/v1",
+      apiKey: "sk-real-secret-do-not-touch",
+      host: "cloud",
+      bundleId: null,
+      description: "my own cloud provider",
+      models: [{ id: "gpt-lookalike", name: "Some Cloud Model" }],
+      disabled: false,
+      providerType: "openai-compat",
+      gpuPolicy: null,
+    };
+    await upsertProvider(db, foreign);
+    const before = await dbRow(db, "chat-test-model");
+
+    await assert.rejects(
+      () => registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir }),
+      (err) => {
+        assert.ok(err instanceof ProviderIdConflictError);
+        assert.equal(err.code, "PROVIDER_ID_CONFLICT");
+        assert.equal(err.modelId, "chat-test-model");
+        return true;
+      },
+    );
+
+    const after = await dbRow(db, "chat-test-model");
+    assert.equal(after.base_url, before.base_url);
+    assert.equal(after.api_key, before.api_key);
+    assert.equal(after.host, before.host);
+    assert.equal(after.models, before.models);
+    assert.equal(after.gpu_policy, before.gpu_policy);
+    assert.equal(after.lamport_ts, before.lamport_ts, "no write at all happened -- not even a no-op upsert bump");
+
+    const state = loadState(dir);
+    assert.equal(state.reservations["chat-test-model"], undefined, "no port reservation leaked by the rejected call");
+    assert.equal(state.registry["chat-test-model"], undefined, "no registry entry leaked by the rejected call");
+  } finally { cleanup(); }
+});
+
+test("registerModel: a native row for a DIFFERENT catalog model at a colliding id is also refused", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    // Native-tagged, but for a different model's id -- still not "ours" for
+    // THIS registration.
+    await upsertProvider(db, {
+      id: "chat-test-model",
+      baseUrl: "http://127.0.0.1:18150/v1",
+      apiKey: null,
+      host: "local",
+      bundleId: null,
+      description: "native, but a different model",
+      models: [{ id: "some-other-catalog-id", task: "chat", contextLen: 4096 }],
+      disabled: false,
+      providerType: "openai-compat",
+      gpuPolicy: { runtime: "native" },
+    });
+
+    await assert.rejects(
+      () => registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir }),
+      ProviderIdConflictError,
+    );
+
+    const state = loadState(dir);
+    assert.equal(state.reservations["chat-test-model"], undefined);
+  } finally { cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
 // unregisterModel — order + effects
 // ---------------------------------------------------------------------------
 
@@ -398,6 +476,40 @@ test("unregisterModel: missing blob (already deleted) is not an error", async ()
     const outcome = await unregisterModel({ modelId: "chat-test-model", db, dir });
     assert.equal(outcome.deleted, false);
     assert.equal(outcome.disabled, true);
+  } finally { cleanup(); }
+});
+
+test("register -> unregister -> re-register cycle: port freed and re-used, disabled flips back to 0, no stale base_url", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const first = await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+    const firstPort = first.port;
+
+    const rowAfterFirst = await dbRow(db, "chat-test-model");
+    assert.equal(Number(rowAfterFirst.disabled), 0);
+
+    await unregisterModel({ modelId: "chat-test-model", db, dir });
+    const rowAfterUnregister = await dbRow(db, "chat-test-model");
+    assert.equal(Number(rowAfterUnregister.disabled), 1, "soft-deleted, not hard-deleted");
+    const stateAfterUnregister = loadState(dir);
+    assert.equal(stateAfterUnregister.reservations["chat-test-model"], undefined, "port freed");
+
+    // Re-register must NOT be treated as a foreign-id collision: the
+    // surviving (disabled) row is still native-tagged for this exact
+    // catalog model, so ownership holds even though state.registry was
+    // cleared by unregister.
+    const second = await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+
+    assert.equal(second.port, firstPort, "the freed port is the lowest free port again, so it's re-used");
+    assert.equal(second.baseUrl, `http://127.0.0.1:${firstPort}/v1`, "no stale base_url from the torn-down registration");
+
+    const rowAfterSecond = await dbRow(db, "chat-test-model");
+    assert.equal(Number(rowAfterSecond.disabled), 0, "disabled flips back to 0");
+    assert.equal(rowAfterSecond.base_url, second.baseUrl);
+
+    const stateAfterSecond = loadState(dir);
+    assert.equal(stateAfterSecond.reservations["chat-test-model"].port, firstPort);
+    assert.ok(stateAfterSecond.registry["chat-test-model"], "registry entry rewritten on re-register");
   } finally { cleanup(); }
 });
 

--- a/tests/models-runtime.test.js
+++ b/tests/models-runtime.test.js
@@ -1,0 +1,768 @@
+/**
+ * Tests for servers/gateway/models/runtime.js + native-lock.js — llama.cpp
+ * binary asset management and llama-server child supervision (Item G,
+ * Task 8).
+ *
+ * No real llama-server binary is ever spawned and no real network traffic
+ * ever leaves this process: `identityProbe` is exercised against the
+ * in-process stub server fixture (`tests/fixtures/stub-llama-server.mjs`);
+ * `startModel`'s supervision logic is exercised against a fake `spawn`
+ * that returns a plain `EventEmitter` standing in for a `ChildProcess`;
+ * `ensureRuntime`'s download step is exercised against a local
+ * node:http fixture server (same technique `tests/models-manager.test.js`
+ * uses for its huggingface.co allowlist tests: a real hostname in the URL
+ * + an injected DNS `lookup` forced to 127.0.0.1), with the actual system
+ * `tar` binary doing real extraction of a real (test-fabricated) tarball —
+ * so the checksum-before-chmod ordering guarantee is proven end to end,
+ * not just asserted against a mock.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import http from "node:http";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  RuntimeAssetError,
+  RuntimeChecksumError,
+  resolveAsset,
+  isAllowedRuntimeHost,
+  buildRuntimeDownloadUrl,
+  ensureRuntime,
+  buildLlamaServerArgs,
+  startModel,
+  stopModel,
+  identityProbe,
+  probeSetprivAvailable,
+  __resetSetprivProbeCacheForTest,
+  getStatusSnapshot,
+} from "../servers/gateway/models/runtime.js";
+import { acquireHostLock, lockPathFor } from "../servers/gateway/models/native-lock.js";
+import { startStubLlamaServer } from "./fixtures/stub-llama-server.mjs";
+
+function scratchDir(tag) {
+  return mkdtempSync(join(tmpdir(), `models-runtime-${tag}-`));
+}
+
+function withScratch(tag, fn) {
+  const dir = scratchDir(tag);
+  return Promise.resolve()
+    .then(() => fn(dir))
+    .finally(() => rmSync(dir, { recursive: true, force: true }));
+}
+
+// ---------------------------------------------------------------------------
+// identityProbe
+// ---------------------------------------------------------------------------
+
+test("identity probe reports resident when the served id matches the alias", async () => {
+  const stub = await startStubLlamaServer({ modelId: "qwen3-4b" });
+  try {
+    const result = await identityProbe(stub.baseUrl, "qwen3-4b", fetch);
+    assert.equal(result, "resident");
+  } finally {
+    await stub.close();
+  }
+});
+
+test("identity probe rejects a live server whose served id != alias", async () => {
+  const stub = await startStubLlamaServer({ modelId: "some-other-model" });
+  try {
+    const result = await identityProbe(stub.baseUrl, "qwen3-4b", fetch);
+    assert.equal(result, "conflict");
+    assert.notEqual(result, "resident");
+  } finally {
+    await stub.close();
+  }
+});
+
+test("identity probe reports down when nothing is listening", async () => {
+  // Grab a real ephemeral port, close the listener immediately so nothing
+  // is bound there, then probe it — a real connection-refused, not a mock.
+  const stub = await startStubLlamaServer({ modelId: "x" });
+  const deadPort = stub.port;
+  await stub.close();
+  const result = await identityProbe(`http://127.0.0.1:${deadPort}`, "qwen3-4b", fetch);
+  assert.equal(result, "down");
+});
+
+test("identity probe reports down on malformed JSON from a live server", async () => {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("not json");
+  });
+  await new Promise((resolvePromise) => server.listen(0, "127.0.0.1", resolvePromise));
+  const port = server.address().port;
+  try {
+    const result = await identityProbe(`http://127.0.0.1:${port}`, "qwen3-4b", fetch);
+    assert.equal(result, "down");
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// startModel — args, process group
+// ---------------------------------------------------------------------------
+
+function fakeChild(pid) {
+  const ee = new EventEmitter();
+  ee.pid = pid;
+  ee.kill = () => {
+    setImmediate(() => ee.emit("exit", 0, "SIGTERM"));
+  };
+  return ee;
+}
+
+test("startModel passes --alias/--port/--host args and spawns detached (own process group)", async () => {
+  const calls = [];
+  const spawn = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return fakeChild(9001);
+  };
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/qwen3-4b.gguf",
+    alias: "qwen3-4b",
+    port: 18100,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true, // no idle timer noise for this test
+  });
+  try {
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].cmd, "/opt/llamacpp/llama-server");
+    const args = calls[0].args;
+    assert.ok(args.includes("--alias"));
+    assert.equal(args[args.indexOf("--alias") + 1], "qwen3-4b");
+    assert.ok(args.includes("--port"));
+    assert.equal(args[args.indexOf("--port") + 1], "18100");
+    assert.ok(args.includes("--host"));
+    assert.equal(args[args.indexOf("--host") + 1], "127.0.0.1");
+    assert.equal(calls[0].opts.detached, true);
+    assert.equal(handle.live, true);
+    assert.equal(handle.state, "running");
+  } finally {
+    await handle.stop();
+  }
+});
+
+test("startModel wraps the command in setpriv --pdeathsig=SIGTERM when available", async () => {
+  const calls = [];
+  const spawn = (cmd, args) => {
+    calls.push({ cmd, args });
+    return fakeChild(9002);
+  };
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/qwen3-4b.gguf",
+    alias: "qwen3-4b-setpriv",
+    port: 18101,
+    spawn,
+    setprivAvailable: true,
+    keepWarm: true,
+  });
+  try {
+    assert.equal(calls[0].cmd, "setpriv");
+    assert.deepEqual(calls[0].args.slice(0, 2), ["--pdeathsig=SIGTERM", "/opt/llamacpp/llama-server"]);
+    assert.ok(calls[0].args.includes("--alias"));
+  } finally {
+    await handle.stop();
+  }
+});
+
+test("buildLlamaServerArgs includes model, alias, port, host", () => {
+  const args = buildLlamaServerArgs({ ggufPath: "/m/x.gguf", alias: "x", port: 18150, host: "127.0.0.1" });
+  assert.deepEqual(args, ["--model", "/m/x.gguf", "--alias", "x", "--port", "18150", "--host", "127.0.0.1"]);
+});
+
+// ---------------------------------------------------------------------------
+// startModel — restart with backoff, gives up at maxRestarts
+// ---------------------------------------------------------------------------
+
+test("startModel restarts with backoff up to maxRestarts, then goes unhealthy with lastError", async () => {
+  const children = [];
+  const spawn = () => {
+    const child = fakeChild(9100 + children.length);
+    children.push(child);
+    return child;
+  };
+  // Synchronous "timer": fires the callback immediately so the restart
+  // chain plays out deterministically within this test, no real clock.
+  const timeoutCalls = [];
+  const setTimeoutFn = (fn, ms) => {
+    timeoutCalls.push(ms);
+    fn();
+    return timeoutCalls.length;
+  };
+  const clearTimeoutFn = () => {};
+
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "restart-test-model",
+    port: 18102,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true, // isolate from idle-timer scheduling entirely
+    maxRestarts: 3,
+    setTimeoutFn,
+    clearTimeoutFn,
+  });
+
+  assert.equal(children.length, 1);
+  children[0].emit("exit", 1, null);
+  // The injected setTimeoutFn fires its callback synchronously, so by the
+  // time `emit` returns, the restart chain has already respawned once and
+  // `state` is back to "running" (not left at the intermediate
+  // "restarting" value — there's no async gap to observe it in).
+  assert.equal(handle.restartCount, 1);
+  assert.equal(handle.state, "running");
+  assert.equal(children.length, 2);
+
+  children[1].emit("exit", 1, null);
+  assert.equal(children.length, 3);
+  assert.equal(handle.restartCount, 2);
+
+  children[2].emit("exit", 1, null);
+  assert.equal(children.length, 4);
+  assert.equal(handle.restartCount, 3);
+
+  // Fourth failure: restartCount(3) >= maxRestarts(3) -> give up.
+  children[3].emit("exit", 1, "SIGSEGV");
+  assert.equal(children.length, 4); // no fifth spawn
+  assert.equal(handle.state, "unhealthy");
+  assert.equal(handle.restartCount, 3);
+  assert.match(handle.lastError, /SIGSEGV/);
+  assert.equal(handle.live, false);
+});
+
+// ---------------------------------------------------------------------------
+// startModel — idle timer
+// ---------------------------------------------------------------------------
+
+test("idle timer stops the process after the configured idle period", async () => {
+  const timerCalls = [];
+  const setTimeoutFn = (fn, ms) => {
+    const id = timerCalls.length;
+    timerCalls.push({ fn, ms });
+    return id;
+  };
+  const clearTimeoutFn = () => {};
+  let killed = false;
+  const spawn = () => {
+    const child = fakeChild(9200);
+    child.kill = () => {
+      killed = true;
+      setImmediate(() => child.emit("exit", 0, "SIGTERM"));
+    };
+    return child;
+  };
+
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "idle-test-model",
+    port: 18103,
+    spawn,
+    setprivAvailable: false,
+    idleMinutes: 30,
+    setTimeoutFn,
+    clearTimeoutFn,
+  });
+
+  assert.equal(timerCalls.length, 1);
+  assert.equal(timerCalls[0].ms, 30 * 60 * 1000);
+  assert.equal(handle.live, true);
+
+  await timerCalls[0].fn(); // simulate the idle period elapsing
+
+  assert.equal(killed, true);
+  assert.equal(handle.state, "stopped");
+  assert.equal(handle.live, false);
+});
+
+test("keepWarm disables the idle timer entirely", async () => {
+  const timerCalls = [];
+  const setTimeoutFn = (fn, ms) => {
+    timerCalls.push({ fn, ms });
+    return timerCalls.length;
+  };
+  const spawn = () => fakeChild(9300);
+
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "keepwarm-test-model",
+    port: 18104,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true,
+    idleMinutes: 30,
+    setTimeoutFn,
+    clearTimeoutFn: () => {},
+  });
+
+  assert.equal(timerCalls.length, 0); // never scheduled
+  await handle.stop();
+});
+
+test("alwaysResident also disables the idle timer", async () => {
+  const timerCalls = [];
+  const setTimeoutFn = (fn, ms) => {
+    timerCalls.push({ fn, ms });
+    return timerCalls.length;
+  };
+  const spawn = () => fakeChild(9301);
+
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "alwaysresident-test-model",
+    port: 18105,
+    spawn,
+    setprivAvailable: false,
+    alwaysResident: true,
+    setTimeoutFn,
+    clearTimeoutFn: () => {},
+  });
+
+  assert.equal(timerCalls.length, 0);
+  await handle.stop();
+});
+
+test("getStatusSnapshot reports every tracked model and drops it once stopped", async () => {
+  const spawn = () => fakeChild(9400);
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "snapshot-test-model",
+    port: 18106,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true,
+  });
+  const before = getStatusSnapshot();
+  assert.ok(before.some((s) => s.alias === "snapshot-test-model" && s.live === true));
+  await handle.stop();
+  const after = getStatusSnapshot();
+  assert.ok(!after.some((s) => s.alias === "snapshot-test-model"));
+});
+
+test("stopModel(handle) is equivalent to handle.stop()", async () => {
+  const spawn = () => fakeChild(9500);
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "stopmodel-test-model",
+    port: 18107,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true,
+  });
+  await stopModel(handle);
+  assert.equal(handle.state, "stopped");
+  assert.equal(handle.live, false);
+});
+
+// ---------------------------------------------------------------------------
+// probeSetprivAvailable
+// ---------------------------------------------------------------------------
+
+test("probeSetprivAvailable returns true when the probe command succeeds", () => {
+  const result = probeSetprivAvailable({ force: true, execFileSyncImpl: () => "" });
+  assert.equal(result, true);
+  __resetSetprivProbeCacheForTest();
+});
+
+test("probeSetprivAvailable returns false when the probe command throws", () => {
+  const result = probeSetprivAvailable({
+    force: true,
+    execFileSyncImpl: () => {
+      throw new Error("not found");
+    },
+  });
+  assert.equal(result, false);
+  __resetSetprivProbeCacheForTest();
+});
+
+test("probeSetprivAvailable caches after the first real call", () => {
+  __resetSetprivProbeCacheForTest();
+  let calls = 0;
+  const impl = () => {
+    calls += 1;
+    return "";
+  };
+  probeSetprivAvailable({ execFileSyncImpl: impl });
+  probeSetprivAvailable({ execFileSyncImpl: impl });
+  assert.equal(calls, 1);
+  __resetSetprivProbeCacheForTest();
+});
+
+// ---------------------------------------------------------------------------
+// native-lock.js
+// ---------------------------------------------------------------------------
+
+test("acquireHostLock: second acquire in-process returns null while first is held; released -> acquirable", async () => {
+  await withScratch("lock-conflict", (dir) => {
+    const release1 = acquireHostLock("local-llm", { runtimeDir: dir });
+    assert.ok(typeof release1 === "function");
+    assert.ok(existsSync(lockPathFor("local-llm", { runtimeDir: dir })));
+
+    const release2 = acquireHostLock("local-llm", { runtimeDir: dir });
+    assert.equal(release2, null); // held elsewhere (this same process, but a live pid)
+
+    release1();
+    assert.ok(!existsSync(lockPathFor("local-llm", { runtimeDir: dir })));
+
+    const release3 = acquireHostLock("local-llm", { runtimeDir: dir });
+    assert.ok(typeof release3 === "function");
+    release3();
+  });
+});
+
+test("acquireHostLock: different mutex groups don't contend", async () => {
+  await withScratch("lock-groups", (dir) => {
+    const releaseA = acquireHostLock("group-a", { runtimeDir: dir });
+    const releaseB = acquireHostLock("group-b", { runtimeDir: dir });
+    assert.ok(releaseA);
+    assert.ok(releaseB);
+    releaseA();
+    releaseB();
+  });
+});
+
+test("acquireHostLock: steals a stale lock left by a dead owner pid", async () => {
+  await withScratch("lock-stale", (dir) => {
+    const deadPid = 999999; // never released
+    const releaseDead = acquireHostLock("local-llm", {
+      runtimeDir: dir,
+      pid: deadPid,
+      isProcessAlive: () => true, // pretend it's alive at acquire time
+    });
+    assert.ok(releaseDead); // acquired, but deliberately never called (simulates a crash)
+
+    // A fresh acquirer now sees the pid as dead and should steal the lock.
+    const releaseLive = acquireHostLock("local-llm", {
+      runtimeDir: dir,
+      pid: process.pid,
+      isProcessAlive: (pid) => pid !== deadPid,
+    });
+    assert.ok(typeof releaseLive === "function");
+    releaseLive();
+  });
+});
+
+test("acquireHostLock: does NOT steal a lock whose owner is confirmed alive", async () => {
+  await withScratch("lock-alive", (dir) => {
+    const ownerPid = 424242;
+    const release1 = acquireHostLock("local-llm", {
+      runtimeDir: dir,
+      pid: ownerPid,
+      isProcessAlive: () => true,
+    });
+    assert.ok(release1);
+
+    const release2 = acquireHostLock("local-llm", {
+      runtimeDir: dir,
+      pid: process.pid,
+      isProcessAlive: (pid) => pid === ownerPid,
+    });
+    assert.equal(release2, null);
+    release1();
+  });
+});
+
+test("acquireHostLock: corrupt lock content is treated as stale and stolen", async () => {
+  await withScratch("lock-corrupt", (dir) => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(lockPathFor("local-llm", { runtimeDir: dir }), "not-a-pid", "utf8");
+    const release = acquireHostLock("local-llm", { runtimeDir: dir, isProcessAlive: () => true });
+    assert.ok(typeof release === "function");
+    release();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAsset
+// ---------------------------------------------------------------------------
+
+function makeRuntimeBlock(overrides = {}) {
+  return {
+    name: "llama.cpp",
+    release: "b10068",
+    assets: {
+      "linux-x64-vulkan": { file: "llama-vulkan.tar.gz", sha256: "vk-sha", min_glibc: "2.34" },
+      "linux-x64-cpu": { file: "llama-cpu.tar.gz", sha256: "cpu-sha", min_glibc: "2.34" },
+      "darwin-arm64": { file: "llama-arm64.tar.gz", sha256: "arm-sha" },
+      "darwin-x64": { file: "llama-x64.tar.gz", sha256: "x64-sha" },
+    },
+    ...overrides,
+  };
+}
+
+test("resolveAsset: WSL2 probe forces the cpu asset even when accel says cuda", () => {
+  const probe = { platform: "linux", wsl2: true, accel: "cuda", ramAvailableMb: 16000 };
+  const result = resolveAsset(probe, makeRuntimeBlock(), { lddOutput: "ldd (Ubuntu GLIBC 2.35-0ubuntu3) 2.35" });
+  assert.equal(result.error, undefined);
+  assert.equal(result.key, "linux-x64-cpu");
+});
+
+test("resolveAsset: unknown platform returns a typed error, never a guess", () => {
+  const probe = { platform: "windows" };
+  const result = resolveAsset(probe, makeRuntimeBlock());
+  assert.ok(result.error instanceof RuntimeAssetError);
+  assert.equal(result.error.code, "UNSUPPORTED_PLATFORM");
+  assert.equal(result.key, undefined);
+});
+
+test("resolveAsset: darwin picks arm64 vs x64 by injected arch", () => {
+  const probe = { platform: "darwin", accel: "metal" };
+  const arm = resolveAsset(probe, makeRuntimeBlock(), { arch: "arm64" });
+  assert.equal(arm.key, "darwin-arm64");
+  const x64 = resolveAsset(probe, makeRuntimeBlock(), { arch: "x64" });
+  assert.equal(x64.key, "darwin-x64");
+});
+
+test("resolveAsset: unsupported darwin arch returns a typed error", () => {
+  const probe = { platform: "darwin", accel: "metal" };
+  const result = resolveAsset(probe, makeRuntimeBlock(), { arch: "ppc64" });
+  assert.ok(result.error instanceof RuntimeAssetError);
+  assert.equal(result.error.code, "UNSUPPORTED_PLATFORM");
+});
+
+test("resolveAsset: glibc too old for vulkan falls back to the cpu asset when cpu's requirement is met", () => {
+  const runtimeBlock = makeRuntimeBlock({
+    assets: {
+      "linux-x64-vulkan": { file: "llama-vulkan.tar.gz", sha256: "vk-sha", min_glibc: "2.34" },
+      "linux-x64-cpu": { file: "llama-cpu.tar.gz", sha256: "cpu-sha", min_glibc: "2.17" },
+    },
+  });
+  const probe = { platform: "linux", wsl2: false, accel: "vulkan" };
+  const result = resolveAsset(probe, runtimeBlock, { lddOutput: "ldd (GNU libc) 2.17" });
+  assert.equal(result.error, undefined);
+  assert.equal(result.key, "linux-x64-cpu");
+});
+
+test("resolveAsset: glibc too old for every asset returns an honest typed error, not a guess", () => {
+  const runtimeBlock = makeRuntimeBlock({
+    assets: {
+      "linux-x64-vulkan": { file: "llama-vulkan.tar.gz", sha256: "vk-sha", min_glibc: "2.34" },
+      "linux-x64-cpu": { file: "llama-cpu.tar.gz", sha256: "cpu-sha", min_glibc: "2.34" },
+    },
+  });
+  const probe = { platform: "linux", wsl2: false, accel: "vulkan" };
+  const result = resolveAsset(probe, runtimeBlock, { lddOutput: "ldd (GNU libc) 2.17" });
+  assert.ok(result.error instanceof RuntimeAssetError);
+  assert.equal(result.error.code, "GLIBC_TOO_OLD");
+  assert.equal(result.key, undefined);
+});
+
+test("resolveAsset: undetectable glibc (no ldd output) is treated as unmet, not assumed fine", () => {
+  const probe = { platform: "linux", wsl2: false, accel: "vulkan" };
+  const result = resolveAsset(probe, makeRuntimeBlock(), { lddOutput: null });
+  // Both assets in makeRuntimeBlock() require 2.34; undetectable can't
+  // confirm either, so this must be the honest error, never a resident guess.
+  assert.ok(result.error instanceof RuntimeAssetError);
+  assert.equal(result.error.code, "GLIBC_TOO_OLD");
+});
+
+test("resolveAsset: no catalog entry for the resolved key is a typed NO_ASSET error", () => {
+  const runtimeBlock = makeRuntimeBlock({ assets: { "linux-x64-vulkan": { file: "v.tar.gz", sha256: "s", min_glibc: "2.34" } } });
+  const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+  const result = resolveAsset(probe, runtimeBlock, {});
+  assert.ok(result.error instanceof RuntimeAssetError);
+  assert.equal(result.error.code, "NO_ASSET");
+});
+
+test("resolveAsset: cpu accel goes straight to the cpu asset (no vulkan attempt)", () => {
+  const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+  const result = resolveAsset(probe, makeRuntimeBlock(), { lddOutput: "ldd (GNU libc) 2.35" });
+  assert.equal(result.key, "linux-x64-cpu");
+});
+
+test("resolveAsset: vulkan accel with sufficient glibc picks the vulkan asset", () => {
+  const probe = { platform: "linux", wsl2: false, accel: "vulkan" };
+  const result = resolveAsset(probe, makeRuntimeBlock(), { lddOutput: "ldd (GNU libc) 2.35" });
+  assert.equal(result.key, "linux-x64-vulkan");
+});
+
+// ---------------------------------------------------------------------------
+// isAllowedRuntimeHost / buildRuntimeDownloadUrl
+// ---------------------------------------------------------------------------
+
+test("isAllowedRuntimeHost allows exactly github.com and objects.githubusercontent.com", () => {
+  assert.equal(isAllowedRuntimeHost("github.com"), true);
+  assert.equal(isAllowedRuntimeHost("objects.githubusercontent.com"), true);
+  assert.equal(isAllowedRuntimeHost("evilgithub.com"), false);
+  assert.equal(isAllowedRuntimeHost("huggingface.co"), false);
+  assert.equal(isAllowedRuntimeHost(""), false);
+  assert.equal(isAllowedRuntimeHost(undefined), false);
+});
+
+test("buildRuntimeDownloadUrl builds a releases/download URL", () => {
+  const url = buildRuntimeDownloadUrl("b10068", "llama-b10068-bin-ubuntu-x64.tar.gz");
+  assert.equal(url, "https://github.com/ggml-org/llama.cpp/releases/download/b10068/llama-b10068-bin-ubuntu-x64.tar.gz");
+});
+
+// ---------------------------------------------------------------------------
+// ensureRuntime — real tar extraction, checksum-before-chmod ordering
+// ---------------------------------------------------------------------------
+
+function startFixtureServer(handler) {
+  return new Promise((resolvePromise, reject) => {
+    const srv = http.createServer(handler);
+    srv.listen(0, "127.0.0.1", () => resolvePromise({ srv, port: srv.address().port }));
+    srv.on("error", reject);
+  });
+}
+
+/** Forces every hostname to 127.0.0.1 — same technique (and the same
+ * both-shapes handling) as `tests/models-manager.test.js`'s
+ * `lookupToLocalhost`, needed for Node's happy-eyeballs multi-address
+ * connect path (`{ all: true }`) as well as the classic single-address
+ * callback shape. */
+function forceGithubLookup() {
+  return (_hostname, options, callback) => {
+    if (options && options.all) {
+      callback(null, [{ address: "127.0.0.1", family: 4 }]);
+    } else {
+      callback(null, "127.0.0.1", 4);
+    }
+  };
+}
+
+/** Fabricate a real gzip tarball (via the system `tar`) containing a
+ * single file named `llama-server` with the given content. Returns the
+ * archive bytes and its sha256 — a genuine end-to-end fixture, not a
+ * hand-rolled fake of tar's format. */
+function makeRealTarball(dir) {
+  const payloadDir = join(dir, "payload");
+  mkdirSync(payloadDir, { recursive: true });
+  writeFileSync(join(payloadDir, "llama-server"), "#!/bin/sh\necho fake-llama-server\n");
+  const archivePath = join(dir, "llama-runtime.tar.gz");
+  execFileSync("tar", ["-czf", archivePath, "-C", payloadDir, "llama-server"]);
+  const bytes = readFileSync(archivePath);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  return { bytes, sha256 };
+}
+
+test("ensureRuntime downloads, verifies, extracts (real tar), and chmods only after verification", async () => {
+  await withScratch("ensure-happy", async (dir) => {
+    const buildDir = join(dir, "build");
+    mkdirSync(buildDir, { recursive: true });
+    const { bytes, sha256 } = makeRealTarball(buildDir);
+
+    const { srv, port } = await startFixtureServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/gzip" });
+      res.end(bytes);
+    });
+
+    const chmodCalls = [];
+    const runtimeBlock = {
+      release: "test-rel",
+      assets: { "linux-x64-cpu": { file: "llama-runtime.tar.gz", sha256, min_glibc: "2.0" } },
+    };
+    const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+
+    try {
+      const binPath = await ensureRuntime(join(dir, "crow-home"), runtimeBlock, probe, {
+        lddOutput: "ldd (GNU libc) 2.35",
+        baseUrl: `http://github.com:${port}`,
+        insecureHttpHosts: ["github.com"],
+        lookup: forceGithubLookup(port),
+        chmodFn: (p, mode) => chmodCalls.push({ p, mode }),
+      });
+
+      assert.ok(existsSync(binPath));
+      assert.equal(chmodCalls.length, 1);
+      assert.equal(chmodCalls[0].p, binPath);
+      assert.equal(chmodCalls[0].mode, 0o755);
+      assert.equal(readFileSync(binPath, "utf8").includes("fake-llama-server"), true);
+
+      // Idempotent: a second call reuses the manifest, no re-download
+      // (fixture server would 200 again anyway, but chmod must NOT be
+      // called a second time for an already-installed asset).
+      const binPath2 = await ensureRuntime(join(dir, "crow-home"), runtimeBlock, probe, {
+        lddOutput: "ldd (GNU libc) 2.35",
+        baseUrl: `http://github.com:${port}`,
+        insecureHttpHosts: ["github.com"],
+        lookup: forceGithubLookup(port),
+        chmodFn: (p, mode) => chmodCalls.push({ p, mode }),
+      });
+      assert.equal(binPath2, binPath);
+      assert.equal(chmodCalls.length, 1); // unchanged — reused the manifest
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+test("ensureRuntime never chmods when the downloaded archive fails checksum verification", async () => {
+  await withScratch("ensure-checksum-fail", async (dir) => {
+    const buildDir = join(dir, "build");
+    mkdirSync(buildDir, { recursive: true });
+    const { bytes } = makeRealTarball(buildDir);
+
+    const { srv, port } = await startFixtureServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/gzip" });
+      res.end(bytes);
+    });
+
+    const chmodCalls = [];
+    const runtimeBlock = {
+      release: "test-rel-bad",
+      assets: { "linux-x64-cpu": { file: "llama-runtime.tar.gz", sha256: "0000000000000000000000000000000000000000000000000000000000000000", min_glibc: "2.0" } },
+    };
+    const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+
+    try {
+      await assert.rejects(
+        () => ensureRuntime(join(dir, "crow-home"), runtimeBlock, probe, {
+          lddOutput: "ldd (GNU libc) 2.35",
+          baseUrl: `http://github.com:${port}`,
+          insecureHttpHosts: ["github.com"],
+          lookup: forceGithubLookup(port),
+          chmodFn: (p, mode) => chmodCalls.push({ p, mode }),
+        }),
+        (err) => {
+          assert.ok(err instanceof RuntimeChecksumError);
+          return true;
+        },
+      );
+      assert.equal(chmodCalls.length, 0); // unverified binary never made executable
+      // The staging archive must not survive a checksum failure either.
+      const releaseDir = join(dir, "crow-home", "runtimes", "llamacpp", "test-rel-bad");
+      const staged = existsSync(join(releaseDir, ".download-linux-x64-cpu.tmp"));
+      assert.equal(staged, false);
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+test("ensureRuntime rejects a resolveAsset failure before attempting any download", async () => {
+  await withScratch("ensure-bad-platform", async (dir) => {
+    const runtimeBlock = makeRuntimeBlock();
+    const probe = { platform: "windows" };
+    await assert.rejects(
+      () => ensureRuntime(dir, runtimeBlock, probe, {}),
+      (err) => {
+        assert.ok(err instanceof RuntimeAssetError);
+        assert.equal(err.code, "UNSUPPORTED_PLATFORM");
+        return true;
+      },
+    );
+  });
+});

--- a/tests/models-runtime.test.js
+++ b/tests/models-runtime.test.js
@@ -39,6 +39,7 @@ import { join } from "node:path";
 import {
   RuntimeAssetError,
   RuntimeChecksumError,
+  RuntimeDownloadTimeoutError,
   resolveAsset,
   isAllowedRuntimeHost,
   buildRuntimeDownloadUrl,
@@ -344,6 +345,137 @@ test("alwaysResident also disables the idle timer", async () => {
 
   assert.equal(timerCalls.length, 0);
   await handle.stop();
+});
+
+// ---------------------------------------------------------------------------
+// startModel — onTerminal (Task 9 review round 1: gpu-orchestrator's native
+// host lock is released exactly when this fires, so it must fire exactly
+// once per terminal transition and NEVER for a restart that still has
+// budget left)
+// ---------------------------------------------------------------------------
+
+test("onTerminal fires exactly once when the idle timer stops the process", async () => {
+  const timerCalls = [];
+  const setTimeoutFn = (fn, ms) => {
+    timerCalls.push({ fn, ms });
+    return timerCalls.length;
+  };
+  const clearTimeoutFn = () => {};
+  const spawn = () => fakeChild(9210);
+  const terminalCalls = [];
+
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "onterminal-idle-model",
+    port: 18113,
+    spawn,
+    setprivAvailable: false,
+    idleMinutes: 30,
+    setTimeoutFn,
+    clearTimeoutFn,
+    onTerminal: (reason) => terminalCalls.push(reason),
+  });
+
+  assert.deepEqual(terminalCalls, [], "not terminal while running");
+  await timerCalls[0].fn(); // simulate the idle period elapsing -> handle.stop()
+  assert.deepEqual(terminalCalls, ["stopped"]);
+  assert.equal(handle.state, "stopped");
+});
+
+test("onTerminal fires exactly once when restarts are exhausted (unhealthy), never for a restart still under budget", async () => {
+  const children = [];
+  const spawn = () => {
+    const child = fakeChild(9220 + children.length);
+    children.push(child);
+    return child;
+  };
+  const setTimeoutFn = (fn) => {
+    fn(); // synchronous restart chain, mirrors the existing backoff test
+    return children.length;
+  };
+  const clearTimeoutFn = () => {};
+  const terminalCalls = [];
+
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "onterminal-restart-model",
+    port: 18114,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true,
+    maxRestarts: 2,
+    setTimeoutFn,
+    clearTimeoutFn,
+    onTerminal: (reason) => terminalCalls.push(reason),
+  });
+
+  children[0].emit("exit", 1, null); // restart 1 of 2 -- NOT terminal
+  assert.deepEqual(terminalCalls, [], "a restart still under budget is not a terminal transition");
+  children[1].emit("exit", 1, null); // restart 2 of 2 -- NOT terminal
+  assert.deepEqual(terminalCalls, []);
+  children[2].emit("exit", 1, "SIGSEGV"); // restartCount(2) >= maxRestarts(2) -> unhealthy, terminal
+  assert.deepEqual(terminalCalls, ["unhealthy"]);
+  assert.equal(handle.state, "unhealthy");
+
+  // A caller (like gpu-orchestrator's release()) that got the single
+  // onTerminal call must never see a second one even if something later
+  // also calls stop() on an already-unhealthy handle.
+  await handle.stop();
+  assert.deepEqual(terminalCalls, ["unhealthy"], "onTerminal is idempotent — fires at most once per handle");
+});
+
+test("onTerminal fires exactly once on an explicit stop() and is idempotent across a double stop()", async () => {
+  const spawn = () => fakeChild(9230);
+  const terminalCalls = [];
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "onterminal-stop-model",
+    port: 18115,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true,
+    onTerminal: (reason) => terminalCalls.push(reason),
+  });
+
+  await handle.stop();
+  assert.deepEqual(terminalCalls, ["stopped"]);
+  await handle.stop(); // double-stop — must not double-fire
+  assert.deepEqual(terminalCalls, ["stopped"]);
+});
+
+test("onTerminal defaults to a no-op and never breaks supervision when it throws", async () => {
+  const spawn = () => fakeChild(9240);
+  // No onTerminal passed at all — default must be a safe no-op.
+  const handle = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "onterminal-default-model",
+    port: 18116,
+    spawn,
+    setprivAvailable: false,
+    keepWarm: true,
+  });
+  await handle.stop(); // must not throw
+  assert.equal(handle.state, "stopped");
+
+  const spawn2 = () => fakeChild(9241);
+  const handle2 = startModel({
+    binPath: "/opt/llamacpp/llama-server",
+    ggufPath: "/models/x.gguf",
+    alias: "onterminal-throwing-model",
+    port: 18117,
+    spawn: spawn2,
+    setprivAvailable: false,
+    keepWarm: true,
+    onTerminal: () => {
+      throw new Error("a caller's terminal hook must never break supervision");
+    },
+  });
+  await handle2.stop(); // must not throw/propagate the callback's error
+  assert.equal(handle2.state, "stopped");
 });
 
 test("getStatusSnapshot reports every tracked model and drops it once stopped", async () => {
@@ -789,6 +921,38 @@ test("downloadRuntimeAsset deletes the partial file on a mid-stream error", asyn
         },
       );
       assert.equal(existsSync(dest), false); // partial file cleaned up, not left behind
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+test("downloadRuntimeAsset rejects a stalled connection with RuntimeDownloadTimeoutError instead of hanging forever", async () => {
+  await withScratch("dl-stall-timeout", async (dir) => {
+    // Accepts the connection but never writes a byte and never ends the
+    // response — a genuine stalled-socket simulation (Task 9 review round
+    // 1, finding 2b: "no promise may hang forever on a stalled TCP
+    // connection").
+    const { srv, port } = await startFixtureServer(() => {});
+    const dest = join(dir, "stalled-runtime.tar.gz");
+    try {
+      await assert.rejects(
+        () => downloadRuntimeAsset({
+          url: `http://github.com:${port}/releases/download/x/y.tar.gz`,
+          dest,
+          expectedSha: null,
+          lookup: forceGithubLookup(),
+          insecureHttpHosts: ["github.com"],
+          timeoutMs: 50, // tiny for a fast test — production default is 120s
+        }),
+        (err) => {
+          assert.ok(err instanceof RuntimeDownloadTimeoutError, `expected RuntimeDownloadTimeoutError, got ${err}`);
+          assert.equal(err.code, "DOWNLOAD_TIMEOUT");
+          assert.equal(err.timeoutMs, 50);
+          return true;
+        },
+      );
+      assert.equal(existsSync(dest), false, "no partial file — the stall was never past the connect/header phase");
     } finally {
       await new Promise((r) => srv.close(r));
     }

--- a/tests/models-runtime.test.js
+++ b/tests/models-runtime.test.js
@@ -29,6 +29,9 @@ import {
   writeFileSync,
   mkdirSync,
   readFileSync,
+  renameSync,
+  unlinkSync,
+  createWriteStream as fsWriteStream,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -40,6 +43,7 @@ import {
   isAllowedRuntimeHost,
   buildRuntimeDownloadUrl,
   ensureRuntime,
+  downloadRuntimeAsset,
   buildLlamaServerArgs,
   startModel,
   stopModel,
@@ -48,7 +52,7 @@ import {
   __resetSetprivProbeCacheForTest,
   getStatusSnapshot,
 } from "../servers/gateway/models/runtime.js";
-import { acquireHostLock, lockPathFor } from "../servers/gateway/models/native-lock.js";
+import { acquireHostLock, lockPathFor, stealStaleLock } from "../servers/gateway/models/native-lock.js";
 import { startStubLlamaServer } from "./fixtures/stub-llama-server.mjs";
 
 function scratchDir(tag) {
@@ -494,6 +498,81 @@ test("acquireHostLock: corrupt lock content is treated as stale and stolen", asy
   });
 });
 
+test("native-lock: rename-atomic steal never clobbers a winner's fresh lock (dual-steal TOCTOU regression)", async () => {
+  // Reproduces the exact race a reviewer caught against an earlier
+  // (unlink-based) version of stealStaleLock: two racers, A and B, both
+  // read the SAME stale lock. A completes its whole steal-and-create
+  // cycle first. B — simulated here at the moment it decided to steal,
+  // holding the pid it read BEFORE A acted — only gets around to its own
+  // steal attempt afterward, when the file at lockPath is no longer the
+  // original stale one but A's brand-new live lock. B must detect that
+  // mismatch and back off rather than destroy A's lock.
+  await withScratch("lock-toctou", async (dir) => {
+    const lockPath = lockPathFor("local-llm", { runtimeDir: dir });
+    const deadPid = 888888;
+    const winnerPid = 777777;
+
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(lockPath, String(deadPid), "utf8"); // the original stale lock both racers see
+
+    // Racer A ("the winner") runs a complete acquire through the public
+    // API — read stale pid -> rename-steal -> discard -> fresh create.
+    const releaseWinner = acquireHostLock("local-llm", {
+      runtimeDir: dir,
+      pid: winnerPid,
+      isProcessAlive: (p) => p !== deadPid,
+    });
+    assert.ok(typeof releaseWinner === "function");
+    assert.equal(readFileSync(lockPath, "utf8"), String(winnerPid));
+
+    // Racer B ("the loser") is simulated at the exact point it decided to
+    // steal: it captured `existingPid: deadPid` before A did anything,
+    // and is only now attempting the rename. This specific interleaving
+    // can't be forced through the public `acquireHostLock` entry point
+    // alone (a real re-read there always reflects current disk state),
+    // so this calls the exported primitive directly with the STALE belief
+    // B actually held at decision time.
+    stealStaleLock({
+      fs: { renameSync, readFileSync, unlinkSync },
+      lockPath,
+      existingPid: deadPid,
+    });
+
+    // A's fresh, live lock must be completely intact — the mismatch
+    // (staged content is winnerPid, not the deadPid B was expecting) must
+    // have been detected and the file put back, never discarded.
+    assert.equal(readFileSync(lockPath, "utf8"), String(winnerPid));
+
+    // And B, now going through the normal acquireHostLock path, correctly
+    // sees the winner's lock as live and gets null back — it does NOT
+    // end up holding a lock while the winner's lock is present.
+    const releaseLoser = acquireHostLock("local-llm", {
+      runtimeDir: dir,
+      pid: 555555,
+      isProcessAlive: (p) => p === winnerPid,
+    });
+    assert.equal(releaseLoser, null);
+
+    releaseWinner();
+  });
+});
+
+test("stealStaleLock: a rename that finds nothing at lockPath (already claimed) is a silent no-op", async () => {
+  await withScratch("lock-steal-noop", async (dir) => {
+    const lockPath = lockPathFor("local-llm", { runtimeDir: dir });
+    // Nothing exists at lockPath at all — represents the case where a
+    // different racer's rename already won AND that racer had also
+    // already finished discarding (or the lock was legitimately released
+    // in between). Must not throw, must not create anything.
+    assert.doesNotThrow(() => stealStaleLock({
+      fs: { renameSync, readFileSync, unlinkSync },
+      lockPath,
+      existingPid: 123,
+    }));
+    assert.equal(existsSync(lockPath), false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // resolveAsset
 // ---------------------------------------------------------------------------
@@ -617,7 +696,7 @@ test("buildRuntimeDownloadUrl builds a releases/download URL", () => {
 });
 
 // ---------------------------------------------------------------------------
-// ensureRuntime — real tar extraction, checksum-before-chmod ordering
+// Shared fixtures for downloadRuntimeAsset / ensureRuntime tests below
 // ---------------------------------------------------------------------------
 
 function startFixtureServer(handler) {
@@ -658,6 +737,68 @@ function makeRealTarball(dir) {
   return { bytes, sha256 };
 }
 
+// ---------------------------------------------------------------------------
+// downloadRuntimeAsset — partial-file cleanup on a mid-stream error
+// ---------------------------------------------------------------------------
+
+/** A `createWriteStream` that writes a few real bytes to disk and then
+ * asynchronously emits an "error" — simulates a network drop / ENOSPC
+ * partway through a download against a REAL partial file on disk, so the
+ * cleanup assertion is checking a genuine leftover, not a hypothetical
+ * one. */
+function createFlakyWriteStream(dest) {
+  const real = fsWriteStream(dest);
+  let bytesSeen = 0;
+  const originalWrite = real.write.bind(real);
+  real.write = (chunk, ...rest) => {
+    bytesSeen += chunk.length;
+    const ok = originalWrite(chunk, ...rest);
+    if (bytesSeen > 200 && !real.__failed) {
+      real.__failed = true;
+      setImmediate(() => real.emit("error", Object.assign(new Error("simulated mid-stream failure"), { code: "EIO" })));
+    }
+    return ok;
+  };
+  return real;
+}
+
+test("downloadRuntimeAsset deletes the partial file on a mid-stream error", async () => {
+  await withScratch("dl-stream-error", async (dir) => {
+    const { srv, port } = await startFixtureServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/gzip" });
+      res.write(Buffer.alloc(2000, 7));
+      // Give the flaky write-stream time to raise its injected error
+      // before the response ends, so the failure path (not a clean
+      // finish) is what actually resolves the download promise.
+      setTimeout(() => res.end(), 100);
+    });
+    const dest = join(dir, "partial-runtime.tar.gz");
+    try {
+      await assert.rejects(
+        () => downloadRuntimeAsset({
+          url: `http://github.com:${port}/releases/download/x/y.tar.gz`,
+          dest,
+          expectedSha: null,
+          lookup: forceGithubLookup(),
+          insecureHttpHosts: ["github.com"],
+          createWriteStream: createFlakyWriteStream,
+        }),
+        (err) => {
+          assert.equal(err.code, "EIO");
+          return true;
+        },
+      );
+      assert.equal(existsSync(dest), false); // partial file cleaned up, not left behind
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureRuntime — real tar extraction, checksum-before-chmod ordering
+// ---------------------------------------------------------------------------
+
 test("ensureRuntime downloads, verifies, extracts (real tar), and chmods only after verification", async () => {
   await withScratch("ensure-happy", async (dir) => {
     const buildDir = join(dir, "build");
@@ -686,10 +827,22 @@ test("ensureRuntime downloads, verifies, extracts (real tar), and chmods only af
       });
 
       assert.ok(existsSync(binPath));
+      // binPath is under the FINAL releaseDir; chmod ran on the file while
+      // it was still in the staging extract dir (before the finalize
+      // rename), so the two paths differ by design — assert on shape
+      // (same basename, correct mode) rather than string equality.
       assert.equal(chmodCalls.length, 1);
-      assert.equal(chmodCalls[0].p, binPath);
+      assert.ok(chmodCalls[0].p.endsWith("llama-server"));
+      assert.ok(chmodCalls[0].p.includes(".extract-linux-x64-cpu-test-rel.tmp"));
       assert.equal(chmodCalls[0].mode, 0o755);
       assert.equal(readFileSync(binPath, "utf8").includes("fake-llama-server"), true);
+
+      // Finalization is a real rename: no leftover staging dir, no
+      // leftover download tmp file, next to the now-populated releaseDir.
+      const runtimesDir = join(dir, "crow-home", "runtimes", "llamacpp");
+      assert.equal(existsSync(join(runtimesDir, ".extract-linux-x64-cpu-test-rel.tmp")), false);
+      assert.equal(existsSync(join(runtimesDir, ".download-linux-x64-cpu-test-rel.tmp")), false);
+      assert.equal(existsSync(join(runtimesDir, "test-rel", ".crow-runtime-installed.json")), true);
 
       // Idempotent: a second call reuses the manifest, no re-download
       // (fixture server would 200 again anyway, but chmod must NOT be
@@ -742,10 +895,13 @@ test("ensureRuntime never chmods when the downloaded archive fails checksum veri
         },
       );
       assert.equal(chmodCalls.length, 0); // unverified binary never made executable
-      // The staging archive must not survive a checksum failure either.
-      const releaseDir = join(dir, "crow-home", "runtimes", "llamacpp", "test-rel-bad");
-      const staged = existsSync(join(releaseDir, ".download-linux-x64-cpu.tmp"));
-      assert.equal(staged, false);
+      // A checksum failure happens entirely inside downloadRuntimeAsset,
+      // before ensureRuntime ever touches the staging extract dir or
+      // releaseDir — none of the three should exist.
+      const runtimesDir = join(dir, "crow-home", "runtimes", "llamacpp");
+      assert.equal(existsSync(join(runtimesDir, ".download-linux-x64-cpu-test-rel-bad.tmp")), false);
+      assert.equal(existsSync(join(runtimesDir, ".extract-linux-x64-cpu-test-rel-bad.tmp")), false);
+      assert.equal(existsSync(join(runtimesDir, "test-rel-bad")), false);
     } finally {
       await new Promise((r) => srv.close(r));
     }

--- a/tests/models-state.test.js
+++ b/tests/models-state.test.js
@@ -1,0 +1,290 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+import net from "node:net";
+
+import {
+  PORT_RANGE_START,
+  PORT_RANGE_END,
+  PortRangeExhaustedError,
+  statePath,
+  loadState,
+  saveState,
+  allocatePort,
+  releasePort,
+  reconcileOnBoot,
+} from "../servers/gateway/models/state.js";
+
+function scratchDir(tag) {
+  return mkdtempSync(join(tmpdir(), `models-state-${tag}-`));
+}
+
+function withScratch(tag, fn) {
+  const dir = scratchDir(tag);
+  return Promise.resolve()
+    .then(() => fn(dir))
+    .finally(() => rmSync(dir, { recursive: true, force: true }));
+}
+
+function listenOn(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+// ---------------------------------------------------------------------------
+// Port allocation
+// ---------------------------------------------------------------------------
+
+test("allocatePort returns the lowest free port, starting at 18100", async () => {
+  await withScratch("alloc-first", async () => {
+    const state = { reservations: {}, journal: {}, registry: {} };
+    const port = await allocatePort(state, "model-a");
+    assert.equal(port, PORT_RANGE_START);
+    assert.equal(state.reservations["model-a"].port, PORT_RANGE_START);
+  });
+});
+
+test("allocatePort skips ports already reserved in state", async () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  const first = await allocatePort(state, "model-a");
+  const second = await allocatePort(state, "model-b");
+  assert.equal(first, PORT_RANGE_START);
+  assert.equal(second, PORT_RANGE_START + 1);
+  assert.notEqual(first, second);
+});
+
+test("allocatePort records owner {crowHome, pid} and createdAt", async () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  const port = await allocatePort(state, "model-a", { crowHome: "/fake/crow-home", pid: 4242 });
+  const reservation = state.reservations["model-a"];
+  assert.equal(reservation.port, port);
+  assert.equal(reservation.owner.crowHome, "/fake/crow-home");
+  assert.equal(reservation.owner.pid, 4242);
+  assert.equal(typeof reservation.createdAt, "string");
+  assert.ok(!Number.isNaN(Date.parse(reservation.createdAt)));
+});
+
+test("allocatePort bind-tests and skips a port actually held on the host", async () => {
+  const held = await listenOn(PORT_RANGE_START);
+  try {
+    const state = { reservations: {}, journal: {}, registry: {} };
+    const port = await allocatePort(state, "model-a");
+    assert.equal(port, PORT_RANGE_START + 1);
+  } finally {
+    await closeServer(held);
+  }
+});
+
+test("releasePort frees a reservation so its port can be reallocated", async () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  const port = await allocatePort(state, "model-a");
+  assert.equal(port, PORT_RANGE_START);
+  releasePort(state, "model-a");
+  assert.equal(state.reservations["model-a"], undefined);
+  const reallocated = await allocatePort(state, "model-b");
+  assert.equal(reallocated, PORT_RANGE_START);
+});
+
+test("releasePort on a modelId with no reservation is a no-op", () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  assert.doesNotThrow(() => releasePort(state, "never-reserved"));
+});
+
+test("allocatePort throws a typed PortRangeExhaustedError once the range is full", async () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  const rangeSize = PORT_RANGE_END - PORT_RANGE_START + 1;
+  for (let i = 0; i < rangeSize; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await allocatePort(state, `model-${i}`);
+  }
+  assert.equal(Object.keys(state.reservations).length, rangeSize);
+  await assert.rejects(
+    () => allocatePort(state, "model-overflow"),
+    (err) => {
+      assert.ok(err instanceof PortRangeExhaustedError);
+      assert.equal(err.code, "PORT_RANGE_EXHAUSTED");
+      return true;
+    }
+  );
+});
+
+// ---------------------------------------------------------------------------
+// State file persistence
+// ---------------------------------------------------------------------------
+
+test("statePath derives from the injected dir, never os.homedir()", () => {
+  const p = statePath("/some/injected/dir");
+  assert.equal(p, join("/some/injected/dir", "models", "state.json"));
+  assert.ok(!p.includes(homedir()));
+});
+
+test("loadState on a missing state file returns an empty state, not a throw", async () => {
+  await withScratch("load-missing", async (dir) => {
+    const state = loadState(dir);
+    assert.deepEqual(state, { reservations: {}, journal: {}, registry: {} });
+    assert.ok(!existsSync(statePath(dir)));
+  });
+});
+
+test("saveState + loadState round-trip atomically and deep-equal", async () => {
+  await withScratch("roundtrip", async (dir) => {
+    const state = {
+      reservations: {
+        "model-a": { port: 18101, owner: { crowHome: dir, pid: 999 }, createdAt: "2026-07-18T00:00:00.000Z" },
+      },
+      journal: {
+        "model-b": { url: "https://example.test/model-b.gguf", dest: "/tmp/model-b.gguf.part", bytesDone: 1024, expectedSha: "abc123", startedAt: "2026-07-18T00:01:00.000Z" },
+      },
+      registry: {
+        "model-c": { file: "model-c-q4.gguf", quant: "Q4_K_M", catalogId: "model-c", registeredAt: "2026-07-17T00:00:00.000Z" },
+      },
+    };
+    saveState(dir, state);
+    assert.ok(existsSync(statePath(dir)));
+    const reloaded = loadState(dir);
+    assert.deepEqual(reloaded, state);
+  });
+});
+
+test("saveState never leaves a stray tmp file behind after a successful write", async () => {
+  await withScratch("tmp-cleanup", async (dir) => {
+    saveState(dir, { reservations: {}, journal: {}, registry: {} });
+    const entries = readdirSync(join(dir, "models"));
+    assert.deepEqual(entries, ["state.json"]);
+  });
+});
+
+test("loadState on a corrupt (non-JSON) state file returns an empty state, not a throw", async () => {
+  await withScratch("load-corrupt", async (dir) => {
+    mkdirSync(join(dir, "models"), { recursive: true });
+    writeFileSync(statePath(dir), "{ not valid json", "utf8");
+    const state = loadState(dir);
+    assert.deepEqual(state, { reservations: {}, journal: {}, registry: {} });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Boot reconciliation
+// ---------------------------------------------------------------------------
+
+test("reconcileOnBoot frees a reservation whose owner pid is dead and has no provider row", () => {
+  const state = {
+    reservations: {
+      "model-dead": { port: 18100, owner: { crowHome: "/x", pid: 111 }, createdAt: "2026-07-18T00:00:00.000Z" },
+    },
+    journal: {},
+    registry: {},
+  };
+  const result = reconcileOnBoot({
+    state,
+    listProviderRows: () => [],
+    isProcessAlive: (pid) => pid !== 111,
+  });
+  assert.equal(result.freedReservations.length, 1);
+  assert.equal(result.freedReservations[0].modelId, "model-dead");
+  assert.equal(result.freedReservations[0].port, 18100);
+  assert.equal(state.reservations["model-dead"], undefined);
+});
+
+test("reconcileOnBoot keeps a reservation whose owner pid is dead but has a live provider row", () => {
+  const state = {
+    reservations: {
+      "model-live": { port: 18100, owner: { crowHome: "/x", pid: 222 }, createdAt: "2026-07-18T00:00:00.000Z" },
+    },
+    journal: {},
+    registry: {},
+  };
+  const result = reconcileOnBoot({
+    state,
+    listProviderRows: () => [{ modelId: "model-live" }],
+    isProcessAlive: () => false,
+  });
+  assert.equal(result.freedReservations.length, 0);
+  assert.ok(state.reservations["model-live"]);
+});
+
+test("reconcileOnBoot keeps a reservation whose owner pid is alive", () => {
+  const state = {
+    reservations: {
+      "model-alive": { port: 18100, owner: { crowHome: "/x", pid: 333 }, createdAt: "2026-07-18T00:00:00.000Z" },
+    },
+    journal: {},
+    registry: {},
+  };
+  const result = reconcileOnBoot({
+    state,
+    listProviderRows: () => [],
+    isProcessAlive: (pid) => pid === 333,
+  });
+  assert.equal(result.freedReservations.length, 0);
+  assert.ok(state.reservations["model-alive"]);
+});
+
+test("reconcileOnBoot flags a provider row whose reservation is missing", () => {
+  const state = { reservations: {}, journal: {}, registry: {} };
+  const result = reconcileOnBoot({
+    state,
+    listProviderRows: () => [{ modelId: "model-orphan", providerId: "p1" }],
+    isProcessAlive: () => true,
+  });
+  assert.equal(result.orphanRows.length, 1);
+  assert.equal(result.orphanRows[0].modelId, "model-orphan");
+});
+
+test("reconcileOnBoot does not flag a provider row that has a matching reservation", () => {
+  const state = {
+    reservations: {
+      "model-ok": { port: 18100, owner: { crowHome: "/x", pid: 444 }, createdAt: "2026-07-18T00:00:00.000Z" },
+    },
+    journal: {},
+    registry: {},
+  };
+  const result = reconcileOnBoot({
+    state,
+    listProviderRows: () => [{ modelId: "model-ok" }],
+    isProcessAlive: () => true,
+  });
+  assert.equal(result.orphanRows.length, 0);
+});
+
+test("reconcileOnBoot lists every journal entry as a resumable download", () => {
+  const state = {
+    reservations: {},
+    journal: {
+      "model-x": { url: "https://example.test/x.gguf", dest: "/tmp/x.gguf.part", bytesDone: 512, expectedSha: "deadbeef", startedAt: "2026-07-18T00:00:00.000Z" },
+      "model-y": { url: "https://example.test/y.gguf", dest: "/tmp/y.gguf.part", bytesDone: 0, expectedSha: "cafef00d", startedAt: "2026-07-18T00:05:00.000Z" },
+    },
+    registry: {},
+  };
+  const result = reconcileOnBoot({
+    state,
+    listProviderRows: () => [],
+    isProcessAlive: () => true,
+  });
+  assert.equal(result.resumableDownloads.length, 2);
+  const ids = result.resumableDownloads.map((d) => d.modelId).sort();
+  assert.deepEqual(ids, ["model-x", "model-y"]);
+  const x = result.resumableDownloads.find((d) => d.modelId === "model-x");
+  assert.equal(x.url, "https://example.test/x.gguf");
+  assert.equal(x.bytesDone, 512);
+});
+
+test("reconcileOnBoot does not mutate state.journal or state.registry", () => {
+  const state = {
+    reservations: {},
+    journal: { "model-x": { url: "u", dest: "d", bytesDone: 0, expectedSha: "s", startedAt: "t" } },
+    registry: { "model-z": { file: "f", quant: "q", catalogId: "c", registeredAt: "t" } },
+  };
+  const before = JSON.stringify(state);
+  reconcileOnBoot({ state, listProviderRows: () => [], isProcessAlive: () => true });
+  assert.equal(JSON.stringify(state), before);
+});


### PR DESCRIPTION
Second of five Item G PRs (spec: Gitea `crow-engineering` `specs/2026-07-18-item-g-model-catalog-design.md` r3 SIGNED OFF; plan `plans/2026-07-18-item-g-implementation.md`, Tasks 5–10 + final-review fix wave). Builds the core native-model stack on PR G-A's foundations. **No user-facing UI yet** (panel is PR G-C) and nothing auto-starts on existing installs — the code paths activate only when a native model is registered.

**What's in it (11 commits — 6 features, 5 review-driven fix rounds):**
- `models/state.js` — per-CROW_HOME state file: bind-tested port reservations (18100–18199 loopback, owner-recorded), download journal, model registry, boot reconciliation (wired into real gateway boot via `initOrchestrator`).
- `models/manager.js` — GGUF download pipeline: streamed + incremental sha256, Range-resume with prefix re-hash (corrupted-prefix regression-tested), HTTPS-only with per-hop host allowlist (label-suffix matching, adversarially bypass-tested), typed errors incl. socket-idle timeout, serial queue with idempotent enqueue; provider registration with ownership-guarded ids (`ProviderIdConflictError` — an id collision can no longer clobber an existing provider row), ordered delete flow, bindings enumeration for the confirm dialog.
- `models/runtime.js` + `models/native-lock.js` — llama.cpp binary asset resolution (WSL2→CPU, glibc fallback), sha-verified-before-executable install with staged atomic extraction, supervised llama-server children (`--alias`-pinned, restart-backoff, idle-unload with traffic-touch, `onTerminal` lifecycle hooks), tri-state identity probe (a live server with the wrong alias is a **conflict**, never resident), rename-atomic advisory host lock (TOCTOU dual-steal race closed and 3-way-race-verified).
- `gpu-orchestrator.js` — `runtime:"native"` branch across all five bundleId choke points; host lock held for the life of residency (cross-gateway double-load blocked, verified by two-gateway trace); binary resolution outside the shared single-flight; symmetric same-process sibling eviction (Docker↔native); documented v1 limitation: cross-process Docker-vs-native arbitration.
- `routes/chat.js` + i18n — size-scaled native readiness timeout, honest "model loading/failed" copy (EN + real ES, parity-gate green), Docker-compose hint unreachable for native providers.

**Review rigor:** every task had an independent reviewer with adversarial/mutation testing; 4 task-level fix rounds closed 6 Important findings (HTTPS enforcement, provider clobber, lock TOCTOU, lock lifetime, download-in-single-flight, asymmetric eviction). The final whole-branch review then caught **2 Criticals no task-scoped review could see** — the probe cache was never populated in production (native path would have been dead on arrival) and the idle timer lacked any `touch()` caller (30-minute kill timer under active load) — plus 3 Importants, all fixed in the final commit and re-verified (probe fix live-proven on this host's GPU). Follow-up ledger (journal-quant field, slow-drip total cap, Task-12 handle accessor, tmp-sweep in PR G-D, etc.) is recorded for the remaining PRs.

**Suite:** 2262/2262 pass, 0 fail, 0 skip (new baseline; 2116 + 146 new tests). `check-ports` + `build-registry --check` + `validate-model-catalog` clean. No schema changes (native marking rides gpu_policy JSON); no new host ports; no new deps.