### PR TITLE
feat(c1): engine + starter-content plumbing (C1 PR A)

### DIFF
--- a/registry/model-catalog.json
+++ b/registry/model-catalog.json
@@ -37,8 +37,9 @@
       "min_runtime_version": "b10068",
       "default_quant": "Q4_K_M",
       "first_run_default": true,
+      "chat_template_kwargs": { "enable_thinking": false },
       "tags": ["chat", "small", "cpu-capable"],
-      "notes": "Small class default. Runs on CPU alone (min_vram_mb: 0) on an 8 GB RAM machine; this is the first model Crow offers on a fresh install.",
+      "notes": "Small class default. Runs on CPU alone (min_vram_mb: 0) on an 8 GB RAM machine; this is the first model Crow offers on a fresh install. chat_template_kwargs suppresses Qwen3's <think> reasoning block: on a small model the thinking preamble is noisy filler that ruins the first-chat experience, and the llm-router's fast voice route already defaults to the same enable_thinking:false.",
       "quants": [
         {
           "file": "Qwen3-4B-Q4_K_M.gguf",

--- a/scripts/validate-model-catalog.js
+++ b/scripts/validate-model-catalog.js
@@ -24,6 +24,10 @@
  *     ungated with at least one quant carrying min_vram_mb:0 (CPU-capable) —
  *     first_run_default is the model Crow offers as the default first
  *     install on a machine with no GPU.
+ *   - chat_template_kwargs, when present, must be a plain object (arrays,
+ *     strings, and null are rejected) — it is threaded verbatim into
+ *     llama-server's --jinja request body and into the openai adapter's
+ *     chat_template_kwargs pass-through (C1 Task 1).
  */
 
 import { readFileSync } from "node:fs";
@@ -114,6 +118,15 @@ export function validateCatalog(catalog) {
 
     if (model.first_run_default === true) {
       firstRunDefaults.push(model);
+    }
+
+    if (model.chat_template_kwargs !== undefined) {
+      const isPlainObject = model.chat_template_kwargs !== null
+        && typeof model.chat_template_kwargs === "object"
+        && !Array.isArray(model.chat_template_kwargs);
+      if (!isPlainObject) {
+        errors.push(`${label}: chat_template_kwargs must be a plain object when present, got ${JSON.stringify(model.chat_template_kwargs)}`);
+      }
     }
 
     if (!Number.isNaN(releaseBuild) && model.min_runtime_version != null) {

--- a/servers/gateway/ai/resolve-profile.js
+++ b/servers/gateway/ai/resolve-profile.js
@@ -11,7 +11,43 @@
  * is kept as a thin backwards-compat wrapper during the phased rollout.
  */
 
+import { readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { loadProviders as loadCachedProviders } from "../../shared/providers.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const MODEL_CATALOG_PATH = resolve(dirname(__filename), "..", "..", "..", "registry", "model-catalog.json");
+
+// mtime-checked cache — mirrors gpu-orchestrator.js's `defaultLoadCatalog`
+// (same rationale: this can run on every chat turn once a native model's
+// provider row predates chat_template_kwargs, so a bare readFileSync +
+// JSON.parse per call is wasted work for a file that only changes on
+// deploy).
+let _catalogCache = null;
+let _catalogCacheMtimeMs = null;
+
+/** Healing fallback (C1 Task 1): look up a model's catalog entry by id, for
+ * provider rows registered before this change carried `chatTemplateKwargs`
+ * in their `models[]` JSON. Never throws — an unreadable/missing catalog
+ * degrades to `null`, same as "no fallback available". */
+function catalogModelEntry(id) {
+  let mtimeMs;
+  try {
+    mtimeMs = statSync(MODEL_CATALOG_PATH).mtimeMs;
+  } catch {
+    return null;
+  }
+  try {
+    if (!_catalogCache || mtimeMs !== _catalogCacheMtimeMs) {
+      _catalogCache = JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+      _catalogCacheMtimeMs = mtimeMs;
+    }
+  } catch {
+    return null;
+  }
+  return (_catalogCache?.models || []).find((m) => m.id === id) || null;
+}
 
 function firstModelId(models) {
   if (!Array.isArray(models)) return null;
@@ -42,6 +78,25 @@ async function resolveFromDb(db, providerId, modelId) {
     pickedModel = modelId;
   }
 
+  const pickedEntry = models.find((m) => typeof m === "object" && m.id === pickedModel);
+  let chatTemplateKwargs =
+    pickedEntry && pickedEntry.chatTemplateKwargs && typeof pickedEntry.chatTemplateKwargs === "object"
+      ? pickedEntry.chatTemplateKwargs
+      : undefined;
+  if (!chatTemplateKwargs) {
+    // Healing fallback: rows registered before the catalog carried the
+    // field. Only for native-runtime rows (provider id IS the catalog
+    // model id) — see catalogModelEntry's doc.
+    let policy = null;
+    try { policy = typeof r.gpu_policy === "string" ? JSON.parse(r.gpu_policy) : r.gpu_policy; } catch {}
+    if (policy && policy.runtime === "native") {
+      const cat = catalogModelEntry(providerId);
+      if (cat && cat.chat_template_kwargs && typeof cat.chat_template_kwargs === "object") {
+        chatTemplateKwargs = cat.chat_template_kwargs;
+      }
+    }
+  }
+
   return {
     baseUrl: r.base_url,
     apiKey: r.api_key || "none",
@@ -49,6 +104,7 @@ async function resolveFromDb(db, providerId, modelId) {
     provider_id: providerId,
     provider_type: r.provider_type || null,
     host: r.host || "local",
+    chatTemplateKwargs,
   };
 }
 

--- a/servers/gateway/dashboard/panels/onboarding/starter-content.js
+++ b/servers/gateway/dashboard/panels/onboarding/starter-content.js
@@ -13,9 +13,13 @@
  * (servers/memory/server.js:176-214); `crow_regenerate_embeddings`
  * backfills vector search later once a provider exists.
  *
- * Task 3 extends this module with the starter agent + conversation: keep
- * exports limited to STARTER_SOURCE, seedStarterMemories, and
- * clearStarterMemories.
+ * Task 3 extends this module with the starter agent + conversation
+ * (createStarterArtifacts): a `crow-starter` pi_bot_defs row built from the
+ * "personal-assistant" Bot Builder template, plus a matching
+ * chat_conversations row pre-populated with the same persona/system_prompt
+ * so the first-run chat and the pi bot behave identically. Both point at
+ * whatever provider/model resolveStarterProvider() picks — see its doc
+ * comment for the selection order.
  *
  * Sync: starter rows are per-install by construction and must never ride to
  * paired instances — servers/sharing/instance-sync.js's shouldSyncRow
@@ -28,7 +32,26 @@
  * than pay the emit cost for zero effect.
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
+import { getTemplate, applyTemplate } from "../bot-builder/templates.js";
+import { defaultDefinition } from "../bot-builder/data-queries.js";
+import { readSetting, upsertSetting } from "../../settings/registry.js";
+import { t } from "../../shared/i18n.js";
+
+const __filename = fileURLToPath(import.meta.url);
+// onboarding/starter-content.js -> panels -> dashboard -> gateway -> servers
+// -> repo root -> registry/model-catalog.json
+const MODEL_CATALOG_PATH = resolvePath(
+  dirname(__filename),
+  "..", "..", "..", "..", "..",
+  "registry", "model-catalog.json"
+);
+
 export const STARTER_SOURCE = "starter";
+export const STARTER_BOT_ID = "crow-starter";
+const STARTER_CONVERSATION_SETTING_KEY = "starter_conversation_id";
 
 const STARTER_MEMORIES = {
   en: [
@@ -162,4 +185,162 @@ export async function clearStarterMemories(db, { syncManager } = {}) {
     args: [STARTER_SOURCE],
   });
   return { deleted: Number(result.rowsAffected || 0) };
+}
+
+/**
+ * Pick the provider/model pair the starter agent + conversation should use.
+ *
+ * Order:
+ *   1. The catalog's `first_run_default` model id, IF a non-disabled
+ *      `providers` row with that exact id exists. Native model registration
+ *      (servers/gateway/models/manager.js registerModel) always registers a
+ *      provider whose id IS the catalog model id, so this row existing is
+ *      the marker that the recommended first-run model is actually running
+ *      locally — providerId and modelId are both that catalog id.
+ *   2. Else the newest enabled provider that has at least one model
+ *      (`ORDER BY rowid DESC` — rowid tracks insertion order even though
+ *      `id` is a TEXT primary key). modelId is the first entry of its
+ *      `models` JSON. Providers with an empty `models` array (e.g. a
+ *      no_auto_provider placeholder row) are unusable for chat and skipped.
+ *   3. Else null — no provider is usable yet (e.g. a totally fresh install
+ *      before any model has been registered).
+ *
+ * @param {{execute: (arg: {sql: string, args: any[]}) => Promise<any>}} db
+ * @returns {Promise<{providerId: string, modelId: string} | null>}
+ */
+export async function resolveStarterProvider(db) {
+  let firstRunDefaultId = null;
+  try {
+    const catalog = JSON.parse(readFileSync(MODEL_CATALOG_PATH, "utf8"));
+    const model = (catalog.models || []).find((m) => m.first_run_default === true);
+    firstRunDefaultId = model ? model.id : null;
+  } catch {
+    // Catalog missing/unreadable — fall through to the provider scan.
+  }
+
+  if (firstRunDefaultId) {
+    const { rows } = await db.execute({
+      sql: "SELECT id FROM providers WHERE id = ? AND disabled = 0",
+      args: [firstRunDefaultId],
+    });
+    if (rows.length) {
+      return { providerId: firstRunDefaultId, modelId: firstRunDefaultId };
+    }
+  }
+
+  const { rows } = await db.execute({
+    sql: "SELECT id, models FROM providers WHERE disabled = 0 ORDER BY rowid DESC",
+    args: [],
+  });
+  for (const row of rows) {
+    let models;
+    try {
+      models = JSON.parse(row.models || "[]");
+    } catch {
+      models = [];
+    }
+    if (Array.isArray(models) && models.length && models[0] && models[0].id) {
+      return { providerId: row.id, modelId: models[0].id };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build the shared persona/system_prompt text used by BOTH the starter bot
+ * def and the starter conversation (single source, per Task 3 spec) — the
+ * "personal-assistant" template's prompt plus a short memory-first addendum.
+ * Small models narrate tool use instead of emitting it
+ * (servers/gateway/routes/llm-router.js:48-53), so the addendum explicitly
+ * instructs the tool call rather than just describing memory as a capability.
+ *
+ * @param {object} tpl - a BOT_TEMPLATES entry (from getTemplate)
+ * @returns {string}
+ */
+function buildStarterPersona(tpl) {
+  return (
+    `${tpl.system_prompt} When the user asks what you remember or asks you ` +
+    `to remember something, you MUST call the crow_memory tool — never ` +
+    `describe the call, make it. Starter memories about Crow exist; recall ` +
+    `answers from them.`
+  );
+}
+
+/**
+ * Create the starter agent (`crow-starter` pi_bot_defs row) and its matching
+ * starter conversation (chat_conversations row), idempotently.
+ *
+ * Idempotency: the `dashboard_settings` key `starter_conversation_id` is the
+ * source of truth for "did this already run" — a title-based lookup is
+ * fragile across language switches/renames. On entry, if that setting is
+ * set AND the referenced conversation row still exists, the existing ids are
+ * returned as-is (no re-resolution of provider/model, no new rows) even if
+ * resolveStarterProvider() would now pick something different. The bot def
+ * itself is separately idempotent on `bot_id = 'crow-starter'` (SELECT
+ * before INSERT) so a second call after a wiped `dashboard_settings` row
+ * still can't create a duplicate bot.
+ *
+ * @param {{execute: (arg: {sql: string, args: any[]}) => Promise<any>}} db
+ * @param {{lang?: string}} [opts] - "en" | "es" (falls back to "en")
+ * @returns {Promise<
+ *   {conversationId: number, botId: string, providerId: string, modelId: string}
+ *   | {error: "no_provider"}
+ * >}
+ */
+export async function createStarterArtifacts(db, { lang } = {}) {
+  const existingConvIdRaw = await readSetting(db, STARTER_CONVERSATION_SETTING_KEY);
+  if (existingConvIdRaw) {
+    const existingConvId = Number(existingConvIdRaw);
+    const { rows } = await db.execute({
+      sql: "SELECT id, provider, model FROM chat_conversations WHERE id = ?",
+      args: [existingConvId],
+    });
+    if (rows.length) {
+      return {
+        conversationId: existingConvId,
+        botId: STARTER_BOT_ID,
+        providerId: rows[0].provider,
+        modelId: rows[0].model,
+      };
+    }
+    // Setting points at a row that no longer exists (e.g. deleted by the
+    // operator) — fall through and recreate.
+  }
+
+  const resolved = await resolveStarterProvider(db);
+  if (!resolved) return { error: "no_provider" };
+  const { providerId, modelId } = resolved;
+
+  const tpl = getTemplate("personal-assistant");
+  const def = defaultDefinition(STARTER_BOT_ID, null, `${providerId}/${modelId}`);
+  applyTemplate(def, tpl, {
+    availableMcp: new Set(tpl.tools.crow_mcp),
+    availableSkills: new Set(tpl.skills),
+  });
+  const persona = buildStarterPersona(tpl);
+  def.system_prompt = persona;
+
+  const existingBot = await db.execute({
+    sql: "SELECT bot_id FROM pi_bot_defs WHERE bot_id = ?",
+    args: [STARTER_BOT_ID],
+  });
+  if (!existingBot.rows.length) {
+    const displayName = t("starter.botName", lang);
+    await db.execute({
+      sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition, project_id, enabled) VALUES (?,?,?,NULL,1)",
+      args: [STARTER_BOT_ID, displayName, JSON.stringify(def)],
+    });
+  }
+
+  const title = t("starter.convTitle", lang);
+  const convResult = await db.execute({
+    sql: "INSERT INTO chat_conversations (title, provider, model, system_prompt) VALUES (?,?,?,?)",
+    args: [title, providerId, modelId, persona],
+  });
+  const conversationId = Number(convResult.lastInsertRowid);
+
+  await upsertSetting(db, STARTER_CONVERSATION_SETTING_KEY, String(conversationId));
+
+  return { conversationId, botId: STARTER_BOT_ID, providerId, modelId };
 }

--- a/servers/gateway/dashboard/panels/onboarding/starter-content.js
+++ b/servers/gateway/dashboard/panels/onboarding/starter-content.js
@@ -1,0 +1,165 @@
+/**
+ * Onboarding starter content (C1/C3).
+ *
+ * Seeds a handful of `source='starter'` rows into `memories` during the
+ * first-run wizard so a brand-new install isn't a completely empty Memory
+ * panel — genuinely useful, recallable facts about Crow itself, written in
+ * Crow's first-person-neutral voice.
+ *
+ * Writes go straight through SQL rather than the memory MCP server:
+ * this module runs inside the gateway process at wizard time, before any
+ * MCP round-trip is available and before any embedding provider is
+ * configured. That's fine — FTS works with zero embedding providers
+ * (servers/memory/server.js:176-214); `crow_regenerate_embeddings`
+ * backfills vector search later once a provider exists.
+ *
+ * Task 3 extends this module with the starter agent + conversation: keep
+ * exports limited to STARTER_SOURCE, seedStarterMemories, and
+ * clearStarterMemories.
+ *
+ * Sync: starter rows are per-install by construction and must never ride to
+ * paired instances — servers/sharing/instance-sync.js's shouldSyncRow
+ * excludes any `memories` row with source='starter' (same convention as
+ * providers' gpu_policy.local_only), which is the single choke point for
+ * both emit and apply. Because of that, clearStarterMemories does NOT emit
+ * per-row delete sync events even when a syncManager is supplied: no peer
+ * ever received these rows (they never synced in), so a delete-apply would
+ * be a guaranteed no-op — simpler and safer to just skip it entirely rather
+ * than pay the emit cost for zero effect.
+ */
+
+export const STARTER_SOURCE = "starter";
+
+const STARTER_MEMORIES = {
+  en: [
+    {
+      content:
+        "Crow is your private AI that remembers. Anything you tell it to remember is stored here on your own machine — nothing leaves unless you pair or share it.",
+      category: "general",
+      context: null,
+      tags: "crow,starter,about",
+      importance: 5,
+    },
+    {
+      content:
+        "To save something, just say 'remember that …' in chat. To find it later, ask 'what do you remember about …'.",
+      category: "process",
+      context: null,
+      tags: "memory,starter,how-to",
+      importance: 5,
+    },
+    {
+      content:
+        "The dashboard sidebar has Memory (browse everything saved), Messages (chat), Bot Builder (create agents), and Extensions (add abilities like blogs, research, and file storage).",
+      category: "general",
+      context: null,
+      tags: "dashboard,starter,where",
+      importance: 5,
+    },
+    {
+      content:
+        "Your AI model runs locally. You can download bigger models or switch models in the Model Catalog panel; cloud providers can be added in Settings under AI.",
+      category: "process",
+      context: null,
+      tags: "models,starter",
+      importance: 5,
+    },
+    {
+      content:
+        "These starter memories are examples seeded during setup. You can delete them all at once in Settings, Help and Setup.",
+      category: "general",
+      context: null,
+      tags: "starter,cleanup",
+      importance: 5,
+    },
+  ],
+  es: [
+    {
+      content:
+        "Crow es tu IA privada que recuerda. Todo lo que le pidas recordar se guarda aquí, en tu propio equipo — nada sale de aquí a menos que lo emparejes o lo compartas.",
+      category: "general",
+      context: null,
+      tags: "crow,starter,about",
+      importance: 5,
+    },
+    {
+      content:
+        "Para guardar algo, solo di 'recuerda que …' en el chat. Para encontrarlo después, pregunta '¿qué recuerdas sobre …?'.",
+      category: "process",
+      context: null,
+      tags: "memory,starter,how-to",
+      importance: 5,
+    },
+    {
+      content:
+        "La barra lateral del panel tiene Memoria (explora todo lo guardado), Mensajes (chat), Bot Builder (crea agentes) y Extensiones (añade funciones como blogs, investigación y almacenamiento de archivos).",
+      category: "general",
+      context: null,
+      tags: "dashboard,starter,where",
+      importance: 5,
+    },
+    {
+      content:
+        "Tu modelo de IA se ejecuta localmente. Puedes descargar modelos más grandes o cambiar de modelo en el panel de Catálogo de Modelos; los proveedores en la nube se pueden añadir en Configuración, en AI.",
+      category: "process",
+      context: null,
+      tags: "models,starter",
+      importance: 5,
+    },
+    {
+      content:
+        "Estas memorias iniciales son ejemplos creados durante la configuración. Puedes eliminarlas todas a la vez en Configuración, en Ayuda y configuración inicial.",
+      category: "general",
+      context: null,
+      tags: "starter,cleanup",
+      importance: 5,
+    },
+  ],
+};
+
+/**
+ * Seed the starter memories for the given language into `memories`.
+ * Idempotent: if any `source='starter'` row already exists, this is a
+ * no-op (handles both re-running the wizard and a second gateway racing
+ * the same first-run path).
+ *
+ * @param {{execute: (arg: {sql: string, args: any[]}) => Promise<any>}} db
+ * @param {string} lang - "en" | "es" (falls back to "en" if unknown)
+ * @returns {Promise<{inserted: number, skipped: boolean}>}
+ */
+export async function seedStarterMemories(db, lang) {
+  const existing = await db.execute({
+    sql: "SELECT COUNT(*) n FROM memories WHERE source = ?",
+    args: [STARTER_SOURCE],
+  });
+  if (Number(existing.rows[0].n) > 0) {
+    return { inserted: 0, skipped: true };
+  }
+
+  const rows = STARTER_MEMORIES[lang] || STARTER_MEMORIES.en;
+  for (const row of rows) {
+    await db.execute({
+      sql: "INSERT INTO memories (content, category, context, tags, source, importance) VALUES (?,?,?,?, 'starter', ?)",
+      args: [row.content, row.category, row.context, row.tags, row.importance],
+    });
+  }
+  return { inserted: rows.length, skipped: false };
+}
+
+/**
+ * Delete all starter-seeded memories. Used by the Settings > Help and Setup
+ * "clear starter memories" action (Task 4).
+ *
+ * @param {{execute: (arg: {sql: string, args: any[]}) => Promise<any>}} db
+ * @param {{syncManager?: object}} [opts] - accepted for interface
+ *   stability with future callers; deliberately unused (see module
+ *   docblock — starter rows never sync, so there's nothing to emit).
+ * @returns {Promise<{deleted: number}>}
+ */
+export async function clearStarterMemories(db, { syncManager } = {}) {
+  const result = await db.execute({
+    sql: "DELETE FROM memories WHERE source = ?",
+    args: [STARTER_SOURCE],
+  });
+  return { deleted: Number(result.rowsAffected || 0) };
+}

--- a/servers/gateway/dashboard/panels/onboarding/starter-content.js
+++ b/servers/gateway/dashboard/panels/onboarding/starter-content.js
@@ -260,10 +260,10 @@ export async function resolveStarterProvider(db) {
  */
 function buildStarterPersona(tpl) {
   return (
-    `${tpl.system_prompt} When the user asks what you remember or asks you ` +
-    `to remember something, you MUST call the crow_memory tool — never ` +
-    `describe the call, make it. Starter memories about Crow exist; recall ` +
-    `answers from them.`
+    `${tpl.system_prompt} When the user asks what you remember, or asks you ` +
+    `to remember something, you MUST use your memory tools and actually make ` +
+    `the tool call — never describe or narrate it instead. Starter memories ` +
+    `about Crow exist; recall answers from them.`
   );
 }
 

--- a/servers/gateway/dashboard/settings/sections/help-setup.js
+++ b/servers/gateway/dashboard/settings/sections/help-setup.js
@@ -3,9 +3,10 @@
  */
 
 import { escapeHtml } from "../../shared/components.js";
-import { t } from "../../shared/i18n.js";
+import { t, fill } from "../../shared/i18n.js";
 import { getProxyStatus } from "../../../proxy.js";
 import { STEP_KEYS } from "../../panels/onboarding.js";
+import { STARTER_SOURCE, clearStarterMemories } from "../../panels/onboarding/starter-content.js";
 
 export default {
   id: "help-setup",
@@ -52,6 +53,32 @@ export default {
     };
     const ht = helpT[currentLang] || helpT.en;
 
+    const csrfToken = req?.csrfToken || "";
+    const { rows: starterCountRows } = await db.execute({
+      sql: "SELECT COUNT(*) n FROM memories WHERE source = ?",
+      args: [STARTER_SOURCE],
+    });
+    const starterCount = Number(starterCountRows[0]?.n || 0);
+    // Flash is a fixed status enum mapped to i18n — never free text from the
+    // URL (mirrors sync-conflicts.js's flash pattern).
+    const starterFlash = req?.query?.helpSetupMsg === "cleared"
+      ? `<div style="margin-bottom:0.75rem;padding:0.6rem 0.75rem;background:var(--crow-bg-deep);border-left:3px solid var(--crow-accent);border-radius:4px;font-size:0.85rem">
+           ${escapeHtml(t("helpSetup.starterCleared", currentLang))}
+         </div>`
+      : "";
+    const starterBody = starterCount > 0
+      ? `<p style="font-size:0.85rem;line-height:1.6;margin-bottom:0.75rem">${escapeHtml(fill(t("helpSetup.starterCount", currentLang), { n: starterCount }))}</p>
+         <form method="POST" action="/dashboard/settings" onsubmit="return confirm(${escapeHtml(JSON.stringify(t("helpSetup.starterClearConfirm", currentLang)))})">
+           <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}" />
+           <input type="hidden" name="action" value="help_setup_clear_starter" />
+           <button type="submit" class="btn btn-secondary" style="font-size:0.85rem">${escapeHtml(t("helpSetup.starterClear", currentLang))}</button>
+         </form>`
+      : `<p style="font-size:0.85rem;color:var(--crow-text-muted)">${escapeHtml(t("helpSetup.starterNone", currentLang))}</p>`;
+    const starterHtml = `
+      <h4 style="font-size:0.9rem;color:var(--crow-text-muted);margin:1.25rem 0 0.5rem">${escapeHtml(t("helpSetup.starterTitle", currentLang))}</h4>
+      ${starterFlash}
+      ${starterBody}`;
+
     const proxyStatus = getProxyStatus();
     const coreTools = 49;
     let externalToolCount = 0;
@@ -78,10 +105,19 @@ export default {
         <span style="font-size:0.8rem;color:var(--crow-text-muted)">${coreTools} ${ht.core} + ${externalToolCount} ${ht.external} &mdash; ~${(estimatedTokens / 1000).toFixed(1)}K ${ht.tokensOfContext}</span>
         ${!routerDisabled ? `<span style="font-size:0.75rem;background:color-mix(in srgb, var(--crow-success) 15%, transparent);color:var(--crow-success);padding:2px 8px;border-radius:4px">${ht.routerAvailable}</span>` : ""}
       </div>
-      <p style="color:var(--crow-text-muted);font-size:0.8rem;margin-top:0.5rem">${ht.contextDoc}</p>`;
+      <p style="color:var(--crow-text-muted);font-size:0.8rem;margin-top:0.5rem">${ht.contextDoc}</p>
+      ${starterHtml}`;
   },
 
-  async handleAction() {
+  async handleAction({ req, res, db, action }) {
+    if (!action || !action.startsWith("help_setup_")) return false;
+
+    if (action === "help_setup_clear_starter") {
+      await clearStarterMemories(db);
+      res.redirectAfterPost("/dashboard/settings?section=help-setup&helpSetupMsg=cleared");
+      return true;
+    }
+
     return false;
   },
 };

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1845,6 +1845,9 @@ export const translations = {
     en: "Something went wrong with that action. Refresh the page and try again.",
     es: "Algo salió mal con esa acción. Actualiza la página e inténtalo de nuevo.",
   },
+  // ─── Starter agent + conversation (C1/C3 Task 3) ───
+  "starter.botName": { en: "My Crow", es: "Mi Crow" },
+  "starter.convTitle": { en: "Chat with your Crow", es: "Chatea con tu Crow" },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1848,6 +1848,22 @@ export const translations = {
   // ─── Starter agent + conversation (C1/C3 Task 3) ───
   "starter.botName": { en: "My Crow", es: "Mi Crow" },
   "starter.convTitle": { en: "Chat with your Crow", es: "Chatea con tu Crow" },
+  // ─── Help & Setup: clear starter content (C1/C3 Task 4) ───
+  "helpSetup.starterTitle": { en: "Starter content", es: "Contenido inicial" },
+  "helpSetup.starterCount": {
+    en: "{n} starter memories from first-run setup. This only removes memories — the starter bot and its conversation are managed separately in Bot Builder and Messages.",
+    es: "{n} memorias iniciales de la configuración de primer uso. Esto solo elimina memorias: el bot inicial y su conversación se gestionan por separado en Bot Builder y Mensajes.",
+  },
+  "helpSetup.starterClear": { en: "Clear starter memories", es: "Borrar memorias iniciales" },
+  "helpSetup.starterClearConfirm": {
+    en: "Delete all starter memories? This only affects memories — the starter bot and its conversation stay put. This can't be undone.",
+    es: "¿Eliminar todas las memorias iniciales? Esto solo afecta a las memorias: el bot inicial y su conversación no se tocan. Esto no se puede deshacer.",
+  },
+  "helpSetup.starterCleared": { en: "Starter memories cleared.", es: "Memorias iniciales eliminadas." },
+  "helpSetup.starterNone": {
+    en: "No starter memories left to clear.",
+    es: "No quedan memorias iniciales por borrar.",
+  },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -657,6 +657,7 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
     readinessInitialDelayMs = READINESS_INITIAL_DELAY_MS,
     storageClass = "ssd",
     nativeReadinessTimeoutMsFn = nativeReadinessTimeoutMs,
+    loadCatalogFn = defaultLoadCatalog,
   } = opts;
 
   const alias = nativeAlias(p);
@@ -688,8 +689,19 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
     if (typeof onTerminal === "function") onTerminal(reason);
   };
 
+  // Scoped --jinja (C1 Task 1): chat_template_kwargs in request bodies is
+  // only honored under llama-server's jinja engine; scoped per-model — the
+  // other catalog models are not template-verified under --jinja.
+  let extraArgs = [];
+  try {
+    const entry = (loadCatalogFn()?.models || []).find((m) => m.id === providerName);
+    if (entry && entry.chat_template_kwargs && typeof entry.chat_template_kwargs === "object") {
+      extraArgs = ["--jinja"];
+    }
+  } catch { /* catalog unreadable → no extra args, model starts as before */ }
+
   console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port}, readinessTimeoutMs=${readinessTimeoutMs})`);
-  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal: wrappedOnTerminal });
+  const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal: wrappedOnTerminal, extraArgs });
   _nativeHandles.set(providerName, handle);
 
   const result = await waitForNativeReady(p.baseUrl, alias, {

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -1226,7 +1226,14 @@ export async function registerModel({
   // embedding servers don't contend for the chat mutex group.
 
   const baseUrl = `http://127.0.0.1:${port}/v1`;
-  const models = [{ id: model.id, task: model.task, contextLen: model.context_len }];
+  const models = [{
+    id: model.id,
+    task: model.task,
+    contextLen: model.context_len,
+    ...(model.chat_template_kwargs && typeof model.chat_template_kwargs === "object"
+      ? { chatTemplateKwargs: model.chat_template_kwargs }
+      : {}),
+  }];
   const description = `${model.family} ${quantEntry.quant} (native)`;
 
   const upserted = await upsertProviderFn(db, {

--- a/servers/gateway/routes/chat.js
+++ b/servers/gateway/routes/chat.js
@@ -81,6 +81,23 @@ export function providerNotReadyError(providerName, isNative, lang) {
   };
 }
 
+/**
+ * Build `adapter.chatStream()`'s per-call options (C1 Task 1). Pure —
+ * regression seam for the thinking-suppression chain. `cfg` is a
+ * `resolveProviderConfig()` result (or null); its optional
+ * `chatTemplateKwargs` is threaded through ONLY when present, so cloud
+ * adapters and adapters ignorant of the option see no new field. (The
+ * openai adapter reads `options.chatTemplateKwargs` per call — verified
+ * ai/adapters/openai.js:142-148; other adapters ignore unknown options.)
+ */
+export function chatStreamOptionsFor(cfg, signal) {
+  const opts = { signal };
+  if (cfg && cfg.chatTemplateKwargs && typeof cfg.chatTemplateKwargs === "object") {
+    opts.chatTemplateKwargs = cfg.chatTemplateKwargs;
+  }
+  return opts;
+}
+
 export default function chatRouter(dashboardAuth) {
   const router = Router();
 
@@ -572,7 +589,13 @@ export default function chatRouter(dashboardAuth) {
       }
 
       // Get provider adapter (profile-aware; per-message overrides honored)
+      // `resolvedProviderCfg` (C1 Task 1) carries the resolveProviderConfig
+      // result purely so its optional `chatTemplateKwargs` can reach the
+      // chatStream call below — hoisted above the branches because the
+      // `cfg` locals inside them are branch-scoped `const`s, out of scope
+      // at the call site.
       let adapter;
+      let resolvedProviderCfg = null;
       try {
         const providerDiffers = effectiveProvider && effectiveProvider !== conversation.provider;
         if (providerDiffers) {
@@ -581,6 +604,7 @@ export default function chatRouter(dashboardAuth) {
           // (accepts provider_id or provider_type), fall back to
           // models.json if no DB row matches.
           const cfg = await resolveProviderConfig(db, effectiveProvider, effectiveModel).catch(() => null);
+          resolvedProviderCfg = cfg;
           if (cfg) {
             const { createAdapterFromProfile: fromProfile } = await import("../ai/provider.js");
             // DB rows for bundle-registered local providers (crow-swap-*,
@@ -613,11 +637,19 @@ export default function chatRouter(dashboardAuth) {
             // mode profiles ignore the db arg and use embedded fields.
             const result = await createAdapterFromProfile(profile, effectiveModel, db);
             adapter = result.adapter;
+            // createAdapterFromProfile never calls resolveProviderConfig
+            // itself — fetch it separately, purely to obtain
+            // chatTemplateKwargs (C1 Task 1, deviation 6: inline-config
+            // profiles with no provider_id stay unsuppressed).
+            if (profile.provider_id) {
+              resolvedProviderCfg = await resolveProviderConfig(db, profile.provider_id, profile.model_id).catch(() => null);
+            }
           }
         } else {
           // No profile: try DB-first resolver on the conversation's
           // provider/model (Quick Chat). Fall back to env on miss.
           const cfg = await resolveProviderConfig(db, effectiveProvider, effectiveModel).catch(() => null);
+          resolvedProviderCfg = cfg;
           if (cfg) {
             const { createAdapterFromProfile: fromProfile } = await import("../ai/provider.js");
             // DB rows for bundle-registered local providers (crow-swap-*,
@@ -747,9 +779,7 @@ export default function chatRouter(dashboardAuth) {
         let roundOutputTokens = 0;
 
         try {
-          for await (const event of adapter.chatStream(aiMessages, tools, {
-            signal: abortController.signal,
-          })) {
+          for await (const event of adapter.chatStream(aiMessages, tools, chatStreamOptionsFor(resolvedProviderCfg, abortController.signal))) {
             if (abortController.signal.aborted) break;
 
             switch (event.type) {

--- a/servers/memory/server.js
+++ b/servers/memory/server.js
@@ -597,7 +597,7 @@ export function createMemoryServer(dbPath, options = {}) {
 
       // Emit sync entry
       if (syncManager) {
-        const updated = { id, content, category, tags, importance, context };
+        const updated = { id, content, category, tags, importance, context, source: rows[0].source ?? null };
         // Remove undefined fields
         for (const k of Object.keys(updated)) { if (updated[k] === undefined) delete updated[k]; }
         syncManager.emitChange("memories", "update", updated).catch(() => {});
@@ -687,7 +687,7 @@ export function createMemoryServer(dbPath, options = {}) {
 
       // Emit sync entry
       if (syncManager) {
-        syncManager.emitChange("memories", "delete", { id }).catch(() => {});
+        syncManager.emitChange("memories", "delete", { id, source: memory.source ?? null }).catch(() => {});
       }
 
       return { content: [{ type: "text", text: `Memory #${id} deleted.` }] };

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -279,6 +279,12 @@ function shouldSyncRow(table, row) {
     if (host === "localhost" || host === "::1" || /^127\./.test(host)) return false;
     return true;
   }
+  if (table === "memories") {
+    // Starter/demo content seeded by onboarding (C1) is per-install: it must
+    // never ride to paired instances (same convention as providers
+    // gpu_policy.local_only above — one gate covers emit AND apply).
+    if (row && row.source === "starter") return false;
+  }
   if (table !== "dashboard_settings") return true;
   if (!row || !row.key) return false;
   // dashboard_settings holds only the global scope; per-instance overrides live

--- a/tests/chat-template-kwargs.test.js
+++ b/tests/chat-template-kwargs.test.js
@@ -193,6 +193,31 @@ test("resolveProviderConfig heals a pre-Task-1 native row (no chatTemplateKwargs
   assert.deepEqual(cfg.chatTemplateKwargs, { enable_thinking: false });
 });
 
+test("healing fallback does NOT apply to non-native gpu_policy rows (docker runtime at a catalog-colliding id)", async () => {
+  // Regression guard: a provider at catalog-colliding id (qwen3-4b) with a
+  // truthy gpuPolicy but non-native runtime (docker) must NOT fall back to
+  // the catalog entry's chat_template_kwargs. The healing fallback is
+  // native-only — docker/cloud runtime providers are admin-managed and should
+  // be treated as "already configured" even if the models[] entry lacks the
+  // field.
+  //
+  // Note: we upsert AFTER the native healing-fallback test, so this replaces
+  // the native provider row at id "qwen3-4b" with a docker one.
+  await upsertProvider(db, {
+    id: "qwen3-4b",
+    baseUrl: "http://127.0.0.1:9413/v1",
+    host: "local",
+    bundleId: null,
+    description: "test",
+    models: [{ id: "qwen3-4b" }],
+    disabled: false,
+    providerType: null,
+    gpuPolicy: { runtime: "docker", imageName: "some-image" },
+  });
+  const cfg = await resolveProviderConfig(db, "qwen3-4b", "qwen3-4b");
+  assert.equal(cfg.chatTemplateKwargs, undefined);
+});
+
 // --- chatStreamOptionsFor: pure helper -------------------------------------
 
 test("chatStreamOptionsFor threads chatTemplateKwargs when present", () => {

--- a/tests/chat-template-kwargs.test.js
+++ b/tests/chat-template-kwargs.test.js
@@ -1,0 +1,216 @@
+/**
+ * Thinking-suppression chain (C1 Task 1): catalog `chat_template_kwargs` ->
+ * scoped `--jinja` on native start -> provider row `chatTemplateKwargs` ->
+ * resolve-profile healing fallback -> chat.js's `chatStreamOptionsFor` pure
+ * helper -> the openai adapter's `chat_template_kwargs` pass-through
+ * (verified separately at ai/adapters/openai.js:142-148).
+ *
+ * This file drives the REAL mechanisms, not mocks of them:
+ *   - the real catalog JSON (registry/model-catalog.json) for the
+ *     first_run_default assertion and the resolve-profile healing fallback
+ *     (qwen3-4b's real entry, patched by this task, is the fixture);
+ *   - `acquireProvider` (the real native-start path in gpu-orchestrator.js,
+ *     mirroring tests/gpu-orchestrator-native.test.js's injection style) for
+ *     the scoped --jinja assertion;
+ *   - a real sqlite DB (scripts/init-db.js schema) + the real
+ *     `upsertProvider` writer for the resolve-profile tests, mirroring
+ *     tests/providers-sync-wire.test.js / tests/providers-backfill.test.js.
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { upsertProvider } from "../servers/shared/providers-db.js";
+import { resolveProviderConfig } from "../servers/gateway/ai/resolve-profile.js";
+import { acquireProvider, _setNativeHandleForTest } from "../servers/gateway/gpu-orchestrator.js";
+import { chatStreamOptionsFor } from "../servers/gateway/routes/chat.js";
+import { _resetProviderHealth } from "../servers/gateway/provider-health.js";
+
+// --- catalog: first_run_default carries the suppression default ---------
+
+test("catalog first_run_default carries enable_thinking:false", async () => {
+  const catalog = JSON.parse(await readFile(new URL("../registry/model-catalog.json", import.meta.url), "utf8"));
+  const def = catalog.models.find((m) => m.first_run_default);
+  assert.ok(def, "a first_run_default model must exist");
+  assert.deepEqual(def.chat_template_kwargs, { enable_thinking: false });
+});
+
+// --- scoped --jinja on the real native-start path ------------------------
+
+/** A native provider row shaped like manager.js's registerModel output,
+ * mirroring tests/gpu-orchestrator-native.test.js's `nativeProv`. */
+function nativeProv(port, alias, extra = {}) {
+  const { gpuPolicy, ...rest } = extra;
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    host: "local",
+    bundleId: null,
+    models: [{ id: alias, task: "chat" }],
+    gpuPolicy: { runtime: "native", ...gpuPolicy },
+    ...rest,
+  };
+}
+
+function fakeHandle() {
+  return {
+    live: true,
+    async stop() { this.live = false; },
+    status() { return { live: this.live }; },
+  };
+}
+
+function baseNativeOpts({ cfg, identityProbeFn, loadCatalogFn, startCalls }) {
+  return {
+    cfg,
+    identityProbeFn,
+    acquireHostLockFn: () => () => {},
+    startModelFn: (params) => {
+      startCalls.push(params);
+      return fakeHandle();
+    },
+    ensureRuntimeFn: async () => "/fake/runtimes/llamacpp/b1/llama-server",
+    loadStateFn: () => ({ registry: { "qwen3-4b": { file: "model.gguf" } } }),
+    resolveDataDirFn: () => "/fake/crow-home",
+    loadCatalogFn,
+    getCachedProbeFn: () => ({ platform: "linux", accel: "cpu" }),
+    readinessTimeoutMs: 200,
+    readinessPollMs: 5,
+    readinessInitialDelayMs: 0,
+  };
+}
+
+test("native start threads --jinja when the catalog entry carries chat_template_kwargs", async () => {
+  _resetProviderHealth();
+  _setNativeHandleForTest("qwen3-4b", null);
+  const cfg = { providers: { "qwen3-4b": nativeProv(9401, "qwen3-4b") } };
+  // First call is the pre-start fast-path check (must miss so a start is
+  // actually attempted); subsequent calls are the post-start readiness
+  // poll (mirrors tests/gpu-orchestrator-native.test.js's pattern).
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return probeCalls === 1 ? "down" : "resident";
+  };
+  const startCalls = [];
+  const loadCatalogFn = () => ({
+    runtime: { release: "b1", assets: {} },
+    models: [{ id: "qwen3-4b", chat_template_kwargs: { enable_thinking: false } }],
+  });
+  const ok = await acquireProvider("qwen3-4b", baseNativeOpts({ cfg, identityProbeFn, loadCatalogFn, startCalls }));
+  assert.equal(ok, true);
+  assert.equal(startCalls.length, 1);
+  assert.ok(Array.isArray(startCalls[0].extraArgs) && startCalls[0].extraArgs.includes("--jinja"),
+    `expected extraArgs to include --jinja, got ${JSON.stringify(startCalls[0].extraArgs)}`);
+});
+
+test("native start omits --jinja when the catalog entry has no chat_template_kwargs", async () => {
+  _resetProviderHealth();
+  _setNativeHandleForTest("qwen3-4b", null);
+  const cfg = { providers: { "qwen3-4b": nativeProv(9402, "qwen3-4b") } };
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return probeCalls === 1 ? "down" : "resident";
+  };
+  const startCalls = [];
+  const loadCatalogFn = () => ({
+    runtime: { release: "b1", assets: {} },
+    models: [{ id: "qwen3-4b" }],
+  });
+  const ok = await acquireProvider("qwen3-4b", baseNativeOpts({ cfg, identityProbeFn, loadCatalogFn, startCalls }));
+  assert.equal(ok, true);
+  assert.equal(startCalls.length, 1);
+  assert.ok(!startCalls[0].extraArgs || startCalls[0].extraArgs.length === 0,
+    `expected extraArgs to be absent/empty, got ${JSON.stringify(startCalls[0].extraArgs)}`);
+});
+
+// --- resolve-profile: provider-row patterns -------------------------------
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-chat-template-kwargs-test-"));
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir },
+  stdio: "pipe",
+  cwd: join(import.meta.dirname, ".."),
+});
+const db = createDbClient(join(tmpDir, "crow.db"));
+
+after(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("resolveProviderConfig returns chatTemplateKwargs from a provider row that carries it", async () => {
+  await upsertProvider(db, {
+    id: "kwargs-row-a",
+    baseUrl: "http://127.0.0.1:9410/v1",
+    host: "local",
+    bundleId: null,
+    description: "test",
+    models: [{ id: "qwen3-4b", task: "chat", contextLen: 8192, chatTemplateKwargs: { enable_thinking: false } }],
+    disabled: false,
+    providerType: null,
+  });
+  const cfg = await resolveProviderConfig(db, "kwargs-row-a", "qwen3-4b");
+  assert.deepEqual(cfg.chatTemplateKwargs, { enable_thinking: false });
+});
+
+test("resolveProviderConfig returns undefined chatTemplateKwargs for a row without it and no native gpu_policy", async () => {
+  await upsertProvider(db, {
+    id: "kwargs-row-b",
+    baseUrl: "http://127.0.0.1:9411/v1",
+    host: "local",
+    bundleId: null,
+    description: "test",
+    models: [{ id: "some-model", task: "chat", contextLen: 8192 }],
+    disabled: false,
+    providerType: null,
+  });
+  const cfg = await resolveProviderConfig(db, "kwargs-row-b", "some-model");
+  assert.equal(cfg.chatTemplateKwargs, undefined);
+});
+
+test("resolveProviderConfig heals a pre-Task-1 native row (no chatTemplateKwargs) from the catalog", async () => {
+  // Pre-Task-1 registration shape: models[] entry has no chatTemplateKwargs
+  // field at all, but gpu_policy.runtime is "native" and the provider id IS
+  // the catalog model id (qwen3-4b) — exactly crow prod's shape before this
+  // change shipped.
+  await upsertProvider(db, {
+    id: "qwen3-4b",
+    baseUrl: "http://127.0.0.1:9412/v1",
+    host: "local",
+    bundleId: null,
+    description: "test",
+    models: [{ id: "qwen3-4b" }],
+    disabled: false,
+    providerType: null,
+    gpuPolicy: { runtime: "native", mutexGroup: "local-llm" },
+  });
+  const cfg = await resolveProviderConfig(db, "qwen3-4b", "qwen3-4b");
+  assert.deepEqual(cfg.chatTemplateKwargs, { enable_thinking: false });
+});
+
+// --- chatStreamOptionsFor: pure helper -------------------------------------
+
+test("chatStreamOptionsFor threads chatTemplateKwargs when present", () => {
+  const sig = new AbortController().signal;
+  const opts = chatStreamOptionsFor({ chatTemplateKwargs: { enable_thinking: false } }, sig);
+  assert.deepEqual(opts, { signal: sig, chatTemplateKwargs: { enable_thinking: false } });
+});
+
+test("chatStreamOptionsFor omits the key for a null cfg", () => {
+  const sig = new AbortController().signal;
+  const opts = chatStreamOptionsFor(null, sig);
+  assert.deepEqual(opts, { signal: sig });
+  assert.ok(!("chatTemplateKwargs" in opts));
+});
+
+test("chatStreamOptionsFor omits the key for a cfg with no chatTemplateKwargs", () => {
+  const sig = new AbortController().signal;
+  const opts = chatStreamOptionsFor({}, sig);
+  assert.deepEqual(opts, { signal: sig });
+  assert.ok(!("chatTemplateKwargs" in opts));
+});

--- a/tests/help-setup-starter.test.js
+++ b/tests/help-setup-starter.test.js
@@ -44,8 +44,8 @@ async function seedStarterRow(db, content) {
   });
 }
 
-function fakeReq(body = {}) {
-  return { csrfToken: "test-csrf", query: {}, body, headers: {} };
+function fakeReq(body = {}, query = {}) {
+  return { csrfToken: "test-csrf", query, body, headers: {} };
 }
 
 const CLEAR_ACTION = 'value="help_setup_clear_starter"';
@@ -140,6 +140,11 @@ test("render: after clearing, the section shows the 'cleared' flash and 'none' c
     action: "help_setup_clear_starter",
   });
 
-  const html = await section.render({ req: fakeReq(), db, lang: "en" });
+  const html = await section.render({
+    req: fakeReq({}, { helpSetupMsg: "cleared" }),
+    db,
+    lang: "en",
+  });
+  assert.ok(html.includes("Starter memories cleared"), "flash text present");
   assert.ok(!html.includes(CLEAR_ACTION), "no clear form once starter memories are gone");
 });

--- a/tests/help-setup-starter.test.js
+++ b/tests/help-setup-starter.test.js
@@ -1,0 +1,145 @@
+/**
+ * C1/C3 Task 4 — "clear starter content" action on the Help & Setup
+ * settings section.
+ *
+ * render() shows a count of `source='starter'` memories and, when > 0, a
+ * confirm-gated POST form (action=help_setup_clear_starter). handleAction()
+ * dispatches that action through clearStarterMemories(db) (Task 2/3) —
+ * memories only, never the starter bot/conversation.
+ *
+ * Uses a real init-db database (same harness pattern as
+ * tests/sync-conflicts-restore-ui.test.js) rather than a hand-rolled db
+ * stub, so the COUNT/DELETE SQL is exercised for real.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClient } from "@libsql/client";
+import section from "../servers/gateway/dashboard/settings/sections/help-setup.js";
+import { STARTER_SOURCE } from "../servers/gateway/dashboard/panels/onboarding/starter-content.js";
+
+const dirs = [];
+after(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+function fresh() {
+  const dir = mkdtempSync(join(tmpdir(), "help-setup-starter-"));
+  dirs.push(dir);
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  return createClient({ url: "file:" + join(dir, "crow.db") });
+}
+
+async function seedStarterRow(db, content) {
+  await db.execute({
+    sql: "INSERT INTO memories (content, category, source, importance) VALUES (?, 'general', ?, 5)",
+    args: [content, STARTER_SOURCE],
+  });
+}
+
+function fakeReq(body = {}) {
+  return { csrfToken: "test-csrf", query: {}, body, headers: {} };
+}
+
+const CLEAR_ACTION = 'value="help_setup_clear_starter"';
+
+test("render: n=3 starter rows shows the count and a confirm-gated clear form", async () => {
+  const db = fresh();
+  await seedStarterRow(db, "one");
+  await seedStarterRow(db, "two");
+  await seedStarterRow(db, "three");
+
+  const html = await section.render({ req: fakeReq(), db, lang: "en" });
+
+  assert.ok(html.includes(CLEAR_ACTION), "clear form action present");
+  assert.ok(html.includes('method="POST"'), "form posts");
+  assert.match(html, /name="_csrf"/, "CSRF token included");
+  assert.match(html, /onsubmit="return confirm\(/, "confirm-gated submit");
+  assert.match(html, /\b3\b/, "renders the current starter count");
+});
+
+test("render: n=0 starter rows shows the 'none' copy and no clear form", async () => {
+  const db = fresh();
+
+  const html = await section.render({ req: fakeReq(), db, lang: "en" });
+
+  assert.ok(!html.includes(CLEAR_ACTION), "no clear form when there is nothing to clear");
+});
+
+test("handleAction: help_setup_clear_starter deletes source='starter' rows only and returns true", async () => {
+  const db = fresh();
+  await seedStarterRow(db, "one");
+  await seedStarterRow(db, "two");
+  await db.execute({
+    sql: "INSERT INTO memories (content, category, source, importance) VALUES ('kept', 'general', 'user', 5)",
+    args: [],
+  });
+
+  let redirectedTo = null;
+  const res = { redirectAfterPost(url) { redirectedTo = url; } };
+
+  const handled = await section.handleAction({
+    req: fakeReq({ action: "help_setup_clear_starter" }),
+    res,
+    db,
+    action: "help_setup_clear_starter",
+  });
+
+  assert.equal(handled, true, "action handled");
+  assert.ok(redirectedTo, "redirected back to the section");
+  assert.match(redirectedTo, /section=help-setup/);
+
+  const { rows: starterRows } = await db.execute({
+    sql: "SELECT COUNT(*) n FROM memories WHERE source = ?",
+    args: [STARTER_SOURCE],
+  });
+  assert.equal(Number(starterRows[0].n), 0, "all starter rows deleted");
+
+  const { rows: keptRows } = await db.execute({
+    sql: "SELECT COUNT(*) n FROM memories WHERE source = 'user'",
+    args: [],
+  });
+  assert.equal(Number(keptRows[0].n), 1, "non-starter memory untouched");
+});
+
+test("handleAction: non-matching action returns false and does not delete anything", async () => {
+  const db = fresh();
+  await seedStarterRow(db, "one");
+
+  const res = { redirectAfterPost() { throw new Error("must not redirect"); } };
+  const handled = await section.handleAction({
+    req: fakeReq({ action: "some_other_action" }),
+    res,
+    db,
+    action: "some_other_action",
+  });
+
+  assert.equal(handled, false, "unrelated action not handled");
+
+  const { rows } = await db.execute({
+    sql: "SELECT COUNT(*) n FROM memories WHERE source = ?",
+    args: [STARTER_SOURCE],
+  });
+  assert.equal(Number(rows[0].n), 1, "starter row untouched");
+});
+
+test("render: after clearing, the section shows the 'cleared' flash and 'none' copy", async () => {
+  const db = fresh();
+  await seedStarterRow(db, "one");
+  await section.handleAction({
+    req: fakeReq({ action: "help_setup_clear_starter" }),
+    res: { redirectAfterPost() {} },
+    db,
+    action: "help_setup_clear_starter",
+  });
+
+  const html = await section.render({ req: fakeReq(), db, lang: "en" });
+  assert.ok(!html.includes(CLEAR_ACTION), "no clear form once starter memories are gone");
+});

--- a/tests/model-catalog-validate.test.js
+++ b/tests/model-catalog-validate.test.js
@@ -141,3 +141,48 @@ test("null quant sha256 is rejected when the model entry is gated:false", () => 
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /sha256/i.test(e)));
 });
+
+// --- chat_template_kwargs (C1 Task 1) ---
+
+test("seed qwen3-4b (first_run_default) carries chat_template_kwargs enable_thinking:false", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "qwen3-4b");
+  assert.equal(model.first_run_default, true);
+  assert.deepEqual(model.chat_template_kwargs, { enable_thinking: false });
+  const result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+});
+
+test("a model with no chat_template_kwargs still validates cleanly", () => {
+  const catalog = loadSeed();
+  const model = firstModel(catalog, "phi-4-mini-instruct");
+  assert.equal(model.chat_template_kwargs, undefined);
+  const result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+});
+
+test("chat_template_kwargs as an array fails", () => {
+  const catalog = loadSeed();
+  firstModel(catalog, "qwen3-4b").chat_template_kwargs = ["enable_thinking"];
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));
+});
+
+test("chat_template_kwargs as a string fails", () => {
+  const catalog = loadSeed();
+  firstModel(catalog, "qwen3-4b").chat_template_kwargs = "enable_thinking:false";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));
+});
+
+test("chat_template_kwargs as null fails", () => {
+  const catalog = loadSeed();
+  firstModel(catalog, "qwen3-4b").chat_template_kwargs = null;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));
+});

--- a/tests/starter-content.test.js
+++ b/tests/starter-content.test.js
@@ -27,6 +27,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDbClient } from "../servers/db.js";
 import { shouldSyncRowForTest } from "../servers/sharing/instance-sync.js";
+import { createMemoryServer } from "../servers/memory/server.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   STARTER_SOURCE,
   STARTER_BOT_ID,
@@ -184,6 +187,87 @@ test("shouldSyncRow excludes memories rows with source='starter' (both direction
     shouldSyncRowForTest("memories", { id: 3, content: "z", source: null }),
     true
   );
+});
+
+test("crow_update_memory and crow_delete_memory emit payloads carrying source='starter' for a starter row (C-A final review fix)", async () => {
+  // Regression for the finding: the INSERT emit always carried `source`, but
+  // the UPDATE emit built { id, content, category, tags, importance, context }
+  // (no source) and the DELETE emit sent { id } only. shouldSyncRow('memories', row)
+  // gates on row.source === 'starter' — a payload missing that field can't be
+  // excluded, so editing/deleting a starter row would have broadcast a bare-id
+  // mutation that could clobber/delete an unrelated row at the same id on a
+  // paired peer. Drive the REAL MCP tool handlers (not a hand-built payload) so
+  // this fails if the fix ever regresses.
+  const testDir = mkdtempSync(join(tmpdir(), "crow-startersync-test-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: testDir },
+    stdio: "pipe",
+    cwd: REPO_ROOT,
+  });
+  const dbPath = join(testDir, "crow.db");
+
+  const emitted = [];
+  const spySync = {
+    emitChange: async (table, op, row) => { emitted.push({ table, op, row }); return 1; },
+  };
+
+  const memServer = createMemoryServer(dbPath, { syncManager: spySync });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await memServer.connect(serverTransport);
+  const client = new Client({ name: "test-starter-sync", version: "0" });
+  await client.connect(clientTransport);
+
+  try {
+    // Seed a starter-sourced memory directly (mirrors seedStarterMemories'
+    // shape) so we control its id.
+    const seedDb = createDbClient(dbPath);
+    const insertResult = await seedDb.execute({
+      sql: "INSERT INTO memories (content, category, source, importance) VALUES (?,?,?,?)",
+      args: ["A starter fact about Crow.", "general", STARTER_SOURCE, 5],
+    });
+    const starterId = Number(insertResult.lastInsertRowid);
+    seedDb.close();
+
+    // --- UPDATE ---
+    await client.callTool({
+      name: "crow_update_memory",
+      arguments: { id: starterId, content: "An edited starter fact." },
+    });
+
+    const updateEmit = emitted.find((e) => e.table === "memories" && e.op === "update");
+    assert.ok(updateEmit, "crow_update_memory fired an emitChange('memories','update',...)");
+    assert.equal(updateEmit.row.source, STARTER_SOURCE, "update payload carries source='starter'");
+    assert.equal(
+      shouldSyncRowForTest("memories", updateEmit.row),
+      false,
+      "the actual update wire payload is excluded by shouldSyncRow"
+    );
+
+    // --- DELETE (preview then confirm, per crow_delete_memory's token flow) ---
+    const preview = await client.callTool({
+      name: "crow_delete_memory",
+      arguments: { id: starterId, confirm_token: "" },
+    });
+    const tokenMatch = /confirm_token:\s*"([^"]+)"/.exec(preview.content[0].text);
+    assert.ok(tokenMatch, "preview call returned a confirm_token");
+
+    await client.callTool({
+      name: "crow_delete_memory",
+      arguments: { id: starterId, confirm_token: tokenMatch[1] },
+    });
+
+    const deleteEmit = emitted.find((e) => e.table === "memories" && e.op === "delete");
+    assert.ok(deleteEmit, "crow_delete_memory fired an emitChange('memories','delete',...)");
+    assert.equal(deleteEmit.row.source, STARTER_SOURCE, "delete payload carries source='starter'");
+    assert.equal(
+      shouldSyncRowForTest("memories", deleteEmit.row),
+      false,
+      "the actual delete wire payload is excluded by shouldSyncRow"
+    );
+  } finally {
+    await client.close();
+    rmSync(testDir, { recursive: true, force: true });
+  }
 });
 
 // ── STARTER_BOT_ID ───────────────────────────────────────────────────────────

--- a/tests/starter-content.test.js
+++ b/tests/starter-content.test.js
@@ -1,0 +1,148 @@
+/**
+ * starter-content.js — onboarding starter memories (C1/C3 Task 2).
+ *
+ *   seedStarterMemories(db, lang) inserts a handful of `source='starter'`
+ *   rows into `memories` (idempotent — no-ops if any starter row exists).
+ *   clearStarterMemories(db) deletes only those rows (used by Task 4's
+ *   Settings > Help and Setup action).
+ *   shouldSyncRow('memories', row) excludes source='starter' rows from
+ *   instance-sync (starter/demo content is per-install, same convention as
+ *   providers' gpu_policy.local_only).
+ *
+ * Harness follows tests/instance-sync.test.js: real init-db.js schema in a
+ * tmp dir so the memories_fts triggers exist (FTS works with zero embedding
+ * providers — memory/server.js:176-214).
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient } from "../servers/db.js";
+import { shouldSyncRowForTest } from "../servers/sharing/instance-sync.js";
+import {
+  STARTER_SOURCE,
+  seedStarterMemories,
+  clearStarterMemories,
+} from "../servers/gateway/dashboard/panels/onboarding/starter-content.js";
+
+// ── Shared setup ─────────────────────────────────────────────────────────────
+
+const tmpDir = mkdtempSync(join(tmpdir(), "crow-startercontent-test-"));
+
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: tmpDir },
+  stdio: "pipe",
+  cwd: join(import.meta.dirname, ".."),
+});
+
+const DB_PATH = join(tmpDir, "crow.db");
+const db = createDbClient(DB_PATH);
+
+after(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── STARTER_SOURCE ────────────────────────────────────────────────────────────
+
+test("STARTER_SOURCE is the 'starter' marker", () => {
+  assert.equal(STARTER_SOURCE, "starter");
+});
+
+// ── seedStarterMemories ───────────────────────────────────────────────────────
+
+test("seedStarterMemories inserts rows marked source='starter' and is idempotent", async () => {
+  const first = await seedStarterMemories(db, "en");
+  assert.ok(first.inserted >= 4 && first.inserted <= 8, "a handful of rows");
+  const second = await seedStarterMemories(db, "en");
+  assert.equal(second.inserted, 0);
+  const { rows } = await db.execute({
+    sql: "SELECT COUNT(*) n FROM memories WHERE source='starter'",
+    args: [],
+  });
+  assert.equal(Number(rows[0].n), first.inserted);
+});
+
+test("starter rows are FTS-searchable with zero embedding providers", async () => {
+  const { rows } = await db.execute({
+    sql: "SELECT m.content FROM memories_fts f JOIN memories m ON m.id=f.rowid WHERE memories_fts MATCH ?",
+    args: ["remember"],
+  });
+  assert.ok(rows.length > 0);
+});
+
+// ── clearStarterMemories ──────────────────────────────────────────────────────
+
+test("clearStarterMemories deletes only starter rows", async () => {
+  const tmpDir2 = mkdtempSync(join(tmpdir(), "crow-startercontent-clear-test-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: tmpDir2 },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db2 = createDbClient(join(tmpDir2, "crow.db"));
+  try {
+    await db2.execute({
+      sql: "INSERT INTO memories (content, source) VALUES ('user row','manual')",
+      args: [],
+    });
+    await seedStarterMemories(db2, "en");
+    const { deleted } = await clearStarterMemories(db2);
+    assert.ok(deleted > 0);
+    const { rows } = await db2.execute({ sql: "SELECT source FROM memories", args: [] });
+    assert.deepEqual(rows.map((r) => r.source), ["manual"]);
+  } finally {
+    rmSync(tmpDir2, { recursive: true, force: true });
+  }
+});
+
+// ── lang="es" ──────────────────────────────────────────────────────────────
+
+test("seedStarterMemories(db, 'es') inserts real Spanish translations", async () => {
+  const tmpDir3 = mkdtempSync(join(tmpdir(), "crow-startercontent-es-test-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: tmpDir3 },
+    stdio: "pipe",
+    cwd: join(import.meta.dirname, ".."),
+  });
+  const db3 = createDbClient(join(tmpDir3, "crow.db"));
+  try {
+    const result = await seedStarterMemories(db3, "es");
+    assert.ok(result.inserted > 0);
+    const { rows } = await db3.execute({
+      sql: "SELECT content FROM memories WHERE source='starter'",
+      args: [],
+    });
+    // Real translation, not the EN string reused: must not equal the EN
+    // "general/about" row and should contain Spanish-specific wording.
+    assert.ok(
+      rows.some((r) => /recuerda|almacenad|guardad/i.test(r.content)),
+      "expected at least one Spanish row using recordar-family vocabulary"
+    );
+    assert.ok(
+      rows.every((r) => !/^Crow is your private AI/.test(r.content)),
+      "es rows must not be the untranslated EN string"
+    );
+  } finally {
+    rmSync(tmpDir3, { recursive: true, force: true });
+  }
+});
+
+// ── shouldSyncRow exclusion ────────────────────────────────────────────────
+
+test("shouldSyncRow excludes memories rows with source='starter' (both directions use the same gate)", () => {
+  assert.equal(
+    shouldSyncRowForTest("memories", { id: 1, content: "x", source: "starter" }),
+    false
+  );
+  assert.equal(
+    shouldSyncRowForTest("memories", { id: 2, content: "y", source: "manual" }),
+    true
+  );
+  assert.equal(
+    shouldSyncRowForTest("memories", { id: 3, content: "z", source: null }),
+    true
+  );
+});

--- a/tests/starter-content.test.js
+++ b/tests/starter-content.test.js
@@ -333,3 +333,71 @@ test("createStarterArtifacts: idempotency survives via dashboard_settings even i
     cleanup();
   }
 });
+
+test("resolveStarterProvider falls through when the first_run_default row is disabled", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    // Disabled first-run default provider — should be skipped.
+    await insertProvider(sdb, { id: FIRST_RUN_DEFAULT_ID, models: [{ id: FIRST_RUN_DEFAULT_ID }], disabled: 1 });
+    // Enabled fallback provider.
+    await insertProvider(sdb, { id: "cloud-x", models: [{ id: "gpt-x" }] });
+
+    const result = await resolveStarterProvider(sdb);
+    // Must pick the enabled provider, not the disabled first-run default.
+    assert.deepEqual(result, { providerId: "cloud-x", modelId: "gpt-x" });
+  } finally {
+    cleanup();
+  }
+});
+
+test("createStarterArtifacts recreates the conversation when starter_conversation_id points at a deleted row", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: FIRST_RUN_DEFAULT_ID, models: [{ id: FIRST_RUN_DEFAULT_ID }] });
+
+    // First run: creates bot + conversation.
+    const first = await createStarterArtifacts(sdb, { lang: "en" });
+    const firstConvId = first.conversationId;
+    assert.ok(Number.isInteger(firstConvId));
+
+    // Verify initial state: 1 bot, 1 conversation.
+    const botsAfterFirst = await sdb.execute({ sql: "SELECT COUNT(*) n FROM pi_bot_defs", args: [] });
+    assert.equal(Number(botsAfterFirst.rows[0].n), 1);
+    const convsAfterDelete = await sdb.execute({ sql: "SELECT COUNT(*) n FROM chat_conversations", args: [] });
+    assert.equal(Number(convsAfterDelete.rows[0].n), 1);
+
+    // Delete the conversation row (simulating operator cleanup or DB inconsistency).
+    await sdb.execute({
+      sql: "DELETE FROM chat_conversations WHERE id = ?",
+      args: [firstConvId],
+    });
+
+    // Verify the row is gone.
+    const convsAfterDeleteVerify = await sdb.execute({
+      sql: "SELECT COUNT(*) n FROM chat_conversations",
+      args: [],
+    });
+    assert.equal(Number(convsAfterDeleteVerify.rows[0].n), 0);
+
+    // Second run: should recreate conversation with a NEW id (not re-use the deleted id).
+    const second = await createStarterArtifacts(sdb, { lang: "en" });
+    const secondConvId = second.conversationId;
+
+    // Must have created a new conversation (different id).
+    assert.notEqual(secondConvId, firstConvId);
+    assert.ok(Number.isInteger(secondConvId));
+
+    // Verify new conversation row exists.
+    const convsAfterSecond = await sdb.execute({
+      sql: "SELECT COUNT(*) n FROM chat_conversations WHERE id = ?",
+      args: [secondConvId],
+    });
+    assert.equal(Number(convsAfterSecond.rows[0].n), 1);
+
+    // Verify no duplicate bot was created (still 1 bot row).
+    const botsAfterSecond = await sdb.execute({ sql: "SELECT COUNT(*) n FROM pi_bot_defs", args: [] });
+    assert.equal(Number(botsAfterSecond.rows[0].n), 1);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/starter-content.test.js
+++ b/tests/starter-content.test.js
@@ -1,5 +1,6 @@
 /**
- * starter-content.js — onboarding starter memories (C1/C3 Task 2).
+ * starter-content.js — onboarding starter memories + starter agent/conversation
+ * (C1/C3 Tasks 2-3).
  *
  *   seedStarterMemories(db, lang) inserts a handful of `source='starter'`
  *   rows into `memories` (idempotent — no-ops if any starter row exists).
@@ -8,6 +9,10 @@
  *   shouldSyncRow('memories', row) excludes source='starter' rows from
  *   instance-sync (starter/demo content is per-install, same convention as
  *   providers' gpu_policy.local_only).
+ *   resolveStarterProvider(db) picks the provider/model pair the starter
+ *   agent + conversation should use (Task 3).
+ *   createStarterArtifacts(db, {lang}) creates the `crow-starter` pi_bot_defs
+ *   row and its matching chat_conversations row, idempotently (Task 3).
  *
  * Harness follows tests/instance-sync.test.js: real init-db.js schema in a
  * tmp dir so the memories_fts triggers exist (FTS works with zero embedding
@@ -17,16 +22,21 @@
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { readFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDbClient } from "../servers/db.js";
 import { shouldSyncRowForTest } from "../servers/sharing/instance-sync.js";
 import {
   STARTER_SOURCE,
+  STARTER_BOT_ID,
   seedStarterMemories,
   clearStarterMemories,
+  resolveStarterProvider,
+  createStarterArtifacts,
 } from "../servers/gateway/dashboard/panels/onboarding/starter-content.js";
+
+const REPO_ROOT = join(import.meta.dirname, "..");
 
 // ── Shared setup ─────────────────────────────────────────────────────────────
 
@@ -35,7 +45,7 @@ const tmpDir = mkdtempSync(join(tmpdir(), "crow-startercontent-test-"));
 execFileSync(process.execPath, ["scripts/init-db.js"], {
   env: { ...process.env, CROW_DATA_DIR: tmpDir },
   stdio: "pipe",
-  cwd: join(import.meta.dirname, ".."),
+  cwd: REPO_ROOT,
 });
 
 const DB_PATH = join(tmpDir, "crow.db");
@@ -44,6 +54,35 @@ const db = createDbClient(DB_PATH);
 after(() => {
   rmSync(tmpDir, { recursive: true, force: true });
 });
+
+// ── Task 3 shared helpers ───────────────────────────────────────────────────
+
+/** The real catalog's first_run_default model id (currently "qwen3-4b"). */
+const CATALOG = JSON.parse(readFileSync(join(REPO_ROOT, "registry", "model-catalog.json"), "utf8"));
+const FIRST_RUN_DEFAULT_ID = CATALOG.models.find((m) => m.first_run_default === true).id;
+
+/** Fresh scratch DB per test — provider/bot/conversation state must not leak
+ * across resolveStarterProvider/createStarterArtifacts scenarios. */
+function makeScratchDb() {
+  const dir = mkdtempSync(join(tmpdir(), "crow-starterartifacts-test-"));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: REPO_ROOT,
+  });
+  const scratchDb = createDbClient(join(dir, "crow.db"));
+  return {
+    db: scratchDb,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+async function insertProvider(scratchDb, { id, models, disabled = 0 }) {
+  await scratchDb.execute({
+    sql: "INSERT INTO providers (id, base_url, models, disabled) VALUES (?,?,?,?)",
+    args: [id, "http://127.0.0.1:9/v1", JSON.stringify(models), disabled],
+  });
+}
 
 // ── STARTER_SOURCE ────────────────────────────────────────────────────────────
 
@@ -145,4 +184,152 @@ test("shouldSyncRow excludes memories rows with source='starter' (both direction
     shouldSyncRowForTest("memories", { id: 3, content: "z", source: null }),
     true
   );
+});
+
+// ── STARTER_BOT_ID ───────────────────────────────────────────────────────────
+
+test("STARTER_BOT_ID is the 'crow-starter' marker", () => {
+  assert.equal(STARTER_BOT_ID, "crow-starter");
+});
+
+// ── resolveStarterProvider ───────────────────────────────────────────────────
+
+test("resolveStarterProvider: picks the native first_run_default provider row when present", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: FIRST_RUN_DEFAULT_ID, models: [{ id: FIRST_RUN_DEFAULT_ID }] });
+    const result = await resolveStarterProvider(sdb);
+    assert.deepEqual(result, { providerId: FIRST_RUN_DEFAULT_ID, modelId: FIRST_RUN_DEFAULT_ID });
+  } finally {
+    cleanup();
+  }
+});
+
+test("resolveStarterProvider: falls back to the newest enabled provider with a model when no native default row exists", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: "cloud-x", models: [{ id: "gpt-x" }] });
+    const result = await resolveStarterProvider(sdb);
+    assert.deepEqual(result, { providerId: "cloud-x", modelId: "gpt-x" });
+  } finally {
+    cleanup();
+  }
+});
+
+test("resolveStarterProvider: a provider with empty models[] is unusable -> null", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: "no-auto-provider", models: [] });
+    const result = await resolveStarterProvider(sdb);
+    assert.equal(result, null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("resolveStarterProvider: no provider rows -> null", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    const result = await resolveStarterProvider(sdb);
+    assert.equal(result, null);
+  } finally {
+    cleanup();
+  }
+});
+
+// ── createStarterArtifacts ───────────────────────────────────────────────────
+
+test("createStarterArtifacts: no provider -> {error:'no_provider'} and creates nothing", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    const result = await createStarterArtifacts(sdb, { lang: "en" });
+    assert.deepEqual(result, { error: "no_provider" });
+    const bots = await sdb.execute({ sql: "SELECT COUNT(*) n FROM pi_bot_defs", args: [] });
+    assert.equal(Number(bots.rows[0].n), 0);
+    const convs = await sdb.execute({ sql: "SELECT COUNT(*) n FROM chat_conversations", args: [] });
+    assert.equal(Number(convs.rows[0].n), 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("createStarterArtifacts: creates a bot def + conversation, and is idempotent on a second call", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: FIRST_RUN_DEFAULT_ID, models: [{ id: FIRST_RUN_DEFAULT_ID }] });
+
+    const first = await createStarterArtifacts(sdb, { lang: "en" });
+    assert.equal(first.botId, STARTER_BOT_ID);
+    assert.equal(first.providerId, FIRST_RUN_DEFAULT_ID);
+    assert.equal(first.modelId, FIRST_RUN_DEFAULT_ID);
+    assert.ok(Number.isInteger(first.conversationId));
+
+    const botsAfterFirst = await sdb.execute({ sql: "SELECT COUNT(*) n FROM pi_bot_defs", args: [] });
+    assert.equal(Number(botsAfterFirst.rows[0].n), 1);
+    const convsAfterFirst = await sdb.execute({ sql: "SELECT COUNT(*) n FROM chat_conversations", args: [] });
+    assert.equal(Number(convsAfterFirst.rows[0].n), 1);
+
+    const second = await createStarterArtifacts(sdb, { lang: "en" });
+    assert.deepEqual(second, first);
+
+    const botsAfterSecond = await sdb.execute({ sql: "SELECT COUNT(*) n FROM pi_bot_defs", args: [] });
+    assert.equal(Number(botsAfterSecond.rows[0].n), 1);
+    const convsAfterSecond = await sdb.execute({ sql: "SELECT COUNT(*) n FROM chat_conversations", args: [] });
+    assert.equal(Number(convsAfterSecond.rows[0].n), 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("createStarterArtifacts: bot definition is a well-formed pi memory-tooled def; conversation shares its system_prompt", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: FIRST_RUN_DEFAULT_ID, models: [{ id: FIRST_RUN_DEFAULT_ID }] });
+    const result = await createStarterArtifacts(sdb, { lang: "en" });
+
+    const botRow = await sdb.execute({
+      sql: "SELECT definition, display_name FROM pi_bot_defs WHERE bot_id = ?",
+      args: [STARTER_BOT_ID],
+    });
+    assert.equal(botRow.rows.length, 1);
+    const def = JSON.parse(botRow.rows[0].definition);
+    assert.equal(def.engine, "pi");
+    assert.ok(def.tools.crow_mcp.includes("crow-memory/crow_recall_by_context"));
+    assert.equal(def.models.default, `${FIRST_RUN_DEFAULT_ID}/${FIRST_RUN_DEFAULT_ID}`);
+    assert.equal(botRow.rows[0].display_name, "My Crow");
+    assert.ok(def.system_prompt && def.system_prompt.length > 0);
+
+    const convRow = await sdb.execute({
+      sql: "SELECT title, provider, model, system_prompt FROM chat_conversations WHERE id = ?",
+      args: [result.conversationId],
+    });
+    assert.equal(convRow.rows.length, 1);
+    assert.equal(convRow.rows[0].title, "Chat with your Crow");
+    assert.equal(convRow.rows[0].provider, FIRST_RUN_DEFAULT_ID);
+    assert.equal(convRow.rows[0].model, FIRST_RUN_DEFAULT_ID);
+    assert.ok(convRow.rows[0].system_prompt && convRow.rows[0].system_prompt.length > 0);
+    assert.equal(convRow.rows[0].system_prompt, def.system_prompt);
+  } finally {
+    cleanup();
+  }
+});
+
+test("createStarterArtifacts: idempotency survives via dashboard_settings even if resolveStarterProvider's inputs later change", async () => {
+  const { db: sdb, cleanup } = makeScratchDb();
+  try {
+    await insertProvider(sdb, { id: "cloud-x", models: [{ id: "gpt-x" }] });
+    const first = await createStarterArtifacts(sdb, { lang: "en" });
+    assert.equal(first.providerId, "cloud-x");
+
+    // A newer provider row now exists; without the dashboard_settings gate
+    // this would resolve to a different provider on a naive re-run.
+    await insertProvider(sdb, { id: FIRST_RUN_DEFAULT_ID, models: [{ id: FIRST_RUN_DEFAULT_ID }] });
+    const second = await createStarterArtifacts(sdb, { lang: "en" });
+    assert.deepEqual(second, first);
+
+    const convs = await sdb.execute({ sql: "SELECT COUNT(*) n FROM chat_conversations", args: [] });
+    assert.equal(Number(convs.rows[0].n), 1);
+  } finally {
+    cleanup();
+  }
 });


