### PR TITLE
fix(models): Item G PR G-F — native-start hotfix wave (glibc collection, cache refresh, cold probe, error cause, asset host)

### DIFF
--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -414,6 +414,19 @@ export async function isProviderReady(providerName) {
  *
  * `opts.cfg` overrides the provider config this resolves `providerName`
  * from (tests only; forwarded to `acquireProvider` too — see its doc).
+ *
+ * `opts.onError`, if given, is invoked with the underlying thrown error
+ * whenever this function is about to collapse it into a plain `false`
+ * (Item G, PR G-F, defect 4). The tri-state return contract (`null` /
+ * `true` / `false`) is relied on verbatim by several other callers
+ * (`chat.js`, `llm-router.js`) that never pass `onError` and are
+ * completely unaffected — this is an additive, opt-in seam, not a
+ * change to what gets returned. `routes/models.js`'s start route is the
+ * one caller that passes it, so it can thread the real reason (e.g.
+ * `GLIBC_TOO_OLD`) into its 502 response instead of the generic
+ * "failed to become ready" message that used to be the only thing a
+ * caller ever saw — the actual cause previously reached nothing but
+ * this function's own `console.warn` below.
  */
 export async function maybeAcquireLocalProvider(providerName, opts = {}) {
   if (!providerName) return null;
@@ -427,6 +440,9 @@ export async function maybeAcquireLocalProvider(providerName, opts = {}) {
     return await acquireProvider(providerName, opts);
   } catch (err) {
     console.warn(`[gpu-orchestrator] maybeAcquireLocalProvider(${providerName}) failed: ${err.message}`);
+    if (typeof opts.onError === "function") {
+      try { opts.onError(err); } catch { /* caller's observer must never break this function */ }
+    }
     return false;
   }
 }

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -73,7 +73,7 @@ import { basename, join } from "node:path";
 
 import { allocatePort, loadState, releasePort, saveState } from "./state.js";
 import { disableProvider, listProvidersAll, upsertProvider } from "../../shared/providers-db.js";
-import { invalidateProvidersCache } from "../../shared/providers.js";
+import { invalidateProvidersCache, invalidateAndRefreshProvidersCache } from "../../shared/providers.js";
 
 // ---------------------------------------------------------------------------
 // Typed errors
@@ -1141,6 +1141,16 @@ export function pickChatMutexGroup(existingRows) {
  * Injectable seams (`allocatePortFn`/`listProvidersAllFn`/`upsertProviderFn`/
  * `invalidateCacheFn`) default to the real implementations; tests use them
  * to observe call order without needing to intercept module internals.
+ * `invalidateCacheFn` defaults to `invalidateAndRefreshProvidersCache`
+ * (Item G, PR G-F, defect 2), NOT the plain sync `invalidateProvidersCache`
+ * — this function's caller (the download-then-register route, or any
+ * caller that immediately turns around and asks whether the model it just
+ * registered is startable) needs the row to be visible in the very next
+ * `loadProviders()` call, which the plain invalidate can't guarantee (it
+ * only clears the cache; the next `loadProviders()` call fires an
+ * un-awaited background DB refresh and returns the stale/fallback
+ * snapshot in the meantime). Awaiting the real refresh here closes that
+ * window.
  *
  * Provider-id collision guard: `modelId` doubles as the provider row's `id`
  * (see the section header comment), which means a user's own cloud/bundle
