### PR TITLE
pm-workspace: digest Briefing section + sync-flag dedupe

### DIFF
--- a/bundles/pm-workspace/server/digest/adapters/briefing.js
+++ b/bundles/pm-workspace/server/digest/adapters/briefing.js
@@ -1,0 +1,38 @@
+/**
+ * Digest adapter — stored briefing (week-ahead / daily).
+ *
+ * Renders the tasks bundle's stored briefing for the digest date
+ * (tasks_briefings, written via tasks_store_briefing) so a
+ * briefing-prep ritual can lead the morning email with distilled
+ * follow-ups instead of raw feeds.
+ *
+ * Returns null when there is simply no briefing for the date — the
+ * section is omitted rather than rendered as noise. Real failures
+ * (db errors) degrade to an unavailable section.
+ */
+
+import { createTasksDbClient } from "../../db.js";
+
+export async function briefingSection(config, date) {
+  const section = { title: "Briefing", available: false };
+  let tdb = null;
+  try {
+    tdb = createTasksDbClient(config);
+    if (!tdb) return null;
+    const { rows } = await tdb.execute({
+      sql: "SELECT content, created_at FROM tasks_briefings WHERE briefing_date = ? LIMIT 1",
+      args: [date],
+    });
+    if (!rows.length) return null;
+    section.available = true;
+    section.markdown = String(rows[0].content || "");
+    section.note = `stored ${rows[0].created_at}`;
+  } catch (err) {
+    // Missing table (older tasks bundle) is a quiet omit; anything else surfaces.
+    if (/no such table/i.test(err.message)) return null;
+    section.reason = `briefing unavailable: ${err.message}`;
+  } finally {
+    try { tdb?.close?.(); } catch { /* ignore */ }
+  }
+  return section;
+}

--- a/bundles/pm-workspace/server/digest/adapters/monday-local.js
+++ b/bundles/pm-workspace/server/digest/adapters/monday-local.js
@@ -26,19 +26,25 @@ export async function mondayLocalSection(db) {
       };
     }
 
