### PR TITLE
feat(models): Item G PR G-D — ops integration (native-runtime orphan sweep, stale tmp cleanup, port attribution)

### DIFF
--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -91,6 +91,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 9090 | 127.0.0.1 | linkding (existing) | existing |
 | 11434 | 127.0.0.1 | ollama (existing) | existing |
 | 13378 | 127.0.0.1 | audiobookshelf (existing) | existing |
+| 18100-18199 | gateway-internal loopback | native model servers (per-CROW_HOME dynamic range, not bundle ports — managed by servers/gateway/models/state.js) | informational |
 | 18789 | 127.0.0.1 | openclaw-old-docker (pre-existing external process) | existing |
 | 19999 | 127.0.0.1 | netdata | MVP PR 2 |
 | 32400 | host | plex (host networking, existing) | existing |

--- a/scripts/ops/kill-orphan-gateways.sh
+++ b/scripts/ops/kill-orphan-gateways.sh
@@ -41,6 +41,44 @@
 #     means a process that merely happens to mention that path in an
 #     unrelated argument can never be swept.
 #
+#     ADOPTION CROSS-CHECK (fix round 1, Critical finding): `setpriv
+#     --pdeathsig=SIGTERM` and startModel's own SIGTERM-the-group `stop()`
+#     path mean a llama-server almost always dies WITH its gateway — but
+#     that's a mitigation, not a guarantee (setpriv can be absent on the
+#     host, or lose the pdeathsig race on a hard crash), and when it
+#     survives, the RESTARTED gateway can legitimately ADOPT it instead of
+#     respawning: gpu-orchestrator.js's acquireOrStartNative calls
+#     identityProbe first, and a "resident" result (the surviving process is
+#     still correctly answering as the right alias) returns
+#     `{freshStart:false}` WITHOUT ever touching `_nativeHandles` or calling
+#     `startModel` again — traffic gets routed to it, but this pid's ppid
+#     stays 1 forever and it is never back under any gateway's supervision.
+#     `models/state.js`'s `reconcileOnBoot` already encodes the correct rule
+#     for this exact situation ("a live provider row means the runtime is
+#     still legitimately using that port even though the reserving pid is
+#     gone" — see its doc) and deliberately does NOT free that reservation.
+#     Sweep 3 mirrors that rule before ever signaling a candidate: derive
+#     the candidate's own CROW_HOME from the SAME exe/cwd match above (the
+#     path fragment before "/runtimes/llamacpp/" is exactly the `dir`
+#     `state.js`'s `statePath(dir)` expects), parse the candidate's OWN
+#     bound port from its OWN cmdline's "--port" flag (buildLlamaServerArgs
+#     in runtime.js always includes it, setpriv-wrapped or not — chosen over
+#     ss/lsof so this needs no extra host tool and reflects exactly what the
+#     process was launched with, matching state.json's own semantics), and
+#     if THAT CROW_HOME's models/state.json holds ANY reservation for that
+#     port, the candidate is skipped (logged) as an adopted native model,
+#     never signaled. Fails CLOSED on ambiguity: if the candidate's own
+#     CROW_HOME or port can't be determined at all (a raced/vanished
+#     process, an unexpected invocation shape), it is also skipped rather
+#     than guessed — a wrongly-killed live model cannot be undone, while a
+#     genuinely orphaned process just gets caught on the next sweep. A
+#     reservation-less llama-server on a random port remains reapable (truly
+#     abandoned — its reservation was deleted or never existed). Residual
+#     case, stated honestly: if a reservation IS present but the model is
+#     actually dead (crashed without ever calling releasePort), the process
+#     has already exited on its own — there is nothing left for this sweep
+#     to kill either way, so skipping it here costs nothing.
+#
 # PROTECTION (checked at candidate selection AND before every signal):
 #   1. systemd-owned: any process whose /proc/<pid>/cgroup places it inside a
 #      *.service cgroup belongs to systemd — in EVERY unit state. This is the
