### PR TITLE
feat(bots): gateway-supervised bot runtime — bridge tick in-process + Discord child supervision (C4-C)

### DIFF
--- a/scripts/pi-bots/bridge_tick.mjs
+++ b/scripts/pi-bots/bridge_tick.mjs
@@ -1,181 +1,24 @@
 #!/usr/bin/env node
 /**
- * Crow Bot Builder — unattended bridge tick (Phase 1).
+ * Crow Bot Builder — unattended bridge tick CLI entrypoint (Phase 1).
  *
- * The bridge's OWN timer (NOT schedules / pipeline-runner — plan §2). Run by
- * pibot-bridge.timer every ~1 min, mirroring mpa-router. For each pi_bot_def
- * with a gmail gateway: search that bot's +alias recipient for threads whose
- * NEWEST message is an un-processed user inbound (To contains the +alias),
- * then drive bridge.handleInbound once with the real gmail sendReply.
- *
- * "Processed" = bot_sessions.updated_at for (bot_id,thread) >= the newest
- * inbound message's date. handleInbound bumps updated_at, so the next tick
- * skips until a NEWER user reply arrives. flock guards against overlap.
- * No Gmail filter/label needed (search-based); a label is a Phase-2 optim.
+ * Thin wrapper: ALL logic (lock, flag check, reap preflight, gmail scan,
+ * handleInbound, job drain) lives in bridge_tick_lib.mjs so the gateway can
+ * run the exact same tick in-process (C4 Task 6) without a child process per
+ * poll. Run by pibot-bridge.timer every ~1 min, mirroring mpa-router.
+ * Systemd behavior is unchanged: exits 0 even on a skip (locked / runtime
+ * off / engine missing) — the timer keeps firing regardless. The lib itself
+ * unlinks its lock file in `finally` on every path (including a thrown tick
+ * body), so this wrapper's crash catch only needs to log + exit(1); by the
+ * time a throw reaches here the lib has already cleaned up after itself.
  */
-import Database from "better-sqlite3";
-import { execFile } from "node:child_process";
-import { openSync, closeSync, existsSync, statSync, unlinkSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { handleInbound } from "./bridge.mjs";
-import { reapStalePi } from "./pi_lifecycle.mjs";
-import { gmailSenderAllowed } from "./gateways/base.mjs";
-import { botsDbPath } from "./instance-paths.mjs";
-import { botRuntimeEnabledSync } from "./runtime-gate.mjs";
-
-// gmail_io.mjs is dependency-free and lives beside this file — run it with
-// the SAME node running this tick (process.execPath) and derive its path from
-// our own location, never from an assumed /home/<user>/crow checkout.
-const NODE = process.execPath;
-const GIO = fileURLToPath(new URL("./gmail_io.mjs", import.meta.url));
-const CROW_DB = botsDbPath();
-const LOCK = "/tmp/pibot-bridge-tick.lock";
-
-function db() { const d = new Database(CROW_DB); d.pragma("busy_timeout = 10000"); return d; }
-function gio(args, ms = 90000) {
-  return new Promise((res) => execFile(NODE, [GIO, ...args], { timeout: ms, maxBuffer: 8e6 },
-    (e, so, se) => res({ code: e ? (e.code ?? 1) : 0, out: so || "", err: se || "" })));
-}
-function parseResult(out) {
-  const m = out.match(/RESULT (\{[\s\S]*\})\s*$/);
-  if (!m) return null;
-  try { const r = JSON.parse(m[1]); return r.text ? JSON.parse(r.text) : r; } catch { return null; }
-}
-
-// crude single-instance guard (systemd already serializes Type=oneshot, this
-// is belt-and-suspenders): refuse if a fresh lock file exists.
-function acquireLock() {
-  try {
-    if (existsSync(LOCK)) {
-      const age = Date.now() - (statSync(LOCK).mtimeMs);
-      if (age < 9 * 60 * 1000) return false; // a tick from <9min ago may still run
-    }
-    closeSync(openSync(LOCK, "w"));
-    return true;
-  } catch { return true; }
-}
+import { runBridgeTick } from "./bridge_tick_lib.mjs";
 
 (async () => {
-  if (!acquireLock()) { console.log("[tick] another tick holds the lock — skip"); process.exit(0); }
-  // F3b: respect the per-instance runtime toggle. Timer keeps firing; when the
-  // operator has bot_runtime off, the tick is a no-op (release lock + exit).
-  {
-    const _g = db();
-    let on = false;
-    try { on = botRuntimeEnabledSync(_g); } finally { _g.close(); }
-    if (!on) { try { unlinkSync(LOCK); } catch {} console.log("[tick] bot_runtime off — skip"); process.exit(0); }
-  }
-  // Pre-flight: reap any abandoned/stuck/runaway pi from a previously crashed
-  // tick before doing more work (plan §10 risk #4). Runs every ~1 min via the
-  // existing timer — no extra systemd unit. The pure-bash backstop in
-  // ~/bin/memory-watchdog.sh is the independent 5-min safety net.
-  try {
-    const sweep = reapStalePi({ log: (m) => console.log("[tick] " + m) });
-    if (sweep.reaped.length) console.log(`[tick] reaped ${sweep.reaped.length} stale pi (scanned ${sweep.scanned})`);
-  } catch (e) { console.error("[tick] reaper error (non-fatal): " + (e && e.message || e)); }
-  const d = db();
-  let defs = [];
-  try {
-    defs = d.prepare("SELECT bot_id, definition FROM pi_bot_defs WHERE enabled=1").all();
-  } catch { console.log("[tick] pi_bot_defs missing — nothing to do"); process.exit(0); }
-
-  let processed = 0;
-  for (const row of defs) {
-    let def; try { def = JSON.parse(row.definition || "{}"); } catch { continue; }
-    const gw = (def.gateways || []).find((g) => g.type === "gmail" && g.address);
-    if (!gw) continue;
-    const alias = gw.address;                         // e.g. user+<x>@example.com
-    const plus = (alias.match(/\+([^@]+)@/) || [])[1]; // <x>
-
-    const srch = await gio(["search", "--query", `to:${alias} newer_than:2d`, "--max", "10"]);
-    const sres = parseResult(srch.out);
-    const threads = (sres && (sres.data?.threads || sres.threads)) || [];
-    for (const th of threads) {
-      const tid = th.id || th.thread_id || th.threadId;
-      if (!tid) continue;
-      const tr = await gio(["thread", "--id", tid], 60000);
-      const tres = parseResult(tr.out);
-      const msgs = (tres && (tres.data?.messages || tres.messages)) || [];
-      if (!msgs.length) continue;
-      const newest = msgs[msgs.length - 1];
-      const to = String(newest.to || (newest.headers && newest.headers.to) || "");
-      const isUserInbound = to.includes("+" + plus + "@");
-      if (!isUserInbound) continue;                   // newest is a bot reply -> nothing to do
-      // Gmail MCP returns the full plain-text body under `body_text` (current
-       // field name) or `plaintext_body` (legacy). Both ~unlimited length.
-       // `snippet` is Gmail's 200-char preview — last-resort fallback ONLY
-       // when both full-body fields are absent. Previously this read
-       // plaintext_body || snippet, which silently truncated EVERY inbound to
-       // ~200 chars (bot only saw the message preview, not what the user typed).
-      const body = (newest.body_text || newest.plaintext_body || newest.snippet || "").trim();
-      const msgDate = Date.parse(newest.date || (newest.headers && newest.headers.date) || "") || Date.now();
-
-      // Reply-recipient = actual sender of `newest` (so the bot's reply lands
-      // back in the user's inbox, not the bot's own mailbox — it was once
-      // hardcoded to the operator's address, which routed replies to the bot
-      // itself). The sender wall derives from the bot def's per-gateway
-      // allowlist (gw.allowlist — the same field the Bot Builder edits) and
-      // FAILS CLOSED when unconfigured: an empty allowlist means nobody can
-      // trigger a bot reply, never everybody. That's the safety wall against
-      // a third party emailing the +alias and getting a bot reply.
-      const fromHeader = String(newest.from || (newest.headers && newest.headers.from) || "");
-      const fromMatch = fromHeader.match(/<([^>]+)>/);
-      const replyTo = (fromMatch ? fromMatch[1] : fromHeader).trim().toLowerCase();
-      if (!gmailSenderAllowed(gw.allowlist, replyTo)) {
-        console.log(`[tick] skip thread=${tid} — sender '${replyTo}' not in this gateway's allowlist${Array.isArray(gw.allowlist) && gw.allowlist.length ? "" : " (no allowlist configured — set one on the bot's Gateways tab)"}`);
-        continue;
-      }
-
-      const sess = d.prepare("SELECT updated_at, status FROM bot_sessions WHERE bot_id=? AND gateway_thread_id=? ORDER BY id DESC LIMIT 1").get(row.bot_id, tid);
-      const sessTs = sess ? Date.parse(sess.updated_at + "Z") || 0 : 0;
-      if (sess && sess.status !== "stopped" && sessTs >= msgDate) continue; // already processed this inbound
-      if (sess && sess.status === "stopped" && !/\bresume\b/i.test(body)) {
-        // honor stop until the user explicitly says resume
-        continue;
-      }
-
-      console.log(`[tick] bot=${row.bot_id} thread=${tid} from=${replyTo} -> handleInbound (${body.slice(0, 50)})`);
-      try {
-        const r = await handleInbound({
-          bot_id: row.bot_id, gateway_thread_id: tid, user_message: body,
-          sendReply: async (text) => {
-            // --reply-to <alias> sets the Reply-To: header on the outbound
-            // so when the user clicks Reply in Gmail, it routes back to the
-            // bot's +alias (which bridge_tick monitors) rather than the
-            // bot's bare From: address (which nothing monitors). Without
-            // this, the user's reply lands at the bot's bare From: address
-            // and the bot never sees the follow-up.
-            await gio(["reply", "--to", replyTo,
-              "--reply-to", alias,
-              "--subject", "Re: " + (newest.subject || (newest.headers && newest.headers.subject) || "pibot"),
-              "--thread", tid, "--body", text]);
-          },
-          log: (m) => console.log("  [bridge] " + m),
-        });
-        processed++;
-        console.log(`[tick] done thread=${tid} action=${r.action}`);
-      } catch (e) {
-        console.error(`[tick] handleInbound failed thread=${tid}: ${e.message}`);
-      }
-    }
-  }
-  // Background-job drain (Plan B Part 1 Stage 2). On a Gmail-only deployment with
-  // NO pibot-gateways host, this is the only place queued bot_jobs get run +
-  // delivered. Where a gateways host IS present it's the primary runner; the
-  // atomic single-row claim + the reserved-slot gate inside tickJobs make running
-  // here too safe (whoever claims first wins, never exceeding the pi budget). One
-  // job per invocation keeps this oneshot tick bounded; a long job (up to the 10-
-  // min JOB_TIMEOUT) holds the tick's lock, delaying the next mail poll — the
-  // accepted tradeoff for a host with no dedicated job runner.
-  try {
-    const { tickJobs } = await import("./job_runner.mjs");
-    const { makeChannelDeliverer } = await import("./gateways/deliver.mjs");
-    const deliverChannel = makeChannelDeliverer({ log: (m) => console.log("[tick:deliver] " + m) });
-    const jr = await tickJobs({ log: (m) => console.log("[tick:jobs] " + m), deliverChannel });
-    if (jr && jr.ran) console.log(`[tick] background job ${jr.ran} → ${jr.status}`);
-  } catch (e) { console.error("[tick] job drain error (non-fatal): " + (e && e.message || e)); }
-
-  try { unlinkSync(LOCK); } catch {}
-  console.log(`[tick] complete — processed ${processed} inbound`);
+  const r = await runBridgeTick();
+  if (r && r.skipped) console.log(`[tick] skipped: ${r.skipped}`);
   process.exit(0);
-})().catch((e) => { try { unlinkSync(LOCK); } catch {} console.error("[tick] CRASH " + (e && e.stack || e)); process.exit(1); });
+})().catch((e) => {
+  console.error("[tick] CRASH " + (e && e.stack || e));
+  process.exit(1);
+});