### PR DESCRIPTION
First of three C1/C3 PRs (plan: crow-engineering `plans/2026-07-19-item-c1-c3-implementation.md`, r3, adversarially reviewed ×2 → APPROVE). No UI in this PR — engine/data plumbing the wizard PRs build on.

## What's in it

- **Thinking-suppression chain (Task 1):** catalog gains optional `chat_template_kwargs` (qwen3-4b ships `{"enable_thinking": false}`); `registerModel` propagates it into the provider row's `models[]`; `resolveProviderConfig` returns it, with a catalog **healing fallback** for native rows registered before this change; `chat.js` threads it via new exported `chatStreamOptionsFor(cfg, signal)`; llama-server gets `--jinja` **scoped via extraArgs only for catalog models carrying the field** (never global). Live-proven on real hardware: raw port shows `<think>` (thinking genuinely on by default), dashboard SSE path suppressed.
- **Starter memories (Task 2):** `starter-content.js` seeds 5 EN/ES rows marked `source='starter'`; instance-sync `shouldSyncRow` excludes them (single gate, emit + apply). Final review caught + fixed: memory-server **update/delete emits now carry `source`** so the exclusion covers all three ops (real-handler MCP regression test).
- **Starter agent (Task 3):** `createStarterArtifacts` — pi_bot_defs `crow-starter` from the personal-assistant template + chat_conversations row, byte-identical single-source persona (tool-agnostic memory instruction), `resolveStarterProvider` (first_run_default native → newest enabled with models → null), idempotent via `starter_conversation_id` setting.
- **Settings (Task 4):** Help & Setup "clear starter content" confirm-gated action (memories only; copy says so).

