### PR TITLE
feat(models): Item G PR G-C — Model Catalog panel (curated + Hugging Face browser, downloads, runtime controls)

### DIFF
--- a/servers/gateway/boot/feature-mounts.js
+++ b/servers/gateway/boot/feature-mounts.js
@@ -238,6 +238,19 @@ export async function mountFeatureRoutes(app, deps) {
     console.warn("[notifications] Failed to mount:", err.message);
   }
 
+  // --- Mount Model Catalog Panel API (Item G, Task 12) ---
+  // Own JSON-answering session gate (routes/models.js's
+  // requireDashboardSessionJson) rather than the redirect-based
+  // dashboardAuth every other router here takes — see that file's module
+  // doc. dashboardAuth is still passed for call-site parity; unused.
+  try {
+    const { default: modelsRouter } = await import("../routes/models.js");
+    app.use(modelsRouter(dashboardAuth));
+    console.log("Model Catalog API mounted at /api/models");
+  } catch (err) {
+    console.warn("[models] Failed to mount:", err.message);
+  }
+
   // --- Mount Turbo Streams (server-pushed HTML fragments) ---
   // Private routes under /dashboard/streams/*; the Funnel-reject
   // middleware above blocks public access. See routes/streams.js for the

--- a/servers/gateway/dashboard/index.js
+++ b/servers/gateway/dashboard/index.js
@@ -67,6 +67,7 @@ import filesPanel from "./panels/files.js";
 import healthPanel from "./panels/health.js";
 import memoryPanel from "./panels/memory.js";
 import extensionsPanel from "./panels/extensions.js";
+import modelCatalogPanel from "./panels/model-catalog.js";
 import skillsPanel from "./panels/skills.js";
 import projectsPanel from "./panels/projects.js";
 import settingsPanel from "./panels/settings.js";