@@ -144,6 +182,84 @@ exe_or_cwd_under_native_runtimes() {
     */runtimes/llamacpp/*) return 0 ;;
   esac
   return 1
+}
+
+# The CROW_HOME implied by a native-runtime candidate's exe/cwd — the path
+# fragment BEFORE "/runtimes/llamacpp/" (same exe-then-cwd precedence as
+# exe_or_cwd_under_native_runtimes). This is exactly the `dir` argument
+# `models/state.js`'s `statePath(dir)` expects (`<dir>/models/state.json`),
+# since `ensureRuntime` in runtime.js builds the binary path as
+# `<dir>/runtimes/llamacpp/<release>/...` from that very same `dir`. Prints
+# nothing and returns 1 if neither exe nor cwd matches (fail closed — see
+# the adoption cross-check in the header comment).
+native_crow_home_of() {
+  local target
+  target=$(readlink "/proc/$1/exe" 2>/dev/null) || target=""
+  case "$target" in
+    */runtimes/llamacpp/*) echo "${target%%/runtimes/llamacpp/*}"; return 0 ;;
+  esac
+  target=$(readlink "/proc/$1/cwd" 2>/dev/null) || target=""
+  case "$target" in
+    */runtimes/llamacpp/*) echo "${target%%/runtimes/llamacpp/*}"; return 0 ;;
+  esac
+  return 1
+}
+
+# The port a native-runtime candidate was told to bind, parsed from its OWN
+# cmdline's "--port" flag (buildLlamaServerArgs in runtime.js always
+# includes literal "--port <port>", whether or not setpriv wraps the
+# invocation). Chosen over ss/lsof: no extra host tool required, and this
+# reflects exactly what the process was launched with — the same thing
+# state.json's reservation records, not a live socket scrape that could in
+# principle diverge (a process bound to a DIFFERENT port than it was told
+# to would fail identityProbe's caller anyway). Prints nothing and returns
+# 1 if "--port" isn't found (a raced/vanished process, or an unexpected
+# invocation shape) — fail closed, never guess.
+native_port_of() {
+  local cmdline prev=""
+  cmdline=$(cmdline_of "$1")
+  # shellcheck disable=SC2086  # deliberate field-split to walk argv tokens
+  set -- $cmdline
+  while [ "$#" -gt 0 ]; do
+    if [ "$prev" = "--port" ]; then
+      echo "$1"
+      return 0
+    fi
+    prev="$1"
+    shift
+  done
+  return 1
+}
+
+# Adoption cross-check (fix round 1, Critical finding — see the Sweep 3
+# header comment for the full scenario): does `statePath`'s models/
+# state.json hold ANY reservation for `port`? Prints the reserving modelId
+# and returns 0 if so; prints nothing and returns 1 otherwise (missing/
+# corrupt state file, or no matching reservation — both mean "not
+# protected by this check", not "protected"). Parsed with `node` rather
+# than `jq`: every Crow host already requires node to run the gateway
+# itself, so this adds no new host dependency (jq is NOT a guaranteed
+# install-time dependency — confirmed absent from scripts/crow-install.sh).
+port_reserved_model() {
+  local state_path="$1" port="$2"
+  [ -f "$state_path" ] || return 1
+  node - "$state_path" "$port" <<'EOF' 2>/dev/null
+const fs = require("node:fs");
+try {
+  const state = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+  const port = parseInt(process.argv[3], 10);
+  const reservations = (state && typeof state.reservations === "object" && state.reservations) || {};
+  for (const [modelId, r] of Object.entries(reservations)) {
+    if (r && r.port === port) {
+      process.stdout.write(modelId);
+      process.exit(0);
+    }
+  }
+  process.exit(1);
+} catch {
+  process.exit(1);
+}
+EOF
 }
 
 # systemd-owned: the pid's cgroup path contains a *.service component.
@@ -286,6 +402,22 @@ for pid in $(pgrep -f "$NATIVE_PATTERN" 2>/dev/null); do
   ppid=$(ppid_of "$pid") || continue
   [ "$ppid" = "1" ] || continue
   exe_or_cwd_under_native_runtimes "$pid" || continue
+
+  # Adoption cross-check (fix round 1) — see the Sweep 3 header comment.
+  # Fail CLOSED: if this candidate's own CROW_HOME or bound port can't be
+  # determined, skip rather than guess.
+  native_home=$(native_crow_home_of "$pid")
+  native_port=$(native_port_of "$pid")
+  if [ -z "$native_home" ] || [ -z "$native_port" ]; then
+    log "skipping native model runtime pid $pid — could not determine its own CROW_HOME/port, refusing to guess"
+    continue
+  fi
+  reserved_model=$(port_reserved_model "${native_home}/models/state.json" "$native_port")
+  if [ -n "$reserved_model" ]; then
+    log "skipping adopted native model on port $native_port (reserved for '$reserved_model' in ${native_home}/models/state.json) — pid $pid"
+    continue
+  fi
+
   # A native runtime process has no children of its own to worry about
   # (unlike the gateway/bundle sweeps, there is no downstream lock-holder
   # depending on it), but stamp+reap through the same single-pid "tree" for

--- a/scripts/ops/kill-orphan-gateways.sh
+++ b/scripts/ops/kill-orphan-gateways.sh
@@ -19,6 +19,27 @@
 #     cmdline matches ORPHAN_BUNDLE_PATTERN, whose /proc/<pid>/cwd contains
 #     "/bundles/", and which is not protected → same TERM→wait→KILL
 #     (subtree included).
+#   Sweep 3 (orphaned native model runtime processes — Item G, Task 14):
+#     every ppid==1 process whose cmdline matches ORPHAN_NATIVE_PATTERN AND
+#     whose /proc/<pid>/exe OR /proc/<pid>/cwd contains the path fragment
+#     "/runtimes/llamacpp/" (under ANY CROW_HOME — no literal ~/.crow
+#     anywhere in this check), and which is not protected → same
+#     TERM→wait→KILL. This is a llama-server process (Item G's native model
+#     runtime, servers/gateway/models/runtime.js's startModel) that outlived
+#     its gateway: it runs detached in its own process group precisely so a
+#     gateway restart/swap doesn't kill an in-flight generation, but that
+#     also means a gateway that died WITHOUT a clean stop() leaves it
+#     running forever, holding a GPU/RAM allocation and a port reservation
+#     no live process still owns. The cmdline match is a cheap first filter
+#     (a llama-server invocation's argv always includes its own binPath,
+#     which lives under <CROW_HOME>/runtimes/llamacpp/<release>/, whether or
+#     not it's wrapped in `setpriv --pdeathsig=SIGTERM ...`); the exe/cwd
+#     check is the actual identity proof — `setpriv` execve's the target
+#     program, so /proc/<pid>/exe of the RUNNING process (setpriv-wrapped or
+#     not) always resolves to the real llama-server binary path, never to
+#     setpriv's own path. Requiring that check (not just the cmdline regex)
+#     means a process that merely happens to mention that path in an
+#     unrelated argument can never be swept.
 #
 # PROTECTION (checked at candidate selection AND before every signal):
 #   1. systemd-owned: any process whose /proc/<pid>/cgroup places it inside a
@@ -53,6 +74,10 @@
 #                          Default: node.*servers/gateway/index\.js
 #   ORPHAN_BUNDLE_PATTERN  regex (pgrep -f) selecting bundle-child processes
 #                          for sweep 2. Default: node server/index\.js
+#   ORPHAN_NATIVE_PATTERN  regex (pgrep -f) selecting candidate native model
+#                          runtime processes for sweep 3 (see above — cmdline
+#                          match is only the first filter, exe/cwd is the
+#                          real identity check). Default: runtimes/llamacpp
 #   ORPHAN_DRY_RUN         set to 1 to only PRINT the victims (pid + cmdline);
 #                          nothing is signalled. Default: 0
 #
@@ -66,6 +91,7 @@ set -u
 
 MATCH_PATTERN="${ORPHAN_MATCH_PATTERN:-node.*servers/gateway/index\.js}"
 BUNDLE_PATTERN="${ORPHAN_BUNDLE_PATTERN:-node server/index\.js}"
+NATIVE_PATTERN="${ORPHAN_NATIVE_PATTERN:-runtimes/llamacpp}"
 DRY_RUN="${ORPHAN_DRY_RUN:-0}"
 
 log() {
@@ -79,7 +105,9 @@ ppid_of() {
   local stat rest
   stat=$(cat "/proc/$1/stat" 2>/dev/null) || return 1
   rest=${stat##*) }
-  # rest = "<state> <ppid> ..."
+  # rest = "<state> <ppid> ..." — deliberately unquoted: this splits rest
+  # into positional fields on whitespace, which is the whole point here.
+  # shellcheck disable=SC2086
   set -- $rest
   echo "$2"
 }
@@ -90,6 +118,7 @@ starttime_of() {
   local stat rest
   stat=$(cat "/proc/$1/stat" 2>/dev/null) || return 1
   rest=${stat##*) }
+  # shellcheck disable=SC2086  # deliberate field-split, see ppid_of above
   set -- $rest
   echo "${20}"
 }
@@ -99,6 +128,23 @@ cmdline_of() {
 }
 
 alive() { [ -d "/proc/$1" ]; }
+
+# True iff pid's exe symlink OR cwd symlink contains "/runtimes/llamacpp/"
+# — the actual identity proof for sweep 3 (see the header comment on why
+# this, not just the cmdline pattern, is what makes a candidate real).
+# Any CROW_HOME: this is a substring test, never anchored to ~/.crow.
+exe_or_cwd_under_native_runtimes() {
+  local target
+  target=$(readlink "/proc/$1/exe" 2>/dev/null) || target=""
+  case "$target" in
+    */runtimes/llamacpp/*) return 0 ;;
+  esac
+  target=$(readlink "/proc/$1/cwd" 2>/dev/null) || target=""
+  case "$target" in
+    */runtimes/llamacpp/*) return 0 ;;
+  esac
+  return 1
+}
 
 # systemd-owned: the pid's cgroup path contains a *.service component.
 systemd_owned() {
@@ -212,7 +258,7 @@ for pid in $(pgrep -f "$MATCH_PATTERN" 2>/dev/null); do
   # Children first, gateway itself last — killing the gateway first would
   # re-parent its bundle children to init and their DB locks would survive.
   tree="$(stamp_pids "$(descendants_of "$pid") $pid")"
-  log "orphan gateway pid $pid (ppid=1) — reaping subtree: $(echo $tree | tr '\n' ' ')"
+  log "orphan gateway pid $pid (ppid=1) — reaping subtree: $(echo "$tree" | tr '\n' ' ')"
   reap_tree "$tree" "orphan gateway subtree"
 done
 
@@ -230,6 +276,24 @@ for pid in $(pgrep -f "$BUNDLE_PATTERN" 2>/dev/null); do
   tree="$(stamp_pids "$(descendants_of "$pid") $pid")"
   log "orphaned bundle child pid $pid (ppid=1, cwd=$cwd) — reaping"
   reap_tree "$tree" "orphaned bundle child"
+done
+
+# --- Sweep 3: orphaned native model runtime processes (ppid==1, exe/cwd
+# under ANY CROW_HOME's runtimes/llamacpp/) — Item G, Task 14 ----------------
+for pid in $(pgrep -f "$NATIVE_PATTERN" 2>/dev/null); do
+  [ "$pid" = "$$" ] && continue
+  protected "$pid" && continue
+  ppid=$(ppid_of "$pid") || continue
+  [ "$ppid" = "1" ] || continue
+  exe_or_cwd_under_native_runtimes "$pid" || continue
+  # A native runtime process has no children of its own to worry about
+  # (unlike the gateway/bundle sweeps, there is no downstream lock-holder
+  # depending on it), but stamp+reap through the same single-pid "tree" for
+  # a uniform, already-hardened code path (protection + starttime
+  # re-verification on every signal).
+  tree="$(stamp_pids "$pid")"
+  log "orphaned native model runtime pid $pid (ppid=1) — reaping: $(cmdline_of "$pid")"
+  reap_tree "$tree" "orphaned native model runtime"
 done
 
 exit 0

--- a/scripts/ops/kill-orphan-gateways.sh
+++ b/scripts/ops/kill-orphan-gateways.sh
@@ -73,11 +73,23 @@
 #     than guessed — a wrongly-killed live model cannot be undone, while a
 #     genuinely orphaned process just gets caught on the next sweep. A
 #     reservation-less llama-server on a random port remains reapable (truly
-#     abandoned — its reservation was deleted or never existed). Residual
-#     case, stated honestly: if a reservation IS present but the model is
-#     actually dead (crashed without ever calling releasePort), the process
-#     has already exited on its own — there is nothing left for this sweep
-#     to kill either way, so skipping it here costs nothing.
+#     abandoned — its reservation was deleted or never existed, i.e. the
+#     state file is missing entirely OR it parsed cleanly with no match for
+#     this port). Residual case, stated honestly: if a reservation IS
+#     present but the model is actually dead (crashed without ever calling
+#     releasePort), the process has already exited on its own — there is
+#     nothing left for this sweep to kill either way, so skipping it here
+#     costs nothing.
+#
+#     Fix round 2: a state file that EXISTS but fails to parse (corrupt
+#     JSON, permission error, unexpected shape) is a DIFFERENT case from
+#     "confirmed no reservation" and must never be silently treated as one —
+#     `port_reserved_model`'s node helper returns a distinct exit code for
+#     it (2, vs. 1 for a confirmed clean miss) specifically so this can't
+#     degrade into "couldn't read it, so assume unreserved, so kill it,"
+#     which would defeat the whole point of this cross-check. That case
+#     fails CLOSED too (skipped, logged) — the same fail-closed principle as
+#     an undeterminable CROW_HOME/port above.
 #
 # PROTECTION (checked at candidate selection AND before every signal):
 #   1. systemd-owned: any process whose /proc/<pid>/cgroup places it inside a
@@ -233,13 +245,24 @@ native_port_of() {
 
 # Adoption cross-check (fix round 1, Critical finding — see the Sweep 3
 # header comment for the full scenario): does `statePath`'s models/
-# state.json hold ANY reservation for `port`? Prints the reserving modelId
-# and returns 0 if so; prints nothing and returns 1 otherwise (missing/
-# corrupt state file, or no matching reservation — both mean "not
-# protected by this check", not "protected"). Parsed with `node` rather
-# than `jq`: every Crow host already requires node to run the gateway
-# itself, so this adds no new host dependency (jq is NOT a guaranteed
-# install-time dependency — confirmed absent from scripts/crow-install.sh).
+# state.json hold ANY reservation for `port`? Exit code is a real 3-way
+# result (fix round 2 — a corrupt state file must NOT silently degrade to
+# "not reserved", or a state file corrupted at the wrong moment could get a
+# legitimately-adopted model killed, defeating the whole point of this
+# check):
+#   0 = reserved — reserving modelId printed on stdout.
+#   1 = CONFIRMED not reserved — the file is missing entirely (never had,
+#       or had and lost, a reservation — explicitly fine to treat as
+#       reapable, see the Sweep-3 header's "residual case" note) OR it
+#       parsed cleanly with no matching port.
+#   2 = UNKNOWN — the file exists but could not be read/parsed (corrupt
+#       JSON, permission error, unexpected shape). Callers MUST treat this
+#       as fail-closed (skip), never as "not reserved" — see the header
+#       comment's fail-closed principle.
+# Parsed with `node` rather than `jq`: every Crow host already requires
+# node to run the gateway itself, so this adds no new host dependency (jq
+# is NOT a guaranteed install-time dependency — confirmed absent from
+# scripts/crow-install.sh).
 port_reserved_model() {
   local state_path="$1" port="$2"
   [ -f "$state_path" ] || return 1
@@ -257,7 +280,7 @@ try {
   }
   process.exit(1);
 } catch {
-  process.exit(1);
+  process.exit(2);
 }
 EOF
 }
@@ -413,8 +436,18 @@ for pid in $(pgrep -f "$NATIVE_PATTERN" 2>/dev/null); do
     continue
   fi
   reserved_model=$(port_reserved_model "${native_home}/models/state.json" "$native_port")
-  if [ -n "$reserved_model" ]; then
+  reserved_rc=$?
+  if [ "$reserved_rc" = "0" ]; then
     log "skipping adopted native model on port $native_port (reserved for '$reserved_model' in ${native_home}/models/state.json) — pid $pid"
+    continue
+  elif [ "$reserved_rc" != "1" ]; then
+    # Fix round 2: exit 2 (state file exists but unreadable/corrupt) or any
+    # other unexpected code must NEVER be treated as "confirmed not
+    # reserved" — only a real exit 1 (missing file, or a clean parse with no
+    # match) means that. Fail CLOSED, same principle as the CROW_HOME/port
+    # check above: a state file corrupted at the wrong moment must not cost
+    # a live, adopted model its life.
+    log "skipping native model runtime pid $pid — ${native_home}/models/state.json unreadable, refusing to guess"
     continue
   fi
 

--- a/servers/gateway/dashboard/settings/sections/ports.js
+++ b/servers/gateway/dashboard/settings/sections/ports.js
@@ -13,6 +13,7 @@ const KIND_LABEL = {
   hardcoded: "bundle",
   managed: "model service",
   core: "core service",
+  "local-model": "local model",
   foreign: "other listener",
 };
 

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -40,6 +40,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -470,6 +471,90 @@ function findBinaryRecursive(fsMod, dir, name) {
 }
 
 // ---------------------------------------------------------------------------
+// Stale tmp sweep (Task 14, PR G-D — follow-up from PR G-B's final review)
+// ---------------------------------------------------------------------------
+
+/** Default max age (ms, 7 days) a `.extract-*.tmp` / `.download-*.tmp`
+ * entry under `<dir>/runtimes/llamacpp/` may sit before {@link
+ * sweepStaleRuntimeTmp} removes it. */
+export const STALE_RUNTIME_TMP_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Matches ONLY the two tmp-naming conventions `ensureRuntime` itself
+ * writes (`.download-<key>-<release>.tmp` files, `.extract-<key>-<release>.tmp`
+ * staging directories) — never a completed `releaseDir` or its manifest,
+ * regardless of key/release content, since both real segments can contain
+ * arbitrary catalog-controlled text. */
+const STALE_TMP_NAME_RE = /^\.(extract|download)-.*\.tmp$/;
+
+/**
+ * Remove stale `.extract-*.tmp` / `.download-*.tmp` entries (files or
+ * directories) under `<dir>/runtimes/llamacpp/` whose mtime is older than
+ * `maxAgeMs` (default {@link STALE_RUNTIME_TMP_MAX_AGE_MS}) — regardless of
+ * whether their key/release matches the catalog's CURRENT `runtime` block.
+ * A catalog release-pin bump, or a process killed mid-download/mid-extract
+ * for a release the catalog no longer points at, would otherwise leave an
+ * orphaned staging entry on disk forever (nothing in `ensureRuntime`'s own
+ * idempotent-manifest path ever revisits a release it isn't currently
+ * asked to install).
+ *
+ * Safety: the removal candidate list comes from `readdirSync` entries
+ * matched against {@link STALE_TMP_NAME_RE} — a real regex test against an
+ * enumerated basename, not a shell glob — so there is no path-expansion
+ * surface, and a `releaseDir` (which never starts with `.extract-` or
+ * `.download-`) is structurally excluded regardless of its own contents.
+ *
+ * Best-effort by design (matches this module's overall stance that a
+ * cleanup pass must never block the actual install/serve path it runs
+ * alongside): a missing `runtimesDir`, a permission error, or an entry that
+ * vanishes between `readdirSync` and `statSync` (raced by a concurrent
+ * `ensureRuntime` finishing its own install) all resolve to "skip that
+ * entry" rather than throwing.
+ *
+ * `now`/`fs` are injectable for deterministic testing; production always
+ * uses the real clock and real fs calls (this function has its own default
+ * fs binding, independent of `ensureRuntime`'s caller-injectable `fs`
+ * option, since a caller mocking `ensureRuntime`'s core install-flow fs
+ * calls for a determinism test has no reason to also intercept this
+ * unrelated best-effort sweep).
+ *
+ * @returns {string[]} absolute paths actually removed (for logging/tests).
+ */
+export function sweepStaleRuntimeTmp(dir, opts = {}) {
+  const {
+    maxAgeMs = STALE_RUNTIME_TMP_MAX_AGE_MS,
+    now = Date.now(),
+    fs = { existsSync, readdirSync, statSync, rmSync },
+  } = opts;
+  const runtimesDir = join(dir, "runtimes", "llamacpp");
+  const removed = [];
+  if (!fs.existsSync(runtimesDir)) return removed;
+  let entries;
+  try {
+    entries = fs.readdirSync(runtimesDir);
+  } catch {
+    return removed;
+  }
+  for (const name of entries) {
+    if (!STALE_TMP_NAME_RE.test(name)) continue;
+    const full = join(runtimesDir, name);
+    let st;
+    try {
+      st = fs.statSync(full);
+    } catch {
+      continue; // vanished between readdir and stat
+    }
+    if (now - st.mtimeMs < maxAgeMs) continue;
+    try {
+      fs.rmSync(full, { recursive: true, force: true });
+      removed.push(full);
+    } catch {
+      /* best effort — a single stubborn entry must not block the rest */
+    }
+  }
+  return removed;
+}
+
+// ---------------------------------------------------------------------------
 // ensureRuntime
 // ---------------------------------------------------------------------------
 
@@ -514,6 +599,12 @@ function findBinaryRecursive(fsMod, dir, name) {
  * attempted, matching this codebase's convention of throwing typed
  * errors at the point of a real mutation (see `manager.js`).
  *
+ * Startup path also runs {@link sweepStaleRuntimeTmp} (best-effort, never
+ * throws into this function) before anything else below — every call site
+ * already knows its own `dir` (CROW_HOME), so this is the natural place to
+ * clean that instance's stale `.extract-*.tmp`/`.download-*.tmp` leftovers
+ * without any new host-wide directory-enumeration logic (Task 14, PR G-D).
+ *
  * @returns {Promise<string>} the executable binary's path.
  */
 export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
@@ -531,7 +622,14 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     chmodFn = chmodSync,
     fs = { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync, rmSync, renameSync },
     timeoutMs = DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS,
+    sweepStaleTmp = sweepStaleRuntimeTmp,
   } = opts;
+
+  try {
+    sweepStaleTmp(dir);
+  } catch {
+    /* best effort — a sweep failure must never block a real install */
+  }
 
   const resolved = resolveAsset(probe, runtimeBlock, { lddOutput, arch, baseUrl });
   if (resolved.error) throw resolved.error;

--- a/servers/gateway/port-inventory.js
+++ b/servers/gateway/port-inventory.js
@@ -10,10 +10,21 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
+import { resolveDataDir } from "../db.js";
+import { loadState, PORT_RANGE_START as NATIVE_MODEL_PORT_START, PORT_RANGE_END as NATIVE_MODEL_PORT_END } from "./models/state.js";
+
 const execFileP = promisify(execFile);
 const CROW_HOME = process.env.CROW_HOME || join(homedir(), ".crow");
 const BUNDLES_DIR = join(CROW_HOME, "bundles");
 const INSTALLED_PATH = join(CROW_HOME, "installed.json");
+
+/** Generic label for a live 18100-18199 listener whose port has no matching
+ * entry in this instance's models/state.json reservations (e.g. a stale/
+ * external process on the port, or a reservation written by a DIFFERENT
+ * CROW_HOME on a shared host — reservations are per-instance, see
+ * models/state.js). Never a guess at a model id when one isn't provably
+ * known. */
+export const GENERIC_LOCAL_MODEL_LABEL = "local model server (native runtime)";
 
 /** Core Crow services: shown, never bundle-attributed. */
 export function coreServices() {
@@ -123,11 +134,22 @@ function addrId(a) {
  * Foreign listeners -> informational. The displayed bound address is the actual
  * ss address when listening, else the declared bind.
  *
+ * `nativeModelPorts` attributes the gateway-internal native-model-runtime
+ * range (18100-18199, see `models/state.js`'s `PORT_RANGE_START/END`) as a
+ * local model server instead of falling into the generic `"foreign"`
+ * bucket the Ports settings section hides behind a collapsed "Other host
+ * listeners" details element (Item G, Task 14) — these are Crow's OWN
+ * spawned llama-server processes, just not bundle/compose-declared ones.
+ * A port in range gets the reserving model's id as `bundleName` when this
+ * instance's state file has a live reservation for it, else the generic
+ * {@link GENERIC_LOCAL_MODEL_LABEL} — never a guessed model id.
+ *
  * @param {Array<{bundleId,bundleName,port:number,bind:string,bindKind:string,proto:string,source:string,portEnvVar?:string}>} endpoints
  * @param {Array<{port:number,boundAddr:string}>} listeners
  * @param {Map<number,string>} coreSet
+ * @param {Map<number,string>} [nativeModelPorts] - port -> modelId, from this instance's models/state.json reservations
  */
-export function attributeAndDetect(endpoints, listeners, coreSet) {
+export function attributeAndDetect(endpoints, listeners, coreSet, nativeModelPorts = new Map()) {
   const ports = new Set([
     ...endpoints.map((e) => e.port).filter((p) => p != null),
     ...listeners.map((l) => l.port),
@@ -168,6 +190,13 @@ export function attributeAndDetect(endpoints, listeners, coreSet) {
       rows.push({
         port, bundleId: null, bundleName: coreSet.get(port), declaredBind: null,
         boundAddr: liveAddr, kind: "core", listening, status: listening ? "up" : "down",
+        shared: false, conflict, conflictReason: conflict ? `Port ${port} has multiple overlapping listeners` : null,
+      });
+    } else if (port >= NATIVE_MODEL_PORT_START && port <= NATIVE_MODEL_PORT_END) {
+      const modelId = nativeModelPorts.get(port) || null;
+      rows.push({
+        port, bundleId: modelId, bundleName: modelId || GENERIC_LOCAL_MODEL_LABEL, declaredBind: null,
+        boundAddr: liveAddr, kind: "local-model", listening: true, status: "up",
         shared: false, conflict, conflictReason: conflict ? `Port ${port} has multiple overlapping listeners` : null,
       });
     } else {
@@ -242,11 +271,33 @@ export async function readListeners() {
   } catch { return []; }
 }
 
+/**
+ * Read this instance's native-model port reservations from
+ * `<resolveDataDir()>/models/state.json` (the same file `models/state.js`'s
+ * `allocatePort`/`releasePort` maintain) as a `Map<port, modelId>`. Missing
+ * or unparseable state resolves to an empty map — `loadState` itself never
+ * throws (see its doc), so a fresh/corrupt state file just yields no
+ * attributions rather than breaking inventory building.
+ */
+export function loadNativeModelPortMap() {
+  const state = loadState(resolveDataDir());
+  const map = new Map();
+  // allocatePort never double-assigns a port across two reservations, so a
+  // collision here would only ever indicate a corrupt/hand-edited state
+  // file — last-write-wins is a defensive fallback, not a real ambiguity.
+  for (const [modelId, reservation] of Object.entries(state.reservations || {})) {
+    if (reservation && Number.isInteger(reservation.port)) {
+      map.set(reservation.port, modelId);
+    }
+  }
+  return map;
+}
+
 let _cache = null; // { at:number, rows }
 /** Build the inventory; `ttlMs`>0 returns a recent cached result (for getPreview). */
 export async function buildPortInventory({ ttlMs = 0, now = 0 } = {}) {
   if (ttlMs > 0 && _cache && now - _cache.at < ttlMs) return _cache.rows;
-  const rows = attributeAndDetect(listInstalledBundles(), await readListeners(), coreServices());
+  const rows = attributeAndDetect(listInstalledBundles(), await readListeners(), coreServices(), loadNativeModelPortMap());
   if (ttlMs > 0) _cache = { at: now, rows };
   return rows;
 }

--- a/tests/kill-orphan-gateways.test.js
+++ b/tests/kill-orphan-gateways.test.js
@@ -29,7 +29,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import {
   mkdtempSync,
@@ -38,6 +38,8 @@ import {
   readFileSync,
   existsSync,
   rmSync,
+  copyFileSync,
+  chmodSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -141,12 +143,15 @@ setInterval(() => {}, 1000);
 /**
  * Spawn `script` orphaned to ppid==1: an intermediate `node -e` parent spawns
  * it detached+unref, prints the pid, and exits immediately (its child is then
- * adopted by init). Returns the pid once /proc shows ppid==1.
+ * adopted by init). Returns the pid once /proc shows ppid==1. `opts.extraArgs`
+ * (default []) are appended to argv after `script` — used by the sweep-3
+ * decoy test to put an arbitrary substring in the process's cmdline without
+ * it being anywhere near the process's actual exe/cwd.
  */
 async function spawnOrphaned(script, opts = {}) {
   const bootstrap = `
 const { spawn } = require("node:child_process");
-const c = spawn(process.execPath, [${JSON.stringify(script)}], {
+const c = spawn(process.execPath, [${JSON.stringify(script)}, ...${JSON.stringify(opts.extraArgs || [])}], {
   detached: true,
   stdio: "ignore",
   cwd: ${JSON.stringify(opts.cwd || tmpdir())},
@@ -169,16 +174,73 @@ process.stdout.write(String(c.pid));
   return pid;
 }
 
+/**
+ * Spawn a real ELF binary at `binPath` (directly exec'd — no interpreter, so
+ * `/proc/<pid>/exe` resolves to `binPath` itself, matching how a real
+ * llama-server process — or its setpriv-wrapped form, which execve's the
+ * target and inherits its /proc/<pid>/exe — actually looks on this host),
+ * orphaned to ppid==1 via the same intermediate-bootstrap technique as
+ * {@link spawnOrphaned}.
+ */
+async function spawnOrphanedBinary(binPath, args = [], opts = {}) {
+  const bootstrap = `
+const { spawn } = require("node:child_process");
+const c = spawn(${JSON.stringify(binPath)}, ${JSON.stringify(args)}, {
+  detached: true,
+  stdio: "ignore",
+  cwd: ${JSON.stringify(opts.cwd || tmpdir())},
+});
+c.unref();
+process.stdout.write(String(c.pid));
+`;
+  const { stdout } = await pExecFile(process.execPath, ["-e", bootstrap]);
+  const pid = parseInt((stdout.match(/\d+/) || [])[0], 10);
+  assert.ok(pid > 1, "bootstrap must print the orphan pid");
+  await waitFor(() => {
+    try {
+      return ppidOf(pid) === 1;
+    } catch {
+      return false;
+    }
+  }, 5000, `pid ${pid} to be re-parented to init (ppid==1)`);
+  return pid;
+}
+
+/** Build a fake native-runtime release layout under a fresh mkdtemp dir:
+ * T/runtimes/llamacpp/vTest/llama-server-fixture — a COPY of the real
+ * `/bin/sleep` binary (a small real ELF executable), so spawning it directly
+ * gives a process whose /proc/<pid>/exe genuinely resolves under
+ * ".../runtimes/llamacpp/..." — the exact identity signal sweep 3 checks,
+ * not a simulation of it. Returns { T, binPath }. */
+function makeFakeNativeRuntime() {
+  const T = mkdtempSync(join(tmpdir(), "orphan-native-test-"));
+  const releaseDir = join(T, "runtimes", "llamacpp", "vTest");
+  mkdirSync(releaseDir, { recursive: true });
+  const binPath = join(releaseDir, "llama-server-fixture");
+  copyFileSync("/bin/sleep", binPath);
+  chmodSync(binPath, 0o755);
+  return { T, binPath };
+}
+
 async function runScript(env) {
-  // Never inherit unscoped defaults in tests: both patterns are ALWAYS set.
+  // Never inherit unscoped defaults in tests: all three patterns are ALWAYS
+  // set (sweep 3's ORPHAN_NATIVE_PATTERN added Task 14 — same rationale as
+  // the other two: an unscoped default could sweep this real host's own
+  // gateway/bundle/native-runtime processes mid-suite-run).
   assert.ok(env.ORPHAN_MATCH_PATTERN, "test must scope ORPHAN_MATCH_PATTERN");
   assert.ok(env.ORPHAN_BUNDLE_PATTERN, "test must scope ORPHAN_BUNDLE_PATTERN");
+  assert.ok(env.ORPHAN_NATIVE_PATTERN, "test must scope ORPHAN_NATIVE_PATTERN");
   const { stdout, stderr } = await pExecFile("bash", [SCRIPT], {
     env: { ...process.env, ...env },
     timeout: 30000,
   });
   return { stdout, stderr };
 }
+
+/** Path to a candidate never present on a real host — the "match nothing"
+ * scope every test that isn't exercising sweep 3 itself uses for
+ * ORPHAN_NATIVE_PATTERN. */
+const NATIVE_PATTERN_NOMATCH = "/nonexistent-orphan-test-path/runtimes/llamacpp/does-not-exist";
 
 function trackedKill(pids) {
   for (const pid of pids) {
@@ -204,6 +266,18 @@ function cleanupTree(spawned, T, childPidFile) {
 
 const pidRe = (pid) => new RegExp(`\\b${pid}\\b`); // anchored: pid 1234 must not match 51234
 
+test("bash -n: script parses", () => {
+  const r = spawnSync("bash", ["-n", SCRIPT]);
+  assert.equal(r.status, 0, r.stderr && r.stderr.toString());
+});
+
+test("shellcheck passes when available (skips otherwise)", (t) => {
+  const which = spawnSync("shellcheck", ["--version"], { stdio: "ignore" });
+  if (which.error) return t.skip("shellcheck not installed");
+  const r = spawnSync("shellcheck", [SCRIPT], { encoding: "utf-8" });
+  assert.equal(r.status, 0, r.stdout);
+});
+
 test("reaps an orphaned fake gateway AND its bundle child (subtree reaping)", async (t) => {
   const prod = await prodMainPids();
   if (prod.length === 0) return t.skip("no crow gateway units on this host");
@@ -227,6 +301,7 @@ test("reaps an orphaned fake gateway AND its bundle child (subtree reaping)", as
     // critical child-also-dies assertion couldn't detect a missing subtree
     // reap (sweep 2 would mask it).
     ORPHAN_BUNDLE_PATTERN: `${escRe(T)}/bundles/does-not-match\\.js`,
+    ORPHAN_NATIVE_PATTERN: NATIVE_PATTERN_NOMATCH,
   });
 
   await waitFor(() => !isAlive(gwPid), 5000, "fake gateway to die");
@@ -261,6 +336,7 @@ test("second sweep reaps an ALREADY-orphaned bundle child (ppid==1, cwd under /b
     // Gateway pattern scoped to a path that matches NOTHING:
     ORPHAN_MATCH_PATTERN: `${escRe(T)}/servers/gateway/does-not-exist\\.js`,
     ORPHAN_BUNDLE_PATTERN: `${escRe(T)}/bundles/fake/server/index\\.js`,
+    ORPHAN_NATIVE_PATTERN: NATIVE_PATTERN_NOMATCH,
   });
 
   await waitFor(() => !isAlive(childPid), 5000, "orphaned bundle child to die");
@@ -285,6 +361,7 @@ test("ORPHAN_DRY_RUN=1 reports victims but kills nothing", async (t) => {
   const { stdout } = await runScript({
     ORPHAN_MATCH_PATTERN: `${escRe(T)}/servers/gateway/fixture-index\\.js`,
     ORPHAN_BUNDLE_PATTERN: `${escRe(T)}/bundles/fake/server/index\\.js`,
+    ORPHAN_NATIVE_PATTERN: NATIVE_PATTERN_NOMATCH,
     ORPHAN_DRY_RUN: "1",
   });
 
@@ -302,6 +379,7 @@ test("script exits 0 even when nothing matches", async (t) => {
   await runScript({
     ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
     ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: NATIVE_PATTERN_NOMATCH,
   });
   assertProdAlive(prod, "after the no-match run");
 });
@@ -333,6 +411,7 @@ test("systemd-owned prod gateways are protected even when the pattern matches th
   const { stdout } = await runScript({
     ORPHAN_MATCH_PATTERN: "node.*servers/gateway/index\\.js",
     ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: NATIVE_PATTERN_NOMATCH,
     ORPHAN_DRY_RUN: "1",
   });
   for (const pid of prod) {
@@ -361,6 +440,7 @@ test("CROW_ALLOW_ORPHAN=1 orphan survives a REAL (non-dry) sweep", async (t) => 
   const { stdout } = await runScript({
     ORPHAN_MATCH_PATTERN: `${escRe(T)}/servers/gateway/fixture-index\\.js`,
     ORPHAN_BUNDLE_PATTERN: `${escRe(T)}/bundles/does-not-match\\.js`,
+    ORPHAN_NATIVE_PATTERN: NATIVE_PATTERN_NOMATCH,
   });
 
   await sleep(2500); // longer than the TERM→KILL grace
@@ -393,4 +473,131 @@ test("fixture filename is invisible to the script's DEFAULT gateway pattern (pro
   } finally {
     rmSync(T, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Sweep 3: orphaned native model runtime processes (Item G, Task 14)
+// ---------------------------------------------------------------------------
+
+test("sweep 3 reaps an orphaned native model runtime process (ppid==1, exe under runtimes/llamacpp/)", async (t) => {
+  const prod = await prodMainPids();
+  if (prod.length === 0) return t.skip("no crow gateway units on this host");
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+
+  const { T, binPath } = makeFakeNativeRuntime();
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const pid = await spawnOrphanedBinary(binPath, ["600"]);
+  spawned.push(pid);
+  assert.ok(isAlive(pid), "native runtime fixture must be alive pre-run");
+
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(binPath),
+  });
+
+  await waitFor(() => !isAlive(pid), 5000, "orphaned native runtime fixture to die");
+  assert.ok(!isAlive(pid), `orphaned native runtime fixture ${pid} must be gone`);
+  assert.match(stdout, /native model runtime/i, "script should log what it did");
+  assertProdAlive(prod, "after the native-runtime reap run");
+});
+
+test("sweep 3 ORPHAN_DRY_RUN=1 names the native runtime victim but kills nothing", async (t) => {
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected (never named as victims)");
+  const prod = await prodMainPids();
+  const { T, binPath } = makeFakeNativeRuntime();
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const pid = await spawnOrphanedBinary(binPath, ["600"]);
+  spawned.push(pid);
+
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(binPath),
+    ORPHAN_DRY_RUN: "1",
+  });
+
+  await sleep(2500); // longer than the script's TERM→KILL grace window
+  assert.ok(isAlive(pid), "dry run must NOT kill the native runtime fixture");
+  assert.match(stdout, pidRe(pid), "dry run must name the native runtime victim");
+  assertProdAlive(prod, "after the native-runtime dry run");
+});
+
+test("sweep 3 requires the exe/cwd identity proof — a cmdline-only decoy (no matching exe/cwd) survives", async (t) => {
+  // The whole point of checking exe/cwd instead of trusting ORPHAN_NATIVE_PATTERN
+  // alone: a process whose cmdline merely MENTIONS the "runtimes/llamacpp"
+  // path fragment (e.g. as an unrelated argument) but isn't actually running
+  // FROM that location must never be treated as a native-runtime candidate.
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const prod = await prodMainPids();
+  const T = mkdtempSync(join(tmpdir(), "orphan-native-decoy-"));
+  const decoyScript = join(T, "decoy.js");
+  writeFileSync(decoyScript, `setInterval(() => {}, 1000);\n`);
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  // decoyArg never exists on disk — it's just an argv token containing the
+  // substring. Neither the decoy's exe (node's own binary) nor its cwd
+  // (tmpdir(), passed as opts.cwd default) is anywhere under it.
+  const decoyArg = join(T, "runtimes", "llamacpp", "not-actually-the-binary");
+  const pid = await spawnOrphaned(decoyScript, { extraArgs: [decoyArg] });
+  spawned.push(pid);
+  assert.ok(isAlive(pid), "decoy must be alive pre-run");
+
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(decoyArg),
+  });
+
+  await sleep(2500);
+  assert.ok(isAlive(pid), "cmdline-only decoy (no matching exe/cwd) must survive sweep 3");
+  assert.doesNotMatch(stdout, pidRe(pid), "decoy must never be named a native-runtime victim");
+  assertProdAlive(prod, "after the decoy run");
+});
+
+test("sweep 3 candidate identity check matches on cwd too, not only exe", async (t) => {
+  // The brief specifies "exe/cwd" — prove the cwd branch independently of
+  // the exe branch: a plain node script (exe = node's own binary, never
+  // under runtimes/llamacpp) whose CWD is set to a fake release dir must
+  // still be reaped.
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const prod = await prodMainPids();
+  const T = mkdtempSync(join(tmpdir(), "orphan-native-cwd-"));
+  const releaseDir = join(T, "runtimes", "llamacpp", "vTest");
+  mkdirSync(releaseDir, { recursive: true });
+  const script = join(releaseDir, "fake-native-child.js");
+  writeFileSync(script, `setInterval(() => {}, 1000);\n`);
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const pid = await spawnOrphaned(script, { cwd: releaseDir });
+  spawned.push(pid);
+  assert.ok(isAlive(pid), "cwd-fixture must be alive pre-run");
+
+  await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(script),
+  });
+
+  await waitFor(() => !isAlive(pid), 5000, "cwd-matched native runtime fixture to die");
+  assert.ok(!isAlive(pid), `cwd-matched native runtime fixture ${pid} must be gone`);
+  assertProdAlive(prod, "after the cwd-match reap run");
 });

--- a/tests/kill-orphan-gateways.test.js
+++ b/tests/kill-orphan-gateways.test.js
@@ -40,6 +40,7 @@ import {
   rmSync,
   copyFileSync,
   chmodSync,
+  realpathSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -206,20 +207,80 @@ process.stdout.write(String(c.pid));
   return pid;
 }
 
+/** Resolve a real, standalone-executable copy source for the native-runtime
+ * fixture binary — must be a real ELF (so a direct copy + direct exec makes
+ * /proc/<pid>/exe genuinely resolve under the fixture's own path, not a
+ * simulation) that TOLERATES ARBITRARY TRAILING ARGV (unlike `/bin/sleep`,
+ * which validates every argument as its own option/duration and exits
+ * immediately on an unrecognized one — verified live: `sleep 600 --port
+ * 18140` exits nonzero before ever sleeping). `python3 -c '<script>' <args>`
+ * hands everything after the script straight to `sys.argv` without
+ * validating it, so a realistic llama-server-shaped cmdline (--model
+ * --alias --port --host) can ride along. Cached after first resolution;
+ * `null` if python3 isn't on this host (tests that need it skip honestly —
+ * python3 is NOT a Crow install-time dependency, only a test-fixture
+ * convenience). */
+let _python3BinCache;
+function resolvePython3Binary() {
+  if (_python3BinCache !== undefined) return _python3BinCache;
+  const which = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf-8" });
+  if (which.status !== 0 || !which.stdout.trim()) {
+    _python3BinCache = null;
+    return _python3BinCache;
+  }
+  try {
+    _python3BinCache = realpathSync(which.stdout.trim());
+  } catch {
+    _python3BinCache = null;
+  }
+  return _python3BinCache;
+}
+
 /** Build a fake native-runtime release layout under a fresh mkdtemp dir:
  * T/runtimes/llamacpp/vTest/llama-server-fixture — a COPY of the real
- * `/bin/sleep` binary (a small real ELF executable), so spawning it directly
- * gives a process whose /proc/<pid>/exe genuinely resolves under
+ * python3 binary (see {@link resolvePython3Binary}), so spawning it
+ * directly gives a process whose /proc/<pid>/exe genuinely resolves under
  * ".../runtimes/llamacpp/..." — the exact identity signal sweep 3 checks,
- * not a simulation of it. Returns { T, binPath }. */
+ * not a simulation of it. Returns { T, binPath } or `null` if python3 isn't
+ * available. */
 function makeFakeNativeRuntime() {
+  const py = resolvePython3Binary();
+  if (!py) return null;
   const T = mkdtempSync(join(tmpdir(), "orphan-native-test-"));
   const releaseDir = join(T, "runtimes", "llamacpp", "vTest");
   mkdirSync(releaseDir, { recursive: true });
   const binPath = join(releaseDir, "llama-server-fixture");
-  copyFileSync("/bin/sleep", binPath);
+  copyFileSync(py, binPath);
   chmodSync(binPath, 0o755);
   return { T, binPath };
+}
+
+/** Spawn `binPath` (from {@link makeFakeNativeRuntime}) orphaned to ppid==1
+ * with a REALISTIC llama-server-shaped cmdline — `--model <gguf> --alias
+ * <alias> --port <port> --host 127.0.0.1`, matching
+ * `runtime.js`'s `buildLlamaServerArgs` shape exactly (the flags Sweep 3's
+ * `native_port_of` actually parses). `port` omitted entirely tests the
+ * fail-closed "couldn't determine a port" path. */
+function spawnFakeNativeModel(binPath, { port, alias = "test-model" } = {}) {
+  const args = ["-c", "import time; time.sleep(600)", "--model", "/fake/model.gguf", "--alias", alias];
+  if (port != null) args.push("--port", String(port), "--host", "127.0.0.1");
+  return spawnOrphanedBinary(binPath, args);
+}
+
+/** Write `T/models/state.json` with a single reservation — the same shape
+ * `models/state.js`'s `saveState`/`allocatePort` produce — so the sweep's
+ * `port_reserved_model` helper (which reads this exact file) sees it. */
+function writeStateReservation(T, modelId, port) {
+  const stateDir = join(T, "models");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, "state.json"),
+    JSON.stringify({
+      reservations: { [modelId]: { port, owner: { crowHome: T, pid: 999999 }, createdAt: new Date().toISOString() } },
+      journal: {},
+      registry: {},
+    }, null, 2),
+  );
 }
 
 async function runScript(env) {
@@ -479,19 +540,23 @@ test("fixture filename is invisible to the script's DEFAULT gateway pattern (pro
 // Sweep 3: orphaned native model runtime processes (Item G, Task 14)
 // ---------------------------------------------------------------------------
 
-test("sweep 3 reaps an orphaned native model runtime process (ppid==1, exe under runtimes/llamacpp/)", async (t) => {
+test("sweep 3 reaps an orphaned native model runtime process (ppid==1, exe under runtimes/llamacpp/, no reservation for its port)", async (t) => {
   const prod = await prodMainPids();
   if (prod.length === 0) return t.skip("no crow gateway units on this host");
   if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const fixture = makeFakeNativeRuntime();
+  if (!fixture) return t.skip("python3 not available to build a realistic native-runtime fixture binary");
+  const { T, binPath } = fixture;
 
-  const { T, binPath } = makeFakeNativeRuntime();
   const spawned = [];
   t.after(() => {
     trackedKill(spawned);
     rmSync(T, { recursive: true, force: true });
   });
 
-  const pid = await spawnOrphanedBinary(binPath, ["600"]);
+  // No T/models/state.json at all — port_reserved_model must treat a
+  // missing state file as "not reserved", not "protected".
+  const pid = await spawnFakeNativeModel(binPath, { port: 18140 });
   spawned.push(pid);
   assert.ok(isAlive(pid), "native runtime fixture must be alive pre-run");
 
@@ -510,14 +575,17 @@ test("sweep 3 reaps an orphaned native model runtime process (ppid==1, exe under
 test("sweep 3 ORPHAN_DRY_RUN=1 names the native runtime victim but kills nothing", async (t) => {
   if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected (never named as victims)");
   const prod = await prodMainPids();
-  const { T, binPath } = makeFakeNativeRuntime();
+  const fixture = makeFakeNativeRuntime();
+  if (!fixture) return t.skip("python3 not available to build a realistic native-runtime fixture binary");
+  const { T, binPath } = fixture;
+
   const spawned = [];
   t.after(() => {
     trackedKill(spawned);
     rmSync(T, { recursive: true, force: true });
   });
 
-  const pid = await spawnOrphanedBinary(binPath, ["600"]);
+  const pid = await spawnFakeNativeModel(binPath, { port: 18141 });
   spawned.push(pid);
 
   const { stdout } = await runScript({
@@ -531,6 +599,122 @@ test("sweep 3 ORPHAN_DRY_RUN=1 names the native runtime victim but kills nothing
   assert.ok(isAlive(pid), "dry run must NOT kill the native runtime fixture");
   assert.match(stdout, pidRe(pid), "dry run must name the native runtime victim");
   assertProdAlive(prod, "after the native-runtime dry run");
+});
+
+// ---------------------------------------------------------------------------
+// Sweep 3 adoption cross-check (fix round 1, Critical finding)
+// ---------------------------------------------------------------------------
+
+test("sweep 3 SKIPS a candidate whose port is reserved in its own CROW_HOME's state.json (adopted model, not reaped)", async (t) => {
+  // The scenario: a crashed gateway's llama-server survived (setpriv absent
+  // or lost the pdeathsig race), got reparented to init (ppid==1), and was
+  // then ADOPTED by the restarted gateway (identityProbe found it already
+  // resident -> freshStart:false, no respawn) — so it's STILL serving live
+  // traffic despite looking exactly like an orphan. reconcileOnBoot leaves
+  // its reservation in state.json for precisely this reason; Sweep 3 must
+  // see that and refuse to kill it.
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const prod = await prodMainPids();
+  const fixture = makeFakeNativeRuntime();
+  if (!fixture) return t.skip("python3 not available to build a realistic native-runtime fixture binary");
+  const { T, binPath } = fixture;
+
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const PORT = 18142;
+  writeStateReservation(T, "adopted-model", PORT);
+  const pid = await spawnFakeNativeModel(binPath, { port: PORT, alias: "adopted-model" });
+  spawned.push(pid);
+  assert.ok(isAlive(pid), "adopted-model fixture must be alive pre-run");
+
+  // DRY_RUN so the skip decision is provable via stdout without racing the
+  // TERM→KILL grace window (also proves the "would have matched but was
+  // protected" path independently of any real signal being sent).
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(binPath),
+    ORPHAN_DRY_RUN: "1",
+  });
+
+  await sleep(2500);
+  assert.ok(isAlive(pid), "adopted-model fixture must survive — it's reserved, not abandoned");
+  assert.match(stdout, /skipping adopted native model on port 18142/i, "script must log the adoption skip");
+  assert.match(stdout, /adopted-model/, "skip log must name the reserving model id");
+  // The pid legitimately appears IN the skip log line itself — what must
+  // never appear is reap_tree's own "would kill"/"SIGTERM" victim framing.
+  assert.doesNotMatch(stdout, /would kill pid \d+.*orphaned native model runtime/i,
+    "an adopted model must never be named a DRY-RUN reap victim");
+  assertProdAlive(prod, "after the adoption-skip dry run");
+});
+
+test("sweep 3 still reaps a candidate whose port has NO reservation at all (truly abandoned, not adopted)", async (t) => {
+  const prod = await prodMainPids();
+  if (prod.length === 0) return t.skip("no crow gateway units on this host");
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const fixture = makeFakeNativeRuntime();
+  if (!fixture) return t.skip("python3 not available to build a realistic native-runtime fixture binary");
+  const { T, binPath } = fixture;
+
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const PORT = 18143;
+  // A state.json EXISTS (unlike the plain reap test above) but reserves a
+  // DIFFERENT port for a different model — proves the cross-check is a
+  // per-port lookup, not "any state file present -> protected".
+  writeStateReservation(T, "some-other-model", PORT + 1000);
+  const pid = await spawnFakeNativeModel(binPath, { port: PORT, alias: "abandoned-model" });
+  spawned.push(pid);
+
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(binPath),
+  });
+
+  await waitFor(() => !isAlive(pid), 5000, "unreserved native runtime fixture to die");
+  assert.ok(!isAlive(pid), `unreserved native runtime fixture ${pid} must be gone`);
+  assert.doesNotMatch(stdout, /skipping adopted native model/i, "must not be logged as an adoption skip");
+  assertProdAlive(prod, "after the truly-abandoned reap run");
+});
+
+test("sweep 3 fails CLOSED when a candidate's own port can't be determined (no --port in its cmdline)", async (t) => {
+  // Never guess: a candidate matching the exe/cwd identity proof but with
+  // no parseable --port must be skipped, not reaped — the whole point of
+  // the adoption cross-check is refusing to kill on incomplete evidence.
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const prod = await prodMainPids();
+  const fixture = makeFakeNativeRuntime();
+  if (!fixture) return t.skip("python3 not available to build a realistic native-runtime fixture binary");
+  const { T, binPath } = fixture;
+
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const pid = await spawnFakeNativeModel(binPath, {}); // no `port` -> no --port flag at all
+  spawned.push(pid);
+
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(binPath),
+  });
+
+  await sleep(2500);
+  assert.ok(isAlive(pid), "a candidate with no determinable port must survive (fail closed)");
+  assert.match(stdout, /could not determine its own CROW_HOME\/port/i, "script must log the fail-closed skip");
+  assertProdAlive(prod, "after the fail-closed run");
 });
 
 test("sweep 3 requires the exe/cwd identity proof — a cmdline-only decoy (no matching exe/cwd) survives", async (t) => {
@@ -587,7 +771,13 @@ test("sweep 3 candidate identity check matches on cwd too, not only exe", async 
     rmSync(T, { recursive: true, force: true });
   });
 
-  const pid = await spawnOrphaned(script, { cwd: releaseDir });
+  // A realistic --port flag so the adoption cross-check (fix round 1) can
+  // determine the candidate's port and proceed past its fail-closed guard;
+  // no T/models/state.json exists at all, so it's correctly unreserved.
+  const pid = await spawnOrphaned(script, {
+    cwd: releaseDir,
+    extraArgs: ["--model", "/fake/model.gguf", "--alias", "cwd-test-model", "--port", "18144", "--host", "127.0.0.1"],
+  });
   spawned.push(pid);
   assert.ok(isAlive(pid), "cwd-fixture must be alive pre-run");
 

--- a/tests/kill-orphan-gateways.test.js
+++ b/tests/kill-orphan-gateways.test.js
@@ -717,6 +717,55 @@ test("sweep 3 fails CLOSED when a candidate's own port can't be determined (no -
   assertProdAlive(prod, "after the fail-closed run");
 });
 
+test("sweep 3 fails CLOSED when its own CROW_HOME's state.json exists but is corrupt (fix round 2)", async (t) => {
+  // The gap this closes: port_reserved_model's node helper used to exit 1
+  // for BOTH "parsed cleanly, no match" AND "couldn't parse it at all" —
+  // the bash wrapper had no way to tell an honest miss apart from an
+  // unreadable file, so a state file corrupted at exactly the wrong moment
+  // would silently read as "not reserved" and get a legitimately-adopted
+  // model killed. A corrupt (but PRESENT) state.json must never be treated
+  // the same as a confirmed clean miss.
+  if (inServiceCgroup()) return t.skip("suite runs inside a *.service cgroup — fixtures would be systemd-protected");
+  const prod = await prodMainPids();
+  const fixture = makeFakeNativeRuntime();
+  if (!fixture) return t.skip("python3 not available to build a realistic native-runtime fixture binary");
+  const { T, binPath } = fixture;
+
+  const spawned = [];
+  t.after(() => {
+    trackedKill(spawned);
+    rmSync(T, { recursive: true, force: true });
+  });
+
+  const PORT = 18145;
+  const stateDir = join(T, "models");
+  mkdirSync(stateDir, { recursive: true });
+  // Deliberately NOT valid JSON — simulates a state file corrupted mid-write
+  // (or by disk corruption, or hand-editing) rather than the clean "no
+  // matching reservation" case another test already covers.
+  writeFileSync(join(stateDir, "state.json"), "{ this is not valid json ][");
+
+  const pid = await spawnFakeNativeModel(binPath, { port: PORT, alias: "maybe-adopted-model" });
+  spawned.push(pid);
+  assert.ok(isAlive(pid), "fixture must be alive pre-run");
+
+  // DRY_RUN so the skip decision is provable via stdout, matching the
+  // reserved-port test's technique.
+  const { stdout } = await runScript({
+    ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
+    ORPHAN_BUNDLE_PATTERN: "/nonexistent-orphan-test-path/server/index\\.js",
+    ORPHAN_NATIVE_PATTERN: escRe(binPath),
+    ORPHAN_DRY_RUN: "1",
+  });
+
+  await sleep(2500);
+  assert.ok(isAlive(pid), "a candidate whose state.json is corrupt must survive (fail closed, not assumed unreserved)");
+  assert.match(stdout, /state\.json unreadable, refusing to guess/i, "script must log the corrupt-state-file skip");
+  assert.doesNotMatch(stdout, /would kill pid \d+.*orphaned native model runtime/i,
+    "must never be framed as a DRY-RUN reap victim");
+  assertProdAlive(prod, "after the corrupt-state-file run");
+});
+
 test("sweep 3 requires the exe/cwd identity proof — a cmdline-only decoy (no matching exe/cwd) survives", async (t) => {
   // The whole point of checking exe/cwd instead of trusting ORPHAN_NATIVE_PATTERN
   // alone: a process whose cmdline merely MENTIONS the "runtimes/llamacpp"

--- a/tests/models-runtime.test.js
+++ b/tests/models-runtime.test.js
@@ -32,6 +32,8 @@ import {
   renameSync,
   unlinkSync,
   createWriteStream as fsWriteStream,
+  utimesSync,
+  statSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -52,6 +54,8 @@ import {
   probeSetprivAvailable,
   __resetSetprivProbeCacheForTest,
   getStatusSnapshot,
+  sweepStaleRuntimeTmp,
+  STALE_RUNTIME_TMP_MAX_AGE_MS,
 } from "../servers/gateway/models/runtime.js";
 import { acquireHostLock, lockPathFor, stealStaleLock } from "../servers/gateway/models/native-lock.js";
 import { startStubLlamaServer } from "./fixtures/stub-llama-server.mjs";
@@ -1079,6 +1083,146 @@ test("ensureRuntime rejects a resolveAsset failure before attempting any downloa
     await assert.rejects(
       () => ensureRuntime(dir, runtimeBlock, probe, {}),
       (err) => {
+        assert.ok(err instanceof RuntimeAssetError);
+        assert.equal(err.code, "UNSUPPORTED_PLATFORM");
+        return true;
+      },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sweepStaleRuntimeTmp (Task 14, PR G-D — stale tmp sweep)
+// ---------------------------------------------------------------------------
+
+/** Backdate a path's mtime by `ageMs` from `now` (real fs call — these
+ * tests exercise sweepStaleRuntimeTmp's default real-fs binding directly,
+ * since it has no test-visible network/process side effects to fake). */
+function backdate(path, ageMs, now = Date.now()) {
+  const t = (now - ageMs) / 1000;
+  utimesSync(path, t, t);
+}
+
+test("sweepStaleRuntimeTmp removes an old .extract-*.tmp directory and .download-*.tmp file, leaves fresh ones and non-tmp paths alone", async () => {
+  await withScratch("sweep-basic", async (dir) => {
+    const runtimesDir = join(dir, "runtimes", "llamacpp");
+    mkdirSync(runtimesDir, { recursive: true });
+
+    const now = Date.now();
+    const eightDaysMs = 8 * 24 * 60 * 60 * 1000;
+    const oneDayMs = 24 * 60 * 60 * 1000;
+
+    // Old staging dir (from a killed extract) — must be removed.
+    const oldExtractDir = join(runtimesDir, ".extract-linux-x64-cpu-old-release.tmp");
+    mkdirSync(oldExtractDir, { recursive: true });
+    writeFileSync(join(oldExtractDir, "partial-file"), "junk");
+    backdate(oldExtractDir, eightDaysMs, now);
+
+    // Old download tmp file (from a killed download) — must be removed.
+    const oldDownloadFile = join(runtimesDir, ".download-linux-x64-cpu-old-release.tmp");
+    writeFileSync(oldDownloadFile, "partial bytes");
+    backdate(oldDownloadFile, eightDaysMs, now);
+
+    // Fresh (recent) staging dir — must survive (an install could be
+    // mid-flight from a concurrent ensureRuntime call).
+    const freshExtractDir = join(runtimesDir, ".extract-linux-x64-cpu-new-release.tmp");
+    mkdirSync(freshExtractDir, { recursive: true });
+    backdate(freshExtractDir, oneDayMs, now);
+
+    // A completed release dir with a similar-looking but non-matching name
+    // must never be touched, regardless of age.
+    const releaseDir = join(runtimesDir, "some-release");
+    mkdirSync(releaseDir, { recursive: true });
+    writeFileSync(join(releaseDir, "llama-server"), "binary");
+    backdate(releaseDir, eightDaysMs, now);
+
+    const removed = sweepStaleRuntimeTmp(dir, { now });
+
+    assert.deepEqual(new Set(removed), new Set([oldExtractDir, oldDownloadFile]));
+    assert.equal(existsSync(oldExtractDir), false, "old staging dir must be gone");
+    assert.equal(existsSync(oldDownloadFile), false, "old download tmp file must be gone");
+    assert.equal(existsSync(freshExtractDir), true, "fresh staging dir must survive");
+    assert.equal(existsSync(releaseDir), true, "a completed release dir must never be touched");
+    assert.equal(existsSync(join(releaseDir, "llama-server")), true);
+  });
+});
+
+test("sweepStaleRuntimeTmp respects the maxAgeMs boundary (default 7 days)", async () => {
+  await withScratch("sweep-boundary", async (dir) => {
+    const runtimesDir = join(dir, "runtimes", "llamacpp");
+    mkdirSync(runtimesDir, { recursive: true });
+    const now = Date.now();
+
+    const justUnder = join(runtimesDir, ".download-x-just-under.tmp");
+    writeFileSync(justUnder, "x");
+    backdate(justUnder, STALE_RUNTIME_TMP_MAX_AGE_MS - 60_000, now);
+
+    const justOver = join(runtimesDir, ".download-x-just-over.tmp");
+    writeFileSync(justOver, "x");
+    backdate(justOver, STALE_RUNTIME_TMP_MAX_AGE_MS + 60_000, now);
+
+    const removed = sweepStaleRuntimeTmp(dir, { now });
+    assert.deepEqual(removed, [justOver]);
+    assert.equal(existsSync(justUnder), true);
+    assert.equal(existsSync(justOver), false);
+  });
+});
+
+test("sweepStaleRuntimeTmp is a no-op when runtimes/llamacpp doesn't exist yet", async () => {
+  await withScratch("sweep-missing-dir", async (dir) => {
+    assert.equal(existsSync(join(dir, "runtimes")), false);
+    const removed = sweepStaleRuntimeTmp(dir);
+    assert.deepEqual(removed, []);
+  });
+});
+
+test("sweepStaleRuntimeTmp never throws on a readdir/stat error (best-effort)", () => {
+  const brokenFs = {
+    existsSync: () => true,
+    readdirSync: () => {
+      throw new Error("boom");
+    },
+    statSync,
+    rmSync: () => {},
+  };
+  assert.doesNotThrow(() => {
+    const removed = sweepStaleRuntimeTmp("/nonexistent-for-this-test", { fs: brokenFs });
+    assert.deepEqual(removed, []);
+  });
+});
+
+test("ensureRuntime sweeps stale tmp leftovers on its startup path before doing anything else", async () => {
+  await withScratch("ensure-sweeps-stale-tmp", async (dir) => {
+    const crowHome = join(dir, "crow-home");
+    const runtimesDir = join(crowHome, "runtimes", "llamacpp");
+    mkdirSync(runtimesDir, { recursive: true });
+    const staleFile = join(runtimesDir, ".download-linux-x64-cpu-ancient-release.tmp");
+    writeFileSync(staleFile, "leftover");
+    backdate(staleFile, STALE_RUNTIME_TMP_MAX_AGE_MS + 60_000);
+
+    // A bad-platform probe makes ensureRuntime reject immediately after the
+    // sweep runs — proves the sweep executes even when the rest of the
+    // function never gets past resolveAsset.
+    const runtimeBlock = makeRuntimeBlock();
+    const probe = { platform: "windows" };
+    await assert.rejects(() => ensureRuntime(crowHome, runtimeBlock, probe, {}));
+
+    assert.equal(existsSync(staleFile), false, "stale tmp leftover must be swept even on an immediate-reject path");
+  });
+});
+
+test("ensureRuntime's stale-tmp sweep failure never blocks the real install", async () => {
+  await withScratch("ensure-sweep-failure-tolerant", async (dir) => {
+    const runtimeBlock = makeRuntimeBlock();
+    const probe = { platform: "windows" };
+    const throwingSweep = () => {
+      throw new Error("sweep exploded");
+    };
+    await assert.rejects(
+      () => ensureRuntime(dir, runtimeBlock, probe, { sweepStaleTmp: throwingSweep }),
+      (err) => {
+        // Still the REAL error from resolveAsset, not the sweep's throw —
+        // proves the try/catch around the sweep call swallows it.
         assert.ok(err instanceof RuntimeAssetError);
         assert.equal(err.code, "UNSUPPORTED_PLATFORM");
         return true;

--- a/tests/port-inventory.test.js
+++ b/tests/port-inventory.test.js
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { parseComposeHostPorts, parseSsListeners } from "../servers/gateway/port-inventory.js";
+import { PORT_RANGE_START, PORT_RANGE_END, saveState, loadState } from "../servers/gateway/models/state.js";
 
 const one = (yml) => { const r = parseComposeHostPorts(yml); return r.length === 1 ? r[0] : r; };
 
@@ -141,4 +145,114 @@ test("dual-stack wildcard (0.0.0.0 + [::]) on same port -> NOT a conflict", () =
   const rows = attributeAndDetect([], [{ port: 22, boundAddr: "0.0.0.0" }, { port: 22, boundAddr: "[::]" }], core);
   const r = rows.find(x => x.port === 22);
   assert.equal(r.conflict, false);
+});
+
+// ---------------------------------------------------------------------------
+// Native model port attribution (18100-18199) — Item G, Task 14
+// ---------------------------------------------------------------------------
+
+import { loadNativeModelPortMap, GENERIC_LOCAL_MODEL_LABEL } from "../servers/gateway/port-inventory.js";
+
+test("a listening port in the native-model range with a matching reservation attributes to that model id, not foreign", () => {
+  const rows = attributeAndDetect(
+    [], [{ port: 18100, boundAddr: "127.0.0.1" }], core,
+    new Map([[18100, "qwen3-4b-instruct"]]),
+  );
+  const r = rows.find((x) => x.port === 18100);
+  assert.equal(r.kind, "local-model");
+  assert.equal(r.bundleName, "qwen3-4b-instruct");
+  assert.equal(r.bundleId, "qwen3-4b-instruct");
+  assert.equal(r.status, "up");
+  assert.equal(r.listening, true);
+});
+
+test("a listening port in the native-model range with NO matching reservation falls back to the generic label, not foreign", () => {
+  const rows = attributeAndDetect([], [{ port: 18150, boundAddr: "127.0.0.1" }], core, new Map());
+  const r = rows.find((x) => x.port === 18150);
+  assert.equal(r.kind, "local-model");
+  assert.equal(r.bundleName, GENERIC_LOCAL_MODEL_LABEL);
+  assert.equal(r.bundleId, null);
+});
+
+test("nativeModelPorts defaults to an empty map when the 4th arg is omitted (backward compatible call sites)", () => {
+  const rows = attributeAndDetect([], [{ port: 18100, boundAddr: "127.0.0.1" }], core);
+  const r = rows.find((x) => x.port === 18100);
+  assert.equal(r.kind, "local-model");
+  assert.equal(r.bundleName, GENERIC_LOCAL_MODEL_LABEL);
+});
+
+test(`a listening port just outside the range (${PORT_RANGE_START - 1} / ${PORT_RANGE_END + 1}) stays foreign`, () => {
+  const rows = attributeAndDetect(
+    [],
+    [{ port: PORT_RANGE_START - 1, boundAddr: "0.0.0.0" }, { port: PORT_RANGE_END + 1, boundAddr: "0.0.0.0" }],
+    core,
+    new Map([[PORT_RANGE_START - 1, "should-not-attribute"], [PORT_RANGE_END + 1, "should-not-attribute"]]),
+  );
+  assert.equal(rows.find((x) => x.port === PORT_RANGE_START - 1).kind, "foreign");
+  assert.equal(rows.find((x) => x.port === PORT_RANGE_END + 1).kind, "foreign");
+});
+
+test("the range boundaries themselves (PORT_RANGE_START, PORT_RANGE_END) attribute as local-model", () => {
+  const rows = attributeAndDetect(
+    [], [{ port: PORT_RANGE_START, boundAddr: "127.0.0.1" }, { port: PORT_RANGE_END, boundAddr: "127.0.0.1" }], core,
+  );
+  assert.equal(rows.find((x) => x.port === PORT_RANGE_START).kind, "local-model");
+  assert.equal(rows.find((x) => x.port === PORT_RANGE_END).kind, "local-model");
+});
+
+test("a bundle-declared endpoint on a port inside the native range still wins (compose attribution takes priority)", () => {
+  // Extremely unlikely in practice (the range is gateway-internal), but the
+  // endpoint branch is checked first in attributeAndDetect regardless — this
+  // pins that ordering so a future change can't silently invert it.
+  const rows = attributeAndDetect(
+    [ep("some-bundle", 18100, "loopback")],
+    [{ port: 18100, boundAddr: "127.0.0.1" }],
+    core,
+    new Map([[18100, "some-model"]]),
+  );
+  const r = rows.find((x) => x.port === 18100);
+  assert.equal(r.kind, "hardcoded"); // ep() fixtures use source:"compose" with no portEnvVar
+  assert.equal(r.bundleId, "some-bundle");
+});
+
+function withCrowDataDir(dir, fn) {
+  const prev = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.CROW_DATA_DIR;
+    else process.env.CROW_DATA_DIR = prev;
+  }
+}
+
+test("loadNativeModelPortMap reads reservations from this instance's models/state.json, keyed by port", () => {
+  const dir = mkdtempSync(join(tmpdir(), "port-inventory-state-"));
+  try {
+    withCrowDataDir(dir, () => {
+      const state = loadState(dir);
+      state.reservations["qwen3-4b-instruct"] = { port: 18100, owner: { crowHome: dir, pid: 12345 }, createdAt: new Date().toISOString() };
+      state.reservations["llama-3-8b"] = { port: 18101, owner: { crowHome: dir, pid: 12346 }, createdAt: new Date().toISOString() };
+      saveState(dir, state);
+
+      const map = loadNativeModelPortMap();
+      assert.equal(map.get(18100), "qwen3-4b-instruct");
+      assert.equal(map.get(18101), "llama-3-8b");
+      assert.equal(map.size, 2);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadNativeModelPortMap returns an empty map when no state file exists yet", () => {
+  const dir = mkdtempSync(join(tmpdir(), "port-inventory-state-missing-"));
+  try {
+    withCrowDataDir(dir, () => {
+      const map = loadNativeModelPortMap();
+      assert.equal(map.size, 0);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Fourth of five Item G PRs (spec: Gitea `crow-engineering` `specs/2026-07-18-item-g-model-catalog-design.md` r3 SIGNED OFF; plan Task 14 + two review-driven fix rounds).

**What's in it (3 commits):**
- `scripts/ops/kill-orphan-gateways.sh` — Sweep 3 reaps genuinely-abandoned llama-server orphans (ppid==1 + kernel-authoritative exe/cwd identity proof under any CROW_HOME's `runtimes/llamacpp/`, routed through the existing `protected()`/`reap_tree` machinery unchanged). **Two safety properties the review forced:** (1) the orphan-then-adoption case — a survivor of a crashed gateway that a restarted gateway re-adopts via the identity probe — is protected by a state-reservation cross-check mirroring `reconcileOnBoot`'s "live reservation = still in use" rule; (2) a corrupt/unreadable `state.json` **fails closed** (3-way exit contract; only a definitive "parsed, no match" reaps — "refusing to guess" is logged otherwise). Decoy tests prove the identity proof is load-bearing; `ORPHAN_DRY_RUN=1` on this 3-gateway host verified zero candidates at every round.
- `runtime.js` — `sweepStaleRuntimeTmp()` clears `.extract-*.tmp`/`.download-*.tmp` older than 7 days on `ensureRuntime` (the PR G-B follow-up), name-pattern-scoped so real release dirs/manifests can never match.
- `port-inventory.js` + Ports settings — 18100–18199 attribute as "local model" with the reserving model id from `models/state.json` instead of `kind:"foreign"`. `docs/developers/port-allocation.md` gains the informational reserved-range row (`check-ports` unaffected — it scans compose files only).

**Recorded follow-ups:** `ports.js` `KIND_LABEL` strings are raw/untranslated (pre-existing pattern, all 5 entries — file-wide i18n migration filed); manual `ORPHAN_DRY_RUN=1` pass once a real native model is resident (Sweep 3 proven on fixture ELFs + real-host zero-candidate runs so far).

**Suite:** 2378/2378 pass, 0 fail, 0 skip (new baseline; +27 over #235). shellcheck clean; check-ports green. No schema changes, no new deps.