## Spec deviations (adjudicated in plan, reviewer-verified)

1. Starter marking = `source='starter'` (no metadata column exists; maker-lab precedent; zero schema change).
2. Download ETA computed client-side later (no server ETA field) — C-B.
3. "Starter agent" = dual artifact (chat conversation carries the aha; pi bot is the Bot-Builder-editable artifact — pi engine ships in C4).
4. Suggested prompts (C-B) render on any empty AI conversation.
5. Suppression is catalog-driven + model-scoped; profile-path hole for inline-config profiles documented (deviation 6).

## Ride-documented minors (final-review triage)

(a) profile-branch kwargs vs per-message model override — unreachable for native 1:1 providers; (b) bot+conversation writes non-transactional — one-statement crash window, self-heals; (c) partial starter delete then re-seed doesn't backfill — brief-literal, clear-all is the supported flow; (d) settings action unguarded on throw — matches sync-conflicts precedent.

## Pre-existing findings surfaced (not caused here, follow-ups filed)

- Funkwhale `fw_upload_track` schema (`file_base64.maxLength: 200000000`) breaks llama-server tool-calling grammar init for any tools-enabled native chat (repro matrix in task report; independent of `--jinja`).
- Transient empty-providers read right after download completion under heavy load (matches Item G follow-up).

Suite: **2472/2472/0/0** (baseline 2434 + 38). No schema changes, no new deps, no new ports.