@@ -1173,7 +1183,7 @@ export async function registerModel({
   allocatePortFn = allocatePort,
   listProvidersAllFn = listProvidersAll,
   upsertProviderFn = upsertProvider,
-  invalidateCacheFn = invalidateProvidersCache,
+  invalidateCacheFn = invalidateAndRefreshProvidersCache,
   registryExtra = {},
 }) {
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -303,7 +303,17 @@ export function resolveAsset(probe, runtimeBlock, opts = {}) {
 // Runtime asset download (own allowlist — see module doc)
 // ---------------------------------------------------------------------------
 
-const RUNTIME_ALLOWED_HOSTS = new Set(["github.com", "objects.githubusercontent.com"]);
+// "objects.githubusercontent.com" was GitHub's release-asset redirect
+// target historically and "release-assets.githubusercontent.com" is the
+// target observed live as of Item G, PR G-F (confirmed via `curl -sIL`
+// against a real release URL, 2026-07-19) — both are kept since GitHub
+// may serve either depending on the release/rollout, and there's no
+// signal here that the old host is fully retired.
+const RUNTIME_ALLOWED_HOSTS = new Set([
+  "github.com",
+  "objects.githubusercontent.com",
+  "release-assets.githubusercontent.com",
+]);
 
 /** Default socket-idle timeout for a runtime-asset download hop
  * (~120s, per Task 9 review round 1: "no promise may hang forever on a
@@ -311,9 +321,11 @@ const RUNTIME_ALLOWED_HOSTS = new Set(["github.com", "objects.githubusercontent.
  * `downloadRuntimeAsset({ timeoutMs })` / `ensureRuntime(..., { timeoutMs })`. */
 export const DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS = 120_000;
 
-/** True iff `hostname` is exactly "github.com" or "objects.githubusercontent.com"
- * (GitHub's release-asset redirect target). No subdomain wildcarding —
- * these are the two literal hosts a llama.cpp release download hits. */
+/** True iff `hostname` is exactly "github.com", "objects.githubusercontent.com",
+ * or "release-assets.githubusercontent.com" (GitHub's release-asset
+ * redirect targets — see RUNTIME_ALLOWED_HOSTS's comment for why both
+ * githubusercontent hosts are kept). No subdomain wildcarding — these
+ * are the literal hosts a llama.cpp release download hits. */
 export function isAllowedRuntimeHost(hostname) {
   if (typeof hostname !== "string" || hostname.length === 0) return false;
   return RUNTIME_ALLOWED_HOSTS.has(hostname.toLowerCase());

--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -56,7 +56,13 @@ import { join, relative } from "node:path";
  * thrown directly by that function — see its doc) for every "can't
  * honestly pick an asset" case: unsupported platform/arch, no catalog
  * entry for the resolved key, or glibc too old for every candidate.
- * `code` is one of UNSUPPORTED_PLATFORM | NO_ASSET | GLIBC_TOO_OLD. */
+ * `code` is one of UNSUPPORTED_PLATFORM | NO_ASSET | GLIBC_TOO_OLD |
+ * GLIBC_UNKNOWN. `GLIBC_UNKNOWN` is thrown by `ensureRuntime` itself
+ * (not `resolveAsset`, which never probes the host — see its doc) when
+ * it tried to collect `ldd --version` and the collection itself failed
+ * (missing binary, non-zero exit, ...) — a DISTINCT, honest code from
+ * `GLIBC_TOO_OLD`, which means "asked, and it's too old". Conflating the
+ * two would silently mislabel "couldn't ask" as "asked and failed". */
 export class RuntimeAssetError extends Error {
   constructor(message, code, details = {}) {
     super(message);
@@ -149,6 +155,20 @@ export function parseGlibcVersion(lddOutput) {
   const m = /(\d+)\.(\d+)\s*$/.exec(firstLine.trim());
   if (!m) return null;
   return { major: Number.parseInt(m[1], 10), minor: Number.parseInt(m[2], 10) };
+}
+
+/**
+ * Run `ldd --version` and return its raw stdout. Honestly THROWS on
+ * failure (missing `ldd`, non-zero exit, ...) rather than swallowing it
+ * into an empty/undefined result — `ensureRuntime` (the only caller)
+ * turns a throw here into a distinct `GLIBC_UNKNOWN`-coded
+ * `RuntimeAssetError`, never the `GLIBC_TOO_OLD` lie (see that class's
+ * doc). `execFileSyncImpl` is injectable so tests never shell out to a
+ * real `ldd` — same DI pattern as `chmodFn`/`extract` in `ensureRuntime`
+ * and `execFileSyncImpl` in `defaultExtractTarGz` below.
+ */
+export function collectLddOutput(execFileSyncImpl = execFileSyncNode) {
+  return execFileSyncImpl("ldd", ["--version"], { encoding: "utf8" });
 }
 
 /** True iff `actual` ({major,minor}, possibly null) satisfies `required`
@@ -605,6 +625,25 @@ export function sweepStaleRuntimeTmp(dir, opts = {}) {
  * clean that instance's stale `.extract-*.tmp`/`.download-*.tmp` leftovers
  * without any new host-wide directory-enumeration logic (Task 14, PR G-D).
  *
+ * glibc detection (Item G, PR G-F, blocker fix): `resolveAsset` is
+ * deliberately pure and never probes the host itself (see its doc), but
+ * its ONLY production caller — `gpu-orchestrator.js`'s
+ * `resolveNativeBinPath` — never passed `opts.lddOutput` through to
+ * `ensureRuntime`. That left `resolveAsset` treating every linux host's
+ * glibc as "undetectable" (its documented fail-closed stance), which
+ * means `GLIBC_TOO_OLD` fired UNCONDITIONALLY on every linux host,
+ * including ones with a perfectly modern glibc. `ensureRuntime` — unlike
+ * `resolveAsset` — is already an async, host-touching function (it
+ * downloads and extracts real files), so it's the right seam to actually
+ * collect `ldd --version` when the caller left `opts.lddOutput`
+ * undefined AND `probe.platform === "linux"`. An explicitly injected
+ * `opts.lddOutput` (including `null`) still wins outright — collection
+ * only fires on `undefined`, so no double-collection and tests stay
+ * hermetic. If collection itself fails (`ldd` missing, non-zero exit,
+ * ...), that's an honest `GLIBC_UNKNOWN` `RuntimeAssetError` — NEVER
+ * silently treated as `GLIBC_TOO_OLD` (asked-and-failed is not the same
+ * claim as couldn't-ask).
+ *
  * @returns {Promise<string>} the executable binary's path.
  */
 export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
@@ -623,6 +662,8 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     fs = { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync, rmSync, renameSync },
     timeoutMs = DEFAULT_RUNTIME_DOWNLOAD_TIMEOUT_MS,
     sweepStaleTmp = sweepStaleRuntimeTmp,
+    execFileSyncImpl = execFileSyncNode,
+    collectLddOutputFn = collectLddOutput,
   } = opts;
 
   try {
@@ -631,7 +672,20 @@ export async function ensureRuntime(dir, runtimeBlock, probe, opts = {}) {
     /* best effort — a sweep failure must never block a real install */
   }
 
-  const resolved = resolveAsset(probe, runtimeBlock, { lddOutput, arch, baseUrl });
+  let effectiveLddOutput = lddOutput;
+  if (effectiveLddOutput === undefined && probe && probe.platform === "linux") {
+    try {
+      effectiveLddOutput = collectLddOutputFn(execFileSyncImpl);
+    } catch (err) {
+      throw new RuntimeAssetError(
+        `Could not determine host glibc version (\`ldd --version\` failed: ${err.message}) — refusing to guess a runtime asset`,
+        "GLIBC_UNKNOWN",
+        { cause: err.message },
+      );
+    }
+  }
+
+  const resolved = resolveAsset(probe, runtimeBlock, { lddOutput: effectiveLddOutput, arch, baseUrl });
   if (resolved.error) throw resolved.error;
 
   const runtimesDir = join(dir, "runtimes", "llamacpp");

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -207,10 +207,22 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
 
   // --- Catalog -------------------------------------------------------------
 
-  router.get("/api/models/catalog", (req, res) => {
+  router.get("/api/models/catalog", async (req, res) => {
     try {
       const catalog = loadCatalogFn();
-      const probe = getCachedProbeFn();
+      // Fix (Item G, PR G-F, defect 3): the cache is only warmed by
+      // resolveNativeBinPath's own cold-cache fix (gpu-orchestrator.js) or
+      // an explicit POST /reprobe — neither of which a client that opens
+      // the catalog without ever starting/reprobing a model triggers. That
+      // left every quant's fitBadge permanently "unknown" for such a
+      // client. One-shot, same pattern as resolveNativeBinPath: reprobe
+      // only on a cold cache; reprobe() caches its own result, so every
+      // subsequent request in the process lifetime takes the cheap
+      // getCachedProbeFn() path again.
+      let probe = getCachedProbeFn();
+      if (!probe) {
+        probe = await reprobeFn({ modelsDir: resolveDir() });
+      }
       const state = loadStateFn(resolveDir());
       const models = (catalog.models || []).map((model) => {
         const regEntry = state.registry[model.id] || null;
@@ -567,10 +579,17 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
       return res.status(404).json({ error: `${modelId} is not installed`, code: "NOT_INSTALLED" });
     }
     try {
-      const result = await maybeAcquireLocalProviderFn(modelId);
+      // Fix (Item G, PR G-F, defect 4): the 502 below used to swallow the
+      // underlying typed error (e.g. GLIBC_TOO_OLD) entirely — it reached
+      // only the gateway's own console.warn, never the caller. `onError`
+      // captures it (opt-in seam on maybeAcquireLocalProvider, see its
+      // doc) so it can ride along in the response body as `cause`.
+      let startError = null;
+      const result = await maybeAcquireLocalProviderFn(modelId, { onError: (err) => { startError = err; } });
       if (result === true) return res.json({ running: true });
       if (result === false) {
-        return res.status(502).json({ error: "Model failed to become ready in time", code: "START_FAILED" });
+        const cause = startError ? { code: startError.code || "UNKNOWN", message: startError.message } : null;
+        return res.status(502).json({ error: "Model failed to become ready in time", code: "START_FAILED", cause });
       }
       return res.status(409).json({
         error: `${modelId} is not a locally-orchestratable native provider`,

--- a/servers/shared/providers.js
+++ b/servers/shared/providers.js
@@ -63,6 +63,34 @@ async function refreshCache() {
   _cacheLoadedAt = Date.now();
 }
 
+/**
+ * Invalidate the cache AND await a real refresh before returning (Item G,
+ * PR G-F, defect 2). `invalidateProvidersCache()` above only clears the
+ * cache and leaves the next `loadProviders()` call to fire an un-awaited
+ * background `refreshCache()` — fine for the common "somebody else will
+ * call `loadProviders()` again eventually and see the update" case, but
+ * wrong for a caller that's about to hand the row it just wrote to
+ * something that needs to see it RIGHT NOW: a fresh native-model
+ * registration followed immediately by the start route's
+ * `maybeAcquireLocalProvider` -> `loadProviders()` lookup was invisible
+ * for up to one DB round-trip, which `loadProviders()`'s synchronous
+ * contract can never await — the lookup fell through to the stale/
+ * models.json-fallback cache and 409'd `NOT_NATIVE` for a model that was
+ * already durably registered.
+ *
+ * `loadProviders()` itself stays synchronous on purpose (see its doc —
+ * many hot-path callers, e.g. the orchestrator, can't be made async), so
+ * this is a separate, deliberately async sibling for the handful of
+ * callers (today: `manager.js`'s `registerModel`) that CAN await —
+ * they pass this as their `invalidateCacheFn` instead of the plain sync
+ * `invalidateProvidersCache`.
+ */
+export async function invalidateAndRefreshProvidersCache() {
+  invalidateProvidersCache();
+  await refreshCache();
+  return _cache;
+}
+
 function loadFromModelsJson() {
   for (const p of repoModelsJsonSearchPaths()) {
     try {

--- a/tests/models-panel.test.js
+++ b/tests/models-panel.test.js
@@ -271,6 +271,65 @@ test("GET /api/models/catalog: reflects registered/running state from state.json
 });
 
 // ---------------------------------------------------------------------------
+// Catalog — cold-cache reprobe (Item G, PR G-F, defect 3: the route used to
+// read getCachedProbeFn() raw, so a client that never opened the full panel
+// (which fires its own reprobe-on-open effect) or hit POST /reprobe itself
+// saw a permanent fitBadge:"unknown" for every quant.)
+// ---------------------------------------------------------------------------
+
+test("GET /api/models/catalog: a cold probe cache is warmed via a one-shot reprobe — real badges, not permanent 'unknown'", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let reprobeCalls = 0;
+    let cached = null; // simulates probe.js's own module-level cache: null until reprobeFn "runs"
+    await withServer({
+      dir: h.dir,
+      loadCatalogFn: makeCatalog,
+      getCachedProbeFn: () => cached,
+      reprobeFn: async () => {
+        reprobeCalls++;
+        cached = FIXED_PROBE;
+        return FIXED_PROBE;
+      },
+    }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog", { headers: authHeaders(token) });
+      assert.equal(r.status, 200);
+      const body = await r.json();
+      assert.deepEqual(body.probe, FIXED_PROBE, "the response carries the freshly-reprobed hardware, not null");
+      const quants = Object.fromEntries(body.models[0].quants.map((q) => [q.quant, q.fitBadge]));
+      assert.equal(quants["Q4_K_M"], "fits", "a cold-cache request still gets a real fit badge, not 'unknown'");
+      assert.equal(reprobeCalls, 1, "reprobe fired exactly once for the cold-cache request");
+
+      // A SECOND request in the same process must reuse the now-warm
+      // cache (mirroring probe.js's real getCachedProbe()/reprobe()
+      // module-cache contract) — reprobe must not fire again.
+      const r2 = await fetch(base + "/api/models/catalog", { headers: authHeaders(token) });
+      assert.equal(r2.status, 200);
+      assert.equal(reprobeCalls, 1, "reprobe called exactly once across two requests — the second reused the warm cache");
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("GET /api/models/catalog: a warm probe cache never triggers a reprobe", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    let reprobeCalls = 0;
+    await withServer({
+      dir: h.dir,
+      loadCatalogFn: makeCatalog,
+      getCachedProbeFn: () => FIXED_PROBE,
+      reprobeFn: async () => { reprobeCalls++; return FIXED_PROBE; },
+    }, async (base) => {
+      const r = await fetch(base + "/api/models/catalog", { headers: authHeaders(token) });
+      assert.equal(r.status, 200);
+      assert.equal(reprobeCalls, 0, "an already-warm cache is used as-is — no reprobe call at all");
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
 // Download gate
 // ---------------------------------------------------------------------------
 
@@ -878,6 +937,62 @@ test("POST /api/models/:id/start: reaches maybeAcquireLocalProvider and maps tru
       const notNative = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
       assert.equal(notNative.status, 409);
       assert.equal((await notNative.json()).code, "NOT_NATIVE");
+    });
+  } finally { await h.cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Start route — surfaces the real failure reason (Item G, PR G-F, defect 4:
+// the 502 used to swallow the underlying typed error — e.g. GLIBC_TOO_OLD —
+// entirely; it reached only the gateway's own console.warn, never the
+// caller/panel.)
+// ---------------------------------------------------------------------------
+
+test("POST /api/models/:id/start: a start failure threads the underlying error's code+message into the 502 body as `cause`", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+
+    let sawOnErrorOpts = false;
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      maybeAcquireLocalProviderFn: async (id, opts) => {
+        sawOnErrorOpts = typeof opts?.onError === "function";
+        opts.onError(Object.assign(new Error("glibc too old for any linux runtime asset (need >= 2.34)"), { code: "GLIBC_TOO_OLD" }));
+        return false;
+      },
+    }, async (base) => {
+      const failed = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(failed.status, 502);
+      const body = await failed.json();
+      assert.equal(body.code, "START_FAILED");
+      assert.ok(sawOnErrorOpts, "the route passed an onError observer to maybeAcquireLocalProviderFn");
+      assert.equal(body.cause?.code, "GLIBC_TOO_OLD", "the underlying typed error's code reached the response body");
+      assert.match(body.cause?.message, /glibc too old/i);
+    });
+  } finally { await h.cleanup(); }
+});
+
+test("POST /api/models/:id/start: a start failure with no captured error still returns a well-formed 502 with cause:null", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      // Stub never calls onError — mirrors a plain readiness-timeout
+      // (no underlying thrown error at all, just `false`).
+      maybeAcquireLocalProviderFn: async () => false,
+    }, async (base) => {
+      const failed = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(failed.status, 502);
+      const body = await failed.json();
+      assert.equal(body.code, "START_FAILED");
+      assert.equal(body.cause, null);
     });
   } finally { await h.cleanup(); }
 });

--- a/tests/models-registration.test.js
+++ b/tests/models-registration.test.js
@@ -167,6 +167,37 @@ test("registerModel: allocates a port already recorded in state.json reservation
   } finally { cleanup(); }
 });
 
+// ---------------------------------------------------------------------------
+// registerModel + loadProviders() — no invisible-registration window
+// (Item G, PR G-F, defect 2: the DEFAULT invalidateCacheFn used to be the
+// plain sync invalidateProvidersCache(), which only clears the cache — the
+// very next loadProviders() call fires an un-awaited background DB refresh
+// and returns the stale/models.json-fallback snapshot in the meantime.
+// A start-route lookup immediately after a fresh native registration saw
+// the models.json fallback, found no such provider, and 409'd NOT_NATIVE
+// for a model that was already durably registered.)
+// ---------------------------------------------------------------------------
+
+test("registerModel: the registered provider is visible to the very next loadProviders() call — no stale-cache window, no sleep/poll", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const { loadProviders, invalidateProvidersCache } = await import("../servers/shared/providers.js");
+    // Start from a deterministic cold cache regardless of what earlier
+    // tests in this process left behind.
+    invalidateProvidersCache();
+
+    await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+
+    // Deliberately NO await/sleep/poll here — the very next synchronous
+    // loadProviders() call (the same one the start route's
+    // maybeAcquireLocalProvider makes) must already see the fresh row.
+    const cfg = loadProviders();
+    const p = cfg.providers["chat-test-model"];
+    assert.ok(p, "the just-registered provider is visible on the very next loadProviders() call");
+    assert.equal(p.gpuPolicy?.runtime, "native");
+  } finally { cleanup(); }
+});
+
 test("registerModel: invalidates the providers cache exactly once, AFTER the row is durably written", async () => {
   const { db, dir, cleanup } = freshLibsql();
   try {

--- a/tests/models-runtime.test.js
+++ b/tests/models-runtime.test.js
@@ -56,6 +56,7 @@ import {
   getStatusSnapshot,
   sweepStaleRuntimeTmp,
   STALE_RUNTIME_TMP_MAX_AGE_MS,
+  collectLddOutput,
 } from "../servers/gateway/models/runtime.js";
 import { acquireHostLock, lockPathFor, stealStaleLock } from "../servers/gateway/models/native-lock.js";
 import { startStubLlamaServer } from "./fixtures/stub-llama-server.mjs";
@@ -1088,6 +1089,143 @@ test("ensureRuntime rejects a resolveAsset failure before attempting any downloa
         return true;
       },
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureRuntime — self-collected ldd output (Item G, PR G-F, blocker fix:
+// resolveNativeBinPath never passed opts.lddOutput, so every linux host hit
+// resolveAsset's fail-closed "undetectable == too old" branch and got
+// GLIBC_TOO_OLD unconditionally, even on hosts with a perfectly modern
+// glibc — see runtime.js's ensureRuntime doc, "glibc detection" section).
+// ---------------------------------------------------------------------------
+
+test("collectLddOutput: runs the injected execFileSyncImpl as `ldd --version`", () => {
+  let sawArgs = null;
+  const out = collectLddOutput((cmd, args, opts) => {
+    sawArgs = [cmd, args, opts];
+    return "ldd (GNU libc) 2.35\n";
+  });
+  assert.equal(out, "ldd (GNU libc) 2.35\n");
+  assert.equal(sawArgs[0], "ldd");
+  assert.deepEqual(sawArgs[1], ["--version"]);
+});
+
+test("ensureRuntime: undefined opts.lddOutput on a linux probe triggers self-collection, and the collected value picks the right asset", async () => {
+  await withScratch("ensure-ldd-collect", async (dir) => {
+    const buildDir = join(dir, "build");
+    mkdirSync(buildDir, { recursive: true });
+    const { bytes, sha256 } = makeRealTarball(buildDir);
+
+    const { srv, port } = await startFixtureServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/gzip" });
+      res.end(bytes);
+    });
+
+    // Only a cpu asset in this catalog block — accel:"cpu" below means
+    // resolveAsset never even attempts the (absent) vulkan key, so a
+    // successful resolve here proves the collected glibc satisfied the
+    // cpu asset's own min_glibc gate.
+    const runtimeBlock = {
+      release: "test-rel-ldd-collect",
+      assets: { "linux-x64-cpu": { file: "llama-runtime.tar.gz", sha256, min_glibc: "2.17" } },
+    };
+    const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+
+    let execCalls = 0;
+    let sawArgs = null;
+
+    try {
+      const binPath = await ensureRuntime(join(dir, "crow-home"), runtimeBlock, probe, {
+        // lddOutput deliberately OMITTED — must be self-collected.
+        baseUrl: `http://github.com:${port}`,
+        insecureHttpHosts: ["github.com"],
+        lookup: forceGithubLookup(port),
+        chmodFn: () => {},
+        execFileSyncImpl: (cmd, args) => {
+          execCalls++;
+          sawArgs = [cmd, args];
+          return "ldd (GNU libc) 2.35\n";
+        },
+      });
+      assert.ok(existsSync(binPath), "resolved and installed a real asset with no injected lddOutput");
+      assert.equal(execCalls, 1, "the ldd collector ran exactly once");
+      assert.deepEqual(sawArgs, ["ldd", ["--version"]]);
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+test("ensureRuntime: a failing ldd collection is an honest GLIBC_UNKNOWN error, never the GLIBC_TOO_OLD lie", async () => {
+  await withScratch("ensure-ldd-collect-fail", async (dir) => {
+    const runtimeBlock = makeRuntimeBlock();
+    const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+    await assert.rejects(
+      () => ensureRuntime(dir, runtimeBlock, probe, {
+        execFileSyncImpl: () => {
+          throw new Error("spawnSync ldd ENOENT");
+        },
+      }),
+      (err) => {
+        assert.ok(err instanceof RuntimeAssetError);
+        assert.equal(err.code, "GLIBC_UNKNOWN");
+        assert.notEqual(err.code, "GLIBC_TOO_OLD", "couldn't-ask must never be relabeled as asked-and-too-old");
+        assert.match(err.message, /ENOENT/);
+        return true;
+      },
+    );
+  });
+});
+
+test("ensureRuntime: an explicitly injected opts.lddOutput (even undefined-looking falsy values like null) wins outright — the collector never runs", async () => {
+  await withScratch("ensure-ldd-injected-wins", async (dir) => {
+    const buildDir = join(dir, "build");
+    mkdirSync(buildDir, { recursive: true });
+    const { bytes, sha256 } = makeRealTarball(buildDir);
+    const { srv, port } = await startFixtureServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/gzip" });
+      res.end(bytes);
+    });
+    const runtimeBlock = {
+      release: "test-rel-ldd-injected",
+      assets: { "linux-x64-cpu": { file: "llama-runtime.tar.gz", sha256, min_glibc: "2.17" } },
+    };
+    const probe = { platform: "linux", wsl2: false, accel: "cpu" };
+    let execCalls = 0;
+    try {
+      const binPath = await ensureRuntime(join(dir, "crow-home"), runtimeBlock, probe, {
+        lddOutput: "ldd (GNU libc) 2.35",
+        baseUrl: `http://github.com:${port}`,
+        insecureHttpHosts: ["github.com"],
+        lookup: forceGithubLookup(port),
+        chmodFn: () => {},
+        execFileSyncImpl: () => {
+          execCalls++;
+          return "ldd (GNU libc) 2.35";
+        },
+      });
+      assert.ok(existsSync(binPath));
+      assert.equal(execCalls, 0, "the collector must never run when lddOutput is explicitly injected");
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+
+    // A null lddOutput (resolveAsset's own "explicitly unknown" test case)
+    // is still NOT `undefined` — collection must not fire for it either.
+    let nullExecCalls = 0;
+    await assert.rejects(
+      () => ensureRuntime(dir, runtimeBlock, probe, {
+        lddOutput: null,
+        execFileSyncImpl: () => { nullExecCalls++; return "ldd (GNU libc) 2.35"; },
+      }),
+      (err) => {
+        assert.ok(err instanceof RuntimeAssetError);
+        assert.equal(err.code, "GLIBC_TOO_OLD", "null lddOutput still resolves via resolveAsset's own fail-closed path");
+        return true;
+      },
+    );
+    assert.equal(nullExecCalls, 0, "an explicit null must not trigger collection either");
   });
 });
 

--- a/tests/models-runtime.test.js
+++ b/tests/models-runtime.test.js
@@ -42,6 +42,7 @@ import {
   RuntimeAssetError,
   RuntimeChecksumError,
   RuntimeDownloadTimeoutError,
+  RuntimeHostNotAllowedError,
   resolveAsset,
   isAllowedRuntimeHost,
   buildRuntimeDownloadUrl,
@@ -818,9 +819,14 @@ test("resolveAsset: vulkan accel with sufficient glibc picks the vulkan asset", 
 // isAllowedRuntimeHost / buildRuntimeDownloadUrl
 // ---------------------------------------------------------------------------
 
-test("isAllowedRuntimeHost allows exactly github.com and objects.githubusercontent.com", () => {
+test("isAllowedRuntimeHost allows exactly github.com, objects.githubusercontent.com, and release-assets.githubusercontent.com", () => {
   assert.equal(isAllowedRuntimeHost("github.com"), true);
   assert.equal(isAllowedRuntimeHost("objects.githubusercontent.com"), true);
+  // Item G, PR G-F follow-up: GitHub's release-asset redirect target
+  // observed live as of 2026-07-19 (confirmed via `curl -sIL` against a
+  // real release URL) — objects.githubusercontent.com is kept alongside
+  // it since there's no signal it's fully retired.
+  assert.equal(isAllowedRuntimeHost("release-assets.githubusercontent.com"), true);
   assert.equal(isAllowedRuntimeHost("evilgithub.com"), false);
   assert.equal(isAllowedRuntimeHost("huggingface.co"), false);
   assert.equal(isAllowedRuntimeHost(""), false);
@@ -958,6 +964,81 @@ test("downloadRuntimeAsset rejects a stalled connection with RuntimeDownloadTime
         },
       );
       assert.equal(existsSync(dest), false, "no partial file — the stall was never past the connect/header phase");
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadRuntimeAsset — redirect-host allowlist (Item G, PR G-F follow-up:
+// GitHub's release-asset redirect target observed live as of 2026-07-19 is
+// release-assets.githubusercontent.com, not the previously-hardcoded
+// objects.githubusercontent.com — confirmed via `curl -sIL` against a real
+// release URL. Both hosts are now allowed; every hop is still re-checked
+// against the allowlist, so an attacker-controlled redirect to anything
+// else is still refused.)
+// ---------------------------------------------------------------------------
+
+test("downloadRuntimeAsset follows a real github.com -> release-assets.githubusercontent.com redirect chain", async () => {
+  await withScratch("dl-redirect-release-assets", async (dir) => {
+    const buildDir = join(dir, "build");
+    mkdirSync(buildDir, { recursive: true });
+    const { bytes, sha256 } = makeRealTarball(buildDir);
+
+    const { srv, port } = await startFixtureServer((req, res) => {
+      if (req.url.startsWith("/releases/download/")) {
+        // The first hop, as if it came from github.com — redirects to the
+        // OTHER allowed host. forceGithubLookup() resolves every hostname
+        // to 127.0.0.1, so this single fixture server plays both hops.
+        res.writeHead(302, { location: `http://release-assets.githubusercontent.com:${port}/blob/x?sig=abc` });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/gzip" });
+      res.end(bytes);
+    });
+
+    const dest = join(dir, "redirected-runtime.tar.gz");
+    try {
+      await downloadRuntimeAsset({
+        url: `http://github.com:${port}/releases/download/x/y.tar.gz`,
+        dest,
+        expectedSha: sha256,
+        lookup: forceGithubLookup(),
+        insecureHttpHosts: ["github.com", "release-assets.githubusercontent.com"],
+      });
+      assert.ok(readFileSync(dest).equals(bytes), "the redirected download landed the real payload, checksum-verified");
+    } finally {
+      await new Promise((r) => srv.close(r));
+    }
+  });
+});
+
+test("downloadRuntimeAsset still refuses a redirect to a host outside the runtime allowlist", async () => {
+  await withScratch("dl-redirect-refused", async (dir) => {
+    const { srv, port } = await startFixtureServer((req, res) => {
+      res.writeHead(302, { location: `http://evil-cdn.example.com:${port}/payload` });
+      res.end();
+    });
+
+    const dest = join(dir, "refused-runtime.tar.gz");
+    try {
+      await assert.rejects(
+        () => downloadRuntimeAsset({
+          url: `http://github.com:${port}/releases/download/x/y.tar.gz`,
+          dest,
+          expectedSha: null,
+          lookup: forceGithubLookup(),
+          insecureHttpHosts: ["github.com", "evil-cdn.example.com"],
+        }),
+        (err) => {
+          assert.ok(err instanceof RuntimeHostNotAllowedError);
+          assert.equal(err.hostname, "evil-cdn.example.com");
+          return true;
+        },
+      );
+      assert.equal(existsSync(dest), false, "an unallowed redirect target never gets a partial file written");
     } finally {
       await new Promise((r) => srv.close(r));
     }


### PR DESCRIPTION
Hotfix wave from Item G's real-model acceptance smoke, which caught what no unit test could: **the native start path was unconditionally broken on every Linux host** — `resolveNativeBinPath`'s production call never supplied `ldd` output, so the glibc gate fail-closed to `GLIBC_TOO_OLD` regardless of the actual version (every unit test had injected the value; the integration seam never wired it).

**Five fixes (each live-reproduced before fixing, live-proven after):**
1. `ensureRuntime` self-collects `ldd --version` on linux when the caller omits it (injectable; `resolveAsset` stays pure). Collection failure → honest `GLIBC_UNKNOWN`, never the `GLIBC_TOO_OLD` lie.
2. `invalidateAndRefreshProvidersCache()` — `registerModel` now awaits the DB cache refresh, closing the window where a just-registered model was invisible (`NOT_NATIVE` 409) behind the models.json fallback. `loadProviders()` stays sync; no other caller affected.
3. `GET /api/models/catalog` awaits a one-shot `reprobe()` on a cold cache — API-only clients no longer see permanent `unknown` fit badges.
4. Start-route 502s now carry the underlying typed error as `cause:{code,message}` (opt-in `onError` observer; chat/llm-router callers verified untouched) — `GLIBC_TOO_OLD`-class reasons no longer hide in server logs behind a generic `START_FAILED`.
5. `release-assets.githubusercontent.com` added to the runtime-asset allowlist (GitHub moved its release redirect target; verified live) — `objects.githubusercontent.com` kept.

**Live proof on this host (fully unstubbed — real probe, real self-collected ldd, real network):** `ensureRuntime` resolves `linux-x64-vulkan`, downloads through GitHub's real 302 to the new host, verifies the pinned sha256, extracts, and executes the real `llama-server` (version 10068). The acceptance smoke re-runs end-to-end after this merges.

**Recorded follow-up:** `RuntimeExtractionError` embeds a CROW_HOME filesystem path in its message, now transported to the 502 `cause` — redact paths at the route boundary (pre-existing message, new transport; dashboard-session-gated audience).

**Suite:** 2434/2434 pass, 0 fail, 0 skip (new baseline; +11 over #237). No schema changes, no new deps.