### PR TITLE
feat(bundles): Item G PR G-E — G-6 inference-bundle audit + anti-rot contract

### DIFF
--- a/bundles/capstone-tracker/manifest.json
+++ b/bundles/capstone-tracker/manifest.json
@@ -25,7 +25,7 @@
     {"name": "EMAIL_TO",                       "description": "Destination for audit digests + alerts",           "required": true},
     {"name": "IMAP_HOST",                      "description": "IMAP hostname for email monitor",                  "default": "imap.gmail.com", "required": true},
     {"name": "IMAP_PORT",                      "description": "IMAP port",                                        "default": "993",       "required": true},
-    {"name": "OCR_VISION_URL",                 "description": "OpenAI-compatible vision endpoint (local Qwen)",   "default": "http://100.118.41.122:8003/v1", "required": true},
+    {"name": "OCR_VISION_URL",                 "description": "OpenAI-compatible vision endpoint base URL (e.g. http://<your-llm-host>:<port>/v1) -- point this at your own local vision-capable inference endpoint (llama.cpp/vLLM/Ollama). No default is shipped; every installer's LLM host differs.", "required": true},
     {"name": "OCR_VISION_MODEL",               "description": "Vision model alias",                               "default": "qwen3.6-35b-a3b", "required": true},
     {"name": "OCR_VISION_API_KEY",             "description": "API key for vision endpoint (llama-server: 'none')","default": "none",     "required": false},
     {"name": "CAPSTONE_TRACKER_INTERNAL_URL",  "description": "Self URL for in-container HTTP callbacks",         "default": "http://127.0.0.1:8000", "required": true}

--- a/bundles/capstone-tracker/src/services/notes_ocr.py
+++ b/bundles/capstone-tracker/src/services/notes_ocr.py
@@ -27,6 +27,7 @@ def _load_trocr():
         return _trocr_processor, _trocr_model
     try:
         from transformers import TrOCRProcessor, VisionEncoderDecoderModel
+
         logger.info("Loading TrOCR model (this may take a moment)...")
         _trocr_processor = TrOCRProcessor.from_pretrained(
             "microsoft/trocr-base-handwritten"
@@ -123,7 +124,7 @@ def ocr_with_vision(image: Image.Image) -> str:
     """Use OpenAI-compatible vision endpoint (local Qwen by default) to transcribe handwriting.
 
     Endpoint + model + key come from env (see plan § 4.0.5):
-        OCR_VISION_URL    e.g. http://100.118.41.122:8003/v1
+        OCR_VISION_URL    e.g. http://<your-llm-host>:<port>/v1
         OCR_VISION_MODEL  e.g. qwen3.6-35b-a3b
         OCR_VISION_API_KEY e.g. "none" (llama-server accepts any value)
     """
@@ -150,8 +151,8 @@ def ocr_with_vision(image: Image.Image) -> str:
                         {
                             "type": "text",
                             "text": "Transcribe the handwriting in this image accurately. "
-                                    "Return only the transcribed text, nothing else. "
-                                    "If the image is blank or contains no text, return an empty string.",
+                            "Return only the transcribed text, nothing else. "
+                            "If the image is blank or contains no text, return an empty string.",
                         },
                     ],
                 }

--- a/bundles/faster-whisper-server/manifest.json
+++ b/bundles/faster-whisper-server/manifest.json
@@ -10,6 +10,7 @@
   },
   "env_vars": [],
   "port": 8004,
+  "no_auto_provider": "Not an LLM chat endpoint -- speech-to-text is wired via sttProfileSeed below, which seeds a dedicated STT profile (provider: fasterwhisper) pointing at this container's OpenAI-compatible /v1/audio/transcriptions endpoint on install (see servers/gateway/routes/bundles.js seedProfile()). No LLM providers[] entry applies.",
   "sttProfileSeed": {
     "name": "Faster-Whisper (local)",
     "provider": "fasterwhisper",

--- a/bundles/kokoro-tts/manifest.json
+++ b/bundles/kokoro-tts/manifest.json
@@ -10,6 +10,7 @@
   },
   "env_vars": [],
   "port": 8880,