--- a/scripts/pi-bots/bridge_tick_lib.mjs
+++ b/scripts/pi-bots/bridge_tick_lib.mjs
@@ -1,0 +1,272 @@
+/**
+ * Crow Bot Builder — unattended bridge tick (Phase 1), as a callable library.
+ *
+ * The bridge's OWN timer (NOT schedules / pipeline-runner — plan §2). Historically
+ * run only by pibot-bridge.timer (mirroring mpa-router) via the CLI wrapper
+ * bridge_tick.mjs; C4 Task 6 also drives this same function from an in-process
+ * gateway interval, so ALL the DB-touching / lock-owning logic lives HERE and
+ * bridge_tick.mjs is a thin process.exit(0) shell around runBridgeTick().
+ *
+ * For each pi_bot_def with a gmail gateway: search that bot's +alias recipient
+ * for threads whose NEWEST message is an un-processed user inbound (To contains
+ * the +alias), then drive bridge.handleInbound once with the real gmail
+ * sendReply.
+ *
+ * "Processed" = bot_sessions.updated_at for (bot_id,thread) >= the newest
+ * inbound message's date. handleInbound bumps updated_at, so the next tick
+ * skips until a NEWER user reply arrives. A lock file guards against overlap.
+ * No Gmail filter/label needed (search-based); a label is a Phase-2 optim.
+ *
+ * Behavior deltas vs the old CLI-only body (all three deliberate, not bugs):
+ *  - runBridgeTick RETURNS a result object instead of calling process.exit —
+ *    the gateway interval calls this every ~60s in-process and must never see
+ *    its own process torn down.
+ *  - the main better-sqlite3 handle now closes in try/finally on EVERY path
+ *    (previously only reachable via process.exit, which never ran the close —
+ *    at a 60s gateway cadence that leaked ~1,440 handles/day).
+ *  - the lock file is now instance-scoped: `/tmp/pibot-bridge-tick-<hash>.lock`
+ *    where <hash> is a short sha256 prefix of the resolved crow.db path, so
+ *    co-hosted instances (crow + MPA + a Rn on the same box) don't serialize
+ *    each other's ticks. It is unlinked in `finally` on ALL paths — including
+ *    the pi_bot_defs-missing catch, which previously exited WITHOUT unlinking
+ *    (in gateway mode on a fresh DB that wedged every subsequent tick into
+ *    skipped:"locked" for 9 minutes, forever) — and a resolvePiCli()-null
+ *    early exit checks BEFORE any gmail I/O (honest cheap no-op on
+ *    engine-less installs).
+ */
+import Database from "better-sqlite3";
+import { execFile } from "node:child_process";
+import { openSync, closeSync, existsSync, statSync, unlinkSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { handleInbound } from "./bridge.mjs";
+import { reapStalePi } from "./pi_lifecycle.mjs";
+import { gmailSenderAllowed } from "./gateways/base.mjs";
+import { botsDbPath } from "./instance-paths.mjs";
+import { botRuntimeEnabledSync } from "./runtime-gate.mjs";
+import { resolvePiCli } from "./pi_resolver.mjs";
+
+// gmail_io.mjs is dependency-free and lives beside this file — run it with
+// the SAME node running this tick (process.execPath) and derive its path from
+// our own location, never from an assumed /home/<user>/crow checkout.
+const NODE = process.execPath;
+const GIO = fileURLToPath(new URL("./gmail_io.mjs", import.meta.url));
+
+function defaultDbFactory(path) {
+  const d = new Database(path);
+  d.pragma("busy_timeout = 10000");
+  return d;
+}
+
+/** Exported for tests: the exact instance-scoped lock path runBridgeTick uses. */
+export function lockPathFor(dbPath) {
+  const hash = createHash("sha256").update(dbPath).digest("hex").slice(0, 8);
+  return `/tmp/pibot-bridge-tick-${hash}.lock`;
+}
+
+function gio(args, ms = 90000) {
+  return new Promise((res) => execFile(NODE, [GIO, ...args], { timeout: ms, maxBuffer: 8e6 },
+    (e, so, se) => res({ code: e ? (e.code ?? 1) : 0, out: so || "", err: se || "" })));
+}
+function parseResult(out) {
+  const m = out.match(/RESULT (\{[\s\S]*\})\s*$/);
+  if (!m) return null;
+  try { const r = JSON.parse(m[1]); return r.text ? JSON.parse(r.text) : r; } catch { return null; }
+}
+
+// crude single-instance guard (systemd already serializes Type=oneshot, this
+// is belt-and-suspenders): refuse if a fresh lock file exists.
+function acquireLock(lockPath) {
+  try {
+    if (existsSync(lockPath)) {
+      const age = Date.now() - (statSync(lockPath).mtimeMs);
+      if (age < 9 * 60 * 1000) return false; // a tick from <9min ago may still run
+    }
+    closeSync(openSync(lockPath, "w"));
+    return true;
+  } catch { return true; }
+}
+
+/**
+ * Run one bridge tick. Never throws for expected/handled conditions (lock
+ * held, runtime off, engine missing, per-thread/per-job errors) — those come
+ * back as a normal result object. An UNEXPECTED throw (e.g. the injected db
+ * factory itself failing) propagates as a rejected promise; the lock is still
+ * unlinked first (outer finally) and any already-open db handle is still
+ * closed first (inner finally) before the rejection reaches the caller.
+ *
+ * @param {object} [opts]
+ * @param {(...a:any[]) => void} [opts.log] defaults to console.log; every
+ *   "[tick] ..." line the old CLI-only body printed is routed through this.
+ * @param {(path:string) => import("better-sqlite3").Database} [opts._dbFactory]
+ *   test/gateway seam — defaults to `new Database(path)` + busy_timeout pragma.
+ * @param {() => ({cliPath:string}|null)} [opts._resolvePiCli] test seam —
+ *   defaults to the real resolvePiCli() from pi_resolver.mjs.
+ * @returns {Promise<{ok:true, skipped?: "runtime_disabled"|"engine_missing"|"locked", bots?: number, handled?: number, errors?: string[]}>}
+ */
+export async function runBridgeTick({
+  log = (...a) => console.log(...a),
+  _dbFactory = defaultDbFactory,
+  _resolvePiCli = resolvePiCli,
+} = {}) {
+  const CROW_DB = botsDbPath();
+  const LOCK = lockPathFor(CROW_DB);
+
+  if (!acquireLock(LOCK)) {
+    log("[tick] another tick holds the lock — skip");
+    return { ok: true, skipped: "locked" };
+  }
+
+  try {
+    // Cheap, DB-free, before any gmail I/O: an engine-less install is an
+    // honest no-op, not a buried spawn failure three steps downstream.
+    if (!_resolvePiCli()) {
+      log("[tick] bot engine (pi) not installed — skip");
+      return { ok: true, skipped: "engine_missing" };
+    }
+
+    // F3b: respect the per-instance runtime toggle. Timer/interval keeps
+    // firing; when the operator has bot_runtime off, the tick is a no-op.
+    {
+      const _g = _dbFactory(CROW_DB);
+      let on = false;
+      try { on = botRuntimeEnabledSync(_g); } finally { _g.close(); }
+      if (!on) {
+        log("[tick] bot_runtime off — skip");
+        return { ok: true, skipped: "runtime_disabled" };
+      }
+    }
+
+    // Pre-flight: reap any abandoned/stuck/runaway pi from a previously crashed
+    // tick before doing more work (plan §10 risk #4). Runs every ~1 min via the
+    // existing timer (or the gateway interval) — no extra systemd unit. The
+    // pure-bash backstop in ~/bin/memory-watchdog.sh is the independent 5-min
+    // safety net.
+    try {
+      const sweep = reapStalePi({ log: (m) => log("[tick] " + m) });
+      if (sweep.reaped.length) log(`[tick] reaped ${sweep.reaped.length} stale pi (scanned ${sweep.scanned})`);
+    } catch (e) { log("[tick] reaper error (non-fatal): " + (e && e.message || e)); }
+
+    const d = _dbFactory(CROW_DB);
+    const errors = [];
+    try {
+      let defs = [];
+      try {
+        defs = d.prepare("SELECT bot_id, definition FROM pi_bot_defs WHERE enabled=1").all();
+      } catch {
+        log("[tick] pi_bot_defs missing — nothing to do");
+        return { ok: true, bots: 0, handled: 0, errors };
+      }
+
+      let processed = 0;
+      for (const row of defs) {
+        let def; try { def = JSON.parse(row.definition || "{}"); } catch { continue; }
+        const gw = (def.gateways || []).find((g) => g.type === "gmail" && g.address);
+        if (!gw) continue;
+        const alias = gw.address;                         // e.g. user+<x>@example.com
+        const plus = (alias.match(/\+([^@]+)@/) || [])[1]; // <x>
+
+        const srch = await gio(["search", "--query", `to:${alias} newer_than:2d`, "--max", "10"]);
+        const sres = parseResult(srch.out);
+        const threads = (sres && (sres.data?.threads || sres.threads)) || [];
+        for (const th of threads) {
+          const tid = th.id || th.thread_id || th.threadId;
+          if (!tid) continue;
+          const tr = await gio(["thread", "--id", tid], 60000);
+          const tres = parseResult(tr.out);
+          const msgs = (tres && (tres.data?.messages || tres.messages)) || [];
+          if (!msgs.length) continue;
+          const newest = msgs[msgs.length - 1];
+          const to = String(newest.to || (newest.headers && newest.headers.to) || "");
+          const isUserInbound = to.includes("+" + plus + "@");
+          if (!isUserInbound) continue;                   // newest is a bot reply -> nothing to do
+          // Gmail MCP returns the full plain-text body under `body_text` (current
+          // field name) or `plaintext_body` (legacy). Both ~unlimited length.
+          // `snippet` is Gmail's 200-char preview — last-resort fallback ONLY
+          // when both full-body fields are absent. Previously this read
+          // plaintext_body || snippet, which silently truncated EVERY inbound to
+          // ~200 chars (bot only saw the message preview, not what the user typed).
+          const body = (newest.body_text || newest.plaintext_body || newest.snippet || "").trim();
+          const msgDate = Date.parse(newest.date || (newest.headers && newest.headers.date) || "") || Date.now();
+
+          // Reply-recipient = actual sender of `newest` (so the bot's reply lands
+          // back in the user's inbox, not the bot's own mailbox — it was once
+          // hardcoded to the operator's address, which routed replies to the bot
+          // itself). The sender wall derives from the bot def's per-gateway
+          // allowlist (gw.allowlist — the same field the Bot Builder edits) and
+          // FAILS CLOSED when unconfigured: an empty allowlist means nobody can
+          // trigger a bot reply, never everybody. That's the safety wall against
+          // a third party emailing the +alias and getting a bot reply.
+          const fromHeader = String(newest.from || (newest.headers && newest.headers.from) || "");
+          const fromMatch = fromHeader.match(/<([^>]+)>/);
+          const replyTo = (fromMatch ? fromMatch[1] : fromHeader).trim().toLowerCase();
+          if (!gmailSenderAllowed(gw.allowlist, replyTo)) {
+            log(`[tick] skip thread=${tid} — sender '${replyTo}' not in this gateway's allowlist${Array.isArray(gw.allowlist) && gw.allowlist.length ? "" : " (no allowlist configured — set one on the bot's Gateways tab)"}`);
+            continue;
+          }
+
+          const sess = d.prepare("SELECT updated_at, status FROM bot_sessions WHERE bot_id=? AND gateway_thread_id=? ORDER BY id DESC LIMIT 1").get(row.bot_id, tid);
+          const sessTs = sess ? Date.parse(sess.updated_at + "Z") || 0 : 0;
+          if (sess && sess.status !== "stopped" && sessTs >= msgDate) continue; // already processed this inbound
+          if (sess && sess.status === "stopped" && !/\bresume\b/i.test(body)) {
+            // honor stop until the user explicitly says resume
+            continue;
+          }
+
+          log(`[tick] bot=${row.bot_id} thread=${tid} from=${replyTo} -> handleInbound (${body.slice(0, 50)})`);
+          try {
+            const r = await handleInbound({
+              bot_id: row.bot_id, gateway_thread_id: tid, user_message: body,
+              sendReply: async (text) => {
+                // --reply-to <alias> sets the Reply-To: header on the outbound
+                // so when the user clicks Reply in Gmail, it routes back to the
+                // bot's +alias (which bridge_tick monitors) rather than the
+                // bot's bare From: address (which nothing monitors). Without
+                // this, the user's reply lands at the bot's bare From: address
+                // and the bot never sees the follow-up.
+                await gio(["reply", "--to", replyTo,
+                  "--reply-to", alias,
+                  "--subject", "Re: " + (newest.subject || (newest.headers && newest.headers.subject) || "pibot"),
+                  "--thread", tid, "--body", text]);
+              },
+              log: (m) => log("  [bridge] " + m),
+            });
+            processed++;
+            log(`[tick] done thread=${tid} action=${r.action}`);
+          } catch (e) {
+            const msg = `[tick] handleInbound failed thread=${tid}: ${e.message}`;
+            log(msg);
+            errors.push(msg);
+          }
+        }
+      }
+
+      // Background-job drain (Plan B Part 1 Stage 2). On a Gmail-only deployment with
+      // NO pibot-gateways host, this is the only place queued bot_jobs get run +
+      // delivered. Where a gateways host IS present it's the primary runner; the
+      // atomic single-row claim + the reserved-slot gate inside tickJobs make running
+      // here too safe (whoever claims first wins, never exceeding the pi budget). One
+      // job per invocation keeps this oneshot tick bounded; a long job (up to the 10-
+      // min JOB_TIMEOUT) holds the tick's lock, delaying the next mail poll — the
+      // accepted tradeoff for a host with no dedicated job runner.
+      try {
+        const { tickJobs } = await import("./job_runner.mjs");
+        const { makeChannelDeliverer } = await import("./gateways/deliver.mjs");
+        const deliverChannel = makeChannelDeliverer({ log: (m) => log("[tick:deliver] " + m) });
+        const jr = await tickJobs({ log: (m) => log("[tick:jobs] " + m), deliverChannel });
+        if (jr && jr.ran) log(`[tick] background job ${jr.ran} → ${jr.status}`);
+      } catch (e) {
+        const msg = "[tick] job drain error (non-fatal): " + (e && e.message || e);
+        log(msg);
+        errors.push(msg);
+      }
+
+      log(`[tick] complete — processed ${processed} inbound`);
+      return { ok: true, bots: defs.length, handled: processed, errors };
+    } finally {
+      d.close();
+    }
+  } finally {
+    try { unlinkSync(LOCK); } catch {}
+  }
+}

--- a/scripts/run-suite.mjs
+++ b/scripts/run-suite.mjs
@@ -90,6 +90,12 @@ env.CROW_DATA_DIR = join(scratch, "data");
 // or instance-sync traffic.
 env.CROW_DISABLE_NOSTR = "1";
 env.CROW_DISABLE_INSTANCE_SYNC = "1";
+// C4 Task 6: the gateway-supervised bot runtime arms a 60s bridge-tick
+// interval and a discord child on any host where bot_runtime resolves true
+// (including the isMpaHost fallback) — a scratch suite gateway must never
+// double-poll pi_bot_defs alongside a real host's own bot-runtime/systemd
+// units, so it's forced off suite-wide exactly like Nostr/instance-sync above.
+env.CROW_DISABLE_BOT_RUNTIME = "1";
 // The suite must never believe it is supervised: a systemd-launched context
 // (CI runner, systemd-run, VS Code remote) leaks INVOCATION_ID, and code
 // under test would arm real restart/exit paths inside test processes.

--- a/servers/gateway/boot/post-listen.js
+++ b/servers/gateway/boot/post-listen.js
@@ -196,6 +196,17 @@ export async function runPostListenSetup(server, app, deps) {
     });
   });
 
