### PR TITLE
feat(bundles): bot-engine bundle, npm_required install hardening, engine status (C4-B)

### DIFF
--- a/bundles/bot-engine/manifest.json
+++ b/bundles/bot-engine/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "bot-engine",
+  "name": "Bot Engine (pi)",
+  "description": "The agent engine behind Bot Builder's email and chat channels (Gmail, Discord, Telegram, Slack). Installs the pi coding agent as a per-instance npm payload — no Docker, no open ports, no system services.",
+  "type": "bundle",
+  "category": "ai",
+  "version": "1.0.0",
+  "origin": "official",
+  "npm_required": true,
+  "requires": { "min_ram_mb": 512, "min_disk_mb": 400 },
+  "env_vars": [],
+  "verify_paths": ["node_modules/@earendil-works/pi-coding-agent/dist/cli.js"]
+}

--- a/bundles/bot-engine/package-lock.json
+++ b/bundles/bot-engine/package-lock.json
@@ -1,0 +1,1564 @@
+{
+  "name": "crow-bot-engine",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-bot-engine",
+      "version": "1.0.0",
+      "dependencies": {
+        "@earendil-works/pi-coding-agent": "0.74.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1091.0.tgz",
+      "integrity": "sha512-THeQe5ftFfJD0DdSanD3BjXjjbOWK5mhJX1pEzDUH9VgBRGB9KFCIDTfgWOj6hZ8HTMpZdjF2WjqopuESleEAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/eventstream-handler-node": "^3.972.29",
+        "@aws-sdk/middleware-eventstream": "^3.972.24",
+        "@aws-sdk/middleware-websocket": "^3.972.41",
+        "@aws-sdk/token-providers": "3.1091.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.29.tgz",
+      "integrity": "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.24.tgz",
+      "integrity": "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.41.tgz",
+      "integrity": "sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1091.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1091.0.tgz",
+      "integrity": "sha512-l+/H0KCTcUZzE4RVT+eW5E94BRKX4vsuvquWvldzIjiDkGonMJM0sOtdZYeW4z5hq953jY+wESFGpCxs0K62GQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.2.tgz",
+      "integrity": "sha512-RPlB3bi2z+VQK0HRhBK73kXOQI1fFmRgWzzT6+ihB7JYfh29jb7eAfYvpx8rlf248gUAYaLQ8JYa+43l09rPmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.2",
+        "ignore": "^7.0.5",
+        "typebox": "^1.1.24",
+        "yaml": "^2.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.2.tgz",
+      "integrity": "sha512-ukQBHGDm20k9ZUS2cGjNN9vDJp/48r35xmvgSx3paCaC06r2N/PLuRZoJmwQ1ZM7f8T3072odv9YPWn+77w0LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "typebox": "^1.1.24"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.74.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.2.tgz",
+      "integrity": "sha512-4Ey/ZgKw8Rq/cLhKtam7ze+LrTg+cNGRMCcAm0HCteHyVbYGbYqbbV8KzXW6fD/X64+213E9PJvIiPfpKJ1kOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.2",
+        "@earendil-works/pi-ai": "^0.74.2",
+        "@earendil-works/pi-tui": "^0.74.2",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "diff": "^8.0.2",
+        "glob": "^13.0.1",
+        "highlight.js": "^10.7.3",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.74.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.2.tgz",
+      "integrity": "sha512-valQPz74qbdydRqII6t9rJ46YANMOOJeDhKm25a1ZrWvWwdjAaAEu6s3ur/LWz84Wkkwcbub2ZkVjzCZi8gFGA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.5.0.tgz",
+      "integrity": "sha512-S/r6tkiUHblaDJGsb84WS0ePTF2YHVta2EoTi1NJqHNt5mfRRS2uE4v7hCYV134+an+fk6WgG3+aFfinJbQBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
+      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.11.tgz",
+      "integrity": "sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.8.tgz",
+      "integrity": "sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.8.tgz",
+      "integrity": "sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.7.tgz",
+      "integrity": "sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
+      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/bot-engine/package.json
+++ b/bundles/bot-engine/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "crow-bot-engine",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": { "@earendil-works/pi-coding-agent": "0.74.2" }
+}

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -302,6 +302,25 @@
       "official": true
     },
     {
+      "id": "bot-engine",
+      "name": "Bot Engine (pi)",
+      "description": "The agent engine behind Bot Builder's email and chat channels (Gmail, Discord, Telegram, Slack). Installs the pi coding agent as a per-instance npm payload — no Docker, no open ports, no system services.",
+      "type": "bundle",
+      "category": "ai",
+      "version": "1.0.0",
+      "origin": "official",
+      "npm_required": true,
+      "requires": {
+        "min_ram_mb": 512,
+        "min_disk_mb": 400
+      },
+      "env_vars": [],
+      "verify_paths": [
+        "node_modules/@earendil-works/pi-coding-agent/dist/cli.js"
+      ],
+      "official": true
+    },
+    {
       "id": "browser",
       "name": "Browser Automation",
       "version": "1.0.0",

--- a/registry/collections.json
+++ b/registry/collections.json
@@ -54,6 +54,13 @@
         { "id": "uptime-kuma", "kind": "deploys" },
         { "id": "data-dashboard", "kind": "builtin" }
       ]
+    },
+    {
+      "id": "agents",
+      "name": "Agents",
+      "description": "Run AI bots on email and chat — the bot engine plus everything Bot Builder needs to put an agent on a channel.",
+      "icon": "🤖",
+      "members": [ { "id": "bot-engine", "kind": "builtin" } ]
     }
   ]
 }

--- a/registry/collections.json
+++ b/registry/collections.json
@@ -59,7 +59,7 @@
       "id": "agents",
       "name": "Agents",
       "description": "Run AI bots on email and chat — the bot engine plus everything Bot Builder needs to put an agent on a channel.",
-      "icon": "🤖",
+      "icon": "bot",
       "members": [ { "id": "bot-engine", "kind": "builtin" } ]
     }
   ]