@@ -99,6 +100,7 @@ export default function dashboardRouter(mcpAuthMiddleware) {
   registerPanel(blogPanel);
   registerPanel(filesPanel);
   registerPanel(extensionsPanel);
+  registerPanel(modelCatalogPanel);
   registerPanel(skillsPanel);
   registerPanel(settingsPanel);
   registerPanel(contactsPanel);

--- a/servers/gateway/dashboard/nav-registry.js
+++ b/servers/gateway/dashboard/nav-registry.js
@@ -51,6 +51,7 @@ const DEFAULT_NAV_PANEL_ASSIGNMENTS = {
   "bot-builder": "agents",
   "bot-board": "agents",
   skills: "agents",
+  "model-catalog": "agents",
   connect: "connections",
   contacts: "connections",
   messages: "connections",

--- a/servers/gateway/dashboard/panels/model-catalog.js
+++ b/servers/gateway/dashboard/panels/model-catalog.js
@@ -1,0 +1,1095 @@
+/**
+ * Model Catalog Panel — Item G Task 13
+ *
+ * Browse the curated catalog (registry/model-catalog.json), download +
+ * register GGUF models as local providers, start/stop/remove them, and
+ * (advanced) search Hugging Face directly for GGUF repos.
+ *
+ * Architecture: server-side render (SSR) for the initial page — this panel
+ * imports the SAME read-only model-management functions Task 12's
+ * `routes/models.js` uses (`probe.js`, `state.js`, `runtime.js`,
+ * `gpu-orchestrator.js`'s `getNativeHandle`) directly, rather than doing a
+ * self-referential HTTP fetch of its own API on first paint. All later
+ * interaction (download, start/stop, delete, HF search, HF token) is driven
+ * client-side against the real `/api/models/*` routes from Task 12,
+ * consumed verbatim (this file never modifies `routes/models.js`).
+ *
+ * Security note: all server-rendered dynamic content is escaped via
+ * escapeHtml(). Client-side DOM built from API responses (HF search results,
+ * profile/bot names in the delete-confirmation dialog) uses textContent, not
+ * innerHTML — those values are either external (Hugging Face) or
+ * user-authored (profile/bot names) and must never be parsed as markup.
+ *
+ * ABSOLUTE RULE: the client-side <script> block below is built inside a
+ * template literal and must never contain a literal backtick character.
+ * Every string inside the browser JS uses single quotes and `+`
+ * concatenation — see docs on this rule at the top of extensions/client.js,
+ * the established sibling pattern this file follows.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
+
+import { t, tJs, fill } from "../shared/i18n.js";
+import { escapeHtml, button, callout, tabs } from "../shared/components.js";
+import { resolveDataDir } from "../../../db.js";
+import { getCachedProbe, reprobe, fitBadge } from "../../models/probe.js";
+import { loadState } from "../../models/state.js";
+import { getStatusSnapshot } from "../../models/runtime.js";
+import { getNativeHandle } from "../../gpu-orchestrator.js";
+import { listProvidersAll } from "../../../shared/providers-db.js";
+import { HF_TOKEN_PROVIDER_ID } from "../../routes/models.js";
+
+const __filename = fileURLToPath(import.meta.url);
+// dashboard/panels/model-catalog.js -> dashboard -> gateway -> servers -> repo root
+const MODEL_CATALOG_PATH = resolvePath(dirname(__filename), "..", "..", "..", "..", "registry", "model-catalog.json");
+
+function defaultLoadCatalog() {
+  try {
+    const parsed = JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : { runtime: {}, models: [] };
+  } catch {
+    return { runtime: {}, models: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+const SIZE_CLASSES = ["small", "mid", "large"];
+
+/** "small" | "mid" | "large" | "other" — from the catalog's curation-policy
+ * tags (spec §3), not a dedicated schema field. */
+export function sizeClassOf(model) {
+  const tags = model?.tags || [];
+  for (const c of SIZE_CLASSES) {
+    if (tags.includes(c)) return c;
+  }
+  return "other";
+}
+
+export function groupBySizeClass(models) {
+  const groups = { small: [], mid: [], large: [], other: [] };
+  for (const m of models || []) {
+    groups[sizeClassOf(m)].push(m);
+  }
+  return groups;
+}
+
+/** MB -> a human string, GB above 1024 MB. Never throws on null/NaN. */
+export function formatMb(n) {
+  if (n === null || n === undefined || !Number.isFinite(n)) return null;
+  if (n >= 1024) return (n / 1024).toFixed(1) + " GB";
+  return Math.round(n) + " MB";
+}
+
+const FIT_ORDER = ["fits", "tight", "wont_fit", "unknown"];
+
+export function fitLabelKey(badgeName) {
+  switch (badgeName) {
+    case "fits": return "models.fitFits";
+    case "tight": return "models.fitTight";
+    case "wont_fit": return "models.fitWontFit";
+    default: return "models.fitUnknown";
+  }
+}
+
+export function fitHintKey(badgeName) {
+  switch (badgeName) {
+    case "fits": return "models.fitFitsHint";
+    case "tight": return "models.fitTightHint";
+    case "wont_fit": return "models.fitWontFitHint";
+    default: return "models.fitUnknownHint";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data assembly (injectable for tests — mirrors routes/models.js's opts seam)
+// ---------------------------------------------------------------------------
+
+export async function loadPanelData({
+  db,
+  dir,
+  loadCatalogFn = defaultLoadCatalog,
+  getCachedProbeFn = getCachedProbe,
+  reprobeFn = reprobe,
+  fitBadgeFn = fitBadge,
+  loadStateFn = loadState,
+  getStatusSnapshotFn = getStatusSnapshot,
+  getNativeHandleFn = getNativeHandle,
+  listProvidersAllFn = listProvidersAll,
+} = {}) {
+  const resolvedDir = dir || resolveDataDir();
+  const catalog = loadCatalogFn();
+
+  // The probe cache is null until something calls reprobe() — today only a
+  // native acquire warms it (gpu-orchestrator.js's resolveNativeBinPath).
+  // A fresh install's first Model Catalog view would otherwise show every
+  // fit badge as "unknown" with no explanation. Warm it here too, once, on
+  // a cache miss — same fix shape as the orchestrator's own, cheap because
+  // probe.js caches the result for every other reader.
+  let probe = getCachedProbeFn();
+  if (!probe) {
+    try {
+      probe = await reprobeFn({ modelsDir: resolvedDir });
+    } catch {
+      probe = null; // honest "couldn't detect" state; every fit badge below falls back to "unknown"
+    }
+  }
+
+  const state = loadStateFn(resolvedDir);
+
+  const models = (catalog.models || []).map((model) => {
+    const regEntry = state.registry[model.id] || null;
+    const handle = getNativeHandleFn(model.id);
+    const quants = (model.quants || []).map((q) => ({
+      quant: q.quant,
+      size_mb: q.size_mb,
+      min_ram_mb: q.min_ram_mb,
+      min_vram_mb: q.min_vram_mb,
+      fitBadge: fitBadgeFn(probe, q),
+    }));
+    return {
+      id: model.id,
+      family: model.family,
+      lab: model.lab,
+      license: model.license,
+      gated: !!model.gated,
+      task: model.task,
+      context_len: model.context_len,
+      tags: model.tags || [],
+      notes: model.notes || null,
+      default_quant: model.default_quant,
+      first_run_default: !!model.first_run_default,
+      registered: !!regEntry,
+      registeredQuant: regEntry ? regEntry.quant : null,
+      running: !!(handle && handle.live),
+      quants,
+    };
+  });
+
+  const snapshot = getStatusSnapshotFn();
+  const byAlias = new Map(snapshot.map((s) => [s.alias, s]));
+  const runtimeModels = Object.keys(state.registry).map((modelId) => {
+    const status = byAlias.get(modelId);
+    return status
+      ? { modelId, ...status }
+      : { modelId, state: "stopped", live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null };
+  });
+
+  // Estimated RAM/VRAM in use — derived from catalog quant costs for models
+  // currently live, since nothing tracks true live usage. Labeled
+  // "estimated" everywhere it's rendered.
+  let estimatedRamMb = 0;
+  let estimatedVramMb = 0;
+  const quantLookup = new Map(); // modelId -> quant -> {min_ram_mb, min_vram_mb}
+  for (const m of models) {
+    const byQuant = new Map(m.quants.map((q) => [q.quant, q]));
+    quantLookup.set(m.id, byQuant);
+  }
+  for (const rm of runtimeModels) {
+    if (!rm.live) continue;
+    const regEntry = state.registry[rm.modelId];
+    const quant = regEntry ? regEntry.quant : null;
+    const q = quant && quantLookup.get(rm.modelId)?.get(quant);
+    if (q) {
+      estimatedRamMb += q.min_ram_mb || 0;
+      estimatedVramMb += q.min_vram_mb || 0;
+    }
+  }
+
+  let hfTokenConfigured = false;
+  if (db) {
+    try {
+      const providers = await listProvidersAllFn(db);
+      hfTokenConfigured = providers.some((p) => p.id === HF_TOKEN_PROVIDER_ID && !!p.apiKey);
+    } catch {
+      hfTokenConfigured = false; // best-effort; the client-side GET /api/models/hf-token is authoritative
+    }
+  }
+
+  return {
+    runtime: { name: catalog.runtime?.name ?? null, release: catalog.runtime?.release ?? null },
+    probe,
+    models,
+    runtimeModels,
+    estimatedRamMb,
+    estimatedVramMb,
+    hfTokenConfigured,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CSS
+// ---------------------------------------------------------------------------
+
+function panelStyles() {
+  return `<style>
+.mcat-intro { font-size:0.85rem; color:var(--crow-text-secondary); line-height:1.5; max-width:64ch; margin-bottom:1.25rem; }
+
+/* Runtime status strip */
+.mcat-strip {
+  background:var(--crow-bg-surface);
+  border:1px solid var(--crow-border);
+  border-left:3px solid var(--crow-accent);
+  border-radius:var(--crow-radius-card, 12px);
+  padding:1rem 1.25rem;
+  margin-bottom:1.5rem;
+}
+.mcat-strip__title {
+  font-family:'Fraunces',serif; font-weight:600; font-size:1rem;
+  color:var(--crow-text-primary); margin-bottom:0.5rem;
+}
+.mcat-strip__line { font-size:0.82rem; color:var(--crow-text-secondary); margin-bottom:0.35rem; line-height:1.5; }
+.mcat-strip__line strong { color:var(--crow-text-primary); font-weight:600; }
+.mcat-strip__notice {
+  font-size:0.78rem; color:var(--crow-text-muted);
+  background:var(--crow-bg-deep); border-radius:8px;
+  padding:0.5rem 0.75rem; margin:0.5rem 0;
+}
+.mcat-strip__actions { margin-top:0.6rem; display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center; }
+.mcat-strip__status { font-size:0.8rem; color:var(--crow-text-muted); }
+
+/* Model groups + grid */
+.mcat-group { margin-bottom:2rem; }
+.mcat-group__title {
+  font-family:'Fraunces',serif; font-weight:600; font-size:1.05rem;
+  color:var(--crow-text-primary); margin-bottom:0.75rem;
+}
+.mcat-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(280px, 1fr));
+  gap:1rem;
+}
+
+/* Model card */
+.mcat-card {
+  background:var(--crow-bg-surface);
+  border:1px solid var(--crow-border);
+  border-radius:var(--crow-radius-card, 12px);
+  padding:1.1rem 1.15rem;
+  display:flex; flex-direction:column; gap:0.5rem;
+  transition:border-color 0.15s, box-shadow 0.15s;
+}
+.mcat-card:hover { border-color:var(--crow-accent); box-shadow:0 8px 24px rgba(0,0,0,0.18); }
+.mcat-card__head { display:flex; align-items:baseline; gap:0.5rem; flex-wrap:wrap; }
+.mcat-card__title { font-family:'Fraunces',serif; font-weight:600; font-size:1.02rem; color:var(--crow-text-primary); }
+.mcat-card__badge {
+  font-size:0.62rem; font-weight:600; text-transform:uppercase; letter-spacing:0.04em;
+  padding:0.1rem 0.4rem; border-radius:4px;
+}
+.mcat-card__badge--recommended { color:var(--crow-accent); background:var(--crow-accent-muted); }
+.mcat-card__badge--gated { color:var(--crow-warning); background:rgba(245,158,11,0.14); }
+.mcat-card__badge--running { color:var(--crow-success); background:rgba(34,197,94,0.14); }
+.mcat-card__meta { font-size:0.75rem; color:var(--crow-text-muted); font-family:'JetBrains Mono',monospace; }
+.mcat-card__tags { display:flex; flex-wrap:wrap; gap:0.3rem; }
+.mcat-card__tag {
+  font-size:0.68rem; padding:0.1rem 0.45rem; border-radius:4px;
+  background:var(--crow-bg-elevated); color:var(--crow-text-secondary);
+}
+.mcat-card__notes { font-size:0.8rem; color:var(--crow-text-secondary); line-height:1.45; }
+
+.mcat-card__quant-row { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
+.mcat-quant-select {
+  flex:1 1 auto; min-width:0;
+  padding:0.35rem 0.5rem;
+  border:1px solid var(--crow-border); border-radius:6px;
+  background:var(--crow-bg-deep); color:var(--crow-text-primary);
+  font-size:0.78rem; font-family:'JetBrains Mono',monospace;
+}
+.mcat-fit-pill {
+  display:inline-flex; align-items:center; gap:0.3rem;
+  font-size:0.68rem; font-weight:600; text-transform:uppercase; letter-spacing:0.03em;
+  padding:0.15rem 0.5rem; border-radius:999px; white-space:nowrap;
+}
+.mcat-fit-pill--fits { color:var(--crow-success); background:rgba(34,197,94,0.14); }
+.mcat-fit-pill--tight { color:var(--crow-warning); background:rgba(245,158,11,0.14); }
+.mcat-fit-pill--wont_fit { color:var(--crow-error); background:rgba(239,68,68,0.14); }
+.mcat-fit-pill--unknown { color:var(--crow-text-muted); background:var(--crow-bg-elevated); }
+.mcat-card__fit-hint { font-size:0.72rem; color:var(--crow-text-muted); line-height:1.4; }
+
+.mcat-card__notice {
+  font-size:0.75rem; line-height:1.45; color:var(--crow-text-muted);
+  background:var(--crow-bg-deep); border-radius:8px; padding:0.5rem 0.65rem;
+}
+.mcat-card__notice--warning { color:var(--crow-warning); }
+
+.mcat-card__actions { display:flex; gap:0.4rem; flex-wrap:wrap; margin-top:auto; padding-top:0.35rem; }
+.mcat-card__status-text { font-size:0.75rem; color:var(--crow-text-muted); min-height:1.1em; }
+.mcat-card__progress-track {
+  height:6px; border-radius:3px; background:var(--crow-bg-deep); overflow:hidden;
+}
+.mcat-card__progress-bar { height:100%; width:0%; background:var(--crow-accent); transition:width 0.2s linear; }
+
+/* Browse Hugging Face tab */
+.mcat-hf__search-row { display:flex; gap:0.5rem; margin:0.75rem 0 1.25rem; flex-wrap:wrap; }
+.mcat-hf__search-input {
+  flex:1 1 260px; min-width:0;
+  padding:0.55rem 0.75rem;
+  border:1px solid var(--crow-border); border-radius:var(--crow-radius-card, 12px);
+  background:var(--crow-bg-surface); color:var(--crow-text-primary);
+  font-size:0.88rem; font-family:'DM Sans',sans-serif;
+}
+.mcat-hf__results { display:flex; flex-direction:column; gap:0.6rem; }
+.mcat-hf-result {
+  background:var(--crow-bg-surface); border:1px solid var(--crow-border);
+  border-radius:var(--crow-radius-card, 12px); padding:0.85rem 1rem;
+}
+.mcat-hf-result__title { font-family:'JetBrains Mono',monospace; font-weight:600; font-size:0.88rem; color:var(--crow-text-primary); }
+.mcat-hf-result__meta { font-size:0.75rem; color:var(--crow-text-muted); margin-top:0.2rem; }
+.mcat-hf-result__notice { font-size:0.75rem; color:var(--crow-text-muted); margin-top:0.35rem; }
+
+.mcat-hf-token { margin-top:1.5rem; padding-top:1.25rem; border-top:1px solid var(--crow-border); }
+.mcat-hf-token__heading { font-family:'Fraunces',serif; font-weight:600; font-size:0.95rem; margin-bottom:0.4rem; }
+.mcat-hf-token__row { display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center; margin:0.5rem 0; }
+.mcat-hf-token__input {
+  flex:1 1 240px; min-width:0;
+  padding:0.5rem 0.65rem;
+  border:1px solid var(--crow-border); border-radius:8px;
+  background:var(--crow-bg-deep); color:var(--crow-text-primary);
+  font-size:0.85rem; font-family:'JetBrains Mono',monospace;
+}
+.mcat-hf-token__status { font-size:0.78rem; color:var(--crow-text-muted); }
+.mcat-hf-token__hint { font-size:0.72rem; color:var(--crow-text-muted); margin-top:0.35rem; line-height:1.4; }
+
+/* Delete-confirmation modal */
+#mcat-modal-overlay {
+  display:none; position:fixed; top:0; left:0; width:100%; height:100%;
+  background:rgba(0,0,0,0.6); z-index:1000; align-items:center; justify-content:center;
+  backdrop-filter:blur(4px); -webkit-backdrop-filter:blur(4px);
+}
+#mcat-modal-content {
+  background:var(--crow-bg-surface); border:1px solid var(--crow-border);
+  border-radius:var(--crow-radius-card, 12px); padding:1.5rem;
+  max-width:460px; width:90%; max-height:80vh; overflow-y:auto;
+  box-sizing:border-box; word-wrap:break-word; box-shadow:0 20px 60px rgba(0,0,0,0.5);
+}
+.mcat-modal__title { font-family:'Fraunces',serif; font-size:1.1rem; font-weight:600; margin-bottom:0.6rem; color:var(--crow-text-primary); }
+.mcat-modal__list { list-style:none; margin:0.5rem 0 1rem; padding:0; font-size:0.85rem; color:var(--crow-text-secondary); }
+.mcat-modal__list li { padding:0.25rem 0; border-bottom:1px solid var(--crow-border); }
+.mcat-modal__list li:last-child { border-bottom:none; }
+.mcat-modal__actions { display:flex; gap:0.5rem; justify-content:flex-end; margin-top:1rem; }
+
+@media (max-width:600px) {
+  .mcat-grid { grid-template-columns:1fr; }
+}
+</style>`;
+}
+
+// ---------------------------------------------------------------------------
+// HTML builders
+// ---------------------------------------------------------------------------
+
+function renderFitPill(badgeName, lang) {
+  const cls = FIT_ORDER.includes(badgeName) ? badgeName : "unknown";
+  return `<span class="mcat-fit-pill mcat-fit-pill--${cls}">${escapeHtml(t(fitLabelKey(badgeName), lang))}</span>`;
+}
+
+function renderRuntimeStrip(data, lang) {
+  const { runtime, probe, runtimeModels, estimatedRamMb, estimatedVramMb } = data;
+
+  const binaryLine = runtime.name
+    ? escapeHtml(fill(t("models.runtimeBinary", lang), { name: runtime.name, release: runtime.release || "" }))
+    : escapeHtml(t("models.runtimeNoBinary", lang));
+
+  let hardwareLine;
+  const notices = [];
+  if (!probe) {
+    hardwareLine = escapeHtml(t("models.runtimeNoBinary", lang));
+  } else {
+    const ram = formatMb(probe.ramAvailableMb) || "?";
+    const disk = formatMb(probe.diskFreeMb) || "?";
+    hardwareLine = escapeHtml(fill(t("models.runtimeHardware", lang), { accel: probe.accel, ram, disk }));
+    if (probe.gpuName) {
+      hardwareLine += " · " + escapeHtml(fill(t("models.runtimeGpu", lang), { gpu: probe.gpuName, vram: formatMb(probe.vramMb) || "?" }));
+    }
+    if (probe.wsl2) notices.push(t("models.runtimeWsl2", lang));
+    else if (probe.accel === "cpu" && !probe.gpuName) notices.push(t("models.runtimeNoGpu", lang));
+    if (Array.isArray(probe.unknown) && probe.unknown.length > 0) {
+      notices.push(fill(t("models.runtimeUnknownFields", lang), { fields: probe.unknown.join(", ") }));
+    }
+  }
+
+  const runningRows = runtimeModels.filter((m) => m.live);
+  const usageLine = runningRows.length
+    ? escapeHtml(fill(t("models.runtimeEstimatedRam", lang), {
+        ram: (formatMb(estimatedRamMb) || "0 MB") + (estimatedVramMb > 0 ? " + " + (formatMb(estimatedVramMb) || "0 MB") + " VRAM" : ""),
+      }))
+    : escapeHtml(t("models.runtimeNoModelsRunning", lang));
+
+  const rowsHtml = runtimeModels.map((m) => {
+    const stateKey = m.live ? "models.runtimeStateRunning" : m.state === "unhealthy" ? "models.runtimeStateUnhealthy" : "models.runtimeStateStopped";
+    const actionBtn = m.live
+      ? button(t("models.actionStop", lang), { variant: "secondary", size: "sm", attrs: `data-action="stop" data-model-id="${escapeHtml(m.modelId)}"` })
+      : button(t("models.actionStart", lang), { variant: "secondary", size: "sm", attrs: `data-action="start" data-model-id="${escapeHtml(m.modelId)}"` });
+    return `<tr>
+      <td class="mono">${escapeHtml(m.modelId)}</td>
+      <td>${escapeHtml(t(stateKey, lang))}</td>
+      <td class="mono">${m.port != null ? escapeHtml(String(m.port)) : "—"}</td>
+      <td class="mono">${m.pid != null ? escapeHtml(String(m.pid)) : "—"}</td>
+      <td class="mono">${escapeHtml(String(m.restartCount || 0))}</td>
+      <td>${m.lastError ? escapeHtml(String(m.lastError)) : "—"}</td>
+      <td>${actionBtn}</td>
+    </tr>`;
+  }).join("");
+
+  const table = runtimeModels.length
+    ? `<table class="data-table" style="margin-top:0.75rem"><thead><tr>
+        <th>${escapeHtml(t("models.runtimeColModel", lang))}</th>
+        <th>${escapeHtml(t("models.runtimeColState", lang))}</th>
+        <th>${escapeHtml(t("models.runtimeColPort", lang))}</th>
+        <th>${escapeHtml(t("models.runtimeColPid", lang))}</th>
+        <th>${escapeHtml(t("models.runtimeColRestarts", lang))}</th>
+        <th>${escapeHtml(t("models.runtimeColLastError", lang))}</th>
+        <th>${escapeHtml(t("models.runtimeColActions", lang))}</th>
+      </tr></thead><tbody>${rowsHtml}</tbody></table>`
+    : "";
+
+  const noticesHtml = notices.map((n) => `<div class="mcat-strip__notice">${escapeHtml(n)}</div>`).join("");
+
+  return `<div class="mcat-strip" id="mcat-runtime-strip">
+    <div class="mcat-strip__title">${escapeHtml(t("models.runtimeHeading", lang))}</div>
+    <div class="mcat-strip__line"><strong>${binaryLine}</strong></div>
+    <div class="mcat-strip__line">${hardwareLine}</div>
+    ${noticesHtml}
+    <div class="mcat-strip__line">${usageLine}</div>
+    <div id="mcat-active-downloads" class="mcat-strip__status"></div>
+    ${table}
+    <div class="mcat-strip__actions">
+      ${button(t("models.runtimeReprobe", lang), { variant: "secondary", size: "sm", attrs: 'data-action="reprobe"' })}
+      <span id="mcat-reprobe-status" class="mcat-strip__status"></span>
+    </div>
+  </div>`;
+}
+
+function renderModelCard(model, lang, hfTokenConfigured) {
+  const defaultQuant = model.quants.find((q) => q.quant === model.default_quant) || model.quants[0] || null;
+
+  const options = model.quants.map((q) => {
+    const sel = q.quant === (defaultQuant && defaultQuant.quant) ? " selected" : "";
+    const label = q.quant + " — " + (formatMb(q.size_mb) || "?") + " — " + t(fitLabelKey(q.fitBadge), lang);
+    return `<option value="${escapeHtml(q.quant)}" data-fit="${escapeHtml(q.fitBadge)}" data-size-mb="${q.size_mb ?? ""}" data-min-ram-mb="${q.min_ram_mb ?? ""}"${sel}>${escapeHtml(label)}</option>`;
+  }).join("");
+
+  const quantSelect = model.quants.length > 1
+    ? `<select class="mcat-quant-select" data-model-id="${escapeHtml(model.id)}" aria-label="${escapeHtml(t("models.quantLabel", lang))}">${options}</select>`
+    : "";
+
+  const initialFit = defaultQuant ? defaultQuant.fitBadge : "unknown";
+  const fitPillHtml = `<span class="mcat-fit-hint" data-model-id="${escapeHtml(model.id)}">${renderFitPill(initialFit, lang)}</span>`;
+  const fitHintHtml = `<div class="mcat-card__fit-hint" data-model-id="${escapeHtml(model.id)}">${escapeHtml(t(fitHintKey(initialFit), lang))}</div>`;
+
+  const badges = [];
+  if (model.first_run_default) badges.push(`<span class="mcat-card__badge mcat-card__badge--recommended">${escapeHtml(t("models.recommendedBadge", lang))}</span>`);
+  if (model.gated) badges.push(`<span class="mcat-card__badge mcat-card__badge--gated">${escapeHtml(t("models.gatedBadge", lang))}</span>`);
+  if (model.running) badges.push(`<span class="mcat-card__badge mcat-card__badge--running">${escapeHtml(t("models.statusRunning", lang))}</span>`);
+
+  const otherTags = (model.tags || []).filter((tag) => !SIZE_CLASSES.includes(tag));
+  const tagsHtml = otherTags.length
+    ? `<div class="mcat-card__tags">${otherTags.map((tag) => `<span class="mcat-card__tag">${escapeHtml(tag)}</span>`).join("")}</div>`
+    : "";
+
+  let gatedNotice = "";
+  if (model.gated) {
+    const key = hfTokenConfigured ? "models.gatedTokenConfigured" : "models.gatedNoToken";
+    gatedNotice = `<div class="mcat-card__notice mcat-card__notice--warning">${escapeHtml(t(key, lang))}</div>`;
+  }
+
+  // Won't-fit: the Download action is not offered at all (per spec — no
+  // override affordance in the curated UI); the reason is shown as text
+  // instead. Tight/unknown: Download stays enabled, with the fit hint above
+  // already showing the honest warning copy.
+  let actionHtml;
+  if (model.running) {
+    actionHtml = `${button(t("models.actionStop", lang), { variant: "secondary", size: "sm", attrs: `data-action="stop" data-model-id="${escapeHtml(model.id)}"` })}` +
+      `${button(t("models.actionRemove", lang), { variant: "danger", size: "sm", attrs: `data-action="remove" data-model-id="${escapeHtml(model.id)}"` })}`;
+  } else if (model.registered) {
+    actionHtml = `${button(t("models.actionStart", lang), { variant: "primary", size: "sm", attrs: `data-action="start" data-model-id="${escapeHtml(model.id)}"` })}` +
+      `${button(t("models.actionRemove", lang), { variant: "danger", size: "sm", attrs: `data-action="remove" data-model-id="${escapeHtml(model.id)}"` })}`;
+  } else if (initialFit === "wont_fit") {
+    actionHtml = `<div class="mcat-card__notice">${escapeHtml(t("models.fitWontFitHint", lang))}</div>`;
+  } else {
+    actionHtml = button(t("models.actionDownload", lang), {
+      variant: "primary", size: "sm",
+      attrs: `data-action="download" data-model-id="${escapeHtml(model.id)}"`,
+    });
+  }
+
+  return `<div class="mcat-card" data-model-id="${escapeHtml(model.id)}">
+    <div class="mcat-card__head">
+      <span class="mcat-card__title">${escapeHtml(model.id)}</span>
+      ${badges.join("")}
+    </div>
+    <div class="mcat-card__meta">${escapeHtml(fill(t("models.cardLab", lang), { lab: model.lab || "?" }))} · ${escapeHtml(fill(t("models.cardLicense", lang), { license: model.license || "?" }))} · ${escapeHtml(fill(t("models.cardContext", lang), { n: model.context_len ?? "?" }))}</div>
+    ${tagsHtml}
+    ${model.notes ? `<p class="mcat-card__notes">${escapeHtml(model.notes)}</p>` : ""}
+    <div class="mcat-card__quant-row">${quantSelect}${fitPillHtml}</div>
+    ${fitHintHtml}
+    ${gatedNotice}
+    <div class="mcat-card__actions" data-model-id="${escapeHtml(model.id)}">${actionHtml}</div>
+    <div class="mcat-card__status-text" data-model-id="${escapeHtml(model.id)}"></div>
+    <div class="mcat-card__progress-track" data-model-id="${escapeHtml(model.id)}" hidden><div class="mcat-card__progress-bar"></div></div>
+  </div>`;
+}
+
+function renderCuratedTab(data, lang) {
+  const groups = groupBySizeClass(data.models);
+  const order = [
+    ["small", "models.groupSmall"],
+    ["mid", "models.groupMid"],
+    ["large", "models.groupLarge"],
+    ["other", "models.groupOther"],
+  ];
+  const sections = order
+    .filter(([key]) => groups[key].length > 0)
+    .map(([key, titleKey]) => {
+      const cards = groups[key].map((m) => renderModelCard(m, lang, data.hfTokenConfigured)).join("");
+      return `<div class="mcat-group">
+        <div class="mcat-group__title">${escapeHtml(t(titleKey, lang))}</div>
+        <div class="mcat-grid">${cards}</div>
+      </div>`;
+    })
+    .join("");
+
+  if (!data.models.length) {
+    return `<div class="mcat-empty">${escapeHtml(t("models.emptyCatalog", lang))}</div>`;
+  }
+  return sections;
+}
+
+function renderHfTab(data, lang) {
+  const tokenStatus = data.hfTokenConfigured ? t("models.hfTokenConfigured", lang) : t("models.hfTokenNotConfigured", lang);
+  return `
+    ${callout(escapeHtml(t("models.hfIntro", lang)), "warning")}
+    <div class="mcat-hf__search-row">
+      <input type="text" id="mcat-hf-search-input" class="mcat-hf__search-input" placeholder="${escapeHtml(t("models.hfSearchPlaceholder", lang))}" aria-label="${escapeHtml(t("models.hfSearchLabel", lang))}">
+      ${button(t("models.hfSearchButton", lang), { variant: "primary", size: "md", attrs: 'id="mcat-hf-search-btn"' })}
+    </div>
+    <div id="mcat-hf-status" class="mcat-strip__status"></div>
+    <div id="mcat-hf-results" class="mcat-hf__results"></div>
+
+    <div class="mcat-hf-token">
+      <div class="mcat-hf-token__heading">${escapeHtml(t("models.hfTokenLabel", lang))}</div>
+      <div id="mcat-hf-token-status" class="mcat-hf-token__status">${escapeHtml(tokenStatus)}</div>
+      <div class="mcat-hf-token__row">
+        <input type="password" id="mcat-hf-token-input" class="mcat-hf-token__input" autocomplete="off" placeholder="${escapeHtml(t("models.hfTokenPlaceholder", lang))}">
+        ${button(t("models.hfTokenSave", lang), { variant: "primary", size: "sm", attrs: 'id="mcat-hf-token-save"' })}
+        ${button(t("models.hfTokenClear", lang), { variant: "secondary", size: "sm", attrs: 'id="mcat-hf-token-clear"' })}
+      </div>
+      <div class="mcat-hf-token__hint">${escapeHtml(t("models.hfTokenHint", lang))}</div>
+    </div>`;
+}
+
+// ---------------------------------------------------------------------------
+// Client-side JavaScript
+// ---------------------------------------------------------------------------
+//
+// ABSOLUTE RULE: no backtick character below this line, inside the returned
+// template literal's <script> content. Every browser-side string is single
+// or double quoted; concatenation only.
+
+function modelCatalogClientJS(lang) {
+  return `
+    <div id="mcat-modal-overlay">
+      <div id="mcat-modal-content"></div>
+    </div>
+
+    <script>
+      (function () {
+        var API = "/api/models";
+
+        function hideModal() { document.getElementById("mcat-modal-overlay").style.display = "none"; }
+        function showModal() { document.getElementById("mcat-modal-overlay").style.display = "flex"; }
+        document.getElementById("mcat-modal-overlay").addEventListener("click", function (e) {
+          if (e.target === this) hideModal();
+        });
+
+        function apiFetch(path, opts) {
+          var init = opts || {};
+          init.headers = init.headers || { "Content-Type": "application/json" };
+          return fetch(API + path, init).then(function (r) {
+            return r.json().then(function (data) { return { ok: r.ok, status: r.status, data: data }; }).catch(function () {
+              return { ok: r.ok, status: r.status, data: {} };
+            });
+          });
+        }
+
+        function fmtBytes(n) {
+          if (n === null || n === undefined || isNaN(n)) return "?";
+          if (n >= 1024 * 1024 * 1024) return (n / (1024 * 1024 * 1024)).toFixed(1) + " GB";
+          if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(1) + " MB";
+          if (n >= 1024) return (n / 1024).toFixed(1) + " KB";
+          return n + " B";
+        }
+
+        var ERROR_MESSAGES = {
+          NETWORK_DENIED: '${tJs("models.errNetworkDenied", lang)}',
+          UNAUTHENTICATED: '${tJs("models.errUnauthenticated", lang)}',
+          UNKNOWN_MODEL: '${tJs("models.errUnknownModel", lang)}',
+          UNKNOWN_QUANT: '${tJs("models.errUnknownQuant", lang)}',
+          NOT_INSTALLED: '${tJs("models.errNotInstalled", lang)}',
+          START_FAILED: '${tJs("models.errStartFailed", lang)}',
+          NOT_NATIVE: '${tJs("models.errNotNative", lang)}',
+          MISSING_QUERY: '${tJs("models.errMissingQuery", lang)}',
+          HF_UPSTREAM_ERROR: '${tJs("models.errHfUpstream", lang)}',
+          BAD_TOKEN: '${tJs("models.errBadToken", lang)}',
+          INTERNAL: '${tJs("models.errInternal", lang)}'
+        };
+
+        function messageFor(code, fallback) {
+          return ERROR_MESSAGES[code] || fallback || '${tJs("models.errInternal", lang)}';
+        }
+
+        // --- Card status helpers ---
+        function statusEl(modelId) { return document.querySelector('.mcat-card__status-text[data-model-id="' + modelId + '"]'); }
+        function progressTrack(modelId) { return document.querySelector('.mcat-card__progress-track[data-model-id="' + modelId + '"]'); }
+        function setStatus(modelId, text) {
+          var el = statusEl(modelId);
+          if (el) el.textContent = text;
+        }
+        function setProgress(modelId, pct, visible) {
+          var track = progressTrack(modelId);
+          if (!track) return;
+          track.hidden = !visible;
+          var bar = track.querySelector(".mcat-card__progress-bar");
+          if (bar) bar.style.width = (pct || 0) + "%";
+        }
+
+        // --- Quant select -> fit pill/hint live update ---
+        document.querySelectorAll(".mcat-quant-select").forEach(function (sel) {
+          sel.addEventListener("change", function () {
+            var modelId = sel.dataset.modelId;
+            var opt = sel.options[sel.selectedIndex];
+            var fit = opt.getAttribute("data-fit") || "unknown";
+            var pillWrap = document.querySelector('.mcat-fit-hint[data-model-id="' + modelId + '"]');
+            if (pillWrap) {
+              pillWrap.replaceChildren();
+              var span = document.createElement("span");
+              span.className = "mcat-fit-pill mcat-fit-pill--" + fit;
+              span.textContent = FIT_LABELS[fit] || FIT_LABELS.unknown;
+              pillWrap.appendChild(span);
+            }
+            var hint = document.querySelector('.mcat-card__fit-hint[data-model-id="' + modelId + '"]');
+            if (hint) hint.textContent = FIT_HINTS[fit] || FIT_HINTS.unknown;
+          });
+        });
+
+        var FIT_LABELS = {
+          fits: '${tJs("models.fitFits", lang)}',
+          tight: '${tJs("models.fitTight", lang)}',
+          wont_fit: '${tJs("models.fitWontFit", lang)}',
+          unknown: '${tJs("models.fitUnknown", lang)}'
+        };
+        var FIT_HINTS = {
+          fits: '${tJs("models.fitFitsHint", lang)}',
+          tight: '${tJs("models.fitTightHint", lang)}',
+          wont_fit: '${tJs("models.fitWontFitHint", lang)}',
+          unknown: '${tJs("models.fitUnknownHint", lang)}'
+        };
+
+        // --- Download flow ---
+        function pollDownload(jobId, modelId) {
+          apiFetch("/downloads").then(function (res) {
+            if (!res.ok) { setStatus(modelId, messageFor("INTERNAL")); return; }
+            var job = (res.data.downloads || []).filter(function (j) { return j.id === jobId; })[0];
+            if (!job) { setTimeout(function () { pollDownload(jobId, modelId); }, 1500); return; }
+            if (job.status === "downloading" || job.status === "registering") {
+              var pct = job.totalBytes ? Math.round((job.bytesDone / job.totalBytes) * 100) : 0;
+              setProgress(modelId, pct, true);
+              var label = job.status === "registering"
+                ? '${tJs("models.actionRegistering", lang)}'
+                : '${tJs("models.actionDownloading", lang)}' + " " + fmtBytes(job.bytesDone) + (job.totalBytes ? " / " + fmtBytes(job.totalBytes) : "");
+              setStatus(modelId, label);
+              setTimeout(function () { pollDownload(jobId, modelId); }, 1500);
+            } else if (job.status === "done") {
+              setProgress(modelId, 100, false);
+              var card = document.querySelector('.mcat-card[data-model-id="' + modelId + '"]');
+              var actions = card ? card.querySelector(".mcat-card__actions") : null;
+              if (actions) {
+                actions.replaceChildren();
+                var link = document.createElement("a");
+                link.className = "btn btn-primary btn-sm";
+                link.href = "/dashboard/messages";
+                link.textContent = '${tJs("models.actionTryInChat", lang)}';
+                actions.appendChild(link);
+              }
+              setStatus(modelId, '${tJs("models.downloadSuccess", lang)}');
+            } else if (job.status === "error") {
+              setProgress(modelId, 0, false);
+              var raw = job.error || "";
+              var gated = card_isGated(modelId);
+              var looksLicense = gated && raw.indexOf("403") !== -1;
+              var msg = looksLicense
+                ? '${tJs("models.downloadErrorGated", lang)}'
+                : messageFor(job.errorCode, raw);
+              setStatus(modelId, msg);
+              var card2 = document.querySelector('.mcat-card[data-model-id="' + modelId + '"]');
+              var actions2 = card2 ? card2.querySelector(".mcat-card__actions") : null;
+              if (actions2) {
+                actions2.replaceChildren();
+                var retryBtn = document.createElement("button");
+                retryBtn.type = "button";
+                retryBtn.className = "btn btn-primary btn-sm";
+                retryBtn.setAttribute("data-action", "download");
+                retryBtn.setAttribute("data-model-id", modelId);
+                retryBtn.textContent = '${tJs("models.actionRetry", lang)}';
+                actions2.appendChild(retryBtn);
+              }
+            }
+          }).catch(function () {
+            setTimeout(function () { pollDownload(jobId, modelId); }, 3000);
+          });
+        }
+
+        function card_isGated(modelId) {
+          var card = document.querySelector('.mcat-card[data-model-id="' + modelId + '"]');
+          return !!(card && card.querySelector(".mcat-card__badge--gated"));
+        }
+
+        function startDownload(modelId) {
+          var sel = document.querySelector('.mcat-quant-select[data-model-id="' + modelId + '"]');
+          var quant = sel ? sel.value : null;
+          var fit = "fits";
+          if (sel) {
+            var opt = sel.options[sel.selectedIndex];
+            fit = opt.getAttribute("data-fit") || "fits";
+          } else {
+            var pill = document.querySelector('.mcat-fit-hint[data-model-id="' + modelId + '"] .mcat-fit-pill');
+            if (pill) {
+              var m = pill.className.match(/mcat-fit-pill--(\\S+)/);
+              if (m) fit = m[1];
+            }
+          }
+          setStatus(modelId, '${tJs("models.actionDownloading", lang)}');
+          apiFetch("/download", {
+            method: "POST",
+            body: JSON.stringify({ modelId: modelId, quant: quant, force: fit !== "fits" })
+          }).then(function (res) {
+            if (res.ok || res.status === 202) {
+              pollDownload(res.data.jobId, modelId);
+            } else {
+              setStatus(modelId, messageFor(res.data.code, res.data.error));
+            }
+          }).catch(function () {
+            setStatus(modelId, messageFor("INTERNAL"));
+          });
+        }
+
+        // --- Start / stop ---
+        function startModel(modelId) {
+          setStatus(modelId, '${tJs("models.actionStarting", lang)}');
+          apiFetch("/" + encodeURIComponent(modelId) + "/start", { method: "POST" }).then(function (res) {
+            if (res.ok) {
+              setTimeout(function () { location.reload(); }, 1200);
+            } else {
+              setStatus(modelId, messageFor(res.data.code, res.data.error));
+            }
+          }).catch(function () { setStatus(modelId, messageFor("INTERNAL")); });
+        }
+
+        function stopModel(modelId) {
+          setStatus(modelId, '${tJs("models.actionStopping", lang)}');
+          apiFetch("/" + encodeURIComponent(modelId) + "/stop", { method: "POST" }).then(function (res) {
+            if (res.ok) {
+              setTimeout(function () { location.reload(); }, 1000);
+            } else {
+              setStatus(modelId, messageFor(res.data.code, res.data.error));
+            }
+          }).catch(function () { setStatus(modelId, messageFor("INTERNAL")); });
+        }
+
+        // --- Delete (confirm-then-delete) ---
+        function showDeleteConfirm(modelId, bindings) {
+          var frag = document.createElement("div");
+
+          var title = document.createElement("div");
+          title.className = "mcat-modal__title";
+          title.textContent = '${tJs("models.deleteConfirmTitle", lang)}'.replace("{model}", modelId);
+          frag.appendChild(title);
+
+          var intro = document.createElement("p");
+          intro.textContent = '${tJs("models.deleteConfirmIntro", lang)}';
+          frag.appendChild(intro);
+
+          var profiles = (bindings && bindings.profiles) || [];
+          var bots = (bindings && bindings.bots) || [];
+          if (profiles.length === 0 && bots.length === 0) {
+            var none = document.createElement("p");
+            none.textContent = '${tJs("models.deleteNoBindings", lang)}';
+            frag.appendChild(none);
+          } else {
+            var bindIntro = document.createElement("p");
+            bindIntro.textContent = '${tJs("models.deleteBindingsIntro", lang)}';
+            frag.appendChild(bindIntro);
+            var list = document.createElement("ul");
+            list.className = "mcat-modal__list";
+            profiles.forEach(function (p) {
+              var li = document.createElement("li");
+              li.textContent = (p && p.name) ? p.name : (p && p.id) || "?";
+              list.appendChild(li);
+            });
+            bots.forEach(function (b) {
+              var li = document.createElement("li");
+              li.textContent = (b && b.display_name) ? b.display_name : (b && b.bot_id) || "?";
+              list.appendChild(li);
+            });
+            frag.appendChild(list);
+          }
+
+          var actions = document.createElement("div");
+          actions.className = "mcat-modal__actions";
+
+          var cancelBtn = document.createElement("button");
+          cancelBtn.type = "button";
+          cancelBtn.className = "btn btn-secondary btn-sm";
+          cancelBtn.textContent = '${tJs("models.deleteCancelButton", lang)}';
+          cancelBtn.addEventListener("click", hideModal);
+          actions.appendChild(cancelBtn);
+
+          var confirmBtn = document.createElement("button");
+          confirmBtn.type = "button";
+          confirmBtn.className = "btn btn-danger btn-sm";
+          confirmBtn.textContent = '${tJs("models.deleteConfirmButton", lang)}';
+          confirmBtn.addEventListener("click", function () {
+            confirmBtn.disabled = true;
+            apiFetch("/" + encodeURIComponent(modelId) + "?confirm=true", { method: "DELETE" }).then(function (res) {
+              hideModal();
+              if (res.ok) {
+                setStatus(modelId, '${tJs("models.deleteSuccess", lang)}');
+                setTimeout(function () { location.reload(); }, 800);
+              } else {
+                setStatus(modelId, messageFor(res.data.code, res.data.error));
+              }
+            }).catch(function () {
+              hideModal();
+              setStatus(modelId, messageFor("INTERNAL"));
+            });
+          });
+          actions.appendChild(confirmBtn);
+          frag.appendChild(actions);
+
+          var mc = document.getElementById("mcat-modal-content");
+          mc.replaceChildren();
+          mc.appendChild(frag);
+          showModal();
+        }
+
+        function requestDelete(modelId) {
+          apiFetch("/" + encodeURIComponent(modelId), { method: "DELETE" }).then(function (res) {
+            if (res.ok && res.data && res.data.requiresConfirm) {
+              showDeleteConfirm(modelId, res.data.bindings);
+            } else if (!res.ok) {
+              setStatus(modelId, messageFor(res.data.code, res.data.error));
+            }
+          }).catch(function () { setStatus(modelId, messageFor("INTERNAL")); });
+        }
+
+        // --- Delegated action clicks ---
+        document.addEventListener("click", function (e) {
+          var el = e.target.closest("[data-action]");
+          if (!el) return;
+          var action = el.getAttribute("data-action");
+          var modelId = el.getAttribute("data-model-id");
+          if (action === "download" && modelId) startDownload(modelId);
+          else if (action === "start" && modelId) startModel(modelId);
+          else if (action === "stop" && modelId) stopModel(modelId);
+          else if (action === "remove" && modelId) requestDelete(modelId);
+          else if (action === "reprobe") {
+            var statusSpan = document.getElementById("mcat-reprobe-status");
+            if (statusSpan) statusSpan.textContent = '${tJs("models.runtimeReprobing", lang)}';
+            apiFetch("/reprobe", { method: "POST" }).then(function () {
+              location.reload();
+            }).catch(function () {
+              if (statusSpan) statusSpan.textContent = messageFor("INTERNAL");
+            });
+          }
+        });
+
+        // --- Runtime strip: active downloads count (refreshed independently) ---
+        function refreshActiveDownloads() {
+          apiFetch("/downloads").then(function (res) {
+            if (!res.ok) return;
+            var active = (res.data.downloads || []).filter(function (j) {
+              return j.status === "downloading" || j.status === "registering";
+            });
+            var el = document.getElementById("mcat-active-downloads");
+            if (!el) return;
+            el.textContent = active.length > 0
+              ? '${tJs("models.runtimeActiveDownloads", lang)}'.replace("{n}", String(active.length))
+              : "";
+          }).catch(function () {});
+        }
+        refreshActiveDownloads();
+        setInterval(refreshActiveDownloads, 5000);
+
+        // --- Browse Hugging Face search ---
+        function renderHfResults(results) {
+          var wrap = document.getElementById("mcat-hf-results");
+          wrap.replaceChildren();
+          if (!results || results.length === 0) {
+            var empty = document.createElement("div");
+            empty.className = "mcat-strip__status";
+            empty.textContent = '${tJs("models.hfSearchEmpty", lang)}';
+            wrap.appendChild(empty);
+            return;
+          }
+          results.forEach(function (r) {
+            var card = document.createElement("div");
+            card.className = "mcat-hf-result";
+
+            var title = document.createElement("div");
+            title.className = "mcat-hf-result__title";
+            title.textContent = r.id;
+            card.appendChild(title);
+
+            var meta = document.createElement("div");
+            meta.className = "mcat-hf-result__meta";
+            var parts = [];
+            if (typeof r.downloads === "number") parts.push('${tJs("models.hfResultDownloads", lang)}'.replace("{n}", String(r.downloads)));
+            if (typeof r.likes === "number") parts.push('${tJs("models.hfResultLikes", lang)}'.replace("{n}", String(r.likes)));
+            parts.push(r.license ? r.license : '${tJs("models.hfResultLicenseUnknown", lang)}');
+            parts.push('${tJs("models.hfResultFiles", lang)}'.replace("{n}", String((r.ggufFiles || []).length)));
+            meta.textContent = parts.join(" · ");
+            card.appendChild(meta);
+
+            var pillWrap = document.createElement("div");
+            pillWrap.style.marginTop = "0.3rem";
+            var pill = document.createElement("span");
+            pill.className = "mcat-fit-pill mcat-fit-pill--unknown";
+            pill.textContent = FIT_LABELS.unknown;
+            pillWrap.appendChild(pill);
+            card.appendChild(pillWrap);
+
+            var fitNotice = document.createElement("div");
+            fitNotice.className = "mcat-hf-result__notice";
+            fitNotice.textContent = '${tJs("models.hfFitUnknownHint", lang)}';
+            card.appendChild(fitNotice);
+
+            if (r.gated) {
+              var gatedNotice = document.createElement("div");
+              gatedNotice.className = "mcat-hf-result__notice";
+              gatedNotice.textContent = mcat_hfTokenConfigured
+                ? '${tJs("models.hfGatedWithToken", lang)}'
+                : '${tJs("models.hfGatedNoToken", lang)}';
+              card.appendChild(gatedNotice);
+            }
+
+            var link = document.createElement("a");
+            link.href = "https://huggingface.co/" + r.id;
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
+            link.className = "mcat-hf-result__notice";
+            link.style.display = "inline-block";
+            link.style.marginTop = "0.35rem";
+            link.textContent = '${tJs("models.hfViewOnHf", lang)}';
+            card.appendChild(link);
+
+            wrap.appendChild(card);
+          });
+        }
+
+        function runHfSearch() {
+          var input = document.getElementById("mcat-hf-search-input");
+          var q = input ? input.value.trim() : "";
+          var statusEl2 = document.getElementById("mcat-hf-status");
+          if (!q) { if (statusEl2) statusEl2.textContent = messageFor("MISSING_QUERY"); return; }
+          if (statusEl2) statusEl2.textContent = '${tJs("models.hfSearching", lang)}';
+          apiFetch("/hf-search?q=" + encodeURIComponent(q)).then(function (res) {
+            if (statusEl2) statusEl2.textContent = "";
+            if (res.ok) {
+              renderHfResults(res.data.results);
+            } else {
+              if (statusEl2) statusEl2.textContent = messageFor(res.data.code, res.data.error);
+            }
+          }).catch(function () {
+            if (statusEl2) statusEl2.textContent = messageFor("HF_UPSTREAM_ERROR");
+          });
+        }
+
+        var hfSearchBtn = document.getElementById("mcat-hf-search-btn");
+        if (hfSearchBtn) hfSearchBtn.addEventListener("click", runHfSearch);
+        var hfSearchInput = document.getElementById("mcat-hf-search-input");
+        if (hfSearchInput) hfSearchInput.addEventListener("keydown", function (e) {
+          if (e.key === "Enter") { e.preventDefault(); runHfSearch(); }
+        });
+
+        // --- HF token save/clear ---
+        var mcat_hfTokenConfigured = ${JSON.stringify(false)};
+        apiFetch("/hf-token").then(function (res) {
+          if (res.ok) {
+            mcat_hfTokenConfigured = !!res.data.configured;
+            var statusDiv = document.getElementById("mcat-hf-token-status");
+            if (statusDiv) statusDiv.textContent = mcat_hfTokenConfigured
+              ? '${tJs("models.hfTokenConfigured", lang)}'
+              : '${tJs("models.hfTokenNotConfigured", lang)}';
+          }
+        }).catch(function () {});
+
+        function saveOrClearToken(value) {
+          var statusDiv = document.getElementById("mcat-hf-token-status");
+          apiFetch("/hf-token", { method: "POST", body: JSON.stringify({ token: value }) }).then(function (res) {
+            var input = document.getElementById("mcat-hf-token-input");
+            if (input) input.value = "";
+            if (res.ok) {
+              mcat_hfTokenConfigured = !!res.data.configured;
+              if (statusDiv) statusDiv.textContent = mcat_hfTokenConfigured
+                ? '${tJs("models.hfTokenSaved", lang)}'
+                : '${tJs("models.hfTokenCleared", lang)}';
+            } else if (statusDiv) {
+              statusDiv.textContent = '${tJs("models.hfTokenSaveFailed", lang)}'.replace("{error}", messageFor(res.data.code, res.data.error));
+            }
+          }).catch(function () {
+            if (statusDiv) statusDiv.textContent = '${tJs("models.hfTokenSaveFailed", lang)}'.replace("{error}", messageFor("INTERNAL"));
+          });
+        }
+
+        var saveBtn = document.getElementById("mcat-hf-token-save");
+        if (saveBtn) saveBtn.addEventListener("click", function () {
+          var input = document.getElementById("mcat-hf-token-input");
+          saveOrClearToken(input ? input.value.trim() : "");
+        });
+        var clearBtn = document.getElementById("mcat-hf-token-clear");
+        if (clearBtn) clearBtn.addEventListener("click", function () { saveOrClearToken(""); });
+      })();
+    </script>`;
+}
+
+// ---------------------------------------------------------------------------
+// Panel export
+// ---------------------------------------------------------------------------
+
+export default {
+  id: "model-catalog",
+  name: "Model Catalog",
+  icon: "models",
+  route: "/dashboard/model-catalog",
+  navOrder: 16,
+  category: "ai",
+
+  async handler(req, res, { db, layout, lang }) {
+    let data;
+    try {
+      data = await loadPanelData({ db });
+    } catch (err) {
+      const content = `<div class="mcat-empty">${escapeHtml(t("models.emptyCatalog", lang))} (${escapeHtml(err.message)})</div>`;
+      return layout({ title: t("models.pageTitle", lang), content });
+    }
+
+    const tabsHtml = tabs([
+      { id: "curated", label: t("models.tabCurated", lang), content: renderCuratedTab(data, lang) },
+      { id: "browse-hf", label: t("models.tabBrowseHf", lang), content: renderHfTab(data, lang) },
+    ]);
+
+    const content = `
+      ${panelStyles()}
+      <p class="mcat-intro">${escapeHtml(t("models.pageIntro", lang))}</p>
+      ${renderRuntimeStrip(data, lang)}
+      ${tabsHtml}
+      ${modelCatalogClientJS(lang)}
+    `;
+
+    return layout({ title: t("models.pageTitle", lang), content });
+  },
+};

--- a/servers/gateway/dashboard/panels/model-catalog.js
+++ b/servers/gateway/dashboard/panels/model-catalog.js
@@ -179,8 +179,13 @@ export async function loadPanelData({
   const snapshot = getStatusSnapshotFn();
   const byAlias = new Map(snapshot.map((s) => [s.alias, s]));
   const runtimeModels = Object.keys(state.registry).map((modelId) => {
+    // Task 13 fix round 3: hf-browser-registered models have no curated
+    // card (they're not in the catalog at all), so the runtime strip is
+    // their ONLY surface — it needs to know their source to offer a
+    // Remove affordance there instead.
+    const source = state.registry[modelId]?.source || "curated";
     const status = byAlias.get(modelId);
-    if (status) return { modelId, ...status };
+    if (status) return { modelId, source, ...status };
     // Task 13 fix round 1, finding c: distinguish "never started" from
     // "was resident when the gateway restarted, hasn't re-warmed yet" via
     // the persisted wasLive marker — same classification GET /api/models/
@@ -189,6 +194,7 @@ export async function loadPanelData({
     const entry = state.registry[modelId];
     return {
       modelId,
+      source,
       state: registryEntryRuntimeStateFn(entry, false),
       live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null,
     };
@@ -411,7 +417,7 @@ function renderFitPill(badgeName, lang) {
   return `<span class="mcat-fit-pill mcat-fit-pill--${cls}">${escapeHtml(t(fitLabelKey(badgeName), lang))}</span>`;
 }
 
-function renderRuntimeStrip(data, lang) {
+export function renderRuntimeStrip(data, lang) {
   const { runtime, probe, runtimeModels, estimatedRamMb, estimatedVramMb } = data;
 
   const binaryLine = runtime.name
@@ -459,6 +465,16 @@ function renderRuntimeStrip(data, lang) {
     const actionBtn = m.live
       ? button(t("models.actionStop", lang), { variant: "secondary", size: "sm", attrs: `data-action="stop" data-model-id="${escapeHtml(m.modelId)}"` })
       : button(t("models.actionStart", lang), { variant: "secondary", size: "sm", attrs: `data-action="start" data-model-id="${escapeHtml(m.modelId)}"` });
+    // Task 13 fix round 3: an hf-browser-registered model has NO curated
+    // card (its id is never in the catalog), so the runtime strip is the
+    // only place it can ever be removed from — give it a Remove button
+    // here, reusing the exact same delegated data-action="remove" ->
+    // requestDelete -> confirm-modal -> DELETE?confirm=true flow the
+    // curated cards already use. Curated rows keep relying on their own
+    // card's Remove button, unchanged.
+    const removeBtn = m.source === "hf-browser"
+      ? button(t("models.actionRemove", lang), { variant: "danger", size: "sm", attrs: `data-action="remove" data-model-id="${escapeHtml(m.modelId)}"` })
+      : "";
     return `<tr>
       <td class="mono">${escapeHtml(m.modelId)}</td>
       <td>${stateCell}</td>
@@ -466,7 +482,7 @@ function renderRuntimeStrip(data, lang) {
       <td class="mono">${m.pid != null ? escapeHtml(String(m.pid)) : "—"}</td>
       <td class="mono">${escapeHtml(String(m.restartCount || 0))}</td>
       <td>${m.lastError ? escapeHtml(String(m.lastError)) : "—"}</td>
-      <td>${actionBtn}</td>
+      <td>${actionBtn}${removeBtn}</td>
     </tr>`;
   }).join("");
 
@@ -569,7 +585,7 @@ function renderModelCard(model, lang, hfTokenConfigured) {
   </div>`;
 }
 
-function renderCuratedTab(data, lang) {
+export function renderCuratedTab(data, lang) {
   const groups = groupBySizeClass(data.models);
   const order = [
     ["small", "models.groupSmall"],
@@ -625,7 +641,7 @@ function renderHfTab(data, lang) {
 // template literal's <script> content. Every browser-side string is single
 // or double quoted; concatenation only.
 
-function modelCatalogClientJS(lang) {
+export function modelCatalogClientJS(lang) {
   return `
     <div id="mcat-modal-overlay">
       <div id="mcat-modal-content"></div>
@@ -675,7 +691,13 @@ function modelCatalogClientJS(lang) {
           INVALID_HF_REPO: '${tJs("models.errInvalidHf", lang)}',
           INVALID_HF_FILE: '${tJs("models.errInvalidHf", lang)}',
           NO_VERIFIABLE_CHECKSUM: '${tJs("models.errNoVerifiableChecksum", lang)}',
-          HF_FILE_NOT_FOUND: '${tJs("models.errHfUpstream", lang)}'
+          HF_FILE_NOT_FOUND: '${tJs("models.errHfUpstream", lang)}',
+          // Task 13 fix round 3: Hugging Face answers an unauthenticated
+          // gated download 401 (no/invalid token), distinct from 403
+          // (authenticated but the license hasn't been accepted yet) —
+          // maps to the same "requires a Hugging Face login" copy the
+          // pre-download three-state notice already uses.
+          HTTP_401: '${tJs("models.gatedNoToken", lang)}'
         };
 
         function messageFor(code, fallback) {
@@ -697,7 +719,45 @@ function modelCatalogClientJS(lang) {
           if (bar) bar.style.width = (pct || 0) + "%";
         }
 
-        // --- Quant select -> fit pill/hint live update ---
+        // --- Quant select -> fit pill/hint/action-area live update ---
+        //
+        // Task 13 fix round 3 (GATING): the action area MUST also
+        // re-render on quant change — a default-wont_fit entry with a
+        // fitting alternate quant was otherwise never downloadable (the
+        // disabled notice from the server-render never went away), and
+        // conversely a default-fits entry switched to a wont_fit quant
+        // left the enabled Download button showing for a quant the
+        // server will refuse. See refreshCardActions below.
+        function refreshCardActions(modelId, fit) {
+          var card = document.querySelector('.mcat-card[data-model-id="' + modelId + '"]');
+          if (!card) return;
+          var actions = card.querySelector(".mcat-card__actions");
+          if (!actions) return;
+          // Registered/running cards show Start/Stop + Remove regardless
+          // of quant selection — the quant selector only matters for a
+          // not-yet-installed model (same branch structure the
+          // server-render's renderModelCard uses). A "remove" button is
+          // present in BOTH the running and registered-not-running
+          // branches, absent in the not-installed ones, so its presence
+          // is a reliable signal to leave the actions area alone here.
+          if (actions.querySelector('[data-action="remove"]')) return;
+          actions.replaceChildren();
+          if (fit === "wont_fit") {
+            var notice = document.createElement("div");
+            notice.className = "mcat-card__notice";
+            notice.textContent = FIT_HINTS.wont_fit;
+            actions.appendChild(notice);
+          } else {
+            var btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "btn btn-primary btn-sm";
+            btn.setAttribute("data-action", "download");
+            btn.setAttribute("data-model-id", modelId);
+            btn.textContent = '${tJs("models.actionDownload", lang)}';
+            actions.appendChild(btn);
+          }
+        }
+
         document.querySelectorAll(".mcat-quant-select").forEach(function (sel) {
           sel.addEventListener("change", function () {
             var modelId = sel.dataset.modelId;
@@ -713,6 +773,7 @@ function modelCatalogClientJS(lang) {
             }
             var hint = document.querySelector('.mcat-card__fit-hint[data-model-id="' + modelId + '"]');
             if (hint) hint.textContent = FIT_HINTS[fit] || FIT_HINTS.unknown;
+            refreshCardActions(modelId, fit);
           });
         });
 
@@ -793,30 +854,47 @@ function modelCatalogClientJS(lang) {
           return !!(card && card.querySelector(".mcat-card__badge--gated"));
         }
 
-        function startDownload(modelId) {
+        // Task 13 fix round 3 (GATING): NEVER auto-force from the selected
+        // quant's fit badge — that silently bypassed the server's 409
+        // WONT_FIT gate the moment the button next to a wont_fit-selected
+        // quant was clicked (contradicting the spec's "won't fit =
+        // disabled"). The initial call is always force:false; only an
+        // explicit second click on the "Download anyway" button the 409
+        // branch below renders (mirrors startHfDownload's WONT_FIT
+        // handling) retries with force:true. tight/unknown quants need no
+        // special handling here — the server already accepts them without
+        // force (force is inert for those two), so they succeed on the
+        // very first, unforced call.
+        function startDownload(modelId, force) {
           var sel = document.querySelector('.mcat-quant-select[data-model-id="' + modelId + '"]');
           var quant = sel ? sel.value : null;
-          var fit = "fits";
-          if (sel) {
-            var opt = sel.options[sel.selectedIndex];
-            fit = opt.getAttribute("data-fit") || "fits";
-          } else {
-            var pill = document.querySelector('.mcat-fit-hint[data-model-id="' + modelId + '"] .mcat-fit-pill');
-            if (pill) {
-              var m = pill.className.match(/mcat-fit-pill--(\\S+)/);
-              if (m) fit = m[1];
-            }
-          }
           setStatus(modelId, '${tJs("models.actionDownloading", lang)}');
           apiFetch("/download", {
             method: "POST",
-            body: JSON.stringify({ modelId: modelId, quant: quant, force: fit !== "fits" })
+            body: JSON.stringify({ modelId: modelId, quant: quant, force: !!force })
           }).then(function (res) {
             if (res.ok || res.status === 202) {
               pollDownload(res.data.jobId, modelId);
-            } else {
-              setStatus(modelId, messageFor(res.data.code, res.data.error));
+              return;
             }
+            if (res.status === 409 && res.data && res.data.code === "WONT_FIT") {
+              setStatus(modelId, messageFor("WONT_FIT", res.data.error));
+              var card = document.querySelector('.mcat-card[data-model-id="' + modelId + '"]');
+              var actions = card ? card.querySelector(".mcat-card__actions") : null;
+              if (actions) {
+                actions.replaceChildren();
+                var forceBtn = document.createElement("button");
+                forceBtn.type = "button";
+                forceBtn.className = "btn btn-danger btn-sm";
+                forceBtn.textContent = '${tJs("models.actionForceDownload", lang)}';
+                forceBtn.addEventListener("click", function () {
+                  startDownload(modelId, true);
+                });
+                actions.appendChild(forceBtn);
+              }
+              return;
+            }
+            setStatus(modelId, messageFor(res.data && res.data.code, res.data && res.data.error));
           }).catch(function () {
             setStatus(modelId, messageFor("INTERNAL"));
           });

--- a/servers/gateway/dashboard/panels/model-catalog.js
+++ b/servers/gateway/dashboard/panels/model-catalog.js
@@ -1,18 +1,23 @@
 /**
- * Model Catalog Panel — Item G Task 13
+ * Model Catalog Panel — Item G Task 13 (+ fix round 1: Browse-HF downloads,
+ * the "reloading after update" runtime state, typed gated-retry detection)
  *
  * Browse the curated catalog (registry/model-catalog.json), download +
  * register GGUF models as local providers, start/stop/remove them, and
- * (advanced) search Hugging Face directly for GGUF repos.
+ * search Hugging Face directly for GGUF repos — including downloading an
+ * arbitrary (un-vetted, HF-sha-verified) file straight from a search result
+ * via `POST /api/models/hf-download` (fix round 1, finding 1).
  *
  * Architecture: server-side render (SSR) for the initial page — this panel
  * imports the SAME read-only model-management functions Task 12's
  * `routes/models.js` uses (`probe.js`, `state.js`, `runtime.js`,
  * `gpu-orchestrator.js`'s `getNativeHandle`) directly, rather than doing a
  * self-referential HTTP fetch of its own API on first paint. All later
- * interaction (download, start/stop, delete, HF search, HF token) is driven
- * client-side against the real `/api/models/*` routes from Task 12,
- * consumed verbatim (this file never modifies `routes/models.js`).
+ * interaction (download, start/stop, delete, HF search, HF token,
+ * Browse-HF download) is driven client-side against the real
+ * `/api/models/*` routes, consumed verbatim — this file never modifies
+ * `routes/models.js` (that file's own fix-round-1 changes, incl.
+ * `POST /hf-download`, were made directly, not through this panel).
  *
  * Security note: all server-rendered dynamic content is escaped via
  * escapeHtml(). Client-side DOM built from API responses (HF search results,
@@ -35,7 +40,7 @@ import { t, tJs, fill } from "../shared/i18n.js";
 import { escapeHtml, button, callout, tabs } from "../shared/components.js";
 import { resolveDataDir } from "../../../db.js";
 import { getCachedProbe, reprobe, fitBadge } from "../../models/probe.js";
-import { loadState } from "../../models/state.js";
+import { loadState, registryEntryRuntimeState } from "../../models/state.js";
 import { getStatusSnapshot } from "../../models/runtime.js";
 import { getNativeHandle } from "../../gpu-orchestrator.js";
 import { listProvidersAll } from "../../../shared/providers-db.js";
@@ -120,6 +125,7 @@ export async function loadPanelData({
   getStatusSnapshotFn = getStatusSnapshot,
   getNativeHandleFn = getNativeHandle,
   listProvidersAllFn = listProvidersAll,
+  registryEntryRuntimeStateFn = registryEntryRuntimeState,
 } = {}) {
   const resolvedDir = dir || resolveDataDir();
   const catalog = loadCatalogFn();
@@ -174,9 +180,18 @@ export async function loadPanelData({
   const byAlias = new Map(snapshot.map((s) => [s.alias, s]));
   const runtimeModels = Object.keys(state.registry).map((modelId) => {
     const status = byAlias.get(modelId);
-    return status
-      ? { modelId, ...status }
-      : { modelId, state: "stopped", live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null };
+    if (status) return { modelId, ...status };
+    // Task 13 fix round 1, finding c: distinguish "never started" from
+    // "was resident when the gateway restarted, hasn't re-warmed yet" via
+    // the persisted wasLive marker — same classification GET /api/models/
+    // runtime uses, mirrored here for SSR (see state.js's
+    // registryEntryRuntimeState doc for the exact contract).
+    const entry = state.registry[modelId];
+    return {
+      modelId,
+      state: registryEntryRuntimeStateFn(entry, false),
+      live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null,
+    };
   });
 
   // Estimated RAM/VRAM in use — derived from catalog quant costs for models
@@ -341,6 +356,15 @@ function panelStyles() {
 .mcat-hf-result__meta { font-size:0.75rem; color:var(--crow-text-muted); margin-top:0.2rem; }
 .mcat-hf-result__notice { font-size:0.75rem; color:var(--crow-text-muted); margin-top:0.35rem; }
 
+/* Per-file download rows (Task 13 fix round 1, finding 1) */
+.mcat-hf-result__files-list {
+  margin-top:0.6rem; padding-top:0.5rem; border-top:1px solid var(--crow-border);
+  display:flex; flex-direction:column; gap:0.4rem;
+}
+.mcat-hf-result__file-row { display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap; }
+.mcat-hf-result__file-name { font-size:0.78rem; color:var(--crow-text-secondary); flex:1 1 auto; min-width:0; word-break:break-all; }
+.mcat-hf-result__file-actions { flex-shrink:0; }
+
 .mcat-hf-token { margin-top:1.5rem; padding-top:1.25rem; border-top:1px solid var(--crow-border); }
 .mcat-hf-token__heading { font-family:'Fraunces',serif; font-weight:600; font-size:0.95rem; margin-bottom:0.4rem; }
 .mcat-hf-token__row { display:flex; gap:0.5rem; flex-wrap:wrap; align-items:center; margin:0.5rem 0; }
@@ -420,13 +444,24 @@ function renderRuntimeStrip(data, lang) {
     : escapeHtml(t("models.runtimeNoModelsRunning", lang));
 
   const rowsHtml = runtimeModels.map((m) => {
-    const stateKey = m.live ? "models.runtimeStateRunning" : m.state === "unhealthy" ? "models.runtimeStateUnhealthy" : "models.runtimeStateStopped";
+    // Task 13 fix round 1, finding c: "stopped_after_restart" is its own
+    // distinct, honest state — a model that was resident when the gateway
+    // last went down, not yet re-warmed — never conflated with a plain
+    // never-started "Not running".
+    const stateKey = m.live
+      ? "models.runtimeStateRunning"
+      : m.state === "unhealthy" ? "models.runtimeStateUnhealthy"
+      : m.state === "stopped_after_restart" ? "models.runtimeStateReloading"
+      : "models.runtimeStateStopped";
+    const stateCell = m.state === "stopped_after_restart"
+      ? escapeHtml(t(stateKey, lang)) + `<div class="mcat-strip__status">${escapeHtml(t("models.runtimeStateReloadingHint", lang))}</div>`
+      : escapeHtml(t(stateKey, lang));
     const actionBtn = m.live
       ? button(t("models.actionStop", lang), { variant: "secondary", size: "sm", attrs: `data-action="stop" data-model-id="${escapeHtml(m.modelId)}"` })
       : button(t("models.actionStart", lang), { variant: "secondary", size: "sm", attrs: `data-action="start" data-model-id="${escapeHtml(m.modelId)}"` });
     return `<tr>
       <td class="mono">${escapeHtml(m.modelId)}</td>
-      <td>${escapeHtml(t(stateKey, lang))}</td>
+      <td>${stateCell}</td>
       <td class="mono">${m.port != null ? escapeHtml(String(m.port)) : "—"}</td>
       <td class="mono">${m.pid != null ? escapeHtml(String(m.pid)) : "—"}</td>
       <td class="mono">${escapeHtml(String(m.restartCount || 0))}</td>
@@ -635,7 +670,12 @@ function modelCatalogClientJS(lang) {
           MISSING_QUERY: '${tJs("models.errMissingQuery", lang)}',
           HF_UPSTREAM_ERROR: '${tJs("models.errHfUpstream", lang)}',
           BAD_TOKEN: '${tJs("models.errBadToken", lang)}',
-          INTERNAL: '${tJs("models.errInternal", lang)}'
+          INTERNAL: '${tJs("models.errInternal", lang)}',
+          WONT_FIT: '${tJs("models.errWontFit", lang)}',
+          INVALID_HF_REPO: '${tJs("models.errInvalidHf", lang)}',
+          INVALID_HF_FILE: '${tJs("models.errInvalidHf", lang)}',
+          NO_VERIFIABLE_CHECKSUM: '${tJs("models.errNoVerifiableChecksum", lang)}',
+          HF_FILE_NOT_FOUND: '${tJs("models.errHfUpstream", lang)}'
         };
 
         function messageFor(code, fallback) {
@@ -719,8 +759,13 @@ function modelCatalogClientJS(lang) {
             } else if (job.status === "error") {
               setProgress(modelId, 0, false);
               var raw = job.error || "";
+              // Task 13 fix round 1, finding d: keys off the TYPED error
+              // code manager.js's HttpStatusError now attaches to the job
+              // (errorCode === "HTTP_403"), never string-matching the raw
+              // message — a message-format change can no longer silently
+              // break this detection.
               var gated = card_isGated(modelId);
-              var looksLicense = gated && raw.indexOf("403") !== -1;
+              var looksLicense = gated && job.errorCode === "HTTP_403";
               var msg = looksLicense
                 ? '${tJs("models.downloadErrorGated", lang)}'
                 : messageFor(job.errorCode, raw);
@@ -924,6 +969,183 @@ function modelCatalogClientJS(lang) {
         refreshActiveDownloads();
         setInterval(refreshActiveDownloads, 5000);
 
+        // --- Browse Hugging Face downloads (Task 13 fix round 1, finding 1) ---
+        //
+        // Each search result can list several GGUF files; a download
+        // targets ONE specific (repo, file) pair, so each file gets its
+        // own row with its own status/progress/actions — captured via
+        // closures (not the delegated data-action pattern the curated
+        // cards use), since a repo/file string can contain characters that
+        // are awkward to round-trip through a CSS attribute selector.
+
+        function pollHfDownload(jobId, statusSpan, progressTrack, actions, repoId, file) {
+          apiFetch("/downloads").then(function (res) {
+            if (!res.ok) { statusSpan.textContent = messageFor("INTERNAL"); return; }
+            var job = (res.data.downloads || []).filter(function (j) { return j.id === jobId; })[0];
+            if (!job) {
+              setTimeout(function () { pollHfDownload(jobId, statusSpan, progressTrack, actions, repoId, file); }, 1500);
+              return;
+            }
+            if (job.status === "downloading" || job.status === "registering") {
+              var pct = job.totalBytes ? Math.round((job.bytesDone / job.totalBytes) * 100) : 0;
+              progressTrack.hidden = false;
+              var bar = progressTrack.querySelector(".mcat-card__progress-bar");
+              if (bar) bar.style.width = pct + "%";
+              statusSpan.textContent = job.status === "registering"
+                ? '${tJs("models.actionRegistering", lang)}'
+                : '${tJs("models.actionDownloading", lang)}' + " " + fmtBytes(job.bytesDone) + (job.totalBytes ? " / " + fmtBytes(job.totalBytes) : "");
+              setTimeout(function () { pollHfDownload(jobId, statusSpan, progressTrack, actions, repoId, file); }, 1500);
+            } else if (job.status === "done") {
+              progressTrack.hidden = true;
+              statusSpan.textContent = '${tJs("models.downloadSuccess", lang)}';
+              actions.replaceChildren();
+              var link = document.createElement("a");
+              link.className = "btn btn-primary btn-sm";
+              link.href = "/dashboard/messages";
+              link.textContent = '${tJs("models.actionTryInChat", lang)}';
+              actions.appendChild(link);
+            } else if (job.status === "error") {
+              progressTrack.hidden = true;
+              // Finding d: keys off the typed HTTP_403 code, not string-matching.
+              var looksLicense = job.errorCode === "HTTP_403";
+              statusSpan.textContent = looksLicense
+                ? '${tJs("models.downloadErrorGated", lang)}'
+                : messageFor(job.errorCode, job.error);
+              actions.replaceChildren();
+              var retryBtn = document.createElement("button");
+              retryBtn.type = "button";
+              retryBtn.className = "btn btn-primary btn-sm";
+              retryBtn.textContent = '${tJs("models.actionRetry", lang)}';
+              retryBtn.addEventListener("click", function () {
+                showHfDownloadConfirm(repoId, file, false, statusSpan, progressTrack, actions);
+              });
+              actions.appendChild(retryBtn);
+            }
+          }).catch(function () {
+            setTimeout(function () { pollHfDownload(jobId, statusSpan, progressTrack, actions, repoId, file); }, 3000);
+          });
+        }
+
+        function startHfDownload(repoId, file, statusSpan, progressTrack, actions, force) {
+          actions.replaceChildren();
+          statusSpan.textContent = '${tJs("models.actionDownloading", lang)}';
+          apiFetch("/hf-download", {
+            method: "POST",
+            body: JSON.stringify({ hfRepo: repoId, file: file, force: !!force })
+          }).then(function (res) {
+            if (res.ok || res.status === 202) {
+              pollHfDownload(res.data.jobId, statusSpan, progressTrack, actions, repoId, file);
+              return;
+            }
+            if (res.data && res.data.code === "WONT_FIT") {
+              statusSpan.textContent = messageFor("WONT_FIT", res.data.error);
+              var forceBtn = document.createElement("button");
+              forceBtn.type = "button";
+              forceBtn.className = "btn btn-danger btn-sm";
+              forceBtn.textContent = '${tJs("models.actionForceDownload", lang)}';
+              forceBtn.addEventListener("click", function () {
+                startHfDownload(repoId, file, statusSpan, progressTrack, actions, true);
+              });
+              actions.appendChild(forceBtn);
+              return;
+            }
+            statusSpan.textContent = messageFor(res.data && res.data.code, res.data && res.data.error);
+            var retryBtn = document.createElement("button");
+            retryBtn.type = "button";
+            retryBtn.className = "btn btn-primary btn-sm";
+            retryBtn.textContent = '${tJs("models.actionRetry", lang)}';
+            retryBtn.addEventListener("click", function () {
+              showHfDownloadConfirm(repoId, file, false, statusSpan, progressTrack, actions);
+            });
+            actions.appendChild(retryBtn);
+          }).catch(function () {
+            statusSpan.textContent = messageFor("INTERNAL");
+          });
+        }
+
+        function showHfDownloadConfirm(repoId, file, gated, statusSpan, progressTrack, actions) {
+          var frag = document.createElement("div");
+
+          var title = document.createElement("div");
+          title.className = "mcat-modal__title";
+          title.textContent = '${tJs("models.hfDownloadConfirmTitle", lang)}'.replace("{file}", file);
+          frag.appendChild(title);
+
+          var warn = document.createElement("p");
+          warn.textContent = '${tJs("models.hfDownloadConfirmWarning", lang)}';
+          frag.appendChild(warn);
+
+          if (gated) {
+            var gatedP = document.createElement("p");
+            gatedP.textContent = mcat_hfTokenConfigured
+              ? '${tJs("models.hfGatedWithToken", lang)}'
+              : '${tJs("models.hfGatedNoToken", lang)}';
+            frag.appendChild(gatedP);
+          }
+
+          var modalActions = document.createElement("div");
+          modalActions.className = "mcat-modal__actions";
+
+          var cancelBtn = document.createElement("button");
+          cancelBtn.type = "button";
+          cancelBtn.className = "btn btn-secondary btn-sm";
+          cancelBtn.textContent = '${tJs("models.deleteCancelButton", lang)}';
+          cancelBtn.addEventListener("click", hideModal);
+          modalActions.appendChild(cancelBtn);
+
+          var confirmBtn = document.createElement("button");
+          confirmBtn.type = "button";
+          confirmBtn.className = "btn btn-primary btn-sm";
+          confirmBtn.textContent = '${tJs("models.hfDownloadConfirmButton", lang)}';
+          confirmBtn.addEventListener("click", function () {
+            hideModal();
+            startHfDownload(repoId, file, statusSpan, progressTrack, actions, false);
+          });
+          modalActions.appendChild(confirmBtn);
+          frag.appendChild(modalActions);
+
+          var mc = document.getElementById("mcat-modal-content");
+          mc.replaceChildren();
+          mc.appendChild(frag);
+          showModal();
+        }
+
+        function buildHfFileRow(repoId, file, gated) {
+          var row = document.createElement("div");
+          row.className = "mcat-hf-result__file-row";
+
+          var nameSpan = document.createElement("span");
+          nameSpan.className = "mcat-hf-result__file-name mono";
+          nameSpan.textContent = file;
+          row.appendChild(nameSpan);
+
+          var statusSpan = document.createElement("span");
+          statusSpan.className = "mcat-card__status-text";
+          row.appendChild(statusSpan);
+
+          var actions = document.createElement("span");
+          actions.className = "mcat-hf-result__file-actions";
+          var downloadBtn = document.createElement("button");
+          downloadBtn.type = "button";
+          downloadBtn.className = "btn btn-primary btn-sm";
+          downloadBtn.textContent = '${tJs("models.actionDownload", lang)}';
+          downloadBtn.addEventListener("click", function () {
+            showHfDownloadConfirm(repoId, file, gated, statusSpan, progressTrack, actions);
+          });
+          actions.appendChild(downloadBtn);
+          row.appendChild(actions);
+
+          var progressTrack = document.createElement("div");
+          progressTrack.className = "mcat-card__progress-track";
+          progressTrack.hidden = true;
+          var progressBar = document.createElement("div");
+          progressBar.className = "mcat-card__progress-bar";
+          progressTrack.appendChild(progressBar);
+          row.appendChild(progressTrack);
+
+          return row;
+        }
+
         // --- Browse Hugging Face search ---
         function renderHfResults(results) {
           var wrap = document.getElementById("mcat-hf-results");
@@ -985,6 +1207,16 @@ function modelCatalogClientJS(lang) {
             link.style.marginTop = "0.35rem";
             link.textContent = '${tJs("models.hfViewOnHf", lang)}';
             card.appendChild(link);
+
+            var files = r.ggufFiles || [];
+            if (files.length > 0) {
+              var filesWrap = document.createElement("div");
+              filesWrap.className = "mcat-hf-result__files-list";
+              files.forEach(function (f) {
+                filesWrap.appendChild(buildHfFileRow(r.id, f, !!r.gated));
+              });
+              card.appendChild(filesWrap);
+            }
 
             wrap.appendChild(card);
           });

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -686,6 +686,11 @@ export const translations = {
   "models.runtimeStateRunning": { en: "Running", es: "En ejecución" },
   "models.runtimeStateStopped": { en: "Not running", es: "No se está ejecutando" },
   "models.runtimeStateUnhealthy": { en: "Crashed", es: "Fallido" },
+  "models.runtimeStateReloading": { en: "Reloading after update", es: "Recargando tras la actualización" },
+  "models.runtimeStateReloadingHint": {
+    en: "This model was running before the gateway restarted — click Start to bring it back.",
+    es: "Este modelo estaba en ejecución antes de que se reiniciara la puerta de enlace — haz clic en Iniciar para volver a activarlo.",
+  },
   "models.runtimeColModel": { en: "Model", es: "Modelo" },
   "models.runtimeColState": { en: "State", es: "Estado" },
   "models.runtimeColPort": { en: "Port", es: "Puerto" },
@@ -771,6 +776,21 @@ export const translations = {
   "models.hfResultLicenseUnknown": { en: "License unknown", es: "Licencia desconocida" },
   "models.hfResultFiles": { en: "{n} GGUF file(s)", es: "{n} archivo(s) GGUF" },
   "models.hfViewOnHf": { en: "View on Hugging Face", es: "Ver en Hugging Face" },
+
+  // Browse Hugging Face downloads (Task 13 fix round 1, finding 1)
+  "models.hfDownloadConfirmTitle": { en: "Download {file}?", es: "¿Descargar {file}?" },
+  "models.hfDownloadConfirmWarning": {
+    en: "This file is not curated by Crow. You are trusting the uploader's file — model files are parsed by the local runtime, and a malicious file targets exactly that parser.",
+    es: "Este archivo no está seleccionado por Crow. Confías en el archivo de quien lo subió — los archivos de modelo son analizados por el runtime local, y un archivo malicioso apunta exactamente a ese analizador.",
+  },
+  "models.hfDownloadConfirmButton": { en: "Download anyway", es: "Descargar de todos modos" },
+  "models.actionForceDownload": { en: "Download anyway (may not fit)", es: "Descargar de todos modos (puede no caber)" },
+  "models.errWontFit": { en: "This file is unlikely to fit on this hardware.", es: "Es poco probable que este archivo quepa en este hardware." },
+  "models.errInvalidHf": { en: "That doesn't look like a valid Hugging Face repo or file.", es: "Eso no parece ser un repositorio o archivo válido de Hugging Face." },
+  "models.errNoVerifiableChecksum": {
+    en: "This file has no verifiable checksum — refusing to download an unverifiable file.",
+    es: "Este archivo no tiene una suma de verificación comprobable — nos negamos a descargar un archivo no verificable.",
+  },
   "models.hfFitUnknownHint": {
     en: "File size isn't available from search results — check the file size on Hugging Face before downloading.",
     es: "El tamaño del archivo no está disponible en los resultados de búsqueda — verifica el tamaño en Hugging Face antes de descargar.",

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -23,6 +23,7 @@ export const translations = {
   "nav.blog": { en: "Blog", es: "Blog" },
   "nav.files": { en: "Files", es: "Archivos" },
   "nav.extensions": { en: "Extensions", es: "Extensiones" },
+  "nav.model-catalog": { en: "Model Catalog", es: "Catálogo de modelos" },
   "nav.skills": { en: "Skills", es: "Habilidades" },
   "nav.settings": { en: "Settings", es: "Ajustes" },
   "nav.contacts": { en: "Contacts", es: "Contactos" },
@@ -654,6 +655,162 @@ export const translations = {
   "extensions.configureFailed": { en: "Save failed", es: "Error al guardar" },
   "extensions.collectionBusy": { en: "Another install is already running — wait for it to finish.", es: "Ya hay otra instalación en curso — espera a que termine." },
   "extensions.noResults": { en: "No add-ons match your search.", es: "Ningún complemento coincide con tu búsqueda." },
+
+  // ─── Model Catalog Panel (Item G) ───
+  "models.pageTitle": { en: "Model Catalog", es: "Catálogo de modelos" },
+  "models.pageIntro": {
+    en: "Browse a curated catalog of local models, or search Hugging Face directly for advanced options. Downloaded models register automatically and are ready to use in chat.",
+    es: "Explora un catálogo seleccionado de modelos locales, o busca directamente en Hugging Face para opciones avanzadas. Los modelos descargados se registran automáticamente y quedan listos para usar en el chat.",
+  },
+  "models.tabCurated": { en: "Curated", es: "Seleccionados" },
+  "models.tabBrowseHf": { en: "Browse Hugging Face", es: "Explorar Hugging Face" },
+  "models.emptyCatalog": { en: "The model catalog could not be loaded.", es: "No se pudo cargar el catálogo de modelos." },
+
+  // Runtime status strip
+  "models.runtimeHeading": { en: "Runtime status", es: "Estado del runtime" },
+  "models.runtimeBinary": { en: "Runtime: {name} {release}", es: "Runtime: {name} {release}" },
+  "models.runtimeNoBinary": { en: "No runtime detected yet.", es: "Aún no se ha detectado el runtime." },
+  "models.runtimeHardware": { en: "Detected: {accel} · RAM available: {ram} · Disk free: {disk}", es: "Detectado: {accel} · RAM disponible: {ram} · Disco libre: {disk}" },
+  "models.runtimeGpu": { en: "GPU: {gpu} ({vram})", es: "GPU: {gpu} ({vram})" },
+  "models.runtimeNoGpu": { en: "No GPU detected — running on CPU only.", es: "No se detectó GPU — se ejecuta solo en CPU." },
+  "models.runtimeWsl2": {
+    en: "Running under WSL2 — CPU only in this version; GPU acceleration is not yet available inside WSL2.",
+    es: "Ejecutándose en WSL2 — solo CPU en esta versión; la aceleración por GPU aún no está disponible dentro de WSL2.",
+  },
+  "models.runtimeUnknownFields": { en: "Couldn't detect: {fields}", es: "No se pudo detectar: {fields}" },
+  "models.runtimeReprobe": { en: "Re-detect hardware", es: "Volver a detectar hardware" },
+  "models.runtimeReprobing": { en: "Detecting...", es: "Detectando..." },
+  "models.runtimeActiveDownloads": { en: "{n} download(s) in progress", es: "{n} descarga(s) en curso" },
+  "models.runtimeEstimatedRam": { en: "Estimated resources in use by running models: {ram}", es: "Recursos estimados en uso por los modelos en ejecución: {ram}" },
+  "models.runtimeNoModelsRunning": { en: "No models currently running.", es: "No hay modelos en ejecución actualmente." },
+  "models.runtimeStateRunning": { en: "Running", es: "En ejecución" },
+  "models.runtimeStateStopped": { en: "Not running", es: "No se está ejecutando" },
+  "models.runtimeStateUnhealthy": { en: "Crashed", es: "Fallido" },
+  "models.runtimeColModel": { en: "Model", es: "Modelo" },
+  "models.runtimeColState": { en: "State", es: "Estado" },
+  "models.runtimeColPort": { en: "Port", es: "Puerto" },
+  "models.runtimeColPid": { en: "PID", es: "PID" },
+  "models.runtimeColRestarts": { en: "Restarts", es: "Reinicios" },
+  "models.runtimeColLastError": { en: "Last error", es: "Último error" },
+  "models.runtimeColActions": { en: "Actions", es: "Acciones" },
+
+  // Curated tab
+  "models.groupSmall": { en: "Small (CPU-capable)", es: "Pequeños (compatibles con CPU)" },
+  "models.groupMid": { en: "Mid-size", es: "Tamaño medio" },
+  "models.groupLarge": { en: "Large", es: "Grandes" },
+  "models.groupOther": { en: "Other", es: "Otros" },
+  "models.recommendedBadge": { en: "Recommended first model", es: "Modelo recomendado para empezar" },
+  "models.gatedBadge": { en: "Gated", es: "Acceso restringido" },
+  "models.statusRunning": { en: "Running", es: "En ejecución" },
+  "models.cardLab": { en: "Lab: {lab}", es: "Laboratorio: {lab}" },
+  "models.cardLicense": { en: "License: {license}", es: "Licencia: {license}" },
+  "models.cardContext": { en: "{n} token context", es: "Contexto de {n} tokens" },
+  "models.quantLabel": { en: "Variant", es: "Variante" },
+
+  // Fit badges
+  "models.fitFits": { en: "Fits", es: "Cabe" },
+  "models.fitTight": { en: "Tight", es: "Ajustado" },
+  "models.fitWontFit": { en: "Won't fit", es: "No cabe" },
+  "models.fitUnknown": { en: "Unknown", es: "Desconocido" },
+  "models.fitFitsHint": { en: "Comfortably fits your detected hardware.", es: "Se ajusta cómodamente a tu hardware detectado." },
+  "models.fitTightHint": { en: "Close to your limits — may run slowly or use swap.", es: "Cerca de tus límites — puede ejecutarse lento o usar memoria de intercambio." },
+  "models.fitWontFitHint": { en: "Needs more RAM/VRAM than this machine has available.", es: "Necesita más RAM/VRAM de la que esta máquina tiene disponible." },
+  "models.fitUnknownHint": { en: "Couldn't verify fit — this may not run.", es: "No se pudo verificar si es compatible — puede que no funcione." },
+
+  // Actions
+  "models.actionDownload": { en: "Download", es: "Descargar" },
+  "models.actionDownloading": { en: "Downloading...", es: "Descargando..." },
+  "models.actionRegistering": { en: "Registering...", es: "Registrando..." },
+  "models.actionStart": { en: "Start", es: "Iniciar" },
+  "models.actionStarting": { en: "Starting...", es: "Iniciando..." },
+  "models.actionStop": { en: "Stop", es: "Detener" },
+  "models.actionStopping": { en: "Stopping...", es: "Deteniendo..." },
+  "models.actionRemove": { en: "Remove", es: "Eliminar" },
+  "models.actionRetry": { en: "Retry", es: "Reintentar" },
+  "models.actionTryInChat": { en: "Try it in chat", es: "Probarlo en el chat" },
+  "models.downloadSuccess": { en: "Registered — try it in chat.", es: "Registrado — pruébalo en el chat." },
+  "models.downloadErrorGated": {
+    en: "Download failed. This model is gated — accept the license on huggingface.co, then retry.",
+    es: "Error al descargar. Este modelo tiene acceso restringido — acepta la licencia en huggingface.co y vuelve a intentarlo.",
+  },
+
+  // Gated three-state copy
+  "models.gatedNoToken": {
+    en: "This model requires a Hugging Face login. Add a token in the Browse Hugging Face tab below, then retry.",
+    es: "Este modelo requiere iniciar sesión en Hugging Face. Agrega un token en la pestaña Explorar Hugging Face y vuelve a intentarlo.",
+  },
+  "models.gatedTokenConfigured": {
+    en: "A Hugging Face token is configured. If the download fails, accept this model's license on huggingface.co, then retry.",
+    es: "Hay un token de Hugging Face configurado. Si la descarga falla, acepta la licencia de este modelo en huggingface.co y vuelve a intentarlo.",
+  },
+
+  // Delete confirmation
+  "models.deleteConfirmTitle": { en: "Remove {model}?", es: "¿Eliminar {model}?" },
+  "models.deleteConfirmIntro": {
+    en: "This will stop the model, delete the downloaded file, and remove it as a provider.",
+    es: "Esto detendrá el modelo, eliminará el archivo descargado y lo quitará como proveedor.",
+  },
+  "models.deleteBindingsIntro": { en: "The following will be affected:", es: "Lo siguiente se verá afectado:" },
+  "models.deleteNoBindings": { en: "Nothing else references this model.", es: "Nada más hace referencia a este modelo." },
+  "models.deleteConfirmButton": { en: "Remove anyway", es: "Eliminar de todos modos" },
+  "models.deleteCancelButton": { en: "Cancel", es: "Cancelar" },
+  "models.deleteSuccess": { en: "Removed.", es: "Eliminado." },
+
+  // Browse Hugging Face tab
+  "models.hfIntro": {
+    en: "Search Hugging Face directly for GGUF models. These are not curated by Crow — you are trusting the uploader's file; model files are parsed by the local runtime, and a malicious file targets exactly that parser.",
+    es: "Busca directamente en Hugging Face modelos GGUF. Crow no selecciona estos modelos — confías en el archivo de quien lo subió; los archivos de modelo son analizados por el runtime local, y un archivo malicioso apunta exactamente a ese analizador.",
+  },
+  "models.hfSearchLabel": { en: "Search Hugging Face", es: "Buscar en Hugging Face" },
+  "models.hfSearchPlaceholder": { en: "e.g. mistral, llama, gguf...", es: "por ejemplo: mistral, llama, gguf..." },
+  "models.hfSearchButton": { en: "Search", es: "Buscar" },
+  "models.hfSearching": { en: "Searching...", es: "Buscando..." },
+  "models.hfSearchEmpty": { en: "No GGUF repositories matched your search.", es: "Ningún repositorio GGUF coincide con tu búsqueda." },
+  "models.hfResultDownloads": { en: "{n} downloads", es: "{n} descargas" },
+  "models.hfResultLikes": { en: "{n} likes", es: "{n} me gusta" },
+  "models.hfResultLicenseUnknown": { en: "License unknown", es: "Licencia desconocida" },
+  "models.hfResultFiles": { en: "{n} GGUF file(s)", es: "{n} archivo(s) GGUF" },
+  "models.hfViewOnHf": { en: "View on Hugging Face", es: "Ver en Hugging Face" },
+  "models.hfFitUnknownHint": {
+    en: "File size isn't available from search results — check the file size on Hugging Face before downloading.",
+    es: "El tamaño del archivo no está disponible en los resultados de búsqueda — verifica el tamaño en Hugging Face antes de descargar.",
+  },
+  "models.hfGatedNoToken": { en: "Gated — requires a Hugging Face login.", es: "Acceso restringido — requiere iniciar sesión en Hugging Face." },
+  "models.hfGatedWithToken": {
+    en: "Gated — your token may still need the license accepted on huggingface.co.",
+    es: "Acceso restringido — es posible que tu token aún necesite que se acepte la licencia en huggingface.co.",
+  },
+
+  // Hugging Face token
+  "models.hfTokenLabel": { en: "Hugging Face token (optional)", es: "Token de Hugging Face (opcional)" },
+  "models.hfTokenPlaceholder": { en: "hf_...", es: "hf_..." },
+  "models.hfTokenSave": { en: "Save token", es: "Guardar token" },
+  "models.hfTokenClear": { en: "Clear token", es: "Borrar token" },
+  "models.hfTokenConfigured": { en: "A token is configured.", es: "Hay un token configurado." },
+  "models.hfTokenNotConfigured": {
+    en: "No token configured — gated models will say so before you download.",
+    es: "No hay un token configurado — los modelos con acceso restringido lo indicarán antes de descargar.",
+  },
+  "models.hfTokenSaved": { en: "Token saved.", es: "Token guardado." },
+  "models.hfTokenCleared": { en: "Token cleared.", es: "Token borrado." },
+  "models.hfTokenSaveFailed": { en: "Could not save token: {error}", es: "No se pudo guardar el token: {error}" },
+  "models.hfTokenHint": {
+    en: "Stored the same way cloud provider API keys are — never displayed again after saving.",
+    es: "Se guarda de la misma forma que las claves API de los proveedores en la nube — nunca se vuelve a mostrar después de guardarlo.",
+  },
+
+  // Error-code mapping (Task 12 route error codes -> user-facing copy)
+  "models.errNetworkDenied": { en: "Not reachable from this network.", es: "No es accesible desde esta red." },
+  "models.errUnauthenticated": { en: "Your session expired — reload the page and log in again.", es: "Tu sesión expiró — recarga la página e inicia sesión de nuevo." },
+  "models.errUnknownModel": { en: "Unknown model.", es: "Modelo desconocido." },
+  "models.errUnknownQuant": { en: "Unknown variant for this model.", es: "Variante desconocida para este modelo." },
+  "models.errNotInstalled": { en: "This model isn't installed.", es: "Este modelo no está instalado." },
+  "models.errStartFailed": { en: "The model failed to start in time.", es: "El modelo no pudo iniciarse a tiempo." },
+  "models.errNotNative": { en: "This model can't be started this way.", es: "Este modelo no se puede iniciar de esta forma." },
+  "models.errMissingQuery": { en: "Enter a search term.", es: "Ingresa un término de búsqueda." },
+  "models.errHfUpstream": { en: "Hugging Face is unreachable right now.", es: "Hugging Face no está disponible en este momento." },
+  "models.errBadToken": { en: "That token doesn't look valid.", es: "Ese token no parece válido." },
+  "models.errInternal": { en: "Something went wrong.", es: "Algo salió mal." },
 
   // ─── Skills Panel ───
   "skills.pageTitle": { en: "Skills", es: "Habilidades" },

--- a/servers/gateway/dashboard/shared/layout.js
+++ b/servers/gateway/dashboard/shared/layout.js
@@ -858,6 +858,7 @@ const NAV_ICONS = {
   mic: `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="2" width="6" height="11" rx="3"/><path d="M5 10a7 7 0 0 0 14 0"/><line x1="12" y1="17" x2="12" y2="21"/><line x1="9" y1="21" x2="15" y2="21"/></svg>`,
   contacts: `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
   skills: `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/><line x1="8" y1="7" x2="16" y2="7"/><line x1="8" y1="11" x2="14" y2="11"/></svg>`,
+  models: `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="1" x2="9" y2="4"/><line x1="15" y1="1" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="23"/><line x1="15" y1="20" x2="15" y2="23"/><line x1="1" y1="9" x2="4" y2="9"/><line x1="1" y1="15" x2="4" y2="15"/><line x1="20" y1="9" x2="23" y2="9"/><line x1="20" y1="15" x2="23" y2="15"/></svg>`,
   default: `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>`,
 };
 

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -75,6 +75,10 @@ import {
 } from "./provider-health.js";
 import { resolveDataDir, createDbClient } from "../db.js";
 import { loadState, saveState, reconcileOnBoot } from "./models/state.js";
+// wasLive-marker plumbing lives in this file (not state.js) so it can reuse
+// `startNativeAndAwaitReady`'s ALREADY-resolved `dir` — see
+// `persistLivenessMarker`'s doc below for why this deliberately never
+// calls the bare `resolveDataDir()` on its own.
 import { acquireHostLock } from "./models/native-lock.js";
 import { identityProbe, startModel, stopModel, ensureRuntime, nativeReadinessTimeoutMs } from "./models/runtime.js";
 import { getCachedProbe, reprobe } from "./models/probe.js";
@@ -560,6 +564,42 @@ async function waitForNativeReady(baseUrl, alias, {
 }
 
 /**
+ * Persist the "was this model live" marker `state.js`'s
+ * `registryEntryRuntimeState` reads to distinguish a deliberately-stopped
+ * model from one that's mid-restart-recovery (Task 13 fix round 1, finding
+ * c — the panel's "reloading after update" state).
+ *
+ * Deliberately uses the REAL `loadState`/`saveState` against the EXACT
+ * `dir` its caller already resolved (via the injectable `resolveDataDirFn`
+ * every existing test in this file stubs to something like
+ * `"/fake/crow-home"`) rather than re-resolving `resolveDataDir()` itself —
+ * a bare, unmocked `resolveDataDir()` call falls back to the REAL
+ * `~/.crow/data` when `CROW_DATA_DIR` isn't set in the calling process,
+ * which every test in this file that exercises the native-start path is
+ * exactly that case (`node --test <this file>` alone, outside `npm test`'s
+ * scratch-CROW_HOME wrapper). Wrapped in try/catch and never throws: this
+ * is a UI-only marker, and a fixture/test `dir` that was never meant to be
+ * written to must degrade to a harmless no-op (an EACCES/ENOENT at a path
+ * like `/fake/crow-home`), never break process supervision or the caller's
+ * return value.
+ */
+function persistLivenessMarker(dir, modelId, { wasLive }) {
+  try {
+    const state = loadState(dir);
+    const entry = state.registry?.[modelId];
+    if (!entry) return; // nothing registered under this id — nothing to mark
+    state.registry[modelId] = {
+      ...entry,
+      wasLive,
+      lastStoppedAt: wasLive ? null : new Date().toISOString(),
+    };
+    saveState(dir, state);
+  } catch (err) {
+    console.warn(`[gpu-orchestrator] failed to persist liveness marker for ${modelId}: ${err.message}`);
+  }
+}
+
+/**
  * Start a native provider's llama-server process and wait for it to report
  * itself resident. Binds the EXACT port already encoded in `p.baseUrl` —
  * NEVER re-allocates a fresh one from the port pool. A bind failure (the
@@ -622,8 +662,18 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
 
   const binPath = preResolvedBinPath || await resolveNativeBinPath(p, opts);
 
+  // Wrap the caller's onTerminal (if any — `acquireOrStartNative` passes
+  // its lock-release closure here) so the SAME single, exactly-once
+  // terminal transition also clears the wasLive marker BEFORE the lock
+  // frees and BEFORE any restart could happen — finding c above. Reuses
+  // this function's own already-resolved `dir`, never re-resolves it.
+  const wrappedOnTerminal = (reason) => {
+    persistLivenessMarker(dir, providerName, { wasLive: false });
+    if (typeof onTerminal === "function") onTerminal(reason);
+  };
+
   console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port}, readinessTimeoutMs=${readinessTimeoutMs})`);
-  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal });
+  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal: wrappedOnTerminal });
   _nativeHandles.set(providerName, handle);
 
   const result = await waitForNativeReady(p.baseUrl, alias, {
@@ -637,6 +687,7 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
   if (result === "resident") {
     console.log(`[gpu-orchestrator] ${providerName} ready`);
     _lastUsedAt.set(providerName, Date.now());
+    persistLivenessMarker(dir, providerName, { wasLive: true });
     return true;
   }
 

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -188,6 +188,23 @@ export function _setNativeHandleForTest(name, handle) {
   else _nativeHandles.set(name, handle);
 }
 
+/**
+ * Read-only accessor for this process's live `startModel()` handle for a
+ * native-runtime provider (Item G, Task 12 follow-up from PR G-B's final
+ * review: the models panel's stop/delete routes need to reach a live
+ * process handle to hand into `manager.js`'s `unregisterModel({
+ * runtimeHandle })` / to call `.stop()` directly, and `_nativeHandles` had
+ * no public accessor — only the test-only seed/clear setter above).
+ * Returns the handle (`{ live, stop(), status(), touch() }`, see
+ * `runtime.js`'s `startModel` doc) or `null` if this process has no live
+ * handle for `providerName` (nothing started here since boot, or it was
+ * already stopped). Deliberately just a getter — no new mutation surface;
+ * callers that need to stop it call `.stop()` on the returned handle
+ * themselves (mirroring the sibling-eviction code in this same file). */
+export function getNativeHandle(providerName) {
+  return _nativeHandles.get(providerName) || null;
+}
+
 // -----------------------------------------------------------------------
 // Bundle control
 // -----------------------------------------------------------------------

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -1,6 +1,7 @@
 /**
  * GGUF model download + registration pipeline (Item G, native model
- * runtime, Tasks 6-7).
+ * runtime, Tasks 6-7; Task 13 fix round 1 added Browse-Hugging-Face
+ * downloads and a typed HTTP-status error).
  *
  * Everything above `// --- provider registration (Task 7) ---` is the
  * download engine (Task 6) — it only ever touches the filesystem +
@@ -8,6 +9,14 @@
  * a downloaded blob into a running llama.cpp provider row (`registerModel`),
  * tears one down (`unregisterModel`), and answers "what points at this
  * provider" for the delete-confirmation dialog (`providerBindings`).
+ *
+ * The "Browse Hugging Face — un-vetted-repo downloads" section (search for
+ * that heading below, just above `deleteModel`) is Task 13 fix round 1:
+ * `downloadHfFile`/`fetchHfPathInfo` let the panel's advanced search tab
+ * download an arbitrary GGUF file the operator picked, verified against a
+ * sha256 fetched live from Hugging Face — reusing this same download
+ * engine (`downloadModel`) via a synthetic one-model catalog, not a
+ * parallel implementation.
  *
  * Two layers (Task 6, downloads):
  *
@@ -164,6 +173,61 @@ export class DownloadTimeoutError extends Error {
  * `runtime.js`'s `DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS`). Injectable end to
  * end via `fetchModelBlob({ timeoutMs })` / `downloadModel({ timeoutMs })`. */
 export const DEFAULT_DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/** Thrown when a download hop returns a non-redirect, non-200/206 HTTP
+ * status (Task 13 fix round 1, finding d). Replaces a bare `Error` so
+ * callers can branch on `.statusCode`/`.code` (`"HTTP_403"`, `"HTTP_404"`,
+ * ...) instead of string-matching the message — the panel's gated-model
+ * retry copy in particular needs to detect "this was specifically a 403"
+ * without parsing free text that could drift. */
+export class HttpStatusError extends Error {
+  constructor(statusCode, url) {
+    super(`Unexpected HTTP status ${statusCode} downloading ${url}`);
+    this.name = "HttpStatusError";
+    this.code = `HTTP_${statusCode}`;
+    this.statusCode = statusCode;
+  }
+}
+
+/** Thrown by `fetchHfPathInfo` on a non-2xx response from Hugging Face's
+ * paths-info API (network error, or the API itself refusing/erroring —
+ * confirmed live: a repo Hugging Face won't resolve returns 401, not 404,
+ * so this is intentionally NOT statusCode-specific). */
+export class HfMetadataError extends Error {
+  constructor(message, statusCode) {
+    super(message);
+    this.name = "HfMetadataError";
+    this.code = "HF_METADATA_ERROR";
+    this.statusCode = statusCode ?? null;
+  }
+}
+
+/** Thrown when the requested file does not appear in the repo at all —
+ * confirmed live: Hugging Face's paths-info API answers a nonexistent path
+ * inside a real repo with `200 []`, not a 404, so this must be detected by
+ * an empty/missing result, not inferred from the HTTP status. */
+export class HfFileNotFoundError extends Error {
+  constructor(hfRepo, file) {
+    super(`File not found in Hugging Face repo ${hfRepo}: ${file}`);
+    this.name = "HfFileNotFoundError";
+    this.code = "HF_FILE_NOT_FOUND";
+  }
+}
+
+/** Thrown when Hugging Face reports the requested file with no LFS `oid` —
+ * i.e. it isn't an LFS-tracked object, so there is no content-hash we can
+ * verify a download against (a non-LFS `oid` is a git blob SHA-1 over a
+ * git-wrapped object, not a bare-content sha256 — it would never match
+ * `fetchModelBlob`'s streamed sha256 of the raw bytes, so trusting it would
+ * be actively misleading, not just weaker). The un-vetted/advanced-tab
+ * download path never downloads a file it cannot verify. */
+export class NoVerifiableChecksumError extends Error {
+  constructor(file) {
+    super(`This file has no verifiable checksum (not LFS-tracked): ${file}`);
+    this.name = "NoVerifiableChecksumError";
+    this.code = "NO_VERIFIABLE_CHECKSUM";
+  }
+}
 
 /** Thrown by `registerModel` when a provider row already exists at the
  * target id and was NOT registered by this native runtime for this catalog
@@ -341,7 +405,7 @@ async function openStream({ url, headers, lookup, maxRedirects, insecureHttpHost
     }
     if (res.statusCode !== 200 && res.statusCode !== 206) {
       res.resume();
-      throw new Error(`Unexpected HTTP status ${res.statusCode} downloading ${currentUrl}`);
+      throw new HttpStatusError(res.statusCode, currentUrl);
     }
     return { res, finalUrl: currentUrl };
   }
@@ -485,6 +549,7 @@ export async function fetchModelBlob({
   createWriteStream = fsCreateWriteStream,
   insecureHttpHosts = [],
   timeoutMs = DEFAULT_DOWNLOAD_TIMEOUT_MS,
+  extraHeaders,
 }) {
   assertNotSymlink(dest);
 
@@ -496,7 +561,11 @@ export async function fetchModelBlob({
     await rehashPrefix(dest, effectiveResumeFrom, hash);
   }
 
-  const headers = {};
+  // `extraHeaders` (e.g. an HF `Authorization: Bearer <token>` for a gated
+  // repo — Task 13 fix round 1) is caller-supplied and merged first, so the
+  // Range header this function computes for a resume can never be
+  // shadowed by it.
+  const headers = { ...(extraHeaders || {}) };
   if (effectiveResumeFrom > 0) headers.Range = `bytes=${effectiveResumeFrom}-`;
 
   const { res } = await openStream({ url, headers, lookup, maxRedirects, insecureHttpHosts, timeoutMs });
@@ -562,6 +631,7 @@ export async function downloadModel({
   journalIntervalMs = 1000,
   insecureHttpHosts,
   timeoutMs,
+  extraHeaders,
 }) {
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
   const blobDir = modelsBlobDir(dir);
@@ -615,6 +685,7 @@ export async function downloadModel({
       createWriteStream,
       insecureHttpHosts,
       timeoutMs,
+      extraHeaders,
       onProgress: wrappedOnProgress,
     });
     const s = loadState(dir);
@@ -639,6 +710,219 @@ export async function downloadModel({
     persistJournal(bytesDone);
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Browse Hugging Face — un-vetted-repo downloads (Task 13 fix round 1,
+// finding 1: Kevin decided to build this in-PR).
+//
+// The curated path above trusts a PR-reviewed, sha256-pinned catalog entry.
+// This path has no such review — the operator is choosing an arbitrary
+// GGUF file out of Hugging Face's public search. The ONE non-negotiable
+// safety property this section exists to guarantee: a file is NEVER
+// downloaded (or, having been downloaded, never registered as a runnable
+// provider) without an independently-fetched, verified sha256 to check it
+// against. Hugging Face's `paths-info` API is queried BEFORE any byte of
+// the file itself is requested; if it reports no LFS `oid` for the path
+// (i.e. the file isn't LFS-tracked — a git-blob `oid` is a SHA-1 over a
+// git-wrapped object, not a content sha256, and would never match anyway),
+// this refuses outright rather than downloading something it cannot verify.
+// ---------------------------------------------------------------------------
+
+/** Strict shape check for a Hugging Face repo id: exactly `owner/name`, two
+ * path segments, conservative charset (letters/digits/`_`/`.`/`-`) — no
+ * traversal, no query strings, no extra segments. Reused by
+ * `routes/models.js`'s `POST /hf-download` 400 gate so the shape rule lives
+ * in exactly one place. */
+const HF_REPO_SHAPE_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,96}\/[A-Za-z0-9][A-Za-z0-9_.-]{0,96}$/;
+export function isValidHfRepoId(hfRepo) {
+  return typeof hfRepo === "string" && HF_REPO_SHAPE_RE.test(hfRepo);
+}
+
+/** Strict shape check for a single filename requested from a Hugging Face
+ * repo: no path separators (so it can never escape the repo root or the
+ * on-disk blobs dir once handed to `sanitizeFilename`), not `.`/`..`,
+ * conservative charset. */
+const HF_FILE_SHAPE_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,255}$/;
+export function isValidHfFilename(file) {
+  if (typeof file !== "string" || !file) return false;
+  if (file.includes("/") || file.includes("\\")) return false;
+  if (file === "." || file === "..") return false;
+  return HF_FILE_SHAPE_RE.test(file);
+}
+
+/** Reduce a Hugging Face filename to a safe, DB-friendly provider/model id:
+ * strip the `.gguf` extension, lowercase, collapse any run of characters
+ * outside `[a-z0-9._-]` into a single `-`, trim leading/trailing `-`.
+ * `registerModel`'s provider-id collision guard applies to whatever this
+ * returns exactly as it does for a curated catalog id — no special-casing
+ * needed there (Task 13 fix round 1, finding 1). */
+export function deriveModelIdFromFilename(file) {
+  const base = String(file ?? "").replace(/\.gguf$/i, "");
+  const slug = base
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+  if (!slug) {
+    throw new UnsafeDestinationError(`Could not derive a model id from filename: ${JSON.stringify(file)}`);
+  }
+  return slug;
+}
+
+/**
+ * Query Hugging Face's `paths-info` API for one file's LFS sha256 + size,
+ * BEFORE downloading anything. Confirmed against the real API (2026-07-19):
+ * `POST {hfApiBase}/api/models/{hfRepo}/paths-info/main` with
+ * `{paths:[file], expand:true}` returns `[{path, size, oid, lfs:{oid,
+ * size}}]` for a file that exists — `lfs.oid` IS the content sha256 for an
+ * LFS-tracked object (independently verified: matches the catalog's own
+ * pinned sha256 for `qwen3-4b`'s Q4_K_M file byte-for-byte). A path that
+ * doesn't exist in an otherwise-valid repo answers `200 []`, not a 404 —
+ * `HfFileNotFoundError` covers that case explicitly rather than trusting
+ * the HTTP status. A non-LFS file has no `lfs` key at all — `sha256` comes
+ * back `null` and the caller (`downloadHfFile`) refuses to proceed.
+ *
+ * @returns {Promise<{sha256: string|null, sizeBytes: number|null}>}
+ */
+export async function fetchHfPathInfo({
+  hfRepo,
+  file,
+  hfApiBase = "https://huggingface.co",
+  hfToken,
+  fetchImpl = fetch,
+  timeoutMs = 8000,
+}) {
+  const url = `${hfApiBase}/api/models/${hfRepo}/paths-info/main`;
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(hfToken ? { Authorization: `Bearer ${hfToken}` } : {}),
+      },
+      body: JSON.stringify({ paths: [file], expand: true }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    // Covers network errors AND AbortSignal.timeout() firing — matches
+    // routes/models.js's existing /hf-search collapse-to-one-code pattern.
+    throw new HfMetadataError(`Hugging Face metadata request failed: ${err.message || err}`);
+  }
+  if (!res.ok) {
+    throw new HfMetadataError(`Hugging Face metadata request failed (${res.status})`, res.status);
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    throw new HfMetadataError(`Hugging Face metadata response was not valid JSON: ${err.message}`);
+  }
+  const entry = Array.isArray(body) ? body.find((e) => e && e.path === file) : null;
+  if (!entry) {
+    throw new HfFileNotFoundError(hfRepo, file);
+  }
+  const sha256 = entry.lfs && typeof entry.lfs.oid === "string" ? entry.lfs.oid : null;
+  const sizeBytes = typeof entry.size === "number"
+    ? entry.size
+    : (entry.lfs && typeof entry.lfs.size === "number" ? entry.lfs.size : null);
+  return { sha256, sizeBytes };
+}
+
+/**
+ * Download one arbitrary GGUF file out of a Hugging Face repo the operator
+ * picked from the Browse-Hugging-Face search tab — not a curated catalog
+ * entry. Verifies the file's sha256 (fetched via `fetchHfPathInfo`, BEFORE
+ * any download traffic) and refuses outright if Hugging Face reports none
+ * (`NoVerifiableChecksumError` — see module doc above). Reuses the exact
+ * same journaled, resumable, incrementally-hashed engine curated downloads
+ * use (`downloadModel`) by building a one-model, one-quant SYNTHETIC
+ * catalog around the verified file — every safety property `downloadModel`/
+ * `fetchModelBlob` already have (host allowlist, https-only, symlink
+ * refusal, incremental sha256, resumable journal, disk-full/timeout
+ * handling) applies unchanged; nothing here re-implements any of it.
+ *
+ * `hfToken`, if given, is forwarded as `Authorization: Bearer <token>` to
+ * BOTH the metadata call and the actual file download (`extraHeaders`,
+ * threaded through `downloadModel`/`fetchModelBlob` — Task 13 fix round 1)
+ * — required for a gated repo's file to download at all.
+ *
+ * @returns {Promise<{path: string, sha256: string, modelId: string,
+ *   sizeMb: number|null, catalog: object}>} `catalog` is the synthetic
+ *   catalog this call built — the caller (routes/models.js) passes it
+ *   straight through to `registerModel`, which needs a catalog to resolve
+ *   the same entry back out of.
+ */
+export async function downloadHfFile({
+  hfRepo,
+  file,
+  dir,
+  onProgress,
+  hfToken,
+  hfApiBase,
+  fetchHfPathInfoFn = fetchHfPathInfo,
+  downloadModelFn = downloadModel,
+  lookup,
+  baseUrl,
+  maxRedirects,
+  createWriteStream,
+  journalIntervalMs,
+  insecureHttpHosts,
+  timeoutMs,
+}) {
+  if (!isValidHfRepoId(hfRepo)) {
+    throw new UnsafeDestinationError(`Invalid Hugging Face repo id: ${JSON.stringify(hfRepo)}`);
+  }
+  if (!isValidHfFilename(file)) {
+    throw new UnsafeDestinationError(`Invalid Hugging Face file name: ${JSON.stringify(file)}`);
+  }
+
+  const { sha256, sizeBytes } = await fetchHfPathInfoFn({ hfRepo, file, hfApiBase, hfToken });
+  if (!sha256) {
+    throw new NoVerifiableChecksumError(file);
+  }
+
+  const modelId = deriveModelIdFromFilename(file);
+  // Decimal MB (bytes / 1e6), matching the curated catalog's own size_mb
+  // convention — independently confirmed live against qwen3-4b's pinned
+  // catalog entry (2497280256 bytes -> 2497.28, exactly the catalog's
+  // size_mb). Used both as this synthetic quant's `size_mb` (fed into
+  // `fitBadge` by the route) and, via `registerModel`, as the registry
+  // entry's `sizeMb` that scales the native readiness timeout.
+  const sizeMb = typeof sizeBytes === "number" ? sizeBytes / 1_000_000 : null;
+
+  const catalog = {
+    models: [{
+      id: modelId,
+      family: hfRepo.split("/")[1] || hfRepo,
+      hf_repo: hfRepo,
+      task: "chat",
+      context_len: null,
+      default_quant: "hf",
+      quants: [{ file, quant: "hf", sha256, size_mb: sizeMb, min_ram_mb: sizeMb, min_vram_mb: 0 }],
+    }],
+  };
+
+  const extraHeaders = hfToken ? { Authorization: `Bearer ${hfToken}` } : undefined;
+
+  const result = await downloadModelFn({
+    modelId,
+    quant: "hf",
+    dir,
+    catalog,
+    onProgress,
+    lookup,
+    baseUrl,
+    maxRedirects,
+    createWriteStream,
+    journalIntervalMs,
+    insecureHttpHosts,
+    timeoutMs,
+    extraHeaders,
+  });
+
+  return { ...result, modelId, sizeMb, catalog };
 }
 
 /**
@@ -841,7 +1125,18 @@ export function pickChatMutexGroup(existingRows) {
  * catalog `size_mb`, MB, may be a float) is read back by
  * `gpu-orchestrator.js`'s native acquire path to scale the readiness
  * timeout to the model's actual size (Item G, Task 10) — it is NOT used by
- * `unregisterModel` or anything else in this file.
+ * `unregisterModel` or anything else in this file. Two more fields ride the
+ * same object but are NOT written here: `wasLive`/`lastStoppedAt`
+ * (Task 13 fix round 1, finding c) are set by `gpu-orchestrator.js` the
+ * first time the model actually becomes resident, not at registration time
+ * — a freshly-registered, never-started model correctly has neither.
+ *
+ * `registryExtra` (Task 13 fix round 1, finding 1), if given, is
+ * shallow-merged into the registry entry AFTER the fields above — the only
+ * caller today is `routes/models.js`'s `POST /hf-download` handler, which
+ * passes `{ source: "hf-browser" }` so the panel/registry can tell a
+ * Browse-Hugging-Face registration apart from a curated one. Defaults to
+ * `{}` (no-op) so every existing call site is unaffected.
  *
  * Injectable seams (`allocatePortFn`/`listProvidersAllFn`/`upsertProviderFn`/
  * `invalidateCacheFn`) default to the real implementations; tests use them
@@ -879,6 +1174,7 @@ export async function registerModel({
   listProvidersAllFn = listProvidersAll,
   upsertProviderFn = upsertProvider,
   invalidateCacheFn = invalidateProvidersCache,
+  registryExtra = {},
 }) {
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
 
@@ -905,6 +1201,7 @@ export async function registerModel({
     catalogId: model.id,
     registeredAt: new Date().toISOString(),
     sizeMb: Number.isFinite(quantEntry.size_mb) ? quantEntry.size_mb : null,
+    ...registryExtra,
   };
   saveState(dir, state);
 

--- a/servers/gateway/models/state.js
+++ b/servers/gateway/models/state.js
@@ -10,8 +10,14 @@
  *   - journal: in-progress model downloads (url/dest/bytesDone/expectedSha/
  *     startedAt) so a killed download can resume instead of restarting.
  *   - registry: models this CROW_HOME has actually installed (file/quant/
- *     catalogId/registeredAt), independent of whether a runtime is
- *     currently running for them.
+ *     catalogId/registeredAt/sizeMb), independent of whether a runtime is
+ *     currently running for them. Two optional fields ride the same entry:
+ *     `wasLive`/`lastStoppedAt` (Task 13 fix round 1, finding c — see
+ *     `registryEntryRuntimeState` below, written by `gpu-orchestrator.js`)
+ *     and `source` (e.g. `"hf-browser"` — Task 13 fix round 1, finding 1,
+ *     written by `manager.js`'s `registerModel` via its `registryExtra`
+ *     param) distinguishing an un-vetted Browse-Hugging-Face registration
+ *     from a curated one.
  *
  * `dir` is always injected by the caller — this module never guesses a
  * path itself. Production callers pass `resolveDataDir()` (the same
@@ -141,6 +147,38 @@ export async function allocatePort(state, modelId, { crowHome = resolveDataDir()
 /** Free modelId's port reservation, if any. No-op if it has none. */
 export function releasePort(state, modelId) {
   delete state.reservations[modelId];
+}
+
+/**
+ * Classify a registry entry's runtime state for the panel (Task 13 fix
+ * round 1, finding c — the "reloading after update" state).
+ *
+ * `live` is whatever `GET /api/models/runtime` (or the panel's SSR
+ * equivalent) already determined from the in-process handle snapshot for
+ * this process lifetime — this function never touches that itself, it only
+ * decides what to say when `live` is false.
+ *
+ * `entry.wasLive` is set by `gpu-orchestrator.js` the moment a native model
+ * actually becomes resident, and cleared back to `false` (with
+ * `lastStoppedAt` stamped) the moment it reaches ANY terminal state
+ * (explicit stop, sibling swap-out, idle-unload, crash-exhausted) WHILE
+ * that same gateway process is still running. That ordering is exactly
+ * what makes `wasLive === true` combined with `live === false` mean "this
+ * process never got the chance to see it stop" — i.e. the gateway itself
+ * restarted out from under a resident model — rather than "the user (or
+ * the system) deliberately stopped it," which always clears the marker
+ * before any restart could intervene. A model that was never started at
+ * all (or was cleanly stopped before the restart) has `wasLive` `false`/
+ * absent and correctly reads as plain `"stopped"`.
+ *
+ * @param {{wasLive?: boolean}|null|undefined} entry - a `state.registry[modelId]` entry
+ * @param {boolean} live - true iff this process currently has a live handle for it
+ * @returns {"running"|"stopped_after_restart"|"stopped"}
+ */
+export function registryEntryRuntimeState(entry, live) {
+  if (live) return "running";
+  if (entry && entry.wasLive === true) return "stopped_after_restart";
+  return "stopped";
 }
 
 /**

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -42,12 +42,12 @@
  * `models: []` array, so it is never a candidate for chat routing, mutex
  * arbitration, or the Providers-tab's enabled-row rendering paths (all of
  * which either skip disabled rows or key off `models[].task === "chat"`).
- * This intentionally means the token rides this instance's existing
- * provider fleet-sync (`servers/sharing/instance-sync.js`'s `SYNCED_TABLES`
- * includes `"providers"`, and `api_key` is not in that table's
- * `EXCLUDED_COLUMNS`) — the same already-accepted trade-off Settings ->
- * Providers keys make today (see `providers-db.js`'s module doc), not a
- * new one introduced here.
+ * UNLIKE a real cloud-provider key, this row is never broadcast to paired
+ * instances: it carries `gpu_policy: { local_only: true }`, a marker
+ * `shouldSyncRow`'s providers branch (`servers/sharing/instance-sync.js`)
+ * checks and excludes on BOTH emit and apply — see that function's doc for
+ * why this is a general convention (any providers row can opt out this
+ * way), not a hardcoded check against this one reserved id.
  */
 
 import { Router } from "express";
@@ -543,7 +543,15 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
         models: [],
         disabled: true,
         providerType: null,
-        gpuPolicy: null,
+        // local_only: true is the general convention `shouldSyncRow`'s
+        // providers branch (servers/sharing/instance-sync.js) checks to
+        // exclude a row from fleet instance-sync entirely — this row's
+        // base_url is a real (non-loopback) host, so without this marker
+        // it would otherwise sync in plaintext to every paired instance.
+        // Deliberately non-null (not `null`) even on a re-POST: upsertProvider's
+        // SQL COALESCEs a null gpu_policy into "keep existing" on UPDATE, so a
+        // null write here would silently fail to (re-)establish the marker.
+        gpuPolicy: { local_only: true },
       });
       await invalidateCacheFn();
       res.json({ configured: !!cleaned });

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -301,6 +301,19 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
         return res.status(202).json({ jobId, status: existing.status });
       }
 
+      // Task 13 fix round 2 (Important, confirmed Concern-1 from round 1):
+      // a gated curated entry (e.g. gemma-3-27b-it) could never actually
+      // authenticate its download even with a token configured — nothing
+      // forwarded it. Same lookup /hf-download already does, threaded the
+      // same way (extraHeaders -> downloadModel -> fetchModelBlob).
+      let hfToken = null;
+      const tokenDb = dbFactory();
+      try {
+        hfToken = await getHfToken(tokenDb);
+      } catch { /* best effort — an un-gated model still downloads fine unauthenticated */ }
+      finally { try { tokenDb.close(); } catch { /* best effort */ } }
+      const extraHeaders = hfToken ? { Authorization: `Bearer ${hfToken}` } : undefined;
+
       const dir = resolveDir();
       const job = {
         id: jobId,
@@ -325,6 +338,7 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
             quant: resolved.quantId,
             dir,
             catalog,
+            extraHeaders,
             onProgress: ({ bytesDone, totalBytes }) => {
               job.bytesDone = bytesDone;
               if (totalBytes != null) job.totalBytes = totalBytes;
@@ -491,14 +505,23 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
 
   router.delete("/api/models/:id", async (req, res) => {
     const modelId = req.params.id;
+    // Existence check is state.registry presence, NOT catalog membership
+    // (Task 13 fix round 2, critical regression fix) — an hf-browser
+    // model's derived id is never in the curated catalog, so gating on
+    // findModel() alone made every hf-browser download an unstoppable,
+    // undeletable zombie. findModel() is kept ONLY to distinguish "a real
+    // curated id that just hasn't been downloaded yet" (404 NOT_INSTALLED,
+    // existing behavior, still tested) from "never heard of this id at
+    // all" (400 UNKNOWN_MODEL) — it is never read again below this gate.
     const catalog = loadCatalogFn();
     const model = findModel(catalog, modelId);
-    if (!model) {
-      return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
-    }
     const dir = resolveDir();
     const state = loadStateFn(dir);
-    if (!state.registry[modelId]) {
+    const regEntry = state.registry[modelId];
+    if (!model && !regEntry) {
+      return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
+    }
+    if (!regEntry) {
       return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
     }
 
@@ -531,13 +554,16 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
 
   router.post("/api/models/:id/start", async (req, res) => {
     const modelId = req.params.id;
+    // See DELETE's comment above (Task 13 fix round 2): existence is
+    // state.registry presence, not catalog membership.
     const catalog = loadCatalogFn();
     const model = findModel(catalog, modelId);
-    if (!model) {
+    const state = loadStateFn(resolveDir());
+    const regEntry = state.registry[modelId];
+    if (!model && !regEntry) {
       return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
     }
-    const state = loadStateFn(resolveDir());
-    if (!state.registry[modelId]) {
+    if (!regEntry) {
       return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
     }
     try {
@@ -557,13 +583,16 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
 
   router.post("/api/models/:id/stop", async (req, res) => {
     const modelId = req.params.id;
+    // See DELETE's comment above (Task 13 fix round 2): existence is
+    // state.registry presence, not catalog membership.
     const catalog = loadCatalogFn();
     const model = findModel(catalog, modelId);
-    if (!model) {
+    const state = loadStateFn(resolveDir());
+    const regEntry = state.registry[modelId];
+    if (!model && !regEntry) {
       return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
     }
-    const state = loadStateFn(resolveDir());
-    if (!state.registry[modelId]) {
+    if (!regEntry) {
       return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
     }
     try {

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -1,0 +1,558 @@
+/**
+ * Model catalog panel API routes (Item G, Task 12).
+ *
+ * Dashboard-session-gated JSON routes the models panel (Task 13) drives:
+ * catalog browsing (with per-quant fit badges), hardware probe, GGUF
+ * downloads (with journaled progress), install/uninstall, start/stop of a
+ * native llama.cpp process, and a Hugging Face search proxy + token store.
+ *
+ * Auth: every route under `/api/models` is gated by
+ * `requireDashboardSessionJson` below, NOT the redirect-based
+ * `dashboardAuth` middleware every other panel router uses. This is a
+ * deliberate choice, not an oversight: `dashboardAuth` 302-redirects an
+ * unauthenticated request to `/dashboard/login`, which is correct for a
+ * browser navigation but wrong for a JSON API a client-side panel polls
+ * (download progress, runtime status) — a redirect response to a `fetch()`
+ * caller is not obviously distinguishable from success without extra
+ * client-side plumbing every other panel API in this codebase also skips.
+ * `requireDashboardSessionJson` runs the SAME two checks `dashboardAuth`
+ * does (`isAllowedNetwork`, then the `crow_session` cookie via
+ * `verifySession`) but answers with `401`/`403` JSON instead — the same
+ * pattern `routes/admin-backup.js`'s `requireLocalhost`/`requireToken` and
+ * `routes/audio-proxy.js`'s `peer_auth_required` already use for JSON-only
+ * routes in this codebase. `dashboardAuth` is still accepted as this
+ * factory's first argument (unused) purely so the call site in
+ * `boot/feature-mounts.js` matches every sibling router's
+ * `xRouter(dashboardAuth)` shape.
+ *
+ * NEVER add `/api/models` to `PUBLIC_FUNNEL_PREFIXES` — see CLAUDE.md's
+ * "Network exposure invariant".
+ *
+ * No CSRF middleware here: matching `routes/push.js`/`routes/notifications.js`
+ * (state-changing JSON routes mounted at the app root, outside the
+ * `/dashboard` router `csrfMiddleware` is scoped to) — the session cookie
+ * itself (HttpOnly, SameSite=Lax) is this route family's only defense
+ * against cross-origin calls, identical to its siblings.
+ *
+ * HF token storage: `POST /api/models/hf-token` reuses the EXACT storage
+ * path Settings -> Providers uses for cloud-provider API keys —
+ * `servers/shared/providers-db.js`'s `upsertProvider`/`listProvidersAll`,
+ * i.e. the `providers.api_key` column — under a reserved id
+ * (`HF_TOKEN_PROVIDER_ID`) that is always `disabled: true` with an empty
+ * `models: []` array, so it is never a candidate for chat routing, mutex
+ * arbitration, or the Providers-tab's enabled-row rendering paths (all of
+ * which either skip disabled rows or key off `models[].task === "chat"`).
+ * This intentionally means the token rides this instance's existing
+ * provider fleet-sync (`servers/sharing/instance-sync.js`'s `SYNCED_TABLES`
+ * includes `"providers"`, and `api_key` is not in that table's
+ * `EXCLUDED_COLUMNS`) — the same already-accepted trade-off Settings ->
+ * Providers keys make today (see `providers-db.js`'s module doc), not a
+ * new one introduced here.
+ */
+
+import { Router } from "express";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
+
+import { createDbClient, resolveDataDir } from "../../db.js";
+import { isAllowedNetwork, verifySession, parseCookies } from "../dashboard/auth.js";
+import { listProvidersAll, upsertProvider } from "../../shared/providers-db.js";
+import { invalidateProvidersCache } from "../../shared/providers.js";
+import { getCachedProbe, reprobe, fitBadge } from "../models/probe.js";
+import { loadState } from "../models/state.js";
+import { enqueueDownload, registerModel, unregisterModel, providerBindings } from "../models/manager.js";
+import { getStatusSnapshot } from "../models/runtime.js";
+import { getNativeHandle, maybeAcquireLocalProvider } from "../gpu-orchestrator.js";
+
+const __filename = fileURLToPath(import.meta.url);
+// routes/models.js -> gateway -> servers -> repo root -> registry/model-catalog.json
+const MODEL_CATALOG_PATH = resolvePath(dirname(__filename), "..", "..", "..", "registry", "model-catalog.json");
+
+/** Reserved provider id the Hugging Face API token is stashed under — see
+ * the module doc's "HF token storage" section. Namespaced well outside any
+ * real catalog model id shape (those are bare family slugs like
+ * "qwen3-4b") so a future catalog entry can never collide with it. */
+export const HF_TOKEN_PROVIDER_ID = "crow-hf-token";
+
+const SESSION_COOKIE = "crow_session";
+const HF_SEARCH_TIMEOUT_MS = 8000;
+
+// ---------------------------------------------------------------------------
+// Auth (JSON-answering — see module doc)
+// ---------------------------------------------------------------------------
+
+/** Exported for direct unit testing without booting a whole express app. */
+export function requireDashboardSessionJson(req, res, next) {
+  if (!isAllowedNetwork(req)) {
+    return res.status(403).json({ error: "Not reachable from this network", code: "NETWORK_DENIED" });
+  }
+  const token = parseCookies(req)[SESSION_COOKIE];
+  verifySession(token)
+    .then((valid) => {
+      if (!valid) return res.status(401).json({ error: "Not authenticated", code: "UNAUTHENTICATED" });
+      req.dashboardSession = token;
+      next();
+    })
+    .catch(() => res.status(401).json({ error: "Not authenticated", code: "UNAUTHENTICATED" }));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function defaultLoadCatalog() {
+  return JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+}
+
+function findModel(catalog, modelId) {
+  if (typeof modelId !== "string" || !modelId) return null;
+  return (catalog?.models || []).find((m) => m.id === modelId) || null;
+}
+
+function findQuant(model, quant) {
+  const quantId = quant || model.default_quant;
+  const entry = (model?.quants || []).find((q) => q.quant === quantId);
+  return entry ? { quantId, entry } : null;
+}
+
+function jobIdFor(modelId, quant) {
+  return `${modelId}::${quant}`;
+}
+
+function publicJob(job) {
+  return {
+    id: job.id,
+    modelId: job.modelId,
+    quant: job.quant,
+    status: job.status,
+    bytesDone: job.bytesDone,
+    totalBytes: job.totalBytes,
+    startedAt: job.startedAt,
+    error: job.error,
+    errorCode: job.errorCode,
+    providerId: job.providerId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Function} dashboardAuth - accepted for call-site parity with every
+ *   sibling router (`xRouter(dashboardAuth)`); NOT used — see module doc.
+ * @param {object} [opts] - injectable seams (tests only; production omits
+ *   all of these, using the real implementations imported above).
+ */
+export default function modelsRouter(dashboardAuth, opts = {}) {
+  const {
+    dir: staticDir,
+    dbFactory = createDbClient,
+    loadCatalogFn = defaultLoadCatalog,
+    getCachedProbeFn = getCachedProbe,
+    reprobeFn = reprobe,
+    fitBadgeFn = fitBadge,
+    loadStateFn = loadState,
+    enqueueDownloadFn = enqueueDownload,
+    registerModelFn = registerModel,
+    unregisterModelFn = unregisterModel,
+    providerBindingsFn = providerBindings,
+    listProvidersAllFn = listProvidersAll,
+    upsertProviderFn = upsertProvider,
+    invalidateCacheFn = invalidateProvidersCache,
+    getStatusSnapshotFn = getStatusSnapshot,
+    getNativeHandleFn = getNativeHandle,
+    maybeAcquireLocalProviderFn = maybeAcquireLocalProvider,
+    hfApiBase = "https://huggingface.co",
+    fetchImplFn = fetch,
+    hfSearchTimeoutMs = HF_SEARCH_TIMEOUT_MS,
+  } = opts;
+
+  const router = Router();
+
+  function resolveDir() {
+    return typeof staticDir === "string" && staticDir ? staticDir : resolveDataDir();
+  }
+
+  async function getHfToken(db) {
+    const providers = await listProvidersAllFn(db);
+    const row = providers.find((p) => p.id === HF_TOKEN_PROVIDER_ID);
+    return row?.apiKey || null;
+  }
+
+  // Every /api/models/* route requires a valid dashboard session — see
+  // module doc for why this is a bespoke JSON-answering gate, not the
+  // redirect-based `dashboardAuth` param above.
+  router.use("/api/models", requireDashboardSessionJson);
+
+  // In-memory download-job tracker (module-scope map keyed by
+  // "<modelId>::<quant>", one gateway process, matches `manager.js`'s
+  // `enqueueDownload` idempotency key). Lost on restart by design — a
+  // restarted gateway resumes an interrupted download from `state.js`'s
+  // on-disk journal (see `manager.js`'s `downloadModel` doc), it just
+  // shows up here as a fresh job the next time it's (re-)triggered.
+  const downloadJobs = new Map();
+
+  // --- Catalog -------------------------------------------------------------
+
+  router.get("/api/models/catalog", (req, res) => {
+    try {
+      const catalog = loadCatalogFn();
+      const probe = getCachedProbeFn();
+      const state = loadStateFn(resolveDir());
+      const models = (catalog.models || []).map((model) => {
+        const regEntry = state.registry[model.id] || null;
+        const handle = getNativeHandleFn(model.id);
+        const quants = (model.quants || []).map((q) => ({
+          quant: q.quant,
+          size_mb: q.size_mb,
+          min_ram_mb: q.min_ram_mb,
+          min_vram_mb: q.min_vram_mb,
+          fitBadge: fitBadgeFn(probe, q),
+        }));
+        return {
+          id: model.id,
+          family: model.family,
+          lab: model.lab,
+          license: model.license,
+          gated: !!model.gated,
+          task: model.task,
+          context_len: model.context_len,
+          tags: model.tags || [],
+          notes: model.notes || null,
+          default_quant: model.default_quant,
+          first_run_default: !!model.first_run_default,
+          registered: !!regEntry,
+          registeredQuant: regEntry ? regEntry.quant : null,
+          running: !!(handle && handle.live),
+          quants,
+        };
+      });
+      res.json({
+        runtime: { name: catalog.runtime?.name ?? null, release: catalog.runtime?.release ?? null },
+        probe,
+        models,
+      });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
+  // --- Hardware probe --------------------------------------------------------
+
+  router.get("/api/models/probe", (req, res) => {
+    res.json({ probe: getCachedProbeFn() });
+  });
+
+  router.post("/api/models/reprobe", async (req, res) => {
+    try {
+      const probe = await reprobeFn({ modelsDir: resolveDir() });
+      res.json({ probe });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
+  // --- Downloads -------------------------------------------------------------
+
+  router.post("/api/models/download", async (req, res) => {
+    try {
+      const { modelId, quant, force } = req.body || {};
+      const catalog = loadCatalogFn();
+      const model = findModel(catalog, modelId);
+      if (!model) {
+        return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
+      }
+      const resolved = findQuant(model, quant);
+      if (!resolved) {
+        return res.status(400).json({ error: `Unknown quant for ${modelId}: ${quant}`, code: "UNKNOWN_QUANT" });
+      }
+
+      const probe = getCachedProbeFn();
+      const badge = fitBadgeFn(probe, resolved.entry);
+      // Gate: only a definitive "won't fit" is blocked, and only without an
+      // explicit override. "tight" and "unknown" are always allowed —
+      // fail-closed already happened at badge-computation time (an
+      // "unknown" badge is itself the honest signal; it doesn't ALSO block
+      // the download), so `force` is accepted-but-irrelevant for those two.
+      if (badge === "wont_fit" && force !== true) {
+        return res.status(409).json({
+          error: `This quant is unlikely to fit on this hardware (fitBadge: ${badge}). Pass force:true to download anyway.`,
+          code: "WONT_FIT",
+          fitBadge: badge,
+        });
+      }
+
+      const jobId = jobIdFor(modelId, resolved.quantId);
+      const existing = downloadJobs.get(jobId);
+      if (existing && (existing.status === "downloading" || existing.status === "registering")) {
+        return res.status(202).json({ jobId, status: existing.status });
+      }
+
+      const dir = resolveDir();
+      const job = {
+        id: jobId,
+        modelId,
+        quant: resolved.quantId,
+        status: "downloading",
+        bytesDone: 0,
+        totalBytes: null,
+        startedAt: new Date().toISOString(),
+        error: null,
+        errorCode: null,
+        providerId: null,
+      };
+      downloadJobs.set(jobId, job);
+
+      // Fire-and-forget: the HTTP response returns the job id immediately;
+      // progress/completion is polled via GET /api/models/downloads.
+      (async () => {
+        try {
+          await enqueueDownloadFn({
+            modelId,
+            quant: resolved.quantId,
+            dir,
+            catalog,
+            onProgress: ({ bytesDone, totalBytes }) => {
+              job.bytesDone = bytesDone;
+              if (totalBytes != null) job.totalBytes = totalBytes;
+            },
+          });
+        } catch (err) {
+          job.status = "error";
+          job.error = err.message;
+          job.errorCode = err.code || "DOWNLOAD_FAILED";
+          return;
+        }
+
+        const db = dbFactory();
+        try {
+          job.status = "registering";
+          const provider = await registerModelFn({ modelId, quant: resolved.quantId, catalog, db, dir });
+          job.status = "done";
+          job.providerId = provider.id;
+        } catch (err) {
+          job.status = "error";
+          job.error = err.message;
+          job.errorCode = err.code || "REGISTER_FAILED";
+        } finally {
+          try { db.close(); } catch { /* best effort */ }
+        }
+      })();
+
+      res.status(202).json({ jobId, status: job.status });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
+  router.get("/api/models/downloads", (req, res) => {
+    res.json({ downloads: Array.from(downloadJobs.values()).map(publicJob) });
+  });
+
+  // --- Install / uninstall -----------------------------------------------
+
+  router.delete("/api/models/:id", async (req, res) => {
+    const modelId = req.params.id;
+    const catalog = loadCatalogFn();
+    const model = findModel(catalog, modelId);
+    if (!model) {
+      return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
+    }
+    const dir = resolveDir();
+    const state = loadStateFn(dir);
+    if (!state.registry[modelId]) {
+      return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
+    }
+
+    const db = dbFactory();
+    try {
+      const bindings = await providerBindingsFn(db, modelId);
+
+      // Guard: without ?confirm=true (or a JSON body { confirm: true }),
+      // report what deleting this model would break and stop — the
+      // client re-issues the same DELETE with confirm once the operator
+      // has seen the bindings. Two calls, one endpoint (documented here
+      // for Task 13, since the brief left the exact confirm mechanism to
+      // this task's judgment).
+      const confirmed = req.query.confirm === "true" || req.body?.confirm === true;
+      if (!confirmed) {
+        return res.status(200).json({ requiresConfirm: true, modelId, bindings });
+      }
+
+      const handle = getNativeHandleFn(modelId);
+      const result = await unregisterModelFn({ modelId, db, dir, runtimeHandle: handle });
+      res.json({ deleted: true, modelId, disabled: result.disabled, fileDeleted: result.deleted, bindings });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    } finally {
+      try { db.close(); } catch { /* best effort */ }
+    }
+  });
+
+  // --- Start / stop ----------------------------------------------------------
+
+  router.post("/api/models/:id/start", async (req, res) => {
+    const modelId = req.params.id;
+    const catalog = loadCatalogFn();
+    const model = findModel(catalog, modelId);
+    if (!model) {
+      return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
+    }
+    const state = loadStateFn(resolveDir());
+    if (!state.registry[modelId]) {
+      return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
+    }
+    try {
+      const result = await maybeAcquireLocalProviderFn(modelId);
+      if (result === true) return res.json({ running: true });
+      if (result === false) {
+        return res.status(502).json({ error: "Model failed to become ready in time", code: "START_FAILED" });
+      }
+      return res.status(409).json({
+        error: `${modelId} is not a locally-orchestratable native provider`,
+        code: "NOT_NATIVE",
+      });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
+  router.post("/api/models/:id/stop", async (req, res) => {
+    const modelId = req.params.id;
+    const catalog = loadCatalogFn();
+    const model = findModel(catalog, modelId);
+    if (!model) {
+      return res.status(400).json({ error: `Unknown model id: ${modelId}`, code: "UNKNOWN_MODEL" });
+    }
+    const state = loadStateFn(resolveDir());
+    if (!state.registry[modelId]) {
+      return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
+    }
+    try {
+      const handle = getNativeHandleFn(modelId);
+      if (handle && handle.live) await handle.stop();
+      res.json({ running: false });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
+  // --- Runtime status strip ------------------------------------------------
+
+  router.get("/api/models/runtime", (req, res) => {
+    try {
+      const state = loadStateFn(resolveDir());
+      const snapshot = getStatusSnapshotFn();
+      const byAlias = new Map(snapshot.map((s) => [s.alias, s]));
+      const models = Object.keys(state.registry).map((modelId) => {
+        const status = byAlias.get(modelId);
+        return status
+          ? { modelId, ...status }
+          : { modelId, state: "stopped", live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null };
+      });
+      const activeDownloads = Array.from(downloadJobs.values())
+        .filter((j) => j.status === "downloading" || j.status === "registering").length;
+      res.json({ probe: getCachedProbeFn(), models, activeDownloads });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
+  // --- Hugging Face search proxy + token store --------------------------
+
+  router.get("/api/models/hf-search", async (req, res) => {
+    const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+    if (!q) return res.status(400).json({ error: "q query param required", code: "MISSING_QUERY" });
+
+    let token = null;
+    const db = dbFactory();
+    try {
+      token = await getHfToken(db);
+    } catch { /* search still works unauthenticated */ }
+    finally { try { db.close(); } catch { /* best effort */ } }
+
+    const url = `${hfApiBase}/api/models?search=${encodeURIComponent(q)}&filter=gguf&limit=20&full=true`;
+    try {
+      const upstream = await fetchImplFn(url, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: AbortSignal.timeout(hfSearchTimeoutMs),
+      });
+      if (!upstream.ok) {
+        return res.status(502).json({
+          error: `Hugging Face API returned ${upstream.status}`,
+          code: "HF_UPSTREAM_ERROR",
+          status: upstream.status,
+        });
+      }
+      const body = await upstream.json();
+      const results = (Array.isArray(body) ? body : [])
+        .map((repo) => {
+          const ggufFiles = (repo.siblings || [])
+            .map((s) => s?.rfilename)
+            .filter((name) => typeof name === "string" && /\.gguf$/i.test(name));
+          const licenseTag = (repo.tags || []).find((t) => typeof t === "string" && t.startsWith("license:"));
+          return {
+            id: repo.id || repo.modelId,
+            gated: repo.gated === true || repo.gated === "auto" || repo.gated === "manual",
+            downloads: repo.downloads ?? null,
+            likes: repo.likes ?? null,
+            license: licenseTag ? licenseTag.slice("license:".length) : (repo.license || null),
+            ggufFiles,
+          };
+        })
+        .filter((r) => r.ggufFiles.length > 0);
+      res.json({ query: q, results });
+    } catch (err) {
+      // Covers network errors AND AbortSignal.timeout() firing — either
+      // way, the caller gets an honest 502, never an unbounded hang.
+      res.status(502).json({ error: `Hugging Face API request failed: ${err.message || err}`, code: "HF_UPSTREAM_ERROR" });
+    }
+  });
+
+  router.get("/api/models/hf-token", async (req, res) => {
+    const db = dbFactory();
+    try {
+      const token = await getHfToken(db);
+      res.json({ configured: !!token });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    } finally {
+      try { db.close(); } catch { /* best effort */ }
+    }
+  });
+
+  router.post("/api/models/hf-token", async (req, res) => {
+    const { token } = req.body || {};
+    if (token !== undefined && token !== null && typeof token !== "string") {
+      return res.status(400).json({ error: "token must be a string", code: "BAD_TOKEN" });
+    }
+    // Never logged: no console.* call anywhere in this handler touches
+    // `token`/`cleaned`, and errors below carry only DB error text.
+    const cleaned = typeof token === "string" ? token.trim() : "";
+    const db = dbFactory();
+    try {
+      await upsertProviderFn(db, {
+        id: HF_TOKEN_PROVIDER_ID,
+        baseUrl: "https://huggingface.co",
+        apiKey: cleaned || null,
+        host: "external",
+        bundleId: null,
+        description: "Hugging Face API token (models catalog downloads — not an LLM provider)",
+        models: [],
+        disabled: true,
+        providerType: null,
+        gpuPolicy: null,
+      });
+      await invalidateCacheFn();
+      res.json({ configured: !!cleaned });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    } finally {
+      try { db.close(); } catch { /* best effort */ }
+    }
+  });
+
+  return router;
+}

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -60,8 +60,11 @@ import { isAllowedNetwork, verifySession, parseCookies } from "../dashboard/auth
 import { listProvidersAll, upsertProvider } from "../../shared/providers-db.js";
 import { invalidateProvidersCache } from "../../shared/providers.js";
 import { getCachedProbe, reprobe, fitBadge } from "../models/probe.js";
-import { loadState } from "../models/state.js";
-import { enqueueDownload, registerModel, unregisterModel, providerBindings } from "../models/manager.js";
+import { loadState, registryEntryRuntimeState } from "../models/state.js";
+import {
+  enqueueDownload, registerModel, unregisterModel, providerBindings,
+  downloadHfFile, fetchHfPathInfo, isValidHfRepoId, isValidHfFilename, deriveModelIdFromFilename,
+} from "../models/manager.js";
 import { getStatusSnapshot } from "../models/runtime.js";
 import { getNativeHandle, maybeAcquireLocalProvider } from "../gpu-orchestrator.js";
 
@@ -132,6 +135,11 @@ function publicJob(job) {
     error: job.error,
     errorCode: job.errorCode,
     providerId: job.providerId,
+    // "curated" (default, omitted historically — every existing job before
+    // this field existed is implicitly curated) | "hf-browser" (Task 13 fix
+    // round 1, finding 1) — lets the panel tell which progress UI a given
+    // job belongs to without re-deriving it from the id shape.
+    source: job.source || "curated",
   };
 }
 
@@ -167,6 +175,9 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
     hfApiBase = "https://huggingface.co",
     fetchImplFn = fetch,
     hfSearchTimeoutMs = HF_SEARCH_TIMEOUT_MS,
+    registryEntryRuntimeStateFn = registryEntryRuntimeState,
+    downloadHfFileFn = downloadHfFile,
+    fetchHfPathInfoFn = fetchHfPathInfo,
   } = opts;
 
   const router = Router();
@@ -351,6 +362,131 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
     res.json({ downloads: Array.from(downloadJobs.values()).map(publicJob) });
   });
 
+  // --- Browse Hugging Face download (Task 13 fix round 1, finding 1 —
+  // Kevin decided to build this in this PR rather than leave the tab
+  // search-only) ---------------------------------------------------------
+  //
+  // Shares the download-job map + GET /downloads polling surface with the
+  // curated /download route above (jobs carry `source: "hf-browser"` —
+  // see publicJob) but is otherwise a SEPARATE pipeline: no catalog entry
+  // exists for an arbitrary Hugging Face file, so the fit gate's size and
+  // the download's sha256 are both fetched live from Hugging Face's
+  // paths-info API (`manager.js`'s `fetchHfPathInfo`) BEFORE any download
+  // traffic — see that function's doc for why a nonexistent path and a
+  // non-LFS (unverifiable) file are each their own typed, honest failure,
+  // never conflated with a generic upstream error.
+  router.post("/api/models/hf-download", async (req, res) => {
+    try {
+      const { hfRepo, file, force } = req.body || {};
+      if (!isValidHfRepoId(hfRepo)) {
+        return res.status(400).json({ error: `Invalid Hugging Face repo id: ${JSON.stringify(hfRepo)}`, code: "INVALID_HF_REPO" });
+      }
+      if (!isValidHfFilename(file)) {
+        return res.status(400).json({ error: `Invalid file name: ${JSON.stringify(file)}`, code: "INVALID_HF_FILE" });
+      }
+
+      let token = null;
+      const tokenDb = dbFactory();
+      try {
+        token = await getHfToken(tokenDb);
+      } catch { /* best effort — an un-gated file still downloads fine unauthenticated */ }
+      finally { try { tokenDb.close(); } catch { /* best effort */ } }
+
+      let pathInfo;
+      try {
+        pathInfo = await fetchHfPathInfoFn({ hfRepo, file, hfApiBase, hfToken: token });
+      } catch (err) {
+        const code = err.code === "HF_FILE_NOT_FOUND" ? "HF_FILE_NOT_FOUND" : "HF_UPSTREAM_ERROR";
+        const status = err.code === "HF_FILE_NOT_FOUND" ? 404 : 502;
+        return res.status(status).json({ error: err.message, code });
+      }
+      if (!pathInfo.sha256) {
+        return res.status(422).json({
+          error: "This file has no verifiable checksum (it isn't LFS-tracked) — refusing to download an unverifiable file.",
+          code: "NO_VERIFIABLE_CHECKSUM",
+        });
+      }
+
+      const sizeMb = typeof pathInfo.sizeBytes === "number" ? pathInfo.sizeBytes / 1_000_000 : null;
+      const probe = getCachedProbeFn();
+      const badge = fitBadgeFn(probe, { min_ram_mb: sizeMb, min_vram_mb: 0 });
+      if (badge === "wont_fit" && force !== true) {
+        return res.status(409).json({
+          error: `This file is unlikely to fit on this hardware (fitBadge: ${badge}). Pass force:true to download anyway.`,
+          code: "WONT_FIT",
+          fitBadge: badge,
+        });
+      }
+
+      const modelId = deriveModelIdFromFilename(file);
+      const jobId = jobIdFor(modelId, "hf");
+      const existing = downloadJobs.get(jobId);
+      if (existing && (existing.status === "downloading" || existing.status === "registering")) {
+        return res.status(202).json({ jobId, status: existing.status });
+      }
+
+      const dir = resolveDir();
+      const job = {
+        id: jobId,
+        modelId,
+        quant: "hf",
+        status: "downloading",
+        bytesDone: 0,
+        totalBytes: sizeMb != null ? Math.round(sizeMb * 1_000_000) : null,
+        startedAt: new Date().toISOString(),
+        error: null,
+        errorCode: null,
+        providerId: null,
+        source: "hf-browser",
+      };
+      downloadJobs.set(jobId, job);
+
+      // Fire-and-forget — identical shape to the curated /download handler.
+      (async () => {
+        let catalog;
+        try {
+          const result = await downloadHfFileFn({
+            hfRepo,
+            file,
+            dir,
+            hfToken: token,
+            onProgress: ({ bytesDone, totalBytes }) => {
+              job.bytesDone = bytesDone;
+              if (totalBytes != null) job.totalBytes = totalBytes;
+            },
+          });
+          catalog = result.catalog;
+        } catch (err) {
+          job.status = "error";
+          job.error = err.message;
+          job.errorCode = err.code || "DOWNLOAD_FAILED";
+          return;
+        }
+
+        const db = dbFactory();
+        try {
+          job.status = "registering";
+          const provider = await registerModelFn({
+            modelId, quant: "hf", catalog, db, dir,
+            registryExtra: { source: "hf-browser" },
+          });
+          job.status = "done";
+          job.providerId = provider.id;
+        } catch (err) {
+          job.status = "error";
+          job.error = err.message;
+          job.errorCode = err.code || "REGISTER_FAILED";
+        } finally {
+          try { db.close(); } catch { /* best effort */ }
+        }
+      })();
+
+      res.status(202).json({ jobId, status: job.status });
+    } catch (err) {
+      res.status(500).json({ error: err.message, code: "INTERNAL" });
+    }
+  });
+
   // --- Install / uninstall -----------------------------------------------
 
   router.delete("/api/models/:id", async (req, res) => {
@@ -448,9 +584,17 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
       const byAlias = new Map(snapshot.map((s) => [s.alias, s]));
       const models = Object.keys(state.registry).map((modelId) => {
         const status = byAlias.get(modelId);
-        return status
-          ? { modelId, ...status }
-          : { modelId, state: "stopped", live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null };
+        if (status) return { modelId, ...status };
+        // Task 13 fix round 1, finding c: distinguish "never started" from
+        // "was resident when the gateway went down and hasn't re-warmed
+        // yet" via the persisted wasLive marker (state.registry[modelId])
+        // — see registryEntryRuntimeState's doc for the exact contract.
+        const entry = state.registry[modelId];
+        return {
+          modelId,
+          state: registryEntryRuntimeStateFn(entry, false),
+          live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null,
+        };
       });
       const activeDownloads = Array.from(downloadJobs.values())
         .filter((j) => j.status === "downloading" || j.status === "registering").length;

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -233,6 +233,33 @@ function shouldSyncRow(table, row) {
     return Boolean(row.group_uid);
   }
   if (table === "providers") {
+    if (!row) return false;
+    // Local-only marker (Item G, Task 12 fix round 1): a providers row
+    // whose gpu_policy JSON carries `local_only: true` is riding the
+    // providers table's storage mechanics for something that is NOT a real
+    // LLM/embedding endpoint — e.g. the model catalog's stashed Hugging
+    // Face API token (servers/gateway/routes/models.js's
+    // HF_TOKEN_PROVIDER_ID row: base_url "https://huggingface.co",
+    // disabled, models: [] — a real, non-loopback host, so it would
+    // otherwise pass the loopback carve-out below and sync in plaintext to
+    // every paired instance). This is deliberately a general convention —
+    // ANY future providers row that needs to opt out of fleet sync sets
+    // this same marker — not a hardcoded check against one reserved id.
+    // Checked BEFORE the base_url/loopback logic (a local-only row may have
+    // a perfectly real, non-loopback base_url) and gates BOTH emit
+    // (emitChange) and apply (_applyEntry) — this function is their single
+    // shared choke point, same as the loopback carve-out below.
+    // Malformed gpu_policy JSON is not treated as local_only (fails open
+    // to the existing loopback/host checks, not silently dropped).
+    if (row.gpu_policy) {
+      let policy = null;
+      try {
+        policy = typeof row.gpu_policy === "string" ? JSON.parse(row.gpu_policy) : row.gpu_policy;
+      } catch {
+        policy = null; // malformed JSON -> fall through, not local_only
+      }
+      if (policy && policy.local_only === true) return false;
+    }
     // Loopback endpoints are per-instance by construction: a peer dialing
     // 127.0.0.1 reaches ITSELF, never the origin's service. They're also
     // co-owned by every instance's locality predicate (loopback matches
@@ -241,7 +268,7 @@ function shouldSyncRow(table, row) {
     // apply) is the only clean single-writer story. Missing/malformed
     // base_url → defensive false: a providers row without a parseable
     // endpoint shouldn't sync either.
-    if (!row || !row.base_url) return false;
+    if (!row.base_url) return false;
     let hostname;
     try {
       hostname = new URL(row.base_url).hostname;

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -22,6 +22,9 @@
 
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   pollResidency,
   acquireProvider,
@@ -36,6 +39,7 @@ import {
 } from "../servers/gateway/gpu-orchestrator.js";
 import { _resetProviderHealth, getProviderHealth } from "../servers/gateway/provider-health.js";
 import { nativeReadinessTimeoutMs } from "../servers/gateway/models/runtime.js";
+import { loadState, saveState } from "../servers/gateway/models/state.js";
 
 // --- fixtures ------------------------------------------------------------
 
@@ -824,4 +828,119 @@ test("Fix 3: freed reservations are persisted via saveStateFn", async () => {
     }),
   });
   assert.equal(saveCalls, 1, "saveState was called because a reservation was freed");
+});
+
+// --- Task 13 fix round 1, finding c: the wasLive marker ("reloading after
+// update") ---------------------------------------------------------------
+//
+// Uses a REAL scratch dir (not the `startCapableOpts` fixture's fake
+// "/fake/crow-home") so persistence genuinely happens against the real
+// state.js module and is verifiable via loadState() — a stronger proof
+// than injecting a fake loadStateFn/saveStateFn pair, and the exact
+// end-to-end path production runs.
+
+function scratchStateDir() {
+  return mkdtempSync(join(tmpdir(), "gpu-orch-waslive-"));
+}
+
+test("Finding c: a successful native start persists wasLive:true on the registry entry", async () => {
+  const dir = scratchStateDir();
+  try {
+    saveState(dir, { reservations: {}, journal: {}, registry: { "native-target": { file: "model.gguf" } } });
+    const cfg = { providers: { "native-target": nativeProv(18150, "qwen3-4b") } };
+    let probeCalls = 0;
+    const identityProbeFn = async () => {
+      probeCalls += 1;
+      return probeCalls === 1 ? "down" : "resident"; // fast-path miss, then resident once "started"
+    };
+
+    const result = await acquireProvider("native-target", {
+      ...startCapableOpts({ cfg, identityProbeFn }),
+      resolveDataDirFn: () => dir,
+    });
+
+    assert.equal(result, true);
+    const entry = loadState(dir).registry["native-target"];
+    assert.equal(entry.wasLive, true);
+    assert.equal(entry.lastStoppedAt, null);
+    // pre-existing fields survive the merge untouched
+    assert.equal(entry.file, "model.gguf");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Finding c: the handle reaching a terminal state (stop/crash) clears wasLive and stamps lastStoppedAt — BEFORE any restart could see it", async () => {
+  const dir = scratchStateDir();
+  try {
+    saveState(dir, { reservations: {}, journal: {}, registry: { "native-target": { file: "model.gguf" } } });
+    const cfg = { providers: { "native-target": nativeProv(18151, "qwen3-4b") } };
+    let probeCalls = 0;
+    const identityProbeFn = async () => {
+      probeCalls += 1;
+      return probeCalls === 1 ? "down" : "resident"; // fast-path miss, then resident once "started"
+    };
+    let capturedOnTerminal = null;
+    const startModelFn = (params) => {
+      capturedOnTerminal = params.onTerminal;
+      return fakeHandle();
+    };
+
+    const result = await acquireProvider("native-target", {
+      ...startCapableOpts({ cfg, identityProbeFn, startModelFn }),
+      resolveDataDirFn: () => dir,
+    });
+    assert.equal(result, true);
+    assert.equal(loadState(dir).registry["native-target"].wasLive, true, "sanity: it became live first");
+
+    // Simulate the real runtime.js handle later reaching a terminal state
+    // (idle-unload, crash-exhausted, explicit stop) — same simulation
+    // pattern the pre-existing "host lock is held for the life of
+    // residency" test above uses.
+    capturedOnTerminal("stopped");
+
+    const after = loadState(dir).registry["native-target"];
+    assert.equal(after.wasLive, false);
+    assert.ok(typeof after.lastStoppedAt === "string" && after.lastStoppedAt.length > 0, "lastStoppedAt is stamped");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Finding c: a boot-fresh gateway process (no in-memory handle) sees a previously-live, still-marked registry entry — this is the 'reloading after update' signal GET /runtime reads", async () => {
+  const dir = scratchStateDir();
+  try {
+    // Simulates state left behind by a PRIOR process that died/restarted
+    // while this model was resident: wasLive:true, no corresponding
+    // in-memory handle in THIS (fresh) process — this test doesn't touch
+    // acquireProvider at all, it just proves the persisted marker survives
+    // as plain JSON and reads back exactly as written, independent of the
+    // orchestrator's in-memory state.
+    saveState(dir, {
+      reservations: {},
+      journal: {},
+      registry: { "native-target": { file: "model.gguf", wasLive: true, lastStoppedAt: null } },
+    });
+    const entry = loadState(dir).registry["native-target"];
+    assert.equal(entry.wasLive, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Finding c: persisting the marker against an unwritable dir never throws and never blocks a successful acquire (safety net)", async () => {
+  // "/fake/crow-home" (startCapableOpts' own default resolveDataDirFn
+  // stand-in) is deliberately never created on disk — loadState() against
+  // it degrades to an empty registry, so persistLivenessMarker's
+  // no-matching-entry early return is what actually keeps this safe (see
+  // its doc) — this test pins that the acquire itself still succeeds
+  // regardless.
+  const cfg = { providers: { "native-target": nativeProv(18152, "qwen3-4b") } };
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return probeCalls === 1 ? "down" : "resident";
+  };
+  const result = await acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn }));
+  assert.equal(result, true, "an unwritable/fake persistence dir never blocks a successful start");
 });

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -108,6 +108,36 @@ beforeEach(() => {
   _setNativeHandleForTest("native-sib", null);
 });
 
+// --- getNativeHandle (Item G, Task 12 follow-up: read-only accessor for the
+// panel's stop/delete routes — see gpu-orchestrator.js's doc on it) --------
+
+test("getNativeHandle: null when no handle was ever seeded for this provider name", async () => {
+  const { getNativeHandle } = await import("../servers/gateway/gpu-orchestrator.js");
+  assert.equal(getNativeHandle("native-target"), null);
+  assert.equal(getNativeHandle("some-unknown-provider"), null);
+});
+
+test("getNativeHandle: returns the exact handle object seeded via the test seam, live reflects in place", async () => {
+  const { getNativeHandle } = await import("../servers/gateway/gpu-orchestrator.js");
+  const handle = fakeHandle({ live: true });
+  _setNativeHandleForTest("native-target", handle);
+  assert.equal(getNativeHandle("native-target"), handle);
+
+  // Mutating the handle's own `live` flag (as `runtime.js`'s real
+  // startModel/stop() do in place) is visible through the accessor without
+  // re-seeding — it's a live reference into the module's map, not a copy.
+  handle.live = false;
+  assert.equal(getNativeHandle("native-target").live, false);
+});
+
+test("getNativeHandle: clearing via the test seam (null) makes it null again — the accessor has no separate mutation surface", async () => {
+  const { getNativeHandle } = await import("../servers/gateway/gpu-orchestrator.js");
+  _setNativeHandleForTest("native-target", fakeHandle({ live: true }));
+  assert.notEqual(getNativeHandle("native-target"), null);
+  _setNativeHandleForTest("native-target", null);
+  assert.equal(getNativeHandle("native-target"), null);
+});
+
 // --- touch point 5: pollResidency compose-file gate (named blocker) -----
 
 test("pollResidency never releases a native provider's residency for lacking a compose file", async () => {

--- a/tests/i18n-global-parity.test.js
+++ b/tests/i18n-global-parity.test.js
@@ -76,6 +76,11 @@ const IDENTICAL_OK = new Set([
   "contacts.manual",
   "contacts.groupColor", // "Color" is Spanish too
   "connect.localStdioHeading", // "Local (stdio)"
+  // Model Catalog panel (Item G Task 13, reviewed 2026-07-18)
+  "models.runtimeBinary", // "Runtime: {name} {release}" — "runtime" is used untranslated in Spanish tech contexts
+  "models.runtimeGpu", // "GPU: {gpu} ({vram})" — GPU is an acronym, unchanged in Spanish
+  "models.runtimeColPid", // "PID" — abbreviation, unchanged in Spanish
+  "models.hfTokenPlaceholder", // "hf_..." — literal input placeholder prefix, language-neutral
 ]);
 
 const keys = Object.keys(translations);

--- a/tests/model-catalog-client-contract.test.js
+++ b/tests/model-catalog-client-contract.test.js
@@ -1,0 +1,375 @@
+/**
+ * Model Catalog panel client — BEHAVIOR, executed (Task 13 fix round 3,
+ * the GATING finding).
+ *
+ * A source-text regex over the client script (what the rest of this
+ * panel's test suite otherwise relies on) cannot prove a click computed
+ * the right request body, or that a DOM node was actually removed/added —
+ * exactly the class of bug this round's finding was: `startDownload` sent
+ * `force: fit !== "fits"` and a string-match test would have stayed green
+ * forever, because the STRING "force:" appears in the file regardless of
+ * whether it's ever `true` when it shouldn't be.
+ *
+ * So this file RUNS the real client against real server-rendered markup:
+ *   renderRuntimeStrip()/renderCuratedTab() → the same HTML the panel serves
+ *   linkedom                                → a DOM for it
+ *   node:vm                                 → evaluate modelCatalogClientJS("en")
+ * and asserts on the resulting DOM state / captured fetch calls after real
+ * change/click events — mirrors tests/extensions-client-contract.test.js's
+ * established pattern for this exact class of panel.
+ *
+ * Nothing here boots a real gateway, opens a DB, or reads
+ * registry/model-catalog.json — every `data` object is a synthetic fixture,
+ * including multi-quant entries the CURRENT shipped catalog doesn't have
+ * yet (schema + CI already allow them; this is the "latent" case the
+ * finding named).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { parseHTML } from "linkedom";
+
+import { renderRuntimeStrip, renderCuratedTab, modelCatalogClientJS } from "../servers/gateway/dashboard/panels/model-catalog.js";
+
+const CLIENT_HTML = modelCatalogClientJS("en");
+/** The IIFE the browser would execute, lifted out of the emitted <script>. */
+const CLIENT_JS = CLIENT_HTML.slice(
+  CLIENT_HTML.indexOf("<script>") + "<script>".length,
+  CLIENT_HTML.lastIndexOf("</script>"),
+);
+/** Everything before the <script> — the #mcat-modal-overlay the client mounts into. */
+const OVERLAY_HTML = CLIENT_HTML.slice(0, CLIENT_HTML.indexOf("<script>"));
+
+function baseData({ models = [], runtimeModels = [], hfTokenConfigured = false } = {}) {
+  return {
+    runtime: { name: "llama.cpp", release: "b10068" },
+    probe: { platform: "linux", wsl2: false, accel: "cpu", gpuName: null, vramMb: null, ramAvailableMb: 8000, diskFreeMb: 500_000, unknown: [] },
+    models,
+    runtimeModels,
+    estimatedRamMb: 0,
+    estimatedVramMb: 0,
+    hfTokenConfigured,
+  };
+}
+
+/**
+ * Render the strip + curated tab, build a DOM, and execute the real
+ * client against it.
+ *
+ * @param {Function} [fetchImpl] (url, init) => {ok, status, json()} — a
+ *   stub response shape; omit for a blanket harmless 200 {}.
+ */
+function boot({ models = [], runtimeModels = [], hfTokenConfigured = false, fetchImpl } = {}) {
+  const data = baseData({ models, runtimeModels, hfTokenConfigured });
+  const stripHtml = renderRuntimeStrip(data, "en");
+  const curatedHtml = renderCuratedTab(data, "en");
+
+  const { window, document } = parseHTML(
+    `<html><body>${stripHtml}<div class="tabs"><div class="tab-panels"><div class="tab-panel tab-active" data-tab-panel="curated">${curatedHtml}</div></div></div>${OVERLAY_HTML}</body></html>`,
+  );
+
+  // linkedom@0.18's HTMLSelectElement has a working `.value` GETTER
+  // (once an <option>'s own `.selected` is set directly) but a broken
+  // `selectedIndex` getter (always undefined) and a no-op `.value`
+  // SETTER — a real browser supports both. The panel's own change
+  // handler reads `sel.options[sel.selectedIndex]`, so this patch (a
+  // DOM-shim fix, not a product workaround) makes `selectedIndex`
+  // actually reflect whichever <option> has `.selected === true`,
+  // matching real DOM semantics — tests select a quant via
+  // `selectQuant()` below, which sets `.selected` directly since
+  // `sel.value = "..."` is a silent no-op in this linkedom version.
+  if (!window.HTMLSelectElement.prototype.__mcatSelectedIndexPatched) {
+    Object.defineProperty(window.HTMLSelectElement.prototype, "selectedIndex", {
+      configurable: true,
+      get() { return [...this.options].findIndex((o) => o.selected); },
+    });
+    window.HTMLSelectElement.prototype.__mcatSelectedIndexPatched = true;
+  }
+
+  const calls = [];       // every fetch the client made: {url, init, body}
+  const timers = [];      // setTimeout is queued, never real: tests flush it
+  const location = { href: "https://crow.test/dashboard/model-catalog", reload() {} };
+
+  const fetchStub = (url, init) => {
+    const body = init && init.body ? JSON.parse(init.body) : null;
+    calls.push({ url: String(url), init, body });
+    const result = fetchImpl ? fetchImpl(String(url), init) : { ok: true, status: 200, json: () => Promise.resolve({}) };
+    return Promise.resolve(result);
+  };
+
+  const ctx = vm.createContext({
+    window, document, location,
+    fetch: fetchStub,
+    console,
+    setTimeout: (fn) => { timers.push(fn); return timers.length; },
+    clearTimeout: () => {},
+    setInterval: () => 0,
+  });
+  vm.runInContext(CLIENT_JS, ctx);
+
+  const $ = (sel) => document.querySelector(sel);
+  const $$ = (sel) => [...document.querySelectorAll(sel)];
+  const click = (el) => el.dispatchEvent(new window.Event("click", { bubbles: true }));
+  const change = (el) => el.dispatchEvent(new window.Event("change", { bubbles: true }));
+  /** Select an <option> by value and fire change — `sel.value = "..."` is
+   * a no-op setter in this linkedom version (see the patch above), so
+   * this sets `.selected` on the matching <option> directly instead. */
+  const selectQuant = (sel, value) => {
+    for (const opt of sel.options) opt.selected = (opt.value === value);
+    change(sel);
+  };
+  /** Drain the promise microtask queue (the fetch stub resolves immediately). */
+  const settle = async () => { for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r)); };
+  const flushTimers = () => { const q = timers.splice(0); q.forEach((fn) => fn()); };
+
+  return { window, document, $, $$, click, change, selectQuant, settle, flushTimers, calls };
+}
+
+const downloadCalls = (calls) => calls.filter((c) => c.url.indexOf("/download") !== -1 && c.url.indexOf("/downloads") === -1);
+
+// ─── 1a. Never auto-force; a 409 WONT_FIT surfaces an explicit confirm ───
+
+test("BEHAVIOR: startDownload never computes force from the client's own fit belief — the FIRST attempt always sends force:false", async () => {
+  const model = {
+    id: "single-quant-model", family: "fam", lab: "Lab", license: "mit", gated: false,
+    task: "chat", context_len: 4096, tags: ["chat", "small"], notes: null,
+    default_quant: "Q4", first_run_default: false, registered: false, registeredQuant: null, running: false,
+    quants: [{ quant: "Q4", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" }],
+  };
+  const { $, click, calls, settle } = boot({ models: [model] });
+
+  const downloadBtn = $('.mcat-card__actions[data-model-id="single-quant-model"] [data-action="download"]');
+  assert.ok(downloadBtn, "a fits quant renders a Download button");
+
+  click(downloadBtn);
+  await settle();
+
+  const call = downloadCalls(calls)[0];
+  assert.ok(call, "clicking Download posted to /download");
+  assert.equal(call.body.force, false, "no force sent on a plain, unforced click");
+});
+
+test("BEHAVIOR: a server 409 WONT_FIT (the source of truth, not the client's stale badge) surfaces an explicit 'Download anyway' confirm; only confirming retries with force:true", async () => {
+  const model = {
+    id: "single-quant-model", family: "fam", lab: "Lab", license: "mit", gated: false,
+    task: "chat", context_len: 4096, tags: ["chat", "small"], notes: null,
+    default_quant: "Q4", first_run_default: false, registered: false, registeredQuant: null, running: false,
+    quants: [{ quant: "Q4", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" }],
+  };
+  // The server is the authority on fit at request time (hardware can change
+  // between page render and click) — this fixture simulates the server
+  // disagreeing with the badge that was true when the page rendered,
+  // exactly the case an auto-force silently steamrolled.
+  let attempt = 0;
+  const fetchImpl = (url) => {
+    if (url.indexOf("/download") !== -1 && url.indexOf("/downloads") === -1) {
+      attempt += 1;
+      if (attempt === 1) {
+        return { ok: false, status: 409, json: () => Promise.resolve({ code: "WONT_FIT", error: "won't fit", fitBadge: "wont_fit" }) };
+      }
+      return { ok: true, status: 202, json: () => Promise.resolve({ jobId: "single-quant-model::Q4", status: "downloading" }) };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  };
+  const { $, click, calls, settle } = boot({ models: [model], fetchImpl });
+
+  const actions = $('.mcat-card__actions[data-model-id="single-quant-model"]');
+  const downloadBtn = actions.querySelector('[data-action="download"]');
+  click(downloadBtn);
+  await settle();
+
+  assert.equal(downloadCalls(calls).length, 1, "no silent retry happened on its own");
+  assert.equal(downloadCalls(calls)[0].body.force, false);
+
+  const confirmBtn = actions.querySelector("button");
+  assert.ok(confirmBtn, "the 409 replaced the action area with an explicit confirm button");
+  assert.notEqual(confirmBtn, downloadBtn, "a fresh element, not the original button silently relabeled");
+  assert.equal(confirmBtn.getAttribute("data-action"), null, "NOT wired through the delegated data-action handler — a second listener there would double-fire this exact click");
+  assert.equal(confirmBtn.textContent, "Download anyway (may not fit)");
+
+  click(confirmBtn);
+  await settle();
+
+  const after = downloadCalls(calls);
+  assert.equal(after.length, 2, "exactly one retry, triggered only by the explicit confirm click");
+  assert.equal(after[1].body.force, true, "the confirmed retry is the ONLY call that ever carries force:true");
+});
+
+// ─── 1b. Quant-select change re-renders the action area ───
+
+test("BEHAVIOR: switching from a wont_fit default to a fitting quant reveals the Download button (previously undownloadable no matter what the operator picked)", async () => {
+  const model = {
+    id: "multi-quant-model", family: "fam", lab: "Lab", license: "mit", gated: false,
+    task: "chat", context_len: 4096, tags: ["chat", "mid"], notes: null,
+    default_quant: "Q_BIG", first_run_default: false, registered: false, registeredQuant: null, running: false,
+    quants: [
+      { quant: "Q_BIG", size_mb: 90_000, min_ram_mb: 90_000, min_vram_mb: 0, fitBadge: "wont_fit" },
+      { quant: "Q_SMALL", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" },
+    ],
+  };
+  const { $, selectQuant, click, calls } = boot({ models: [model] });
+
+  const actions = $('.mcat-card__actions[data-model-id="multi-quant-model"]');
+  assert.equal(actions.querySelector('[data-action="download"]'), null, "wont_fit default renders NO Download button (per spec: disabled, not silently clickable)");
+  assert.ok(actions.querySelector(".mcat-card__notice"), "a notice explains why instead");
+
+  const sel = $('.mcat-quant-select[data-model-id="multi-quant-model"]');
+  selectQuant(sel, "Q_SMALL");
+
+  const downloadBtn = actions.querySelector('[data-action="download"]');
+  assert.ok(downloadBtn, "selecting the fitting alternate quant reveals the Download button — the entry is now actually downloadable, closing the dead end");
+  assert.equal(actions.querySelector(".mcat-card__notice"), null);
+
+  click(downloadBtn);
+  const call = downloadCalls(calls)[0];
+  assert.equal(call.body.quant, "Q_SMALL", "targets the quant actually selected in the dropdown, not the stale wont_fit default");
+  assert.equal(call.body.force, false);
+});
+
+test("BEHAVIOR: switching from a fitting default to a wont_fit quant HIDES the Download button (never leaves a stale enabled button pointed at an unfittable quant)", () => {
+  const model = {
+    id: "multi-quant-model-2", family: "fam", lab: "Lab", license: "mit", gated: false,
+    task: "chat", context_len: 4096, tags: ["chat", "mid"], notes: null,
+    default_quant: "Q_SMALL", first_run_default: false, registered: false, registeredQuant: null, running: false,
+    quants: [
+      { quant: "Q_SMALL", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" },
+      { quant: "Q_BIG", size_mb: 90_000, min_ram_mb: 90_000, min_vram_mb: 0, fitBadge: "wont_fit" },
+    ],
+  };
+  const { $, selectQuant } = boot({ models: [model] });
+  const actions = $('.mcat-card__actions[data-model-id="multi-quant-model-2"]');
+  assert.ok(actions.querySelector('[data-action="download"]'), "fits default starts with a Download button");
+
+  const sel = $('.mcat-quant-select[data-model-id="multi-quant-model-2"]');
+  selectQuant(sel, "Q_BIG");
+
+  assert.equal(actions.querySelector('[data-action="download"]'), null, "wont_fit selection removes the button entirely");
+  assert.ok(actions.querySelector(".mcat-card__notice"));
+});
+
+test("BEHAVIOR: quant change never touches the action area for an already-registered/running model (Start/Stop/Remove stay put)", () => {
+  const model = {
+    id: "installed-multi-quant", family: "fam", lab: "Lab", license: "mit", gated: false,
+    task: "chat", context_len: 4096, tags: ["chat", "mid"], notes: null,
+    default_quant: "Q_SMALL", first_run_default: false, registered: true, registeredQuant: "Q_SMALL", running: false,
+    quants: [
+      { quant: "Q_SMALL", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" },
+      { quant: "Q_BIG", size_mb: 90_000, min_ram_mb: 90_000, min_vram_mb: 0, fitBadge: "wont_fit" },
+    ],
+  };
+  const { $, selectQuant } = boot({ models: [model] });
+  const actions = $('.mcat-card__actions[data-model-id="installed-multi-quant"]');
+  assert.ok(actions.querySelector('[data-action="start"]'));
+  assert.ok(actions.querySelector('[data-action="remove"]'));
+
+  const sel = $('.mcat-quant-select[data-model-id="installed-multi-quant"]');
+  selectQuant(sel, "Q_BIG");
+
+  assert.ok(actions.querySelector('[data-action="start"]'), "Start button untouched by a quant change on an installed model");
+  assert.ok(actions.querySelector('[data-action="remove"]'), "Remove button untouched");
+  assert.equal(actions.querySelector('[data-action="download"]'), null);
+});
+
+// ─── 2. hf-browser Remove affordance in the runtime strip ───
+
+test("BEHAVIOR: the runtime strip renders a Remove button for hf-browser-sourced entries, and NOT for curated ones", () => {
+  const runtimeModels = [
+    { modelId: "curated-running-model", source: "curated", state: "running", live: true, port: 18101, restartCount: 0, lastError: null, startedAt: "t", pid: 111 },
+    { modelId: "hf-model", source: "hf-browser", state: "stopped", live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null },
+  ];
+  const { $$ } = boot({ models: [], runtimeModels });
+  const removeButtons = $$('button[data-action="remove"]');
+  const removeIds = removeButtons.map((b) => b.getAttribute("data-model-id"));
+  assert.ok(removeIds.includes("hf-model"), "hf-browser row gets a Remove button in the strip (its only removal surface — it has no curated card)");
+  assert.ok(!removeIds.includes("curated-running-model"), "curated row does not duplicate Remove in the strip — its own card already has one");
+});
+
+test("BEHAVIOR: clicking the strip's Remove button for an hf-browser entry goes through the real delete-confirm flow", async () => {
+  const runtimeModels = [
+    { modelId: "hf-model", source: "hf-browser", state: "stopped", live: false, port: null, restartCount: 0, lastError: null, startedAt: null, pid: null },
+  ];
+  const fetchImpl = (url, init) => {
+    if (url.indexOf("/api/models/hf-model") !== -1 || url.endsWith("/hf-model")) {
+      return {
+        ok: true, status: 200,
+        json: () => Promise.resolve({ requiresConfirm: true, modelId: "hf-model", bindings: { profiles: [], bots: [] } }),
+      };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  };
+  const { $, click, settle, document } = boot({ models: [], runtimeModels, fetchImpl });
+  const removeBtn = $('button[data-action="remove"][data-model-id="hf-model"]');
+  assert.ok(removeBtn);
+
+  click(removeBtn);
+  await settle();
+
+  const overlay = document.getElementById("mcat-modal-overlay");
+  assert.equal(overlay.style.display, "flex", "the confirmation modal opened — the strip's Remove reuses the exact same requestDelete/showDeleteConfirm flow the curated cards use");
+  assert.match(document.getElementById("mcat-modal-content").textContent, /nothing else references this model|hf-model/i);
+});
+
+// ─── 3. HTTP_401 -> the gatedNoToken copy ───
+
+test("BEHAVIOR: a job that fails with errorCode HTTP_401 shows the 'requires a Hugging Face login' copy (HF answers an unauthenticated gated download 401, not 403)", async () => {
+  const model = {
+    id: "gated-model", family: "fam", lab: "Lab", license: "gemma", gated: true,
+    task: "chat", context_len: 4096, tags: ["chat", "large", "gated"], notes: null,
+    default_quant: "Q4", first_run_default: false, registered: false, registeredQuant: null, running: false,
+    quants: [{ quant: "Q4", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" }],
+  };
+  const fetchImpl = (url) => {
+    if (url.indexOf("/download") !== -1 && url.indexOf("/downloads") === -1) {
+      return { ok: true, status: 202, json: () => Promise.resolve({ jobId: "gated-model::Q4", status: "downloading" }) };
+    }
+    if (url.indexOf("/downloads") !== -1) {
+      return {
+        ok: true, status: 200,
+        json: () => Promise.resolve({ downloads: [{ id: "gated-model::Q4", status: "error", errorCode: "HTTP_401", error: "Unauthorized", bytesDone: 0, totalBytes: null }] }),
+      };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  };
+  const { $, click, settle } = boot({ models: [model], fetchImpl });
+
+  const downloadBtn = $('.mcat-card__actions[data-model-id="gated-model"] [data-action="download"]');
+  click(downloadBtn);
+  await settle();
+
+  const statusEl = $('.mcat-card__status-text[data-model-id="gated-model"]');
+  assert.equal(
+    statusEl.textContent,
+    "This model requires a Hugging Face login. Add a token in the Browse Hugging Face tab below, then retry.",
+  );
+});
+
+test("BEHAVIOR: HTTP_403 still shows the distinct 'accept the license, then retry' copy (401 and 403 stay separately meaningful)", async () => {
+  const model = {
+    id: "gated-model-403", family: "fam", lab: "Lab", license: "gemma", gated: true,
+    task: "chat", context_len: 4096, tags: ["chat", "large", "gated"], notes: null,
+    default_quant: "Q4", first_run_default: false, registered: false, registeredQuant: null, running: false,
+    quants: [{ quant: "Q4", size_mb: 500, min_ram_mb: 500, min_vram_mb: 0, fitBadge: "fits" }],
+  };
+  const fetchImpl = (url) => {
+    if (url.indexOf("/download") !== -1 && url.indexOf("/downloads") === -1) {
+      return { ok: true, status: 202, json: () => Promise.resolve({ jobId: "gated-model-403::Q4", status: "downloading" }) };
+    }
+    if (url.indexOf("/downloads") !== -1) {
+      return {
+        ok: true, status: 200,
+        json: () => Promise.resolve({ downloads: [{ id: "gated-model-403::Q4", status: "error", errorCode: "HTTP_403", error: "Forbidden", bytesDone: 0, totalBytes: null }] }),
+      };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  };
+  const { $, click, settle } = boot({ models: [model], fetchImpl });
+
+  const downloadBtn = $('.mcat-card__actions[data-model-id="gated-model-403"] [data-action="download"]');
+  click(downloadBtn);
+  await settle();
+
+  const statusEl = $('.mcat-card__status-text[data-model-id="gated-model-403"]');
+  assert.match(statusEl.textContent, /accept the license/i);
+  assert.doesNotMatch(statusEl.textContent, /requires a Hugging Face login/);
+});

--- a/tests/models-manager.test.js
+++ b/tests/models-manager.test.js
@@ -55,6 +55,15 @@ import {
   UnsafeDestinationError,
   DownloadProtocolError,
   DownloadTimeoutError,
+  HttpStatusError,
+  HfMetadataError,
+  HfFileNotFoundError,
+  NoVerifiableChecksumError,
+  isValidHfRepoId,
+  isValidHfFilename,
+  deriveModelIdFromFilename,
+  fetchHfPathInfo,
+  downloadHfFile,
   fetchModelBlob,
 } from "../servers/gateway/models/manager.js";
 import { loadState } from "../servers/gateway/models/state.js";
@@ -1003,4 +1012,356 @@ test("enqueueDownload is idempotent per modelId: a second enqueue while one is i
   } finally {
     await stopServer(srv);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Task 13 fix round 1, finding d: typed HTTP status error
+// ---------------------------------------------------------------------------
+
+test("a non-redirect, non-200/206 HTTP status throws a typed HttpStatusError with statusCode + code", async () => {
+  const { srv, port } = await startServer((req, res) => {
+    res.writeHead(403, { "content-type": "text/plain" });
+    res.end("Forbidden");
+  });
+  try {
+    const dir = scratchDir("http-status");
+    try {
+      await assert.rejects(
+        () => downloadModel({
+          modelId: "test-model", dir, catalog: makeCatalog(),
+          lookup: lookupToLocalhost, baseUrl: `http://huggingface.co:${port}`, insecureHttpHosts: INSECURE_HF,
+        }),
+        (err) => {
+          assert.ok(err instanceof HttpStatusError, `expected HttpStatusError, got ${err.constructor.name}`);
+          assert.equal(err.statusCode, 403);
+          assert.equal(err.code, "HTTP_403");
+          return true;
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("HttpStatusError.code varies with the actual status (404 -> HTTP_404)", async () => {
+  const { srv, port } = await startServer((req, res) => {
+    res.writeHead(404);
+    res.end();
+  });
+  try {
+    await assert.rejects(
+      () => fetchModelBlob({
+        url: `http://huggingface.co:${port}/repo/resolve/main/f.gguf`,
+        dest: join(scratchDir("http-404"), "f.gguf"),
+        lookup: lookupToLocalhost,
+        insecureHttpHosts: INSECURE_HF,
+      }),
+      (err) => {
+        assert.equal(err.code, "HTTP_404");
+        assert.equal(err.statusCode, 404);
+        return true;
+      },
+    );
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Task 13 fix round 1, finding 1: Browse Hugging Face downloads
+// ---------------------------------------------------------------------------
+
+/** Shape validators — pure, no I/O. */
+test("isValidHfRepoId: exactly owner/name, conservative charset, no traversal", () => {
+  assert.equal(isValidHfRepoId("Qwen/Qwen3-4B-GGUF"), true);
+  assert.equal(isValidHfRepoId("org-name/repo.name_2"), true);
+  assert.equal(isValidHfRepoId("noSlash"), false);
+  assert.equal(isValidHfRepoId("a/b/c"), false, "extra path segment rejected");
+  assert.equal(isValidHfRepoId("../etc/passwd"), false);
+  assert.equal(isValidHfRepoId("/leading-slash"), false);
+  assert.equal(isValidHfRepoId("trailing-slash/"), false);
+  assert.equal(isValidHfRepoId(""), false);
+  assert.equal(isValidHfRepoId(null), false);
+  assert.equal(isValidHfRepoId(123), false);
+});
+
+test("isValidHfFilename: single sanitized filename, no separators, no traversal", () => {
+  assert.equal(isValidHfFilename("model-Q4_K_M.gguf"), true);
+  assert.equal(isValidHfFilename("a.b_c-9.gguf"), true);
+  assert.equal(isValidHfFilename("dir/model.gguf"), false);
+  assert.equal(isValidHfFilename("..\\model.gguf"), false);
+  assert.equal(isValidHfFilename(".."), false);
+  assert.equal(isValidHfFilename("."), false);
+  assert.equal(isValidHfFilename(""), false);
+  assert.equal(isValidHfFilename(null), false);
+});
+
+test("deriveModelIdFromFilename: strips .gguf, lowercases, collapses unsafe chars, trims", () => {
+  assert.equal(deriveModelIdFromFilename("Foo-Bar_Q4_K_M.gguf"), "foo-bar_q4_k_m");
+  assert.equal(deriveModelIdFromFilename("Weird!!Name??.GGUF"), "weird-name");
+  assert.throws(() => deriveModelIdFromFilename("....gguf"), UnsafeDestinationError);
+  assert.throws(() => deriveModelIdFromFilename(""), UnsafeDestinationError);
+});
+
+/** Local stand-in for Hugging Face's `paths-info` API — routes on method +
+ * URL, independent per-call configurable via `mode`. `fetchHfPathInfo` uses
+ * plain `fetch()` (no DNS-override tricks needed), so this fixture is
+ * addressed directly as `hfApiBase` at its real 127.0.0.1 port. */
+function startHfMetaFixture(sha256, size) {
+  let mode = "ok"; // ok | no-lfs | not-found | error-500
+  let lastHeaders = null;
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      lastHeaders = req.headers;
+      if (mode === "error-500") {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "internal" }));
+        return;
+      }
+      let body = {};
+      try { body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}"); } catch { /* ignore */ }
+      const paths = Array.isArray(body.paths) ? body.paths : [];
+      if (mode === "not-found") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("[]"); // confirmed live behavior: HF answers 200 [] for a path that doesn't exist
+        return;
+      }
+      const results = paths.map((p) => {
+        const entry = { path: p, size, oid: "deadbeef0000gitblobsha1notasha256", type: "file" };
+        if (mode !== "no-lfs") entry.lfs = { oid: sha256, size };
+        return entry;
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(results));
+    });
+  });
+  return new Promise((resolvePromise, reject) => {
+    server.listen(0, "127.0.0.1", () => resolvePromise({
+      base: `http://127.0.0.1:${server.address().port}`,
+      setMode: (m) => { mode = m; },
+      lastHeaders: () => lastHeaders,
+      close: () => new Promise((r) => server.close(r)),
+    }));
+    server.on("error", reject);
+  });
+}
+
+test("fetchHfPathInfo: LFS file -> real sha256 + size", async () => {
+  const fx = await startHfMetaFixture(BLOB_SHA256, BLOB.length);
+  try {
+    const info = await fetchHfPathInfo({ hfRepo: "org/repo", file: "model.gguf", hfApiBase: fx.base });
+    assert.equal(info.sha256, BLOB_SHA256);
+    assert.equal(info.sizeBytes, BLOB.length);
+  } finally {
+    await fx.close();
+  }
+});
+
+test("fetchHfPathInfo: non-LFS file -> sha256 null (never a git blob hash mistaken for content sha256)", async () => {
+  const fx = await startHfMetaFixture(BLOB_SHA256, BLOB.length);
+  fx.setMode("no-lfs");
+  try {
+    const info = await fetchHfPathInfo({ hfRepo: "org/repo", file: "README.md", hfApiBase: fx.base });
+    assert.equal(info.sha256, null);
+  } finally {
+    await fx.close();
+  }
+});
+
+test("fetchHfPathInfo: nonexistent path in a valid repo (200 []) throws HfFileNotFoundError, not a silent empty result", async () => {
+  const fx = await startHfMetaFixture(BLOB_SHA256, BLOB.length);
+  fx.setMode("not-found");
+  try {
+    await assert.rejects(
+      () => fetchHfPathInfo({ hfRepo: "org/repo", file: "nope.gguf", hfApiBase: fx.base }),
+      HfFileNotFoundError,
+    );
+  } finally {
+    await fx.close();
+  }
+});
+
+test("fetchHfPathInfo: upstream 500 throws HfMetadataError with statusCode", async () => {
+  const fx = await startHfMetaFixture(BLOB_SHA256, BLOB.length);
+  fx.setMode("error-500");
+  try {
+    await assert.rejects(
+      () => fetchHfPathInfo({ hfRepo: "org/repo", file: "model.gguf", hfApiBase: fx.base }),
+      (err) => {
+        assert.ok(err instanceof HfMetadataError);
+        assert.equal(err.statusCode, 500);
+        return true;
+      },
+    );
+  } finally {
+    await fx.close();
+  }
+});
+
+test("fetchHfPathInfo: forwards the hfToken as a Bearer Authorization header", async () => {
+  const fx = await startHfMetaFixture(BLOB_SHA256, BLOB.length);
+  try {
+    await fetchHfPathInfo({ hfRepo: "org/repo", file: "model.gguf", hfApiBase: fx.base, hfToken: "hf_secrettoken123" });
+    assert.equal(fx.lastHeaders().authorization, "Bearer hf_secrettoken123");
+  } finally {
+    await fx.close();
+  }
+});
+
+/** Combined fixture serving BOTH the paths-info API (POST, addressed via
+ * plain 127.0.0.1 as `hfApiBase`) AND the actual resolve/download endpoint
+ * (GET, addressed via the real "huggingface.co" hostname + `lookup`
+ * override + `insecureHttpHosts`, exactly like every other download-engine
+ * test in this file) — `downloadHfFile` talks to both. */
+function startHfCombinedFixture(blob, sha256) {
+  let downloadHeaders = null;
+  let servedBlob = blob;
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      if (req.method === "POST" && /\/paths-info\//.test(req.url)) {
+        let body = {};
+        try { body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}"); } catch { /* ignore */ }
+        const paths = Array.isArray(body.paths) ? body.paths : [];
+        const results = paths.map((p) => ({ path: p, size: blob.length, oid: "gitblobsha1", lfs: { oid: sha256, size: blob.length } }));
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(results));
+        return;
+      }
+      // GET /{repo}/resolve/main/{file}
+      downloadHeaders = req.headers;
+      res.writeHead(200, { "Content-Length": String(servedBlob.length) });
+      res.end(servedBlob);
+    });
+  });
+  return new Promise((resolvePromise, reject) => {
+    server.listen(0, "127.0.0.1", () => resolvePromise({
+      port: server.address().port,
+      setServedBlob: (b) => { servedBlob = b; },
+      downloadHeaders: () => downloadHeaders,
+      close: () => new Promise((r) => server.close(r)),
+    }));
+    server.on("error", reject);
+  });
+}
+
+test("downloadHfFile: verifies the fetched sha256, streams to disk, registers via the SAME synthetic catalog it returns", async () => {
+  const fx = await startHfCombinedFixture(BLOB, BLOB_SHA256);
+  try {
+    const dir = scratchDir("hf-download-ok");
+    try {
+      const result = await downloadHfFile({
+        hfRepo: "org/repo",
+        file: "org-model-Q4_K_M.gguf",
+        dir,
+        hfApiBase: `http://127.0.0.1:${fx.port}`,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${fx.port}`,
+        insecureHttpHosts: INSECURE_HF,
+      });
+      assert.equal(result.sha256, BLOB_SHA256);
+      assert.equal(result.modelId, "org-model-q4_k_m");
+      assert.ok(result.sizeMb > 0);
+      assert.equal(result.catalog.models[0].id, "org-model-q4_k_m");
+      assert.equal(result.catalog.models[0].quants[0].sha256, BLOB_SHA256);
+      assert.ok(existsSync(result.path));
+      assert.equal(readFileSync(result.path).length, BLOB.length);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await fx.close();
+  }
+});
+
+test("downloadHfFile: a file with no LFS oid is refused BEFORE any download traffic (NoVerifiableChecksumError)", async () => {
+  const fx = await startHfMetaFixture(BLOB_SHA256, BLOB.length);
+  fx.setMode("no-lfs");
+  try {
+    const dir = scratchDir("hf-download-nolfs");
+    try {
+      await assert.rejects(
+        () => downloadHfFile({
+          hfRepo: "org/repo", file: "README.md", dir,
+          hfApiBase: fx.base,
+        }),
+        NoVerifiableChecksumError,
+      );
+      // Never touched the blobs dir at all — refused before any download attempt.
+      assert.equal(existsSync(join(dir, "models", "blobs")), false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await fx.close();
+  }
+});
+
+test("downloadHfFile: a mismatched sha256 (blob doesn't match what paths-info reported) throws ChecksumError and deletes the bad file", async () => {
+  const wrongBlob = makeBlob(400_000); // different content -> different real sha256 than BLOB_SHA256
+  const fx = await startHfCombinedFixture(wrongBlob, BLOB_SHA256); // paths-info LIES: claims BLOB_SHA256 but serves wrongBlob
+  try {
+    const dir = scratchDir("hf-download-mismatch");
+    try {
+      await assert.rejects(
+        () => downloadHfFile({
+          hfRepo: "org/repo",
+          file: "org-model-Q4_K_M.gguf",
+          dir,
+          hfApiBase: `http://127.0.0.1:${fx.port}`,
+          lookup: lookupToLocalhost,
+          baseUrl: `http://huggingface.co:${fx.port}`,
+          insecureHttpHosts: INSECURE_HF,
+        }),
+        ChecksumError,
+      );
+      const dest = join(dir, "models", "blobs", "org-model-Q4_K_M.gguf");
+      assert.equal(existsSync(dest), false, "the mismatched file is deleted, never left on disk to be mistaken for good");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await fx.close();
+  }
+});
+
+test("downloadHfFile: forwards hfToken as a Bearer Authorization header to the ACTUAL download request too (needed for gated repos)", async () => {
+  const fx = await startHfCombinedFixture(BLOB, BLOB_SHA256);
+  try {
+    const dir = scratchDir("hf-download-token");
+    try {
+      await downloadHfFile({
+        hfRepo: "org/repo",
+        file: "org-model-Q4_K_M.gguf",
+        dir,
+        hfToken: "hf_secrettoken456",
+        hfApiBase: `http://127.0.0.1:${fx.port}`,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${fx.port}`,
+        insecureHttpHosts: INSECURE_HF,
+      });
+      assert.equal(fx.downloadHeaders().authorization, "Bearer hf_secrettoken456");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await fx.close();
+  }
+});
+
+test("downloadHfFile: rejects an invalid repo id / filename shape before any network call", async () => {
+  await assert.rejects(
+    () => downloadHfFile({ hfRepo: "../etc/passwd", file: "x.gguf", dir: scratchDir("hf-bad-repo") }),
+    UnsafeDestinationError,
+  );
+  await assert.rejects(
+    () => downloadHfFile({ hfRepo: "org/repo", file: "../../x.gguf", dir: scratchDir("hf-bad-file") }),
+    UnsafeDestinationError,
+  );
 });

--- a/tests/models-panel-ui.test.js
+++ b/tests/models-panel-ui.test.js
@@ -1,0 +1,414 @@
+/**
+ * Model Catalog panel UI (Item G, Task 13).
+ *
+ * Three layers:
+ *  1. Pure helpers (sizeClassOf/groupBySizeClass/formatMb/fitLabelKey/fitHintKey)
+ *     — no I/O, no injection needed.
+ *  2. `loadPanelData` — the injectable data-assembly seam (mirrors
+ *     routes/models.js's opts pattern from Task 12), with fakes standing in
+ *     for probe/state/runtime/providers so this stays fast and DB-free where
+ *     it can be.
+ *  3. The real panel `handler` mounted behind the REAL `dashboardAuth`
+ *     middleware in a scratch express app, exercising the actual dashboard
+ *     auth convention (403 network-denied / 303-redirect unauthenticated /
+ *     200 authenticated) exactly the way `servers/gateway/dashboard/index.js`
+ *     wires every panel route — same harness shape
+ *     `tests/models-panel.test.js` uses for the Task 12 routes (real
+ *     scratch libsql via scripts/init-db.js, a session token seeded into
+ *     oauth_tokens, `Tailscale-User-Login` to satisfy isAllowedNetwork over
+ *     plain loopback).
+ *
+ * Also covers the two hard invariants called out in the brief:
+ *   - zero literal backticks inside the client <script> block, and
+ *   - no raw i18n key leaks into the rendered HTML (every `models.*`/`nav.*`
+ *     key used by the panel must resolve to real copy).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import http from "node:http";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+
+import modelCatalogPanel, {
+  sizeClassOf,
+  groupBySizeClass,
+  formatMb,
+  fitLabelKey,
+  fitHintKey,
+  loadPanelData,
+} from "../servers/gateway/dashboard/panels/model-catalog.js";
+import { dashboardAuth } from "../servers/gateway/dashboard/auth.js";
+import { translations } from "../servers/gateway/dashboard/shared/i18n.js";
+
+const repoRoot = join(import.meta.dirname, "..");
+
+// ---------------------------------------------------------------------------
+// 1. Pure helpers
+// ---------------------------------------------------------------------------
+
+test("sizeClassOf: reads the small/mid/large tag, falls back to 'other'", () => {
+  assert.equal(sizeClassOf({ tags: ["chat", "small", "cpu-capable"] }), "small");
+  assert.equal(sizeClassOf({ tags: ["chat", "mid"] }), "mid");
+  assert.equal(sizeClassOf({ tags: ["chat", "large", "reasoning"] }), "large");
+  assert.equal(sizeClassOf({ tags: ["chat"] }), "other");
+  assert.equal(sizeClassOf({ tags: [] }), "other");
+  assert.equal(sizeClassOf({}), "other");
+});
+
+test("groupBySizeClass: buckets every model, empty groups stay empty arrays", () => {
+  const models = [
+    { id: "a", tags: ["small"] },
+    { id: "b", tags: ["mid"] },
+    { id: "c", tags: ["mid"] },
+    { id: "d", tags: ["large"] },
+  ];
+  const groups = groupBySizeClass(models);
+  assert.deepEqual(groups.small.map((m) => m.id), ["a"]);
+  assert.deepEqual(groups.mid.map((m) => m.id), ["b", "c"]);
+  assert.deepEqual(groups.large.map((m) => m.id), ["d"]);
+  assert.deepEqual(groups.other, []);
+});
+
+test("formatMb: GB above 1024, MB below, null/NaN pass through as null", () => {
+  assert.equal(formatMb(512), "512 MB");
+  assert.equal(formatMb(2048), "2.0 GB");
+  assert.equal(formatMb(6030), "5.9 GB");
+  assert.equal(formatMb(null), null);
+  assert.equal(formatMb(undefined), null);
+  assert.equal(formatMb(NaN), null);
+});
+
+test("fitLabelKey/fitHintKey: every fit badge maps to a distinct key, unrecognized falls back to unknown", () => {
+  for (const b of ["fits", "tight", "wont_fit"]) {
+    assert.match(fitLabelKey(b), /^models\.fit/);
+    assert.match(fitHintKey(b), /^models\.fit/);
+  }
+  assert.equal(fitLabelKey("bogus"), fitLabelKey("unknown"));
+  assert.equal(fitHintKey("bogus"), fitHintKey("unknown"));
+  // all four are pairwise distinct
+  const labelKeys = new Set(["fits", "tight", "wont_fit", "unknown"].map(fitLabelKey));
+  assert.equal(labelKeys.size, 4);
+});
+
+// ---------------------------------------------------------------------------
+// 2. loadPanelData
+// ---------------------------------------------------------------------------
+
+function fakeCatalog() {
+  return {
+    runtime: { name: "llama.cpp", release: "b10068" },
+    models: [
+      {
+        id: "ui-test-small", family: "fam", lab: "Lab", license: "mit", gated: false,
+        task: "chat", context_len: 4096, tags: ["chat", "small"], notes: "n",
+        default_quant: "Q4", first_run_default: true,
+        quants: [{ file: "f.gguf", quant: "Q4", size_mb: 100, min_ram_mb: 500, min_vram_mb: 0, sha256: "x" }],
+      },
+      {
+        id: "ui-test-gated", family: "fam2", lab: "Lab2", license: "gemma", gated: true,
+        task: "chat", context_len: 8192, tags: ["chat", "large"], notes: null,
+        default_quant: "Q8", first_run_default: false,
+        quants: [{ file: "g.gguf", quant: "Q8", size_mb: 9000, min_ram_mb: 20000, min_vram_mb: 8000, sha256: "y" }],
+      },
+    ],
+  };
+}
+
+test("loadPanelData: maps models with fit badges, registered/running state, and estimates RAM/VRAM in use", async () => {
+  const data = await loadPanelData({
+    dir: "/unused-because-loadStateFn-is-injected",
+    loadCatalogFn: fakeCatalog,
+    getCachedProbeFn: () => ({ platform: "linux", wsl2: false, accel: "vulkan", gpuName: "Fake GPU", vramMb: 12000, ramAvailableMb: 16000, diskFreeMb: 500000, unknown: [] }),
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: { "ui-test-small": { quant: "Q4" } } }),
+    getStatusSnapshotFn: () => ([{ alias: "ui-test-small", state: "running", live: true, port: 18100, restartCount: 0, lastError: null, startedAt: "t", pid: 1 }]),
+    getNativeHandleFn: (id) => (id === "ui-test-small" ? { live: true } : null),
+  });
+
+  assert.equal(data.runtime.name, "llama.cpp");
+  assert.equal(data.models.length, 2);
+  const small = data.models.find((m) => m.id === "ui-test-small");
+  assert.equal(small.registered, true);
+  assert.equal(small.registeredQuant, "Q4");
+  assert.equal(small.running, true);
+  assert.equal(small.quants[0].fitBadge, "fits");
+
+  const gated = data.models.find((m) => m.id === "ui-test-gated");
+  assert.equal(gated.registered, false);
+  assert.equal(gated.running, false);
+  assert.equal(gated.gated, true);
+  // 20000 min_ram_mb vs 16000+12000=28000 effective (min_vram_mb 8000 <= 12000 vram) -> fits
+  assert.equal(gated.quants[0].fitBadge, "fits");
+
+  assert.equal(data.runtimeModels.length, 1);
+  assert.equal(data.runtimeModels[0].modelId, "ui-test-small");
+  assert.equal(data.estimatedRamMb, 500); // only the live model's registered quant counts
+  assert.equal(data.estimatedVramMb, 0);
+});
+
+test("loadPanelData: a registered-but-not-live model contributes nothing to the RAM/VRAM estimate", async () => {
+  const data = await loadPanelData({
+    loadCatalogFn: fakeCatalog,
+    getCachedProbeFn: () => ({ platform: "linux", wsl2: false, accel: "cpu", gpuName: null, vramMb: null, ramAvailableMb: 8000, diskFreeMb: 1000, unknown: [] }),
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: { "ui-test-small": { quant: "Q4" } } }),
+    getStatusSnapshotFn: () => ([]), // never started this process lifetime
+    getNativeHandleFn: () => null,
+  });
+  const small = data.models.find((m) => m.id === "ui-test-small");
+  assert.equal(small.registered, true);
+  assert.equal(small.running, false);
+  assert.equal(data.runtimeModels[0].live, false);
+  assert.equal(data.estimatedRamMb, 0);
+});
+
+test("loadPanelData: wont_fit quant on tiny RAM never falls open to fits/tight", async () => {
+  const data = await loadPanelData({
+    loadCatalogFn: fakeCatalog,
+    getCachedProbeFn: () => ({ platform: "linux", wsl2: false, accel: "cpu", gpuName: null, vramMb: null, ramAvailableMb: 1024, diskFreeMb: 1000, unknown: [] }),
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: {} }),
+    getStatusSnapshotFn: () => ([]),
+    getNativeHandleFn: () => null,
+  });
+  const gated = data.models.find((m) => m.id === "ui-test-gated");
+  assert.equal(gated.quants[0].fitBadge, "wont_fit");
+});
+
+test("loadPanelData: probe cache miss (null) triggers exactly one reprobe call, its result is used", async () => {
+  let reprobeCalls = 0;
+  const data = await loadPanelData({
+    loadCatalogFn: fakeCatalog,
+    getCachedProbeFn: () => null,
+    reprobeFn: async () => {
+      reprobeCalls += 1;
+      return { platform: "linux", wsl2: false, accel: "cpu", gpuName: null, vramMb: null, ramAvailableMb: 999999, diskFreeMb: 999999, unknown: [] };
+    },
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: {} }),
+    getStatusSnapshotFn: () => ([]),
+    getNativeHandleFn: () => null,
+  });
+  assert.equal(reprobeCalls, 1);
+  // huge ramAvailableMb from the reprobe result -> even the gated/large quant fits
+  const gated = data.models.find((m) => m.id === "ui-test-gated");
+  assert.equal(gated.quants[0].fitBadge, "fits");
+});
+
+test("loadPanelData: reprobe failure is honest — probe stays null, every fit badge is 'unknown', never crashes", async () => {
+  const data = await loadPanelData({
+    loadCatalogFn: fakeCatalog,
+    getCachedProbeFn: () => null,
+    reprobeFn: async () => { throw new Error("no vulkaninfo on this box"); },
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: {} }),
+    getStatusSnapshotFn: () => ([]),
+    getNativeHandleFn: () => null,
+  });
+  assert.equal(data.probe, null);
+  for (const m of data.models) {
+    for (const q of m.quants) assert.equal(q.fitBadge, "unknown");
+  }
+});
+
+test("loadPanelData: hfTokenConfigured true only when the reserved provider row has a non-empty apiKey", async () => {
+  const base = {
+    loadCatalogFn: fakeCatalog,
+    getCachedProbeFn: () => ({ platform: "linux", wsl2: false, accel: "cpu", gpuName: null, vramMb: null, ramAvailableMb: 8000, diskFreeMb: 1000, unknown: [] }),
+    loadStateFn: () => ({ reservations: {}, journal: {}, registry: {} }),
+    getStatusSnapshotFn: () => ([]),
+    getNativeHandleFn: () => null,
+  };
+
+  const withToken = await loadPanelData({
+    ...base, db: {},
+    listProvidersAllFn: async () => ([{ id: "crow-hf-token", apiKey: "hf_abc" }]),
+  });
+  assert.equal(withToken.hfTokenConfigured, true);
+
+  const withoutToken = await loadPanelData({
+    ...base, db: {},
+    listProvidersAllFn: async () => ([{ id: "crow-hf-token", apiKey: null }]),
+  });
+  assert.equal(withoutToken.hfTokenConfigured, false);
+
+  const noDb = await loadPanelData(base); // db omitted entirely
+  assert.equal(noDb.hfTokenConfigured, false);
+
+  const dbThrows = await loadPanelData({
+    ...base, db: {},
+    listProvidersAllFn: async () => { throw new Error("db offline"); },
+  });
+  assert.equal(dbThrows.hfTokenConfigured, false); // fails closed, never throws
+});
+
+// ---------------------------------------------------------------------------
+// 3. Full render: real dashboardAuth, real scratch DB, real registry/model-catalog.json
+// ---------------------------------------------------------------------------
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "models-panel-ui-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: repoRoot,
+  });
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return {
+    dir, db,
+    async cleanup() {
+      if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+      else process.env.CROW_DATA_DIR = prevDataDir;
+      try { db.close(); } catch { /* best effort */ }
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function hashToken(tok) { return createHash("sha256").update(tok).digest("hex"); }
+
+async function seedSession(db, token = "ui-test-session-token") {
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  await db.execute({
+    sql: "INSERT INTO oauth_tokens (token, token_type, client_id, scopes, expires_at) VALUES (?, 'access', 'dashboard', 'dashboard', ?)",
+    args: [hashToken(token), expiresAt],
+  });
+  return token;
+}
+
+/** Mounts dashboardAuth exactly the way servers/gateway/index.js does
+ * (the `res.redirectAfterPost` shim it installs globally), then the panel
+ * route the same way servers/gateway/dashboard/index.js's `/dashboard/:panelId`
+ * dispatcher calls `panel.handler(req, res, { db, layout, lang })`. */
+async function withPanelServer(h, fn) {
+  const app = express();
+  app.use((req, res, next) => {
+    res.redirectAfterPost = (url) => res.redirect(303, url);
+    next();
+  });
+  app.get("/dashboard/model-catalog", dashboardAuth, async (req, res) => {
+    const layout = ({ title, content }) => "<html><head><title>" + title + "</title></head><body>" + content + "</body></html>";
+    try {
+      const html = await modelCatalogPanel.handler(req, res, { db: h.db, layout, lang: req.headers["x-test-lang"] === "es" ? "es" : "en" });
+      if (!res.headersSent) res.type("html").send(html);
+    } catch (err) {
+      if (!res.headersSent) res.status(500).send("panel error: " + err.message);
+    }
+  });
+  const server = http.createServer(app);
+  await new Promise((r) => server.listen(0, r));
+  const base = "http://127.0.0.1:" + server.address().port;
+  try {
+    await fn(base);
+  } finally {
+    server.close();
+  }
+}
+
+test("panel route: bare loopback with no tailnet identity is network-denied (403), same as every other panel", async () => {
+  const h = freshLibsql();
+  try {
+    await withPanelServer(h, async (base) => {
+      const r = await fetch(base + "/dashboard/model-catalog");
+      assert.equal(r.status, 403);
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("panel route: tailnet-identified but no session cookie redirects to /dashboard/login (dashboardAuth convention)", async () => {
+  const h = freshLibsql();
+  try {
+    await withPanelServer(h, async (base) => {
+      const r = await fetch(base + "/dashboard/model-catalog", {
+        headers: { "tailscale-user-login": "test@example.com" },
+        redirect: "manual",
+      });
+      assert.equal(r.status, 303);
+      assert.match(r.headers.get("location"), /\/dashboard\/login$/);
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("panel route: authenticated request renders 200 with the curated tab, runtime strip, and a real catalog model card", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withPanelServer(h, async (base) => {
+      const r = await fetch(base + "/dashboard/model-catalog", {
+        headers: { "tailscale-user-login": "test@example.com", cookie: "crow_session=" + token },
+      });
+      assert.equal(r.status, 200);
+      const html = await r.text();
+      assert.match(html, /id="mcat-runtime-strip"/);
+      assert.match(html, /data-tab-panel="curated"/);
+      assert.match(html, /data-tab-panel="browse-hf"/);
+      // real registry/model-catalog.json content — the small, permissively
+      // licensed first_run_default entry must be present
+      assert.match(html, /data-model-id="qwen3-4b"/);
+      assert.match(html, /data-action="download"/);
+      assert.match(html, /id="mcat-hf-search-input"/);
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("panel route: renders in Spanish when lang=es is passed through the layout context", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withPanelServer(h, async (base) => {
+      const r = await fetch(base + "/dashboard/model-catalog", {
+        headers: { "tailscale-user-login": "test@example.com", cookie: "crow_session=" + token, "x-test-lang": "es" },
+      });
+      assert.equal(r.status, 200);
+      const html = await r.text();
+      assert.match(html, /Explorar Hugging Face/);
+      assert.match(html, /Descargar/);
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Hard invariants: zero backticks in client JS, no raw i18n key leakage
+// ---------------------------------------------------------------------------
+
+test("client script block contains ZERO literal backtick characters", () => {
+  const src = readFileSync(join(repoRoot, "servers/gateway/dashboard/panels/model-catalog.js"), "utf8");
+  const scriptStart = src.indexOf("<script>", src.indexOf("function modelCatalogClientJS"));
+  const scriptEnd = src.indexOf("</script>", scriptStart);
+  assert.ok(scriptStart > -1 && scriptEnd > scriptStart, "could not locate the client <script> block");
+  const body = src.slice(scriptStart + "<script>".length, scriptEnd);
+  const backtickCount = (body.match(/`/g) || []).length;
+  assert.equal(backtickCount, 0, "a literal backtick inside the client <script> block would break the whole dashboard");
+});
+
+test("rendered HTML never leaks a raw i18n key as visible text (en and es)", async () => {
+  const h = freshLibsql();
+  try {
+    for (const lang of ["en", "es"]) {
+      const layout = ({ content }) => content;
+      const html = await modelCatalogPanel.handler({}, {}, { db: h.db, layout, lang });
+      const leaks = html.match(/>models\.[A-Za-z0-9]+</g) || [];
+      assert.deepEqual(leaks, [], `raw key leaked into rendered HTML (${lang}): ${leaks.join(", ")}`);
+    }
+  } finally { await h.cleanup(); }
+});
+
+test("every models.* / nav.model-catalog key referenced by the panel source resolves to real en+es copy", () => {
+  const src = readFileSync(join(repoRoot, "servers/gateway/dashboard/panels/model-catalog.js"), "utf8");
+  const used = new Set((src.match(/"models\.[A-Za-z0-9]+"/g) || []).map((s) => s.slice(1, -1)));
+  assert.ok(used.size > 30, "sanity check: expected dozens of models.* keys in the panel source");
+  for (const key of used) {
+    assert.ok(translations[key], `missing i18n key: ${key}`);
+    assert.ok(translations[key].en, `${key} has no en copy`);
+    assert.ok(translations[key].es, `${key} has no es copy`);
+  }
+  assert.ok(translations["nav.model-catalog"], "missing nav.model-catalog i18n key");
+});
+
+test("panel manifest: registered id/route/icon shape matches the panel-registry contract", () => {
+  assert.equal(modelCatalogPanel.id, "model-catalog");
+  assert.equal(modelCatalogPanel.route, "/dashboard/model-catalog");
+  assert.equal(typeof modelCatalogPanel.handler, "function");
+  assert.equal(typeof modelCatalogPanel.navOrder, "number");
+});

--- a/tests/models-panel-ui.test.js
+++ b/tests/models-panel-ui.test.js
@@ -44,6 +44,7 @@ import modelCatalogPanel, {
 } from "../servers/gateway/dashboard/panels/model-catalog.js";
 import { dashboardAuth } from "../servers/gateway/dashboard/auth.js";
 import { translations } from "../servers/gateway/dashboard/shared/i18n.js";
+import { saveState } from "../servers/gateway/models/state.js";
 
 const repoRoot = join(import.meta.dirname, "..");
 
@@ -411,4 +412,54 @@ test("panel manifest: registered id/route/icon shape matches the panel-registry 
   assert.equal(modelCatalogPanel.route, "/dashboard/model-catalog");
   assert.equal(typeof modelCatalogPanel.handler, "function");
   assert.equal(typeof modelCatalogPanel.navOrder, "number");
+});
+
+// ---------------------------------------------------------------------------
+// Task 13 fix round 1
+// ---------------------------------------------------------------------------
+
+test("client script ships the Browse-HF download wiring: the /hf-download endpoint, the confirm dialog, and the per-file row builder", () => {
+  const src = readFileSync(join(repoRoot, "servers/gateway/dashboard/panels/model-catalog.js"), "utf8");
+  const scriptStart = src.indexOf("<script>", src.indexOf("function modelCatalogClientJS"));
+  const scriptEnd = src.indexOf("</script>", scriptStart);
+  const body = src.slice(scriptStart, scriptEnd);
+  assert.match(body, /"\/hf-download"/, "POST /hf-download is called somewhere in the client script");
+  assert.match(body, /function showHfDownloadConfirm/);
+  assert.match(body, /function buildHfFileRow/);
+  assert.match(body, /function pollHfDownload/);
+  // Finding d: the gated-retry detection must key off the typed code, never
+  // the old raw.indexOf("403") string heuristic (both the curated AND the
+  // Browse-HF paths).
+  assert.doesNotMatch(body, /indexOf\("403"\)/);
+  assert.match(body, /errorCode === "HTTP_403"/g);
+});
+
+test("GET /api/models/runtime-equivalent SSR: a registry entry with wasLive:true and no live handle renders the 'reloading after update' state, distinct from plain 'not running'", async () => {
+  const h = freshLibsql();
+  try {
+    // qwen3-4b is a real registry.json/curated catalog id (registry/model-catalog.json)
+    saveState(h.dir, {
+      reservations: {},
+      journal: {},
+      registry: { "qwen3-4b": { file: "qwen3-4b.gguf", quant: "Q4_K_M", wasLive: true, lastStoppedAt: null } },
+    });
+    const layout = ({ content }) => content;
+    const html = await modelCatalogPanel.handler({}, {}, { db: h.db, layout, lang: "en" });
+    assert.match(html, /Reloading after update/);
+    assert.match(html, /running before the gateway restarted/);
+  } finally { await h.cleanup(); }
+});
+
+test("GET /api/models/runtime-equivalent SSR: a registry entry with NO wasLive marker renders plain 'Not running', never 'reloading'", async () => {
+  const h = freshLibsql();
+  try {
+    saveState(h.dir, {
+      reservations: {},
+      journal: {},
+      registry: { "qwen3-4b": { file: "qwen3-4b.gguf", quant: "Q4_K_M" } },
+    });
+    const layout = ({ content }) => content;
+    const html = await modelCatalogPanel.handler({}, {}, { db: h.db, layout, lang: "en" });
+    assert.doesNotMatch(html, /Reloading after update/);
+  } finally { await h.cleanup(); }
 });

--- a/tests/models-panel.test.js
+++ b/tests/models-panel.test.js
@@ -426,6 +426,87 @@ test("POST /api/models/download -> GET /api/models/downloads: job transitions do
 });
 
 // ---------------------------------------------------------------------------
+// Task 13 fix round 2 (Important, confirmed Concern-1 from round 1):
+// curated downloads must forward the stored HF token too — state 3 of the
+// gated three-state flow ("token configured but license not yet accepted")
+// was unreachable for a real gated:true catalog entry (e.g. the seed
+// catalog's gemma-3-27b-it) because nothing ever attached the token to the
+// actual download request.
+// ---------------------------------------------------------------------------
+
+function makeGatedCatalog() {
+  return {
+    version: 1,
+    runtime: { name: "llama.cpp", release: "b10068", assets: {} },
+    models: [{
+      id: "panel-gated-model",
+      family: "GatedFamily",
+      lab: "TestLab",
+      hf_repo: "test/panel-gated-model-GGUF",
+      license: "gemma",
+      gated: true,
+      task: "chat",
+      context_len: 8192,
+      default_quant: "Q4_K_M",
+      tags: ["chat", "gated"],
+      quants: [{ file: "panel-gated-model-Q4_K_M.gguf", quant: "Q4_K_M", size_mb: 500, min_ram_mb: 1000, min_vram_mb: 0, sha256: "abc" }],
+    }],
+  };
+}
+
+test("POST /api/models/download: forwards the stored HF token as an Authorization header when configured (gated:true entry)", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let capturedExtraHeaders = "UNSET";
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeGatedCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      enqueueDownloadFn: async ({ extraHeaders, onProgress }) => {
+        capturedExtraHeaders = extraHeaders;
+        onProgress({ bytesDone: 500, totalBytes: 500 });
+      },
+    };
+    await withServer(opts, async (base) => {
+      const set = await fetch(base + "/api/models/hf-token", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ token: "hf_gatedtoken789" }),
+      });
+      assert.equal(set.status, 200);
+
+      const post = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-gated-model", quant: "Q4_K_M" }),
+      });
+      assert.equal(post.status, 202);
+    });
+    assert.deepEqual(capturedExtraHeaders, { Authorization: "Bearer hf_gatedtoken789" });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/download: sends no Authorization header when no HF token is configured", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let capturedExtraHeaders = "UNSET";
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeGatedCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      enqueueDownloadFn: async ({ extraHeaders, onProgress }) => {
+        capturedExtraHeaders = extraHeaders;
+        onProgress({ bytesDone: 500, totalBytes: 500 });
+      },
+    };
+    await withServer(opts, async (base) => {
+      const post = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-gated-model", quant: "Q4_K_M" }),
+      });
+      assert.equal(post.status, 202);
+    });
+    assert.equal(capturedExtraHeaders, undefined, "no token configured -> extraHeaders is undefined, not a header with an empty/null value");
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
 // Browse Hugging Face download (Task 13 fix round 1, finding 1)
 // ---------------------------------------------------------------------------
 //
@@ -694,6 +775,76 @@ test("POST /api/models/:id/stop: calls handle.stop() when live, no-ops when alre
 
       const r3 = await fetch(base + "/api/models/does-not-exist/stop", { method: "POST", headers: authHeaders(token) });
       assert.equal(r3.status, 400);
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Task 13 fix round 2 (Critical regression): existence is state.registry
+// presence, NOT catalog membership — start/stop/DELETE must all work for a
+// model registered via Browse-HF, whose derived id is (by construction)
+// never in the curated catalog `loadCatalogFn` returns.
+// ---------------------------------------------------------------------------
+
+test("start / stop / DELETE all work for an hf-browser-registered model (not in the catalog at all); a truly unknown id still 400s", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    // Simulates exactly what POST /hf-download's async block does: register
+    // a model whose id is NOT present in the curated catalog `makeCatalog()`
+    // returns (this route's loadCatalogFn) — the whole point of Browse-HF.
+    const hfCatalog = {
+      models: [{
+        id: "some-repo-cool-model-q4", family: "cool-model", hf_repo: "org/some-repo",
+        task: "chat", context_len: null, default_quant: "hf",
+        quants: [{ file: "cool-model-Q4.gguf", quant: "hf", sha256: "d".repeat(64), size_mb: 5, min_ram_mb: 5, min_vram_mb: 0 }],
+      }],
+    };
+    await registerModel({
+      modelId: "some-repo-cool-model-q4", quant: "hf", catalog: hfCatalog, db: h.db, dir: h.dir,
+      registryExtra: { source: "hf-browser" },
+    });
+    // Sanity: this id is genuinely absent from the route's own catalog view.
+    assert.equal(makeCatalog().models.some((m) => m.id === "some-repo-cool-model-q4"), false);
+
+    let stopCalls = 0;
+    const handle = { live: true, stop: async () => { stopCalls++; handle.live = false; } };
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      getNativeHandleFn: (id) => (id === "some-repo-cool-model-q4" ? handle : null),
+      maybeAcquireLocalProviderFn: async () => true,
+    }, async (base) => {
+      const start = await fetch(base + "/api/models/some-repo-cool-model-q4/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(start.status, 200, "start must not 400 UNKNOWN_MODEL for a registered hf-browser model");
+      assert.equal((await start.json()).running, true);
+
+      const stop = await fetch(base + "/api/models/some-repo-cool-model-q4/stop", { method: "POST", headers: authHeaders(token) });
+      assert.equal(stop.status, 200, "stop must not 400 UNKNOWN_MODEL for a registered hf-browser model");
+      assert.equal(stopCalls, 1);
+
+      const preview = await fetch(base + "/api/models/some-repo-cool-model-q4", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(preview.status, 200, "DELETE preview must not 400 UNKNOWN_MODEL for a registered hf-browser model");
+      assert.equal((await preview.json()).requiresConfirm, true);
+
+      const confirmed = await fetch(base + "/api/models/some-repo-cool-model-q4?confirm=true", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(confirmed.status, 200);
+      assert.equal((await confirmed.json()).deleted, true);
+
+      // A genuinely unknown id (neither catalog nor registry) still 400s
+      // on all three routes — the fix narrows the existence check, it
+      // doesn't remove it.
+      const badStart = await fetch(base + "/api/models/totally-bogus-id/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(badStart.status, 400);
+      assert.equal((await badStart.json()).code, "UNKNOWN_MODEL");
+
+      const badStop = await fetch(base + "/api/models/totally-bogus-id/stop", { method: "POST", headers: authHeaders(token) });
+      assert.equal(badStop.status, 400);
+      assert.equal((await badStop.json()).code, "UNKNOWN_MODEL");
+
+      const badDelete = await fetch(base + "/api/models/totally-bogus-id", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(badDelete.status, 400);
+      assert.equal((await badDelete.json()).code, "UNKNOWN_MODEL");
     });
   } finally { await h.cleanup(); }
 });

--- a/tests/models-panel.test.js
+++ b/tests/models-panel.test.js
@@ -192,6 +192,42 @@ test("GET /api/models/catalog: 200 with a valid session", async () => {
   } finally { await h.cleanup(); }
 });
 
+/** Every route this router mounts, as [method, path]. Kept as one literal
+ * list so the parametrized auth test below and its own length assertion
+ * catch a route silently added without auth coverage. */
+const ALL_ROUTES = [
+  ["GET", "/api/models/catalog"],
+  ["GET", "/api/models/probe"],
+  ["POST", "/api/models/reprobe"],
+  ["POST", "/api/models/download"],
+  ["GET", "/api/models/downloads"],
+  ["DELETE", "/api/models/any-model-id"],
+  ["POST", "/api/models/any-model-id/start"],
+  ["POST", "/api/models/any-model-id/stop"],
+  ["GET", "/api/models/runtime"],
+  ["GET", "/api/models/hf-search?q=x"],
+  ["GET", "/api/models/hf-token"],
+  ["POST", "/api/models/hf-token"],
+];
+
+test("EVERY /api/models/* route (all 12) is gated: 403 NETWORK_DENIED with no headers, 401 UNAUTHENTICATED with an allowed network but no/bad session", async () => {
+  assert.equal(ALL_ROUTES.length, 12, "route count drifted — update this list (and the coverage it's meant to guarantee) alongside the router");
+  const h = freshLibsql();
+  try {
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      for (const [method, path] of ALL_ROUTES) {
+        const noHeaders = await fetch(base + path, { method });
+        assert.equal(noHeaders.status, 403, `${method} ${path}: expected 403 with no headers, got ${noHeaders.status}`);
+        assert.equal((await noHeaders.json()).code, "NETWORK_DENIED", `${method} ${path}`);
+
+        const noSession = await fetch(base + path, { method, headers: noSessionHeaders() });
+        assert.equal(noSession.status, 401, `${method} ${path}: expected 401 with network-ok/no-session, got ${noSession.status}`);
+        assert.equal((await noSession.json()).code, "UNAUTHENTICATED", `${method} ${path}`);
+      }
+    });
+  } finally { await h.cleanup(); }
+});
+
 // ---------------------------------------------------------------------------
 // Catalog + fit badges
 // ---------------------------------------------------------------------------
@@ -318,6 +354,35 @@ test("POST /api/models/download: tight and unknown quants are allowed WITHOUT fo
       const unknown = await fetch(base + "/api/models/download", {
         method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
         body: JSON.stringify({ modelId: "panel-test-model", quant: "Q4_K_M" }),
+      });
+      assert.equal(unknown.status, 202);
+    });
+    assert.equal(enqueueCalls, 2);
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/download: tight and unknown quants are ALSO allowed WITH force:true (force is inert, not required, for them)", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let enqueueCalls = 0;
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      enqueueDownloadFn: async ({ onProgress }) => { enqueueCalls++; onProgress({ bytesDone: 10, totalBytes: 10 }); },
+    };
+    await withServer(opts, async (base) => {
+      // tight, force:true
+      const tight = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q5_K_M", force: true }),
+      });
+      assert.equal(tight.status, 202);
+    });
+    // unknown (no cached probe), force:true
+    await withServer({ ...opts, getCachedProbeFn: () => null }, async (base) => {
+      const unknown = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q4_K_M", force: true }),
       });
       assert.equal(unknown.status, 202);
     });
@@ -678,10 +743,18 @@ test("hf-token: GET before/after POST reports only { configured }, never the raw
       console.error = originalError;
     }
     // Verify storage path directly: the exact providers.api_key column, under the reserved id.
-    const row = await h.db.execute({ sql: "SELECT api_key, disabled, models FROM providers WHERE id = ?", args: [HF_TOKEN_PROVIDER_ID] });
+    const row = await h.db.execute({ sql: "SELECT api_key, disabled, models, gpu_policy FROM providers WHERE id = ?", args: [HF_TOKEN_PROVIDER_ID] });
     assert.equal(row.rows[0].api_key, "hf_super-secret-value-should-never-leak");
     assert.equal(Number(row.rows[0].disabled), 1, "never an active routing candidate");
     assert.deepEqual(JSON.parse(row.rows[0].models), []);
+    // Fix round 1: local_only marker — never broadcast to paired instances.
+    assert.deepEqual(JSON.parse(row.rows[0].gpu_policy), { local_only: true });
+    const { shouldSyncRowForTest } = await import("../servers/sharing/instance-sync.js");
+    assert.equal(
+      shouldSyncRowForTest("providers", { base_url: "https://huggingface.co", gpu_policy: row.rows[0].gpu_policy }),
+      false,
+      "the hf-token row as actually written must be rejected by the fleet-sync gate",
+    );
   } finally { await h.cleanup(); }
 });
 

--- a/tests/models-panel.test.js
+++ b/tests/models-panel.test.js
@@ -1,0 +1,727 @@
+/**
+ * Model catalog panel API routes (Item G, Task 12).
+ *
+ * Harness mirrors tests/models-registration.test.js's `freshLibsql()`
+ * (real providers/oauth_tokens/dashboard_settings/pi_bot_defs schema via
+ * `scripts/init-db.js`, CROW_DATA_DIR pointed at a scratch dir — never the
+ * real ~/.crow) plus a boot-a-scratch-express-app step (the pattern
+ * tests/board-stage-api.test.js / tests/settings-scope-guard.test.js use
+ * for JSON route testing: real router, ephemeral `app.listen(0)`, plain
+ * `fetch`).
+ *
+ * Auth is exercised for REAL (not stubbed): a session token is seeded
+ * directly into `oauth_tokens` (same table/hash `dashboard/auth.js`'s
+ * `verifySession` reads), and every authenticated request carries the
+ * `Tailscale-User-Login` header so `isAllowedNetwork` passes over a plain
+ * loopback socket without weakening the check globally via
+ * CROW_DASHBOARD_PUBLIC (see `tests/extension-ws-auth.test.js`'s
+ * `tailnetReq` for the same trick).
+ *
+ * The download ENGINE (`manager.js`'s `enqueueDownload`, real HTTPS to
+ * huggingface.co) is stubbed — this file tests the route's gate/plumbing,
+ * not the download engine itself (that's `tests/models-registration.test.js`
+ * / manager.js's own test file's job). `registerModel`/`unregisterModel`/
+ * `providerBindings` are the REAL implementations (no network, real DB).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import http from "node:http";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+
+import modelsRouter, { requireDashboardSessionJson, HF_TOKEN_PROVIDER_ID } from "../servers/gateway/routes/models.js";
+import { setProviderSyncManager } from "../servers/shared/providers-db.js";
+
+const repoRoot = join(import.meta.dirname, "..");
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "models-panel-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: repoRoot,
+  });
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return {
+    dir, db,
+    async cleanup() {
+      setProviderSyncManager(null);
+      if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+      else process.env.CROW_DATA_DIR = prevDataDir;
+      try { db.close(); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function hashToken(t) { return createHash("sha256").update(t).digest("hex"); }
+
+/** Seed a valid dashboard session directly into oauth_tokens (same shape
+ * `attemptLogin`/`verifySession` in dashboard/auth.js use). */
+async function seedSession(db, token = "test-session-token") {
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  await db.execute({
+    sql: "INSERT INTO oauth_tokens (token, token_type, client_id, scopes, expires_at) VALUES (?, 'access', 'dashboard', 'dashboard', ?)",
+    args: [hashToken(token), expiresAt],
+  });
+  return token;
+}
+
+/** Headers for an authenticated request: tailnet identity header (so
+ * isAllowedNetwork passes over plain loopback) + the session cookie. */
+function authHeaders(token, extra = {}) {
+  return {
+    "tailscale-user-login": "test@example.com",
+    cookie: `crow_session=${token}`,
+    ...extra,
+  };
+}
+
+/** Headers for a request that passes the network check but carries no/a bad
+ * session — isolates the SESSION half of the gate (see module doc). */
+function noSessionHeaders() {
+  return { "tailscale-user-login": "test@example.com" };
+}
+
+function makeCatalog() {
+  return {
+    version: 1,
+    runtime: { name: "llama.cpp", release: "b10068", assets: {} },
+    models: [
+      {
+        id: "panel-test-model",
+        family: "TestFamily",
+        lab: "TestLab",
+        hf_repo: "test/panel-test-model-GGUF",
+        license: "apache-2.0",
+        gated: false,
+        task: "chat",
+        context_len: 8192,
+        min_runtime_version: "b10068",
+        default_quant: "Q4_K_M",
+        first_run_default: true,
+        tags: ["chat", "small"],
+        notes: "test fixture",
+        quants: [
+          // fits: min_ram_mb (1000) well under probe's 4000 ramAvailableMb
+          { file: "panel-test-model-Q4_K_M.gguf", quant: "Q4_K_M", size_mb: 500, min_ram_mb: 1000, min_vram_mb: 0, sha256: "abc" },
+          // tight: min_ram_mb (4200) is within 1.10x of 4000
+          { file: "panel-test-model-Q5_K_M.gguf", quant: "Q5_K_M", size_mb: 700, min_ram_mb: 4200, min_vram_mb: 0, sha256: "def" },
+          // wont_fit: min_ram_mb way over even the 1.10x tolerance
+          { file: "panel-test-model-Q8_0.gguf", quant: "Q8_0", size_mb: 2000, min_ram_mb: 20000, min_vram_mb: 0, sha256: "ghi" },
+        ],
+      },
+    ],
+  };
+}
+
+const FIXED_PROBE = {
+  platform: "linux", wsl2: false, accel: "cpu", gpuName: null, vramMb: null,
+  ramAvailableMb: 4000, diskFreeMb: 100_000, unknown: [],
+};
+
+/** Boot the router on an ephemeral port with the given opts merged onto
+ * sane no-op defaults for anything a given test doesn't care about. */
+async function withServer(opts, fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(modelsRouter((req, res, next) => next(), opts));
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await fn(base);
+  } finally {
+    server.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth gate
+// ---------------------------------------------------------------------------
+
+test("requireDashboardSessionJson: exported for direct unit testing", () => {
+  assert.equal(typeof requireDashboardSessionJson, "function");
+});
+
+test("GET /api/models/catalog: 401 with no/invalid session (network allowed)", async () => {
+  const h = freshLibsql();
+  try {
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog", { headers: noSessionHeaders() });
+      assert.equal(r.status, 401);
+      const body = await r.json();
+      assert.equal(body.code, "UNAUTHENTICATED");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("GET /api/models/catalog: 403 when the network check itself fails (bare loopback, no tailnet header)", async () => {
+  const h = freshLibsql();
+  try {
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog");
+      assert.equal(r.status, 403);
+      const body = await r.json();
+      assert.equal(body.code, "NETWORK_DENIED");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("GET /api/models/catalog: 200 with a valid session", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog", { headers: authHeaders(token) });
+      assert.equal(r.status, 200);
+      const body = await r.json();
+      assert.equal(body.models.length, 1);
+      assert.equal(body.models[0].id, "panel-test-model");
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Catalog + fit badges
+// ---------------------------------------------------------------------------
+
+test("GET /api/models/catalog: computes fits/tight/wont_fit per quant from the cached probe", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog", { headers: authHeaders(token) });
+      const body = await r.json();
+      const quants = Object.fromEntries(body.models[0].quants.map((q) => [q.quant, q.fitBadge]));
+      assert.equal(quants["Q4_K_M"], "fits");
+      assert.equal(quants["Q5_K_M"], "tight");
+      assert.equal(quants["Q8_0"], "wont_fit");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("GET /api/models/catalog: reflects registered/running state from state.json + the native-handle accessor", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+    await withServer({
+      dir: h.dir,
+      loadCatalogFn: makeCatalog,
+      getCachedProbeFn: () => FIXED_PROBE,
+      getNativeHandleFn: (id) => (id === "panel-test-model" ? { live: true } : null),
+    }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog", { headers: authHeaders(token) });
+      const body = await r.json();
+      assert.equal(body.models[0].registered, true);
+      assert.equal(body.models[0].registeredQuant, "Q4_K_M");
+      assert.equal(body.models[0].running, true);
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Download gate
+// ---------------------------------------------------------------------------
+
+test("POST /api/models/download: 400 UNKNOWN_MODEL for a bad model id", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      const r = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "does-not-exist" }),
+      });
+      assert.equal(r.status, 400);
+      assert.equal((await r.json()).code, "UNKNOWN_MODEL");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/download: 400 UNKNOWN_QUANT for a bad quant on a real model", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      const r = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q99_NOPE" }),
+      });
+      assert.equal(r.status, 400);
+      assert.equal((await r.json()).code, "UNKNOWN_QUANT");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/download: wont_fit quant refused with 409 unless force:true", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let enqueueCalls = 0;
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      enqueueDownloadFn: async ({ onProgress }) => { enqueueCalls++; onProgress({ bytesDone: 10, totalBytes: 10 }); },
+    };
+    await withServer(opts, async (base) => {
+      const refused = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q8_0" }),
+      });
+      assert.equal(refused.status, 409);
+      const refusedBody = await refused.json();
+      assert.equal(refusedBody.code, "WONT_FIT");
+      assert.equal(refusedBody.fitBadge, "wont_fit");
+      assert.equal(enqueueCalls, 0, "the download engine must never be invoked when the gate refuses");
+
+      const forced = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q8_0", force: true }),
+      });
+      assert.equal(forced.status, 202);
+      assert.equal(enqueueCalls, 1, "force:true lets the wont_fit quant through to the download engine");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/download: tight and unknown quants are allowed WITHOUT force", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let enqueueCalls = 0;
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      enqueueDownloadFn: async ({ onProgress }) => { enqueueCalls++; onProgress({ bytesDone: 10, totalBytes: 10 }); },
+    };
+    await withServer(opts, async (base) => {
+      // tight
+      const tight = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q5_K_M" }),
+      });
+      assert.equal(tight.status, 202);
+    });
+    // unknown: no cached probe at all
+    await withServer({ ...opts, getCachedProbeFn: () => null }, async (base) => {
+      const unknown = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q4_K_M" }),
+      });
+      assert.equal(unknown.status, 202);
+    });
+    assert.equal(enqueueCalls, 2);
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/download -> GET /api/models/downloads: job transitions downloading -> registering -> done, with a real provider row", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      enqueueDownloadFn: async ({ onProgress }) => { onProgress({ bytesDone: 500, totalBytes: 500 }); },
+    };
+    await withServer(opts, async (base) => {
+      const post = await fetch(base + "/api/models/download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ modelId: "panel-test-model", quant: "Q4_K_M" }),
+      });
+      const { jobId } = await post.json();
+
+      // Poll briefly for the async registerModel step to settle (real DB write, no network).
+      let job = null;
+      for (let i = 0; i < 50; i++) {
+        const r = await fetch(base + "/api/models/downloads", { headers: authHeaders(token) });
+        const body = await r.json();
+        job = body.downloads.find((j) => j.id === jobId);
+        if (job && job.status === "done") break;
+        await new Promise((res) => setTimeout(res, 20));
+      }
+      assert.ok(job, "job present in GET /api/models/downloads");
+      assert.equal(job.status, "done");
+      assert.equal(job.providerId, "panel-test-model");
+      assert.equal(job.bytesDone, 500);
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+test("DELETE /api/models/:id: 400 for a bad model id, 404 for a valid-but-uninstalled model id", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      const bad = await fetch(base + "/api/models/does-not-exist", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(bad.status, 400);
+      assert.equal((await bad.json()).code, "UNKNOWN_MODEL");
+
+      const notInstalled = await fetch(base + "/api/models/panel-test-model", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(notInstalled.status, 404);
+      assert.equal((await notInstalled.json()).code, "NOT_INSTALLED");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("DELETE /api/models/:id: returns bindings + requiresConfirm before deleting; ?confirm=true actually deletes", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+    // Bind an AI profile to this provider so `bindings` is non-empty.
+    await h.db.execute({
+      sql: "INSERT INTO dashboard_settings (key, value) VALUES ('ai_profiles', ?)",
+      args: [JSON.stringify([{ id: "p1", provider_id: "panel-test-model" }])],
+    });
+
+    let stopCalls = 0;
+    const handle = { live: true, stop: async () => { stopCalls++; } };
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      getNativeHandleFn: (id) => (id === "panel-test-model" ? handle : null),
+    }, async (base) => {
+      const preview = await fetch(base + "/api/models/panel-test-model", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(preview.status, 200);
+      const previewBody = await preview.json();
+      assert.equal(previewBody.requiresConfirm, true);
+      assert.equal(previewBody.bindings.profiles.length, 1);
+      assert.equal(stopCalls, 0, "no teardown before confirm");
+
+      const confirmed = await fetch(base + "/api/models/panel-test-model?confirm=true", { method: "DELETE", headers: authHeaders(token) });
+      assert.equal(confirmed.status, 200);
+      const confirmedBody = await confirmed.json();
+      assert.equal(confirmedBody.deleted, true);
+      assert.equal(stopCalls, 1, "the live native handle was stopped as part of teardown");
+    });
+
+    const row = await h.db.execute({ sql: "SELECT disabled FROM providers WHERE id = ?", args: ["panel-test-model"] });
+    assert.equal(Number(row.rows[0].disabled), 1);
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Start / stop reach the accessor
+// ---------------------------------------------------------------------------
+
+test("POST /api/models/:id/stop: calls handle.stop() when live, no-ops when already stopped, 404 when uninstalled", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+
+    let stopCalls = 0;
+    const handle = { live: true, stop: async () => { stopCalls++; handle.live = false; } };
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      getNativeHandleFn: (id) => (id === "panel-test-model" ? handle : null),
+    }, async (base) => {
+      const r1 = await fetch(base + "/api/models/panel-test-model/stop", { method: "POST", headers: authHeaders(token) });
+      assert.equal(r1.status, 200);
+      assert.equal((await r1.json()).running, false);
+      assert.equal(stopCalls, 1);
+
+      // already stopped: idempotent, no second stop() call
+      const r2 = await fetch(base + "/api/models/panel-test-model/stop", { method: "POST", headers: authHeaders(token) });
+      assert.equal(r2.status, 200);
+      assert.equal(stopCalls, 1);
+
+      const r3 = await fetch(base + "/api/models/does-not-exist/stop", { method: "POST", headers: authHeaders(token) });
+      assert.equal(r3.status, 400);
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/:id/start: reaches maybeAcquireLocalProvider and maps true/false/null to 200/502/409; 404 when uninstalled", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+
+    let lastArg = null;
+    let result = true;
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      maybeAcquireLocalProviderFn: async (id) => { lastArg = id; return result; },
+    }, async (base) => {
+      const uninstalled = await fetch(base + "/api/models/panel-test-model-2/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(uninstalled.status, 400); // not in catalog at all
+
+      const ok = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(ok.status, 200);
+      assert.equal(lastArg, "panel-test-model");
+
+      result = false;
+      const failed = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(failed.status, 502);
+      assert.equal((await failed.json()).code, "START_FAILED");
+
+      result = null;
+      const notNative = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(notNative.status, 409);
+      assert.equal((await notNative.json()).code, "NOT_NATIVE");
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Runtime status strip
+// ---------------------------------------------------------------------------
+
+test("GET /api/models/runtime: merges state.registry with the process supervisor's status snapshot", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      getStatusSnapshotFn: () => [{ alias: "panel-test-model", port: 18100, state: "running", live: true, restartCount: 0, lastError: null, startedAt: "2026-01-01T00:00:00.000Z", pid: 4242 }],
+    }, async (base) => {
+      const r = await fetch(base + "/api/models/runtime", { headers: authHeaders(token) });
+      assert.equal(r.status, 200);
+      const body = await r.json();
+      assert.equal(body.models.length, 1);
+      assert.equal(body.models[0].modelId, "panel-test-model");
+      assert.equal(body.models[0].live, true);
+      assert.equal(body.models[0].pid, 4242);
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Hugging Face search proxy
+// ---------------------------------------------------------------------------
+
+/** Minimal local stand-in for `https://huggingface.co/api/models?...` —
+ * no real network touched. Captures the last request's headers so a test
+ * can assert the stored token was (or wasn't) forwarded. */
+function startHfFixture() {
+  let lastHeaders = null;
+  let mode = "ok";
+  const server = http.createServer((req, res) => {
+    lastHeaders = req.headers;
+    if (mode === "500") {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "internal" }));
+      return;
+    }
+    if (mode === "hang") {
+      // never respond — exercises the client-side timeout
+      return;
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify([
+      {
+        id: "org/some-gguf-repo",
+        gated: false,
+        downloads: 1234,
+        likes: 56,
+        tags: ["gguf", "license:apache-2.0"],
+        siblings: [{ rfilename: "some-gguf-repo-Q4_K_M.gguf" }, { rfilename: "README.md" }],
+      },
+      {
+        id: "org/gated-repo",
+        gated: "manual",
+        downloads: 10,
+        likes: 1,
+        tags: ["gguf", "license:mit"],
+        siblings: [{ rfilename: "gated-repo-Q4_K_M.gguf" }],
+      },
+      {
+        // no gguf files at all -> filtered out of results
+        id: "org/no-gguf-repo",
+        gated: false,
+        downloads: 5,
+        likes: 0,
+        tags: ["license:mit"],
+        siblings: [{ rfilename: "model.safetensors" }],
+      },
+    ]));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        base: `http://127.0.0.1:${server.address().port}`,
+        setMode: (m) => { mode = m; },
+        lastHeaders: () => lastHeaders,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+test("GET /api/models/hf-search: works WITHOUT a token, filters to gguf repos, labels gated", async () => {
+  const h = freshLibsql();
+  const fx = await startHfFixture();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE, hfApiBase: fx.base }, async (base) => {
+      const r = await fetch(base + "/api/models/hf-search?q=llama", { headers: authHeaders(token) });
+      assert.equal(r.status, 200);
+      const body = await r.json();
+      assert.equal(body.results.length, 2, "the no-gguf-files repo is filtered out");
+      const gated = body.results.find((x) => x.id === "org/gated-repo");
+      assert.equal(gated.gated, true);
+      const open = body.results.find((x) => x.id === "org/some-gguf-repo");
+      assert.equal(open.gated, false);
+      assert.equal(open.license, "apache-2.0");
+      assert.deepEqual(open.ggufFiles, ["some-gguf-repo-Q4_K_M.gguf"]);
+      assert.ok(!fx.lastHeaders().authorization, "no token stored -> no Authorization header sent upstream");
+    });
+  } finally { await fx.close(); await h.cleanup(); }
+});
+
+test("GET /api/models/hf-search: uses the stored token when present", async () => {
+  const h = freshLibsql();
+  const fx = await startHfFixture();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE, hfApiBase: fx.base }, async (base) => {
+      const set = await fetch(base + "/api/models/hf-token", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ token: "hf_secrettoken123" }),
+      });
+      assert.equal(set.status, 200);
+
+      await fetch(base + "/api/models/hf-search?q=llama", { headers: authHeaders(token) });
+      assert.equal(fx.lastHeaders().authorization, "Bearer hf_secrettoken123");
+    });
+  } finally { await fx.close(); await h.cleanup(); }
+});
+
+test("GET /api/models/hf-search: 400 with no q; 502 on upstream 500 and on a hang (never hangs the caller)", async () => {
+  const h = freshLibsql();
+  const fx = await startHfFixture();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE, hfApiBase: fx.base, hfSearchTimeoutMs: 200 }, async (base) => {
+      const missing = await fetch(base + "/api/models/hf-search", { headers: authHeaders(token) });
+      assert.equal(missing.status, 400);
+      assert.equal((await missing.json()).code, "MISSING_QUERY");
+
+      fx.setMode("500");
+      const upstream500 = await fetch(base + "/api/models/hf-search?q=x", { headers: authHeaders(token) });
+      assert.equal(upstream500.status, 502);
+      assert.equal((await upstream500.json()).code, "HF_UPSTREAM_ERROR");
+
+      fx.setMode("hang");
+      const started = Date.now();
+      const hung = await fetch(base + "/api/models/hf-search?q=x", { headers: authHeaders(token) });
+      assert.equal(hung.status, 502);
+      assert.equal((await hung.json()).code, "HF_UPSTREAM_ERROR");
+      assert.ok(Date.now() - started < 5000, "the route's own timeout fired well before any external hang would");
+    });
+  } finally { await fx.close(); await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// HF token: write-only, never logged
+// ---------------------------------------------------------------------------
+
+test("hf-token: GET before/after POST reports only { configured }, never the raw value; POST body/value never logged", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const logs = [];
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    console.log = (...args) => { logs.push(args.map(String).join(" ")); originalLog.apply(console, args); };
+    console.warn = (...args) => { logs.push(args.map(String).join(" ")); };
+    console.error = (...args) => { logs.push(args.map(String).join(" ")); };
+    try {
+      await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+        const before = await fetch(base + "/api/models/hf-token", { headers: authHeaders(token) });
+        const beforeBody = await before.json();
+        assert.deepEqual(beforeBody, { configured: false });
+
+        const SECRET = "hf_super-secret-value-should-never-leak";
+        const post = await fetch(base + "/api/models/hf-token", {
+          method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+          body: JSON.stringify({ token: SECRET }),
+        });
+        const postBody = await post.json();
+        assert.deepEqual(postBody, { configured: true });
+        assert.ok(!JSON.stringify(postBody).includes(SECRET), "POST response never echoes the token");
+
+        const after = await fetch(base + "/api/models/hf-token", { headers: authHeaders(token) });
+        const afterBody = await after.json();
+        assert.deepEqual(afterBody, { configured: true });
+        assert.ok(!JSON.stringify(afterBody).includes(SECRET), "GET response never returns the raw token");
+
+        assert.ok(
+          !logs.some((l) => l.includes(SECRET)),
+          "the token must never appear in any console.log/warn/error call",
+        );
+      });
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+    // Verify storage path directly: the exact providers.api_key column, under the reserved id.
+    const row = await h.db.execute({ sql: "SELECT api_key, disabled, models FROM providers WHERE id = ?", args: [HF_TOKEN_PROVIDER_ID] });
+    assert.equal(row.rows[0].api_key, "hf_super-secret-value-should-never-leak");
+    assert.equal(Number(row.rows[0].disabled), 1, "never an active routing candidate");
+    assert.deepEqual(JSON.parse(row.rows[0].models), []);
+  } finally { await h.cleanup(); }
+});
+
+test("hf-token: POST with a non-string token 400s", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
+      const r = await fetch(base + "/api/models/hf-token", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ token: 12345 }),
+      });
+      assert.equal(r.status, 400);
+      assert.equal((await r.json()).code, "BAD_TOKEN");
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Probe passthrough
+// ---------------------------------------------------------------------------
+
+test("GET /api/models/probe + POST /api/models/reprobe", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let reprobeCalls = 0;
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog,
+      getCachedProbeFn: () => null,
+      reprobeFn: async () => { reprobeCalls++; return FIXED_PROBE; },
+    }, async (base) => {
+      const before = await fetch(base + "/api/models/probe", { headers: authHeaders(token) });
+      assert.deepEqual(await before.json(), { probe: null });
+
+      const reprobed = await fetch(base + "/api/models/reprobe", { method: "POST", headers: authHeaders(token) });
+      assert.equal(reprobed.status, 200);
+      const body = await reprobed.json();
+      assert.deepEqual(body.probe, FIXED_PROBE);
+      assert.equal(reprobeCalls, 1);
+    });
+  } finally { await h.cleanup(); }
+});

--- a/tests/models-panel.test.js
+++ b/tests/models-panel.test.js
@@ -36,6 +36,7 @@ import { createClient } from "@libsql/client";
 
 import modelsRouter, { requireDashboardSessionJson, HF_TOKEN_PROVIDER_ID } from "../servers/gateway/routes/models.js";
 import { setProviderSyncManager } from "../servers/shared/providers-db.js";
+import { loadState } from "../servers/gateway/models/state.js";
 
 const repoRoot = join(import.meta.dirname, "..");
 
@@ -201,6 +202,7 @@ const ALL_ROUTES = [
   ["POST", "/api/models/reprobe"],
   ["POST", "/api/models/download"],
   ["GET", "/api/models/downloads"],
+  ["POST", "/api/models/hf-download"],
   ["DELETE", "/api/models/any-model-id"],
   ["POST", "/api/models/any-model-id/start"],
   ["POST", "/api/models/any-model-id/stop"],
@@ -210,8 +212,8 @@ const ALL_ROUTES = [
   ["POST", "/api/models/hf-token"],
 ];
 
-test("EVERY /api/models/* route (all 12) is gated: 403 NETWORK_DENIED with no headers, 401 UNAUTHENTICATED with an allowed network but no/bad session", async () => {
-  assert.equal(ALL_ROUTES.length, 12, "route count drifted — update this list (and the coverage it's meant to guarantee) alongside the router");
+test("EVERY /api/models/* route (all 13) is gated: 403 NETWORK_DENIED with no headers, 401 UNAUTHENTICATED with an allowed network but no/bad session", async () => {
+  assert.equal(ALL_ROUTES.length, 13, "route count drifted — update this list (and the coverage it's meant to guarantee) alongside the router");
   const h = freshLibsql();
   try {
     await withServer({ dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE }, async (base) => {
@@ -418,7 +420,191 @@ test("POST /api/models/download -> GET /api/models/downloads: job transitions do
       assert.equal(job.status, "done");
       assert.equal(job.providerId, "panel-test-model");
       assert.equal(job.bytesDone, 500);
+      assert.equal(job.source, "curated", "a curated job (no source override) reports the default \"curated\", not undefined");
     });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Browse Hugging Face download (Task 13 fix round 1, finding 1)
+// ---------------------------------------------------------------------------
+//
+// The download ENGINE (fetchHfPathInfo/downloadHfFile — real network,
+// real checksum verification) is covered end-to-end in
+// tests/models-manager.test.js. These route-level tests stub both via
+// opts (same pattern the curated /download tests above use for
+// enqueueDownloadFn) and focus on the ROUTE's own logic: shape validation,
+// the no-verifiable-checksum refusal, fit-gating from the fetched size,
+// and — running the REAL registerModelFn against the real scratch DB,
+// exactly like the curated download-to-done test above — that the
+// resulting registry entry actually carries `source: "hf-browser"`.
+
+test("POST /api/models/hf-download: 400 INVALID_HF_REPO / INVALID_HF_FILE for malformed shapes, before any network call", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let pathInfoCalls = 0;
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      fetchHfPathInfoFn: async () => { pathInfoCalls += 1; return { sha256: "x", sizeBytes: 1 }; },
+    };
+    await withServer(opts, async (base) => {
+      const badRepo = await fetch(base + "/api/models/hf-download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ hfRepo: "../etc/passwd", file: "x.gguf" }),
+      });
+      assert.equal(badRepo.status, 400);
+      assert.equal((await badRepo.json()).code, "INVALID_HF_REPO");
+
+      const badFile = await fetch(base + "/api/models/hf-download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ hfRepo: "org/repo", file: "../../x.gguf" }),
+      });
+      assert.equal(badFile.status, 400);
+      assert.equal((await badFile.json()).code, "INVALID_HF_FILE");
+    });
+    assert.equal(pathInfoCalls, 0, "an invalid shape is rejected before ever calling out to Hugging Face");
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/hf-download: 422 NO_VERIFIABLE_CHECKSUM when Hugging Face reports no LFS sha for the file", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      fetchHfPathInfoFn: async () => ({ sha256: null, sizeBytes: 1234 }),
+    };
+    await withServer(opts, async (base) => {
+      const r = await fetch(base + "/api/models/hf-download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ hfRepo: "org/repo", file: "README.md" }),
+      });
+      assert.equal(r.status, 422);
+      const body = await r.json();
+      assert.equal(body.code, "NO_VERIFIABLE_CHECKSUM");
+      assert.match(body.error, /no verifiable checksum/i);
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/hf-download: wont_fit (huge fetched size) refused with 409 unless force:true", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      // FIXED_PROBE has ramAvailableMb: 4000 — 900 GB is unfittable by any measure.
+      fetchHfPathInfoFn: async () => ({ sha256: "a".repeat(64), sizeBytes: 900_000_000_000 }),
+      downloadHfFileFn: async () => { throw new Error("must not be called — the fit gate should have refused first"); },
+    };
+    await withServer(opts, async (base) => {
+      const refused = await fetch(base + "/api/models/hf-download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ hfRepo: "org/repo", file: "huge-model.gguf" }),
+      });
+      assert.equal(refused.status, 409);
+      const body = await refused.json();
+      assert.equal(body.code, "WONT_FIT");
+      assert.equal(body.fitBadge, "wont_fit");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/hf-download -> GET /api/models/downloads: job carries source:\"hf-browser\"; on success, the registry entry ALSO carries source:\"hf-browser\" via a REAL registerModel call", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const fakeSha = "b".repeat(64);
+    // Matches exactly what deriveModelIdFromFilename("cool-model-Q4.gguf")
+    // produces — the route derives modelId itself (via the same pure
+    // function the real downloadHfFile uses internally) and passes it to
+    // registerModelFn independent of whatever a stub's returned catalog
+    // claims, so a test fixture whose ids don't agree with that derivation
+    // is internally inconsistent, not a bug in the route.
+    const derivedId = "cool-model-q4";
+    const fakeCatalog = {
+      models: [{
+        id: derivedId,
+        family: "repo",
+        hf_repo: "org/repo",
+        task: "chat",
+        context_len: null,
+        default_quant: "hf",
+        quants: [{ file: "cool-model-Q4.gguf", quant: "hf", sha256: fakeSha, size_mb: 5, min_ram_mb: 5, min_vram_mb: 0 }],
+      }],
+    };
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      fetchHfPathInfoFn: async () => ({ sha256: fakeSha, sizeBytes: 5_000_000 }),
+      downloadHfFileFn: async ({ onProgress }) => {
+        onProgress({ bytesDone: 5_000_000, totalBytes: 5_000_000 });
+        return { path: "/fake/path", sha256: fakeSha, modelId: derivedId, sizeMb: 5, catalog: fakeCatalog };
+      },
+    };
+    await withServer(opts, async (base) => {
+      const post = await fetch(base + "/api/models/hf-download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ hfRepo: "org/repo", file: "cool-model-Q4.gguf" }),
+      });
+      assert.equal(post.status, 202);
+      const { jobId } = await post.json();
+
+      let job = null;
+      for (let i = 0; i < 50; i++) {
+        const r = await fetch(base + "/api/models/downloads", { headers: authHeaders(token) });
+        const body = await r.json();
+        job = body.downloads.find((j) => j.id === jobId);
+        if (job && job.status === "done") break;
+        await new Promise((res) => setTimeout(res, 20));
+      }
+      assert.ok(job, "job present in GET /api/models/downloads");
+      assert.equal(job.source, "hf-browser");
+      assert.equal(job.status, "done");
+      assert.equal(job.providerId, derivedId);
+    });
+
+    const state = loadState(h.dir);
+    assert.equal(state.registry[derivedId].source, "hf-browser");
+    assert.equal(state.registry[derivedId].catalogId, derivedId);
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/hf-download: an engine failure (e.g. checksum mismatch) surfaces its typed errorCode on the job, never registers a provider", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const opts = {
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      fetchHfPathInfoFn: async () => ({ sha256: "c".repeat(64), sizeBytes: 100 }),
+      downloadHfFileFn: async () => {
+        const err = new Error("Checksum mismatch: expected c..., got d...");
+        err.code = "CHECKSUM_MISMATCH";
+        throw err;
+      },
+    };
+    await withServer(opts, async (base) => {
+      const post = await fetch(base + "/api/models/hf-download", {
+        method: "POST", headers: authHeaders(token, { "content-type": "application/json" }),
+        body: JSON.stringify({ hfRepo: "org/repo", file: "bad-model.gguf" }),
+      });
+      const { jobId } = await post.json();
+
+      let job = null;
+      for (let i = 0; i < 50; i++) {
+        const r = await fetch(base + "/api/models/downloads", { headers: authHeaders(token) });
+        const body = await r.json();
+        job = body.downloads.find((j) => j.id === jobId);
+        if (job && job.status === "error") break;
+        await new Promise((res) => setTimeout(res, 20));
+      }
+      assert.ok(job);
+      assert.equal(job.status, "error");
+      assert.equal(job.errorCode, "CHECKSUM_MISMATCH");
+      assert.equal(job.providerId, null);
+    });
+    const state = loadState(h.dir);
+    assert.equal(state.registry["bad-model"], undefined, "never registered");
   } finally { await h.cleanup(); }
 });
 

--- a/tests/models-state.test.js
+++ b/tests/models-state.test.js
@@ -15,6 +15,7 @@ import {
   allocatePort,
   releasePort,
   reconcileOnBoot,
+  registryEntryRuntimeState,
 } from "../servers/gateway/models/state.js";
 
 function scratchDir(tag) {
@@ -287,4 +288,32 @@ test("reconcileOnBoot does not mutate state.journal or state.registry", () => {
   const before = JSON.stringify(state);
   reconcileOnBoot({ state, listProviderRows: () => [], isProcessAlive: () => true });
   assert.equal(JSON.stringify(state), before);
+});
+
+// ---------------------------------------------------------------------------
+// registryEntryRuntimeState (Task 13 fix round 1, finding c — "reloading
+// after update")
+// ---------------------------------------------------------------------------
+
+test("registryEntryRuntimeState: live always wins, regardless of the marker", () => {
+  assert.equal(registryEntryRuntimeState({ wasLive: true }, true), "running");
+  assert.equal(registryEntryRuntimeState({ wasLive: false }, true), "running");
+  assert.equal(registryEntryRuntimeState(null, true), "running");
+});
+
+test("registryEntryRuntimeState: not live + wasLive:true -> stopped_after_restart (the gateway restarted out from under it)", () => {
+  assert.equal(registryEntryRuntimeState({ wasLive: true }, false), "stopped_after_restart");
+  assert.equal(registryEntryRuntimeState({ wasLive: true, lastStoppedAt: null }, false), "stopped_after_restart");
+});
+
+test("registryEntryRuntimeState: not live + wasLive:false/absent -> plain stopped (never started, or deliberately stopped)", () => {
+  assert.equal(registryEntryRuntimeState({ wasLive: false }, false), "stopped");
+  assert.equal(registryEntryRuntimeState({}, false), "stopped");
+  assert.equal(registryEntryRuntimeState(null, false), "stopped");
+  assert.equal(registryEntryRuntimeState(undefined, false), "stopped");
+});
+
+test("registryEntryRuntimeState: a truthy-but-not-strictly-true wasLive (e.g. a stray string) does not accidentally match", () => {
+  assert.equal(registryEntryRuntimeState({ wasLive: "true" }, false), "stopped");
+  assert.equal(registryEntryRuntimeState({ wasLive: 1 }, false), "stopped");
 });

--- a/tests/providers-sync-wire.test.js
+++ b/tests/providers-sync-wire.test.js
@@ -12,6 +12,12 @@
  *   D9: shouldSyncRow('providers') rejects loopback base_urls in both
  *       directions (emit and apply).
  *
+ * Item G Task 12 fix round 1: shouldSyncRow('providers') also rejects any
+ * row whose gpu_policy carries `local_only: true`, independent of
+ * base_url — the general convention that keeps the model-catalog panel's
+ * Hugging Face token (a real, non-loopback "provider" row) off the fleet
+ * sync wire.
+ *
  * Harness follows tests/instance-sync.test.js: real init-db.js schema in a
  * tmp dir, fixed ed25519 identity, stub outbound feeds (no Hypercore).
  */
@@ -106,6 +112,92 @@ test("D9: loopback base_urls never sync; tailnet/LAN/cloud do; malformed/missing
   assert.equal(shouldSyncRowForTest("providers", noUrl), false, "missing base_url");
   assert.equal(shouldSyncRowForTest("providers", providerRow({ base_url: "not a url" })), false, "malformed base_url");
   assert.equal(shouldSyncRowForTest("providers", null), false, "null row");
+});
+
+// ── local_only marker (Item G Task 12 fix round 1) ──────────────────────────
+//
+// A providers row can opt out of fleet sync entirely by setting
+// `gpu_policy.local_only = true`, independent of its base_url (unlike the
+// loopback carve-out, which only ever catches 127.0.0.1/localhost/::1
+// hosts). The models-catalog panel's Hugging Face token row is the first
+// user of this: its base_url is a real, non-loopback host
+// (https://huggingface.co), so WITHOUT the marker it would sail straight
+// past the loopback check above and sync in plaintext to every paired
+// instance. `shouldSyncRowForTest` is the exact function called at BOTH
+// `emitChange` (outbound) and `_applyEntry` (inbound) — see D9's comment
+// above for why one function call proves both directions; the assertions
+// below do the same for this marker.
+
+test("local_only marker: a providers row with gpu_policy.local_only=true never syncs, even with a real non-loopback base_url", () => {
+  const hfTokenRow = providerRow({
+    id: "crow-hf-token",
+    base_url: "https://huggingface.co",
+    disabled: 1,
+    models: "[]",
+    gpu_policy: JSON.stringify({ local_only: true }),
+  });
+  // (a) the exact shape POST /api/models/hf-token writes never syncs —
+  // proven via the SAME gate emitChange/​_applyEntry both call, so this
+  // single assertion covers outbound AND inbound symmetrically.
+  assert.equal(
+    shouldSyncRowForTest("providers", hfTokenRow),
+    false,
+    "a local_only=true row must never sync, regardless of base_url",
+  );
+});
+
+test("local_only marker: a normal external provider row (no marker) still syncs — no over-exclusion", () => {
+  // (b) a real cloud/tailnet provider row, gpu_policy present but WITHOUT
+  // the marker, must be unaffected by this change.
+  const withUnrelatedPolicy = providerRow({ gpu_policy: JSON.stringify({ mutexGroup: "local-llm" }) });
+  assert.equal(shouldSyncRowForTest("providers", withUnrelatedPolicy), true);
+
+  // No gpu_policy at all (the common case for most cloud providers).
+  const noPolicy = providerRow();
+  assert.equal(shouldSyncRowForTest("providers", noPolicy), true);
+
+  // gpu_policy.local_only present but falsy/absent must NOT be treated as
+  // an exclusion — only a literal `=== true` opts a row out.
+  assert.equal(
+    shouldSyncRowForTest("providers", providerRow({ gpu_policy: JSON.stringify({ local_only: false }) })),
+    true,
+    "local_only: false must still sync",
+  );
+  assert.equal(
+    shouldSyncRowForTest("providers", providerRow({ gpu_policy: JSON.stringify({ mutexGroup: "x" }) })),
+    true,
+    "gpu_policy present without a local_only key must still sync",
+  );
+});
+
+test("local_only marker: malformed gpu_policy JSON fails OPEN to the existing loopback/host checks, not silently dropped", () => {
+  // A non-loopback row with garbage gpu_policy must still sync (the
+  // malformed-JSON catch falls through, it does not itself return false).
+  assert.equal(
+    shouldSyncRowForTest("providers", providerRow({ gpu_policy: "{not valid json" })),
+    true,
+  );
+  // A LOOPBACK row with garbage gpu_policy is still correctly rejected —
+  // by the pre-existing loopback check, not the local_only branch.
+  assert.equal(
+    shouldSyncRowForTest("providers", providerRow({ base_url: "http://127.0.0.1:8011/v1", gpu_policy: "{not valid json" })),
+    false,
+  );
+});
+
+test("local_only marker: also gates a LOOPBACK-shaped row (belt and braces, not just the non-loopback HF-token case)", () => {
+  // (c) apply-side symmetry: _applyEntry calls this exact function on the
+  // inbound wire row before ever touching the DB — there is no second,
+  // apply-specific gate to separately mirror (same structure D9 already
+  // relies on above for the loopback carve-out). A local_only row with a
+  // loopback base_url is rejected by EITHER check independently.
+  assert.equal(
+    shouldSyncRowForTest("providers", providerRow({
+      base_url: "http://127.0.0.1:18100/v1",
+      gpu_policy: JSON.stringify({ local_only: true }),
+    })),
+    false,
+  );
 });
 
 // ── D3: excluded bookkeeping columns ─────────────────────────────────────────


### PR DESCRIPTION
Third of five Item G PRs (spec: Gitea `crow-engineering` `specs/2026-07-18-item-g-model-catalog-design.md` r3 SIGNED OFF; plan Tasks 12–13 + three review-driven fix rounds + a final whole-branch review). This is the user-facing surface for the native model runtime shipped in #234.

**What's in it (6 commits):**
- `routes/models.js` — 13 dashboard-session-gated JSON routes: catalog with per-quant fit badges, probe/reprobe, downloads with progress jobs, HF search proxy, HF-token store (**write-only; the token row is sync-excluded via a new `local_only` provider convention — the review proved the original storage would have replicated the token plaintext to paired instances**), model start/stop/delete with a `getNativeHandle` orchestrator accessor, runtime snapshot. All routes auth-swept (26 assertions), never Funnel-exposed.
- `panels/model-catalog.js` — the Extensions → Model Catalog panel: curated tab (size-class groups, honest fit badges, gated three-state copy), **Browse Hugging Face tab with real downloads** (operator-approved mid-review: verified against HF's API-reported sha256, files without a verifiable checksum are refused, un-vetted/parser-risk warning on every confirm), runtime status strip (incl. a true "reloading after update" state distinguished from never-started), delete flow with bindings confirmation — for hf-sourced models too. 112 i18n keys with real Spanish; zero backticks in the client script (regression-tested against rendered output in both languages); XSS discipline is `textContent`-only for all uploader/user-controlled strings.
- Curated gated downloads forward the stored HF token (the spec's "token + accepted license" state was unreachable before the round-2 fix); typed `HttpStatusError` replaces string-matching.

**Review rigor:** per-task independent reviews + 3 fix rounds closed 1 Critical (hf-downloaded models were unmanageable zombies — start/stop/delete gated on the curated catalog) and 3 Importants (plaintext token sync, unreachable gated state, client-side wont_fit force bypass on multi-quant entries — latent today, permanently covered by a new vm-executed client-contract test). A CDP browser round passed all panel checks in EN and ES with zero console errors (13 screenshots archived).

**Investigation note:** the CDP round reported scratch-env SQLite corruption under load (4/4). A dedicated bisect could not reproduce it — 0/4 across this branch and main, including a faithful replay of the original harness — and identified a likely launch-lifecycle artifact (`parent-watch` kills gateways whose spawning shell exits, tearing WAL writes). Filed as an investigation note with the harness preserved; re-opens only with a reproducible case that records its launch mechanism.

**Recorded follow-ups (non-gating):** hf filename-only model identity can collide across repos (silent replace — fold repo owner into the id); state.json liveness-marker write race (label-only impact); download poll loops lack a terminal timeout when a job id vanishes across a restart; `crow-hf-token` row shows (dimmed) in Settings→Providers; settings language form lacks a static `_csrf` fallback for non-Turbo POSTs (general dashboard machinery, found by the CDP round).

**Suite:** 2351/2351 pass, 0 fail (3 environment-dependent skips) — new baseline; +89 tests over #234. check-ports / build-registry / validate-model-catalog clean. No schema changes, no new host ports, no new runtime deps.