+  // C4 Task 6: gateway-supervised bot runtime (bridge tick interval + Discord
+  // child, both gated on the bot_runtime feature flag via runtimeGate — see
+  // bot-runtime.js). Kill switch: CROW_DISABLE_BOT_RUNTIME=1 (forced by
+  // run-suite.mjs for every scratch suite gateway). Non-fatal — a failure
+  // here must not take down the gateway.
+  import("../bot-runtime.js").then(({ initBotRuntime }) => {
+    initBotRuntime().catch((err) => {
+      console.warn(`[bot-runtime] init failed: ${err.message}`);
+    });
+  });
+
   // Start schedule executor
   startScheduler(createDbClient()).catch((err) => {
     console.error("[scheduler] Failed to start:", err.message);

--- a/servers/gateway/bot-runtime.js
+++ b/servers/gateway/bot-runtime.js
@@ -1,0 +1,368 @@
+/**
+ * bot-runtime.js — gateway-supervised bot runtime (C4 Task 6).
+ *
+ * Two long-lived pieces the gateway process now owns directly, instead of
+ * requiring a host operator to install systemd units by hand:
+ *   - the bridge tick (Gmail-driven bots): an in-process interval calling
+ *     `runBridgeTick()` from `scripts/pi-bots/bridge_tick_lib.mjs` (C4 Task 5)
+ *     every `PIBOT_BRIDGE_TICK_MS` (default 60000).
+ *   - the Discord gateway child: a supervised `discord_gateway.mjs` process
+ *     (via `superviseProcess`, C4 Task 1's extraction), started only when at
+ *     least one enabled bot declares a discord gateway with a token.
+ *
+ * Both are gated by the SAME `bot_runtime` feature flag every other pi-bots
+ * runner already respects (`runtime-gate.mjs`'s `runtimeGate`/
+ * `botRuntimeEnabledSync`) — flipping the dashboard toggle arms/disarms this
+ * in-process runtime with NO gateway restart, exactly like the standalone
+ * `pibot-bridge.timer`/`pibot-discord.service` units do today. `runtimeGate`
+ * needs a SYNC better-sqlite3 connection (it calls `conn.prepare` directly),
+ * so this module opens its OWN handle on `botsDbPath()` — post-listen's
+ * async `createDbClient` would make the flag read silently return false
+ * forever (see runtime-gate.mjs:31,35 and the discord_gateway.mjs:222
+ * precedent for the same pattern).
+ *
+ * Mode resolution, in order (env is an INJECTED param, never read from
+ * process.env directly in this function — run-suite.mjs exports
+ * CROW_DISABLE_BOT_RUNTIME=1 suite-wide, and tests need to pass a clean env
+ * object to exercise gateway mode without that kill switch):
+ *   env.CROW_DISABLE_BOT_RUNTIME === "1"  → mode "disabled" (scratch/test kill switch)
+ *   env.PIBOT_SUPERVISOR === "external"   → mode "external" (host systemd manages
+ *                                           the pibot units directly; log one
+ *                                           honest line, do nothing)
+ *   else                                  → mode "gateway"
+ *
+ * Circuit breaker: PIBOT_BREAKER_THRESHOLD (default 3) consecutive tick
+ * failures (the tick threw, OR its result carried `errors` with zero
+ * successful `handled` turns) opens the breaker for PIBOT_BREAKER_COOLDOWN_MS
+ * (default 600000). While open, ticks past the cooldown are attempted as a
+ * single half-open trial: success closes the breaker (failures zeroed);
+ * failure keeps it open and pushes `retryAt` out another cooldown window.
+ * `runtimeGate` stopping the runtime (flag flipped off) RESETS the breaker —
+ * stale failure state must not survive a deliberate off/on cycle. The
+ * breaker is published to `bot-engine-status.js` via `setBreakerSource()` so
+ * the readiness UI and the attach gate see it without importing this module.
+ *
+ * Discord reconcile: subscribes to the shared event bus's
+ * "pibots:defs-changed" event (the same bus `routes/bundles.js`'s
+ * `emitJobChanged` uses for `jobs:changed`), debounced 2s so a burst of tab
+ * saves collapses into one reconcile. Compares the serialized discord
+ * gateway config (token/guild_id/channel_ids/allowlist) across the whole
+ * enabled-bot set: a discord bot appearing starts the child, the last one
+ * disappearing stops it, and ANY config change restarts it — the child only
+ * reads defs at its own startup, so an edited token must not keep the old
+ * Discord session alive under the stale credential.
+ */
+import Database from "better-sqlite3";
+import { fileURLToPath } from "node:url";
+
+import bus from "../shared/event-bus.js";
+import { botsDbPath } from "../../scripts/pi-bots/instance-paths.mjs";
+import { runtimeGate } from "../../scripts/pi-bots/runtime-gate.mjs";
+import { runBridgeTick as defaultRunBridgeTick } from "../../scripts/pi-bots/bridge_tick_lib.mjs";
+import { superviseProcess as defaultSuperviseProcess } from "./process-supervisor.js";
+import { setBreakerSource } from "./bot-engine-status.js";
+
+const DISCORD_GATEWAY_PATH = fileURLToPath(
+  new URL("../../scripts/pi-bots/discord_gateway.mjs", import.meta.url)
+);
+
+const DEBOUNCE_MS = 2000;
+
+function defaultDbFactory(path) {
+  const d = new Database(path);
+  d.pragma("busy_timeout = 10000");
+  return d;
+}
+
+function freshBreaker() {
+  return { open: false, failures: 0, lastError: null, retryAt: null };
+}
+
+function freshState() {
+  return {
+    mode: "disabled",
+    bridge: { armed: false, lastTickAt: null, lastResult: null, breaker: freshBreaker() },
+    discord: { lastError: null },
+  };
+}
+
+let state = freshState();
+
+// Runtime-only wiring, torn down/rebuilt by _resetBotRuntimeForTest().
+let gateHandle = null;
+let ownedConn = null; // the connection WE opened (closed on reset iff we own it)
+let discordHandle = null;
+let discordRegistry = new Map();
+let lastDiscordSignature = null;
+let bridgeTimer = null;
+let reconcileTimer = null;
+let busHandler = null;
+let tickInFlight = false;
+
+/** Read enabled bots' discord gateway configs (token/guild/channels/allowlist). */
+function discordBotConfigs(conn) {
+  let rows = [];
+  try {
+    rows = conn.prepare("SELECT bot_id, definition FROM pi_bot_defs WHERE enabled=1").all();
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const row of rows) {
+    let def;
+    try { def = JSON.parse(row.definition || "{}"); } catch { continue; }
+    const gw = (def.gateways || []).find((g) => g && g.type === "discord" && g.token);
+    if (!gw) continue;
+    out.push({
+      bot_id: row.bot_id,
+      token: gw.token,
+      guild_id: gw.guild_id || null,
+      channel_ids: Array.isArray(gw.channel_ids) ? gw.channel_ids.filter(Boolean) : [],
+      allowlist: Array.isArray(gw.allowlist) ? gw.allowlist.filter(Boolean) : [],
+    });
+  }
+  out.sort((a, b) => (a.bot_id < b.bot_id ? -1 : a.bot_id > b.bot_id ? 1 : 0));
+  return out;
+}
+
+function discordSignature(configs) {
+  return JSON.stringify(configs);
+}
+
+/**
+ * @param {object} [opts]
+ * @param {object} [opts.env] defaults to process.env — the ONLY two reads
+ *   this module does of it are CROW_DISABLE_BOT_RUNTIME and PIBOT_SUPERVISOR
+ *   (mode resolution). Everything else (PIBOT_BRIDGE_TICK_MS,
+ *   PIBOT_BREAKER_THRESHOLD, PIBOT_BREAKER_COOLDOWN_MS) is also read from
+ *   this SAME injected object, so a test exercising gateway mode never needs
+ *   the real process.env to carry them.
+ * @param {(path:string) => import("better-sqlite3").Database} [opts._dbFactory]
+ *   test seam for the connection this module opens on botsDbPath().
+ * @param {import("better-sqlite3").Database} [opts._conn] test seam: use this
+ *   connection directly instead of opening one via _dbFactory/botsDbPath().
+ *   When provided, _resetBotRuntimeForTest() will NOT close it (the caller
+ *   owns its lifetime).
+ * @param {Function} [opts._runBridgeTick] test seam, defaults to the real
+ *   runBridgeTick from bridge_tick_lib.mjs.
+ * @param {Function} [opts._superviseProcess] test seam, defaults to the real
+ *   superviseProcess from process-supervisor.js.
+ * @param {Function} [opts._setIntervalFn]
+ * @param {Function} [opts._clearIntervalFn]
+ * @param {Function} [opts._setTimeoutFn]
+ * @param {Function} [opts._clearTimeoutFn]
+ * @param {import("node:events").EventEmitter} [opts._bus] test seam, defaults
+ *   to the shared event bus.
+ * @param {number} [opts._pollMs] test seam forwarded as runtimeGate's
+ *   pollMs (default 30000) — tests shrink this to observe a flag flip
+ *   without a real 30s wait.
+ */
+export async function initBotRuntime({
+  env = process.env,
+  _dbFactory = defaultDbFactory,
+  _conn = null,
+  _runBridgeTick = defaultRunBridgeTick,
+  _superviseProcess = defaultSuperviseProcess,
+  _setIntervalFn = setInterval,
+  _clearIntervalFn = clearInterval,
+  _setTimeoutFn = setTimeout,
+  _clearTimeoutFn = clearTimeout,
+  _bus = bus,
+  _pollMs = 30000,
+} = {}) {
+  if (env.CROW_DISABLE_BOT_RUNTIME === "1") {
+    state.mode = "disabled";
+    return { mode: "disabled" };
+  }
+  if (env.PIBOT_SUPERVISOR === "external") {
+    state.mode = "external";
+    console.log("[bot-runtime] PIBOT_SUPERVISOR=external — host systemd manages the pibot units; gateway bot-runtime does nothing");
+    return { mode: "external" };
+  }
+
+  state.mode = "gateway";
+
+  const conn = _conn || _dbFactory(botsDbPath());
+  if (!_conn) ownedConn = conn;
+
+  const threshold = Number(env.PIBOT_BREAKER_THRESHOLD) || 3;
+  const cooldownMs = Number(env.PIBOT_BREAKER_COOLDOWN_MS) || 600000;
+  const tickMs = Number(env.PIBOT_BRIDGE_TICK_MS) || 60000;
+
+  setBreakerSource(() => ({ ...state.bridge.breaker }));
+
+  function recordFailure(errMsg) {
+    const breaker = state.bridge.breaker;
+    breaker.failures = (breaker.failures || 0) + 1;
+    breaker.lastError = errMsg || breaker.lastError || null;
+    if (breaker.open || breaker.failures >= threshold) {
+      breaker.open = true;
+      breaker.retryAt = new Date(Date.now() + cooldownMs).toISOString();
+    }
+  }
+
+  function recordSuccess() {
+    state.bridge.breaker = freshBreaker();
+  }
+
+  async function tick() {
+    if (tickInFlight) return; // non-overlap busy guard
+    const breaker = state.bridge.breaker;
+    if (breaker.open) {
+      const retryAtMs = breaker.retryAt ? Date.parse(breaker.retryAt) : 0;
+      if (Date.now() < retryAtMs) return; // still cooling down — skip silently
+      // past retryAt: fall through as a half-open trial
+    }
+    tickInFlight = true;
+    try {
+      let result;
+      try {
+        result = await _runBridgeTick({ log: (...a) => console.log("[bot-runtime]", ...a) });
+      } catch (e) {
+        recordFailure((e && e.message) || String(e));
+        return;
+      }
+      state.bridge.lastTickAt = new Date().toISOString();
+      state.bridge.lastResult = result;
+      const failed = result && Array.isArray(result.errors) && result.errors.length > 0 && !(result.handled > 0);
+      if (failed) {
+        recordFailure(result.errors[result.errors.length - 1]);
+      } else {
+        recordSuccess();
+      }
+    } finally {
+      tickInFlight = false;
+    }
+  }
+
+  function startBridge() {
+    bridgeTimer = _setIntervalFn(tick, tickMs);
+    if (bridgeTimer && bridgeTimer.unref) bridgeTimer.unref();
+    state.bridge.armed = true;
+    console.log(`[bot-runtime] bridge interval armed (${tickMs}ms)`);
+  }
+
+  function stopBridge() {
+    if (bridgeTimer) { _clearIntervalFn(bridgeTimer); bridgeTimer = null; }
+    state.bridge.armed = false;
+  }
+
+  function startDiscord() {
+    if (discordHandle) return;
+    const configs = discordBotConfigs(conn);
+    discordHandle = _superviseProcess({
+      key: "pibot-discord",
+      command: process.execPath,
+      args: [DISCORD_GATEWAY_PATH],
+      env: process.env,
+      maxRestarts: 10,
+      idleMinutes: 0,
+      registry: discordRegistry,
+      onTerminal: (reason) => {
+        state.discord.lastError = `terminal: ${reason}`;
+      },
+    });
+    lastDiscordSignature = discordSignature(configs);
+    console.log("[bot-runtime] discord child started");
+  }
+
+  async function stopDiscord() {
+    if (!discordHandle) return;
+    const h = discordHandle;
+    discordHandle = null;
+    await h.stop();
+    console.log("[bot-runtime] discord child stopped");
+  }
+
+  async function restartDiscord() {
+    await stopDiscord();
+    startDiscord();
+  }
+
+  async function reconcileDiscord() {
+    const configs = discordBotConfigs(conn);
+    if (configs.length === 0) {
+      await stopDiscord();
+      return;
+    }
+    if (!discordHandle) {
+      startDiscord();
+      return;
+    }
+    const sig = discordSignature(configs);
+    if (sig !== lastDiscordSignature) {
+      await restartDiscord();
+    }
+  }
+
+  function scheduleReconcile() {
+    if (reconcileTimer) _clearTimeoutFn(reconcileTimer);
+    reconcileTimer = _setTimeoutFn(() => {
+      reconcileTimer = null;
+      reconcileDiscord().catch((e) => console.warn("[bot-runtime] reconcile error:", e && e.message));
+    }, DEBOUNCE_MS);
+    if (reconcileTimer && reconcileTimer.unref) reconcileTimer.unref();
+  }
+
+  async function start() {
+    startBridge();
+    if (discordBotConfigs(conn).length > 0) startDiscord();
+    busHandler = () => scheduleReconcile();
+    _bus.on("pibots:defs-changed", busHandler);
+  }
+
+  async function stop() {
+    stopBridge();
+    if (busHandler) { _bus.off("pibots:defs-changed", busHandler); busHandler = null; }
+    if (reconcileTimer) { _clearTimeoutFn(reconcileTimer); reconcileTimer = null; }
+    await stopDiscord();
+    // A deliberate off/on cycle must never carry stale failure state into
+    // the next "on" — reset unconditionally on every stop().
+    state.bridge.breaker = freshBreaker();
+  }
+
+  gateHandle = runtimeGate(conn, { start, stop, pollMs: _pollMs, logTag: "bot-runtime" });
+
+  return { mode: "gateway" };
+}
+
+/**
+ * @returns {{ mode: "gateway"|"external"|"disabled",
+ *   bridge: { armed: boolean, lastTickAt: string|null, lastResult: object|null,
+ *             breaker: { open: boolean, failures: number, lastError: string|null, retryAt: string|null } },
+ *   discord: { running: boolean, state: string, restartCount: number, lastError: string|null } }}
+ */
+export function botRuntimeStatus() {
+  return {
+    mode: state.mode,
+    bridge: {
+      armed: state.bridge.armed,
+      lastTickAt: state.bridge.lastTickAt,
+      lastResult: state.bridge.lastResult,
+      breaker: { ...state.bridge.breaker },
+    },
+    discord: {
+      running: !!(discordHandle && discordHandle.live),
+      state: discordHandle ? discordHandle.state : "stopped",
+      restartCount: discordHandle ? discordHandle.restartCount : 0,
+      lastError: state.discord.lastError,
+    },
+  };
+}
+
+/** Test-only: tear down every module-level seam so one test can never leak
+ * timers, bus listeners, or breaker state into the next. */
+export function _resetBotRuntimeForTest() {
+  if (gateHandle) { try { gateHandle.dispose(); } catch {} }
+  gateHandle = null;
+  if (busHandler) { try { bus.off("pibots:defs-changed", busHandler); } catch {} busHandler = null; }
+  if (bridgeTimer) { try { clearInterval(bridgeTimer); } catch {} bridgeTimer = null; }
+  if (reconcileTimer) { try { clearTimeout(reconcileTimer); } catch {} reconcileTimer = null; }
+  if (discordHandle) { try { discordHandle.stop(); } catch {} discordHandle = null; }
+  discordRegistry = new Map();
+  lastDiscordSignature = null;
+  tickInFlight = false;
+  if (ownedConn) { try { ownedConn.close(); } catch {} ownedConn = null; }
+  setBreakerSource(null);
+  state = freshState();
+}

--- a/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
+++ b/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
@@ -18,6 +18,7 @@ import { regenerateBotMcp } from "../bot-mcp-regen.js";
 import { normalizeSkillName } from "../../../../../scripts/pi-bots/skill_proposals.mjs";
 import { t, fill, SUPPORTED_LANGS } from "../../shared/i18n.js";
 import { parseCookies } from "../../auth.js";
+import { emitBotDefsChanged } from "./defs-changed.js";
 
 // Same crow_lang-cookie resolution the dashboard router uses (index.js);
 // defensive because POST handlers can be exercised with header-less reqs.
@@ -74,6 +75,7 @@ export async function handleBotBuilderPost(req, res, { db }) {
     } catch (e) {
       return res.redirectAfterPost("/dashboard/bot-builder?error=" + encodeURIComponent(String(e.message || e)));
     }
+    emitBotDefsChanged(botId);
     // Item 5 PR2 (spec §D4): land on the readiness checklist, not the raw AI tab.
     return res.redirectAfterPost(`/dashboard/bot-builder?bot=${encodeURIComponent(botId)}&tab=review&created=${encodeURIComponent(botId)}`);
   }
@@ -91,9 +93,11 @@ export async function handleBotBuilderPost(req, res, { db }) {
   }
 
   if (action === "toggle") {
+    let toggled = true;
     try {
       await db.execute({ sql: "UPDATE pi_bot_defs SET enabled = 1 - enabled, updated_at=datetime('now') WHERE bot_id=?", args: [b.bot_id] });
-    } catch { /* ignore */ }
+    } catch { toggled = false; /* ignore */ }
+    if (toggled) emitBotDefsChanged(b.bot_id);
     // Back to the review tab (the toggle lives under the Status checklist
     // row there) so the user sees the updated row — PR #191 review m3.
     return res.redirectAfterPost(`/dashboard/bot-builder?bot=${encodeURIComponent(b.bot_id || "")}&tab=review`);
@@ -410,6 +414,7 @@ export async function handleBotBuilderPost(req, res, { db }) {
     } catch (e) {
       return res.redirectAfterPost(`/dashboard/bot-builder?bot=${encodeURIComponent(botId)}&tab=${tab}&error=` + encodeURIComponent(String(e.message || e)));
     }
+    emitBotDefsChanged(botId);
     return res.redirectAfterPost(`/dashboard/bot-builder?bot=${encodeURIComponent(botId)}&tab=${tab}&saved=1${extraQ}`);
   }
 