--- a/servers/gateway/bot-engine-status.js
+++ b/servers/gateway/bot-engine-status.js
@@ -1,0 +1,92 @@
+/**
+ * Bot-engine status — a LEAF module (imports ONLY pi_resolver.mjs).
+ *
+ * Two other subsystems each own a distinct signal about whether the bot
+ * engine ("pi") is usable right now:
+ *   - routes/bundles.js knows about in-flight installs (its in-memory jobs
+ *     Map, via activeJobFor()).
+ *   - bot-runtime.js (PR C4-C) knows about the circuit breaker guarding
+ *     repeated spawn failures.
+ *
+ * Rather than importing either of those directly, each source registers
+ * itself INTO this module at init via a setter (setActiveJobSource /
+ * setBreakerSource). bundles.js is a ~2,500-line file that drags in express,
+ * db.js, peer-forward, and cross-host-auth — importing it from here would
+ * risk an ESM cycle back through anything that imports bot-engine-status
+ * (the readiness UI, the attach gate). Inverting the wiring keeps this
+ * module a leaf so both of those callers can use engineStatus() cheaply and
+ * often without pulling in either dependency graph.
+ *
+ * Precedence, most urgent first (r1-reviewed): installing > absent >
+ * unhealthy > ready. Absent beats a stale open breaker — an uninstalled
+ * engine is "absent", never "unhealthy" (a breaker only means something
+ * once something concrete has been spawned and failed; resolvePiCli()
+ * returning null is ground truth that nothing is there to have failed).
+ *
+ * Every check here is a cheap synchronous fs stat (via resolvePiCli) or a
+ * plain function call — no caching, no async I/O.
+ */
+import { resolvePiCli } from "../../scripts/pi-bots/pi_resolver.mjs";
+
+const BOT_ENGINE_BUNDLE_ID = "bot-engine";
+
+export const ENGINE_CHANNELS = ["gmail", "discord", "telegram", "slack"];
+
+/** wired by bot-runtime.js in PR C4-C: fn() => { open, lastError, retryAt } | null */
+let breakerSource = null;
+/** wired by routes/bundles.js at router construction: fn(bundleId) => job | null */
+let activeJobSource = null;
+
+/** @param {() => ({open: boolean, lastError?: string, retryAt?: string} | null)} fn */
+export function setBreakerSource(fn) {
+  breakerSource = typeof fn === "function" ? fn : null;
+}
+
+/** @param {(bundleId: string) => (object | null)} fn */
+export function setActiveJobSource(fn) {
+  activeJobSource = typeof fn === "function" ? fn : null;
+}
+
+/**
+ * Test-only: set (or clear) both registered sources in one call — mirrors
+ * the _setDockerProbeForTest / _resetDockerProbeForTest idiom in
+ * dashboard/panels/extensions/data-queries.js. Call with no args (or {})
+ * between tests so one test's breaker/job stub can never leak into the
+ * next (this module's sources are plain module-level state, not per-test).
+ *
+ * @param {{breaker?: Function|null, activeJob?: Function|null}} [seams]
+ */
+export function _setSeamsForTest({ breaker = null, activeJob = null } = {}) {
+  breakerSource = typeof breaker === "function" ? breaker : null;
+  activeJobSource = typeof activeJob === "function" ? activeJob : null;
+}
+
+/**
+ * @param {object} [opts]
+ * @param {object} [opts.env] defaults to process.env — forwarded to resolvePiCli
+ * @param {string} [opts.crowHome] forwarded to resolvePiCli (test seam)
+ * @param {string} [opts.repoRoot] forwarded to resolvePiCli (test seam)
+ * @param {string} [opts.execPath] forwarded to resolvePiCli (test seam)
+ * @returns {{state:"installing"}
+ *          |{state:"absent"}
+ *          |{state:"unhealthy", error: string|null, retryAt: string|null}
+ *          |{state:"ready", source: string, cliPath: string}}
+ */
+export function engineStatus({ env = process.env, ...rest } = {}) {
+  const job = activeJobSource?.(BOT_ENGINE_BUNDLE_ID);
+  if (job) return { state: "installing" };
+
+  const resolved = resolvePiCli({ env, ...rest });
+  if (!resolved) return { state: "absent" };
+
+  const breaker = breakerSource?.();
+  if (breaker?.open) {
+    return {
+      state: "unhealthy",
+      error: breaker.lastError ?? null,
+      retryAt: breaker.retryAt ?? null,
+    };
+  }
+
+  return { state: "ready", source: resolved.source, cliPath: resolved.cliPath };
+}