+  "no_auto_provider": "Not an LLM chat endpoint -- text-to-speech is wired via ttsProfileSeed below, which seeds a dedicated TTS profile (provider: kokoro) pointing at this container's OpenAI-compatible /v1/audio/speech endpoint on install (see servers/gateway/routes/bundles.js seedProfile()). No LLM providers[] entry applies.",
   "ttsProfileSeed": {
     "name": "Kokoro (local)",
     "provider": "kokoro",

--- a/bundles/llamacpp-cpu-qwen3-embed/manifest.json
+++ b/bundles/llamacpp-cpu-qwen3-embed/manifest.json
@@ -20,6 +20,7 @@
   "docker": {
     "composefile": "docker-compose.yml"
   },
+  "inference": true,
   "providers": [
     {
       "id": "llamacpp-cpu-embed",

--- a/bundles/llamacpp-qwen72b/manifest.json
+++ b/bundles/llamacpp-qwen72b/manifest.json
@@ -7,6 +7,7 @@
   "requires": { "gpu": true, "min_vram_gb": 60, "platform": "linux-x86_64", "gpu_arch": ["gfx1151"] },
   "env_vars": [],
   "port": 8003,
+  "inference": true,
   "providers": [
     {
       "id": "crow-swap-qwen72b",

--- a/bundles/llamacpp-qwen72b/manifest.json
+++ b/bundles/llamacpp-qwen72b/manifest.json
@@ -6,5 +6,24 @@
   "description": "Top-tier reasoning (Qwen2.5-72B-Instruct Q4_K_M via llama.cpp-ROCm). Replaces vLLM Kimi slot (custom attention segfaults on gfx1151). 64K context, -fa 1 + --no-mmap per kyuz0/amd-strix-halo-toolboxes.",
   "requires": { "gpu": true, "min_vram_gb": 60, "platform": "linux-x86_64", "gpu_arch": ["gfx1151"] },
   "env_vars": [],
-  "port": 8003
+  "port": 8003,
+  "providers": [
+    {
+      "id": "crow-swap-qwen72b",
+      "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+      "apiKey": "none",
+      "description": "Top-tier reasoning specialist (Qwen2.5-72B-Instruct Q4_K_M, on-demand; conflicts with crow-chat)",
+      "models": [
+        {
+          "id": "qwen2.5-72b",
+          "contextLen": 65536,
+          "warm": false,
+          "onDemand": true,
+          "mutexGroup": "8003-swap",
+          "conflictsWith": ["crow-chat"],
+          "priority": "batch"
+        }
+      ]
+    }
+  ]
 }

--- a/bundles/llamacpp-rocm-qwen35-122b-mtp/manifest.json
+++ b/bundles/llamacpp-rocm-qwen35-122b-mtp/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8003,
+  "inference": true,
   "providers": [
     {
       "id": "crow-swap-highend",

--- a/bundles/llamacpp-vulkan-glm-45-air/manifest.json
+++ b/bundles/llamacpp-vulkan-glm-45-air/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8003,
+  "inference": true,
   "providers": [
     {
       "id": "crow-swap-deep",

--- a/bundles/llamacpp-vulkan-qwen3-coder/manifest.json
+++ b/bundles/llamacpp-vulkan-qwen3-coder/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8003,
+  "inference": true,
   "providers": [
     {
       "id": "crow-swap-coder",

--- a/bundles/llamacpp-vulkan-qwen3-embed/manifest.json
+++ b/bundles/llamacpp-vulkan-qwen3-embed/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8004,
+  "inference": true,
   "providers": [
     {
       "id": "crow-embed",

--- a/bundles/llamacpp-vulkan-qwen36-35b-a3b/manifest.json
+++ b/bundles/llamacpp-vulkan-qwen36-35b-a3b/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8003,
+  "inference": true,
   "providers": [
     {
       "id": "crow-chat",

--- a/bundles/localai/manifest.json
+++ b/bundles/localai/manifest.json
@@ -48,5 +48,6 @@
     "port": 8080,
     "path": "/"
   },
+  "no_auto_provider": "LocalAI's OpenAI-compatible endpoint (http://{host}:8080/v1) is live once the container starts, but -- same shape as ollama -- its model catalog is populated post-install: either on first API request (auto-download) or via `docker compose exec localai local-ai models install <name>`, not at install-time, so there is no served model id to write into a static providers[] entry. After a model is installed, add the provider manually via Settings -> LLM -> Providers, base URL http://<host>:8080/v1, with the model id you installed/downloaded (see `local-ai models list` inside the container, or the model gallery name used for the first-use download).",
   "notes": "LocalAI is OpenAI-compatible. Configure AI_PROVIDER=openai and AI_BASE_URL=http://localhost:8080/v1 in .env to use with Crow's AI Chat."
 }

--- a/bundles/ollama/manifest.json
+++ b/bundles/ollama/manifest.json
@@ -44,5 +44,6 @@
     11434
   ],
   "webUI": null,
+  "no_auto_provider": "Ollama's OpenAI-compatible endpoint (http://{host}:11434/v1) is live once the container starts, but its model catalog is populated at pull-time (`docker compose exec ollama ollama pull <model>`), not at install-time -- there is no served model id to write into a static providers[] entry. Registering a provider row with an empty models[] list breaks default profile resolution (resolveProviderConfig() in servers/gateway/ai/resolve-profile.js falls back to model:null when no model_id is stored and models[] is empty). After pulling a model, add the provider manually via Settings -> LLM -> Providers, pointing baseUrl at http://<host>:11434/v1 with the pulled model's name.",
   "notes": "RAM and disk depend on model size. Small models (tinyllama) need ~2GB RAM. Large models (llama3) need 8GB+. Each model uses 2-50GB disk."
 }

--- a/bundles/sdxl/manifest.json
+++ b/bundles/sdxl/manifest.json
@@ -21,6 +21,7 @@
     3005
   ],
   "webUI": null,
+  "no_auto_provider": "Not an LLM chat endpoint -- image generation is wired via the SDXL_SERVICE_URL env var (default http://127.0.0.1:3005), consumed directly by the crow_generate_background MCP tool in servers/storage/server.js (custom /health + /generate JSON API, not OpenAI-compatible /v1/images/generations). No LLM providers[] entry applies.",
   "requires": {
     "min_ram_mb": 4096,
     "min_disk_mb": 25000,

--- a/bundles/vllm-cuda-embed/manifest.json
+++ b/bundles/vllm-cuda-embed/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 9100,
+  "inference": true,
   "providers": [
     {
       "id": "grackle-embed",

--- a/bundles/vllm-cuda-embed/manifest.json
+++ b/bundles/vllm-cuda-embed/manifest.json
@@ -4,7 +4,7 @@
   "name": "vLLM Embeddings — Qwen3-Embedding-0.6B",
   "category": "ai",
   "description": "Multilingual text embeddings (Qwen3-Embedding-0.6B, 1024-dim Matryoshka). Powers semantic search across memory/research/blog. Runs on grackle's RTX 5060 Ti via vLLM-CUDA.",
-  "host": "49cf71ca878643ba7717f344329266fd",
+  "host": "local",
   "requires": {
     "gpu": true,
     "min_vram_gb": 2,

--- a/bundles/vllm-cuda-rerank/manifest.json
+++ b/bundles/vllm-cuda-rerank/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 9101,
+  "inference": true,
   "providers": [
     {
       "id": "grackle-rerank",

--- a/bundles/vllm-cuda-rerank/manifest.json
+++ b/bundles/vllm-cuda-rerank/manifest.json
@@ -4,7 +4,7 @@
   "name": "vLLM Reranker — Qwen3-Reranker-0.6B",
   "category": "ai",
   "description": "Cross-encoder reranker for hybrid FTS+vector retrieval top-K reordering. Multilingual, instruction-aware. Runs on grackle's RTX 5060 Ti via vLLM-CUDA.",
-  "host": "49cf71ca878643ba7717f344329266fd",
+  "host": "local",
   "requires": {
     "gpu": true,
     "min_vram_gb": 2,

--- a/bundles/vllm-cuda-vision/manifest.json
+++ b/bundles/vllm-cuda-vision/manifest.json
@@ -4,7 +4,7 @@
   "name": "vLLM Vision — Qwen3-VL-8B-Instruct-FP8",
   "category": "ai",
   "description": "Vision-language model for image understanding, OCR, structured output. Qwen3-VL-8B in FP8 (Blackwell). On-demand via the GPU orchestrator; mutex with grackle-embed/rerank during burst.",
-  "host": "49cf71ca878643ba7717f344329266fd",
+  "host": "local",
   "requires": {
     "gpu": true,
     "min_vram_gb": 8,

--- a/bundles/vllm-cuda-vision/manifest.json
+++ b/bundles/vllm-cuda-vision/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 9102,
+  "inference": true,
   "providers": [
     {
       "id": "grackle-vision",

--- a/bundles/vllm-rocm-kimi/manifest.json
+++ b/bundles/vllm-rocm-kimi/manifest.json
@@ -11,5 +11,24 @@
     "gpu_arch": ["gfx1151"]
   },
   "env_vars": [],
-  "port": 8003
+  "port": 8003,
+  "providers": [
+    {
+      "id": "crow-swap-kimi",
+      "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+      "apiKey": "none",
+      "description": "Long-context planner specialist (Kimi-Linear-48B-A3B-Instruct BF16, on-demand; conflicts with crow-chat)",
+      "models": [
+        {
+          "id": "kimi-linear-48b",
+          "contextLen": 32768,
+          "warm": false,
+          "onDemand": true,
+          "mutexGroup": "8003-swap",
+          "conflictsWith": ["crow-chat"],
+          "priority": "batch"
+        }
+      ]
+    }
+  ]
 }

--- a/bundles/vllm-rocm-kimi/manifest.json
+++ b/bundles/vllm-rocm-kimi/manifest.json
@@ -12,6 +12,7 @@
   },
   "env_vars": [],
   "port": 8003,
+  "inference": true,
   "providers": [
     {
       "id": "crow-swap-kimi",

--- a/bundles/vllm-rocm-qwen3-32b/manifest.json
+++ b/bundles/vllm-rocm-qwen3-32b/manifest.json
@@ -12,6 +12,7 @@
   },
   "env_vars": [],
   "port": 8002,
+  "inference": true,
   "providers": [
     {
       "id": "crow-mode-a-32b",

--- a/bundles/vllm-rocm-qwen3-32b/manifest.json
+++ b/bundles/vllm-rocm-qwen3-32b/manifest.json
@@ -11,5 +11,21 @@
     "gpu_arch": ["gfx1151"]
   },
   "env_vars": [],
-  "port": 8002
+  "port": 8002,
+  "providers": [
+    {
+      "id": "crow-mode-a-32b",
+      "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+      "apiKey": "none",
+      "description": "Mid-tier reasoning/synthesis endpoint (Qwen3-32B dense BF16)",
+      "models": [
+        {
+          "id": "qwen3-32b",
+          "contextLen": 32768,
+          "warm": true,
+          "priority": "interactive"
+        }
+      ]
+    }
+  ]
 }

--- a/bundles/vllm-rocm-qwen3/manifest.json
+++ b/bundles/vllm-rocm-qwen3/manifest.json
@@ -12,6 +12,7 @@
   },
   "env_vars": [],
   "port": 8001,
+  "inference": true,
   "providers": [
     {
       "id": "crow-dispatch",

--- a/bundles/vllm-rocm-qwen3/manifest.json
+++ b/bundles/vllm-rocm-qwen3/manifest.json
@@ -11,5 +11,21 @@
     "gpu_arch": ["gfx1151"]
   },
   "env_vars": [],
-  "port": 8001
+  "port": 8001,
+  "providers": [
+    {
+      "id": "crow-dispatch",
+      "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+      "apiKey": "none",
+      "description": "Fast tool-dispatch endpoint (Qwen3-4B BF16)",
+      "models": [
+        {
+          "id": "qwen3-4b",
+          "contextLen": 32768,
+          "warm": true,
+          "priority": "maker_lab"
+        }
+      ]
+    }
+  ]
 }

--- a/bundles/vllm-rocm-qwen35-27b/manifest.json
+++ b/bundles/vllm-rocm-qwen35-27b/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8012,
+  "inference": true,
   "providers": [
     {
       "id": "crow-chat",

--- a/bundles/vllm-rocm-qwen35-4b/manifest.json
+++ b/bundles/vllm-rocm-qwen35-4b/manifest.json
@@ -13,6 +13,7 @@
   },
   "env_vars": [],
   "port": 8011,
+  "inference": true,
   "providers": [
     {
       "id": "crow-voice",

--- a/bundles/vllm/manifest.json
+++ b/bundles/vllm/manifest.json
@@ -83,5 +83,6 @@
     "path": "/docs",
     "label": "vLLM API docs"
   },
+  "no_auto_provider": "VLLM_MODEL is a required install-time env var with no default (docker-compose.yml: `--model=${VLLM_MODEL:?Set VLLM_MODEL}`) -- the served model is whatever HuggingFace id the installer types in, so there is no fixed model id this manifest can register at build time. Manifest providers[] has no mechanism to read a resolved env var into a model id (registerProviderFromManifest only substitutes {host_ip}/{port}). After install, add the provider manually via Settings -> LLM -> Providers, pointing baseUrl at http://<host>:${VLLM_HTTP_PORT:-8089}/v1 with the same value used for VLLM_MODEL as the model id (vLLM serves it under --served-model-name=${VLLM_MODEL}).",
   "notes": "Linux x86_64 + NVIDIA GPU required. Recommended classroom shape: Qwen2.5-3B-Instruct at VLLM_MAX_NUM_SEQS=16 on a 16 GB consumer GPU (tested in the Maker Lab Phase 0 benchmark, see bundles/maker-lab/PHASE-0-REPORT.md Spike 5). vLLM's OpenAI-compatible endpoint drops into Maker Lab's MAKER_LAB_LLM_ENDPOINT as-is."
 }

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -2460,6 +2460,7 @@
       "docker": {
         "composefile": "docker-compose.yml"
       },
+      "inference": true,
       "providers": [
         {
           "id": "llamacpp-cpu-embed",
@@ -2498,6 +2499,7 @@
       },
       "env_vars": [],
       "port": 8003,
+      "inference": true,
       "providers": [
         {
           "id": "crow-swap-qwen72b",
@@ -2538,6 +2540,7 @@
       },
       "env_vars": [],
       "port": 8003,
+      "inference": true,
       "providers": [
         {
           "id": "crow-swap-highend",
@@ -2578,6 +2581,7 @@
       },
       "env_vars": [],
       "port": 8003,
+      "inference": true,
       "providers": [
         {
           "id": "crow-swap-deep",
@@ -2618,6 +2622,7 @@
       },
       "env_vars": [],
       "port": 8003,
+      "inference": true,
       "providers": [
         {
           "id": "crow-swap-coder",
@@ -2658,6 +2663,7 @@
       },
       "env_vars": [],
       "port": 8004,
+      "inference": true,
       "providers": [
         {
           "id": "crow-embed",
@@ -2694,6 +2700,7 @@
       },
       "env_vars": [],
       "port": 8003,
+      "inference": true,
       "providers": [
         {
           "id": "crow-chat",
@@ -6015,6 +6022,7 @@
       },
       "env_vars": [],
       "port": 9100,
+      "inference": true,
       "providers": [
         {
           "id": "grackle-embed",
@@ -6057,6 +6065,7 @@
       },
       "env_vars": [],
       "port": 9101,
+      "inference": true,
       "providers": [
         {
           "id": "grackle-rerank",
@@ -6092,6 +6101,7 @@
       },
       "env_vars": [],
       "port": 9102,
+      "inference": true,
       "providers": [
         {
           "id": "grackle-vision",
@@ -6127,6 +6137,7 @@
       },
       "env_vars": [],
       "port": 8003,
+      "inference": true,
       "providers": [
         {
           "id": "crow-swap-kimi",
@@ -6166,6 +6177,7 @@
       },
       "env_vars": [],
       "port": 8001,
+      "inference": true,
       "providers": [
         {
           "id": "crow-dispatch",
@@ -6200,6 +6212,7 @@
       },
       "env_vars": [],
       "port": 8002,
+      "inference": true,
       "providers": [
         {
           "id": "crow-mode-a-32b",
@@ -6235,6 +6248,7 @@
       },
       "env_vars": [],
       "port": 8012,
+      "inference": true,
       "providers": [
         {
           "id": "crow-chat",
@@ -6270,6 +6284,7 @@
       },
       "env_vars": [],
       "port": 8011,
+      "inference": true,
       "providers": [
         {
           "id": "crow-voice",

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -2769,6 +2769,7 @@
         "port": 8080,
         "path": "/"
       },
+      "no_auto_provider": "LocalAI's OpenAI-compatible endpoint (http://{host}:8080/v1) is live once the container starts, but -- same shape as ollama -- its model catalog is populated post-install: either on first API request (auto-download) or via `docker compose exec localai local-ai models install <name>`, not at install-time, so there is no served model id to write into a static providers[] entry. After a model is installed, add the provider manually via Settings -> LLM -> Providers, base URL http://<host>:8080/v1, with the model id you installed/downloaded (see `local-ai models list` inside the container, or the model gallery name used for the first-use download).",
       "notes": "LocalAI is OpenAI-compatible. Configure AI_PROVIDER=openai and AI_BASE_URL=http://localhost:8080/v1 in .env to use with Crow's AI Chat.",
       "official": true
     },

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -1074,6 +1074,7 @@
       },
       "env_vars": [],
       "port": 8004,
+      "no_auto_provider": "Not an LLM chat endpoint -- speech-to-text is wired via sttProfileSeed below, which seeds a dedicated STT profile (provider: fasterwhisper) pointing at this container's OpenAI-compatible /v1/audio/transcriptions endpoint on install (see servers/gateway/routes/bundles.js seedProfile()). No LLM providers[] entry applies.",
       "sttProfileSeed": {
         "name": "Faster-Whisper (local)",
         "provider": "fasterwhisper",
@@ -2179,6 +2180,7 @@
       },
       "env_vars": [],
       "port": 8880,
+      "no_auto_provider": "Not an LLM chat endpoint -- text-to-speech is wired via ttsProfileSeed below, which seeds a dedicated TTS profile (provider: kokoro) pointing at this container's OpenAI-compatible /v1/audio/speech endpoint on install (see servers/gateway/routes/bundles.js seedProfile()). No LLM providers[] entry applies.",
       "ttsProfileSeed": {
         "name": "Kokoro (local)",
         "provider": "kokoro",
@@ -2496,6 +2498,27 @@
       },
       "env_vars": [],
       "port": 8003,
+      "providers": [
+        {
+          "id": "crow-swap-qwen72b",
+          "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+          "apiKey": "none",
+          "description": "Top-tier reasoning specialist (Qwen2.5-72B-Instruct Q4_K_M, on-demand; conflicts with crow-chat)",
+          "models": [
+            {
+              "id": "qwen2.5-72b",
+              "contextLen": 65536,
+              "warm": false,
+              "onDemand": true,
+              "mutexGroup": "8003-swap",
+              "conflictsWith": [
+                "crow-chat"
+              ],
+              "priority": "batch"
+            }
+          ]
+        }
+      ],
       "official": true
     },
     {
@@ -4258,6 +4281,7 @@
         11434
       ],
       "webUI": null,
+      "no_auto_provider": "Ollama's OpenAI-compatible endpoint (http://{host}:11434/v1) is live once the container starts, but its model catalog is populated at pull-time (`docker compose exec ollama ollama pull <model>`), not at install-time -- there is no served model id to write into a static providers[] entry. Registering a provider row with an empty models[] list breaks default profile resolution (resolveProviderConfig() in servers/gateway/ai/resolve-profile.js falls back to model:null when no model_id is stored and models[] is empty). After pulling a model, add the provider manually via Settings -> LLM -> Providers, pointing baseUrl at http://<host>:11434/v1 with the pulled model's name.",
       "notes": "RAM and disk depend on model size. Small models (tinyllama) need ~2GB RAM. Large models (llama3) need 8GB+. Each model uses 2-50GB disk.",
       "official": true
     },
@@ -5239,6 +5263,7 @@
         3005
       ],
       "webUI": null,
+      "no_auto_provider": "Not an LLM chat endpoint -- image generation is wired via the SDXL_SERVICE_URL env var (default http://127.0.0.1:3005), consumed directly by the crow_generate_background MCP tool in servers/storage/server.js (custom /health + /generate JSON API, not OpenAI-compatible /v1/images/generations). No LLM providers[] entry applies.",
       "requires": {
         "min_ram_mb": 4096,
         "min_disk_mb": 25000,
@@ -5969,6 +5994,7 @@
         "path": "/docs",
         "label": "vLLM API docs"
       },
+      "no_auto_provider": "VLLM_MODEL is a required install-time env var with no default (docker-compose.yml: `--model=${VLLM_MODEL:?Set VLLM_MODEL}`) -- the served model is whatever HuggingFace id the installer types in, so there is no fixed model id this manifest can register at build time. Manifest providers[] has no mechanism to read a resolved env var into a model id (registerProviderFromManifest only substitutes {host_ip}/{port}). After install, add the provider manually via Settings -> LLM -> Providers, pointing baseUrl at http://<host>:${VLLM_HTTP_PORT:-8089}/v1 with the same value used for VLLM_MODEL as the model id (vLLM serves it under --served-model-name=${VLLM_MODEL}).",
       "notes": "Linux x86_64 + NVIDIA GPU required. Recommended classroom shape: Qwen2.5-3B-Instruct at VLLM_MAX_NUM_SEQS=16 on a 16 GB consumer GPU (tested in the Maker Lab Phase 0 benchmark, see bundles/maker-lab/PHASE-0-REPORT.md Spike 5). vLLM's OpenAI-compatible endpoint drops into Maker Lab's MAKER_LAB_LLM_ENDPOINT as-is.",
       "official": true
     },
@@ -5978,7 +6004,7 @@
       "name": "vLLM Embeddings — Qwen3-Embedding-0.6B",
       "category": "ai",
       "description": "Multilingual text embeddings (Qwen3-Embedding-0.6B, 1024-dim Matryoshka). Powers semantic search across memory/research/blog. Runs on grackle's RTX 5060 Ti via vLLM-CUDA.",
-      "host": "49cf71ca878643ba7717f344329266fd",
+      "host": "local",
       "requires": {
         "gpu": true,
         "min_vram_gb": 2,
@@ -6020,7 +6046,7 @@
       "name": "vLLM Reranker — Qwen3-Reranker-0.6B",
       "category": "ai",
       "description": "Cross-encoder reranker for hybrid FTS+vector retrieval top-K reordering. Multilingual, instruction-aware. Runs on grackle's RTX 5060 Ti via vLLM-CUDA.",
-      "host": "49cf71ca878643ba7717f344329266fd",
+      "host": "local",
       "requires": {
         "gpu": true,
         "min_vram_gb": 2,
@@ -6055,7 +6081,7 @@
       "name": "vLLM Vision — Qwen3-VL-8B-Instruct-FP8",
       "category": "ai",
       "description": "Vision-language model for image understanding, OCR, structured output. Qwen3-VL-8B in FP8 (Blackwell). On-demand via the GPU orchestrator; mutex with grackle-embed/rerank during burst.",
-      "host": "49cf71ca878643ba7717f344329266fd",
+      "host": "local",
       "requires": {
         "gpu": true,
         "min_vram_gb": 8,
@@ -6101,6 +6127,27 @@
       },
       "env_vars": [],
       "port": 8003,
+      "providers": [
+        {
+          "id": "crow-swap-kimi",
+          "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+          "apiKey": "none",
+          "description": "Long-context planner specialist (Kimi-Linear-48B-A3B-Instruct BF16, on-demand; conflicts with crow-chat)",
+          "models": [
+            {
+              "id": "kimi-linear-48b",
+              "contextLen": 32768,
+              "warm": false,
+              "onDemand": true,
+              "mutexGroup": "8003-swap",
+              "conflictsWith": [
+                "crow-chat"
+              ],
+              "priority": "batch"
+            }
+          ]
+        }
+      ],
       "official": true
     },
     {
@@ -6119,6 +6166,22 @@
       },
       "env_vars": [],
       "port": 8001,
+      "providers": [
+        {
+          "id": "crow-dispatch",
+          "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+          "apiKey": "none",
+          "description": "Fast tool-dispatch endpoint (Qwen3-4B BF16)",
+          "models": [
+            {
+              "id": "qwen3-4b",
+              "contextLen": 32768,
+              "warm": true,
+              "priority": "maker_lab"
+            }
+          ]
+        }
+      ],
       "official": true
     },
     {
@@ -6137,6 +6200,22 @@
       },
       "env_vars": [],
       "port": 8002,
+      "providers": [
+        {
+          "id": "crow-mode-a-32b",
+          "baseUrlTemplate": "http://{host_ip}:{port}/v1",
+          "apiKey": "none",
+          "description": "Mid-tier reasoning/synthesis endpoint (Qwen3-32B dense BF16)",
+          "models": [
+            {
+              "id": "qwen3-32b",
+              "contextLen": 32768,
+              "warm": true,
+              "priority": "interactive"
+            }
+          ]
+        }
+      ],
       "official": true
     },
     {

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -60,18 +60,18 @@ export function buildRegistry(opts = {}) {
     try {
       manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     } catch (e) {
-      audit.push({ id, type: "?", surfaces: [], ok: false, errors: [`manifest.json parse error: ${e.message}`], status: "invalid" });
+      audit.push({ id, type: "?", surfaces: [], ok: false, errors: [`manifest.json parse error: ${e.message}`], warnings: [], status: "invalid" });
       continue;
     }
     const bundleDir = join(bundlesRoot, id);
-    const { ok, errors } = validateManifest(manifest, bundleDir, { bundleExists });
+    const { ok, errors, warnings } = validateManifest(manifest, bundleDir, { bundleExists });
     const isTracked = trackedSet === null ? true : trackedSet.has(id);
     const isDraft = manifest.draft === true;
     let status = "published";
     if (!ok) status = "invalid";
     else if (isDraft) status = "draft";
     else if (!isTracked) status = "untracked";
-    audit.push({ id, type: manifest.type, surfaces: detectSurfaces(manifest), ok, errors, status });
+    audit.push({ id, type: manifest.type, surfaces: detectSurfaces(manifest), ok, errors, warnings: warnings || [], status });
     if (ok && !isDraft && isTracked) {
       // `official` is DERIVED, never trusted from the manifest: first-party
       // (no `origin`, or `origin: "official"`) stamps true; a third-party
@@ -100,6 +100,7 @@ function main() {
     const surf = (a.surfaces || []).join("+") || "-";
     const errs = a.errors && a.errors.length ? "  :: " + a.errors.join("; ") : "";
     console.log(`${tag} ${a.id.padEnd(28)} ${(a.type || "?").padEnd(10)} ${surf}${errs}`);
+    for (const w of a.warnings || []) console.log(`  WARN      ${a.id.padEnd(28)} :: ${w}`);
   }
   const n = (s) => audit.filter((a) => a.status === s).length;
   console.log(`\n${audit.length} bundles | ${registry["add-ons"].length} published | ${n("invalid")} invalid | ${n("draft")} draft | ${n("untracked")} untracked`);

--- a/scripts/lib/bundle-contract.mjs
+++ b/scripts/lib/bundle-contract.mjs
@@ -16,6 +16,75 @@ const schema = JSON.parse(
 const ajv = new Ajv({ allErrors: true, strict: false });
 const validateShape = ajv.compile(schema);
 
+// --- G-6 anti-rot: inference-endpoint provider contract + instance-leak scan ---
+
+/** A compose `ports:` stanza, list or inline-array form (heuristic — text match, not a YAML parse). */
+const PORT_MAPPING_RE = /\bports:\s*(\n[ \t]*-[ \t]*\S.*|[ \t]*\[[^\]]*\])/;
+/** Command/entrypoint markers that smell like an OpenAI-compat inference server. */
+const INFERENCE_CMD_RE = /--served-model-name|llama-server|vllm|ollama/i;
+
+/**
+ * Heuristic-only (WARN, never fails the build): does this bundle's compose file
+ * expose a host port AND run something that looks like an OpenAI-compat
+ * inference server, per the marker list above? Matched against the raw file
+ * text (not a real YAML parse — no yaml dependency in this repo, and a text
+ * heuristic is all a WARN needs).
+ */
+function composeLooksLikeInferenceEndpoint(bundleDir, composefileRel) {
+  if (typeof composefileRel !== "string" || !composefileRel) return false;
+  const p = isAbsolute(composefileRel) ? composefileRel : join(bundleDir, composefileRel);
+  if (!existsSync(p)) return false;
+  let text;
+  try {
+    text = readFileSync(p, "utf8");
+  } catch {
+    return false;
+  }
+  return PORT_MAPPING_RE.test(text) && INFERENCE_CMD_RE.test(text);
+}
+
+/** Tailscale CGNAT range: 100.64.0.0/10 (100.64.x.x - 100.127.x.x). */
+const TAILSCALE_IP_RE = /\b100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}\b/;
+/** Any *.ts.net hostname (Tailscale MagicDNS). */
+const TS_NET_RE = /\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.ts\.net\b/i;
+/** 32-hex-char instance-id shape (as minted by servers/shared instance-identity code). */
+const INSTANCE_ID_HEX32_RE = /^[0-9a-f]{32}$/i;
+const ALLOWED_HOST_VALUES = new Set(["local", "cloud"]);
+
+/**
+ * Recursively scan every string value in a manifest for a leaked Tailscale
+ * identity: a tailnet IP, a *.ts.net hostname, or (scoped to keys literally
+ * named "host") a 32-hex instance-id string other than "local"/"cloud".
+ * This is the generalized form of the #217 leak class (see
+ * bundles/vllm-cuda-*'s host de-pin, Task 15) — run against every string in
+ * every manifest, not just a hardcoded field.
+ */
+function scanForInstanceLeaks(value, path, errors) {
+  if (value == null) return;
+  if (typeof value === "string") {
+    if (TAILSCALE_IP_RE.test(value)) {
+      errors.push(`leaked Tailscale-range IP in ${path}: "${value}"`);
+    }
+    if (TS_NET_RE.test(value)) {
+      errors.push(`leaked *.ts.net hostname in ${path}: "${value}"`);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => scanForInstanceLeaks(v, `${path}[${i}]`, errors));
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [k, v] of Object.entries(value)) {
+      const childPath = path ? `${path}.${k}` : k;
+      if (k === "host" && typeof v === "string" && INSTANCE_ID_HEX32_RE.test(v) && !ALLOWED_HOST_VALUES.has(v)) {
+        errors.push(`leaked instance-id-shaped value in ${childPath}: "${v}" (host must be "local"/"cloud", not a pinned peer id)`);
+      }
+      scanForInstanceLeaks(v, childPath, errors);
+    }
+  }
+}
+
 /** Surfaces a manifest declares, by key presence. */
 export function detectSurfaces(manifest) {
   const s = [];
@@ -38,14 +107,14 @@ function fileExists(bundleDir, rel) {
  * @param {object} manifest parsed manifest.json
  * @param {string} bundleDir absolute path to the bundle directory
  * @param {{bundleExists?: (id:string)=>boolean}} [opts] resolver for requires.bundles / optional_bundles
- * @returns {{ok: boolean, errors: string[]}}
+ * @returns {{ok: boolean, errors: string[], warnings: string[]}}
  */
 export function validateManifest(manifest, bundleDir, opts = {}) {
   // 1. Shape (ajv)
   const shapeOk = validateShape(manifest);
   if (!shapeOk) {
     const errors = (validateShape.errors || []).map((e) => `shape ${e.instancePath || "/"} ${e.message}`);
-    return { ok: false, errors };
+    return { ok: false, errors, warnings: [] };
   }
 
   const errors = [];
@@ -93,5 +162,46 @@ export function validateManifest(manifest, bundleDir, opts = {}) {
     }
   }
 
-  return { ok: errors.length === 0, errors };
+  const warnings = [];
+
+  // 5. Inference-endpoint provider contract (G-6 anti-rot).
+  //    - `inference: true` promises a resolvable OpenAI-compat endpoint and
+  //      must carry a non-empty providers[] array (see the 15 llamacpp-*/
+  //      vllm-* manifests stamped by Task 16).
+  //    - `no_auto_provider`, when present at all, must be a real non-empty
+  //      reason string, not a stub/empty placeholder (see Task 15's 5
+  //      side-channel/dynamic-model bundles).
+  //    - a manifest declaring neither flag, whose compose looks like it runs
+  //      an OpenAI-compat server on an exposed port, gets a WARN (heuristics
+  //      don't hard-gate — this catches drift, it doesn't block it).
+  const isInference = manifest && manifest.inference === true;
+  const hasNoAutoProvider = Boolean(manifest) && Object.prototype.hasOwnProperty.call(manifest, "no_auto_provider");
+
+  if (hasNoAutoProvider) {
+    const reason = manifest.no_auto_provider;
+    if (typeof reason !== "string" || reason.trim() === "") {
+      errors.push(`no_auto_provider must be a non-empty string when present, got ${JSON.stringify(reason)}`);
+    }
+  }
+
+  if (isInference) {
+    if (!Array.isArray(manifest.providers) || manifest.providers.length === 0) {
+      errors.push(`inference: true requires a non-empty providers[] array`);
+    }
+  } else if (!hasNoAutoProvider && manifest && manifest.docker) {
+    if (composeLooksLikeInferenceEndpoint(bundleDir, manifest.docker.composefile)) {
+      warnings.push(
+        `compose exposes a port and a command matching an OpenAI-compat inference server ` +
+          `(--served-model-name/llama-server/vllm/ollama), but the manifest declares neither ` +
+          `"inference": true nor "no_auto_provider" — verify whether this bundle needs a providers[] block`,
+      );
+    }
+  }
+
+  // 6. Instance-identity leak scan (generalized #217 leak class): no manifest
+  //    may carry a tailnet IP, a *.ts.net hostname, or (in a "host" field) a
+  //    pinned 32-hex instance id.
+  scanForInstanceLeaks(manifest, "", errors);
+
+  return { ok: errors.length === 0, errors, warnings };
 }

--- a/scripts/lib/bundle-contract.mjs
+++ b/scripts/lib/bundle-contract.mjs
@@ -22,13 +22,28 @@ const validateShape = ajv.compile(schema);
 const PORT_MAPPING_RE = /\bports:\s*(\n[ \t]*-[ \t]*\S.*|[ \t]*\[[^\]]*\])/;
 /** Command/entrypoint markers that smell like an OpenAI-compat inference server. */
 const INFERENCE_CMD_RE = /--served-model-name|llama-server|vllm|ollama/i;
+/** A compose `command:` key present at all (list or inline form) — i.e. an image-default entrypoint is NOT being used as-is. */
+const COMMAND_OVERRIDE_RE = /\bcommand:\s*(\n[ \t]*-[ \t]*\S|\[[^\]]*\]|\S)/;
+/**
+ * Image names that ship a self-contained OpenAI-compat server with no compose
+ * command override at all (models arrive post-install via the image's own
+ * CLI/API, e.g. LocalAI's `local-ai models install <name>` / first-use
+ * download — the same "unknowable at manifest-write time" shape as ollama).
+ * Only consulted when there is NO command override (see below) — a bundle
+ * that overrides the command is judged on that command, not its image name.
+ */
+const INFERENCE_IMAGE_RE = /\bimage:\s*.*\blocal-?ai\b/i;
 
 /**
  * Heuristic-only (WARN, never fails the build): does this bundle's compose file
  * expose a host port AND run something that looks like an OpenAI-compat
- * inference server, per the marker list above? Matched against the raw file
- * text (not a real YAML parse — no yaml dependency in this repo, and a text
- * heuristic is all a WARN needs).
+ * inference server? Matched against the raw file text (not a real YAML parse
+ * — no yaml dependency in this repo, and a text heuristic is all a WARN
+ * needs). Two ways to trip it:
+ *   1. a command/entrypoint marker (--served-model-name/llama-server/vllm/ollama)
+ *      anywhere in the file, or
+ *   2. no `command:` override at all, and the image name matches a known
+ *      self-contained-server pattern (currently just localai/local-ai).
  */
 function composeLooksLikeInferenceEndpoint(bundleDir, composefileRel) {
   if (typeof composefileRel !== "string" || !composefileRel) return false;
@@ -40,7 +55,10 @@ function composeLooksLikeInferenceEndpoint(bundleDir, composefileRel) {
   } catch {
     return false;
   }
-  return PORT_MAPPING_RE.test(text) && INFERENCE_CMD_RE.test(text);
+  if (!PORT_MAPPING_RE.test(text)) return false;
+  if (INFERENCE_CMD_RE.test(text)) return true;
+  if (!COMMAND_OVERRIDE_RE.test(text) && INFERENCE_IMAGE_RE.test(text)) return true;
+  return false;
 }
 
 /** Tailscale CGNAT range: 100.64.0.0/10 (100.64.x.x - 100.127.x.x). */

--- a/tests/bundle-inference-contract.test.js
+++ b/tests/bundle-inference-contract.test.js
@@ -1,0 +1,281 @@
+/**
+ * bundle-inference-contract — Task 16 (G-6 anti-rot contract, PR G-E part 2).
+ *
+ * Adds three contract rules to scripts/lib/bundle-contract.mjs, closing the
+ * gap Task 15 could only fix by hand-auditing once:
+ *
+ *   1. `inference: true` requires a non-empty `providers[]` array (a manifest
+ *      that claims to be an inference endpoint but ships no way to reach it
+ *      is the exact "installed but inert" bug Task 15 fixed by hand).
+ *   2. `no_auto_provider`, when present at all, must be a real non-empty
+ *      reason string — an empty stub defeats the purpose of the field.
+ *   3. A manifest declaring NEITHER flag, whose compose file exposes a port
+ *      and runs something that smells like an OpenAI-compat inference
+ *      server (--served-model-name / llama-server / vllm / ollama), gets a
+ *      WARN — heuristics don't hard-gate the build, they just flag drift.
+ *
+ * Plus a fourth, unrelated-but-adjacent rule added in the same task: a
+ * generalized instance-identity leak scan (the #217 leak class, generalized
+ * beyond the one hardcoded string Task 15 grepped for by hand) — no manifest
+ * string value anywhere may contain a Tailscale-range IP or a *.ts.net
+ * hostname, and no "host" field may carry a pinned 32-hex instance id.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateManifest } from "../scripts/lib/bundle-contract.mjs";
+import { buildRegistry } from "../scripts/build-registry.mjs";
+
+/** Make a throwaway bundle dir <root>/<id> with optional files {relpath: content}. */
+function tmpBundle(id, files = {}) {
+  const root = mkdtempSync(join(tmpdir(), "crowbundle-inf-"));
+  const dir = join(root, id);
+  mkdirSync(dir, { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const p = join(dir, rel);
+    mkdirSync(join(p, ".."), { recursive: true });
+    writeFileSync(p, content);
+  }
+  return dir;
+}
+
+const BASE = { id: "demo", name: "Demo", description: "d", type: "bundle", category: "misc" };
+
+const ONE_PROVIDER = [
+  {
+    id: "demo-provider",
+    baseUrlTemplate: "http://{host_ip}:{port}/v1",
+    apiKey: "none",
+    description: "test",
+    models: [{ id: "demo-model", warm: true }],
+  },
+];
+
+// --- 1. inference: true requires providers[] ---
+
+test("inference: true with no providers field fails", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, inference: true }, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("inference: true requires a non-empty providers[]")));
+});
+
+test("inference: true with an empty providers[] array fails", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, inference: true, providers: [] }, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("inference: true requires a non-empty providers[]")));
+});
+
+test("inference: true with a non-empty providers[] array passes", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, inference: true, providers: ONE_PROVIDER }, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+test("providers[] without inference: true is not itself an error (e.g. future opt-out)", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, providers: ONE_PROVIDER }, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+// --- 2. no_auto_provider must be a non-empty string when present ---
+
+test("no_auto_provider: empty string fails", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, no_auto_provider: "" }, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("no_auto_provider must be a non-empty string")));
+});
+
+test("no_auto_provider: whitespace-only string fails", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, no_auto_provider: "   " }, dir);
+  assert.equal(r.ok, false);
+});
+
+test("no_auto_provider: non-string value fails", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, no_auto_provider: true }, dir);
+  assert.equal(r.ok, false);
+});
+
+test("no_auto_provider: real reason string passes", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE, no_auto_provider: "Model unknowable at install-time." }, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+test("clean manifest (no inference, no providers, no no_auto_provider, no docker) passes", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest({ ...BASE }, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+  assert.deepEqual(r.warnings, []);
+});
+
+// --- 3. heuristic WARN: neither flag present + compose looks like an
+//        OpenAI-compat inference server. Never fails the build. ---
+
+const INFERENCE_LOOKING_COMPOSE = `services:
+  demo:
+    image: ghcr.io/ggml-org/llama.cpp:server
+    ports:
+      - "127.0.0.1:8099:8000"
+    entrypoint: ["llama-server"]
+    command:
+      - -m
+      - /models/demo.gguf
+      - --port
+      - "8000"
+`;
+
+test("WARN: compose exposes a port + llama-server, manifest has neither inference nor no_auto_provider", () => {
+  const dir = tmpBundle("demo", { "docker-compose.yml": INFERENCE_LOOKING_COMPOSE });
+  const r = validateManifest({ ...BASE, docker: { composefile: "docker-compose.yml" } }, dir);
+  assert.equal(r.ok, true, "heuristic must warn, not fail: " + r.errors.join("; "));
+  assert.equal(r.errors.length, 0);
+  assert.ok(r.warnings.length >= 1, "expected a WARN for the inference-looking compose");
+  assert.ok(r.warnings.some((w) => w.includes("OpenAI-compat")));
+});
+
+test("no WARN when inference: true + providers[] already present", () => {
+  const dir = tmpBundle("demo", { "docker-compose.yml": INFERENCE_LOOKING_COMPOSE });
+  const m = { ...BASE, inference: true, providers: ONE_PROVIDER, docker: { composefile: "docker-compose.yml" } };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+  assert.deepEqual(r.warnings, []);
+});
+
+test("no WARN when no_auto_provider carries a real reason (side-channel bundle)", () => {
+  const dir = tmpBundle("demo", { "docker-compose.yml": INFERENCE_LOOKING_COMPOSE });
+  const m = { ...BASE, no_auto_provider: "Dynamic model, unknowable at install-time.", docker: { composefile: "docker-compose.yml" } };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+  assert.deepEqual(r.warnings, []);
+});
+
+test("no WARN for an ordinary compose with a port but no inference-server command marker", () => {
+  const ordinary = `services:\n  demo:\n    image: nginx\n    ports:\n      - "8080:80"\n`;
+  const dir = tmpBundle("demo", { "docker-compose.yml": ordinary });
+  const r = validateManifest({ ...BASE, docker: { composefile: "docker-compose.yml" } }, dir);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.warnings, []);
+});
+
+test("no WARN for a compose with an inference marker but no exposed port", () => {
+  const noPort = `services:\n  demo:\n    image: ghcr.io/ggml-org/llama.cpp:server\n    entrypoint: ["llama-server"]\n    command: ["-m", "/models/demo.gguf"]\n`;
+  const dir = tmpBundle("demo", { "docker-compose.yml": noPort });
+  const r = validateManifest({ ...BASE, docker: { composefile: "docker-compose.yml" } }, dir);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.warnings, []);
+});
+
+// --- 4. generalized instance-identity leak scan ---
+
+test("leak: tailnet IP nested inside an env_vars default fails", () => {
+  const dir = tmpBundle("demo");
+  const m = {
+    ...BASE,
+    env_vars: [{ name: "SOME_URL", description: "d", default: "http://100.118.41.122:8003/v1" }],
+  };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("leaked Tailscale-range IP")), r.errors.join("; "));
+});
+
+test("leak: *.ts.net hostname anywhere in a manifest string fails", () => {
+  const dir = tmpBundle("demo");
+  const m = { ...BASE, notes: "See https://crow.dachshund-chromatic.ts.net:8444/ for the dashboard." };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("leaked *.ts.net hostname")), r.errors.join("; "));
+});
+
+test("leak: 32-hex instance-id-shaped value in a host field fails", () => {
+  const dir = tmpBundle("demo");
+  const m = { ...BASE, host: "49cf71ca878643ba7717f344329266fd" };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("leaked instance-id-shaped value")), r.errors.join("; "));
+});
+
+test("leak: a 32-hex string in a field NOT named 'host' is not flagged by the hex rule", () => {
+  const dir = tmpBundle("demo");
+  const m = { ...BASE, notes: "checksum abcdef0123456789abcdef0123456789" };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+test("leak: host: 'local' and host: 'cloud' are allowed", () => {
+  const dir = tmpBundle("demo");
+  assert.equal(validateManifest({ ...BASE, host: "local" }, dir).ok, true);
+  assert.equal(validateManifest({ ...BASE, host: "cloud" }, dir).ok, true);
+});
+
+test("leak: loopback URLs (127.0.0.1 / localhost) are allowed", () => {
+  const dir = tmpBundle("demo");
+  const m = {
+    ...BASE,
+    env_vars: [
+      { name: "A", description: "d", default: "http://127.0.0.1:8003/v1" },
+      { name: "B", description: "d", default: "http://localhost:11434" },
+    ],
+  };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, true, r.errors.join("; "));
+});
+
+test("leak scan is recursive: catches a tailnet IP nested inside providers[].models[]", () => {
+  const dir = tmpBundle("demo");
+  const m = {
+    ...BASE,
+    inference: true,
+    providers: [
+      {
+        id: "p",
+        baseUrlTemplate: "http://{host_ip}:{port}/v1",
+        description: "d",
+        models: [{ id: "m", notes: "warmed from 100.90.1.2 during migration" }],
+      },
+    ],
+  };
+  const r = validateManifest(m, dir);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("leaked Tailscale-range IP")), r.errors.join("; "));
+});
+
+test("malformed manifest (null) does not throw when the leak scan runs", () => {
+  const dir = tmpBundle("demo");
+  const r = validateManifest(null, dir);
+  assert.equal(r.ok, false);
+  assert.ok(Array.isArray(r.errors) && r.errors.length > 0);
+});
+
+// --- Integration: the real bundles/ tree passes the FULL contract,
+//     proving Task 15's providers/no_auto_provider fields + Task 16's
+//     inference:true stamps are internally consistent and capstone-tracker's
+//     leaked IP default is actually fixed. ---
+
+test("all tracked real bundle manifests pass the full contract (inference + no_auto_provider + leak scan)", () => {
+  const { audit } = buildRegistry();
+  const invalid = audit.filter((a) => a.status === "invalid");
+  assert.equal(invalid.length, 0, "invalid manifests: " + invalid.map((a) => `${a.id} [${a.errors.join(", ")}]`).join(" | "));
+});
+
+test("capstone-tracker no longer carries the leaked OCR_VISION_URL default IP", () => {
+  const { audit } = buildRegistry();
+  const entry = audit.find((a) => a.id === "capstone-tracker");
+  assert.ok(entry, "capstone-tracker must still be a bundle in the tree");
+  assert.equal(entry.ok, true, "capstone-tracker must pass the contract: " + entry.errors.join("; "));
+});
+
+test("every real inference bundle (providers[] present) is stamped inference: true", () => {
+  const { registry } = buildRegistry();
+  for (const entry of registry["add-ons"]) {
+    if (Array.isArray(entry.providers) && entry.providers.length > 0) {
+      assert.equal(entry.inference, true, `${entry.id} has providers[] but is not stamped inference: true`);
+    }
+  }
+});