--- a/servers/gateway/dashboard/panels/bot-builder/defs-changed.js
+++ b/servers/gateway/dashboard/panels/bot-builder/defs-changed.js
@@ -1,0 +1,20 @@
+/**
+ * Bot Builder — defs-changed bus emit helper (C4 Task 6).
+ *
+ * Every successful bot-def mutation (create, wizard create, any tab save,
+ * enable/disable toggle, delete) must notify bot-runtime.js's Discord
+ * reconcile so an edited/added/removed discord gateway config is picked up
+ * within one debounce window — without a gateway restart. Pulled out into
+ * this tiny leaf module (rather than living in api-handlers.js) so
+ * wizard.js and delete-bot.js can both import it too: api-handlers.js
+ * already imports both of THOSE modules, so a helper living there would be
+ * an import cycle.
+ */
+import bus from "../../../../shared/event-bus.js";
+
+/** Non-throwing — a broken subscriber must never break the primary DB write. */
+export function emitBotDefsChanged(botId) {
+  try {
+    bus.emit("pibots:defs-changed", { bot_id: botId || null });
+  } catch {}
+}

--- a/servers/gateway/dashboard/panels/bot-builder/delete-bot.js
+++ b/servers/gateway/dashboard/panels/bot-builder/delete-bot.js
@@ -34,6 +34,7 @@ import { escapeHtml, section, callout } from "../../shared/components.js";
 import { csrfInput } from "../../shared/csrf.js";
 import { t, fill } from "../../shared/i18n.js";
 import { readSetting, writeSetting } from "../../settings/registry.js";