--- a/servers/gateway/dashboard/panels/extensions/html.js
+++ b/servers/gateway/dashboard/panels/extensions/html.js
@@ -20,6 +20,7 @@ export const ICON_MAP = {
   cloud: "☁️",
   image: "\u{1F5BC}️",
   book: "\u{1F4D6}",
+  bot: "\u{1F916}",
   home: "\u{1F3E0}",
   archive: "\u{1F4E6}",
   mic: "\u{1F3A4}",

--- a/servers/gateway/models/state.js
+++ b/servers/gateway/models/state.js
@@ -125,14 +125,25 @@ function canBind(port) {
  * `owner.crowHome` defaults to `resolveDataDir()` (call-time, not a
  * module-load constant, so it reflects whichever CROW_HOME this process
  * is actually running under) and can be overridden for tests.
+ *
+ * `canBind` (the probe function) defaults to the module's real bind-test
+ * and can be overridden for tests. This matters because `node --test` runs
+ * separate test files as concurrent processes: another file's real
+ * `allocatePort` call can transiently hold 127.0.0.1:<port> in this same
+ * 18100-18199 range at the exact moment this call probes it, so a test
+ * asserting an *exact* returned port must stub this out to be hermetic.
  */
-export async function allocatePort(state, modelId, { crowHome = resolveDataDir(), pid = process.pid } = {}) {
+export async function allocatePort(
+  state,
+  modelId,
+  { crowHome = resolveDataDir(), pid = process.pid, canBind: canBindFn = canBind } = {}
+) {
   const reservedPorts = new Set(Object.values(state.reservations).map((r) => r.port));
   for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
     if (reservedPorts.has(port)) continue;
     // eslint-disable-next-line no-await-in-loop -- ports must be probed in
     // ascending order, one at a time; parallelizing would race binds.
-    const free = await canBind(port);
+    const free = await canBindFn(port);
     if (!free) continue;
     state.reservations[modelId] = {
       port,

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -297,6 +297,35 @@ export function _createJobForTest(bundleId, action) { return createJob(bundleId,
 export function _getJobForTest(id) { return jobs.get(id); }
 export function _finishJobForTest(job, status) { return finishJob(job, status); }
 
+/**
+ * C4 Task 3 (r1 critical #4): the unfinished ("running") install job for
+ * bundleId, if any — either a direct single-bundle install job whose
+ * bundleId matches, OR an in-flight "install-set" job whose collection
+ * contains bundleId as a member (r2: an Agents-collection install must read
+ * as "installing" for every member it's carrying, not just the literal
+ * collection id — this is what lets a later status seam (Task 4) report
+ * a member bundle as installing instead of absent).
+ *
+ * Exported (not wired into a status seam here — that's Task 4's
+ * setActiveJobSource) so POST /bundles/api/install can refuse a second
+ * concurrent install of the SAME bundle right now, and Task 4 can reuse the
+ * exact same lookup for engineStatus.
+ *
+ * @param {string} bundleId
+ * @returns {{id:string}|null}
+ */
+export function activeJobFor(bundleId) {
+  for (const job of jobs.values()) {
+    if (job.status !== "running") continue;
+    if (job.action === "install" && job.bundleId === bundleId) return job;
+    if (job.action === "install-set") {
+      const collection = getCollection(job.bundleId, _collectionsPathOverride || undefined);
+      if (collection?.members?.some((m) => m.id === bundleId)) return job;
+    }
+  }
+  return null;
+}
+
 // Broadcasts the job's new state to any live Turbo Stream subscribers
 // (see /dashboard/streams/jobs in routes/streams.js). All mutations go
 // through appendLog/finishJob so this is the chokepoint. Non-throwing.
@@ -353,16 +382,30 @@ function copyBundleRefreshItem(appSrc, destDir, item) {
 
 /**
  * True iff the repo package.json declares a dependency NAME absent from the
- * installed bundle's node_modules/ — the ONLY npm-install trigger (R1/R2:
- * narrow, added-dep-only; a removed dep or a version-range-only bump must NOT
- * fire a boot-time npm install). existsSync(join(nm, depName)) handles
- * @scope/name naturally.
+ * installed bundle's node_modules/ (R1/R2: narrow, added-dep-only; a removed
+ * dep or a version-range-only bump must NOT fire a boot-time npm install), OR
+ * (C4 Task 3) the dependency IS present but is pinned to an exact semver
+ * (`/^\d+\.\d+\.\d+$/`) in the repo package.json and the installed copy's own
+ * package.json reports a different version — version-drift on an exact pin
+ * must also refresh, since presence-by-name alone would bless a stale
+ * install forever. Range-pinned deps stay presence-only: existence of the
+ * name is the only thing checked, exactly as before.
+ * existsSync(join(nm, depName)) handles @scope/name naturally.
  */
 function bundleNeedsNpmInstall(appSrc, destDir) {
   const pkg = readJsonSafe(join(appSrc, "package.json"), null);
   if (!pkg || !pkg.dependencies || typeof pkg.dependencies !== "object") return false;
   const nodeModules = join(destDir, "node_modules");
-  return Object.keys(pkg.dependencies).some((depName) => !existsSync(join(nodeModules, depName)));
+  return Object.keys(pkg.dependencies).some((depName) => {
+    const depDir = join(nodeModules, depName);
+    if (!existsSync(depDir)) return true;
+    const pin = pkg.dependencies[depName];
+    if (typeof pin === "string" && /^\d+\.\d+\.\d+$/.test(pin)) {
+      const installedPkg = readJsonSafe(join(depDir, "package.json"), null);
+      if (!installedPkg || installedPkg.version !== pin) return true;
+    }
+    return false;
+  });
 }
 
 /**
@@ -1303,14 +1346,53 @@ export async function runInstallJob(bundleId, envVars, { job, installedSnapshot,
     // immediately dies with ERR_MODULE_NOT_FOUND for the SDK, which
     // surfaces user-side as "I don't have a music player integration
     // installed" or similar mysteries.
-    if (existsSync(join(destDir, "package.json")) && !existsSync(join(destDir, "node_modules"))) {
+    //
+    // C4 Task 3: manifest.npm_required === true means the bundle is USELESS
+    // without a working install (e.g. bot-engine's pi CLI) — hard-fail on any
+    // npm problem instead of the warn-only behavior every other bundle keeps.
+    // Never skip because node_modules exists: an interrupted prior install can
+    // leave a PARTIAL tree that would pass an absence-only check on retry
+    // (r1 critical #3), so npm_required bundles always rm -rf node_modules
+    // first and reinstall clean.
+    const pkgJsonPath = join(destDir, "package.json");
+    if (manifest?.npm_required === true) {
+      if (!existsSync(pkgJsonPath)) {
+        appendLog(job, "npm install failed: package.json missing from bundle (npm_required)");
+        rmSync(destDir, { recursive: true, force: true });
+        return { ok: false, reason: "npm install failed: package.json missing from bundle" };
+      }
+
+      rmSync(join(destDir, "node_modules"), { recursive: true, force: true });
+      const hasLock = existsSync(join(destDir, "package-lock.json"));
+      const npmArgs = [
+        hasLock ? "ci" : "install",
+        "--omit=optional", "--no-audit", "--no-fund", "--ignore-scripts",
+      ];
+      appendLog(job, `Installing bundle dependencies (npm ${npmArgs[0]}, required)…`);
+      try {
+        // run()'s default execFile timeout is already 300_000 (pi payload can
+        // exceed 120s on slow links) — no override needed here.
+        await run("npm", npmArgs, { cwd: destDir });
+        appendLog(job, "Dependencies installed");
+      } catch (err) {
+        const stderrTail = String(err.stderr || err.message || "").slice(-2000).trim();
+        appendLog(job, `npm install failed: ${stderrTail}`);
+        rmSync(destDir, { recursive: true, force: true });
+        return { ok: false, reason: `npm install failed: ${stderrTail}` };
+      }
+
+      const missing = (manifest.verify_paths || []).filter((p) => !existsSync(join(destDir, p)));
+      if (missing.length > 0) {
+        appendLog(job, `npm install verification failed: missing ${missing.join(", ")}`);
+        rmSync(destDir, { recursive: true, force: true });
+        return { ok: false, reason: `npm install failed: verify_paths missing: ${missing.join(", ")}` };
+      }
+    } else if (existsSync(pkgJsonPath) && !existsSync(join(destDir, "node_modules"))) {
       appendLog(job, "Installing bundle dependencies (npm install)…");
       try {
-        execFileSync("npm", ["install", "--omit=optional", "--no-audit", "--no-fund"], {
+        await run("npm", ["install", "--omit=optional", "--no-audit", "--no-fund"], {
           cwd: destDir,
-          env: process.env,
           timeout: 120_000,
-          stdio: "pipe",
         });
         appendLog(job, "Dependencies installed");
       } catch (err) {
@@ -1907,6 +1989,20 @@ export default function bundlesRouter() {
     // job creation.
     if (isInstallSetRunning()) {
       return res.status(409).json({ error: "A collection install is in progress — wait for it to finish and try again." });
+    }
+
+    // C4 Task 3 (r1 critical #4): refuse a second concurrent install of the
+    // SAME bundle — without this, two rapid clicks (or a client retry racing
+    // its own in-flight request) run runInstallJob twice concurrently against
+    // the same destDir. `error` is required: the shipped extensions client
+    // renders res.data.error verbatim on a non-ok install (client.js:425).
+    const existingJob = activeJobFor(bundle_id);
+    if (existingJob) {
+      return res.status(409).json({
+        code: "already_installing",
+        job_id: existingJob.id,
+        error: `${bundle_id} is already installing (job ${existingJob.id}) — attach to that job instead of starting a new install.`,
+      });
     }
 
     // Create job for async tracking

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -39,6 +39,7 @@ import { writeSetting } from "../dashboard/settings/registry.js";
 import { getCollection } from "../dashboard/panels/extensions/collections.js";
 import { dockerAvailable } from "../dashboard/panels/extensions/data-queries.js";
 import { beginInstallSet, endInstallSet, isInstallSetRunning } from "../install-lock.js";
+import { setActiveJobSource } from "../bot-engine-status.js";
 import {
   CROW_HOME,
   BUNDLES_DIR,
@@ -1867,6 +1868,11 @@ export function planInstallSet(collection) {
  */
 export default function bundlesRouter() {
   const router = Router();
+
+  // C4 Task 4: register this module's jobs Map as bot-engine-status's active-job
+  // source. Inverted (bundles.js calls INTO bot-engine-status, not the reverse) so
+  // bot-engine-status stays a leaf — it must never import this 2,500-line file.
+  setActiveJobSource(activeJobFor);
 
   // Cross-host verification. dashboard/index.js routes ANY request bearing an
   // x-crow-signature header straight here, BEFORE dashboardAuth and CSRF — so a

--- a/tests/bot-engine-status.test.js
+++ b/tests/bot-engine-status.test.js
@@ -1,0 +1,139 @@
+/**
+ * bot-engine-status — C4 Task 4.
+ *
+ * engineStatus() is the single leaf-level readiness check the attach gate
+ * and the readiness UI both call. Its four states have a strict precedence
+ * (r1-reviewed): installing > absent > unhealthy > ready. The two
+ * interesting precedence cases are:
+ *   - installing beats everything, even a resolved+healthy engine (an
+ *     in-flight reinstall of bot-engine must read as "installing", not
+ *     whatever the pre-reinstall disk state happens to look like).
+ *   - absent beats a stale open breaker — an uninstalled engine must never
+ *     read as "unhealthy" just because some earlier process left a breaker
+ *     open; resolvePiCli() returning null is ground truth.
+ *
+ * "absent" needs resolvePiCli() to miss on EVERY ladder rung (env, bundle,
+ * repo, global) — not just the ones this test module controls directly.
+ * The global rung derives from process.execPath, which on a dev box with
+ * pi installed globally under nvm genuinely resolves to a real cli.js (this
+ * was confirmed on crow's dev worktree before writing this test) — so an
+ * absent test that doesn't override execPath would spuriously pass through
+ * to "ready". absentOpts() below points crowHome/repoRoot/execPath at three
+ * fresh empty tmp dirs so every rung misses regardless of the host.
+ */
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  engineStatus,
+  _setSeamsForTest,
+  ENGINE_CHANNELS,
+} from "../servers/gateway/bot-engine-status.js";
+
+function emptyTmp(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/** Opts guaranteed to miss every resolvePiCli rung, on any host. */
+function absentOpts() {
+  const crowHome = emptyTmp("crow-bes-home-");
+  const repoRoot = emptyTmp("crow-bes-repo-");
+  const execDir = emptyTmp("crow-bes-exec-");
+  return {
+    env: { ...process.env, CROW_HOME: crowHome, PIBOT_PI_CLI: undefined },
+    crowHome,
+    repoRoot,
+    execPath: join(execDir, "node"),
+  };
+}
+
+/** A real tmp file + env override that makes resolvePiCli hit the "env" rung. */
+function readyEnv() {
+  const dir = emptyTmp("crow-bes-cli-");
+  const cliPath = join(dir, "cli.js");
+  writeFileSync(cliPath, "// fixture pi cli\n");
+  return { env: { ...process.env, PIBOT_PI_CLI: cliPath }, cliPath };
+}
+
+beforeEach(() => {
+  // Reset both registered sources before every test — they are module-level
+  // state, so one test's stub must never bleed into the next.
+  _setSeamsForTest();
+});
+
+test("ENGINE_CHANNELS lists the supported bot channels", () => {
+  assert.deepEqual(ENGINE_CHANNELS, ["gmail", "discord", "telegram", "slack"]);
+});
+
+test("absent: resolvePiCli misses on every rung (env/bundle/repo/global)", () => {
+  const status = engineStatus(absentOpts());
+  assert.deepEqual(status, { state: "absent" });
+});
+
+test("ready: PIBOT_PI_CLI points at a real file, no breaker, no active job", () => {
+  const { env, cliPath } = readyEnv();
+  const status = engineStatus({ env });
+  assert.equal(status.state, "ready");
+  assert.equal(status.source, "env");
+  assert.equal(status.cliPath, cliPath);
+});
+
+test("unhealthy: engine resolves fine but the breaker is open", () => {
+  const { env } = readyEnv();
+  _setSeamsForTest({
+    breaker: () => ({ open: true, lastError: "spawn ENOENT", retryAt: "2026-07-21T00:00:00Z" }),
+  });
+  const status = engineStatus({ env });
+  assert.deepEqual(status, {
+    state: "unhealthy",
+    error: "spawn ENOENT",
+    retryAt: "2026-07-21T00:00:00Z",
+  });
+});
+
+test("unhealthy: missing lastError/retryAt on the breaker report null, not undefined", () => {
+  const { env } = readyEnv();
+  _setSeamsForTest({ breaker: () => ({ open: true }) });
+  const status = engineStatus({ env });
+  assert.deepEqual(status, { state: "unhealthy", error: null, retryAt: null });
+});
+
+test("installing: an unfinished bot-engine install job takes precedence over a ready+healthy engine", () => {
+  const { env } = readyEnv();
+  _setSeamsForTest({
+    activeJob: (bundleId) => (bundleId === "bot-engine" ? { id: "42" } : null),
+  });
+  const status = engineStatus({ env });
+  assert.deepEqual(status, { state: "installing" });
+});
+
+test("installing only fires for the bot-engine bundle id, not any other job", () => {
+  const { env } = readyEnv();
+  _setSeamsForTest({
+    activeJob: (bundleId) => (bundleId === "some-other-bundle" ? { id: "1" } : null),
+  });
+  const status = engineStatus({ env });
+  assert.equal(status.state, "ready");
+});
+
+test("precedence: installing beats absent — a job can be running before the engine ever lands on disk", () => {
+  _setSeamsForTest({ activeJob: () => ({ id: "1" }) });
+  const status = engineStatus(absentOpts());
+  assert.deepEqual(status, { state: "installing" });
+});
+
+test("precedence: absent beats a stale open breaker — an uninstalled engine is absent, never unhealthy", () => {
+  _setSeamsForTest({ breaker: () => ({ open: true, lastError: "stale from a previous install" }) });
+  const status = engineStatus(absentOpts());
+  assert.deepEqual(status, { state: "absent" });
+});
+
+test("precedence: unhealthy beats ready — an open breaker wins even when resolvePiCli succeeds", () => {
+  const { env } = readyEnv();
+  _setSeamsForTest({ breaker: () => ({ open: true, lastError: "x" }) });
+  const status = engineStatus({ env });
+  assert.equal(status.state, "unhealthy");
+});

--- a/tests/bundle-npm-required.test.js
+++ b/tests/bundle-npm-required.test.js
@@ -1,0 +1,394 @@
+/**
+ * npm_required hard-fail + concurrent-install guard — C4 Task 3.
+ *
+ * At the generic npm-install site in runInstallJob, manifest.npm_required ===
+ * true means the bundle is USELESS without a working install (bot-engine's pi
+ * CLI, added in C4 Task 2) — any npm problem must hard-fail the install
+ * (destDir removed, installed.json never gains the bundle), unlike every
+ * other bundle's warn-only behavior. A pre-existing node_modules must never
+ * be trusted as "already installed": an interrupted prior install can leave a
+ * partial tree, so npm_required bundles always rm -rf node_modules and
+ * reinstall clean, then verify manifest.verify_paths[] actually materialized.
+ *
+ * Seam: PATH-stubbed fake `npm` (pattern: tests/docker-point-of-use.test.js's
+ * fake `docker` on PATH) — no real npm or network is ever touched. The fake
+ * writes an args log so a test can assert `npm ci` vs `npm install` and the
+ * flags, and can conditionally materialize the fixture's verify_paths file.
+ *
+ * All tests share ONE scratch CROW_HOME (set once at module load, matching
+ * tests/bundles-install-job.test.js), so — following the per-test-unique-id
+ * convention in tests/bundle-version-refresh.test.js — every test uses its
+ * OWN bundle id. Without this, a successful install in one test would leave
+ * behind an installed.json entry / destDir contents (package-lock.json,
+ * node_modules) that silently corrupts a later test reusing the same id.
+ *
+ * The concurrent-install guard (POST /bundles/api/install returning 409
+ * already_installing) is exercised over real HTTP against the actual
+ * bundlesRouter(), following the tests/install-set-e2e.test.js pattern.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import {
+  mkdtempSync, mkdirSync, writeFileSync, chmodSync, existsSync, readFileSync, rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// bundles.js resolves BUNDLES_DIR/INSTALLED_PATH from CROW_HOME at module
+// load — point it at a scratch dir BEFORE importing (see
+// tests/bundles-install-job.test.js's header comment for the live incident
+// an unisolated run caused).
+process.env.CROW_HOME = mkdtempSync(join(tmpdir(), "crow-test-home-"));
+process.env.CROW_AUTO_UPDATE = "0";
+process.env.CROW_DISABLE_HEALTH_MONITOR = "1";
+process.env.CROW_DISABLE_INSTANCE_SYNC = "1";
+process.env.CROW_DISABLE_NOSTR = "1";
+
+const {
+  default: bundlesRouter,
+  runInstallJob,
+  _createJobForTest,
+  _finishJobForTest,
+  _setAppBundlesForTest,
+} = await import("../servers/gateway/routes/bundles.js");
+
+const VERIFY_REL = "node_modules/@fixture/pkg/dist/cli.js";
+
+function freshRoot(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+/** Build a fresh fixture bundle source tree: npm_required + verify_paths, mirroring bot-engine's manifest shape (never depends on the real pi package). */
+function buildFixture(id, { withLock = true } = {}) {
+  const root = freshRoot("crow-fixture-npmreq-");
+  const dir = join(root, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+    id,
+    name: "Fixture npm_required",
+    type: "bundle",
+    category: "ai",
+    version: "1.0.0",
+    description: "d",
+    npm_required: true,
+    requires: { min_ram_mb: 1, min_disk_mb: 1 },
+    env_vars: [],
+    verify_paths: [VERIFY_REL],
+  }, null, 2));
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name: id,
+    dependencies: { "@fixture/pkg": "1.0.0" },
+  }, null, 2));
+  if (withLock) {
+    writeFileSync(join(dir, "package-lock.json"), JSON.stringify({
+      name: id, lockfileVersion: 3,
+    }, null, 2));
+  }
+  return root;
+}
+
+function readManifest(fixtureRoot, id) {
+  return JSON.parse(readFileSync(join(fixtureRoot, id, "manifest.json"), "utf8"));
+}
+
+function destDirFor(id) {
+  return join(process.env.CROW_HOME, "bundles", id);
+}
+
+// ─── PATH-stubbed fake npm ───
+
+const REAL_PATH = process.env.PATH;
+const STUB_DIR = mkdtempSync(join(tmpdir(), "crow-npm-stub-"));
+const STUB_BIN = join(STUB_DIR, "npm");
+
+/**
+ * Point PATH at a fake `npm` whose behavior is controlled by env vars the
+ * spawned child reads at run time (one binary serves every scenario):
+ *   NPM_STUB_EXIT        — exit code (0 unless set)
+ *   NPM_STUB_STDERR       — stderr text to emit before exiting
+ *   NPM_STUB_MATERIALIZE  — "1" → mkdir -p + write VERIFY_REL under cwd
+ *   NPM_STUB_LOG          — file to append "$@" to, so a test can assert the
+ *                           exact npm subcommand/flags used
+ */
+function stubNpm() {
+  const dollar = "$";
+  const body = [
+    "#!/bin/sh",
+    `if [ -n "${dollar}NPM_STUB_LOG" ]; then echo "${dollar}@" >> "${dollar}NPM_STUB_LOG"; fi`,
+    `if [ -n "${dollar}NPM_STUB_STDERR" ]; then echo "${dollar}NPM_STUB_STDERR" 1>&2; fi`,
+    `if [ "${dollar}NPM_STUB_MATERIALIZE" = "1" ]; then`,
+    `  mkdir -p "${dollar}(dirname "${VERIFY_REL}")"`,
+    `  echo "fixture cli" > "${VERIFY_REL}"`,
+    "fi",
+    `exit "${dollar}{NPM_STUB_EXIT:-0}"`,
+  ].join("\n") + "\n";
+  writeFileSync(STUB_BIN, body);
+  chmodSync(STUB_BIN, 0o755);
+  process.env.PATH = `${STUB_DIR}:${REAL_PATH}`;
+}
+
+function clearNpmStubEnv() {
+  delete process.env.NPM_STUB_EXIT;
+  delete process.env.NPM_STUB_STDERR;
+  delete process.env.NPM_STUB_MATERIALIZE;
+  delete process.env.NPM_STUB_LOG;
+}
+
+function restorePath() {
+  process.env.PATH = REAL_PATH;
+  clearNpmStubEnv();
+}
+
+// ─── npm exit 1 → hard fail ───
+
+test("npm_required: npm exit 1 with stderr → hard fail, destDir removed, job log carries the npm error, installed.json untouched", async () => {
+  const id = "fx-npmreq-failexit";
+  const fixtureRoot = buildFixture(id);
+  _setAppBundlesForTest(fixtureRoot);
+  const job = _createJobForTest(id, "install");
+  try {
+    stubNpm();
+    process.env.NPM_STUB_EXIT = "1";
+    process.env.NPM_STUB_STDERR = "npm ERR! fixture install failure";
+
+    const out = await runInstallJob(id, {}, {
+      job, installedSnapshot: [], consentVerified: false,
+      manifest: readManifest(fixtureRoot, id),
+    });
+
+    assert.equal(out.ok, false, "npm exit !=0 must hard-fail an npm_required install");
+    assert.match(out.reason, /npm install failed/i);
+    assert.match(out.reason, /fixture install failure/);
+    assert.ok(
+      job.log.some((l) => l.includes("fixture install failure")),
+      "job log must carry the npm stderr",
+    );
+
+    assert.equal(existsSync(destDirFor(id)), false, "destDir must be removed on hard fail (clean re-install on retry)");
+
+    const installedPath = join(process.env.CROW_HOME, "installed.json");
+    const installedRaw = existsSync(installedPath) ? readFileSync(installedPath, "utf8") : "[]";
+    assert.ok(!installedRaw.includes(id), "installed.json must never gain a bundle whose npm_required install failed");
+  } finally {
+    _finishJobForTest(job, "failed");
+    restorePath();
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── npm exit 0 but verify_paths missing → hard fail ───
+
+test("npm_required: npm exits 0 but verify_paths is NOT materialized → hard fail, destDir removed", async () => {
+  const id = "fx-npmreq-noverify";
+  const fixtureRoot = buildFixture(id);
+  _setAppBundlesForTest(fixtureRoot);
+  const job = _createJobForTest(id, "install");
+  try {
+    stubNpm();
+    process.env.NPM_STUB_EXIT = "0";
+    // Deliberately do NOT set NPM_STUB_MATERIALIZE — npm "succeeds" (as a
+    // truncated/partial install genuinely can) without the promised artifact.
+
+    const out = await runInstallJob(id, {}, {
+      job, installedSnapshot: [], consentVerified: false,
+      manifest: readManifest(fixtureRoot, id),
+    });
+
+    assert.equal(out.ok, false, "a clean npm exit that doesn't produce verify_paths must still hard-fail");
+    assert.match(out.reason, /verify_paths|verif/i);
+    assert.ok(
+      job.log.some((l) => /verif/i.test(l)),
+      "job log must record the verify_paths failure",
+    );
+    assert.equal(existsSync(destDirFor(id)), false, "destDir must be removed when verify_paths fails to materialize");
+  } finally {
+    _finishJobForTest(job, "failed");
+    restorePath();
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── interrupted-install retry: clean-slate rm before reinstall ───
+
+test("npm_required: interrupted-install retry — a pre-existing partial node_modules is wiped before reinstall, and the retry lands green", async () => {
+  const id = "fx-npmreq-retry";
+  const fixtureRoot = buildFixture(id);
+  _setAppBundlesForTest(fixtureRoot);
+  const job = _createJobForTest(id, "install");
+  const logDir = freshRoot("crow-npmlog-");
+  try {
+    // Simulate a prior interrupted install: destDir already has a partial
+    // node_modules tree. cpSync(sourceDir, destDir) in runInstallJob is
+    // additive, so this stray content survives the file-copy step exactly
+    // like a real interrupted install would — the absence-only check this
+    // task replaces would bless it as "already installed" and skip npm.
+    const destDir = destDirFor(id);
+    mkdirSync(join(destDir, "node_modules", "stale-partial-pkg"), { recursive: true });
+    writeFileSync(join(destDir, "node_modules", "stale-partial-pkg", "marker.txt"), "STALE PARTIAL INSTALL — must be wiped\n");
+
+    stubNpm();
+    process.env.NPM_STUB_EXIT = "0";
+    process.env.NPM_STUB_MATERIALIZE = "1";
+    process.env.NPM_STUB_LOG = join(logDir, "calls.log");
+
+    const out = await runInstallJob(id, {}, {
+      job, installedSnapshot: [], consentVerified: false,
+      manifest: readManifest(fixtureRoot, id),
+    });
+
+    assert.equal(out.ok, true, `expected the retry to succeed, got: ${out.reason}`);
+    assert.ok(existsSync(join(destDir, VERIFY_REL)), "verify_paths file must exist after a successful reinstall");
+    assert.equal(
+      existsSync(join(destDir, "node_modules", "stale-partial-pkg")),
+      false,
+      "the stale partial node_modules entry must be gone — npm_required always rm -rf's node_modules before reinstalling",
+    );
+    assert.ok(
+      existsSync(process.env.NPM_STUB_LOG) && readFileSync(process.env.NPM_STUB_LOG, "utf8").trim().length > 0,
+      "npm must actually run on retry, not be skipped just because node_modules pre-existed",
+    );
+    const npmCall = readFileSync(process.env.NPM_STUB_LOG, "utf8").trim();
+    assert.match(npmCall, /^ci /, "a bundle shipping package-lock.json must use `npm ci`");
+    assert.match(npmCall, /--ignore-scripts/, "npm_required installs must pass --ignore-scripts (Task 2's viability check cleared this)");
+  } finally {
+    _finishJobForTest(job, "complete");
+    restorePath();
+    rmSync(fixtureRoot, { recursive: true, force: true });
+    rmSync(logDir, { recursive: true, force: true });
+  }
+});
+
+// ─── no package-lock.json → falls back to `npm install` ───
+
+test("npm_required: no package-lock.json shipped → falls back to `npm install` (still --ignore-scripts)", async () => {
+  const id = "fx-npmreq-nolock";
+  const fixtureRoot = buildFixture(id, { withLock: false });
+  _setAppBundlesForTest(fixtureRoot);
+  const job = _createJobForTest(id, "install");
+  const logDir = freshRoot("crow-npmlog-");
+  try {
+    stubNpm();
+    process.env.NPM_STUB_EXIT = "0";
+    process.env.NPM_STUB_MATERIALIZE = "1";
+    process.env.NPM_STUB_LOG = join(logDir, "calls.log");
+
+    const out = await runInstallJob(id, {}, {
+      job, installedSnapshot: [], consentVerified: false,
+      manifest: readManifest(fixtureRoot, id),
+    });
+
+    assert.equal(out.ok, true, `expected success, got: ${out.reason}`);
+    const npmCall = readFileSync(process.env.NPM_STUB_LOG, "utf8").trim();
+    assert.match(npmCall, /^install /, "no lockfile → `npm install`, not `npm ci`");
+    assert.match(npmCall, /--ignore-scripts/);
+  } finally {
+    _finishJobForTest(job, "complete");
+    restorePath();
+    rmSync(fixtureRoot, { recursive: true, force: true });
+    rmSync(logDir, { recursive: true, force: true });
+  }
+});
+
+// ─── missing package.json entirely → hard fail (npm_required with nothing to install) ───
+
+test("npm_required: bundle ships no package.json at all → hard fail, destDir removed", async () => {
+  const id = "fx-npmreq-nopkgjson";
+  const fixtureRoot = buildFixture(id);
+  // Remove package.json (and lockfile) after buildFixture wrote them, so the
+  // fixture is otherwise identical (manifest still declares npm_required).
+  rmSync(join(fixtureRoot, id, "package.json"), { force: true });
+  rmSync(join(fixtureRoot, id, "package-lock.json"), { force: true });
+  _setAppBundlesForTest(fixtureRoot);
+  const job = _createJobForTest(id, "install");
+  try {
+    const out = await runInstallJob(id, {}, {
+      job, installedSnapshot: [], consentVerified: false,
+      manifest: readManifest(fixtureRoot, id),
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.reason, /package\.json/i);
+    assert.equal(existsSync(destDirFor(id)), false);
+  } finally {
+    _finishJobForTest(job, "failed");
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+// ─── concurrent-install guard ───
+
+test("concurrent-install guard: a second POST /bundles/api/install for the SAME bundle_id gets 409 already_installing with the first job's id", async () => {
+  const id = "fx-npmreq-concurrent";
+  const fixtureRoot = buildFixture(id);
+  _setAppBundlesForTest(fixtureRoot);
+
+  const app = express();
+  app.use(express.json());
+  app.use(bundlesRouter());
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  // Simulate an in-flight install job for this exact bundle_id directly
+  // (avoids needing to pause a real npm/compose call mid-flight to win the
+  // race deterministically).
+  const existingJob = _createJobForTest(id, "install");
+  try {
+    const res = await fetch(base + "/bundles/api/install", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ bundle_id: id }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 409, `expected 409, got ${res.status}: ${JSON.stringify(body)}`);
+    assert.equal(body.code, "already_installing");
+    assert.equal(body.job_id, existingJob.id);
+    assert.ok(
+      typeof body.error === "string" && body.error.length > 0,
+      "error field is required — the shipped extensions client renders res.data.error on a non-ok install",
+    );
+  } finally {
+    _finishJobForTest(existingJob, "complete");
+    server.close();
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("concurrent-install guard: once the first job finishes, a new install of the same bundle_id is accepted (no stale 409)", async () => {
+  const id = "fx-npmreq-concurrent-cleared";
+  const fixtureRoot = buildFixture(id, { withLock: false });
+  // No package.json at all for this fixture's second install attempt so the
+  // background install (kicked off unawaited by the route) never touches
+  // npm/network — it only needs to prove a fresh job_id is issued, not that
+  // the install itself succeeds.
+  rmSync(join(fixtureRoot, id, "package.json"), { force: true });
+  writeFileSync(join(fixtureRoot, id, "manifest.json"), JSON.stringify({
+    id, name: "Fixture", type: "bundle", category: "ai", version: "1.0.0", description: "d",
+  }, null, 2));
+  _setAppBundlesForTest(fixtureRoot);
+
+  const app = express();
+  app.use(express.json());
+  app.use(bundlesRouter());
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  const finishedJob = _createJobForTest(id, "install");
+  _finishJobForTest(finishedJob, "complete"); // no longer "running"
+  try {
+    const res = await fetch(base + "/bundles/api/install", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ bundle_id: id }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 200, `expected 200, got ${res.status}: ${JSON.stringify(body)}`);
+    assert.ok(body.job_id, "a fresh job must be created once the prior one has finished");
+    assert.notEqual(body.job_id, finishedJob.id);
+  } finally {
+    server.close();
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/bundle-version-refresh.test.js
+++ b/tests/bundle-version-refresh.test.js
@@ -306,6 +306,109 @@ describe("4b — docker-type restriction + declared-root traversal rejection", (
 });
 
 // ---------------------------------------------------------------------------
+// Test 4c (C4 Task 3): version-drift on an EXACT-pinned dep also fires npm —
+// today only an added dep NAME does. A range-pinned dep stays presence-only
+// (no version comparison at all), exactly as before.
+// ---------------------------------------------------------------------------
+describe("npm trigger — exact-pin version-drift (C4 Task 3)", () => {
+  test("an exact-pinned dep whose installed version differs from the pin fires npm (version-drift, not just added-name)", async () => {
+    const id = "widget-npm-pin-drift";
+    const repoRoot = freshRoot("crowrepo-npmpindrift-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "pinned-dep": "2.0.0" } })); // exact semver pin
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    // Installed dep is present by NAME but at the OLD pinned version — the
+    // presence-only check this task replaces would bless this as complete.
+    put(CROW_HOME, `bundles/${id}/node_modules/pinned-dep/package.json`, JSON.stringify({ name: "pinned-dep", version: "1.0.0" }));
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 1, "npm must fire when an exact-pinned dep's installed version differs from the pin");
+    assert.deepEqual(runner.calls[0].args, ["install", "--omit=dev"]);
+  });
+
+  test("an exact-pinned dep already at the pinned version does NOT fire npm", async () => {
+    const id = "widget-npm-pin-match";
+    const repoRoot = freshRoot("crowrepo-npmpinmatch-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "pinned-dep": "2.0.0" } }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    put(CROW_HOME, `bundles/${id}/node_modules/pinned-dep/package.json`, JSON.stringify({ name: "pinned-dep", version: "2.0.0" }));
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 0, "npm must NOT fire when the exact-pinned dep is already at the pinned version");
+  });
+
+  test("range dep unchanged behavior: a range-pinned dep present by name never triggers on version alone", async () => {
+    const id = "widget-npm-range-mismatch";
+    const repoRoot = freshRoot("crowrepo-npmrangemismatch-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "ranged-dep": "^3.0.0" } }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    // Installed version (1.0.0) doesn't even satisfy ^3.0.0 — range deps stay
+    // presence-only, so this must NOT trigger a refresh.
+    put(CROW_HOME, `bundles/${id}/node_modules/ranged-dep/package.json`, JSON.stringify({ name: "ranged-dep", version: "1.0.0" }));
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 0, "range-pinned deps must stay presence-only — no version comparison");
+  });
+
+  test("an exact-pinned dep with no readable installed package.json is treated as drifted (fires npm)", async () => {
+    const id = "widget-npm-pin-unreadable";
+    const repoRoot = freshRoot("crowrepo-npmpinunreadable-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({ id, name: "N", version: "1.0.1", type: "mcp-server", category: "misc", description: "d" }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "pinned-dep": "2.0.0" } }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "mcp-server" }));
+    // pinned-dep/ exists (dir present) but has no package.json inside it.
+    mkdirSync(join(CROW_HOME, `bundles/${id}/node_modules/pinned-dep`), { recursive: true });
+    setInstalled([id]);
+
+    const runner = fakeRunner();
+    await repairInstalledBundleAssets({ appBundles: repoRoot, run: runner });
+    assert.equal(runner.calls.length, 1, "an unreadable installed package.json for an exact-pinned dep must be treated as drift, not silently trusted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4d (C4 Task 3): the boot-time refresh's npm step stays warn-only even
+// for an npm_required bundle — hard-fail must never leak into gateway boot.
+// The install-time hard-fail path (runInstallJob, tests/bundle-npm-required
+// .test.js) is a completely separate code path from refreshVersionedBundle.
+// ---------------------------------------------------------------------------
+describe("npm_required refresh at boot stays warn-only (hard-fail must never leak into gateway boot)", () => {
+  test("an npm_required bundle whose boot-time refresh npm step throws is still just a warning — no throw, no error reported, destDir survives", async () => {
+    const id = "widget-npm-required-boot";
+    const repoRoot = freshRoot("crowrepo-npmrequiredboot-");
+    put(repoRoot, `${id}/manifest.json`, JSON.stringify({
+      id, name: "N", version: "1.0.1", type: "bundle", category: "ai", description: "d",
+      npm_required: true,
+    }));
+    put(repoRoot, `${id}/package.json`, JSON.stringify({ name: id, dependencies: { "added-dep": "^1.0.0" } }));
+
+    put(CROW_HOME, `bundles/${id}/manifest.json`, JSON.stringify({ id, version: "1.0.0", type: "bundle" }));
+    // node_modules exists but lacks added-dep → the npm trigger fires.
+    put(CROW_HOME, `bundles/${id}/node_modules/.keep`, "");
+    setInstalled([id]);
+
+    const throwingRunner = async () => { throw new Error("simulated npm failure at boot"); };
+    const { errors, repaired } = await repairInstalledBundleAssets({ appBundles: repoRoot, run: throwingRunner });
+
+    assert.deepEqual(errors, [], "a failing npm step at boot must never surface as an error — warn-only even for npm_required");
+    assert.ok(repaired.some((r) => r.includes(id)), "the refresh itself must still be reported as having run");
+    assert.ok(existsSync(destBundleDir(id)), "destDir must NOT be removed — boot-time refresh never hard-fails, unlike the install-time path");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Test 5: unreadable/missing installed manifest → falls back to missing-only
 // repair, no throw.
 // ---------------------------------------------------------------------------

--- a/tests/extensions-collections.test.js
+++ b/tests/extensions-collections.test.js
@@ -14,9 +14,9 @@ const manifestOf = (id) =>
   JSON.parse(readFileSync(join(REPO, "bundles", id, "manifest.json"), "utf8"));
 const hasCompose = (id) => existsSync(join(REPO, "bundles", id, "docker-compose.yml"));
 
-test("loader returns the four collections with well-formed shape", () => {
+test("loader returns the five collections with well-formed shape", () => {
   const cols = loadCollections();
-  assert.deepEqual(cols.map((c) => c.id).sort(), ["development", "education", "home-server", "research"]);
+  assert.deepEqual(cols.map((c) => c.id).sort(), ["agents", "development", "education", "home-server", "research"]);
   for (const c of cols) {
     assert.ok(c.name && c.description && c.icon, `${c.id} missing display fields`);
     assert.ok(Array.isArray(c.members) && c.members.length > 0, `${c.id} has no members`);

--- a/tests/models-state.test.js
+++ b/tests/models-state.test.js
@@ -48,7 +48,14 @@ function closeServer(server) {
 test("allocatePort returns the lowest free port, starting at 18100", async () => {
   await withScratch("alloc-first", async () => {
     const state = { reservations: {}, journal: {}, registry: {} };
-    const port = await allocatePort(state, "model-a");
+    // Stub the bind probe: node --test runs test FILES concurrently, and
+    // tests/models-registration.test.js exercises the real allocatePort
+    // over this same 18100-18199 range, so a live bind-probe can find
+    // 18100 transiently held by that other process and correctly skip to
+    // 18101 -- a real cross-file TOCTOU, not a product bug. This test
+    // asserts the exact starting port, so it must not depend on host
+    // network state to be hermetic.
+    const port = await allocatePort(state, "model-a", { canBind: async () => true });
     assert.equal(port, PORT_RANGE_START);
     assert.equal(state.reservations["model-a"].port, PORT_RANGE_START);
   });
@@ -56,8 +63,14 @@ test("allocatePort returns the lowest free port, starting at 18100", async () =>
 
 test("allocatePort skips ports already reserved in state", async () => {
   const state = { reservations: {}, journal: {}, registry: {} };
-  const first = await allocatePort(state, "model-a");
-  const second = await allocatePort(state, "model-b");
+  // Same cross-file TOCTOU as above: both assertions below are exact
+  // ports (not a first+1 relative check would still be racy too -- a
+  // probe collision landing between the two calls could make
+  // first=18100, second=18102), so stub the probe to isolate this test
+  // from models-registration.test.js's concurrent real allocatePort calls.
+  const stub = { canBind: async () => true };
+  const first = await allocatePort(state, "model-a", stub);
+  const second = await allocatePort(state, "model-b", stub);
   assert.equal(first, PORT_RANGE_START);
   assert.equal(second, PORT_RANGE_START + 1);
   assert.notEqual(first, second);
@@ -87,11 +100,15 @@ test("allocatePort bind-tests and skips a port actually held on the host", async
 
 test("releasePort frees a reservation so its port can be reallocated", async () => {
   const state = { reservations: {}, journal: {}, registry: {} };
-  const port = await allocatePort(state, "model-a");
+  // Exact-port assertions again (18100 before AND after release) -- same
+  // cross-file TOCTOU with models-registration.test.js's real allocatePort,
+  // so stub the probe here too.
+  const stub = { canBind: async () => true };
+  const port = await allocatePort(state, "model-a", stub);
   assert.equal(port, PORT_RANGE_START);
   releasePort(state, "model-a");
   assert.equal(state.reservations["model-a"], undefined);
-  const reallocated = await allocatePort(state, "model-b");
+  const reallocated = await allocatePort(state, "model-b", stub);
   assert.equal(reallocated, PORT_RANGE_START);
 });
 


### PR DESCRIPTION
Item C4 PR B — the bot-engine bundle plus the install machinery it needs.

- **`bundles/bot-engine/`**: pure npm-payload bundle (no compose/server/panel/ports) pinning `@earendil-works/pi-coding-agent` **0.74.2** (prod-proven) with a committed lockfile; satisfies the resolver's rung-2 path `CROW_HOME/bundles/bot-engine/node_modules/.../dist/cli.js`. New **Agents** starter collection (`kind: builtin` member) + collections test updated; registry regenerated.
- **`npm_required` manifest flag**: install becomes a HARD gate — clean-slate node_modules, `npm ci --omit=optional --no-audit --no-fund --ignore-scripts` (pi verified script-less-safe), 300s timeout, failure removes destDir and fails the job honestly, success verified against `verify_paths` (the actual rung-2 artifact). Interrupted-install retry proven by test. Non-npm_required bundles keep warn-only semantics.
- **Latent bug fixed en route**: the generic bundle-type npm site referenced `execFileSync` without importing it — a silent no-op since April (live evidence: prod dozzle has no node_modules). It now actually runs npm, still warn-only for legacy bundles. This is a deliberate behavior change.
- **Version-drift refresh**: exact-semver pins now compare installed versions, so a pinned engine bump reinstalls on refresh; boot refresh path stays warn-only (tested).
- **Concurrent-install guard**: `POST /bundles/api/install` → `409 {code:"already_installing", job_id, error}`; `activeJobFor` also matches install-set jobs containing the bundle.
- **`servers/gateway/bot-engine-status.js`**: leaf status module (`engineStatus`: installing > absent > unhealthy > ready; `ENGINE_CHANNELS`; `setBreakerSource`/`setActiveJobSource` inversion — no ESM cycle). Consumers arrive in C4-C/D.

Spec: crow-engineering `specs/2026-07-18-item-c4-bot-engine-bundle-design.md` (Gitea). Note: pi 0.74.2 carries npm-audit HIGH advisories (fix = breaking 0.80.10); the bundle lockfile is outside the root CI audit gate by design — bump decision logged as a follow-up.