--- a/tests/bundle-inference-contract.test.js
+++ b/tests/bundle-inference-contract.test.js
@@ -22,11 +22,15 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { validateManifest } from "../scripts/lib/bundle-contract.mjs";
 import { buildRegistry } from "../scripts/build-registry.mjs";
+
+const APP_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUNDLES_ROOT = join(APP_ROOT, "bundles");
 
 /** Make a throwaway bundle dir <root>/<id> with optional files {relpath: content}. */
 function tmpBundle(id, files = {}) {
@@ -172,6 +176,44 @@ test("no WARN for a compose with an inference marker but no exposed port", () =>
   assert.deepEqual(r.warnings, []);
 });
 
+// --- 3b. image-name marker (no command override): the LocalAI shape ---
+
+const LOCALAI_SHAPED_COMPOSE = `services:
+  demo:
+    image: localai/localai:latest-cpu
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - demo-models:/build/models
+    environment:
+      - THREADS=4
+    restart: unless-stopped
+`;
+
+test("WARN: localai-shaped image (no command override) + exposed port, manifest declares neither flag", () => {
+  const dir = tmpBundle("demo", { "docker-compose.yml": LOCALAI_SHAPED_COMPOSE });
+  const r = validateManifest({ ...BASE, docker: { composefile: "docker-compose.yml" } }, dir);
+  assert.equal(r.ok, true, "heuristic must warn, not fail: " + r.errors.join("; "));
+  assert.equal(r.errors.length, 0);
+  assert.ok(r.warnings.length >= 1, "expected a WARN for the localai-shaped compose");
+});
+
+test("no WARN for a random non-inference image with a port and no command override", () => {
+  const random = `services:\n  demo:\n    image: nginx:latest\n    ports:\n      - "8080:80"\n    restart: unless-stopped\n`;
+  const dir = tmpBundle("demo", { "docker-compose.yml": random });
+  const r = validateManifest({ ...BASE, docker: { composefile: "docker-compose.yml" } }, dir);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.warnings, []);
+});
+
+test("no WARN for a localai-shaped image WITH a command override (image name alone is not enough once command is judged)", () => {
+  const withCommand = `services:\n  demo:\n    image: localai/localai:latest-cpu\n    ports:\n      - "127.0.0.1:8080:8080"\n    command: ["--debug"]\n`;
+  const dir = tmpBundle("demo", { "docker-compose.yml": withCommand });
+  const r = validateManifest({ ...BASE, docker: { composefile: "docker-compose.yml" } }, dir);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.warnings, []);
+});
+
 // --- 4. generalized instance-identity leak scan ---
 
 test("leak: tailnet IP nested inside an env_vars default fails", () => {
@@ -278,4 +320,26 @@ test("every real inference bundle (providers[] present) is stamped inference: tr
       assert.equal(entry.inference, true, `${entry.id} has providers[] but is not stamped inference: true`);
     }
   }
+});
+
+test("localai carries an honest no_auto_provider reason (post-install model catalog, same shape as ollama)", () => {
+  const { registry } = buildRegistry();
+  const localai = registry["add-ons"].find((e) => e.id === "localai");
+  assert.ok(localai, "localai must still be a bundle in the tree");
+  assert.equal(localai.providers, undefined, "localai must not ship an LLM providers[] block");
+  assert.equal(typeof localai.no_auto_provider, "string");
+  assert.ok(localai.no_auto_provider.length > 20, "localai no_auto_provider reason must be a real explanation, not a stub");
+});
+
+test("the real tree produces zero heuristic WARNs (localai's no_auto_provider suppresses its own image-marker match)", () => {
+  const dirs = readdirSync(BUNDLES_ROOT, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name);
+  const allWarnings = [];
+  for (const id of dirs) {
+    const manifestPath = join(BUNDLES_ROOT, id, "manifest.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const { warnings } = validateManifest(manifest, join(BUNDLES_ROOT, id), { bundleExists: () => true });
+    for (const w of warnings) allWarnings.push(`${id}: ${w}`);
+  }
+  assert.deepEqual(allWarnings, [], "unexpected heuristic WARN(s) on the real bundles/ tree");
 });

--- a/tests/bundle-provider-audit.test.js
+++ b/tests/bundle-provider-audit.test.js
@@ -1,0 +1,215 @@
+/**
+ * bundle-provider-audit — Task 15 (G-6 bundle audit part 1, PR G-E).
+ *
+ * Closes the "installed but inert" gap: six chat/LLM bundles
+ * (ollama, llamacpp-qwen72b, vllm, vllm-rocm-{kimi,qwen3,qwen3-32b}) shipped
+ * with no `providers[]` block, so installing them left a running container
+ * with no auto-registered endpoint. Also de-pins three vllm-cuda-* manifests
+ * that carried a maintainer-specific paired-instance id in `host` (the #217
+ * leak class), and gives the three side-channel bundles (faster-whisper,
+ * kokoro-tts, sdxl — wired through STT/TTS profile seeds or a bespoke tool
+ * env var, not an LLM `providers[]` entry) an honest `no_auto_provider`
+ * reason (the field itself is inert metadata until Task 16 adds contract
+ * validation for it).
+ *
+ * Two of the six originally-flagged bundles (ollama, vllm base) ended up
+ * with `no_auto_provider` instead of a `providers[]` block: both have a
+ * served model that is genuinely unknowable at manifest-write time (ollama
+ * pulls models post-install; vllm's VLLM_MODEL is a required env var with
+ * no default), and registering a provider row with an empty models[] list
+ * breaks default profile resolution — see resolve-profile.js's
+ * firstModelId() returning null with nothing to pick from. See
+ * .superpowers/sdd/task-15-report.md for the full investigation.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, readdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { registerProviderFromManifest, setProviderSyncManager } from "../servers/shared/providers-db.js";
+
+const APP_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BUNDLES_ROOT = join(APP_ROOT, "bundles");
+
+function manifest(id) {
+  return JSON.parse(readFileSync(join(BUNDLES_ROOT, id, "manifest.json"), "utf8"));
+}
+
+function compose(id, file = "docker-compose.yml") {
+  return readFileSync(join(BUNDLES_ROOT, id, file), "utf8");
+}
+
+/** Extract the HOST port from a `ports:` mapping line like `"${VAR}:8003:8000"`. */
+function composeHostPort(composeText) {
+  const m = composeText.match(/ports:\s*\n\s*-\s*"[^:"]*:(\d+):\d+"/);
+  return m ? Number(m[1]) : null;
+}
+
+// --- 1. The four bundles with a real, statically-known served model get a
+//        providers[] block whose port matches their compose file. ---
+
+const STATIC_PROVIDER_BUNDLES = {
+  "llamacpp-qwen72b": { providerId: "crow-swap-qwen72b", modelId: "qwen2.5-72b" },
+  "vllm-rocm-kimi": { providerId: "crow-swap-kimi", modelId: "kimi-linear-48b" },
+  "vllm-rocm-qwen3": { providerId: "crow-dispatch", modelId: "qwen3-4b" },
+  "vllm-rocm-qwen3-32b": { providerId: "crow-mode-a-32b", modelId: "qwen3-32b" },
+};
+
+for (const [bundleId, expect] of Object.entries(STATIC_PROVIDER_BUNDLES)) {
+  test(`${bundleId}: providers[] block present, port matches compose, model id matches served-model-name/alias`, () => {
+    const m = manifest(bundleId);
+    assert.ok(Array.isArray(m.providers) && m.providers.length === 1, `${bundleId} must declare exactly one provider`);
+    const p = m.providers[0];
+    assert.equal(p.id, expect.providerId);
+    assert.equal(p.baseUrlTemplate, "http://{host_ip}:{port}/v1");
+    assert.ok(Array.isArray(p.models) && p.models.length === 1, `${bundleId} provider must declare exactly one model`);
+    assert.equal(p.models[0].id, expect.modelId);
+
+    const hostPort = composeHostPort(compose(bundleId));
+    assert.ok(hostPort, `${bundleId} docker-compose.yml must expose a host port`);
+    assert.equal(m.port, hostPort, `${bundleId} manifest.port must match the compose-exposed host port`);
+  });
+}
+
+test("llamacpp-qwen72b / vllm-rocm-kimi share the 8003-swap mutex group and both conflict with crow-chat", () => {
+  const qwen72b = manifest("llamacpp-qwen72b").providers[0].models[0];
+  const kimi = manifest("vllm-rocm-kimi").providers[0].models[0];
+  assert.equal(qwen72b.mutexGroup, "8003-swap");
+  assert.equal(kimi.mutexGroup, "8003-swap");
+  assert.ok(qwen72b.conflictsWith.includes("crow-chat"));
+  assert.ok(kimi.conflictsWith.includes("crow-chat"));
+});
+
+// --- 2. ollama + vllm (base): dynamic/unknowable served model → no_auto_provider,
+//        NOT an empty providers[] block. ---
+
+for (const bundleId of ["ollama", "vllm"]) {
+  test(`${bundleId}: no providers[] block; carries a non-empty no_auto_provider reason`, () => {
+    const m = manifest(bundleId);
+    assert.equal(m.providers, undefined, `${bundleId} must not ship a providers[] block (served model unknowable at manifest-write time)`);
+    assert.equal(typeof m.no_auto_provider, "string");
+    assert.ok(m.no_auto_provider.length > 20, `${bundleId} no_auto_provider reason must be a real explanation, not a stub`);
+  });
+}
+
+// --- 3. Side-channel bundles: non-empty no_auto_provider, no providers[] block. ---
+
+for (const bundleId of ["faster-whisper-server", "kokoro-tts", "sdxl"]) {
+  test(`${bundleId}: non-empty no_auto_provider (side-channel wiring, not an LLM providers[] entry)`, () => {
+    const m = manifest(bundleId);
+    assert.equal(m.providers, undefined, `${bundleId} must not ship an LLM providers[] block`);
+    assert.equal(typeof m.no_auto_provider, "string");
+    assert.ok(m.no_auto_provider.length > 20, `${bundleId} no_auto_provider reason must be a real explanation, not a stub`);
+  });
+}
+
+// --- 4. host de-pin: no manifest anywhere under bundles/ still carries the
+//        leaked maintainer instance id (#217 leak class, anti-rot). ---
+
+test("no bundle manifest carries the leaked maintainer instance id (49cf71ca878643ba7717f344329266fd)", () => {
+  const offenders = [];
+  for (const id of readdirSync(BUNDLES_ROOT, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name)) {
+    const p = join(BUNDLES_ROOT, id, "manifest.json");
+    if (!existsSync(p)) continue;
+    if (readFileSync(p, "utf8").includes("49cf71ca878643ba7717f344329266fd")) offenders.push(id);
+  }
+  assert.deepEqual(offenders, [], `manifests still carrying the leaked instance id: ${offenders.join(", ")}`);
+});
+
+test("vllm-cuda-{embed,rerank,vision}: host is 'local', not a pinned instance id", () => {
+  for (const id of ["vllm-cuda-embed", "vllm-cuda-rerank", "vllm-cuda-vision"]) {
+    assert.equal(manifest(id).host, "local", `${id} manifest.host must be 'local'`);
+  }
+});
+
+// --- 5. Install-path integration: registerProviderFromManifest (the real
+//        seam bundles.js's install() calls after `docker compose up`) writes
+//        a provider row with the right base_url — proven against a scratch
+//        libsql DB, no docker involved. ---
+
+function freshLibsql() {
+  const dir = mkdtempSync(join(tmpdir(), "bundle-provider-audit-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe",
+    cwd: APP_ROOT,
+  });
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  process.env.CROW_DATA_DIR = dir;
+  const db = createClient({ url: "file:" + join(dir, "crow.db") });
+  return {
+    db,
+    cleanup() {
+      setProviderSyncManager(null);
+      if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+      else process.env.CROW_DATA_DIR = prevDataDir;
+      try { db.close(); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function dbRow(db, id) {
+  const { rows } = await db.execute({ sql: "SELECT * FROM providers WHERE id = ?", args: [id] });
+  return rows[0];
+}
+
+test("install path: registering vllm-rocm-qwen3's manifest.providers[0] writes a crow-dispatch row with the right base_url/port/host", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const m = manifest("vllm-rocm-qwen3");
+    const providerDef = m.providers[0];
+    // Mirrors bundles.js's install-time call exactly: host:"local" (or unset)
+    // → hostIp stays the loopback default; port comes from manifest.port.
+    const hostIp = "127.0.0.1";
+    const result = await registerProviderFromManifest({
+      db, manifest: m, providerDef, port: m.port, hostIp,
+    });
+    assert.equal(result.id, "crow-dispatch");
+
+    const row = await dbRow(db, "crow-dispatch");
+    assert.ok(row, "provider row must exist after registration");
+    assert.equal(row.base_url, "http://127.0.0.1:8001/v1");
+    assert.equal(row.host, "local");
+    assert.equal(row.bundle_id, "vllm-rocm-qwen3");
+    const models = JSON.parse(row.models);
+    assert.equal(models[0].id, "qwen3-4b");
+    assert.equal(models[0].priority, "maker_lab");
+  } finally { cleanup(); }
+});
+
+test("install path: registering vllm-cuda-embed's manifest.providers[0] with host:'local' resolves to loopback, not a peer lookup", async () => {
+  const { db, cleanup } = freshLibsql();
+  try {
+    const m = manifest("vllm-cuda-embed");
+    assert.equal(m.host, "local", "precondition: host must already be de-pinned");
+    const providerDef = m.providers[0];
+    const hostIp = "127.0.0.1"; // what bundles.js computes for host:"local" (no getInstance lookup)
+    const result = await registerProviderFromManifest({
+      db, manifest: m, providerDef, port: m.port, hostIp,
+    });
+    const row = await dbRow(db, result.id);
+    assert.equal(row.base_url, "http://127.0.0.1:9100/v1");
+    assert.equal(row.host, "local");
+  } finally { cleanup(); }
+});
+
+// --- 6. Registry drift: providers/no_auto_provider/host changes must be
+//        reflected in the committed registry/add-ons.json (build-registry
+//        spreads the full manifest through, no field allowlist). ---
+
+test("committed registry/add-ons.json carries the new providers[]/no_auto_provider fields (no drift)", async () => {
+  const { buildRegistry, formatRegistry } = await import("../scripts/build-registry.mjs");
+  const { registry } = buildRegistry();
+  const generated = formatRegistry(registry);
+  const current = readFileSync(join(APP_ROOT, "registry", "add-ons.json"), "utf8");
+  assert.equal(current, generated, "registry drift — run `npm run build-registry`");
+
+  const dispatch = registry["add-ons"].find((e) => e.id === "vllm-rocm-qwen3");
+  assert.equal(dispatch.providers[0].id, "crow-dispatch");
+  const ollama = registry["add-ons"].find((e) => e.id === "ollama");
+  assert.equal(typeof ollama.no_auto_provider, "string");
+});


### PR DESCRIPTION
Fifth and final Item G build PR (spec: Gitea `crow-engineering` `specs/2026-07-18-item-g-model-catalog-design.md` r3 SIGNED OFF, section G-6 — the operator's mid-planning addition: "audit them and make sure that they integrate properly into the crow ecosystem as inference endpoints automatically … crow remains super simple to deploy for non technical users").

**What's in it (20 commits — Tasks 15+16 with per-bundle commits and two review fix rounds):**
- **Four bundles gained real `providers` blocks** (llamacpp-qwen72b, vllm-rocm-kimi/qwen3/qwen3-32b) — every port and served-model id cross-checked against the bundle's own compose file, so install → auto-registered working endpoint.
- **Six bundles carry honest `no_auto_provider` reasons** instead of silent inertness: ollama, base vllm, and localai (served model genuinely unknowable at manifest time — post-install pull / required env; the text tells the user exactly what to do), plus faster-whisper-server/kokoro-tts/sdxl (their real wiring is profile seeds / a dedicated env var, documented truthfully).
- **Instance-specific values purged**: the three vllm-cuda bundles' `host` pins to a maintainer instance id → `"local"` (verified against all four read sites); `capstone-tracker`'s env default carrying a live tailnet IP fixed (found by the review's generalized sweep; the default only ever fed the install form — removal verified safe).
- **Anti-rot contract** in `scripts/lib/bundle-contract.mjs`, riding `build-registry --check` in CI: `inference: true` requires a non-empty providers array (15 manifests stamped, enumerated not assumed); `no_auto_provider` must be a real reason; a compose that looks like an inference server with neither flag WARNs (command markers + an image-name marker so command-less bundles like localai can't slip through); and a **generalized instance-leak scan** — tailnet-range IPs (exact 100.64.0.0/10 boundary-tested), `*.ts.net` hostnames, and pinned instance-id host values are hard errors in any manifest string, recursively.

**Review rigor:** independent reviews on both tasks; the reviews themselves found the capstone-tracker leak and the localai blind spot (missing from the original audit list entirely) — both closed in fix rounds with adversarial fixture verification.

**Suite:** 2423/2423 pass, 0 fail, 0 skip (new baseline; +45 over #236). build-registry --check clean, zero warnings on the real tree. No schema changes, no new deps, no behavior change for already-installed bundles (manifest metadata + CI rules).