+import { emitBotDefsChanged } from "./defs-changed.js";
 
 async function count(db, sql, args) {
   try {
@@ -190,5 +191,6 @@ export async function handleDeleteConfirm(req, res, { db }) {
     return res.redirectAfterPost(
       `/dashboard/bot-builder?bot=${encodeURIComponent(botId)}&tab=review&error=` + encodeURIComponent(String(e.message || e)));
   }
+  emitBotDefsChanged(botId);
   return res.redirectAfterPost(`/dashboard/bot-builder?deleted=${encodeURIComponent(botId)}`);
 }

--- a/servers/gateway/dashboard/panels/bot-builder/wizard.js
+++ b/servers/gateway/dashboard/panels/bot-builder/wizard.js
@@ -28,6 +28,7 @@ import {
 } from "./gateway-fields.js";
 import { BOT_TEMPLATES, getTemplate, applyTemplate, availableMcpSet } from "./templates.js";
 import { resolveCrowHome } from "../../../../../scripts/pi-bots/ext_registry.mjs";
+import { emitBotDefsChanged } from "./defs-changed.js";
 
 export const WIZARD_STEP_KEYS = ["template", "basics", "model", "channel", "review"];
 
@@ -394,5 +395,6 @@ export async function handleWizardCreate(req, res, { db, lang }) {
   } catch (e) {
     return res.redirectAfterPost("/dashboard/bot-builder?new=1&error=" + encodeURIComponent(String(e.message || e)));
   }
+  emitBotDefsChanged(botId);
   return res.redirectAfterPost(`/dashboard/bot-builder?bot=${encodeURIComponent(botId)}&tab=review&created=${encodeURIComponent(botId)}`);
 }

