### PR TITLE
fix(memory): FTS OR-fallback — natural-language questions can actually recall

### DIFF
--- a/servers/db.js
+++ b/servers/db.js
@@ -34,6 +34,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * Sanitize user input for use in SQLite FTS5 MATCH queries.
  * Strips FTS5 operators and wraps individual terms in double quotes
  * for safe literal matching. Returns null if no valid terms remain.
+ *
+ * The returned string joins terms with a bare space, which FTS5 parses as
+ * an implicit AND — every term must appear in a row for it to match. That's
+ * the right default for precise recall, but it means an ordinary
+ * multi-word natural-language question (which is mostly function words)
+ * can require all of them verbatim in one row and match nothing. See
+ * `orFromAndFtsQuery` / `ftsMatchWithOrFallback` below for the fallback.
  */
 export function sanitizeFtsQuery(input) {
   if (!input || typeof input !== "string") return null;
@@ -50,6 +57,50 @@ export function sanitizeFtsQuery(input) {
     .map((w) => `"${w}"`)
     .join(" ");
   return terms || null;
+}
+
+/**
+ * Convert an AND-form FTS5 MATCH query (as returned by `sanitizeFtsQuery` —
+ * quoted terms joined by a bare space, i.e. implicit AND) into the same
+ * terms joined with explicit OR. The input is already a sequence of
+ * individually double-quoted terms with no embedded spaces, so splitting
+ * on the single-space separator and rejoining with " OR " is safe and
+ * introduces no new injection surface — every term stays quoted exactly
+ * as sanitizeFtsQuery produced it.
+ *
+ * Returns null for null/empty input. For a single-term query, OR and AND
+ * are identical, so the caller can treat that as "no different fallback".
+ */
+export function orFromAndFtsQuery(safeQuery) {
+  if (!safeQuery) return null;
+  return safeQuery.split(" ").join(" OR ");
+}
+
+/**
+ * Run an FTS5 MATCH query built from `sanitizeFtsQuery` (implicit AND
+ * across terms). If the strict AND query returns zero rows, retry the
+ * identical terms joined with OR before giving up — this is what turns an
+ * honest-but-unhelpful empty result for ordinary multi-word prose ("What
+ * can you remember for me?") into a ranked broader match, while leaving
+ * every precise AND match that already succeeds untouched (the AND query
+ * is always tried first and returned as-is whenever it finds anything).
+ *
+ * Assumes `params[0]` is the FTS MATCH argument produced by
+ * sanitizeFtsQuery, and that `sql` contains `ORDER BY rank` so the OR
+ * fallback still ranks rows matching more terms first.
+ *
+ * @param {{execute: (arg: {sql: string, args: any[]}) => Promise<any>}} db
+ * @param {string} sql
+ * @param {any[]} params
+ * @returns {Promise<any[]>} rows
+ */
+export async function ftsMatchWithOrFallback(db, sql, params) {
+  const result = await db.execute({ sql, args: params });
+  if (result.rows.length > 0) return result.rows;
+  const orQuery = orFromAndFtsQuery(params[0]);
+  if (!orQuery || orQuery === params[0]) return result.rows;
+  const orResult = await db.execute({ sql, args: [orQuery, ...params.slice(1)] });
+  return orResult.rows;
 }
 
 /**

--- a/servers/memory/server.js
+++ b/servers/memory/server.js
@@ -7,7 +7,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { createDbClient, sanitizeFtsQuery, escapeLikePattern } from "../db.js";
+import { createDbClient, sanitizeFtsQuery, escapeLikePattern, ftsMatchWithOrFallback } from "../db.js";
 import { generateCrowContext, PROTECTED_SECTIONS, invalidateContextCache } from "./crow-context.js";
 import { generateToken, validateToken, shouldSkipGates } from "../shared/confirm.js";
 import { createNotification, cleanupNotifications } from "../shared/notifications.js";
@@ -118,7 +118,7 @@ export function createMemoryServer(dbPath, options = {}) {
 
   server.tool(
     "crow_search_memories",
-    "Search persistent memory using full-text search (and semantic search when available). Returns memories ranked by relevance. Use this to recall information from previous sessions.",
+    "Search persistent memory using full-text search (and semantic search when available). Returns memories ranked by relevance; if no memory contains every query word, automatically broadens to memories containing any query word before reporting no results. Use this to recall information from previous sessions.",
     {
       query: z.string().max(500).describe("Search query"),
       category: z.string().max(500).optional().describe("Filter by category"),
@@ -209,8 +209,9 @@ export function createMemoryServer(dbPath, options = {}) {
         sql += " ORDER BY rank LIMIT ?";
         params.push(limit);
 
-        const result = await db.execute({ sql, args: params });
-        rows = result.rows;
+        // Precise AND match first; only if that finds nothing, retry the
+        // same terms OR'd together (rank ordering still applies either way).
+        rows = await ftsMatchWithOrFallback(db, sql, params);
       }
 
       // Merge: semantic results first, then FTS results (deduplicated)
@@ -244,7 +245,7 @@ export function createMemoryServer(dbPath, options = {}) {
 
   server.tool(
     "crow_recall_by_context",
-    "Retrieve memories relevant to a given context. Uses full-text search across content, context, and tags. Memories tagged source='maker-lab' are excluded by default to keep kid-session memories out of generic recall; pass include_maker_lab=true to include them (use this when operating within the maker-lab skill).",
+    "Retrieve memories relevant to a given context. Uses full-text search across content, context, and tags, preferring memories that contain every significant word of the context; if none do, automatically broadens to memories containing any of those words before reporting none found. Memories tagged source='maker-lab' are excluded by default to keep kid-session memories out of generic recall; pass include_maker_lab=true to include them (use this when operating within the maker-lab skill).",
     {
       context: z.string().max(2000).describe("Describe the current context or topic to find relevant memories"),
       limit: z.number().max(100).default(5).describe("Maximum results"),
@@ -276,7 +277,9 @@ export function createMemoryServer(dbPath, options = {}) {
       sql += " ORDER BY rank LIMIT ?";
       params.push(limit);
 
-      const { rows } = await db.execute({ sql, args: params });
+      // Precise AND match first; only if that finds nothing, retry the
+      // same terms OR'd together (rank ordering still applies either way).
+      const rows = await ftsMatchWithOrFallback(db, sql, params);
 
       if (rows.length === 0) {
         return { content: [{ type: "text", text: "No relevant memories found for this context." }] };

--- a/tests/recall-or-fallback.test.js
+++ b/tests/recall-or-fallback.test.js
@@ -1,0 +1,247 @@
+/**
+ * FTS OR-fallback in memory recall (C1 aha-regression fix).
+ *
+ * Root cause (see .superpowers/sdd/c1/recall-miss-investigation.md):
+ * `crow_recall_by_context` and `crow_search_memories` both build their FTS5
+ * MATCH query by quoting each word individually via `sanitizeFtsQuery()`
+ * (servers/db.js) and space-joining them. SQLite FTS5 treats a bare-space
+ * join as an implicit AND, so an ordinary multi-word natural-language
+ * question (mostly function words: "what", "can", "for", "with") requires
+ * EVERY token to appear verbatim in one row — which no free-text starter
+ * memory ever satisfies. All six onboarding suggestion chips (3 EN + 3 ES,
+ * from servers/gateway/dashboard/shared/i18n.js messages.suggest1-3)
+ * reproduce this against the real seeded starter memories
+ * (servers/gateway/dashboard/panels/onboarding/starter-content.js).
+ *
+ * The fix (servers/db.js `ftsMatchWithOrFallback`): run the existing AND
+ * query unchanged; only if it returns zero rows, retry the SAME sanitized
+ * terms joined with OR before giving up. No behavior change when AND
+ * already finds something.
+ *
+ * Harness follows tests/starter-content.test.js: real init-db.js schema
+ * (captures the memories_fts triggers) + createMemoryServer +
+ * InMemoryTransport MCP client so the real tool path is exercised, not a
+ * hand-built SQL query.
+ */
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDbClient, sanitizeFtsQuery } from "../servers/db.js";
+import { createMemoryServer } from "../servers/memory/server.js";
+import { seedStarterMemories } from "../servers/gateway/dashboard/panels/onboarding/starter-content.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+const REPO_ROOT = join(import.meta.dirname, "..");
+
+// The exact six onboarding suggestion-chip strings (i18n.js messages.suggest1-3,
+// en + es). Hardcoded here (not imported) so this test independently pins the
+// literal wording the memo's evidence table reproduced against — if i18n.js
+// wording drifts, this test should be updated deliberately, not silently
+// track the source file.
+const CHIPS_EN = [
+  "What can you remember for me?",
+  "Remember that my favorite color is blue.",
+  "What can you help me with?",
+];
+const CHIPS_ES = [
+  "¿Qué puedes recordar por mí?",
+  "Recuerda que mi color favorito es el azul.",
+  "¿En qué puedes ayudarme?",
+];
+
+const tmpDirs = [];
+after(() => {
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** Fresh scratch DB (real init-db.js schema) seeded with starter memories in `lang`. */
+async function makeSeededDb(lang) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-recall-orfallback-${lang}-`));
+  tmpDirs.push(dir);
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: REPO_ROOT,
+  });
+  const dbPath = join(dir, "crow.db");
+  const db = createDbClient(dbPath);
+  await seedStarterMemories(db, lang);
+  return { dir, dbPath, db };
+}
+
+/** Connect a real MCP client to a real crow-memory server backed by dbPath. */
+async function connectClient(dbPath) {
+  const server = createMemoryServer(dbPath);
+  const client = new Client({ name: "test-recall-or-fallback", version: "0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return client;
+}
+
+function textOf(result) {
+  return result.content.map((c) => c.text || "").join("\n");
+}
+
+// ── Test 1: the aha regression gate — all six chips must return hits ───────
+
+test("crow_recall_by_context: all three EN suggestion chips return memories against the real starter set", async () => {
+  const { dbPath } = await makeSeededDb("en");
+  const client = await connectClient(dbPath);
+  try {
+    for (const chip of CHIPS_EN) {
+      const result = await client.callTool({
+        name: "crow_recall_by_context",
+        arguments: { context: chip },
+      });
+      assert.ok(!result.isError, `chip "${chip}" errored: ${JSON.stringify(result.content)}`);
+      const text = textOf(result);
+      assert.doesNotMatch(
+        text,
+        /No relevant memories found/,
+        `EN chip "${chip}" must return at least one memory (AND-only would return zero — see investigation memo)`
+      );
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+test("crow_recall_by_context: all three ES suggestion chips return memories against the real starter set", async () => {
+  const { dbPath } = await makeSeededDb("es");
+  const client = await connectClient(dbPath);
+  try {
+    for (const chip of CHIPS_ES) {
+      const result = await client.callTool({
+        name: "crow_recall_by_context",
+        arguments: { context: chip },
+      });
+      assert.ok(!result.isError, `chip "${chip}" errored: ${JSON.stringify(result.content)}`);
+      const text = textOf(result);
+      assert.doesNotMatch(
+        text,
+        /No relevant memories found/,
+        `ES chip "${chip}" must return at least one memory (AND-only would return zero — see investigation memo)`
+      );
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+// ── Test 2: AND-precision preserved — no regression when AND already hits ──
+
+test("crow_recall_by_context: a context fully covered by one row returns that row, and the AND query alone already sufficed (no fallback needed)", async () => {
+  const { dbPath, db } = await makeSeededDb("en");
+  const client = await connectClient(dbPath);
+  try {
+    // Every one of these words appears verbatim, together, only in the
+    // "dashboard sidebar" starter row.
+    const context = "dashboard sidebar Bot Builder Extensions";
+    const result = await client.callTool({
+      name: "crow_recall_by_context",
+      arguments: { context },
+    });
+    assert.ok(!result.isError);
+    const text = textOf(result);
+    assert.match(text, /dashboard sidebar has Memory/, "returns the exact matching starter row");
+
+    // Cheaply observe that the AND-only query (pre-fallback) already found
+    // this row by itself, i.e. the tool's fallback path was never needed.
+    const contextWords = context.split(/\s+/).filter((w) => w.length > 2).slice(0, 10).join(" ");
+    const safeQuery = sanitizeFtsQuery(contextWords);
+    const { rows: andRows } = await db.execute({
+      sql: `SELECT m.id FROM memories_fts fts JOIN memories m ON m.id = fts.rowid
+            WHERE memories_fts MATCH ? AND (m.source IS NULL OR m.source != 'maker-lab')`,
+      args: [safeQuery],
+    });
+    assert.ok(andRows.length > 0, "the strict AND query alone already matched — OR fallback was not required");
+  } finally {
+    await client.close();
+  }
+});
+
+// ── Test 3: zero-match honesty — OR fallback must not invent hits ──────────
+
+test("crow_recall_by_context: a context matching no row (AND or OR) returns an honest empty result", async () => {
+  const { dbPath } = await makeSeededDb("en");
+  const client = await connectClient(dbPath);
+  try {
+    const result = await client.callTool({
+      name: "crow_recall_by_context",
+      arguments: { context: "xylophone kumquat zeppelin platypus" },
+    });
+    assert.ok(!result.isError);
+    const text = textOf(result);
+    assert.match(text, /No relevant memories found for this context\./);
+  } finally {
+    await client.close();
+  }
+});
+
+// ── Test 4: crow_search_memories had the identical defect — same fix, same gate ──
+
+test("crow_search_memories: all three EN suggestion chips (as raw queries) return memories against the real starter set", async () => {
+  const { dbPath } = await makeSeededDb("en");
+  const client = await connectClient(dbPath);
+  try {
+    for (const chip of CHIPS_EN) {
+      const result = await client.callTool({
+        name: "crow_search_memories",
+        arguments: { query: chip, semantic: false },
+      });
+      assert.ok(!result.isError, `chip "${chip}" errored: ${JSON.stringify(result.content)}`);
+      const text = textOf(result);
+      assert.doesNotMatch(
+        text,
+        /No memories found matching that query\./,
+        `EN chip "${chip}" must return at least one memory via crow_search_memories`
+      );
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+test("crow_search_memories: all three ES suggestion chips (as raw queries) return memories against the real starter set", async () => {
+  const { dbPath } = await makeSeededDb("es");
+  const client = await connectClient(dbPath);
+  try {
+    for (const chip of CHIPS_ES) {
+      const result = await client.callTool({
+        name: "crow_search_memories",
+        arguments: { query: chip, semantic: false },
+      });
+      assert.ok(!result.isError, `chip "${chip}" errored: ${JSON.stringify(result.content)}`);
+      const text = textOf(result);
+      assert.doesNotMatch(
+        text,
+        /No memories found matching that query\./,
+        `ES chip "${chip}" must return at least one memory via crow_search_memories`
+      );
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+test("crow_search_memories: a query matching no row still returns an honest empty result", async () => {
+  const { dbPath } = await makeSeededDb("en");
+  const client = await connectClient(dbPath);
+  try {
+    const result = await client.callTool({
+      name: "crow_search_memories",
+      arguments: { query: "xylophone kumquat zeppelin platypus", semantic: false },
+    });
+    assert.ok(!result.isError);
+    const text = textOf(result);
+    assert.match(text, /No memories found matching that query\./);
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
Fixes the aha-gating recall miss found in the C1 live proof: `crow_recall_by_context` (and, it turned out, `crow_search_memories` — identical mechanism) space-joins individually-quoted tokens into an implicit FTS5 AND, so any natural multi-word question ("What can you remember for me?") required every token — including function words — to co-occur verbatim in one row. All six C1 suggestion chips (EN+ES) returned zero rows against the starter memories; single-word queries hit. The model's tool call was correct; the tool's matching was the defect.

**Fix (from the ranked investigation memo):** AND-first, OR-fallback — the existing query runs byte-identical (same SQL, rank ORDER BY, LIMIT, maker-lab filter); only when it returns zero rows do the *same already-quoted sanitized tokens* rerun joined with `OR`. Shared helper (`orFromAndFtsQuery` + `ftsMatchWithOrFallback` in `servers/db.js`) used by both tools — one mechanism, no duplication. Injection-safe by construction: the OR transform reshuffles a fully-quoted string the sanitizer already produced (reviewer hand-traced adversarial payloads: embedded quotes, ` OR `, NEAR, `*`, `^`, `:` — all neutralized pre-quoting, unchanged from before). FTS syntax errors still propagate — zero-rows is the only fallback trigger. Single-term queries short-circuit. Tool descriptions updated honestly.

**Tests (7, real mechanism):** real init-db schema + real `createMemoryServer` over in-memory MCP + real `seedStarterMemories` + the byte-identical i18n chip strings — all six chips now hit via both tools (the aha regression gate); AND-precision preserved when AND matches; zero-match honesty (OR finding nothing still returns empty); deletion check flips 4/7 tests red.

Suite **2542/2542/0/0** (2535 + 7). No new deps/schema/ports. Follow-ups filed: `crow_deep_recall` has the same AND-only behavior (pre-existing, untouched); a dedicated adversarial-payload regression test for the sanitizer pair.