+    // The sync re-logs unresolved flags every run (e.g. delete_flagged each
+    // 15-min pull), so collapse to one row per distinct problem with a count —
+    // otherwise a single stale flag fills the whole section.
     const problems = await db.execute({
-      sql: `SELECT run_at, action, board_id, item_ref, detail
+      sql: `SELECT MAX(run_at) AS run_at, action, board_id, item_ref,
+                   detail, COUNT(*) AS n
             FROM pm_sync_log
             WHERE (ok = 0 OR action IN ('conflict','delete_flagged'))
               AND run_at >= datetime('now', '-1 day')
+            GROUP BY board_id, action, item_ref
             ORDER BY run_at DESC LIMIT 10`,
       args: [],
     });
     for (const row of problems.rows) {
+      const times = Number(row.n) > 1 ? ` (×${row.n} in 24h)` : "";
       section.items.push({
-        label: `${row.action} — ${row.item_ref || "?"}`,
+        label: `${row.action} — ${row.item_ref || "?"}${times}`,
         detail: row.detail || "",
-        meta: `board ${row.board_id} · ${row.run_at}`,
+        meta: `board ${row.board_id} · last ${row.run_at}`,
         urgent: true,
       });
     }

--- a/bundles/pm-workspace/server/digest/index.js
+++ b/bundles/pm-workspace/server/digest/index.js
@@ -10,6 +10,7 @@
  */
 
 import { boardsSections } from "./adapters/boards.js";
+import { briefingSection } from "./adapters/briefing.js";
 import { googleSections } from "./adapters/google.js";
 import { mondayLocalSection } from "./adapters/monday-local.js";
 import { boxSection } from "./adapters/box.js";
@@ -46,6 +47,8 @@ export async function assembleDigest(db, config) {
     }
   };
 
+  // Briefing leads the digest — distilled follow-ups before raw feeds.
+  push(await guarded(() => briefingSection(config, localDate()), "Briefing"));
   push(await guarded(() => boardsSections(db, config), "Boards"));
   push(await guarded(() => mondayLocalSection(db), "Monday sync"));
   push(await guarded(() => googleSections(config), "Google"));

--- a/bundles/pm-workspace/server/digest/render.js
+++ b/bundles/pm-workspace/server/digest/render.js
@@ -12,6 +12,7 @@
  *     reason?: string,              // when unavailable
  *     items?: [{ label, detail?, meta?, urgent? }],
  *     table?: { headers: [...], rows: [[...], ...] },
+ *     markdown?: string,            // pre-authored body (briefings) — minimal md subset
  *     note?: string }
  */
 
@@ -32,11 +33,56 @@ const S = {
   urgent: "background:#fee;border-left:4px solid #e74c3c;padding:10px;margin:10px 0;border-radius:4px;",
   meta: "color:#666;font-size:0.85em;",
   unavailable: "color:#999;font-style:italic;font-size:0.9em;",
+  h3: "color:#34495e;margin:14px 0 4px;font-size:1em;",
+  p: "margin:4px 0;",
+  ul: "margin:4px 0;padding-left:22px;",
+  li: "margin:2px 0;",
+  briefing: "background:#f4f9ff;border-left:4px solid #3498db;padding:4px 14px 10px;margin:8px 0;border-radius:4px;",
   table: "width:100%;border-collapse:collapse;margin:8px 0;font-size:0.9em;",
   th: "text-align:left;padding:6px 8px;border-bottom:2px solid #ddd;color:#34495e;",
   td: "padding:6px 8px;border-bottom:1px solid #eee;",
   footer: "margin-top:30px;padding-top:15px;border-top:1px solid #ddd;color:#666;font-size:0.9em;",
 };
+
+/**
+ * Minimal markdown → email HTML for briefing bodies. Supports the subset the
+ * briefing template uses: ## / ### headings, - lists, **bold**, [text](url)
+ * links, and blank-line paragraphs. Everything is escaped first; no raw HTML
+ * passes through.
+ */
+export function mdToHtml(md) {
+  const inline = (s) =>
+    escapeHtml(s)
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(
+        /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+        `<a href="$2" style="color:#3498db">$1</a>`
+      );
+
+  const out = [];
+  let list = null;
+  const closeList = () => {
+    if (list) { out.push("</ul>"); list = null; }
+  };
+  for (const raw of String(md || "").split(/\r?\n/)) {
+    const line = raw.trimEnd();
+    const h = line.match(/^(#{2,4})\s+(.*)$/);
+    if (h) {
+      closeList();
+      out.push(`<h3 style="${S.h3}">${inline(h[2])}</h3>`);
+    } else if (/^[-*]\s+/.test(line)) {
+      if (!list) { out.push(`<ul style="${S.ul}">`); list = true; }
+      out.push(`<li style="${S.li}">${inline(line.replace(/^[-*]\s+/, ""))}</li>`);
+    } else if (line.trim() === "") {
+      closeList();
+    } else {
+      closeList();
+      out.push(`<p style="${S.p}">${inline(line)}</p>`);
+    }
+  }
+  closeList();
+  return out.join("\n");
+}
 
 function renderSectionHtml(section) {
   const out = [`<h2 style="${S.h2}">${escapeHtml(section.title)}</h2>`];
@@ -44,6 +90,10 @@ function renderSectionHtml(section) {
   if (!section.available) {
     out.push(`<p style="${S.unavailable}">${escapeHtml(section.reason || "Unavailable")}</p>`);
     return out.join("\n");
+  }
+
+  if (section.markdown) {
+    out.push(`<div style="${S.briefing}">${mdToHtml(section.markdown)}</div>`);
   }
 
   if (section.table && section.table.rows?.length) {
@@ -68,7 +118,7 @@ function renderSectionHtml(section) {
     }
   }
 
-  if (!section.table?.rows?.length && !section.items?.length) {
+  if (!section.table?.rows?.length && !section.items?.length && !section.markdown) {
     out.push(`<p style="${S.meta}">${escapeHtml(section.note || "Nothing to report.")}</p>`);
   } else if (section.note) {
     out.push(`<p style="${S.meta}">${escapeHtml(section.note)}</p>`);
@@ -124,6 +174,9 @@ export function renderDigest(digest, config = {}) {
       text.push(`  (${section.reason || "unavailable"})`);
       continue;
     }
+    if (section.markdown) {
+      for (const line of String(section.markdown).split(/\r?\n/)) text.push("  " + line);
+    }
     if (section.table?.rows?.length) {
       for (const row of section.table.rows) text.push("  " + row.join(" | "));
     }
@@ -133,7 +186,7 @@ export function renderDigest(digest, config = {}) {
         if (item.meta) text.push(`      ${item.meta}`);
       }
     }
-    if (!section.table?.rows?.length && !section.items?.length) {
+    if (!section.table?.rows?.length && !section.items?.length && !section.markdown) {
       text.push(`  ${section.note || "Nothing to report."}`);
     } else if (section.note) {
       text.push(`  ${section.note}`);
@@ -146,7 +199,10 @@ export function renderDigest(digest, config = {}) {
   const parts = [];
   for (const section of digest.sections) {
     if (!section.available) continue;
-    const n = (section.items?.length || 0) + (section.table?.rows?.length || 0);
+    const n =
+      (section.items?.length || 0) +
+      (section.table?.rows?.length || 0) +
+      (section.markdown ? 1 : 0);
     if (n > 0) parts.push(`${section.title}: ${n}`);
   }
   const summary = parts.length ? parts.join(" · ") : "Nothing to report today.";


### PR DESCRIPTION
## What

1. **Digest Briefing section** — new adapter reads the tasks bundle's `tasks_briefings` row for the send date (written via `tasks_store_briefing`) and renders it at the **top** of the daily digest. This lets a weekly briefing-prep ritual lead the morning email with distilled follow-ups (week map, asks, deadline radar) instead of raw feeds. No briefing stored → section omitted entirely; missing tasks.db/table → omitted; real db errors → unavailable section.
2. **Markdown rendering** — `render.js` gains a `markdown` section field with a minimal, escape-first md subset (`##`/`###` headings, `-` lists, `**bold**`, `[text](url)` links, paragraphs). Plain-text variant passes markdown through verbatim (readable as-is). Summary line counts a briefing as 1.
3. **Sync-flag dedupe** — the Monday sync re-logs unresolved flags every 15-min pull, so a single stale `delete_flagged` filled the digest section with 10 identical rows. Now grouped per (board, action, item_ref) with a `×N in 24h` count.

## Testing

Smoke script (node, against a fixture tasks.db): md subset renders + escapes raw HTML, briefing row found for matching date, null for no-row date and absent db, Briefing section leads the rendered digest, markdown reaches both HTML and text variants, summary counts it. All assertions pass.