--- a/tests/bot-runtime.test.js
+++ b/tests/bot-runtime.test.js
@@ -1,0 +1,645 @@
+// C4 Task 6 — servers/gateway/bot-runtime.js: the gateway-supervised bot
+// runtime (bridge-tick interval + Discord child), both gated by the SAME
+// bot_runtime feature flag every standalone pi-bots runner respects
+// (runtime-gate.mjs). All seams (db conn, runBridgeTick, superviseProcess,
+// bus, timers, pollMs) are injected so nothing here spawns a real process,
+// touches the real event bus, or waits on a real clock longer than a few ms.
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import Database from "better-sqlite3";
+
+import {
+  initBotRuntime,
+  botRuntimeStatus,
+  _resetBotRuntimeForTest,
+} from "../servers/gateway/bot-runtime.js";
+
+// ---------------------------------------------------------------------------
+// fixtures
+// ---------------------------------------------------------------------------
+
+function makeConn() {
+  const d = new Database(":memory:");
+  d.exec(`
+    CREATE TABLE dashboard_settings (
+      key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE dashboard_settings_overrides (
+      key TEXT, instance_id TEXT, value TEXT,
+      updated_at TEXT DEFAULT (datetime('now')), lamport_ts INTEGER DEFAULT 0,
+      PRIMARY KEY(key, instance_id)
+    );
+    CREATE TABLE pi_bot_defs (
+      bot_id TEXT PRIMARY KEY, display_name TEXT, definition TEXT,
+      project_id INTEGER, enabled INTEGER DEFAULT 1,
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+  return d;
+}
+
+function setFlag(conn, enabled) {
+  conn.prepare(
+    "INSERT INTO dashboard_settings (key, value) VALUES ('feature_flags', ?) " +
+    "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+  ).run(JSON.stringify({ bot_runtime: enabled }));
+}
+
+function upsertBot(conn, botId, gateways, enabled = 1) {
+  conn.prepare(
+    "INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,?) " +
+    "ON CONFLICT(bot_id) DO UPDATE SET definition=excluded.definition, enabled=excluded.enabled"
+  ).run(botId, botId, JSON.stringify({ gateways }), enabled);
+}
+
+function removeBot(conn, botId) {
+  conn.prepare("DELETE FROM pi_bot_defs WHERE bot_id=?").run(botId);
+}
+
+function discordGw(token, extra = {}) {
+  return [{ type: "discord", token, guild_id: "g1", channel_ids: ["c1"], allowlist: ["u1"], ...extra }];
+}
+
+/** Fake setInterval/clearInterval/setTimeout/clearTimeout: records + lets the
+ * test invoke scheduled callbacks manually — no real waiting for anything
+ * bot-runtime schedules itself (bridge interval, reconcile debounce). */
+function fakeTimers() {
+  let nextId = 1;
+  const intervals = new Map();
+  const timeouts = new Map();
+  return {
+    setIntervalFn: (fn, ms) => { const id = nextId++; intervals.set(id, { fn, ms }); return id; },
+    clearIntervalFn: (id) => intervals.delete(id),
+    setTimeoutFn: (fn, ms) => { const id = nextId++; timeouts.set(id, { fn, ms }); return id; },
+    clearTimeoutFn: (id) => timeouts.delete(id),
+    intervals,
+    timeouts,
+    lastInterval: () => [...intervals.values()].at(-1),
+    lastTimeout: () => [...timeouts.values()].at(-1),
+  };
+}
+
+function fakeSuperviseProcess() {
+  const calls = [];
+  const handles = [];
+  const fn = (opts) => {
+    calls.push(opts);
+    const handle = {
+      key: opts.key,
+      live: true,
+      state: "running",
+      restartCount: 0,
+      lastError: null,
+      stopCalls: 0,
+      stop: async function stop() {
+        this.stopCalls++;
+        this.live = false;
+        this.state = "stopped";
+        return Promise.resolve();
+      },
+    };
+    handles.push(handle);
+    return handle;
+  };
+  return { fn, calls, handles };
+}
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let conns = [];
+function trackConn(c) { conns.push(c); return c; }
+
+beforeEach(() => {
+  _resetBotRuntimeForTest();
+  conns = [];
+});
+afterEach(() => {
+  _resetBotRuntimeForTest();
+  for (const c of conns) { try { c.close(); } catch {} }
+});
+
+// ---------------------------------------------------------------------------
+// mode resolution
+// ---------------------------------------------------------------------------
+
+test("disabled mode: CROW_DISABLE_BOT_RUNTIME=1 no-ops, status reports disabled/unarmed", async () => {
+  const r = await initBotRuntime({ env: { CROW_DISABLE_BOT_RUNTIME: "1" } });
+  assert.equal(r.mode, "disabled");
+  const status = botRuntimeStatus();
+  assert.equal(status.mode, "disabled");
+  assert.equal(status.bridge.armed, false);
+  assert.equal(status.discord.running, false);
+});
+
+test("external mode: PIBOT_SUPERVISOR=external no-ops (host systemd manages it)", async () => {
+  const r = await initBotRuntime({ env: { PIBOT_SUPERVISOR: "external" } });
+  assert.equal(r.mode, "external");
+  const status = botRuntimeStatus();
+  assert.equal(status.mode, "external");
+  assert.equal(status.bridge.armed, false);
+  assert.equal(status.discord.running, false);
+});
+
+test("env is read from the injected object, never process.env — a clean env with the real process.env carrying CROW_DISABLE_BOT_RUNTIME still runs gateway mode", async () => {
+  const prev = process.env.CROW_DISABLE_BOT_RUNTIME;
+  process.env.CROW_DISABLE_BOT_RUNTIME = "1"; // simulates running under run-suite.mjs
+  try {
+    const conn = trackConn(makeConn());
+    setFlag(conn, false);
+    const timers = fakeTimers();
+    const r = await initBotRuntime({
+      env: {}, // clean injected env — no CROW_DISABLE_BOT_RUNTIME here
+      _conn: conn,
+      _superviseProcess: fakeSuperviseProcess().fn,
+      _setIntervalFn: timers.setIntervalFn,
+      _clearIntervalFn: timers.clearIntervalFn,
+      _setTimeoutFn: timers.setTimeoutFn,
+      _clearTimeoutFn: timers.clearTimeoutFn,
+      _bus: new EventEmitter(),
+      _pollMs: 10,
+    });
+    assert.equal(r.mode, "gateway");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_DISABLE_BOT_RUNTIME;
+    else process.env.CROW_DISABLE_BOT_RUNTIME = prev;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// gateway mode: bridge interval arms + ticks call the lib
+// ---------------------------------------------------------------------------
+
+test("gateway mode: flag on arms the bridge interval and each fire calls runBridgeTick", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  let tickCalls = 0;
+  const runBridgeTick = async () => { tickCalls++; return { ok: true, bots: 0, handled: 0, errors: [] }; };
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: runBridgeTick,
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20); // let runtimeGate's boot tick call start()
+
+  assert.equal(botRuntimeStatus().bridge.armed, true);
+  const interval = timers.lastInterval();
+  assert.ok(interval, "an interval was scheduled");
+  assert.equal(interval.ms, 60000, "default PIBOT_BRIDGE_TICK_MS");
+
+  await interval.fn();
+  assert.equal(tickCalls, 1);
+  await interval.fn();
+  assert.equal(tickCalls, 2);
+  assert.equal(botRuntimeStatus().bridge.lastResult.ok, true);
+});
+
+test("gateway mode: PIBOT_BRIDGE_TICK_MS overrides the default interval period", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  await initBotRuntime({
+    env: { PIBOT_BRIDGE_TICK_MS: "5000" },
+    _conn: conn,
+    _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  assert.equal(timers.lastInterval().ms, 5000);
+});
+
+test("busy guard: an overlapping fire while a tick is in flight is a no-op", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  let tickCalls = 0;
+  let resolveFirst;
+  const runBridgeTick = async () => {
+    tickCalls++;
+    if (tickCalls === 1) return new Promise((res) => { resolveFirst = res; });
+    return { ok: true, bots: 0, handled: 0, errors: [] };
+  };
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: runBridgeTick,
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  const interval = timers.lastInterval();
+
+  const p1 = interval.fn(); // in flight, unresolved
+  await wait(5);
+  const p2 = interval.fn(); // overlapping fire — must be a no-op
+  await p2;
+  assert.equal(tickCalls, 1, "the overlapping fire never called runBridgeTick a second time");
+
+  resolveFirst({ ok: true, bots: 0, handled: 0, errors: [] });
+  await p1;
+
+  await interval.fn(); // now safe to run again
+  assert.equal(tickCalls, 2);
+});
+
+// ---------------------------------------------------------------------------
+// breaker
+// ---------------------------------------------------------------------------
+
+test("breaker: opens after PIBOT_BREAKER_THRESHOLD consecutive failing ticks, then skips while cooling down", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  let tickCalls = 0;
+  const runBridgeTick = async () => {
+    tickCalls++;
+    return { ok: true, bots: 1, handled: 0, errors: ["boom " + tickCalls] };
+  };
+
+  await initBotRuntime({
+    env: { PIBOT_BREAKER_THRESHOLD: "2", PIBOT_BREAKER_COOLDOWN_MS: "50000" },
+    _conn: conn,
+    _runBridgeTick: runBridgeTick,
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  const interval = timers.lastInterval();
+
+  await interval.fn(); // failure 1
+  assert.equal(botRuntimeStatus().bridge.breaker.open, false);
+  await interval.fn(); // failure 2 -> threshold reached
+  const afterOpen = botRuntimeStatus().bridge.breaker;
+  assert.equal(afterOpen.open, true);
+  assert.match(afterOpen.lastError, /boom 2/);
+  assert.ok(afterOpen.retryAt);
+
+  await interval.fn(); // still cooling down (50s cooldown) — must skip, not call the lib
+  assert.equal(tickCalls, 2, "ticks are skipped while the breaker is open and not past retryAt");
+});
+
+test("breaker: a thrown tick counts as a failure too", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  const runBridgeTick = async () => { throw new Error("injected throw"); };
+
+  await initBotRuntime({
+    env: { PIBOT_BREAKER_THRESHOLD: "1", PIBOT_BREAKER_COOLDOWN_MS: "50000" },
+    _conn: conn,
+    _runBridgeTick: runBridgeTick,
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  await timers.lastInterval().fn();
+  const breaker = botRuntimeStatus().bridge.breaker;
+  assert.equal(breaker.open, true);
+  assert.match(breaker.lastError, /injected throw/);
+});
+
+test("breaker: half-open retry after cooldown — success closes it, failure keeps it open", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  let shouldFail = true;
+  let calls = 0;
+  const runBridgeTick = async () => {
+    calls++;
+    if (shouldFail) return { ok: true, bots: 1, handled: 0, errors: ["still broken " + calls] };
+    return { ok: true, bots: 1, handled: 1, errors: [] };
+  };
+
+  await initBotRuntime({
+    env: { PIBOT_BREAKER_THRESHOLD: "1", PIBOT_BREAKER_COOLDOWN_MS: "20" },
+    _conn: conn,
+    _runBridgeTick: runBridgeTick,
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  const interval = timers.lastInterval();
+
+  await interval.fn(); // failure -> opens (threshold 1)
+  assert.equal(botRuntimeStatus().bridge.breaker.open, true);
+  assert.equal(calls, 1);
+
+  await interval.fn(); // still within the 20ms cooldown -> skipped
+  assert.equal(calls, 1);
+
+  await wait(25); // cooldown elapses
+  await interval.fn(); // half-open trial — still failing -> reopens with a fresh retryAt
+  assert.equal(calls, 2);
+  assert.equal(botRuntimeStatus().bridge.breaker.open, true);
+
+  await wait(25);
+  shouldFail = false;
+  await interval.fn(); // half-open trial — now succeeds -> closes
+  assert.equal(calls, 3);
+  const closed = botRuntimeStatus().bridge.breaker;
+  assert.equal(closed.open, false);
+  assert.equal(closed.failures, 0);
+  assert.equal(closed.lastError, null);
+});
+
+test("breaker: flag-off stop() resets it — stale failure state does not survive an off/on cycle", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  const runBridgeTick = async () => ({ ok: true, bots: 1, handled: 0, errors: ["boom"] });
+
+  await initBotRuntime({
+    env: { PIBOT_BREAKER_THRESHOLD: "1", PIBOT_BREAKER_COOLDOWN_MS: "50000" },
+    _conn: conn,
+    _runBridgeTick: runBridgeTick,
+    _superviseProcess: fakeSuperviseProcess().fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  await timers.lastInterval().fn();
+  assert.equal(botRuntimeStatus().bridge.breaker.open, true);
+
+  setFlag(conn, false);
+  await wait(30); // next poll observes inactive -> stop()
+
+  const status = botRuntimeStatus();
+  assert.equal(status.bridge.armed, false);
+  assert.equal(status.bridge.breaker.open, false, "stop() resets the breaker");
+  assert.equal(status.bridge.breaker.failures, 0);
+});
+
+// ---------------------------------------------------------------------------
+// discord supervision
+// ---------------------------------------------------------------------------
+
+test("discord: the child is started only when an enabled bot has a discord gateway with a token", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  const sp = fakeSuperviseProcess();
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+    _superviseProcess: sp.fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  assert.equal(sp.calls.length, 0, "no discord bots yet — child never started");
+  assert.equal(botRuntimeStatus().discord.running, false);
+});
+
+test("discord: a discord-gateway bot at boot starts the child with the expected supervise args", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  upsertBot(conn, "botA", discordGw("tok-1"));
+  const timers = fakeTimers();
+  const sp = fakeSuperviseProcess();
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+    _superviseProcess: sp.fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+
+  assert.equal(sp.calls.length, 1);
+  const call = sp.calls[0];
+  assert.equal(call.key, "pibot-discord");
+  assert.equal(call.command, process.execPath);
+  assert.equal(call.args.length, 1);
+  assert.match(call.args[0], /discord_gateway\.mjs$/);
+  assert.equal(call.maxRestarts, 10);
+  assert.equal(call.idleMinutes, 0);
+  assert.ok(call.registry instanceof Map);
+  assert.equal(botRuntimeStatus().discord.running, true);
+});
+
+test("discord: stopped when runtimeGate stops the runtime on flag-off", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  upsertBot(conn, "botA", discordGw("tok-1"));
+  const timers = fakeTimers();
+  const sp = fakeSuperviseProcess();
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+    _superviseProcess: sp.fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: new EventEmitter(),
+    _pollMs: 10,
+  });
+  await wait(20);
+  assert.equal(botRuntimeStatus().discord.running, true);
+
+  setFlag(conn, false);
+  await wait(30);
+
+  assert.equal(sp.handles[0].stopCalls, 1);
+  assert.equal(botRuntimeStatus().discord.running, false);
+});
+
+// ---------------------------------------------------------------------------
+// defs-changed reconcile (debounced)
+// ---------------------------------------------------------------------------
+
+test("defs-changed reconcile: appear -> start, config change -> restart, disappear -> stop", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  const sp = fakeSuperviseProcess();
+  const testBus = new EventEmitter();
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+    _superviseProcess: sp.fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: testBus,
+    _pollMs: 10,
+  });
+  await wait(20);
+  assert.equal(botRuntimeStatus().discord.running, false, "no discord bots at boot");
+
+  // appear -> start
+  upsertBot(conn, "botA", discordGw("tok-1"));
+  testBus.emit("pibots:defs-changed", { bot_id: "botA" });
+  const debounced1 = timers.lastTimeout();
+  assert.equal(debounced1.ms, 2000, "reconcile is debounced 2s");
+  debounced1.fn(); // fire-and-forget, like the real setTimeout callback
+  await wait(10);
+  assert.equal(sp.calls.length, 1);
+  assert.equal(botRuntimeStatus().discord.running, true);
+
+  // config change (token rotated) -> restart (stop old, start new)
+  upsertBot(conn, "botA", discordGw("tok-2"));
+  testBus.emit("pibots:defs-changed", { bot_id: "botA" });
+  timers.lastTimeout().fn();
+  await wait(10);
+  assert.equal(sp.handles[0].stopCalls, 1, "the OLD handle was stopped");
+  assert.equal(sp.calls.length, 2, "a NEW handle was started");
+  assert.equal(botRuntimeStatus().discord.running, true);
+
+  // disappear -> stop
+  removeBot(conn, "botA");
+  testBus.emit("pibots:defs-changed", { bot_id: "botA" });
+  timers.lastTimeout().fn();
+  await wait(10);
+  assert.equal(sp.handles[1].stopCalls, 1, "the current handle was stopped");
+  assert.equal(botRuntimeStatus().discord.running, false);
+});
+
+test("defs-changed reconcile: a burst of events within the debounce window collapses to one reconcile", async () => {
+  const conn = trackConn(makeConn());
+  setFlag(conn, true);
+  const timers = fakeTimers();
+  const sp = fakeSuperviseProcess();
+  const testBus = new EventEmitter();
+
+  await initBotRuntime({
+    env: {},
+    _conn: conn,
+    _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+    _superviseProcess: sp.fn,
+    _setIntervalFn: timers.setIntervalFn,
+    _clearIntervalFn: timers.clearIntervalFn,
+    _setTimeoutFn: timers.setTimeoutFn,
+    _clearTimeoutFn: timers.clearTimeoutFn,
+    _bus: testBus,
+    _pollMs: 10,
+  });
+  await wait(20);
+
+  upsertBot(conn, "botA", discordGw("tok-1"));
+  testBus.emit("pibots:defs-changed", { bot_id: "botA" });
+  testBus.emit("pibots:defs-changed", { bot_id: "botA" });
+  testBus.emit("pibots:defs-changed", { bot_id: "botA" });
+  assert.equal(timers.timeouts.size, 1, "later emits reschedule the same debounce, not stack new ones");
+
+  timers.lastTimeout().fn();
+  await wait(10);
+  assert.equal(sp.calls.length, 1, "one reconcile ran, one discord child started");
+});
+
+// ---------------------------------------------------------------------------
+// flag-missing default: isMpaHost fallback (the prod double-poll hazard)
+// ---------------------------------------------------------------------------
+
+test("flag-missing default: OFF on a plain (non-MPA-shaped) data dir", async () => {
+  const prevHome = process.env.CROW_HOME;
+  const prevData = process.env.CROW_DATA_DIR;
+  process.env.CROW_HOME = "/tmp/crow-plain-home";
+  process.env.CROW_DATA_DIR = "/tmp/crow-plain-data";
+  try {
+    const conn = trackConn(makeConn()); // no feature_flags row at all
+    const timers = fakeTimers();
+    await initBotRuntime({
+      env: {},
+      _conn: conn,
+      _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+      _superviseProcess: fakeSuperviseProcess().fn,
+      _setIntervalFn: timers.setIntervalFn,
+      _clearIntervalFn: timers.clearIntervalFn,
+      _setTimeoutFn: timers.setTimeoutFn,
+      _clearTimeoutFn: timers.clearTimeoutFn,
+      _bus: new EventEmitter(),
+      _pollMs: 10,
+    });
+    await wait(20);
+    assert.equal(botRuntimeStatus().bridge.armed, false, "plain data dir -> flag-missing resolves OFF");
+  } finally {
+    if (prevHome === undefined) delete process.env.CROW_HOME; else process.env.CROW_HOME = prevHome;
+    if (prevData === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevData;
+  }
+});
+
+test("flag-missing default: ON on a ~/.crow-mpa-shaped data dir (isMpaHost fallback)", async () => {
+  const prevHome = process.env.CROW_HOME;
+  const prevData = process.env.CROW_DATA_DIR;
+  process.env.CROW_HOME = "/home/kh0pp/.crow-mpa";
+  process.env.CROW_DATA_DIR = "/home/kh0pp/.crow-mpa/data";
+  try {
+    const conn = trackConn(makeConn()); // no feature_flags row at all
+    const timers = fakeTimers();
+    await initBotRuntime({
+      env: {},
+      _conn: conn,
+      _runBridgeTick: async () => ({ ok: true, bots: 0, handled: 0, errors: [] }),
+      _superviseProcess: fakeSuperviseProcess().fn,
+      _setIntervalFn: timers.setIntervalFn,
+      _clearIntervalFn: timers.clearIntervalFn,
+      _setTimeoutFn: timers.setTimeoutFn,
+      _clearTimeoutFn: timers.clearTimeoutFn,
+      _bus: new EventEmitter(),
+      _pollMs: 10,
+    });
+    await wait(20);
+    assert.equal(botRuntimeStatus().bridge.armed, true, "~/.crow-mpa-shaped dir -> flag-missing resolves ON");
+  } finally {
+    if (prevHome === undefined) delete process.env.CROW_HOME; else process.env.CROW_HOME = prevHome;
+    if (prevData === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevData;
+  }
+});

--- a/tests/pi-bots-no-mpa-coupling.test.js
+++ b/tests/pi-bots-no-mpa-coupling.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 
 const MODULES = [
-  "bridge.mjs", "bridge_tick.mjs", "tracker.mjs", "skill_promote.mjs",
+  "bridge.mjs", "bridge_tick_lib.mjs", "tracker.mjs", "skill_promote.mjs",
   "skill_provenance.mjs", "model_resolver.mjs", "mcp_writer.mjs",
   "discord_gateway.mjs", "gateways/gateway_runner.mjs",
 ];

--- a/tests/pibot-bridge-tick-lib.test.js
+++ b/tests/pibot-bridge-tick-lib.test.js
@@ -1,0 +1,204 @@
+// C4 Task 5 — bridge_tick as a library. bridge_tick.mjs used to be a
+// process.exit(0)-only CLI script; the gateway now needs to drive the exact
+// same tick in-process (Task 6, ~60s interval) without spawning a child
+// process or killing itself on the first skip. This exercises the extracted
+// runBridgeTick({ log, _dbFactory, _resolvePiCli }) from bridge_tick_lib.mjs
+// and the three mandatory behavior deltas called out in the C4 build brief:
+//   1. returns a result object instead of process.exit
+//   2. the main better-sqlite3 handle closes in try/finally on EVERY path
+//      (previously only reachable via process.exit, which skipped the close)
+//   3. the lock file is instance-scoped (hash of the resolved crow.db path)
+//      and unlinks in `finally` on ALL paths, including the pi_bot_defs
+//      missing catch (which previously exited WITHOUT unlinking).
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync, closeSync, openSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { runBridgeTick, lockPathFor } from "../scripts/pi-bots/bridge_tick_lib.mjs";
+
+const FAKE_PI = { cliPath: "/fake/pi/dist/cli.js", source: "env" };
+const engineOk = () => FAKE_PI;
+const engineMissing = () => null;
+
+/** A fresh scratch data dir with the FULL schema (init-db.js), CROW_DATA_DIR
+ *  pointed at it for the duration of the test, restored afterward. */
+function scratchDataDir(label) {
+  const dir = mkdtempSync(join(tmpdir(), `crow-bridge-tick-${label}-`));
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+  });
+  after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function setBotRuntime(dbPath, enabled) {
+  const d = new Database(dbPath);
+  try {
+    d.prepare(
+      "INSERT INTO dashboard_settings (key, value) VALUES ('feature_flags', ?) " +
+      "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+    ).run(JSON.stringify({ bot_runtime: enabled }));
+  } finally {
+    d.close();
+  }
+}
+
+/** Run a callback with CROW_DATA_DIR (and no CROW_DB_PATH) set, restoring both after. */
+async function withDataDir(dir, fn) {
+  const prevDir = process.env.CROW_DATA_DIR;
+  const prevDbPath = process.env.CROW_DB_PATH;
+  delete process.env.CROW_DB_PATH;
+  process.env.CROW_DATA_DIR = dir;
+  try {
+    return await fn();
+  } finally {
+    if (prevDir === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = prevDir;
+    if (prevDbPath === undefined) delete process.env.CROW_DB_PATH; else process.env.CROW_DB_PATH = prevDbPath;
+  }
+}
+
+function trackingFactory(defaultFactory) {
+  let opens = 0, closes = 0;
+  const factory = (path) => {
+    opens++;
+    const d = defaultFactory(path);
+    const origClose = d.close.bind(d);
+    d.close = () => { closes++; return origClose(); };
+    return d;
+  };
+  return { factory, counts: () => ({ opens, closes }) };
+}
+
+function realFactory(path) {
+  const d = new Database(path);
+  d.pragma("busy_timeout = 10000");
+  return d;
+}
+
+test("runBridgeTick returns a result object (never exits the process)", async () => {
+  const dir = scratchDataDir("returns");
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineMissing, log: () => {} });
+    assert.equal(typeof r, "object");
+    assert.equal(r.ok, true);
+    assert.equal(r.skipped, "engine_missing");
+  });
+});
+
+test("runBridgeTick: engine_missing skip is DB-free and happens before any gmail I/O", async () => {
+  // Deliberately CROW_DATA_DIR pointing at a dir with NO crow.db at all —
+  // if the engine check needed the db first this would throw ENOENT.
+  const dir = mkdtempSync(join(tmpdir(), "crow-bridge-tick-noengine-"));
+  after(() => rmSync(dir, { recursive: true, force: true }));
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineMissing, log: () => {} });
+    assert.deepEqual(r, { ok: true, skipped: "engine_missing" });
+  });
+});
+
+test("runBridgeTick: skipped 'runtime_disabled' when bot_runtime flag is off", async () => {
+  const dir = scratchDataDir("runtime-off");
+  setBotRuntime(join(dir, "crow.db"), false);
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineOk, log: () => {} });
+    assert.equal(r.ok, true);
+    assert.equal(r.skipped, "runtime_disabled");
+  });
+});
+
+test("runBridgeTick: skipped 'locked' when a fresh lock file already exists (instance-scoped path)", async () => {
+  const dir = scratchDataDir("locked");
+  const dbPath = join(dir, "crow.db");
+  const lock = lockPathFor(dbPath);
+  closeSync(openSync(lock, "w"));
+  after(() => { try { rmSync(lock); } catch {} });
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineOk, log: () => {} });
+    assert.equal(r.ok, true);
+    assert.equal(r.skipped, "locked");
+    // We never owned the lock — it must still be there afterward.
+    assert.ok(existsSync(lock));
+  });
+});
+
+test("runBridgeTick: lock released after a normal completed run (0 enabled bots)", async () => {
+  const dir = scratchDataDir("normal-run");
+  const dbPath = join(dir, "crow.db");
+  setBotRuntime(dbPath, true);
+  const lock = lockPathFor(dbPath);
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineOk, log: () => {} });
+    assert.equal(r.ok, true);
+    assert.equal(r.skipped, undefined);
+    assert.equal(r.bots, 0);
+    assert.equal(r.handled, 0);
+    assert.ok(!existsSync(lock), "lock must be gone after a normal completed run");
+  });
+});
+
+test("runBridgeTick: lock released even when pi_bot_defs table is missing (fresh/partial DB)", async () => {
+  // A hand-built minimal DB: dashboard_settings + dashboard_settings_overrides
+  // exist (so botRuntimeEnabledSync can resolve true) but pi_bot_defs does
+  // NOT — the fresh-DB race the brief calls out (gateway ticks before
+  // init-db has run, or a partial/corrupt DB).
+  const dir = mkdtempSync(join(tmpdir(), "crow-bridge-tick-nodefs-"));
+  after(() => rmSync(dir, { recursive: true, force: true }));
+  const dbPath = join(dir, "crow.db");
+  const d = new Database(dbPath);
+  d.exec(`
+    CREATE TABLE dashboard_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT DEFAULT (datetime('now')));
+    CREATE TABLE dashboard_settings_overrides (key TEXT, instance_id TEXT, value TEXT, updated_at TEXT DEFAULT (datetime('now')), lamport_ts INTEGER DEFAULT 0, PRIMARY KEY(key, instance_id));
+  `);
+  d.prepare("INSERT INTO dashboard_settings (key, value) VALUES ('feature_flags', ?)").run(JSON.stringify({ bot_runtime: true }));
+  d.close();
+
+  const lock = lockPathFor(dbPath);
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineOk, log: () => {} });
+    assert.equal(r.ok, true);
+    assert.equal(r.bots, 0);
+    assert.equal(r.handled, 0);
+    assert.ok(!existsSync(lock), "lock must be gone even on the pi_bot_defs-missing early return (old bug: exited without unlinking)");
+  });
+});
+
+test("runBridgeTick: lock released AND db handle closed when the tick body throws unexpectedly", async () => {
+  const dir = scratchDataDir("throws");
+  const dbPath = join(dir, "crow.db");
+  setBotRuntime(dbPath, true);
+  const lock = lockPathFor(dbPath);
+
+  let calls = 0;
+  const throwingFactory = (path) => {
+    calls++;
+    if (calls === 1) throw new Error("injected-boom");
+    return realFactory(path);
+  };
+
+  await withDataDir(dir, async () => {
+    await assert.rejects(
+      () => runBridgeTick({ _resolvePiCli: engineOk, _dbFactory: throwingFactory, log: () => {} }),
+      /injected-boom/
+    );
+    assert.ok(!existsSync(lock), "lock must be released even though the tick body threw");
+  });
+});
+
+test("runBridgeTick: db handle opened via _dbFactory is closed on every path (open/close balance)", async () => {
+  const dir = scratchDataDir("db-balance");
+  const dbPath = join(dir, "crow.db");
+  setBotRuntime(dbPath, true);
+  const { factory, counts } = trackingFactory(realFactory);
+
+  await withDataDir(dir, async () => {
+    const r = await runBridgeTick({ _resolvePiCli: engineOk, _dbFactory: factory, log: () => {} });
+    assert.equal(r.ok, true);
+    const { opens, closes } = counts();
+    assert.ok(opens >= 1, "at least one db handle was opened");
+    assert.equal(opens, closes, `every opened handle must be closed (opens=${opens} closes=${closes})`);
+  });
+});


### PR DESCRIPTION
Item C4 PR C — bots run with no sudo and no systemd on a fresh install: the gateway supervises them.

- **`scripts/pi-bots/bridge_tick_lib.mjs`**: the Gmail tick as a library (`runBridgeTick`) — verified byte-identical move of the tick logic with three deliberate fixes the old `process.exit` masked: the better-sqlite3 handle now closes on every path (was ~1,440 leaked handles/day at gateway cadence), the lock unlinks on ALL paths including the fresh-DB missing-table case (was a 9-minute wedge), and the lock file is instance-scoped (`/tmp/pibot-bridge-tick-<dbhash>.lock`) so co-hosted instances don't serialize each other. `bridge_tick.mjs` is now a thin CLI wrapper — systemd contract unchanged.
- **`servers/gateway/bot-runtime.js`**: mode `PIBOT_SUPERVISOR=gateway|external` (+ `CROW_DISABLE_BOT_RUNTIME` kill switch, set suite-wide in run-suite). Gateway mode follows the `bot_runtime` flag via `runtimeGate` (own sync sqlite handle): 60s bridge interval with busy guard, Discord child supervised via the shared `superviseProcess` (maxRestarts 10, own registry), and a failure breaker (3 consecutive failed ticks → 10-min cooldown → half-open retry) surfaced through `bot-engine-status`'s `setBreakerSource`.
- **`pibots:defs-changed`** bus event from every Bot Builder mutation path → debounced (2s) Discord reconcile: appear→start, config-change→restart, gone→stop.
- Boot wiring in `post-listen.js` (initOrchestrator pattern — init failure can never block boot).
- Suite in-worktree: **2634/2634**, 0 fail.

**Deploy note (binding):** hosts whose pibot systemd units manage an instance (crow-mpa here) must set `PIBOT_SUPERVISOR=external` on that instance's gateway unit before/with this deploy, or Gmail bots double-poll and Discord double-connects. Deploy checklist in the C4 plan (Gitea).