### PR TITLE
fix(models): download-cleanup race (product) + deflake ENOSPC test (both root-caused)

### DIFF
--- a/servers/gateway/models/runtime.js
+++ b/servers/gateway/models/runtime.js
@@ -427,12 +427,37 @@ export async function downloadRuntimeAsset({
         } catch {
           /* already gone */
         }
+        // Wait for `ws`'s own lifecycle (construction -> any queued
+        // write(s) -> destroy/close) to fully settle before rejecting.
+        // `ws`'s underlying fs.open()/write()/close() run on the libuv
+        // threadpool, genuinely asynchronously with respect to this
+        // function's own progress — under real scheduler contention (a
+        // loaded CI runner, many parallel test-file processes) that
+        // background work can still be in flight at the exact instant a
+        // stream/network error fires here. Rejecting immediately (the
+        // previous behavior) let the catch block below's `unlinkSync`
+        // race ahead of it: `unlinkSync` would find nothing yet (silently
+        // swallowing ENOENT), and the still-in-flight open()/write()
+        // would finish moments later, leaving an orphaned partial file
+        // that nothing then cleans up — a real bug (confirmed via a
+        // genuine OS-scheduler-contention repro, not merely a test
+        // artifact): a later caller could mistake that leftover for a
+        // fresh, resumable, or even complete download. Waiting for `ws`'s
+        // "close" event guarantees its on-disk state has stabilized
+        // (whatever was ever going to be written/created has been, and
+        // the fd is closed) before cleanup ever runs.
+        const finish = () => reject(err);
+        if (ws.closed) {
+          finish();
+          return;
+        }
+        ws.once("close", finish);
         try {
           ws.destroy();
         } catch {
-          /* already gone */
+          ws.removeListener("close", finish);
+          finish();
         }
-        reject(err);
       };
       res.on("data", (chunk) => hash.update(chunk));
       res.on("error", fail);

--- a/tests/models-manager.test.js
+++ b/tests/models-manager.test.js
@@ -196,12 +196,32 @@ function makeEnospcWriteStream(thresholdBytes) {
     const real = fsCreateWriteStream(dest, opts);
     let written = 0;
     const originalWrite = real.write.bind(real);
+    const emitEnospc = () => {
+      real.emit("error", Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" }));
+    };
     real.write = (chunk, ...rest) => {
       written += chunk.length;
       if (written > thresholdBytes) {
-        setImmediate(() => {
-          real.emit("error", Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" }));
-        });
+        // A real ENOSPC can only ever surface on a write() to an fd that's
+        // already open -- the OS has no way to fail a write before open()
+        // has completed. `real`'s underlying open() is itself async (fs
+        // streams construct via `_construct`, dispatched on a nextTick that
+        // races the `res.on("data", ...)` handler feeding this write()
+        // override), so under scheduler/I-O contention (parallel test
+        // files, a loaded CI runner) the very first write() here can land
+        // before that open() has finished. Emitting the injected error
+        // immediately in that window models a failure the real OS could
+        // never produce, and lets `real.destroy()` (in the product's
+        // `streamToFile` fail() path) tear the stream down before it has
+        // ever created `dest` on disk -- flaking the "partial file kept"
+        // assertion below with no product bug involved. Waiting for the
+        // real `"open"` event first keeps the injected failure physically
+        // honest and removes the race by construction.
+        if (typeof real.fd === "number") {
+          setImmediate(emitEnospc);
+        } else {
+          real.once("open", () => setImmediate(emitEnospc));
+        }
         return false;
       }
       return originalWrite(chunk, ...rest);


### PR DESCRIPTION
Started as a CI-blocking test flake hunt; ended as one test-fidelity fix AND one genuine product race, both deterministically root-caused. The two flakes were siblings in the same error-ordering class — CI runner load exposed the second the moment the first was fixed.

## Round 1 — test-fidelity fix (`d95ae94e`, test-only)

`models-manager` "ENOSPC keeps the partial file": the fake write stream emitted its injected ENOSPC via bare `setImmediate` without awaiting the real `fs.WriteStream`'s async `open()` — under contention the error beat `open()`, so the destination file never existed. OS-impossible ordering (a write can't fail before its fd opens); the fake now arms the error only after `open`. No assertion changed; mutation check confirms a product regression that unlinked the partial would still fail. Deterministic delay-injection repro: 7/20 fail pre-fix, 0 across a 0–400ms sweep (300+ trials) post-fix.

## Round 2 — genuine product race (`64facaa9`, `servers/gateway/models/runtime.js`)

`models-runtime` "downloadRuntimeAsset deletes the partial on mid-stream error": the error path rejected synchronously without awaiting the write stream's threadpool `open()`/`write()`, so cleanup `unlinkSync` could run first (ENOENT silently swallowed) and the still-in-flight write then created the file with nothing left to delete it — an orphaned partial a real user could hit. Fix: `fail()` now gates rejection on the stream's `close` event (the true terminal state after construction + queued writes + fd close), with an already-closed fast path and a destroy-throw fallback. All three error sources (response error, aborted, write error) route through the same handler. Reviewed: no hang surface (Node ≥20 `writable.closed`; `_construct` guarantees `close` fires), callers see identical error type/order, the sibling keep-partial contract in manager.js untouched, the existing test already asserted the correct post-settle contract and needed no changes.

**Evidence:** real CPU-contention reproduction (taskset-pinned busy-loops), ~4/2600 failures pre-fix → 0/2500 post-fix under identical contention; mutation check green; full suite 2535/2535.