### PR TITLE
fix(models): tool-schema sanitizer — stop oversized bounds breaking native tool-calling

### DIFF
--- a/bundles/funkwhale/server/server.js
+++ b/bundles/funkwhale/server/server.js
@@ -347,7 +347,13 @@ export async function createFunkwhaleServer(options = {}) {
     {
       library_uuid: z.string().uuid(),
       file_path: z.string().max(4096).optional(),
-      file_base64: z.string().max(200_000_000).optional(),
+      // No maxLength here: a 200,000,000-char bound in the advertised schema broke
+      // llama-server's JSON-schema→GBNF tool-calling grammar compiler for every chat
+      // request that included this tool. Real size enforcement belongs in the
+      // handler below (not implemented — currently unbounded, same as before this
+      // change removed the schema-level ceiling) or the upstream Funkwhale API's own
+      // upload limits, not an advisory bound on the advertised MCP schema.
+      file_base64: z.string().optional(),
       filename: z.string().max(500).optional(),
       import_reference: z.string().max(200).optional(),
     },

--- a/servers/gateway/ai/tool-executor.js
+++ b/servers/gateway/ai/tool-executor.js
@@ -713,6 +713,49 @@ export function isExternalSendTool(name) {
   return false;
 }
 
+// Above this, a maxLength/minLength bound is advisory (validation, docs); llama.cpp's
+// native tool-calling compiles every advertised JSON-schema into a GBNF sampling
+// grammar, and a huge bounded-repetition count there is pure poison — it blows up the
+// grammar compiler and hard-fails the WHOLE chat request (not just the one tool), e.g.
+// llama-server's "Failed to initialize samplers: failed to parse grammar" 400. Isolated
+// from Funkwhale's fw_upload_track (file_base64.maxLength: 200_000_000) — see C1
+// live-verification evidence. 4096 is generous for any real string bound; nothing sane
+// needs more, and this only strips the field, it never rejects the tool or the request.
+const SCHEMA_BOUND_LIMIT = 4096;
+
+/**
+ * Recursively walk a JSON-schema-shaped object/array and delete any `maxLength`/
+ * `minLength` numeric bound that exceeds SCHEMA_BOUND_LIMIT. Handles
+ * properties/items/anyOf/oneOf/allOf/additionalProperties-object nesting generically
+ * (it recurses into every object/array value it finds, not just those named keys, so
+ * any future nesting shape is covered for free). Never mutates its input; returns a
+ * new tree. Defensive: any error walking a weird shape (unexpected non-plain-object,
+ * getter that throws, etc.) is swallowed and the ORIGINAL schema is returned
+ * untouched — this must never be the reason a tool fails to advertise.
+ */
+export function sanitizeToolSchema(schema) {
+  try {
+    return walkSchemaNode(schema);
+  } catch {
+    return schema;
+  }
+}
+
+function walkSchemaNode(node) {
+  if (Array.isArray(node)) {
+    return node.map((item) => (item && typeof item === "object" ? walkSchemaNode(item) : item));
+  }
+  if (!node || typeof node !== "object") return node;
+  const out = {};
+  for (const [key, value] of Object.entries(node)) {
+    if ((key === "maxLength" || key === "minLength") && typeof value === "number" && value > SCHEMA_BOUND_LIMIT) {
+      continue; // drop the oversized bound; everything else on this node is kept
+    }
+    out[key] = (value && typeof value === "object") ? walkSchemaNode(value) : value;
+  }
+  return out;
+}
+
 /**
  * Build the MCP tool schemas for the AI provider.
  *
@@ -956,5 +999,13 @@ export function getChatTools(opts = {}) {
     }
   }
 
-  return tools;
+  // Sanitize every advertised schema at this single choke point — core category
+  // tools, addon/promoted tools, and cross-instance remote tools all flow through
+  // here regardless of caller (chat.js, one-shot.js, meta-glasses routes.js via
+  // getChatTools({botDef})). Generic, not funkwhale-specific.
+  // Sanitize every advertised schema at this single choke point — core category
+  // tools, addon/promoted tools, and cross-instance remote tools all flow through
+  // here regardless of caller (chat.js, one-shot.js, meta-glasses routes.js via
+  // getChatTools({botDef})). Generic, not funkwhale-specific.
+  return tools.map((t) => ({ ...t, inputSchema: sanitizeToolSchema(t.inputSchema) }));
 }

--- a/servers/gateway/ai/tool-executor.js
+++ b/servers/gateway/ai/tool-executor.js
@@ -715,13 +715,20 @@ export function isExternalSendTool(name) {
 
 // Above this, a maxLength/minLength bound is advisory (validation, docs); llama.cpp's
 // native tool-calling compiles every advertised JSON-schema into a GBNF sampling
-// grammar, and a huge bounded-repetition count there is pure poison — it blows up the
+// grammar, and a bounded-repetition count there is pure poison — it blows up the
 // grammar compiler and hard-fails the WHOLE chat request (not just the one tool), e.g.
 // llama-server's "Failed to initialize samplers: failed to parse grammar" 400. Isolated
 // from Funkwhale's fw_upload_track (file_base64.maxLength: 200_000_000) — see C1
-// live-verification evidence. 4096 is generous for any real string bound; nothing sane
-// needs more, and this only strips the field, it never rejects the tool or the request.
-const SCHEMA_BOUND_LIMIT = 4096;
+// live-verification evidence.
+//
+// The limit is empirically calibrated, NOT a round "seems generous" guess: live-tested
+// a single string property's maxLength in isolation against the real deployed
+// llama-server build (b10068) — 1000 and 1800 succeeded, 1990 succeeded, 2000 and 4096
+// both reproduced the exact grammar-parse 400, independent of tool count, required-vs-
+// optional, or any other field on the schema. So a limit anywhere near 4096 does NOT
+// protect the request; 1024 is chosen with real margin under the observed ~1990-2000
+// cliff (and under any stricter ceiling a different llama.cpp build might have).
+const SCHEMA_BOUND_LIMIT = 1024;
 
 /**
  * Recursively walk a JSON-schema-shaped object/array and delete any `maxLength`/

--- a/servers/gateway/ai/tool-executor.js
+++ b/servers/gateway/ai/tool-executor.js
@@ -1010,9 +1010,5 @@ export function getChatTools(opts = {}) {
   // tools, addon/promoted tools, and cross-instance remote tools all flow through
   // here regardless of caller (chat.js, one-shot.js, meta-glasses routes.js via
   // getChatTools({botDef})). Generic, not funkwhale-specific.
-  // Sanitize every advertised schema at this single choke point — core category
-  // tools, addon/promoted tools, and cross-instance remote tools all flow through
-  // here regardless of caller (chat.js, one-shot.js, meta-glasses routes.js via
-  // getChatTools({botDef})). Generic, not funkwhale-specific.
   return tools.map((t) => ({ ...t, inputSchema: sanitizeToolSchema(t.inputSchema) }));
 }

--- a/tests/tool-schema-sanitizer.test.js
+++ b/tests/tool-schema-sanitizer.test.js
@@ -21,7 +21,7 @@ import { connectedServers } from "../servers/gateway/proxy.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..");
 
-const BOUND = 4096;
+const BOUND = 1024;
 
 // ---------------------------------------------------------------------------
 // Unit tests: sanitizeToolSchema
@@ -73,13 +73,13 @@ test("sanitizeToolSchema deletes oversized bounds inside anyOf/oneOf/allOf", () 
       { type: "string", maxLength: 100 },
     ],
     oneOf: [{ type: "string", minLength: 50_000_000 }],
-    allOf: [{ type: "string", maxLength: 4096 }],
+    allOf: [{ type: "string", maxLength: 1024 }],
   };
   const out = sanitizeToolSchema(schema);
   assert.equal("maxLength" in out.anyOf[0], false);
   assert.equal(out.anyOf[1].maxLength, 100);
   assert.equal("minLength" in out.oneOf[0], false);
-  assert.equal(out.allOf[0].maxLength, 4096); // exactly at the bound: kept
+  assert.equal(out.allOf[0].maxLength, 1024); // exactly at the bound: kept
 });
 
 test("sanitizeToolSchema deletes oversized bounds inside an object-form additionalProperties", () => {

--- a/tests/tool-schema-sanitizer.test.js
+++ b/tests/tool-schema-sanitizer.test.js
@@ -1,0 +1,242 @@
+/**
+ * Tool-schema sanitizer (C1 standing-gap fix).
+ *
+ * llama-server's native tool-calling compiles every advertised JSON-schema into
+ * a GBNF sampling grammar. An absurd maxLength/minLength bound (Funkwhale's
+ * fw_upload_track file_base64: { maxLength: 200_000_000 }) blows up that
+ * compiler and hard-fails the WHOLE chat request with a 400 ("Failed to
+ * initialize samplers: failed to parse grammar") — not just the one tool.
+ * getChatTools() is the single choke point every chat-path caller (chat.js,
+ * one-shot.js, meta-glasses routes.js) goes through, so sanitizeToolSchema()
+ * is applied there, generically, for every advertised tool.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { getChatTools, sanitizeToolSchema } from "../servers/gateway/ai/tool-executor.js";
+import { connectedServers } from "../servers/gateway/proxy.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+
+const BOUND = 4096;
+
+// ---------------------------------------------------------------------------
+// Unit tests: sanitizeToolSchema
+// ---------------------------------------------------------------------------
+
+test("sanitizeToolSchema deletes an oversized top-level maxLength", () => {
+  const out = sanitizeToolSchema({ type: "string", maxLength: 200_000_000 });
+  assert.equal("maxLength" in out, false);
+  assert.equal(out.type, "string");
+});
+
+test("sanitizeToolSchema deletes an oversized top-level minLength", () => {
+  const out = sanitizeToolSchema({ type: "string", minLength: 5_000_000 });
+  assert.equal("minLength" in out, false);
+  assert.equal(out.type, "string");
+});
+
+test("sanitizeToolSchema deletes an oversized maxLength nested in properties", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      library_uuid: { type: "string" },
+      file_base64: { type: "string", maxLength: 200_000_000 },
+      filename: { type: "string", maxLength: 500 },
+    },
+    required: ["library_uuid"],
+  };
+  const out = sanitizeToolSchema(schema);
+  assert.equal("maxLength" in out.properties.file_base64, false);
+  // sane bound elsewhere on the same schema is untouched
+  assert.equal(out.properties.filename.maxLength, 500);
+  assert.deepEqual(Object.keys(out.properties), Object.keys(schema.properties));
+});
+
+test("sanitizeToolSchema deletes an oversized maxLength nested in array items", () => {
+  const schema = {
+    type: "array",
+    items: { type: "string", maxLength: 10_000_000 },
+  };
+  const out = sanitizeToolSchema(schema);
+  assert.equal("maxLength" in out.items, false);
+  assert.equal(out.items.type, "string");
+});
+
+test("sanitizeToolSchema deletes oversized bounds inside anyOf/oneOf/allOf", () => {
+  const schema = {
+    anyOf: [
+      { type: "string", maxLength: 999_999_999 },
+      { type: "string", maxLength: 100 },
+    ],
+    oneOf: [{ type: "string", minLength: 50_000_000 }],
+    allOf: [{ type: "string", maxLength: 4096 }],
+  };
+  const out = sanitizeToolSchema(schema);
+  assert.equal("maxLength" in out.anyOf[0], false);
+  assert.equal(out.anyOf[1].maxLength, 100);
+  assert.equal("minLength" in out.oneOf[0], false);
+  assert.equal(out.allOf[0].maxLength, 4096); // exactly at the bound: kept
+});
+
+test("sanitizeToolSchema deletes oversized bounds inside an object-form additionalProperties", () => {
+  const schema = {
+    type: "object",
+    additionalProperties: { type: "string", maxLength: 1_000_000 },
+  };
+  const out = sanitizeToolSchema(schema);
+  assert.equal("maxLength" in out.additionalProperties, false);
+});
+
+test("sanitizeToolSchema preserves a sane maxLength (255)", () => {
+  const out = sanitizeToolSchema({ type: "string", maxLength: 255 });
+  assert.equal(out.maxLength, 255);
+});
+
+test("sanitizeToolSchema preserves a sane minLength (1)", () => {
+  const out = sanitizeToolSchema({ type: "string", minLength: 1 });
+  assert.equal(out.minLength, 1);
+});
+
+test("sanitizeToolSchema leaves non-length fields completely untouched", () => {
+  const schema = {
+    type: "object",
+    $schema: "http://json-schema.org/draft-07/schema#",
+    required: ["library_uuid"],
+    additionalProperties: false,
+    properties: { library_uuid: { type: "string", format: "uuid" } },
+  };
+  const out = sanitizeToolSchema(schema);
+  assert.deepEqual(out, schema);
+});
+
+test("sanitizeToolSchema does not mutate its input", () => {
+  const schema = { type: "object", properties: { a: { type: "string", maxLength: 999_999_999 } } };
+  const before = JSON.parse(JSON.stringify(schema));
+  sanitizeToolSchema(schema);
+  assert.deepEqual(schema, before, "original schema object must be untouched");
+});
+
+test("sanitizeToolSchema returns the original on malformed input (null)", () => {
+  assert.equal(sanitizeToolSchema(null), null);
+});
+
+test("sanitizeToolSchema returns the original on malformed input (a string)", () => {
+  assert.equal(sanitizeToolSchema("not a schema"), "not a schema");
+});
+
+test("sanitizeToolSchema returns the original on malformed input (undefined)", () => {
+  assert.equal(sanitizeToolSchema(undefined), undefined);
+});
+
+test("sanitizeToolSchema never throws on a cyclic-ish structure — returns the original", () => {
+  const cyclic = { type: "object", properties: {} };
+  cyclic.properties.self = cyclic; // self-reference
+  assert.doesNotThrow(() => sanitizeToolSchema(cyclic));
+  const out = sanitizeToolSchema(cyclic);
+  // Defensive path: on any walk failure (stack overflow from the cycle), the
+  // ORIGINAL object is returned unchanged (identity-equal), not a partial tree.
+  assert.equal(out, cyclic);
+});
+
+test("sanitizeToolSchema never throws on a getter that throws — returns the original", () => {
+  const evil = { type: "object" };
+  Object.defineProperty(evil, "properties", { enumerable: true, get() { throw new Error("boom"); } });
+  assert.doesNotThrow(() => sanitizeToolSchema(evil));
+  assert.equal(sanitizeToolSchema(evil), evil);
+});
+
+// ---------------------------------------------------------------------------
+// Integration-shaped: getChatTools() output has NO maxLength/minLength > 4096
+// anywhere, across the real tool list (core categories + discover + delegate +
+// bot-cron + any addon tools).
+// ---------------------------------------------------------------------------
+
+function walkForOversizedBounds(node, path, violations) {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => walkForOversizedBounds(item, `${path}[${i}]`, violations));
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node)) {
+    if ((key === "maxLength" || key === "minLength") && typeof value === "number" && value > BOUND) {
+      violations.push(`${path}.${key} = ${value}`);
+    }
+    if (value && typeof value === "object") {
+      walkForOversizedBounds(value, `${path}.${key}`, violations);
+    }
+  }
+}
+
+test("getChatTools() (unbound) output carries no maxLength/minLength above 4096 anywhere", () => {
+  const tools = getChatTools();
+  const violations = [];
+  for (const t of tools) {
+    walkForOversizedBounds(t.inputSchema, t.name, violations);
+  }
+  assert.deepEqual(violations, [], `oversized bounds leaked into advertised tools: ${violations.join(", ")}`);
+});
+
+test("getChatTools() (bound to a bot) output carries no maxLength/minLength above 4096 anywhere", () => {
+  const tools = getChatTools({ botDef: { bot_id: "botA", tools: { crow_mcp: ["memory/crow_store_memory"] } } });
+  const violations = [];
+  for (const t of tools) {
+    walkForOversizedBounds(t.inputSchema, t.name, violations);
+  }
+  assert.deepEqual(violations, [], `oversized bounds leaked into advertised tools: ${violations.join(", ")}`);
+});
+
+// ---------------------------------------------------------------------------
+// Real addon-tool integration: reproduce the exact Funkwhale shape via
+// connectedServers (the real mechanism getChatTools() reads addon tools from)
+// and prove getChatTools() sanitizes it — not a re-implementation, the actual
+// code path a live fw_upload_track connection would go through.
+// ---------------------------------------------------------------------------
+
+test("getChatTools() sanitizes an oversized-maxLength addon tool advertised via connectedServers", () => {
+  const FAKE_ID = "__test_funkwhale_sanitizer__";
+  connectedServers.set(FAKE_ID, {
+    status: "connected",
+    tools: [
+      {
+        name: "fw_upload_track",
+        description: "Upload an audio file.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            library_uuid: { type: "string" },
+            file_base64: { type: "string", maxLength: 200_000_000 },
+          },
+          required: ["library_uuid"],
+          additionalProperties: false,
+          $schema: "http://json-schema.org/draft-07/schema#",
+        },
+      },
+    ],
+  });
+  try {
+    const tools = getChatTools();
+    const fw = tools.find((t) => t.name === "fw_upload_track");
+    assert.ok(fw, "fw_upload_track should be promoted and advertised");
+    assert.equal("maxLength" in fw.inputSchema.properties.file_base64, false,
+      "the oversized bound must be stripped by getChatTools()");
+    assert.equal(fw.inputSchema.properties.file_base64.type, "string", "the rest of the property is untouched");
+  } finally {
+    connectedServers.delete(FAKE_ID);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Funkwhale source fix: the absurd bound is gone from the bundle's own schema
+// (fixes non-chat MCP clients too, independent of the gateway-side sanitizer).
+// ---------------------------------------------------------------------------
+
+test("funkwhale bundle: fw_upload_track's file_base64 no longer declares an absurd maxLength", () => {
+  const src = readFileSync(join(repoRoot, "bundles/funkwhale/server/server.js"), "utf8");
+  assert.equal(src.includes("200_000_000"), false, "the 200-million-char bound must be removed from the source");
+  assert.equal(src.includes("200000000"), false, "the 200-million-char bound must be removed from the source (unscored form)");
+  assert.match(src, /file_base64:\s*z\.string\(\)\.optional\(\)/, "file_base64 should stay a plain optional string (handler enforces size, not the schema)");
+});

--- a/tests/tool-schema-sanitizer.test.js
+++ b/tests/tool-schema-sanitizer.test.js
@@ -171,7 +171,7 @@ function walkForOversizedBounds(node, path, violations) {
   }
 }
 
-test("getChatTools() (unbound) output carries no maxLength/minLength above 4096 anywhere", () => {
+test("getChatTools() (unbound) output carries no maxLength/minLength above 1024 anywhere", () => {
   const tools = getChatTools();
   const violations = [];
   for (const t of tools) {
@@ -180,7 +180,7 @@ test("getChatTools() (unbound) output carries no maxLength/minLength above 4096 
   assert.deepEqual(violations, [], `oversized bounds leaked into advertised tools: ${violations.join(", ")}`);
 });
 
-test("getChatTools() (bound to a bot) output carries no maxLength/minLength above 4096 anywhere", () => {
+test("getChatTools() (bound to a bot) output carries no maxLength/minLength above 1024 anywhere", () => {
   const tools = getChatTools({ botDef: { bot_id: "botA", tools: { crow_mcp: ["memory/crow_store_memory"] } } });
   const violations = [];
   for (const t of tools) {


### PR DESCRIPTION
Fixes the standing prod gap isolated during the C1 build: llama-server's JSON-schema→GBNF grammar compiler 400s ("Failed to initialize samplers: failed to parse grammar") on any tools-enabled native chat when an advertised tool schema carries an oversized bound. Culprit in the wild: Funkwhale `fw_upload_track` (`file_base64.maxLength: 200000000` — and, discovered mid-fix, its `file_path.maxLength: 4096` alone also crashes the compiler).

## What's in it

- **Generic sanitizer at the single choke point:** `sanitizeToolSchema()` applied in `getChatTools()` (the one builder all chat-path callers use — chat.js, one-shot.js, meta-glasses routes). Key-agnostic recursive walker (covers properties/items incl. tuple-form/anyOf/oneOf/allOf/additionalProperties/$defs for free), deletes `maxLength`/`minLength` > `SCHEMA_BOUND_LIMIT`, non-mutating (fresh trees; the MCP servers' own advertised schemas untouched), never throws. Execution-time validation unaffected — the real MCP server's zod schema still enforces its limits on actual calls.
- **Threshold live-calibrated, not guessed:** initial 4096 was disproven against the real b10068 grammar compiler (bisection: 1990 passes, 2000 fails) → `SCHEMA_BOUND_LIMIT = 1024`, documented as build-specific in the constant's comment. Raw probe logs in the evidence bundle.
- **Source fix:** Funkwhale's absurd `maxLength` removed from the advertised schema (size enforcement belongs in the handler; honestly documented as currently unbounded there — same as before, the 200M bound was never real protection).
- **19 tests** incl. a deletion-detectable integration test through the real `connectedServers` singleton (core tools alone structurally can't catch a regression — the addon path is the load-bearing one).

## Live proof (evidence `~/.crow/p4/c1san-liveverify/`)

Against the preserved C1 scratch env with the real unpatched Funkwhale MCP connected (exact prod-gap reproduction): chip-1 message via the real chat SSE → HTTP 200, no grammar error, and the model made a genuine `crow_memory(recall_by_context)` tool call. (The recall itself returned empty — root-caused separately to `recall_by_context`'s implicit-AND FTS matching; fix in the next PR.)

Suite 2491/2491 on branch base (2472 + 19). No new deps, no schema changes, no ports. Follow-ups noted: `SCHEMA_BOUND_LIMIT` recalibration on llama.cpp upgrades; Funkwhale handler-side size enforcement.