### PR TITLE
feat(bot-builder): directed onboarding — engine attach gate, install modal, readiness row, uninstall blast (C4-D)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -379,6 +379,7 @@ export default defineConfig({
           { text: 'Writing Skills', link: '/developers/skills' },
           { text: 'Core Tools', link: '/developers/core-tools' },
           { text: 'Self-Hosted Bundles', link: '/developers/bundles' },
+          { text: 'Bot Engine (pi)', link: '/developers/bot-engine' },
           { text: 'Community Directory', link: '/developers/directory' },
           { text: 'Data Dashboard Dev', link: '/developers/data-dashboard' },
           { text: 'Nominatim GIS Dev', link: '/developers/nominatim' },

--- a/docs/developers/bot-engine.md
+++ b/docs/developers/bot-engine.md
@@ -1,0 +1,107 @@
+---
+title: Bot Engine (pi)
+---
+
+# Bot Engine (pi)
+
+The **bot engine** is the agent runtime behind Bot Builder's message-based channels — Gmail, Discord, Telegram, and Slack. It is [`@earendil-works/pi-coding-agent`](https://www.npmjs.com/package/@earendil-works/pi-coding-agent), pinned to `0.74.2`. Crow's pi-bots bridge (`scripts/pi-bots/`) spawns it per-turn in RPC mode (`--mode rpc`), feeds it the inbound message plus the bot's definition (model, tools, skills, permission policy), and relays its reply back out the channel it arrived on.
+
+Bots on **Crow Messages** or a **voice/device** channel never need the engine — those run their own loop directly against the gateway's model router, not pi. The engine only matters once a bot has an engine-channel gateway attached.
+
+## The bundle
+
+The engine ships as a bundle, `bundles/bot-engine/`, so it installs the same way any other add-on does — from the Extensions page, or automatically the first time a bot's Gateways tab tries to save a gmail/discord/telegram/slack channel while the engine is absent (see [Per-channel gating](#per-channel-gating) below).
+
+```json
+{
+  "id": "bot-engine",
+  "npm_required": true,
+  "verify_paths": ["node_modules/@earendil-works/pi-coding-agent/dist/cli.js"]
+}
+```
+
+`npm_required: true` puts this bundle on a stricter install path than most bundles (which only warn on an `npm install` failure): the installer
+
+1. removes any existing `node_modules` first — never trusts a partial tree left behind by an interrupted prior install to "pass" on retry,
+2. runs `npm ci` (or `npm install` with no lockfile) with `--omit=optional --no-audit --no-fund --ignore-scripts`,
+3. checks every path in `verify_paths` actually exists afterward, and
+4. on *any* failure at any of those steps, deletes the whole installed bundle directory and reports the install as failed.
+
+A bundle with `npm_required: true` is one the platform considers useless without a working install — there is no silent "installed, but the tool won't actually work" state for the bot engine the way there can be for an optional-dependency bundle.
+
+**Uninstall blast radius.** Because uninstalling the engine stops every gmail/discord/telegram/slack bot dead, the Extensions page's uninstall confirmation for `bot-engine` fetches `GET /bundles/api/engine-blast` first and lists every *enabled* bot that has an engine-channel gateway (bot name + channel types) in the confirmation dialog before letting the uninstall proceed. A disabled bot, or a bot whose only gateway is Crow Messages/voice, is not listed — it isn't affected.
+
+## The resolver ladder
+
+`scripts/pi-bots/pi_resolver.mjs` resolves the engine's CLI entrypoint without assuming any host-specific layout. First hit wins:
+
+```
+Ladder (first hit wins):
+  1. PIBOT_PI_CLI env — explicit operator override, trusted verbatim (a bad
+     path surfaces as an honest spawn error rather than being second-guessed).
+  2. <CROW_HOME>/bundles/bot-engine/<pkg>/dist/cli.js — the bot-engine
+     extension payload (per-instance, npm-installed at bundle install time).
+  3. <repo>/node_modules/<pkg>/dist/cli.js — pi as a declared dependency.
+  4. <dirname(execPath)>/../lib/node_modules/<pkg>/dist/cli.js — the global
+     npm root of the RUNNING node. Covers nvm (<prefix>/bin/node +
+     <prefix>/lib/node_modules), /usr/local, and Debian's /usr layout.
+  5. null — callers must surface "bot engine (pi) is not installed", never a
+     buried ENOENT/MODULE_NOT_FOUND from a phantom path.
+```
+
+Step 5 is deliberate: every caller (the bridge, the readiness checklist, the attach gate) gets one honest, actionable error message — `missingEngineMessage()` — instead of a stack trace pointing at a path nobody configured.
+
+## Supervisor modes
+
+The gateway process itself can run the engine's long-lived adapters — no separate systemd install required on a typical host. `servers/gateway/bot-runtime.js` resolves a mode at boot:
+
+| `PIBOT_SUPERVISOR` | Mode | Behavior |
+|---|---|---|
+| *(unset)* | `gateway` (default) | The gateway runs the Gmail bridge tick in-process on an interval (`PIBOT_BRIDGE_TICK_MS`, default 60000ms) and supervises a Discord child process directly. No standalone units to install. |
+| `external` | `external` | The gateway logs one line and does nothing — a host's own `pibot-*@` systemd units (bridge timer, Discord gateway) are the supervisor of record for that instance's bot definitions. |
+| — | `CROW_DISABLE_BOT_RUNTIME=1` forces mode `disabled` regardless of `PIBOT_SUPERVISOR` — the scratch/test kill switch (`scripts/run-suite.mjs` sets this for every suite run so tests never spawn a real bridge tick or Discord child). |
+
+**When to use `external`:** any host that already runs `pibot-*@` systemd units against the same bot definitions database. Running both at once is a **double-run hazard** — the gateway's in-process bridge and the systemd timer would each poll Gmail and answer the same message twice, and the gateway's in-process Discord supervisor would open a second client session on the same bot token that the systemd unit is already using. Set the drop-in on the **gateway** unit (not the pibot units themselves), e.g.:
+
+```ini
+# /etc/systemd/system/<gateway-unit>.service.d/pibot-supervisor.conf
+[Service]
+Environment=PIBOT_SUPERVISOR=external
+```
+
+then `systemctl daemon-reload` and restart the gateway. A host with no pre-existing `pibot-*@` units should leave the default `gateway` mode alone.
+
+## The `bot_runtime` flag and `runtimeGate`
+
+Even in `gateway` mode, the bridge tick and Discord child only actually run while the `feature_flags.bot_runtime` flag is on (**Settings → Bot Runtime**, defaults to on for an MPA-shaped host, off otherwise). `runtimeGate()` (`scripts/pi-bots/runtime-gate.mjs`) polls that flag every 30 seconds (`pollMs`, default 30000) and calls `start()`/`stop()` on a transition, with a `busy` guard so a stop can never overlap an in-flight start. Flipping the dashboard toggle arms or disarms the runtime with **no gateway restart** — the same self-gating rule every standalone pi-bots runner already respects.
+
+## Breaker semantics
+
+The bridge tick is guarded by a circuit breaker so a persistently broken bot (bad credentials, a dead model) can't spam retries forever:
+
+- `PIBOT_BREAKER_THRESHOLD` (default `3`) consecutive tick failures — the tick threw, or its result carried errors with zero successful turns handled — opens the breaker.
+- While open, ticks are skipped silently until `PIBOT_BREAKER_COOLDOWN_MS` (default `600000`, 10 minutes) has elapsed.
+- The first tick after the cooldown is attempted as a **half-open trial**: success closes the breaker and zeroes the failure count; failure keeps it open and pushes `retryAt` out another full cooldown window.
+- A deliberate off/on cycle of the `bot_runtime` flag **resets the breaker unconditionally** — stale failure state from a previous outage must never survive an intentional stop/start.
+
+## Readiness states
+
+The bot engine's status is a single precedence-ordered resolution (`servers/gateway/bot-engine-status.js`), most urgent first:
+
+| State | Meaning |
+|---|---|
+| `installing` | An install job for the `bot-engine` bundle is currently in flight. |
+| `absent` | `resolvePiCli()` found nothing anywhere in the ladder — ground truth that there's nothing installed to have failed. Absent always beats a stale open breaker. |
+| `unhealthy` | The engine resolves, but the circuit breaker (above) is open — carries the last error and `retryAt`. |
+| `ready` | The engine resolves and the breaker is closed. |
+
+The Bot Builder readiness checklist splits `ready` one step further into what the operator actually needs to know: if the runtime mode is `gateway` and the `bot_runtime` flag is off, the row shows **disarmed** (engine installed, but nothing will poll it) instead of a plain green check. Mode `external` never shows disarmed — an external supervisor polls regardless of the in-gateway flag.
+
+## Per-channel gating
+
+Only four gateway types need the engine — `gmail`, `discord`, `telegram`, `slack` (`ENGINE_CHANNELS`). Attaching one of these to a bot while the engine state is `absent` is refused at save time (both the Gateways-tab save and the wizard's final create share the same gate), with a modal offering to install the bundle in place. **Crow Messages** and **voice/device** gateways are never gated — they don't touch pi at all.
+
+## See also
+
+- [Self-Hosted Bundles](./bundles) — the general bundle contract this bundle follows.
+- [Bot Builder tutorial](/guide/bot-builder-tutorial) — the operator-facing walkthrough, including where the install prompt appears.

--- a/docs/guide/bot-builder-tutorial.md
+++ b/docs/guide/bot-builder-tutorial.md
@@ -52,6 +52,8 @@ A **channel** is where people talk to your bot. The template picks a sensible on
 - **Gmail / Discord / Telegram / Slack** need credentials from those services — see the [channel guides](#channel-guides) below. You can also pick the channel now, skip the credentials, and finish later.
 - **No channel yet** is always an option. The bot still works — you can talk to it from its Sessions tab — and you can add a channel any time.
 
+The first time you attach a Gmail, Discord, Telegram, or Slack channel, Crow may prompt you to install the **bot engine** — a small one-time download that powers those channels. It's a normal add-on install (no restart needed), and it only happens once per Crow instance. See the [Bot Engine reference](/developers/bot-engine) if you want the details.
+
 ## Step 6 — Review and create
 
 The last screen shows what you chose: template, name, internal id, model, channel. Click **Create bot**.

--- a/servers/gateway/dashboard/panels/bot-builder.js
+++ b/servers/gateway/dashboard/panels/bot-builder.js
@@ -7,6 +7,7 @@
 import { botBuilderStyles } from "./bot-builder/css.js";
 import { tableMissing } from "./bot-builder/data-queries.js";
 import { escapeHtml, section } from "../shared/components.js";
+import { t } from "../shared/i18n.js";
 import { botRuntimeActive } from "./bot-runtime-flag.js";
 import { handlePeerEdit } from "./bot-builder/peer-edit.js";
 import { handleBotBuilderPost } from "./bot-builder/api-handlers.js";
@@ -16,6 +17,24 @@ import { renderWizard } from "./bot-builder/wizard.js";
 import { renderDeleteConfirm } from "./bot-builder/delete-bot.js";
 
 const PAGE_CSS = botBuilderStyles();
+
+// C4 Task 8: q.error="engine_required" / q.warn="bot_runtime_off" are the
+// ONLY two values these params ever carry from api-handlers.js's Task 7
+// gate (the gateways-tab save redirect) — every other error/warn value
+// keeps rendering raw (baseNotice/warnNotice below), unchanged from before
+// this task. Both banners carry a button engine-gate-client.js wires up
+// (the script ships on every editor tab; see editor.js).
+function engineRequiredBanner(lang) {
+  return `<p class="btb-notice-err">${escapeHtml(t("botbuilder.engineGateBannerErrorBody", lang))} ` +
+    `<button type="button" id="engine-gate-open-btn" class="btb-btn btb-btn-sm btb-btn-inline">` +
+    `${escapeHtml(t("botbuilder.engineGateInstallBtn", lang))}</button></p>`;
+}
+function botRuntimeOffBanner(lang) {
+  return `<p class="btb-notice-warn">${escapeHtml(t("botbuilder.runtimeOffBannerBody", lang))} ` +
+    `<button type="button" id="bot-runtime-enable-btn" class="btb-btn btb-btn-sm btb-btn-inline">` +
+    `${escapeHtml(t("botbuilder.runtimeOffEnableBtn", lang))}</button> ` +
+    `<span id="bot-runtime-enable-status" class="btb-hint"></span></p>`;
+}
 
 export default {
   id: "bot-builder",
@@ -57,10 +76,12 @@ export default {
     // both messages stacked read as a double banner (PR #191 review m2).
     const baseNotice = q.saved ? `<p class="btb-notice-ok">Saved.</p>`
       : q.deleted ? `<p class="btb-notice-ok">Deleted <code>${escapeHtml(String(q.deleted))}</code>.</p>`
+      : q.error === "engine_required" ? engineRequiredBanner(lang)
       : q.error ? `<p class="btb-notice-err">${escapeHtml(String(q.error))}</p>` : "";
     // Soft, non-blocking warning (e.g. AI-tab model pair not in models.json).
     // Independent of the base notice so it can ride alongside a Saved.
-    const warnNotice = q.warn ? `<p class="btb-notice-warn">${escapeHtml(String(q.warn))}</p>` : "";
+    const warnNotice = q.warn === "bot_runtime_off" ? botRuntimeOffBanner(lang)
+      : q.warn ? `<p class="btb-notice-warn">${escapeHtml(String(q.warn))}</p>` : "";
     const notice = runtimeBanner + baseNotice + warnNotice;
 
     // ---- guided-creation wizard (Item 5 PR1, spec §D1) ----

--- a/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
+++ b/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
@@ -20,32 +20,25 @@ import { t, fill, SUPPORTED_LANGS } from "../../shared/i18n.js";
 import { parseCookies } from "../../auth.js";
 import { emitBotDefsChanged } from "./defs-changed.js";
 import { ENGINE_CHANNELS } from "../../../bot-engine-status.js";
-import { botRuntimeStatus } from "../../../bot-runtime.js";
 import { botRuntimeActive } from "../bot-runtime-flag.js";
-import { engineRequiredFor, _setEngineStatusForTest } from "./engine-gate.js";
+import {
+  engineRequiredFor, _setEngineStatusForTest,
+  _setBotRuntimeStatusForTest, resolveBotRuntimeStatus,
+} from "./engine-gate.js";
 
 // Task 7 (C4): the gateways-tab save gate needs two host/process-dependent
 // checks — engineStatus() (whose "global" npm rung resolves off the REAL
 // running node, not anything a test controls) and botRuntimeStatus() (a
 // module singleton only populated by a real initBotRuntime() call: timers,
-// a sync sqlite handle, the event bus — too heavy for a route test). The
-// engine-status pin now lives in the shared ./engine-gate.js (the wizard's
-// create path — wizard.js — needs the SAME pinnable predicate, and it can't
-// import a local pin here without a real ESM cycle since this file already
-// imports handleWizardCreate from wizard.js). Re-exported below so existing
-// importers of `_setEngineStatusForTest` from this file are unaffected.
-// botRuntimeStatus stays local-pinnable here, following the house convention
-// for this kind of host-state seam (bot-engine-status.js's _setSeamsForTest,
-// dashboard/panels/extensions/data-queries.js's _setDockerProbeForTest):
-// null (the default) falls through to the real check.
-export { _setEngineStatusForTest };
-let _botRuntimeStatusPin = null;
-
-/** Test-only: pin botRuntimeStatus()'s result for the runtime-disarmed
- * warning. Pass null to un-pin (falls back to the real botRuntimeStatus()). */
-export function _setBotRuntimeStatusForTest(status) {
-  _botRuntimeStatusPin = status || null;
-}
+// a sync sqlite handle, the event bus — too heavy for a route test). Both
+// pins now live in the shared ./engine-gate.js (the wizard's create path —
+// wizard.js — needs the SAME pinnable engineStatus, and the readiness
+// checklist row — checklist.js, Task 9 — needs BOTH pins; neither can import
+// a local pin here without a real ESM cycle since this file already imports
+// handleWizardCreate from wizard.js). Re-exported below so existing
+// importers of `_setEngineStatusForTest`/`_setBotRuntimeStatusForTest` from
+// this file are unaffected.
+export { _setEngineStatusForTest, _setBotRuntimeStatusForTest };
 
 // Same crow_lang-cookie resolution the dashboard router uses (index.js);
 // defensive because POST handlers can be exercised with header-less reqs.
@@ -448,7 +441,7 @@ export async function handleBotBuilderPost(req, res, { db }) {
         // warning a stranger completes onboarding green and the bot stays
         // silently deaf. installing/unhealthy/ready all pass the gate above
         // (the engine exists); only a disarmed runtime needs a nudge here.
-        const runtime = _botRuntimeStatusPin || botRuntimeStatus();
+        const runtime = resolveBotRuntimeStatus();
         if (runtime && runtime.mode === "gateway") {
           const flagOn = await botRuntimeActive(db);
           if (!flagOn) extraQ += "&warn=bot_runtime_off";

--- a/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
+++ b/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
@@ -10,7 +10,7 @@ import {
   PI_BUILTIN, PI_EXT_ALLOWLIST,
   loadModelOptions, remoteInvocationOn, defaultDefinition, lines,
 } from "./data-queries.js";
-import { normalizeGatewayFields } from "./gateway-fields.js";
+import { normalizeGatewayFields, missingGatewayFields } from "./gateway-fields.js";
 import { handleWizardCreate } from "./wizard.js";
 import { handleDeleteConfirm } from "./delete-bot.js";
 import { readSetting, writeSetting } from "../../settings/registry.js";
@@ -19,6 +19,32 @@ import { normalizeSkillName } from "../../../../../scripts/pi-bots/skill_proposa
 import { t, fill, SUPPORTED_LANGS } from "../../shared/i18n.js";
 import { parseCookies } from "../../auth.js";
 import { emitBotDefsChanged } from "./defs-changed.js";
+import { ENGINE_CHANNELS, engineStatus } from "../../../bot-engine-status.js";
+import { botRuntimeStatus } from "../../../bot-runtime.js";
+
+// Task 7 (C4): the gateways-tab save gate needs two host/process-dependent
+// checks — engineStatus() (whose "global" npm rung resolves off the REAL
+// running node, not anything a test controls) and botRuntimeStatus() (a
+// module singleton only populated by a real initBotRuntime() call: timers,
+// a sync sqlite handle, the event bus — too heavy for a route test). Both
+// are pinnable here, following the house convention for exactly this kind
+// of host-state seam (bot-engine-status.js's _setSeamsForTest,
+// dashboard/panels/extensions/data-queries.js's _setDockerProbeForTest):
+// null (the default) falls through to the real check.
+let _engineStatusPin = null;
+let _botRuntimeStatusPin = null;
+
+/** Test-only: pin engineStatus()'s result for the gateways-tab attach gate.
+ * Pass null to un-pin (falls back to the real engineStatus()). */
+export function _setEngineStatusForTest(status) {
+  _engineStatusPin = status || null;
+}
+
+/** Test-only: pin botRuntimeStatus()'s result for the runtime-disarmed
+ * warning. Pass null to un-pin (falls back to the real botRuntimeStatus()). */
+export function _setBotRuntimeStatusForTest(status) {
+  _botRuntimeStatusPin = status || null;
+}
 
 // Same crow_lang-cookie resolution the dashboard router uses (index.js);
 // defensive because POST handlers can be exercised with header-less reqs.
@@ -394,6 +420,44 @@ export async function handleBotBuilderPost(req, res, { db }) {
     } else if (tab === "triggers") {
       def.triggers.gateway = !!b.tr_gateway;
       def.triggers.cron = (b.tr_cron || "").trim();
+    }
+
+    // Task 7 (C4): server-side attach gate — the primary UX is a client-side
+    // intercept (Task 8, engine absence is known at render); this is only a
+    // backstop for a client bypassing JS. Fires ONLY on a COMPLETE
+    // engine-channel record (type ∈ ENGINE_CHANNELS AND no missing required
+    // fields) — a type-only draft from the dropdown's auto-submit-on-type-
+    // change (W1-4 snap-back doctrine) is inert (no consumer acts on it
+    // until it's complete) and must keep saving exactly as before this gate
+    // existed. Voice/device gateways (glasses/companion) and crow-messages
+    // are never in ENGINE_CHANNELS, so they're never gated here (C4-3).
+    if (tab === "gateways") {
+      const savedGw = (def.gateways || [])[0];
+      if (savedGw && ENGINE_CHANNELS.includes(savedGw.type) && missingGatewayFields(savedGw).length === 0) {
+        const engine = _engineStatusPin || engineStatus({ env: process.env });
+        if (engine.state === "absent") {
+          // Form state is accepted as lost on this path — the fix is
+          // installing the engine, not reposting the same form.
+          return res.redirectAfterPost(
+            `/dashboard/bot-builder?bot=${encodeURIComponent(botId)}&tab=gateways&error=engine_required`
+          );
+        }
+        // Runtime-disarmed surfacing (r1 critical #2): the engine exists,
+        // but nothing will actually poll this gateway until the bot_runtime
+        // flag is on (it defaults off on every non-MPA host) — without this
+        // warning a stranger completes onboarding green and the bot stays
+        // silently deaf. installing/unhealthy/ready all pass the gate above
+        // (the engine exists); only a disarmed runtime needs a nudge here.
+        const runtime = _botRuntimeStatusPin || botRuntimeStatus();
+        if (runtime && runtime.mode === "gateway") {
+          let flagOn = false;
+          try {
+            const raw = await readSetting(db, "feature_flags");
+            flagOn = !!(raw && JSON.parse(raw)?.bot_runtime === true);
+          } catch { /* unparsable flags read as off */ }
+          if (!flagOn) extraQ += "&warn=bot_runtime_off";
+        }
+      }
     }
 
     try {

--- a/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
+++ b/servers/gateway/dashboard/panels/bot-builder/api-handlers.js
@@ -19,26 +19,27 @@ import { normalizeSkillName } from "../../../../../scripts/pi-bots/skill_proposa
 import { t, fill, SUPPORTED_LANGS } from "../../shared/i18n.js";
 import { parseCookies } from "../../auth.js";
 import { emitBotDefsChanged } from "./defs-changed.js";
-import { ENGINE_CHANNELS, engineStatus } from "../../../bot-engine-status.js";
+import { ENGINE_CHANNELS } from "../../../bot-engine-status.js";
 import { botRuntimeStatus } from "../../../bot-runtime.js";
+import { botRuntimeActive } from "../bot-runtime-flag.js";
+import { engineRequiredFor, _setEngineStatusForTest } from "./engine-gate.js";
 
 // Task 7 (C4): the gateways-tab save gate needs two host/process-dependent
 // checks — engineStatus() (whose "global" npm rung resolves off the REAL
 // running node, not anything a test controls) and botRuntimeStatus() (a
 // module singleton only populated by a real initBotRuntime() call: timers,
-// a sync sqlite handle, the event bus — too heavy for a route test). Both
-// are pinnable here, following the house convention for exactly this kind
-// of host-state seam (bot-engine-status.js's _setSeamsForTest,
+// a sync sqlite handle, the event bus — too heavy for a route test). The
+// engine-status pin now lives in the shared ./engine-gate.js (the wizard's
+// create path — wizard.js — needs the SAME pinnable predicate, and it can't
+// import a local pin here without a real ESM cycle since this file already
+// imports handleWizardCreate from wizard.js). Re-exported below so existing
+// importers of `_setEngineStatusForTest` from this file are unaffected.
+// botRuntimeStatus stays local-pinnable here, following the house convention
+// for this kind of host-state seam (bot-engine-status.js's _setSeamsForTest,
 // dashboard/panels/extensions/data-queries.js's _setDockerProbeForTest):
 // null (the default) falls through to the real check.
-let _engineStatusPin = null;
+export { _setEngineStatusForTest };
 let _botRuntimeStatusPin = null;
-
-/** Test-only: pin engineStatus()'s result for the gateways-tab attach gate.
- * Pass null to un-pin (falls back to the real engineStatus()). */
-export function _setEngineStatusForTest(status) {
-  _engineStatusPin = status || null;
-}
 
 /** Test-only: pin botRuntimeStatus()'s result for the runtime-disarmed
  * warning. Pass null to un-pin (falls back to the real botRuntimeStatus()). */
@@ -434,8 +435,7 @@ export async function handleBotBuilderPost(req, res, { db }) {
     if (tab === "gateways") {
       const savedGw = (def.gateways || [])[0];
       if (savedGw && ENGINE_CHANNELS.includes(savedGw.type) && missingGatewayFields(savedGw).length === 0) {
-        const engine = _engineStatusPin || engineStatus({ env: process.env });
-        if (engine.state === "absent") {
+        if (engineRequiredFor(savedGw)) {
           // Form state is accepted as lost on this path — the fix is
           // installing the engine, not reposting the same form.
           return res.redirectAfterPost(
@@ -450,11 +450,7 @@ export async function handleBotBuilderPost(req, res, { db }) {
         // (the engine exists); only a disarmed runtime needs a nudge here.
         const runtime = _botRuntimeStatusPin || botRuntimeStatus();
         if (runtime && runtime.mode === "gateway") {
-          let flagOn = false;
-          try {
-            const raw = await readSetting(db, "feature_flags");
-            flagOn = !!(raw && JSON.parse(raw)?.bot_runtime === true);
-          } catch { /* unparsable flags read as off */ }
+          const flagOn = await botRuntimeActive(db);
           if (!flagOn) extraQ += "&warn=bot_runtime_off";
         }
       }

--- a/servers/gateway/dashboard/panels/bot-builder/checklist.js
+++ b/servers/gateway/dashboard/panels/bot-builder/checklist.js
@@ -19,6 +19,9 @@ import { escapeHtml } from "../../shared/components.js";
 import { t, fill } from "../../shared/i18n.js";
 import { loadModelOptions } from "./data-queries.js";
 import { missingGatewayFields } from "./gateway-fields.js";
+import { ENGINE_CHANNELS } from "../../../bot-engine-status.js";
+import { resolveEngineStatus, resolveBotRuntimeStatus } from "./engine-gate.js";
+import { botRuntimeActive } from "../bot-runtime-flag.js";
 
 const OK = `<span class="btb-ok" aria-hidden="true">&#10003;</span>`;
 const WARN = `<span class="btb-status-warn" aria-hidden="true">&#9888;</span>`;
@@ -27,6 +30,76 @@ const ERR = `<span class="btb-err" aria-hidden="true">&#10007;</span>`;
 function row(icon, label, detail, fixHref, fixLabel) {
   const fix = fixHref ? `<a href="${escapeHtml(fixHref)}">${escapeHtml(fixLabel)}</a>` : "";
   return `<tr><td class="btb-check-icon">${icon}</td><td>${label}</td><td>${detail}</td><td>${fix}</td></tr>`;
+}
+
+// Same row shape as row() above, but the fix cell is already-built HTML
+// (a button wired to a client hook) rather than a plain link — used by the
+// "Bot engine" row's absent/disarmed states below, which act via JS hooks
+// instead of navigating to another tab.
+function rowRawFix(icon, label, detail, fixHtml) {
+  return `<tr><td class="btb-check-icon">${icon}</td><td>${label}</td><td>${detail}</td><td>${fixHtml || ""}</td></tr>`;
+}
+
+/**
+ * "Bot engine" row (C4 Task 9). Shown ONLY when this bot has at least one
+ * ENGINE_CHANNELS-type gateway (gmail/discord/telegram/slack) — voice/device
+ * and crow-messages gateways never need pi installed. Five states, in the
+ * SAME precedence order as engineStatus() itself (bot-engine-status.js):
+ * installing > absent > unhealthy > ready, with "ready" splitting further
+ * into "disarmed" (engine present, but nothing will poll it — the
+ * bot_runtime flag is off) vs plain ready. Reuses the exact pins
+ * resolveEngineStatus()/resolveBotRuntimeStatus() from engine-gate.js so one
+ * _setEngineStatusForTest/_setBotRuntimeStatusForTest call in a test arms
+ * this row the same way it arms the Gateways-tab save gate (Task 7/8).
+ */
+async function renderEngineRow(db, def, lang, tabHref, fixLabel) {
+  const hasEngineChannel = (def.gateways || []).some((g) => g && ENGINE_CHANNELS.includes(g.type));
+  if (!hasEngineChannel) return "";
+
+  const label = t("botbuilder.checkEngine", lang);
+  const status = resolveEngineStatus();
+
+  if (status.state === "installing") {
+    return row(WARN, label, t("botbuilder.checkEngineInstalling", lang), tabHref("gateways"), fixLabel);
+  }
+
+  if (status.state === "absent") {
+    const installBtn =
+      `<button type="button" class="btb-btn btb-btn-sm btb-btn-inline" onclick="window.__crowEngineGateOpen()">` +
+      `${escapeHtml(t("botbuilder.engineGateInstallBtn", lang))}</button>`;
+    return rowRawFix(ERR, label, t("botbuilder.checkEngineAbsent", lang), installBtn);
+  }
+
+  if (status.state === "unhealthy") {
+    const detail = fill(t("botbuilder.checkEngineUnhealthy", lang), {
+      error: escapeHtml(status.error || t("botbuilder.engineGateUnknownError", lang)),
+      retryAt: escapeHtml(status.retryAt || "—"),
+    });
+    return row(ERR, label, detail, tabHref("gateways"), fixLabel);
+  }
+
+  // status.state === "ready" — split disarmed vs plain ready per the
+  // SAME predicate the Gateways-tab save gate uses (api-handlers.js): only
+  // runtime mode "gateway" self-supervises off the bot_runtime flag; a mode
+  // of "external" or "disabled" never disarms (nothing here would poll
+  // regardless of the flag's value).
+  const runtime = resolveBotRuntimeStatus();
+  if (runtime.mode === "gateway") {
+    const flagOn = await botRuntimeActive(db);
+    if (!flagOn) {
+      const enableBtn =
+        `<button type="button" id="bot-runtime-enable-btn" class="btb-btn btb-btn-sm btb-btn-inline">` +
+        `${escapeHtml(t("botbuilder.runtimeOffEnableBtn", lang))}</button> ` +
+        `<span id="bot-runtime-enable-status" class="btb-hint"></span>`;
+      return rowRawFix(WARN, label, t("botbuilder.checkEngineDisarmed", lang), enableBtn);
+    }
+  }
+
+  let detail = fill(t("botbuilder.checkEngineReady", lang), { source: escapeHtml(status.source || "") });
+  if (runtime.mode === "external") {
+    detail += ` · ${t("botbuilder.checkEngineExternalNote", lang)}`;
+  }
+  return row(OK, label, detail, tabHref("gateways"), fixLabel);
 }
 
 /**
@@ -83,6 +156,10 @@ export async function renderReadiness(db, bot, def, lang) {
       rows.push(row(OK, t("botbuilder.checkChannel", lang), detail, tabHref("gateways"), fixLabel));
     }
   }
+
+  // ---- Bot engine (C4 Task 9) — only when a gateway needs pi installed ----
+  const engineRow = await renderEngineRow(db, def, lang, tabHref, fixLabel);
+  if (engineRow) rows.push(engineRow);
 
   // ---- Tools ----
   const tools = def.tools || {};

--- a/servers/gateway/dashboard/panels/bot-builder/css.js
+++ b/servers/gateway/dashboard/panels/bot-builder/css.js
@@ -141,5 +141,26 @@ export function botBuilderStyles() {
   .btb-btn-danger{background:var(--crow-error);color:#fff}
   .btb-del-radius{margin:.5rem 0 .75rem;padding-left:1.2rem;font-size:.9rem}
   .btb-del-radius li{margin:.2rem 0}
+
+  /* Engine-attach gate modal (C4 Task 8) */
+  #engine-gate-modal-overlay{
+    display:none; position:fixed;
+    top:0; left:0; width:100%; height:100%;
+    background:rgba(0,0,0,0.6);
+    z-index:1000;
+    align-items:center; justify-content:center;
+    backdrop-filter:blur(4px);
+    -webkit-backdrop-filter:blur(4px);
+  }
+  #engine-gate-modal-content{
+    background:var(--crow-bg-surface);
+    border:1px solid var(--crow-border);
+    border-radius:var(--crow-radius-card,12px);
+    padding:1.5rem;
+    max-width:480px; width:90%;
+    max-height:80vh; overflow-y:auto; overflow-x:hidden;
+    box-sizing:border-box; word-wrap:break-word;
+    box-shadow:0 20px 60px rgba(0,0,0,0.5);
+  }
 </style>`;
 }

--- a/servers/gateway/dashboard/panels/bot-builder/editor.js
+++ b/servers/gateway/dashboard/panels/bot-builder/editor.js
@@ -31,8 +31,11 @@ import {
   probeAll, probeExtensions, loadVisionProfiles, gatherPeerTools, remoteInvocationOn,
   loadModelOptions, loadSkills,
 } from "./data-queries.js";
-import { renderGatewayFields } from "./gateway-fields.js";
+import { renderGatewayFields, engineGateRequiredDomFields } from "./gateway-fields.js";
 import { renderReadiness } from "./checklist.js";
+import { ENGINE_CHANNELS } from "../../../bot-engine-status.js";
+import { isEngineAbsent } from "./engine-gate.js";
+import { engineGateClientJS } from "./engine-gate-client.js";
 
 // Tab id → i18n key map
 const TAB_KEYS = {
@@ -474,8 +477,21 @@ export async function renderBotEditor(req, res, { db, layout, lang, PAGE_CSS, bo
       gwFields = fb.fields;
       gwHint = fb.hint;
     }
+    // C4 Task 8: arm the client-side engine-gate ONLY for the currently
+    // rendered gwType (a type-only draft that isn't an ENGINE_CHANNELS type
+    // never needs the modal), and only while the engine is actually absent
+    // right now — reusing the SAME pinnable engineStatus() resolution as
+    // Task 7's save-time gate (engine-gate.js's isEngineAbsent()) so tests
+    // can arm both with one call. The required-field DOM names ride along
+    // as a data attribute so the client mirrors Task 7's completeness
+    // predicate against the live form without duplicating field-name
+    // knowledge (gateway-fields.js's engineGateRequiredDomFields()).
+    const engineGateArmed = ENGINE_CHANNELS.includes(gwType) && isEngineAbsent();
+    const engineGateAttrs = engineGateArmed
+      ? ` data-engine-gate="1" data-engine-channels="${escapeHtml(ENGINE_CHANNELS.join(","))}" data-engine-required-fields="${escapeHtml(engineGateRequiredDomFields(gwType).join(","))}"`
+      : "";
     body =
-      `<form method="POST" class="btb-form">${hidden("gateways")}` +
+      `<form method="POST" class="btb-form" id="btb-gateways-form"${engineGateAttrs}>${hidden("gateways")}` +
       `<div class="btb-group"><label>${t("botbuilder.labelGatewayType", lang)}</label>` +
       `<select name="gw_type" class="btb-select" onchange="this.form.requestSubmit ? this.form.requestSubmit() : this.form.submit()">${typeOpts}</select></div>` +
       gwFields + gwHint +
@@ -973,10 +989,13 @@ export async function renderBotEditor(req, res, { db, layout, lang, PAGE_CSS, bo
 
   return res.send(layout({
     title: "Bot Builder — " + botId, // renderLayout escapes the title itself
+    // The engine-gate modal + its overlay markup ship on every tab (not just
+    // gateways) — the readiness checklist on the review tab (Task 9) opens
+    // the identical modal via the stable window.__crowEngineGateOpen hook.
     content: PAGE_CSS + section(
       "",
       `<p><a href="/dashboard/bot-builder">&larr; ${t("botbuilder.noticeAllBots", lang)}</a></p>` + notice +
-      nav + body,
+      nav + body + engineGateClientJS(lang),
       {
         // The heading carries a live status badge — raw HTML by design.
         // Everything user-controlled inside it is escaped here.

--- a/servers/gateway/dashboard/panels/bot-builder/editor.js
+++ b/servers/gateway/dashboard/panels/bot-builder/editor.js
@@ -486,9 +486,18 @@ export async function renderBotEditor(req, res, { db, layout, lang, PAGE_CSS, bo
     // as a data attribute so the client mirrors Task 7's completeness
     // predicate against the live form without duplicating field-name
     // knowledge (gateway-fields.js's engineGateRequiredDomFields()).
+    // data-engine-fields-type pins which gwType that required-fields list
+    // was computed for: the type <select>'s onchange re-submits the form
+    // to re-render fields for whatever type the operator just picked, but
+    // the DOM (and this required-fields list) still reflect the OLD type
+    // until that re-render lands — the client bails out of the gate when
+    // the live select value no longer matches this attribute (bug fix,
+    // C4 Task 8 follow-up: a stale-complete old-type record was hijacking
+    // a harmless type switch and popping the install modal instead of
+    // letting the re-render through).
     const engineGateArmed = ENGINE_CHANNELS.includes(gwType) && isEngineAbsent();
     const engineGateAttrs = engineGateArmed
-      ? ` data-engine-gate="1" data-engine-channels="${escapeHtml(ENGINE_CHANNELS.join(","))}" data-engine-required-fields="${escapeHtml(engineGateRequiredDomFields(gwType).join(","))}"`
+      ? ` data-engine-gate="1" data-engine-channels="${escapeHtml(ENGINE_CHANNELS.join(","))}" data-engine-required-fields="${escapeHtml(engineGateRequiredDomFields(gwType).join(","))}" data-engine-fields-type="${escapeHtml(gwType)}"`
       : "";
     body =
       `<form method="POST" class="btb-form" id="btb-gateways-form"${engineGateAttrs}>${hidden("gateways")}` +

--- a/servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js
+++ b/servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js
@@ -49,6 +49,15 @@ export function engineGateClientJS(lang) {
         var API = "/dashboard/bundles/api";
         var BUNDLE_ID = "bot-engine";
 
+        // Set true by the cancel button and the overlay's click-outside
+        // dismiss - checked before onDone/onInstalled side effects so a
+        // cancelled dialog can't fire an unrequested resubmit once a job
+        // that's still running in the background happens to finish (the
+        // job itself is left running; only this client's callback chain
+        // needs to go inert). Reset at the top of every fresh
+        // openEngineGateModal() call.
+        var engineGateCancelled = false;
+
         function overlayEl() { return document.getElementById("engine-gate-modal-overlay"); }
         function contentEl() { return document.getElementById("engine-gate-modal-content"); }
         function showEngineModal() { var o = overlayEl(); if (o) o.style.display = "flex"; }
@@ -56,7 +65,9 @@ export function engineGateClientJS(lang) {
 
         var overlay = overlayEl();
         if (overlay) {
-          overlay.addEventListener("click", function (e) { if (e.target === overlay) hideEngineModal(); });
+          overlay.addEventListener("click", function (e) {
+            if (e.target === overlay) { engineGateCancelled = true; hideEngineModal(); }
+          });
         }
 
         function setEngineModalContent(el) {
@@ -127,6 +138,7 @@ export function engineGateClientJS(lang) {
         // enough for the "Installed..." status line to be readable before
         // the modal closes out from under it).
         function openEngineGateModal(onInstalled) {
+          engineGateCancelled = false;
           var frag = document.createElement("div");
 
           var h3 = document.createElement("h3");
@@ -155,7 +167,7 @@ export function engineGateClientJS(lang) {
           cancelBtn.type = "button";
           cancelBtn.className = "btn btn-secondary";
           cancelBtn.textContent = '${tJs("common.cancel", lang)}';
-          cancelBtn.addEventListener("click", hideEngineModal);
+          cancelBtn.addEventListener("click", function () { engineGateCancelled = true; hideEngineModal(); });
           btnRow.appendChild(cancelBtn);
 
           var installBtn = document.createElement("button");
@@ -164,8 +176,10 @@ export function engineGateClientJS(lang) {
           installBtn.textContent = '${tJs("botbuilder.engineGateInstallBtn", lang)}';
           installBtn.addEventListener("click", function () {
             startEngineInstall(statusDiv, installBtn, function (success) {
+              if (engineGateCancelled) return;
               if (!success) return;
               setTimeout(function () {
+                if (engineGateCancelled) return;
                 hideEngineModal();
                 if (typeof onInstalled === "function") onInstalled();
               }, 900);
@@ -193,6 +207,7 @@ export function engineGateClientJS(lang) {
         if (gwForm && gwForm.getAttribute("data-engine-gate") === "1") {
           var channels = (gwForm.getAttribute("data-engine-channels") || "").split(",").filter(function (s) { return s; });
           var requiredFields = (gwForm.getAttribute("data-engine-required-fields") || "").split(",").filter(function (s) { return s; });
+          var fieldsType = gwForm.getAttribute("data-engine-fields-type") || "";
           var bypassGate = false;
 
           var fieldNonEmpty = function (name) {
@@ -205,6 +220,18 @@ export function engineGateClientJS(lang) {
           var recordIsComplete = function () {
             var typeEl = gwForm.querySelector("[name='gw_type']");
             var curType = typeEl ? typeEl.value : "";
+            // requiredFields/channels were computed server-side for
+            // fieldsType, not necessarily the LIVE select value: the type
+            // <select>'s onchange re-submits the form to re-render fields
+            // for whichever type the operator just picked, and that
+            // re-submit passes through this SAME listener before the
+            // re-render lands. If the live value has already moved on
+            // from fieldsType, this stale list can't say anything
+            // meaningful about the new type's completeness - bail so the
+            // re-render always gets through, instead of the old type's
+            // now-irrelevant leftover fields hijacking a harmless type
+            // switch into opening the install modal.
+            if (curType !== fieldsType) return false;
             if (channels.indexOf(curType) === -1) return false;
             for (var i = 0; i < requiredFields.length; i++) {
               if (!fieldNonEmpty(requiredFields[i])) return false;

--- a/servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js
+++ b/servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js
@@ -1,0 +1,266 @@
+/**
+ * Bot Builder — engine-attach gate client script (C4 Task 8).
+ *
+ * Two independent behaviors, one shared modal:
+ *   1. Gateways-tab submit intercept (primary path): when the server
+ *      rendered `#btb-gateways-form` with `data-engine-gate="1"` (engine
+ *      absent for the CURRENT gwType, per isEngineAbsent() at render time),
+ *      mirror Task 7's server-side completeness predicate client-side
+ *      against the live DOM (data-engine-channels + data-engine-required-
+ *      fields) and, on a complete record, preventDefault() the submit and
+ *      open the install modal BEFORE the POST — so the operator's typed
+ *      credentials never leave the DOM. On a successful install, the SAME
+ *      still-populated form is resubmitted via requestSubmit() (never
+ *      form.submit() — that would skip the fetch-wrapper's CSRF header
+ *      attach path documented in shared/layout.js).
+ *   2. Backstop banners: `error=engine_required` (a client that bypassed
+ *      the intercept — JS disabled, or a race) renders a friendly banner
+ *      with an "Install bot engine" button (#engine-gate-open-btn) that
+ *      opens the identical modal; success just reloads (the server-side
+ *      gate already discarded the typed values on that path, so there is
+ *      nothing to resubmit). `warn=bot_runtime_off` renders a banner with a
+ *      one-click enable button (#bot-runtime-enable-btn) that POSTs the
+ *      settings action directly and reloads the clean (query-stripped) tab.
+ *
+ * The readiness checklist (Task 9, next) reuses this SAME modal via the
+ * stable global hook window.__crowEngineGateOpen(onInstalled) — one
+ * implementation, per spec open-Q3.
+ *
+ * ABSOLUTE RULE (matches extensions/client.js and onboarding/ai-step-
+ * client.js, the established pattern for served browser JS in this
+ * codebase): the returned <script> string is built inside a template
+ * literal and must never contain a literal backtick character - not even
+ * inside a comment. No literal backticks in the served string (quote style
+ * and concatenation are unconstrained). ES5 style throughout (var, function
+ * expressions, no arrow functions, no let/const, no template literals) -
+ * this file ships unbundled straight to the browser.
+ *
+ * XSS: every dynamic string this script writes into the DOM goes through a
+ * textContent assignment - never innerHTML with a concatenated string.
+ */
+
+import { tJs } from "../../shared/i18n.js";
+
+export function engineGateClientJS(lang) {
+  return `
+    <div id="engine-gate-modal-overlay"><div id="engine-gate-modal-content"></div></div>
+    <script>
+      (function () {
+        var API = "/dashboard/bundles/api";
+        var BUNDLE_ID = "bot-engine";
+
+        function overlayEl() { return document.getElementById("engine-gate-modal-overlay"); }
+        function contentEl() { return document.getElementById("engine-gate-modal-content"); }
+        function showEngineModal() { var o = overlayEl(); if (o) o.style.display = "flex"; }
+        function hideEngineModal() { var o = overlayEl(); if (o) o.style.display = "none"; }
+
+        var overlay = overlayEl();
+        if (overlay) {
+          overlay.addEventListener("click", function (e) { if (e.target === overlay) hideEngineModal(); });
+        }
+
+        function setEngineModalContent(el) {
+          var mc = contentEl();
+          if (!mc) return;
+          mc.replaceChildren();
+          mc.appendChild(el);
+        }
+
+        function pollEngineJob(jobId, statusEl, installBtn, onDone) {
+          fetch(API + "/jobs/" + jobId).then(function (r) { return r.json(); }).then(function (job) {
+            var log = (job && job.log) || [];
+            statusEl.textContent = log[log.length - 1] || '${tJs("botbuilder.engineGateWorking", lang)}';
+            if (job.status === "complete" || job.status === "complete_restart") {
+              statusEl.style.color = "var(--crow-accent)";
+              statusEl.textContent = '${tJs("botbuilder.engineGateDone", lang)}';
+              onDone(true);
+            } else if (job.status === "failed") {
+              statusEl.style.color = "var(--crow-error, #e74c3c)";
+              statusEl.textContent = '${tJs("botbuilder.engineGateInstallFailedPrefix", lang)}' + " " +
+                (log[log.length - 1] || '${tJs("botbuilder.engineGateUnknownError", lang)}');
+              installBtn.disabled = false;
+              installBtn.textContent = '${tJs("botbuilder.engineGateRetryBtn", lang)}';
+              onDone(false);
+            } else {
+              setTimeout(function () { pollEngineJob(jobId, statusEl, installBtn, onDone); }, 1000);
+            }
+          }).catch(function () {
+            setTimeout(function () { pollEngineJob(jobId, statusEl, installBtn, onDone); }, 3000);
+          });
+        }
+
+        function startEngineInstall(statusEl, installBtn, onDone) {
+          installBtn.disabled = true;
+          installBtn.textContent = '${tJs("botbuilder.engineGateInstallingBtn", lang)}';
+          statusEl.style.display = "block";
+          statusEl.style.color = "var(--crow-accent)";
+          statusEl.textContent = '${tJs("botbuilder.engineGateWorking", lang)}';
+
+          fetch(API + "/install", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ bundle_id: BUNDLE_ID, env_vars: {} }),
+          }).then(function (r) {
+            return r.json().then(function (d) { return { ok: r.ok, status: r.status, data: d }; });
+          }).then(function (res) {
+            var jobId = res.data && res.data.job_id;
+            if (jobId && (res.ok || (res.status === 409 && res.data.code === "already_installing"))) {
+              pollEngineJob(jobId, statusEl, installBtn, onDone);
+              return;
+            }
+            statusEl.style.color = "var(--crow-error, #e74c3c)";
+            statusEl.textContent = '${tJs("botbuilder.engineGateInstallFailedPrefix", lang)}' + " " +
+              ((res.data && res.data.error) || '${tJs("botbuilder.engineGateUnknownError", lang)}');
+            installBtn.disabled = false;
+            installBtn.textContent = '${tJs("botbuilder.engineGateRetryBtn", lang)}';
+            onDone(false);
+          }).catch(function () {
+            statusEl.style.color = "var(--crow-error, #e74c3c)";
+            statusEl.textContent = '${tJs("botbuilder.engineGateNetworkError", lang)}';
+            installBtn.disabled = false;
+            installBtn.textContent = '${tJs("botbuilder.engineGateRetryBtn", lang)}';
+            onDone(false);
+          });
+        }
+
+        // onInstalled runs once, ~0.9s after a successful install (long
+        // enough for the "Installed..." status line to be readable before
+        // the modal closes out from under it).
+        function openEngineGateModal(onInstalled) {
+          var frag = document.createElement("div");
+
+          var h3 = document.createElement("h3");
+          h3.style.cssText = "font-family:Fraunces,serif;margin-bottom:0.75rem";
+          h3.textContent = '${tJs("botbuilder.engineGateModalTitle", lang)}';
+          frag.appendChild(h3);
+
+          var body = document.createElement("p");
+          body.style.cssText = "color:var(--crow-text-secondary);font-size:0.9rem;margin-bottom:0.75rem";
+          body.textContent = '${tJs("botbuilder.engineGateModalBody", lang)}';
+          frag.appendChild(body);
+
+          var diskNote = document.createElement("p");
+          diskNote.style.cssText = "color:var(--crow-text-muted);font-size:0.8rem;margin-bottom:1rem";
+          diskNote.textContent = '${tJs("botbuilder.engineGateModalDiskNote", lang)}';
+          frag.appendChild(diskNote);
+
+          var statusDiv = document.createElement("div");
+          statusDiv.style.cssText = "font-size:0.85rem;margin:0.75rem 0;display:none";
+          frag.appendChild(statusDiv);
+
+          var btnRow = document.createElement("div");
+          btnRow.style.cssText = "display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem";
+
+          var cancelBtn = document.createElement("button");
+          cancelBtn.type = "button";
+          cancelBtn.className = "btn btn-secondary";
+          cancelBtn.textContent = '${tJs("common.cancel", lang)}';
+          cancelBtn.addEventListener("click", hideEngineModal);
+          btnRow.appendChild(cancelBtn);
+
+          var installBtn = document.createElement("button");
+          installBtn.type = "button";
+          installBtn.className = "btn btn-primary";
+          installBtn.textContent = '${tJs("botbuilder.engineGateInstallBtn", lang)}';
+          installBtn.addEventListener("click", function () {
+            startEngineInstall(statusDiv, installBtn, function (success) {
+              if (!success) return;
+              setTimeout(function () {
+                hideEngineModal();
+                if (typeof onInstalled === "function") onInstalled();
+              }, 900);
+            });
+          });
+          btnRow.appendChild(installBtn);
+
+          frag.appendChild(btnRow);
+          setEngineModalContent(frag);
+          showEngineModal();
+        }
+
+        // Stable hook for the readiness checklist row (Task 9) and any
+        // other caller — reassigned on every script execution so it always
+        // closes over THIS page's live overlay/content elements (a Turbo
+        // Drive re-render swaps the whole panel body, including these
+        // nodes, on every tab navigation; a one-shot guard here would leave
+        // the hook pointing at detached DOM from a previous tab).
+        window.__crowEngineGateOpen = function (onInstalled) {
+          openEngineGateModal(onInstalled);
+        };
+
+        // --- 1. Gateways-tab submit intercept (primary path) ---
+        var gwForm = document.getElementById("btb-gateways-form");
+        if (gwForm && gwForm.getAttribute("data-engine-gate") === "1") {
+          var channels = (gwForm.getAttribute("data-engine-channels") || "").split(",").filter(function (s) { return s; });
+          var requiredFields = (gwForm.getAttribute("data-engine-required-fields") || "").split(",").filter(function (s) { return s; });
+          var bypassGate = false;
+
+          var fieldNonEmpty = function (name) {
+            var els = gwForm.querySelectorAll("[name='" + name + "']");
+            if (!els.length) return false;
+            var v = els[0].value;
+            return typeof v === "string" && v.trim().length > 0;
+          };
+
+          var recordIsComplete = function () {
+            var typeEl = gwForm.querySelector("[name='gw_type']");
+            var curType = typeEl ? typeEl.value : "";
+            if (channels.indexOf(curType) === -1) return false;
+            for (var i = 0; i < requiredFields.length; i++) {
+              if (!fieldNonEmpty(requiredFields[i])) return false;
+            }
+            return true;
+          };
+
+          gwForm.addEventListener("submit", function (e) {
+            if (bypassGate) { bypassGate = false; return; }
+            if (!recordIsComplete()) return;
+            e.preventDefault();
+            openEngineGateModal(function () {
+              bypassGate = true;
+              if (gwForm.requestSubmit) gwForm.requestSubmit();
+              else gwForm.submit();
+            });
+          });
+        }
+
+        // --- 2a. Backstop banner: error=engine_required ---
+        var openBtn = document.getElementById("engine-gate-open-btn");
+        if (openBtn) {
+          openBtn.addEventListener("click", function () {
+            openEngineGateModal(function () { location.reload(); });
+          });
+        }
+
+        // --- 2b. Backstop banner: warn=bot_runtime_off (one-click enable) ---
+        var runtimeBtn = document.getElementById("bot-runtime-enable-btn");
+        if (runtimeBtn) {
+          runtimeBtn.addEventListener("click", function () {
+            var statusEl = document.getElementById("bot-runtime-enable-status");
+            runtimeBtn.disabled = true;
+            runtimeBtn.textContent = '${tJs("botbuilder.runtimeOffEnabling", lang)}';
+            if (statusEl) statusEl.textContent = "";
+            fetch("/dashboard/settings", {
+              method: "POST",
+              headers: { "Content-Type": "application/x-www-form-urlencoded" },
+              body: "action=set_bot_runtime&enabled=on",
+            }).then(function (r) {
+              if (!r.ok) throw new Error("http " + r.status);
+              if (statusEl) statusEl.textContent = '${tJs("botbuilder.runtimeOffEnabled", lang)}';
+              setTimeout(function () {
+                var url = new URL(location.href);
+                url.searchParams.delete("warn");
+                url.searchParams.delete("error");
+                location.href = url.toString();
+              }, 800);
+            }).catch(function () {
+              runtimeBtn.disabled = false;
+              runtimeBtn.textContent = '${tJs("botbuilder.runtimeOffEnableBtn", lang)}';
+              if (statusEl) statusEl.textContent = '${tJs("botbuilder.runtimeOffEnableFailed", lang)}';
+            });
+          });
+        }
+      })();
+    </script>
+  `;
+}

--- a/servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js
+++ b/servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js
@@ -10,8 +10,8 @@
  *      fields) and, on a complete record, preventDefault() the submit and
  *      open the install modal BEFORE the POST — so the operator's typed
  *      credentials never leave the DOM. On a successful install, the SAME
- *      still-populated form is resubmitted via requestSubmit() (never
- *      form.submit() — that would skip the fetch-wrapper's CSRF header
+ *      still-populated form is resubmitted via requestSubmit() (never the
+ *      bare native submit — that would skip the fetch-wrapper's CSRF header
  *      attach path documented in shared/layout.js).
  *   2. Backstop banners: `error=engine_required` (a client that bypassed
  *      the intercept — JS disabled, or a race) renders a friendly banner
@@ -245,8 +245,7 @@ export function engineGateClientJS(lang) {
             e.preventDefault();
             openEngineGateModal(function () {
               bypassGate = true;
-              if (gwForm.requestSubmit) gwForm.requestSubmit();
-              else gwForm.submit();
+              gwForm.requestSubmit();
             });
           });
         }

--- a/servers/gateway/dashboard/panels/bot-builder/engine-gate.js
+++ b/servers/gateway/dashboard/panels/bot-builder/engine-gate.js
@@ -1,0 +1,42 @@
+/**
+ * Shared engine-attach-gate predicate (Task 7, C4).
+ *
+ * Two save paths need the identical "refuse to attach an engine-channel
+ * gateway while the bot engine is absent" check: the Gateways-tab save in
+ * api-handlers.js, and the wizard's final create in wizard.js. Both need the
+ * SAME pinnable engineStatus() result so a single test call arms both gates.
+ *
+ * This lives in its own leaf module rather than as a local in api-handlers.js
+ * because api-handlers.js already imports handleWizardCreate from wizard.js
+ * — wizard.js importing api-handlers.js's local pin back would be a real
+ * ESM cycle. A shared leaf both sides import avoids that entirely.
+ */
+import { ENGINE_CHANNELS, engineStatus } from "../../../bot-engine-status.js";
+import { missingGatewayFields } from "./gateway-fields.js";
+
+let _engineStatusPin = null;
+
+/** Test-only: pin engineStatus()'s result for the attach gate (both the
+ * Gateways-tab save gate in api-handlers.js and the wizard create gate in
+ * wizard.js). Pass null to un-pin (falls back to the real engineStatus()). */
+export function _setEngineStatusForTest(status) {
+  _engineStatusPin = status || null;
+}
+
+function resolveEngineStatus() {
+  return _engineStatusPin || engineStatus({ env: process.env });
+}
+
+/**
+ * True when `gw` (a single normalized gateway record, e.g. `def.gateways[0]`)
+ * is a COMPLETE engine-channel record (type ∈ ENGINE_CHANNELS AND no missing
+ * required fields) with the bot engine absent — the shared predicate for
+ * "refuse to attach/insert this gateway; the fix is installing the engine,
+ * not reposting the same form." A type-only draft (incomplete fields) is
+ * never gated — no consumer acts on it until it's complete.
+ */
+export function engineRequiredFor(gw) {
+  if (!gw || !ENGINE_CHANNELS.includes(gw.type)) return false;
+  if (missingGatewayFields(gw).length !== 0) return false;
+  return resolveEngineStatus().state === "absent";
+}

--- a/servers/gateway/dashboard/panels/bot-builder/engine-gate.js
+++ b/servers/gateway/dashboard/panels/bot-builder/engine-gate.js
@@ -12,6 +12,7 @@
  * ESM cycle. A shared leaf both sides import avoids that entirely.
  */
 import { ENGINE_CHANNELS, engineStatus } from "../../../bot-engine-status.js";
+import { botRuntimeStatus } from "../../../bot-runtime.js";
 import { missingGatewayFields } from "./gateway-fields.js";
 
 let _engineStatusPin = null;
@@ -23,8 +24,36 @@ export function _setEngineStatusForTest(status) {
   _engineStatusPin = status || null;
 }
 
-function resolveEngineStatus() {
+/**
+ * Full engineStatus() resolution (pinned or real) — exported so any
+ * consumer needing the whole {state, source, cliPath, error, retryAt} shape
+ * (not just the absent/not-absent boolean isEngineAbsent() below) can share
+ * the SAME pin as the attach gate with one _setEngineStatusForTest call.
+ * The readiness checklist row (Task 9, checklist.js) is the first such
+ * consumer — it needs "installing"/"unhealthy"/"ready" detail, not just
+ * absent-or-not.
+ */
+export function resolveEngineStatus() {
   return _engineStatusPin || engineStatus({ env: process.env });
+}
+
+let _botRuntimeStatusPin = null;
+
+/** Test-only: pin botRuntimeStatus()'s result. Moved here from api-handlers.js
+ * (which re-exports this for backward compatibility) so the readiness
+ * checklist row (Task 9) can share the SAME pin as the Gateways-tab save
+ * gate's runtime-disarmed warning — the exact reason engineStatus's pin
+ * already lives in this shared leaf module rather than locally in
+ * api-handlers.js. Pass null to un-pin (falls back to the real
+ * botRuntimeStatus()). */
+export function _setBotRuntimeStatusForTest(status) {
+  _botRuntimeStatusPin = status || null;
+}
+
+/** Full botRuntimeStatus() resolution (pinned or real) — see
+ * _setBotRuntimeStatusForTest above. */
+export function resolveBotRuntimeStatus() {
+  return _botRuntimeStatusPin || botRuntimeStatus();
 }
 
 /**

--- a/servers/gateway/dashboard/panels/bot-builder/engine-gate.js
+++ b/servers/gateway/dashboard/panels/bot-builder/engine-gate.js
@@ -40,3 +40,18 @@ export function engineRequiredFor(gw) {
   if (missingGatewayFields(gw).length !== 0) return false;
   return resolveEngineStatus().state === "absent";
 }
+
+/**
+ * True when the shared, pinnable engineStatus() resolves to "absent" —
+ * used by the Gateways-tab RENDER (Task 8) to decide whether to arm the
+ * client-side gate modal for the currently-selected gwType. Deliberately
+ * independent of record completeness: unlike engineRequiredFor() (which
+ * only fires on a saved, complete record), the render-time check must arm
+ * BEFORE the operator has finished typing — completeness is checked
+ * client-side, live, against the DOM form values at submit time (see
+ * engine-gate-client.js). Shares resolveEngineStatus() so the same
+ * _setEngineStatusForTest pin arms both the render gate and the save gate.
+ */
+export function isEngineAbsent() {
+  return resolveEngineStatus().state === "absent";
+}

--- a/servers/gateway/dashboard/panels/bot-builder/gateway-fields.js
+++ b/servers/gateway/dashboard/panels/bot-builder/gateway-fields.js
@@ -183,6 +183,30 @@ export function buildCrowMessagesGatewayConfig(b) {
   return gw;
 }
 
+// DOM `name` attribute each abstract GATEWAY_REQUIRED_FIELDS entry renders
+// as, for the simple gateway types that are also ENGINE_CHANNELS (gmail/
+// discord/telegram/slack). Lets the C4 Task 8 client-side engine-gate mirror
+// (engine-gate-client.js) check "is this record complete?" against the live
+// form DOM without duplicating field-name knowledge server- and client-side.
+const ENGINE_GATE_DOM_FIELD = {
+  gmail: { address: "gw_address", allowlist: "gw_allowlist" },
+  discord: { token: "gw_token" },
+  telegram: { token: "gw_token" },
+  slack: { bot_token: "gw_bot_token", app_token: "gw_app_token" },
+};
+
+/**
+ * The DOM input `name`s the client must check are non-empty for `gwType` to
+ * count as a complete engine-channel record (Gateways-tab render only —
+ * `gwType` not in ENGINE_GATE_DOM_FIELD returns []).
+ * @param {string} gwType
+ * @returns {string[]}
+ */
+export function engineGateRequiredDomFields(gwType) {
+  const domMap = ENGINE_GATE_DOM_FIELD[gwType];
+  return domMap ? Object.values(domMap) : [];
+}
+
 /**
  * Which required fields (per GATEWAY_REQUIRED_FIELDS) are missing/empty on a
  * gateway record. Array fields count as present only when non-empty.

--- a/servers/gateway/dashboard/panels/bot-builder/wizard.js
+++ b/servers/gateway/dashboard/panels/bot-builder/wizard.js
@@ -29,6 +29,7 @@ import {
 import { BOT_TEMPLATES, getTemplate, applyTemplate, availableMcpSet } from "./templates.js";
 import { resolveCrowHome } from "../../../../../scripts/pi-bots/ext_registry.mjs";
 import { emitBotDefsChanged } from "./defs-changed.js";
+import { engineRequiredFor } from "./engine-gate.js";
 
 export const WIZARD_STEP_KEYS = ["template", "basics", "model", "channel", "review"];
 
@@ -219,7 +220,20 @@ export async function renderWizard(req, res, { db, layout, lang, PAGE_CSS, notic
       step = WIZARD_STEP_KEYS.indexOf("model");
       error = t("botbuilder.createModelInvalid", lang);
     } else {
-      step = last; // unexpected fall-through: re-render review, state intact
+      // Task 7 follow-up (C4): mirror handleWizardCreate's engine-attach
+      // gate so the re-derivation covers every reason it can decline to
+      // send. A complete engine-channel record (gmail/discord/telegram/
+      // slack) with the bot engine absent bounces back to the channel step,
+      // same carry-preserving convention as the name/model checks above.
+      const gwTpl = getTemplate(state.tpl) || BOT_TEMPLATES[BOT_TEMPLATES.length - 1];
+      const gwType = WIZARD_GW_TYPES.includes(state.gw_type) ? state.gw_type : gwTpl.gwType;
+      const gwCandidate = normalizeGatewayFields(gwType, b);
+      if (gwCandidate && engineRequiredFor(gwCandidate[0])) {
+        step = WIZARD_STEP_KEYS.indexOf("channel");
+        error = t("botbuilder.wizEngineRequired", lang);
+      } else {
+        step = last; // unexpected fall-through: re-render review, state intact
+      }
     }
   } else if (req.method === "POST") {
     const posted = Math.min(Math.max(parseInt(b.step, 10) || 0, 0), last);
@@ -357,6 +371,27 @@ export async function handleWizardCreate(req, res, { db, lang }) {
   const def = defaultDefinition(botId, null, state.model);
   const tpl = getTemplate(state.tpl) || BOT_TEMPLATES[BOT_TEMPLATES.length - 1];
 
+  // Channel: simple types normalize through the shared module; crow-messages
+  // gets its minimal host-managed record; device-bound types persist a
+  // type-only draft (same W1-4 draft semantics as the Gateways tab — every
+  // consumer keys on required fields / device binding, never bare type).
+  const gwType = WIZARD_GW_TYPES.includes(state.gw_type) ? state.gw_type : tpl.gwType;
+  const simpleGateways = normalizeGatewayFields(gwType, b);
+
+  // Task 7 follow-up (C4): the same server-side attach gate api-handlers.js
+  // enforces on the Gateways-tab save must also cover wizard create — the
+  // wizard builds a complete engine-channel record through the identical
+  // normalizeGatewayFields machinery, so a bot with a working discord/gmail/
+  // telegram/slack channel could otherwise get INSERTed while the engine is
+  // absent (nothing would ever poll it). Checked before the template
+  // overlay/MCP probe below (which can spawn every MCP server) so a reject
+  // doesn't pay for work whose result is thrown away. Returns WITHOUT
+  // sending, same convention as every other validation failure above
+  // (display_name, model) — the panel handler falls through to renderWizard,
+  // which re-derives this exact failure and re-renders the channel step with
+  // the carry intact.
+  if (simpleGateways && engineRequiredFor(simpleGateways[0])) return;
+
   // Template overlay, filtered against the live probe + skills on THIS
   // install (spec §D2). probeAll() may return {_error} on a fresh install
   // with no canonical mcp.json — availableMcpSet then yields the empty set
@@ -373,12 +408,6 @@ export async function handleWizardCreate(req, res, { db, lang }) {
   }
   applyTemplate(def, tpl, { availableMcp, availableSkills });
 
-  // Channel: simple types normalize through the shared module; crow-messages
-  // gets its minimal host-managed record; device-bound types persist a
-  // type-only draft (same W1-4 draft semantics as the Gateways tab — every
-  // consumer keys on required fields / device binding, never bare type).
-  const gwType = WIZARD_GW_TYPES.includes(state.gw_type) ? state.gw_type : tpl.gwType;
-  const simpleGateways = normalizeGatewayFields(gwType, b);
   if (simpleGateways) {
     def.gateways = simpleGateways;
   } else if (gwType === "crow-messages") {

--- a/servers/gateway/dashboard/panels/extensions/client.js
+++ b/servers/gateway/dashboard/panels/extensions/client.js
@@ -520,103 +520,153 @@ export function extensionsClientJS(lang) {
         });
 
         // --- Uninstall modal ---
+        // "bot-engine" gets an extra pre-fetch (Task 10): the blast-radius
+        // endpoint lists which enabled bot channels would stop working, so
+        // the confirm dialog can warn about them BEFORE the operator commits.
+        // The fetch runs first and the modal is built once it settles (or on
+        // any failure, with an empty list — never blocking the uninstall
+        // flow on this being reachable).
+        var ENGINE_BUNDLE_ID = "bot-engine";
+
+        function buildUninstallModal(id, name, isDocker, blastChannels) {
+          var frag = document.createElement("div");
+
+          var h3 = document.createElement("h3");
+          h3.style.cssText = "font-family:Fraunces,serif;margin-bottom:0.75rem";
+          h3.textContent = '${tJs("extensions.remove", lang)}' + " " + name + "?";
+          frag.appendChild(h3);
+
+          var warnBox = document.createElement("div");
+          warnBox.style.cssText = "background:rgba(231,76,60,0.08);border:1px solid rgba(231,76,60,0.25);border-radius:6px;padding:0.75rem 1rem;margin-bottom:1rem;box-sizing:border-box";
+
+          var warnTitle = document.createElement("div");
+          warnTitle.style.cssText = "font-weight:600;color:var(--crow-error, #e74c3c);margin-bottom:0.35rem;font-size:0.9rem";
+          warnTitle.textContent = '${tJs("extensions.cannotBeUndone", lang)}';
+          warnBox.appendChild(warnTitle);
+
+          var warnText = document.createElement("div");
+          warnText.style.cssText = "color:var(--crow-text-secondary);font-size:0.85rem;line-height:1.5";
+          warnText.textContent = isDocker
+            ? '${tJs("extensions.uninstallDockerDesc", lang)}'
+            : '${tJs("extensions.uninstallDesc", lang)}';
+          warnBox.appendChild(warnText);
+          frag.appendChild(warnBox);
+
+          if (blastChannels && blastChannels.length > 0) {
+            var blastBox = document.createElement("div");
+            blastBox.style.cssText = "background:rgba(231,76,60,0.08);border:1px solid rgba(231,76,60,0.25);border-radius:6px;padding:0.75rem 1rem;margin-bottom:1rem;box-sizing:border-box";
+
+            var blastTitle = document.createElement("div");
+            blastTitle.style.cssText = "font-weight:600;color:var(--crow-error, #e74c3c);margin-bottom:0.35rem;font-size:0.9rem";
+            blastTitle.textContent = '${tJs("extensions.engineBlastHeading", lang)}';
+            blastBox.appendChild(blastTitle);
+
+            var blastList = document.createElement("ul");
+            blastList.style.cssText = "margin:0;padding-left:1.2rem;color:var(--crow-text-secondary);font-size:0.85rem;line-height:1.5";
+            blastChannels.forEach(function(ch) {
+              var chName = (ch && ch.display_name) || "";
+              var chTypes = (ch && ch.types) || [];
+              var li = document.createElement("li");
+              // display_name is user-controlled data — textContent only, never innerHTML.
+              li.textContent = '${tJs("extensions.engineBlastItem", lang)}'
+                .split("{name}").join(chName)
+                .split("{types}").join(chTypes.join(", "));
+              blastList.appendChild(li);
+            });
+            blastBox.appendChild(blastList);
+            frag.appendChild(blastBox);
+          }
+
+          var checkId = null;
+          if (isDocker) {
+            var dataBox = document.createElement("div");
+            dataBox.style.cssText = "background:rgba(240,173,78,0.08);border:1px solid rgba(240,173,78,0.25);border-radius:6px;padding:0.75rem 1rem;margin-bottom:0.75rem;box-sizing:border-box";
+
+            var hint = document.createElement("div");
+            hint.style.cssText = "font-size:0.8rem;color:var(--crow-text-secondary);margin-bottom:0.5rem";
+            hint.textContent = '${tJs("extensions.dataDeleteHint", lang)}';
+            dataBox.appendChild(hint);
+
+            var label = document.createElement("label");
+            label.style.cssText = "display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;color:var(--crow-text-secondary);cursor:pointer;margin:0";
+            var check = document.createElement("input");
+            check.type = "checkbox";
+            check.id = "delete-data-check";
+            checkId = check.id;
+            label.appendChild(check);
+            label.appendChild(document.createTextNode('${tJs("extensions.deleteStoredData", lang)}'));
+            dataBox.appendChild(label);
+
+            frag.appendChild(dataBox);
+          }
+
+          var statusDiv = document.createElement("div");
+          statusDiv.style.cssText = "font-size:0.85rem;margin:0.75rem 0;display:none";
+          frag.appendChild(statusDiv);
+
+          var btnRow = document.createElement("div");
+          btnRow.style.cssText = "display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem";
+
+          var cancelBtn = document.createElement("button");
+          cancelBtn.className = "btn btn-secondary";
+          cancelBtn.textContent = '${tJs("common.cancel", lang)}';
+          cancelBtn.addEventListener("click", hideModal);
+          btnRow.appendChild(cancelBtn);
+
+          var removeBtn = document.createElement("button");
+          removeBtn.style.cssText = "background:var(--crow-error, #e74c3c);color:white;border:none";
+          removeBtn.className = "btn";
+          removeBtn.textContent = '${tJs("extensions.remove", lang)}';
+          removeBtn.addEventListener("click", function() {
+            var deleteData = checkId ? document.getElementById(checkId).checked : false;
+            removeBtn.disabled = true;
+            removeBtn.textContent = '${tJs("extensions.removing", lang)}';
+            statusDiv.style.display = "block";
+            statusDiv.style.color = "var(--crow-accent)";
+            statusDiv.textContent = '${tJs("extensions.stoppingAndRemoving", lang)}';
+
+            apiCall("uninstall", { bundle_id: id, delete_data: deleteData }).then(function(res) {
+              if (res.ok && res.data.job_id) {
+                pollJob(res.data.job_id, statusDiv, removeBtn);
+              } else {
+                statusDiv.style.color = "var(--crow-error, #e74c3c)";
+                statusDiv.textContent = res.data.error || '${tJs("extensions.removalFailed", lang)}';
+                removeBtn.disabled = false;
+                removeBtn.textContent = '${tJs("extensions.retry", lang)}';
+              }
+            }).catch(function() {
+              statusDiv.style.color = "var(--crow-error, #e74c3c)";
+              statusDiv.textContent = '${tJs("extensions.networkError", lang)}';
+              removeBtn.disabled = false;
+              removeBtn.textContent = '${tJs("extensions.retry", lang)}';
+            });
+          });
+          btnRow.appendChild(removeBtn);
+          frag.appendChild(btnRow);
+
+          return frag;
+        }
+
         document.querySelectorAll(".bundle-uninstall").forEach(function(btn) {
           btn.addEventListener("click", function() {
             var id = this.dataset.id;
             var name = this.dataset.name;
             var isDocker = this.dataset.docker === "true";
 
-            var frag = document.createElement("div");
-
-            var h3 = document.createElement("h3");
-            h3.style.cssText = "font-family:Fraunces,serif;margin-bottom:0.75rem";
-            h3.textContent = '${tJs("extensions.remove", lang)}' + " " + name + "?";
-            frag.appendChild(h3);
-
-            var warnBox = document.createElement("div");
-            warnBox.style.cssText = "background:rgba(231,76,60,0.08);border:1px solid rgba(231,76,60,0.25);border-radius:6px;padding:0.75rem 1rem;margin-bottom:1rem;box-sizing:border-box";
-
-            var warnTitle = document.createElement("div");
-            warnTitle.style.cssText = "font-weight:600;color:var(--crow-error, #e74c3c);margin-bottom:0.35rem;font-size:0.9rem";
-            warnTitle.textContent = '${tJs("extensions.cannotBeUndone", lang)}';
-            warnBox.appendChild(warnTitle);
-
-            var warnText = document.createElement("div");
-            warnText.style.cssText = "color:var(--crow-text-secondary);font-size:0.85rem;line-height:1.5";
-            warnText.textContent = isDocker
-              ? '${tJs("extensions.uninstallDockerDesc", lang)}'
-              : '${tJs("extensions.uninstallDesc", lang)}';
-            warnBox.appendChild(warnText);
-            frag.appendChild(warnBox);
-
-            var checkId = null;
-            if (isDocker) {
-              var dataBox = document.createElement("div");
-              dataBox.style.cssText = "background:rgba(240,173,78,0.08);border:1px solid rgba(240,173,78,0.25);border-radius:6px;padding:0.75rem 1rem;margin-bottom:0.75rem;box-sizing:border-box";
-
-              var hint = document.createElement("div");
-              hint.style.cssText = "font-size:0.8rem;color:var(--crow-text-secondary);margin-bottom:0.5rem";
-              hint.textContent = '${tJs("extensions.dataDeleteHint", lang)}';
-              dataBox.appendChild(hint);
-
-              var label = document.createElement("label");
-              label.style.cssText = "display:inline-flex;align-items:center;gap:0.4rem;font-size:0.85rem;color:var(--crow-text-secondary);cursor:pointer;margin:0";
-              var check = document.createElement("input");
-              check.type = "checkbox";
-              check.id = "delete-data-check";
-              checkId = check.id;
-              label.appendChild(check);
-              label.appendChild(document.createTextNode('${tJs("extensions.deleteStoredData", lang)}'));
-              dataBox.appendChild(label);
-
-              frag.appendChild(dataBox);
+            if (id === ENGINE_BUNDLE_ID) {
+              fetch(API + "/engine-blast").then(function(r) {
+                return r.ok ? r.json() : { channels: [] };
+              }).then(function(data) {
+                setModalContent(buildUninstallModal(id, name, isDocker, (data && data.channels) || []));
+                showModal();
+              }).catch(function() {
+                setModalContent(buildUninstallModal(id, name, isDocker, []));
+                showModal();
+              });
+              return;
             }
 
-            var statusDiv = document.createElement("div");
-            statusDiv.style.cssText = "font-size:0.85rem;margin:0.75rem 0;display:none";
-            frag.appendChild(statusDiv);
-
-            var btnRow = document.createElement("div");
-            btnRow.style.cssText = "display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem";
-
-            var cancelBtn = document.createElement("button");
-            cancelBtn.className = "btn btn-secondary";
-            cancelBtn.textContent = '${tJs("common.cancel", lang)}';
-            cancelBtn.addEventListener("click", hideModal);
-            btnRow.appendChild(cancelBtn);
-
-            var removeBtn = document.createElement("button");
-            removeBtn.style.cssText = "background:var(--crow-error, #e74c3c);color:white;border:none";
-            removeBtn.className = "btn";
-            removeBtn.textContent = '${tJs("extensions.remove", lang)}';
-            removeBtn.addEventListener("click", function() {
-              var deleteData = checkId ? document.getElementById(checkId).checked : false;
-              removeBtn.disabled = true;
-              removeBtn.textContent = '${tJs("extensions.removing", lang)}';
-              statusDiv.style.display = "block";
-              statusDiv.style.color = "var(--crow-accent)";
-              statusDiv.textContent = '${tJs("extensions.stoppingAndRemoving", lang)}';
-
-              apiCall("uninstall", { bundle_id: id, delete_data: deleteData }).then(function(res) {
-                if (res.ok && res.data.job_id) {
-                  pollJob(res.data.job_id, statusDiv, removeBtn);
-                } else {
-                  statusDiv.style.color = "var(--crow-error, #e74c3c)";
-                  statusDiv.textContent = res.data.error || '${tJs("extensions.removalFailed", lang)}';
-                  removeBtn.disabled = false;
-                  removeBtn.textContent = '${tJs("extensions.retry", lang)}';
-                }
-              }).catch(function() {
-                statusDiv.style.color = "var(--crow-error, #e74c3c)";
-                statusDiv.textContent = '${tJs("extensions.networkError", lang)}';
-                removeBtn.disabled = false;
-                removeBtn.textContent = '${tJs("extensions.retry", lang)}';
-              });
-            });
-            btnRow.appendChild(removeBtn);
-            frag.appendChild(btnRow);
-
-            setModalContent(frag);
+            setModalContent(buildUninstallModal(id, name, isDocker, []));
             showModal();
           });
         });

--- a/servers/gateway/dashboard/settings/sections/bot-runtime.js
+++ b/servers/gateway/dashboard/settings/sections/bot-runtime.js
@@ -2,12 +2,17 @@
  * Settings Section: Bot Runtime (Multi-Instance group) — F3b.
  *
  * Toggles feature_flags.bot_runtime (local-only; absent from sync-allowlist).
- * When ON, this instance's installed bot-runtime units (pibot-*@<instance>)
- * actually run bots (poll Gmail / answer Telegram/Slack/Discord); the runners
- * self-gate on this flag with no restart. OFF = installed-but-idle. Requires
- * the units to be installed first (scripts/pi-bots/install-runtime.sh).
+ * When ON, the gateway process itself runs bots (poll Gmail / answer
+ * Telegram/Slack/Discord) via bot-runtime.js's in-process bridge tick +
+ * supervised Discord child (C4 Task 6) — no separate install step, no
+ * restart to flip. The old copy here claimed the runtime units had to be
+ * installed first (scripts/pi-bots/install-runtime.sh) — that predates
+ * gateway supervision and is false on every default host now; standalone
+ * systemd units are only relevant on a host explicitly configured with
+ * PIBOT_SUPERVISOR=external (C4 Task 9 reword).
  */
 import { readSetting, writeSetting } from "../registry.js";
+import { t } from "../../shared/i18n.js";
 
 async function readFlags(db) {
   const raw = await readSetting(db, "feature_flags");
@@ -28,16 +33,13 @@ export default {
     return on ? "enabled" : "disabled";
   },
 
-  async render({ db }) {
+  async render({ db, lang }) {
     const flags = await readFlags(db);
     const on = flags.bot_runtime === true;
     return `<form method="POST">
       <input type="hidden" name="action" value="set_bot_runtime">
       <div style="margin-bottom:1rem;color:var(--crow-text-secondary);font-size:0.9rem;line-height:1.5">
-        When enabled, this instance <strong>runs</strong> the bots defined here — polling Gmail and
-        answering Telegram / Slack / Discord. The runtime units must be installed first
-        (<code>scripts/pi-bots/install-runtime.sh</code>); this toggle then starts/stops them with no restart.
-        Off by default. <strong>Local to this instance, never synced.</strong>
+        ${t("settings.botRuntimeBody", lang)}
       </div>
       <label style="display:flex;align-items:center;gap:0.6rem;cursor:pointer">
         <input type="checkbox" name="enabled" ${on ? "checked" : ""}>

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -581,6 +581,8 @@ export const translations = {
   "extensions.uninstallDockerDesc": { en: "This will stop all containers and remove the add-on. The gateway will restart to apply changes.", es: "Esto detendrá todos los contenedores y eliminará el complemento. La puerta de enlace se reiniciará para aplicar los cambios." },
   "extensions.uninstallDesc": { en: "This will remove the add-on and its configuration.", es: "Esto eliminará el complemento y su configuración." },
   "extensions.dataDeleteHint": { en: "Optionally delete all files stored by this service. Leave unchecked to keep data for a future reinstall.", es: "Opcionalmente elimina todos los archivos almacenados por este servicio. Deja sin marcar para conservar los datos para una futura reinstalación." },
+  "extensions.engineBlastHeading": { en: "Uninstalling the bot engine will stop these bot channels from working:", es: "Desinstalar el motor de bots hará que estos canales de bot dejen de funcionar:" },
+  "extensions.engineBlastItem": { en: "{name} ({types})", es: "{name} ({types})" }, // template shape only, no natural-language words to translate
   "extensions.restartingGatewayChanges": { en: "Restarting gateway...", es: "Reiniciando la puerta de enlace..." },
   "extensions.installedDate": { en: "installed", es: "instalado" },
   "extensions.needsRam": { en: "This add-on needs ~", es: "Este complemento necesita ~" },

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1094,6 +1094,28 @@ export const translations = {
   "botbuilder.checkChannelIncomplete": { en: "setup incomplete ({fields}) — this bot can't receive messages yet", es: "configuración incompleta ({fields}): este bot aún no puede recibir mensajes" },
   "botbuilder.checkChannelAllowed": { en: "{n} allowed sender(s)", es: "{n} remitente(s) permitido(s)" },
   "botbuilder.checkChannelDevice": { en: "device {id}", es: "dispositivo {id}" },
+
+  // ─── Bot Builder — readiness checklist "Bot engine" row (C4 Task 9) ───
+  "botbuilder.checkEngine": { en: "Bot engine", es: "Motor de bots" },
+  "botbuilder.checkEngineAbsent": {
+    en: "not installed on this instance yet — this channel can't run until it's installed",
+    es: "aún no está instalado en esta instancia: este canal no puede funcionar hasta instalarlo",
+  },
+  "botbuilder.checkEngineInstalling": { en: "installing…", es: "instalando…" },
+  "botbuilder.checkEngineDisarmed": {
+    en: "engine installed, but the bot runtime is off on this instance — bots won't poll",
+    es: "el motor está instalado, pero el runtime de bots está apagado en esta instancia: los bots no sondearán",
+  },
+  "botbuilder.checkEngineReady": { en: "installed (source: {source})", es: "instalado (origen: {source})" },
+  "botbuilder.checkEngineExternalNote": {
+    en: "managed by system services on this host, not the gateway",
+    es: "gestionado por servicios del sistema en este host, no por el gateway",
+  },
+  "botbuilder.checkEngineUnhealthy": {
+    en: "not responding — {error} (retrying at {retryAt})",
+    es: "no responde — {error} (reintentando a las {retryAt})",
+  },
+
   "botbuilder.checkTools": { en: "Tools", es: "Herramientas" },
   "botbuilder.checkToolsDetail": { en: "{mcp} Crow tools · {builtin} built-in", es: "{mcp} herramientas de Crow · {builtin} integradas" },
   "botbuilder.checkSkills": { en: "Skills & instructions", es: "Habilidades e instrucciones" },
@@ -1521,6 +1543,19 @@ export const translations = {
   "settings.section.remoteInvocation": { en: "Remote Tool Invocation", es: "Invocación de herramientas remotas" },
   "settings.section.remoteBotManagement": { en: "Remote Bot Management", es: "Gestión remota de bots" },
   "settings.section.botRuntime": { en: "Bot Runtime", es: "Ejecución de bots" },
+  "settings.botRuntimeBody": {
+    en: "When enabled, this instance <strong>runs</strong> the bots defined here — polling Gmail and " +
+      "answering Telegram / Slack / Discord. The gateway supervises this itself by default: there is no " +
+      "install step, and this toggle starts or stops it with no restart. Standalone systemd units " +
+      "(<code>scripts/pi-bots/install-runtime.sh</code>) are only used on hosts explicitly configured with " +
+      "<code>PIBOT_SUPERVISOR=external</code>. Off by default. <strong>Local to this instance, never synced.</strong>",
+    es: "Cuando está activado, esta instancia <strong>ejecuta</strong> los bots definidos aquí — sondeando Gmail y " +
+      "respondiendo Telegram / Slack / Discord. El gateway supervisa esto por sí mismo de forma predeterminada: no " +
+      "hay paso de instalación, y este interruptor lo inicia o detiene sin reiniciar. Las unidades systemd " +
+      "independientes (<code>scripts/pi-bots/install-runtime.sh</code>) solo se usan en hosts configurados " +
+      "explícitamente con <code>PIBOT_SUPERVISOR=external</code>. Desactivado de forma predeterminada. " +
+      "<strong>Local a esta instancia, nunca sincronizado.</strong>",
+  },
   "settings.ports.description": { en: "Host ports used by installed bundles and core services, with live status. Read-only.", es: "Puertos del host usados por los paquetes instalados y los servicios principales, con estado en vivo. Solo lectura." },
   "settings.section.llm": { en: "LLM Orchestrator", es: "Orquestador LLM" },
   "settings.section.connections": { en: "Connection URLs", es: "URLs de conexión" },

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1070,6 +1070,7 @@ export const translations = {
   "botbuilder.wizGwFinishLaterNote": { en: "Voice channels need a paired device. Your bot will be created with this channel selected; finish the device setup on its Gateways tab.", es: "Los canales de voz necesitan un dispositivo emparejado. Tu bot se creará con este canal seleccionado; termina la configuración del dispositivo en su pestaña Gateways." },
   "botbuilder.wizGwFinishLaterShort": { en: "finish setup on the Gateways tab", es: "termina la configuración en la pestaña Gateways" },
   "botbuilder.wizGwNoneNote": { en: "You can add a channel any time on the bot's Gateways tab. Until then, you can still talk to it from its Sessions tab.", es: "Puedes añadir un canal en cualquier momento en la pestaña Gateways del bot. Hasta entonces, puedes hablar con él desde su pestaña Sesiones." },
+  "botbuilder.wizEngineRequired": { en: "This channel needs the bot engine installed first — install it, then finish this step.", es: "Este canal necesita primero el motor de bots instalado: instálalo y luego termina este paso." },
   "botbuilder.wizReviewTemplate": { en: "Starting point", es: "Punto de partida" },
   "botbuilder.wizReviewName": { en: "Name", es: "Nombre" },
   "botbuilder.wizReviewBotId": { en: "Internal id", es: "Id interno" },

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1167,6 +1167,37 @@ export const translations = {
   "botbuilder.delConfirmBtn": { en: "Delete permanently", es: "Eliminar permanentemente" },
   "botbuilder.delCancelBtn": { en: "Cancel", es: "Cancelar" },
 
+  // ─── Engine-attach gate (C4 Task 8: modal + banners) ───
+  "botbuilder.engineGateBannerErrorBody": {
+    en: "This channel needs the bot engine, which isn't installed on this instance yet — the save was not applied.",
+    es: "Este canal necesita el motor de bots, que aún no está instalado en esta instancia — el guardado no se aplicó.",
+  },
+  "botbuilder.engineGateInstallBtn": { en: "Install bot engine", es: "Instalar motor de bots" },
+  "botbuilder.runtimeOffBannerBody": {
+    en: "Saved. The bot engine is installed, but the bot runtime is off on this instance — bots won't poll Gmail/Discord/Telegram/Slack until it's on.",
+    es: "Guardado. El motor de bots está instalado, pero el runtime de bots está apagado en esta instancia — los bots no sondearán Gmail/Discord/Telegram/Slack hasta que se active.",
+  },
+  "botbuilder.runtimeOffEnableBtn": { en: "Turn on bot runtime", es: "Activar runtime de bots" },
+  "botbuilder.runtimeOffEnabling": { en: "Enabling...", es: "Activando..." },
+  "botbuilder.runtimeOffEnabled": { en: "Enabled — bots start polling within about a minute.", es: "Activado — los bots empezarán a sondear en aproximadamente un minuto." },
+  "botbuilder.runtimeOffEnableFailed": { en: "Could not enable. Try again from Settings → Bot Runtime.", es: "No se pudo activar. Intenta de nuevo desde Ajustes → Runtime de bots." },
+  "botbuilder.engineGateModalTitle": { en: "Install the bot engine", es: "Instalar el motor de bots" },
+  "botbuilder.engineGateModalBody": {
+    en: "Gmail, Discord, Telegram, and Slack channels are driven by pi, the same coding-agent engine Bot Builder uses to run every bot's turns. It isn't installed on this instance yet.",
+    es: "Los canales de Gmail, Discord, Telegram y Slack funcionan mediante pi, el mismo motor de agente de codificación que Bot Builder usa para ejecutar los turnos de cada bot. Aún no está instalado en esta instancia.",
+  },
+  "botbuilder.engineGateModalDiskNote": {
+    en: "Installs the npm package @earendil-works/pi-coding-agent 0.74.2 (~400 MB disk). No Docker, no sudo, no open ports.",
+    es: "Instala el paquete npm @earendil-works/pi-coding-agent 0.74.2 (~400 MB de disco). Sin Docker, sin sudo, sin puertos abiertos.",
+  },
+  "botbuilder.engineGateInstallingBtn": { en: "Installing...", es: "Instalando..." },
+  "botbuilder.engineGateRetryBtn": { en: "Retry", es: "Reintentar" },
+  "botbuilder.engineGateInstallFailedPrefix": { en: "Install failed:", es: "La instalación falló:" },
+  "botbuilder.engineGateUnknownError": { en: "unknown error", es: "error desconocido" },
+  "botbuilder.engineGateNetworkError": { en: "Network error. Check the connection and retry.", es: "Error de red. Verifica la conexión e intenta de nuevo." },
+  "botbuilder.engineGateWorking": { en: "Working...", es: "Trabajando..." },
+  "botbuilder.engineGateDone": { en: "Installed. Continuing your save...", es: "Instalado. Continuando tu guardado..." },
+
   // ─── Bot Board Panel (W3-4 + W4-3 i18n sweep) ───
   // Status label keys — display counterparts to the frozen CARD_STATUSES data values
   "botboard.statusPending": { en: "Pending", es: "Pendiente" },

--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -39,7 +39,7 @@ import { writeSetting } from "../dashboard/settings/registry.js";
 import { getCollection } from "../dashboard/panels/extensions/collections.js";
 import { dockerAvailable } from "../dashboard/panels/extensions/data-queries.js";
 import { beginInstallSet, endInstallSet, isInstallSetRunning } from "../install-lock.js";
-import { setActiveJobSource } from "../bot-engine-status.js";
+import { setActiveJobSource, ENGINE_CHANNELS } from "../bot-engine-status.js";
 import {
   CROW_HOME,
   BUNDLES_DIR,
@@ -1927,6 +1927,40 @@ export default function bundlesRouter() {
     }
 
     res.json({ bundles: results });
+  });
+
+  // GET /bundles/api/engine-blast — Uninstall blast-radius for the bot engine
+  // (C4 Task 10): which enabled bot channels would stop working if bot-engine
+  // is uninstalled. Reads pi_bot_defs directly (same async createDbClient()
+  // client bot-builder's api-handlers.js already uses for this table — see
+  // its save_gateways handler) rather than pulling in any bot-builder module,
+  // so this route carries no dependency on the bot-builder panel.
+  router.get("/bundles/api/engine-blast", async (req, res) => {
+    const db = createDbClient();
+    try {
+      const { rows } = await db.execute({
+        sql: "SELECT bot_id, display_name, definition FROM pi_bot_defs WHERE enabled = 1",
+        args: [],
+      });
+      const engineChannelSet = new Set(ENGINE_CHANNELS);
+      const channels = [];
+      for (const row of rows) {
+        let def;
+        try { def = JSON.parse(row.definition || "{}"); } catch { def = {}; }
+        const gateways = Array.isArray(def?.gateways) ? def.gateways : [];
+        const types = [...new Set(
+          gateways.map((gw) => gw && gw.type).filter((type) => engineChannelSet.has(type)),
+        )];
+        if (types.length > 0) {
+          channels.push({ bot_id: row.bot_id, display_name: row.display_name, types });
+        }
+      }
+      res.json({ channels });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    } finally {
+      try { db.close(); } catch {}
+    }
   });
 
   // GET /bundles/api/consent-challenge/:id — Mint a consent token for a privileged or consent_required bundle.

--- a/tests/bot-builder-checklist-delete.test.js
+++ b/tests/bot-builder-checklist-delete.test.js
@@ -19,6 +19,9 @@ process.env.CROW_DATA_DIR = dir;
 let db = null;
 let renderReadiness, deleteBlastRadius, handleDeleteConfirm, renderDeleteConfirm;
 let translations = null;
+let _setEngineStatusForTest, _setBotRuntimeStatusForTest, writeSetting;
+
+const origCrowHomeForEngineTests = process.env.CROW_HOME;
 
 before(async () => {
   execFileSync(process.execPath, ["scripts/init-db.js"], {
@@ -36,12 +39,22 @@ before(async () => {
   ({ deleteBlastRadius, handleDeleteConfirm, renderDeleteConfirm } =
     await import("../servers/gateway/dashboard/panels/bot-builder/delete-bot.js"));
   ({ translations } = await import("../servers/gateway/dashboard/shared/i18n.js"));
+  ({ _setEngineStatusForTest, _setBotRuntimeStatusForTest } =
+    await import("../servers/gateway/dashboard/panels/bot-builder/engine-gate.js"));
+  ({ writeSetting } = await import("../servers/gateway/dashboard/settings/registry.js"));
 });
 
 after(async () => {
   try { db && db.close && db.close(); } catch {}
   rmSync(dir, { recursive: true, force: true });
 });
+
+function resetEnginePins() {
+  _setEngineStatusForTest(null);
+  _setBotRuntimeStatusForTest(null);
+  if (origCrowHomeForEngineTests === undefined) delete process.env.CROW_HOME;
+  else process.env.CROW_HOME = origCrowHomeForEngineTests;
+}
 
 const addProvider = (id, models) => db.execute({
   sql: "INSERT INTO providers (id, base_url, models, disabled) VALUES (?,?,?,0)",
@@ -122,6 +135,108 @@ test("disabled bot: Status row warns; missing prompt warns; es renders without b
   const es = await renderReadiness(db, bot, defOf(bot), "es");
   assert.ok(!/botbuilder\.[a-zA-Z_]/.test(es), "no bare i18n keys in es");
   assert.match(es, /desactivado/);
+});
+
+// ---- "Bot engine" row (C4 Task 9) ----
+//
+// Reuses the SAME pins the Gateways-tab save gate (Task 7/8) uses
+// (engine-gate.js's _setEngineStatusForTest/_setBotRuntimeStatusForTest) so
+// these tests are deterministic regardless of what's actually installed on
+// the host running the suite (see bot-builder-engine-gate.test.js's header
+// comment for why the real engineStatus()'s "global" rung can't be relied
+// on here). botRuntimeActive(db) resolution isn't pinned — it reads the
+// real feature_flags setting + isMpaHost(), exactly like the save-gate
+// tests do, since CROW_DATA_DIR here is a plain scratch dir (isMpaHost()
+// false) unless a test explicitly points CROW_HOME at a ".crow-mpa" path.
+
+test("no engine-channel gateway (crow-messages only): 'Bot engine' row absent", async () => {
+  const bot = mkBot({ gateways: [{ type: "crow-messages", allow_paired_instances: true }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.ok(!html.includes("Bot engine"), "row must not render when no gateway needs the engine");
+});
+
+test("no gateways at all: 'Bot engine' row absent", async () => {
+  const bot = mkBot({ gateways: [] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.ok(!html.includes("Bot engine"));
+});
+
+test("engine installing: 'Bot engine' row WARNs with 'installing…'", async () => {
+  _setEngineStatusForTest({ state: "installing" });
+  const bot = mkBot({ gateways: [{ type: "discord", token: "t", allowlist: [], channel_ids: [] }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.match(html, /Bot engine/);
+  assert.match(html, /installing…/);
+  resetEnginePins();
+});
+
+test("engine absent: 'Bot engine' row ERRs with a fix action that opens the Task-8 modal", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const bot = mkBot({ gateways: [{ type: "gmail", address: "a@b.c", allowlist: ["a@b.c"] }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.match(html, /Bot engine/);
+  assert.match(html, /not installed on this instance yet/);
+  assert.match(html, /onclick="window\.__crowEngineGateOpen\(\)"/, "fix action opens the Task-8 modal hook");
+  assert.match(html, />Install bot engine</);
+  resetEnginePins();
+});
+
+test("engine unhealthy: 'Bot engine' row ERRs with the last error + retry time", async () => {
+  _setEngineStatusForTest({ state: "unhealthy", error: "spawn ENOENT", retryAt: "2026-07-21T00:00:00.000Z" });
+  const bot = mkBot({ gateways: [{ type: "telegram", token: "t" }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.match(html, /Bot engine/);
+  assert.match(html, /spawn ENOENT/);
+  assert.match(html, /2026-07-21T00:00:00\.000Z/);
+  resetEnginePins();
+});
+
+test("engine ready + gateway-mode runtime flag OFF: 'Bot engine' row is DISARMED (WARN) with the Task-7 one-click enable", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "bundle", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "gateway" });
+  await writeSetting(db, "feature_flags", JSON.stringify({ bot_runtime: false }), { scope: "local" });
+  const bot = mkBot({ gateways: [{ type: "slack", token: "t" }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.match(html, /Bot engine/);
+  assert.match(html, /bot runtime is off on this instance/);
+  assert.match(html, /id="bot-runtime-enable-btn"/, "same one-click enable mechanism as Task 8's warn banner");
+  assert.match(html, /id="bot-runtime-enable-status"/);
+  resetEnginePins();
+});
+
+test("engine ready + gateway-mode runtime flag ON: 'Bot engine' row is READY (OK) showing the resolution source", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "bundle", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "gateway" });
+  await writeSetting(db, "feature_flags", JSON.stringify({ bot_runtime: true }), { scope: "local" });
+  const bot = mkBot({ gateways: [{ type: "discord", token: "t", allowlist: [], channel_ids: [] }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.match(html, /Bot engine/);
+  assert.match(html, /installed \(source: bundle\)/);
+  assert.ok(!html.includes("bot-runtime-enable-btn"), "no disarmed fix action when the runtime is armed");
+  assert.ok(!html.includes("managed by system services"), "no external-mode note in gateway mode");
+  resetEnginePins();
+});
+
+test("engine ready + runtime mode 'external': 'Bot engine' row is READY (OK) with the external-mode note, never disarmed", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "external" });
+  await writeSetting(db, "feature_flags", JSON.stringify({ bot_runtime: false }), { scope: "local" });
+  const bot = mkBot({ gateways: [{ type: "gmail", address: "a@b.c", allowlist: ["a@b.c"] }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "en");
+  assert.match(html, /Bot engine/);
+  assert.match(html, /installed \(source: env\)/);
+  assert.match(html, /managed by system services/, "external note appended for mode==='external'");
+  assert.ok(!html.includes("bot-runtime-enable-btn"), "external mode is never disarmed regardless of the flag");
+  resetEnginePins();
+});
+
+test("es rendering of the engine row has no bare i18n keys", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const bot = mkBot({ gateways: [{ type: "gmail", address: "a@b.c", allowlist: ["a@b.c"] }] });
+  const html = await renderReadiness(db, bot, defOf(bot), "es");
+  assert.ok(!/botbuilder\.[a-zA-Z_]/.test(html), "no bare i18n keys in es");
+  assert.match(html, /Motor de bots/);
+  resetEnginePins();
 });
 
 // ---- delete ----

--- a/tests/bot-builder-engine-gate-client-contract.test.js
+++ b/tests/bot-builder-engine-gate-client-contract.test.js
@@ -1,0 +1,316 @@
+/**
+ * Bot Builder engine-attach gate CLIENT script — BEHAVIOR, executed (C4
+ * Task 8 fix round).
+ *
+ * tests/bot-builder-engine-gate.test.js proves the SERVER-rendered contract
+ * (which data attributes land on #btb-gateways-form, in what shape). It
+ * cannot prove what the emitted <script> actually DOES with those
+ * attributes against a live DOM — that was exactly the class of bug found
+ * in this round:
+ *
+ *   Bug 1 (stale required-fields list hijacks a type-switch submit): the
+ *   type <select>'s onchange calls form.requestSubmit() to re-render the
+ *   Gateways tab for whatever type the operator just picked. That
+ *   re-submit passes through this SAME script's "submit" listener before
+ *   the server re-render lands, so the DOM still holds the OLD type's
+ *   fields (and this script's `requiredFields` list, captured from the
+ *   OLD type's data-engine-required-fields attribute, still matches them).
+ *   If those old fields happen to be non-empty, recordIsComplete() said
+ *   "complete" for a record that was never submitted as that type,
+ *   preventDefault()'d the harmless re-render, and popped the install
+ *   modal instead. The fix: a data-engine-fields-type attribute pins which
+ *   gwType the required-fields list was computed for; recordIsComplete()
+ *   now bails (false) whenever the LIVE select value has already moved on
+ *   from that pinned type.
+ *
+ *   Bug 2 (cancel doesn't stop a delayed auto-resubmit): clicking Install
+ *   then Cancel hides the dialog, but the fetch-based job poll keeps
+ *   running in the background (the install itself is a real, idempotent
+ *   server-side job — correctly left alone). If that job completes after
+ *   the cancel, onInstalled() used to fire unconditionally, setting
+ *   bypassGate and calling gwForm.requestSubmit() — an unrequested real
+ *   POST the operator never asked for after backing out. The fix: an
+ *   engineGateCancelled flag, set by the cancel button and the overlay's
+ *   click-outside dismiss, checked before both the immediate onDone
+ *   callback and the delayed (900ms) hideEngineModal/onInstalled pair.
+ *
+ * Neither bug is visible to a source-text regex (the string "bypassGate"
+ * or "recordIsComplete" appears in the file regardless of whether the
+ * logic is actually correct) — this file RUNS the real client
+ * (engineGateClientJS) against real server-rendered markup
+ * (renderBotEditor) via linkedom + node:vm, mirroring the established
+ * pattern in tests/model-catalog-client-contract.test.js and
+ * tests/messages-first-run-ux.test.js for this exact class of panel.
+ */
+import { test, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseHTML } from "linkedom";
+
+const dir = mkdtempSync(join(tmpdir(), "btb-engine-gate-client-"));
+process.env.CROW_DATA_DIR = dir;
+
+let db = null;
+let renderBotEditor = null;
+let _setEngineStatusForTest = null;
+
+before(async () => {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: new URL("..", import.meta.url).pathname,
+  });
+  const { createDbClient } = await import("../servers/db.js");
+  db = createDbClient();
+  ({ renderBotEditor } = await import("../servers/gateway/dashboard/panels/bot-builder/editor.js"));
+  ({ _setEngineStatusForTest } = await import("../servers/gateway/dashboard/panels/bot-builder/api-handlers.js"));
+});
+
+after(async () => {
+  try { db && db.close && db.close(); } catch {}
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  // A complete gmail record so the gate arms and recordIsComplete() would
+  // read "complete" for gmail on a fresh render, same fixture shape as
+  // tests/bot-builder-engine-gate.test.js.
+  await db.execute({
+    sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,1) " +
+      "ON CONFLICT(bot_id) DO UPDATE SET definition=excluded.definition",
+    args: ["gate-bot", "Gate Bot", JSON.stringify({ gateways: [{ type: "gmail", address: "bot@x.com", allowlist: ["a@b.c"] }], tools: {}, models: {} })],
+  });
+});
+
+afterEach(() => {
+  _setEngineStatusForTest(null);
+});
+
+const layout = ({ content }) => content;
+
+function mkGetReq(query) {
+  return { method: "GET", query, body: {}, cookies: {}, headers: {} };
+}
+function mkSendRes() {
+  const res = { html: null };
+  res.send = (s) => { res.html = s; return res; };
+  res.redirectAfterPost = () => {};
+  return res;
+}
+
+/**
+ * Render the real Gateways-tab HTML (form + engine-gate-client script +
+ * modal overlay all ship in the SAME renderBotEditor response — see
+ * editor.js's `nav + body + engineGateClientJS(lang)`), mount it in a
+ * linkedom DOM, and execute the real emitted script against it via
+ * node:vm.
+ */
+async function boot() {
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways" });
+  await renderBotEditor(req, res, { db, layout, lang: "en", PAGE_CSS: "", botId: "gate-bot", notice: "", q: req.query });
+  assert.match(res.html, /data-engine-gate="1"/, "precondition: the fixture must actually arm the gate");
+
+  const { window, document } = parseHTML(`<html><body>${res.html}</body></html>`);
+
+  const form = document.getElementById("btb-gateways-form");
+  assert.ok(form, "precondition: the gateways form must be present");
+
+  // linkedom's HTMLFormElement implements neither requestSubmit() nor
+  // submit() (verified against node_modules/linkedom/worker.js) — a real
+  // browser has both. Stub requestSubmit directly on THIS element instance
+  // (an own-property assignment shadows the missing prototype method) so
+  // the client's `if (gwForm.requestSubmit) gwForm.requestSubmit(); else
+  // gwForm.submit();` branch is exercised and its calls are observable,
+  // same pattern as model-catalog-client-contract.test.js's
+  // HTMLSelectElement.prototype patch.
+  const requestSubmitCalls = [];
+  form.requestSubmit = () => { requestSubmitCalls.push(true); };
+
+  // window.__crowEngineGateOpen is reassigned unconditionally on every
+  // script execution (not an `if (window.__x) return` once-guard — verified
+  // by reading engine-gate-client.js), so unlike client.js's messages-panel
+  // guards (tests/messages-first-run-ux.test.js) there is nothing here that
+  // silently leaks stale behavior across boots; still clear it defensively
+  // before each run since it is a window.__-prefixed global and linkedom
+  // mirrors unqualified `window.foo = x` writes onto the real process
+  // globalThis.
+  delete globalThis.__crowEngineGateOpen;
+
+  const calls = []; // fetch calls: {url, init, body}
+  const timers = []; // queued setTimeout callbacks, never real — tests flush them
+  const location = { href: "https://crow.test/dashboard/bot-builder?bot=gate-bot&tab=gateways", reload() {} };
+
+  let fetchImpl = null; // set per-test via setFetchImpl(); default is a harmless 200 {}
+  const fetchStub = (url, init) => {
+    const body = init && init.body ? JSON.parse(init.body) : null;
+    calls.push({ url: String(url), init, body });
+    const result = fetchImpl ? fetchImpl(String(url), init) : { ok: true, status: 200, json: () => Promise.resolve({}) };
+    return Promise.resolve(result);
+  };
+
+  const ctx = vm.createContext({
+    window, document, location,
+    fetch: fetchStub,
+    console,
+    URL,
+    setTimeout: (fn) => { timers.push(fn); return timers.length; },
+    clearTimeout: () => {},
+    setInterval: () => 0,
+  });
+
+  const CLIENT_HTML_START = res.html.indexOf("<script>");
+  const CLIENT_HTML_END = res.html.lastIndexOf("</script>");
+  const CLIENT_JS = res.html.slice(CLIENT_HTML_START + "<script>".length, CLIENT_HTML_END);
+  vm.runInContext(CLIENT_JS, ctx);
+
+  const $ = (sel) => document.querySelector(sel);
+  const click = (el) => el.dispatchEvent(new window.Event("click", { bubbles: true }));
+  const change = (el) => el.dispatchEvent(new window.Event("change", { bubbles: true }));
+  const settle = async () => { for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r)); };
+  const flushTimers = () => { const q = timers.splice(0); q.forEach((fn) => fn()); };
+  /** Fire a real, cancelable "submit" event on the gateways form (what
+   * requestSubmit()/a real submit click both dispatch) and report whether
+   * the client's listener called preventDefault(). */
+  const fireSubmit = () => {
+    const ev = new window.Event("submit", { bubbles: true, cancelable: true });
+    form.dispatchEvent(ev);
+    return ev;
+  };
+  const setFetchImpl = (fn) => { fetchImpl = fn; };
+  const overlay = document.getElementById("engine-gate-modal-overlay");
+  const modalOpen = () => overlay.style.display === "flex";
+
+  return { window, document, $, form, click, change, fireSubmit, settle, flushTimers, setFetchImpl, calls, requestSubmitCalls, overlay, modalOpen };
+}
+
+// ─── Bug 1 regression: a type switch away from a complete old-type record must NOT be intercepted ───
+
+test("BEHAVIOR: switching gw_type on a stale-complete OLD-type record fires the re-render submit through, unintercepted (bug 1)", async () => {
+  const { form, fireSubmit, requestSubmitCalls, modalOpen, change } = await boot();
+
+  assert.equal(form.getAttribute("data-engine-fields-type"), "gmail", "precondition: fields-type attribute pins the type the required-fields list was computed for");
+  assert.equal(form.getAttribute("data-engine-required-fields"), "gw_address,gw_allowlist");
+
+  const typeSel = form.querySelector("[name='gw_type']");
+  assert.ok(typeSel, "precondition: the gw_type select must be present");
+  const discordOpt = [...typeSel.options].find((o) => o.value === "discord");
+  assert.ok(discordOpt, "precondition: discord must be a selectable option");
+
+  // Simulate the onchange handler's mid-flight state: the operator picked
+  // "discord" in the dropdown, but the DOM still holds gmail's fields
+  // (gw_address/gw_allowlist), still non-empty, because the server hasn't
+  // re-rendered yet. This is exactly what this.form.requestSubmit() fires
+  // in a real browser.
+  for (const opt of typeSel.options) opt.selected = (opt.value === "discord");
+  change(typeSel);
+
+  const ev = fireSubmit();
+
+  assert.equal(ev.defaultPrevented, false, "the re-render submit must NOT be intercepted — a stale old-type completeness reading must never block it (bug 1)");
+  assert.equal(modalOpen(), false, "the install modal must not open on a harmless type switch");
+  assert.equal(requestSubmitCalls.length, 0, "no gate-triggered resubmit either — this path never touches the gate at all");
+});
+
+// ─── Complete-record submit IS intercepted and opens the modal ───
+
+test("BEHAVIOR: a complete gmail record with the engine absent (no type switch) IS intercepted and opens the install modal", async () => {
+  const { form, fireSubmit, modalOpen, $ } = await boot();
+
+  assert.equal(form.getAttribute("data-engine-fields-type"), "gmail");
+
+  const ev = fireSubmit();
+
+  assert.equal(ev.defaultPrevented, true, "a genuinely complete record for the CURRENT type must be intercepted");
+  assert.equal(modalOpen(), true, "the install modal must open");
+  assert.ok($("#engine-gate-modal-content button.btn-primary"), "the modal renders an Install button");
+});
+
+// ─── Bug 2 regression: cancel must make a completing job inert ───
+
+test("BEHAVIOR: cancelling the install dialog makes a job that completes afterward inert — no auto-resubmit (bug 2)", async () => {
+  const { form, fireSubmit, click, settle, flushTimers, setFetchImpl, calls, requestSubmitCalls, overlay, modalOpen, $ } = await boot();
+
+  fireSubmit(); // opens the modal
+  assert.equal(modalOpen(), true);
+
+  let jobPollCount = 0;
+  setFetchImpl((url) => {
+    if (url.indexOf("/install") !== -1) {
+      return { ok: true, status: 202, json: () => Promise.resolve({ job_id: "job-cancel-1" }) };
+    }
+    if (url.indexOf("/jobs/job-cancel-1") !== -1) {
+      jobPollCount += 1;
+      if (jobPollCount === 1) {
+        return { ok: true, json: () => Promise.resolve({ status: "downloading", log: ["working"] }) };
+      }
+      return { ok: true, json: () => Promise.resolve({ status: "complete", log: ["done"] }) };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  });
+
+  const installBtn = $("#engine-gate-modal-content button.btn-primary");
+  assert.ok(installBtn);
+  click(installBtn);
+  await settle(); // POST /install -> jobId -> first /jobs poll -> "downloading" -> a 1000ms re-poll timer queued
+
+  assert.equal(jobPollCount, 1, "precondition: the first poll landed and found the job still running");
+  assert.equal(calls.some((c) => c.url.indexOf("/install") !== -1), true);
+
+  // Operator backs out WHILE the job is still in flight.
+  const cancelBtn = $("#engine-gate-modal-content button.btn-secondary");
+  assert.ok(cancelBtn);
+  click(cancelBtn);
+  assert.equal(modalOpen(), false, "cancel hides the modal immediately");
+
+  // The background poll keeps running (per spec: the server-side job is
+  // left alone) and now reports completion.
+  flushTimers();
+  await settle();
+
+  assert.equal(jobPollCount, 2, "precondition: the job did complete after the cancel");
+  assert.equal(requestSubmitCalls.length, 0, "a job completing after cancel must NEVER trigger the auto-resubmit (bug 2)");
+  assert.equal(modalOpen(), false, "still hidden — no side effect reopened or touched it");
+
+  // Drain whatever the (pre-fix) 900ms post-completion timer would have
+  // been, to prove no delayed effect sneaks through either.
+  flushTimers();
+  await settle();
+  assert.equal(requestSubmitCalls.length, 0);
+});
+
+// ─── Successful (uncancelled) install path resubmits exactly once ───
+
+test("BEHAVIOR: a successful install (never cancelled) hides the modal and resubmits the form exactly once", async () => {
+  const { fireSubmit, click, settle, flushTimers, setFetchImpl, requestSubmitCalls, modalOpen, $ } = await boot();
+
+  fireSubmit();
+  assert.equal(modalOpen(), true);
+
+  setFetchImpl((url) => {
+    if (url.indexOf("/install") !== -1) {
+      return { ok: true, status: 202, json: () => Promise.resolve({ job_id: "job-ok-1" }) };
+    }
+    if (url.indexOf("/jobs/job-ok-1") !== -1) {
+      return { ok: true, json: () => Promise.resolve({ status: "complete", log: ["done"] }) };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  });
+
+  const installBtn = $("#engine-gate-modal-content button.btn-primary");
+  click(installBtn);
+  await settle(); // POST /install -> jobId -> /jobs poll -> "complete" -> onDone(true) -> queues the 900ms hide/resubmit timer
+
+  assert.equal(requestSubmitCalls.length, 0, "the resubmit is delayed ~900ms, not immediate");
+
+  flushTimers(); // fire the 900ms timer
+  await settle();
+
+  assert.equal(modalOpen(), false, "the modal closes once installed");
+  assert.equal(requestSubmitCalls.length, 1, "the SAME still-populated form is resubmitted exactly once via requestSubmit()");
+});

--- a/tests/bot-builder-engine-gate.test.js
+++ b/tests/bot-builder-engine-gate.test.js
@@ -44,8 +44,12 @@ let handleBotBuilderPost = null;
 let _setEngineStatusForTest = null;
 let _setBotRuntimeStatusForTest = null;
 let writeSetting = null;
+let handleWizardCreate = null;
+let renderWizard = null;
+let WIZARD_STEP_KEYS = null;
 
 const origPibotPiCli = process.env.PIBOT_PI_CLI;
+const origCrowHome = process.env.CROW_HOME;
 
 before(async () => {
   execFileSync(process.execPath, ["scripts/init-db.js"], {
@@ -61,6 +65,8 @@ before(async () => {
     _setBotRuntimeStatusForTest,
   } = await import("../servers/gateway/dashboard/panels/bot-builder/api-handlers.js"));
   ({ writeSetting } = await import("../servers/gateway/dashboard/settings/registry.js"));
+  ({ handleWizardCreate, renderWizard, WIZARD_STEP_KEYS } =
+    await import("../servers/gateway/dashboard/panels/bot-builder/wizard.js"));
 });
 
 after(async () => {
@@ -73,6 +79,8 @@ beforeEach(async () => {
   _setBotRuntimeStatusForTest(null);
   if (origPibotPiCli === undefined) delete process.env.PIBOT_PI_CLI;
   else process.env.PIBOT_PI_CLI = origPibotPiCli;
+  if (origCrowHome === undefined) delete process.env.CROW_HOME;
+  else process.env.CROW_HOME = origCrowHome;
   // Reset each bot to a plain gmail gateway before every test so a prior
   // test's saved (or rejected) state can't leak into the next.
   await db.execute({
@@ -86,6 +94,8 @@ beforeEach(async () => {
 afterEach(() => {
   _setEngineStatusForTest(null);
   _setBotRuntimeStatusForTest(null);
+  if (origCrowHome === undefined) delete process.env.CROW_HOME;
+  else process.env.CROW_HOME = origCrowHome;
 });
 
 function mkRes() {
@@ -257,4 +267,117 @@ test("engine ready + runtime mode 'disabled' (suite kill switch) → saved, no w
   );
   assert.match(res.redirected, /saved=1/);
   assert.equal(res.redirected.includes("warn=bot_runtime_off"), false, "mode!=='gateway' must never warn");
+});
+
+// ---------------------------------------------------------------------------
+// Review finding 1: the runtime-disarmed warning must read botRuntimeActive(db)
+// (which falls back to isMpaHost() when the flag is unset), NOT hand-roll
+// "unset === off". On an MPA host with an unset flag, the runtime is armed
+// by default — warning anyway would be a false positive.
+// ---------------------------------------------------------------------------
+
+test("MPA-shaped host + UNSET bot_runtime flag + engine ready → saved, NO warn (isMpaHost fallback arms the runtime)", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "gateway" });
+  await writeSetting(db, "feature_flags", JSON.stringify({}), { scope: "local" }); // bot_runtime key absent entirely
+  process.env.CROW_HOME = "/home/x/.crow-mpa"; // isMpaHost() keys off CROW_HOME|CROW_DATA_DIR containing ".crow-mpa"
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "save must succeed: " + res.redirected);
+  assert.equal(res.redirected.includes("warn=bot_runtime_off"), false,
+    "MPA host + unset flag must resolve bot_runtime=true via botRuntimeActive's isMpaHost() fallback: " + res.redirected);
+});
+
+test("plain (non-MPA) host + UNSET bot_runtime flag + engine ready → saved WITH warn", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "gateway" });
+  await writeSetting(db, "feature_flags", JSON.stringify({}), { scope: "local" }); // bot_runtime key absent entirely
+  delete process.env.CROW_HOME; // CROW_DATA_DIR is already a plain tmp dir (no ".crow-mpa")
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "save must succeed: " + res.redirected);
+  assert.match(res.redirected, /warn=bot_runtime_off/,
+    "plain host + unset flag must default off (isMpaHost() false) and warn: " + res.redirected);
+});
+
+// ---------------------------------------------------------------------------
+// Review finding 2: the wizard's final create must be gated the same way the
+// Gateways-tab save is — a complete engine-channel record built via the same
+// normalizeGatewayFields machinery must not be INSERTed while the engine is
+// absent (nothing would ever poll it, and the operator never sees a warning
+// because the row would look fully onboarded).
+// ---------------------------------------------------------------------------
+
+async function addWizProvider(id, models) {
+  await db.execute({
+    sql: "INSERT INTO providers (id, base_url, models, disabled) VALUES (?,?,?,0)",
+    args: [id, "http://127.0.0.1:9999/v1", JSON.stringify(models)],
+  });
+}
+const clearWizProviders = () => db.execute({ sql: "DELETE FROM providers", args: [] });
+const wizBotRow = async (id) =>
+  (await db.execute({ sql: "SELECT bot_id, display_name, definition FROM pi_bot_defs WHERE bot_id=?", args: [id] })).rows[0] || null;
+const wizStepIdx = (k) => WIZARD_STEP_KEYS.indexOf(k);
+
+function mkWizRes() {
+  const res = { redirected: null, html: null };
+  res.redirectAfterPost = (url) => { res.redirected = url; };
+  res.send = (html) => { res.html = html; return res; };
+  return res;
+}
+
+test("wizard create: complete discord record + engine absent → NOT inserted, bounces back to the channel step with the carry intact", async () => {
+  await addWizProvider("wizprov", [{ id: "m1" }]);
+  _setEngineStatusForTest({ state: "absent" });
+  const body = {
+    action: "wizard_create", nav: "create",
+    tpl: "discord-qa", display_name: "Wiz Discord Bot", bot_id: "wiz-discord-bot",
+    model: "wizprov/m1", gw_type: "discord", gw_token: "tok123",
+  };
+  const res = mkWizRes();
+  await handleWizardCreate({ body }, res, { db, lang: "en" });
+  assert.equal(res.redirected, null, "engine-required gate must send nothing (same convention as name/model validation failures)");
+  assert.equal(res.html, null);
+  assert.equal(await wizBotRow("wiz-discord-bot"), null, "no pi_bot_defs row inserted while the engine is absent");
+
+  // panel-handler fall-through: handleWizardCreate sent nothing, so the
+  // caller falls through to renderWizard, which re-derives the failure and
+  // re-renders the CHANNEL step (not review) with the carry intact — the
+  // same PRG-avoidance convention as the existing name/model gate failures.
+  const renderRes = mkWizRes();
+  await renderWizard(
+    { method: "POST", body, query: {}, headers: {} },
+    renderRes,
+    { db, layout: ({ content }) => content, lang: "en", PAGE_CSS: "", notice: "" }
+  );
+  const html = renderRes.html;
+  assert.match(html, new RegExp(`name="step" value="${wizStepIdx("channel")}"`), "re-renders the channel step, not review");
+  assert.match(html, /callout-error/, "shows an error callout");
+  assert.match(html, /<input type="hidden" name="display_name" value="Wiz Discord Bot">/, "entered state preserved");
+  await clearWizProviders();
+  _setEngineStatusForTest(null);
+});
+
+test("wizard create: complete discord record + engine ready → inserted as before", async () => {
+  await addWizProvider("wizprov", [{ id: "m1" }]);
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  const res = mkWizRes();
+  await handleWizardCreate({ body: {
+    action: "wizard_create", nav: "create",
+    tpl: "discord-qa", display_name: "Wiz Discord Bot 2", bot_id: "wiz-discord-bot-2",
+    model: "wizprov/m1", gw_type: "discord", gw_token: "tok123",
+  } }, res, { db, lang: "en" });
+  assert.match(res.redirected, /bot=wiz-discord-bot-2&tab=review&created=wiz-discord-bot-2/, "must PRG on success: " + res.redirected);
+  const row = await wizBotRow("wiz-discord-bot-2");
+  assert.ok(row, "row must be inserted when the engine is ready");
+  const def = JSON.parse(row.definition);
+  assert.deepEqual(def.gateways, [{ type: "discord", token: "tok123", allowlist: [], channel_ids: [] }]);
+  await clearWizProviders();
+  _setEngineStatusForTest(null);
 });

--- a/tests/bot-builder-engine-gate.test.js
+++ b/tests/bot-builder-engine-gate.test.js
@@ -1,0 +1,260 @@
+/**
+ * C4 Task 7 — server-side engine-attach gate + runtime-disarmed warning on
+ * the Bot Builder gateways-tab save path.
+ *
+ * The gate fires ONLY on a functional attach: the saved gateway record has
+ * `type ∈ ENGINE_CHANNELS` (gmail/discord/telegram/slack) AND
+ * `missingGatewayFields(gw).length === 0` (a complete record). An
+ * incomplete draft (the type-only record the dropdown's
+ * onchange="this.form.requestSubmit()" auto-submit produces before the
+ * operator has typed anything — W1-4 snap-back doctrine) must keep saving
+ * exactly as before the gate existed; no consumer acts on an incomplete
+ * record anyway.
+ *
+ * engineStatus()'s real resolution ladder (pi_resolver.mjs) has a "global"
+ * rung keyed off process.execPath that resolves to a REAL install on this
+ * dev box (crow itself hosts a real bot-engine) — so "CROW_HOME empty +
+ * clear PIBOT_PI_CLI" does NOT reliably produce engineStatus().state ===
+ * "absent" here the way it would on a clean CI runner. The absent/ready/
+ * installing/unhealthy scenarios below pin the result via
+ * _setEngineStatusForTest instead, so they're deterministic regardless of
+ * what's installed on the host running the suite. One test (PIBOT_PI_CLI
+ * pointed at a real tmp file) exercises the REAL engineStatus() to prove
+ * the production wiring — rung 1 (env override) always wins verbatim
+ * regardless of host state, so it's safe to rely on directly.
+ *
+ * The runtime-disarmed warning (&warn=bot_runtime_off) reads
+ * botRuntimeStatus().mode, which is a module singleton only populated by a
+ * real initBotRuntime() call (timers, a sync sqlite handle, the event bus)
+ * — too heavy for a route test, so it's pinned the same way via
+ * _setBotRuntimeStatusForTest.
+ */
+import { test, before, after, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "btb-engine-gate-"));
+process.env.CROW_DATA_DIR = dir;
+
+let db = null;
+let handleBotBuilderPost = null;
+let _setEngineStatusForTest = null;
+let _setBotRuntimeStatusForTest = null;
+let writeSetting = null;
+
+const origPibotPiCli = process.env.PIBOT_PI_CLI;
+
+before(async () => {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir },
+    stdio: "pipe",
+    cwd: new URL("..", import.meta.url).pathname,
+  });
+  const { createDbClient } = await import("../servers/db.js");
+  db = createDbClient();
+  ({
+    handleBotBuilderPost,
+    _setEngineStatusForTest,
+    _setBotRuntimeStatusForTest,
+  } = await import("../servers/gateway/dashboard/panels/bot-builder/api-handlers.js"));
+  ({ writeSetting } = await import("../servers/gateway/dashboard/settings/registry.js"));
+});
+
+after(async () => {
+  try { db && db.close && db.close(); } catch {}
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  _setEngineStatusForTest(null);
+  _setBotRuntimeStatusForTest(null);
+  if (origPibotPiCli === undefined) delete process.env.PIBOT_PI_CLI;
+  else process.env.PIBOT_PI_CLI = origPibotPiCli;
+  // Reset each bot to a plain gmail gateway before every test so a prior
+  // test's saved (or rejected) state can't leak into the next.
+  await db.execute({
+    sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,1) " +
+      "ON CONFLICT(bot_id) DO UPDATE SET definition=excluded.definition",
+    args: ["gate-bot", "Gate Bot", JSON.stringify({ gateways: [{ type: "gmail", address: "x@y.z", allowlist: ["x@y.z"] }], tools: {}, models: {} })],
+  });
+  await writeSetting(db, "feature_flags", JSON.stringify({}), { scope: "local" });
+});
+
+afterEach(() => {
+  _setEngineStatusForTest(null);
+  _setBotRuntimeStatusForTest(null);
+});
+
+function mkRes() {
+  const res = { redirected: null };
+  res.redirectAfterPost = (url) => { res.redirected = url; };
+  return res;
+}
+
+async function readDef() {
+  const { rows } = await db.execute({ sql: "SELECT definition FROM pi_bot_defs WHERE bot_id='gate-bot'", args: [] });
+  return JSON.parse(rows[0].definition);
+}
+
+// ---------------------------------------------------------------------------
+// complete engine-channel records, engine absent → rejected
+// ---------------------------------------------------------------------------
+
+test("complete discord record + engine absent → error=engine_required, def unchanged", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const before = await readDef();
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /error=engine_required/, "must redirect with error=engine_required: " + res.redirected);
+  assert.equal(res.redirected.includes("saved=1"), false);
+  const after = await readDef();
+  assert.deepEqual(after, before, "definition must be unchanged when the gate rejects the save");
+});
+
+test("complete gmail record + engine absent → error=engine_required, def unchanged", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const before = await readDef();
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "gmail", gw_address: "bot@x.com", gw_allowlist: "a@b.c" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /error=engine_required/, "must redirect with error=engine_required: " + res.redirected);
+  const after = await readDef();
+  assert.deepEqual(after, before, "definition must be unchanged when the gate rejects the save");
+});
+
+// ---------------------------------------------------------------------------
+// incomplete draft, engine absent → saves exactly as today (draft doctrine)
+// ---------------------------------------------------------------------------
+
+test("incomplete (type-only) discord draft + engine absent → saved as today, not gated", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord" } }, // no gw_token
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "type-only draft must save even with the engine absent: " + res.redirected);
+  const def = await readDef();
+  assert.equal(def.gateways[0]?.type, "discord");
+  assert.equal(def.gateways[0]?.token, "", "no token on the draft");
+});
+
+// ---------------------------------------------------------------------------
+// non-gated types
+// ---------------------------------------------------------------------------
+
+test("complete crow-messages gateway + engine absent → saved (crow-messages never gated)", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "crow-messages", gw_allow_paired_instances: "on" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "crow-messages must never be gated: " + res.redirected);
+  const def = await readDef();
+  assert.equal(def.gateways[0]?.type, "crow-messages");
+});
+
+test("none type + engine absent → saved", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "none" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "none type must never be gated: " + res.redirected);
+  const def = await readDef();
+  assert.deepEqual(def.gateways, []);
+});
+
+// ---------------------------------------------------------------------------
+// engine states that must NOT block (engine exists — only "absent" blocks)
+// ---------------------------------------------------------------------------
+
+test("complete discord record + engine installing → saved (installing does not block)", async () => {
+  _setEngineStatusForTest({ state: "installing" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "installing must not block attach: " + res.redirected);
+});
+
+test("complete discord record + engine unhealthy → saved (unhealthy does not block)", async () => {
+  _setEngineStatusForTest({ state: "unhealthy", error: "boom", retryAt: null });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "unhealthy must not block attach: " + res.redirected);
+});
+
+// ---------------------------------------------------------------------------
+// real engineStatus() integration — PIBOT_PI_CLI rung always wins verbatim
+// ---------------------------------------------------------------------------
+
+test("complete record with PIBOT_PI_CLI pointing at a real tmp stub file (ready) → saved", async () => {
+  const stub = join(dir, "pi-cli-stub.js");
+  writeFileSync(stub, "// stub\n");
+  process.env.PIBOT_PI_CLI = stub;
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "real engineStatus() ready must save: " + res.redirected);
+  assert.equal(res.redirected.includes("warn=bot_runtime_off"), false, "botRuntimeStatus() defaults to mode!=='gateway' with no real init");
+});
+
+// ---------------------------------------------------------------------------
+// runtime-disarmed warning
+// ---------------------------------------------------------------------------
+
+test("engine ready + bot_runtime flag off → saved with warn=bot_runtime_off", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "gateway" });
+  await writeSetting(db, "feature_flags", JSON.stringify({ bot_runtime: false }), { scope: "local" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "save must still succeed: " + res.redirected);
+  assert.match(res.redirected, /warn=bot_runtime_off/, "must warn the runtime is disarmed: " + res.redirected);
+});
+
+test("engine ready + bot_runtime flag on → saved, no warn", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "gateway" });
+  await writeSetting(db, "feature_flags", JSON.stringify({ bot_runtime: true }), { scope: "local" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/, "save must succeed: " + res.redirected);
+  assert.equal(res.redirected.includes("warn=bot_runtime_off"), false, "flag on must not warn: " + res.redirected);
+});
+
+test("engine ready + runtime mode 'disabled' (suite kill switch) → saved, no warn", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  _setBotRuntimeStatusForTest({ mode: "disabled" });
+  await writeSetting(db, "feature_flags", JSON.stringify({ bot_runtime: false }), { scope: "local" });
+  const res = mkRes();
+  await handleBotBuilderPost(
+    { body: { action: "save_gateways", bot_id: "gate-bot", gw_type: "discord", gw_token: "tok123" } },
+    res, { db }
+  );
+  assert.match(res.redirected, /saved=1/);
+  assert.equal(res.redirected.includes("warn=bot_runtime_off"), false, "mode!=='gateway' must never warn");
+});

--- a/tests/bot-builder-engine-gate.test.js
+++ b/tests/bot-builder-engine-gate.test.js
@@ -32,7 +32,7 @@
 import { test, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -47,6 +47,8 @@ let writeSetting = null;
 let handleWizardCreate = null;
 let renderWizard = null;
 let WIZARD_STEP_KEYS = null;
+let renderBotEditor = null;
+let botBuilderPanel = null;
 
 const origPibotPiCli = process.env.PIBOT_PI_CLI;
 const origCrowHome = process.env.CROW_HOME;
@@ -67,6 +69,8 @@ before(async () => {
   ({ writeSetting } = await import("../servers/gateway/dashboard/settings/registry.js"));
   ({ handleWizardCreate, renderWizard, WIZARD_STEP_KEYS } =
     await import("../servers/gateway/dashboard/panels/bot-builder/wizard.js"));
+  ({ renderBotEditor } = await import("../servers/gateway/dashboard/panels/bot-builder/editor.js"));
+  ({ default: botBuilderPanel } = await import("../servers/gateway/dashboard/panels/bot-builder.js"));
 });
 
 after(async () => {
@@ -380,4 +384,112 @@ test("wizard create: complete discord record + engine ready → inserted as befo
   assert.deepEqual(def.gateways, [{ type: "discord", token: "tok123", allowlist: [], channel_ids: [] }]);
   await clearWizProviders();
   _setEngineStatusForTest(null);
+});
+
+// ---------------------------------------------------------------------------
+// C4 Task 8 — client-side gate modal + one-click install, runtime-enable
+// warn banner (server-rendered contract: data attributes for the client
+// mirror, friendly banners instead of raw error/warn values, the zero-
+// backtick client script invariant).
+// ---------------------------------------------------------------------------
+
+const layout = ({ content }) => content;
+
+function mkGetReq(query) {
+  return { method: "GET", query, body: {}, cookies: {}, headers: {} };
+}
+function mkSendRes() {
+  const res = { html: null, redirected: null };
+  res.send = (s) => { res.html = s; return res; };
+  res.redirectAfterPost = (url) => { res.redirected = url; };
+  return res;
+}
+
+test("gateways tab render: complete gmail record + engine absent → form armed with channels + required-fields data attributes", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways" });
+  await renderBotEditor(req, res, { db, layout, lang: "en", PAGE_CSS: "", botId: "gate-bot", notice: "", q: req.query });
+  assert.match(res.html, /id="btb-gateways-form"[^>]*data-engine-gate="1"/, "form must carry the gate attribute");
+  assert.match(res.html, /data-engine-channels="gmail,discord,telegram,slack"/, "channels list must mirror ENGINE_CHANNELS");
+  assert.match(res.html, /data-engine-required-fields="gw_address,gw_allowlist"/, "required DOM field names for gmail");
+  assert.match(res.html, /window\.__crowEngineGateOpen/, "stable hook for the Task 9 readiness row must be present");
+  assert.match(res.html, /id="engine-gate-modal-overlay"/, "modal overlay markup must ship on the page");
+});
+
+test("gateways tab render: engine ready → NOT armed (no data-engine-gate attribute anywhere)", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways" });
+  await renderBotEditor(req, res, { db, layout, lang: "en", PAGE_CSS: "", botId: "gate-bot", notice: "", q: req.query });
+  assert.ok(!/data-engine-gate="1"/.test(res.html), "must not arm the client gate while the engine is ready");
+  // The overlay/hook still ship (Task 9's readiness row may still want the
+  // hook even when this particular tab isn't gated) but the script itself
+  // is unconditional — only the FORM's data attribute is state-dependent.
+  assert.match(res.html, /window\.__crowEngineGateOpen/);
+});
+
+test("gateways tab render: engine absent but gwType is crow-messages (not an ENGINE_CHANNELS type) → NOT armed", async () => {
+  await db.execute({
+    sql: "UPDATE pi_bot_defs SET definition=? WHERE bot_id='gate-bot'",
+    args: [JSON.stringify({ gateways: [{ type: "crow-messages", allow_paired_instances: true }], tools: {}, models: {} })],
+  });
+  _setEngineStatusForTest({ state: "absent" });
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways" });
+  await renderBotEditor(req, res, { db, layout, lang: "en", PAGE_CSS: "", botId: "gate-bot", notice: "", q: req.query });
+  assert.ok(!/data-engine-gate="1"/.test(res.html), "crow-messages is never a gated channel type");
+});
+
+test("bot-builder panel: error=engine_required renders a friendly banner + Install button, never the raw query value", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways", error: "engine_required" });
+  await botBuilderPanel.handler(req, res, { db, layout, lang: "en" });
+  assert.ok(!res.html.includes(">engine_required<"), "must never leak the raw query value as visible text");
+  assert.match(res.html, /class="btb-notice-err"/, "renders as an error notice");
+  assert.match(res.html, /id="engine-gate-open-btn"/, "renders the Install bot engine button");
+  assert.doesNotMatch(res.html, /needs the bot engine.*undefined/i);
+});
+
+test("bot-builder panel: warn=bot_runtime_off renders a friendly banner + one-click enable button, never the raw query value", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways", warn: "bot_runtime_off" });
+  await botBuilderPanel.handler(req, res, { db, layout, lang: "en" });
+  assert.ok(!res.html.includes(">bot_runtime_off<"), "must never leak the raw query value as visible text");
+  assert.match(res.html, /class="btb-notice-warn"/, "renders as a warn notice");
+  assert.match(res.html, /id="bot-runtime-enable-btn"/, "renders the one-click enable button");
+  assert.match(res.html, /id="bot-runtime-enable-status"/, "renders a status span for the async enable result");
+});
+
+test("bot-builder panel: an unrelated error value still renders raw (no regression to the generic fallback)", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
+  const res = mkSendRes();
+  const req = mkGetReq({ bot: "gate-bot", tab: "gateways", error: "unknown_bot" });
+  await botBuilderPanel.handler(req, res, { db, layout, lang: "en" });
+  assert.match(res.html, />unknown_bot</, "generic fallback still renders the raw value verbatim");
+  assert.ok(!/id="engine-gate-open-btn"/.test(res.html), "the engine-gate banner (with its button) must not render for an unrelated error");
+});
+
+test("engine-gate-client.js: zero literal backtick characters inside the emitted <script> block", () => {
+  const src = readFileSync(join(new URL("..", import.meta.url).pathname, "servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js"), "utf8");
+  const scriptStart = src.indexOf("<script>", src.indexOf("function engineGateClientJS"));
+  const scriptEnd = src.indexOf("</script>", scriptStart);
+  assert.ok(scriptStart > -1 && scriptEnd > scriptStart, "could not locate the client <script> block");
+  const body = src.slice(scriptStart + "<script>".length, scriptEnd);
+  const backtickCount = (body.match(/`/g) || []).length;
+  assert.equal(backtickCount, 0, "a literal backtick inside the client <script> block would break the whole dashboard");
+});
+
+test("engine-gate-client.js: emitted script is syntactically valid JS and exposes the stable hook", async () => {
+  const { engineGateClientJS } = await import("../servers/gateway/dashboard/panels/bot-builder/engine-gate-client.js");
+  const out = engineGateClientJS("en");
+  const s = out.indexOf("<script>") + "<script>".length;
+  const e = out.indexOf("</script>");
+  const js = out.slice(s, e);
+  assert.doesNotThrow(() => new Function(js), "emitted client JS must parse without a SyntaxError");
+  assert.match(js, /window\.__crowEngineGateOpen\s*=\s*function/, "must define the stable hook Task 9 will call");
+  assert.match(js, /bundle_id:\s*BUNDLE_ID/, "install POST must target bot-engine");
+  assert.match(js, /already_installing/, "must handle the 409 already_installing adopt-job-id path");
 });

--- a/tests/bot-builder-gateway-draft.test.js
+++ b/tests/bot-builder-gateway-draft.test.js
@@ -7,7 +7,7 @@
  * gmail and the companion fields were unreachable. The type must persist as
  * a device-less draft record.
  */
-import { test, before, after } from "node:test";
+import { test, before, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -19,6 +19,7 @@ process.env.CROW_DATA_DIR = dir;
 
 let db = null;
 let handleBotBuilderPost = null;
+let _setEngineStatusForTest = null;
 
 before(async () => {
   execFileSync(process.execPath, ["scripts/init-db.js"], {
@@ -28,7 +29,8 @@ before(async () => {
   });
   const { createDbClient } = await import("../servers/db.js");
   db = createDbClient();
-  ({ handleBotBuilderPost } = await import("../servers/gateway/dashboard/panels/bot-builder/api-handlers.js"));
+  ({ handleBotBuilderPost, _setEngineStatusForTest } =
+    await import("../servers/gateway/dashboard/panels/bot-builder/api-handlers.js"));
   await db.execute({
     sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,1)",
     args: ["draft-bot", "Draft Bot", JSON.stringify({ gateways: [{ type: "gmail", address: "x@y.z", allowlist: [] }], tools: {}, models: {} })],
@@ -38,6 +40,18 @@ before(async () => {
 after(async () => {
   try { db && db.close && db.close(); } catch {}
   rmSync(dir, { recursive: true, force: true });
+});
+
+// Hermeticity: this file isn't testing the engine-attach gate (that's
+// bot-builder-engine-gate.test.js) — it's testing gateway-field
+// persistence. The one test below that saves a COMPLETE gmail record must
+// pin engineStatus() "ready" so it doesn't depend on whatever the host
+// running the suite happens to have installed (a dev box with a global pi
+// install resolves "ready" via rung 4; a clean CI runner resolves
+// "absent" and the real gate would reject the save). Reset after every
+// test regardless of which one pinned it.
+afterEach(() => {
+  _setEngineStatusForTest(null);
 });
 
 function mkRes() {
@@ -143,6 +157,10 @@ test("selected device wins over a typed name", async () => {
 });
 
 test("switching back to gmail still works after a draft", async () => {
+  // Complete gmail record → the engine-attach gate (Task 7) would fire if
+  // the engine resolved "absent"; pin "ready" so this test is hermetic on
+  // any host, not just one with a global pi install.
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
   const res = mkRes();
   await handleBotBuilderPost(
     { body: { action: "save_gateways", bot_id: "draft-bot", gw_type: "gmail", gw_address: "a@b.c", gw_allowlist: "a@b.c" } },

--- a/tests/bot-builder-wizard.test.js
+++ b/tests/bot-builder-wizard.test.js
@@ -5,7 +5,7 @@
  * of Turbo Drive (data-turbo="false" — render-on-POST is incompatible with
  * Turbo's must-redirect rule, spec round-2 CRITICAL-A) and carry CSRF.
  */
-import { test, before, after } from "node:test";
+import { test, before, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -18,6 +18,7 @@ process.env.CROW_DATA_DIR = dir;
 let db = null;
 let renderWizard, handleWizardCreate, WIZARD_STEP_KEYS, uniqueBotId, slugifyBotId;
 let translations = null;
+let _setEngineStatusForTest = null;
 
 before(async () => {
   execFileSync(process.execPath, ["scripts/init-db.js"], {
@@ -30,11 +31,27 @@ before(async () => {
   ({ renderWizard, handleWizardCreate, WIZARD_STEP_KEYS, uniqueBotId, slugifyBotId } =
     await import("../servers/gateway/dashboard/panels/bot-builder/wizard.js"));
   ({ translations } = await import("../servers/gateway/dashboard/shared/i18n.js"));
+  // wizard.js doesn't re-export the test-only pin (only api-handlers.js
+  // does, for its own consumers) — import the shared leaf module directly,
+  // same seam bot-builder-engine-gate.test.js uses.
+  ({ _setEngineStatusForTest } =
+    await import("../servers/gateway/dashboard/panels/bot-builder/engine-gate.js"));
 });
 
 after(async () => {
   try { db && db.close && db.close(); } catch {}
   rmSync(dir, { recursive: true, force: true });
+});
+
+// Hermeticity: this file isn't testing the engine-attach gate itself (that's
+// bot-builder-engine-gate.test.js) — the two tests below that create a
+// COMPLETE gmail record must pin engineStatus() "ready" so they don't
+// depend on whatever the host running the suite happens to have installed
+// (a dev box with a global pi install resolves "ready" via rung 4; a clean
+// CI runner resolves "absent" and the real gate would reject the create).
+// Reset after every test regardless of which one pinned it.
+afterEach(() => {
+  _setEngineStatusForTest(null);
 });
 
 function mkRes() {
@@ -214,6 +231,7 @@ test("wizard_create (blank/none): inserts row, safe defaults, PRG to review with
 });
 
 test("wizard_create (gmail): channel record parity via the shared normalizer", async () => {
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
   await addProvider("prov", [{ id: "m1" }]);
   const res = mkRes();
   await handleWizardCreate({ body: {
@@ -228,6 +246,10 @@ test("wizard_create (gmail): channel record parity via the shared normalizer", a
 });
 
 test("wizard_create conflict: duplicate submit redirects to the existing bot, never clobbers", async () => {
+  // Not itself a gate test (gw_type "none" here never reaches
+  // engineRequiredFor) but pinned anyway for hermeticity/robustness against
+  // the conflict-tolerance short-circuit's ordering relative to the gate.
+  _setEngineStatusForTest({ state: "ready", source: "env", cliPath: "/fake/cli.js" });
   await addProvider("prov", [{ id: "m1" }]);
   const res = mkRes();
   await handleWizardCreate({ body: {

--- a/tests/bundle-engine-blast.test.js
+++ b/tests/bundle-engine-blast.test.js
@@ -1,0 +1,137 @@
+/**
+ * GET /bundles/api/engine-blast — C4 Task 10.
+ *
+ * The uninstall-confirm flow for the "bot-engine" bundle needs to tell the
+ * operator which bot channels stop working if they go through with it. This
+ * route is the server side of that: enabled pi_bot_defs rows whose parsed
+ * definition.gateways intersect ENGINE_CHANNELS (gmail/discord/telegram/slack
+ * — bot-engine-status.js).
+ *
+ * Isolation: CROW_HOME/CROW_DATA_DIR point at a scratch dir (never the
+ * operator's real ~/.crow — see bundles-auth-bypass.test.js's note about the
+ * uptime-kuma incident), set BEFORE importing bundlesRouter so its
+ * module-load-time path resolution reads the scratch dir.
+ */
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const home = mkdtempSync(join(tmpdir(), "crow-engine-blast-"));
+process.env.CROW_HOME = home;
+process.env.CROW_DATA_DIR = join(home, "data");
+
+execFileSync(process.execPath, ["scripts/init-db.js"], {
+  env: { ...process.env, CROW_DATA_DIR: process.env.CROW_DATA_DIR },
+  stdio: "pipe",
+  cwd: new URL("..", import.meta.url).pathname,
+});
+
+const { default: bundlesRouter } = await import("../servers/gateway/routes/bundles.js");
+const { createDbClient } = await import("../servers/db.js");
+
+const db = createDbClient();
+
+async function withRouter(fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(bundlesRouter());
+  const server = app.listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try { await fn(base); } finally { server.close(); }
+}
+
+async function seedBot(botId, { displayName = botId, gateways = [], enabled = 1 } = {}) {
+  await db.execute({
+    sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,?) " +
+      "ON CONFLICT(bot_id) DO UPDATE SET display_name=excluded.display_name, definition=excluded.definition, enabled=excluded.enabled",
+    args: [botId, displayName, JSON.stringify({ gateways, tools: {}, models: {} }), enabled],
+  });
+}
+
+before(async () => {});
+
+after(async () => {
+  try { db.close(); } catch {}
+  rmSync(home, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await db.execute({ sql: "DELETE FROM pi_bot_defs", args: [] });
+});
+
+test("bot with gmail+discord gateways enabled → listed with both types", async () => {
+  await seedBot("mail-and-chat-bot", {
+    displayName: "Mail & Chat Bot",
+    gateways: [
+      { type: "gmail", address: "x@y.z", allowlist: ["x@y.z"] },
+      { type: "discord", token: "tok" },
+    ],
+  });
+  await withRouter(async (base) => {
+    const res = await fetch(base + "/bundles/api/engine-blast");
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.channels.length, 1);
+    const entry = body.channels[0];
+    assert.equal(entry.bot_id, "mail-and-chat-bot");
+    assert.equal(entry.display_name, "Mail & Chat Bot");
+    assert.deepEqual([...entry.types].sort(), ["discord", "gmail"]);
+  });
+});
+
+test("disabled bot is excluded even with a gated gateway", async () => {
+  await seedBot("disabled-bot", {
+    displayName: "Disabled Bot",
+    gateways: [{ type: "discord", token: "tok" }],
+    enabled: 0,
+  });
+  await withRouter(async (base) => {
+    const res = await fetch(base + "/bundles/api/engine-blast");
+    const body = await res.json();
+    assert.deepEqual(body.channels, []);
+  });
+});
+
+test("bot with only crow-messages/voice gateways is excluded (not an engine channel)", async () => {
+  await seedBot("messages-only-bot", {
+    displayName: "Messages Only Bot",
+    gateways: [
+      { type: "crow-messages", allow_paired_instances: true },
+      { type: "voice" },
+    ],
+  });
+  await withRouter(async (base) => {
+    const res = await fetch(base + "/bundles/api/engine-blast");
+    const body = await res.json();
+    assert.deepEqual(body.channels, []);
+  });
+});
+
+test("malformed definition JSON is tolerated (treated as no gateways, not a 500)", async () => {
+  await db.execute({
+    sql: "INSERT INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,1)",
+    args: ["broken-def-bot", "Broken Def Bot", "{not valid json"],
+  });
+  await withRouter(async (base) => {
+    const res = await fetch(base + "/bundles/api/engine-blast");
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body.channels, []);
+  });
+});
+
+test("multiple enabled bots with gated gateways are all listed", async () => {
+  await seedBot("bot-a", { displayName: "Bot A", gateways: [{ type: "telegram", token: "t" }] });
+  await seedBot("bot-b", { displayName: "Bot B", gateways: [{ type: "slack", token: "t" }] });
+  await withRouter(async (base) => {
+    const res = await fetch(base + "/bundles/api/engine-blast");
+    const body = await res.json();
+    const ids = body.channels.map((c) => c.bot_id).sort();
+    assert.deepEqual(ids, ["bot-a", "bot-b"]);
+  });
+});

--- a/tests/extensions-client-contract.test.js
+++ b/tests/extensions-client-contract.test.js
@@ -685,6 +685,93 @@ test("BEHAVIOR: an unknown category falls back to its slug rather than mislabell
   assert.equal(document.querySelector("#modal-content .ext-card__badge").textContent, "quantum-farming");
 });
 
+// ─── 8. Bot-engine uninstall blast-radius (C4 Task 10) ───
+
+/** engine-blast fetchImpl helper — mirrors installSetFetch()/envFetch() above. */
+function engineBlastFetch(channels) {
+  return (url) => {
+    if (url.includes("/engine-blast")) {
+      return { ok: true, status: 200, json: () => Promise.resolve({ channels }) };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  };
+}
+
+const BOT_ENGINE_BOOT = { installed: { "bot-engine": { version: "1.0.0" } }, collections: [] };
+
+test("BEHAVIOR: uninstalling bot-engine fetches the blast list and shows affected bot channels in the confirm modal", async () => {
+  const { $, click, settle, document, calls } = boot({
+    ...BOT_ENGINE_BOOT,
+    fetchImpl: engineBlastFetch([
+      { bot_id: "mail-bot", display_name: "Mail Bot", types: ["gmail", "discord"] },
+    ]),
+  });
+
+  click($('.bundle-uninstall[data-id="bot-engine"]'));
+  await settle();
+
+  assert.ok(calls.some((c) => c.url.includes("/engine-blast")), "the client fetched the blast-radius endpoint");
+  const content = document.getElementById("modal-content");
+  assert.match(content.textContent, /stop these bot channels from working/i);
+  assert.match(content.textContent, /Mail Bot/);
+  assert.match(content.textContent, /gmail, discord/);
+});
+
+test("BEHAVIOR: uninstalling bot-engine with no affected channels shows no blast warning", async () => {
+  const { $, click, settle, document } = boot({
+    ...BOT_ENGINE_BOOT,
+    fetchImpl: engineBlastFetch([]),
+  });
+
+  click($('.bundle-uninstall[data-id="bot-engine"]'));
+  await settle();
+
+  const content = document.getElementById("modal-content");
+  assert.ok(!/stop these bot channels from working/i.test(content.textContent), "no blast warning when nothing is affected");
+});
+
+test("BEHAVIOR: uninstalling a non-engine bundle never calls the blast-radius endpoint", async () => {
+  const { $, click, settle, calls } = boot({
+    installed: { jellyfin: { version: "1.0.0" } },
+    fetchImpl: engineBlastFetch([{ bot_id: "x", display_name: "X", types: ["gmail"] }]),
+  });
+
+  click($('.bundle-uninstall[data-id="jellyfin"]'));
+  await settle();
+
+  assert.ok(!calls.some((c) => c.url.includes("/engine-blast")), "engine-blast is only fetched for the bot-engine bundle");
+});
+
+test("BEHAVIOR: a bot display_name with HTML-looking content renders as literal text, never as markup", async () => {
+  const { $, click, settle, document } = boot({
+    ...BOT_ENGINE_BOOT,
+    fetchImpl: engineBlastFetch([
+      { bot_id: "evil-bot", display_name: "<b>Evil</b> Bot", types: ["discord"] },
+    ]),
+  });
+
+  click($('.bundle-uninstall[data-id="bot-engine"]'));
+  await settle();
+
+  const content = document.getElementById("modal-content");
+  assert.equal(content.querySelector("b"), null, "the display_name must never be parsed as HTML");
+  assert.match(content.textContent, /<b>Evil<\/b> Bot/, "it renders as literal text via textContent");
+});
+
+test("BEHAVIOR: a failed engine-blast fetch still opens the confirm modal (fails safe, empty list)", async () => {
+  const { $, click, settle, document } = boot({
+    ...BOT_ENGINE_BOOT,
+    fetchImpl: () => Promise.reject(new Error("network down")),
+  });
+
+  click($('.bundle-uninstall[data-id="bot-engine"]'));
+  await settle();
+
+  assert.equal(document.getElementById("modal-overlay").style.display, "flex", "the confirm modal still opens");
+  const content = document.getElementById("modal-content");
+  assert.ok(!/stop these bot channels from working/i.test(content.textContent));
+});
+
 // ─── Cheap smoke checks on the emitted source (NOT the guard — the DOM tests above are) ───
 
 test("SMOKE: the emitted client keeps the one-time Escape listener guard (Turbo must not stack listeners)", () => {

--- a/tests/i18n-global-parity.test.js
+++ b/tests/i18n-global-parity.test.js
@@ -83,6 +83,8 @@ const IDENTICAL_OK = new Set([
   "models.hfTokenPlaceholder", // "hf_..." — literal input placeholder prefix, language-neutral
   // Onboarding AI step three-choice rework (C1/C3 Task 7)
   "onboarding.ai.sizeGb", // "{gb} GB" — the unit abbreviation is unchanged in Spanish
+  // Bot-engine uninstall blast-radius (C4 Task 10)
+  "extensions.engineBlastItem", // "{name} ({types})" — pure template shape, no words to translate
 ]);
 
 const keys = Object.keys(translations);


### PR DESCRIPTION
Item C4 PR D — the point-of-use onboarding surface for the bot engine.

- **Server attach gate** (api-handlers + wizard-create, one shared `engine-gate.js` predicate): a COMPLETE gmail/discord/telegram/slack record with the engine absent is refused (`error=engine_required`); type-only drafts save as before (auto-submit-on-type-change stays ungated). Voice/crow-messages channels never gated.
- **Gate modal + one-click install** (`engine-gate-client.js`, vm/linkedom contract-tested): client intercepts the submit pre-POST (form state preserved), honest copy (pi 0.74.2 npm payload, ~400 MB, no Docker/sudo/ports), streams the install job log, adopts `already_installing` jobs, resubmits via `requestSubmit()` on success. Two client races found in review and fixed + regression-tested (stale type-switch hijack; cancel-then-delayed-resubmit).
- **Runtime-disarmed honesty**: successful engine-channel save with the gateway-mode runtime flag off → `warn=bot_runtime_off` banner with one-click enable (`set_bot_runtime`, `botRuntimeActive` resolver so MPA-default hosts never false-warn).
- **Readiness checklist "Bot engine" row**: five states (absent/installing/disarmed/ready+source/unhealthy), external-mode note; stale "install-runtime.sh required" settings copy reworded (EN+ES).
- **Uninstall blast-radius**: `GET /bundles/api/engine-blast` (dashboard-authed) + extensions confirm modal lists the bots/channels that stop working.
- **Docs**: `docs/developers/bot-engine.md` (bundle, resolver ladder, supervisor modes + the `PIBOT_SUPERVISOR=external` hazard, breaker, states) + sidebar + Bot Builder tutorial pointer.

Proof: full suite **2682/2682** in-worktree; CDP round on a wiped scratch gateway **9/9 PASS** (evidence `~/.crow/p4/c4-cdp-round/`); whole-branch adversarial review clean after one commit-message rewrite. i18n EN+ES parity green; zero backticks in emitted scripts; no new ports; no schema changes.

Spec: crow-engineering `specs/2026-07-18-item-c4-bot-engine-bundle-design.md` (Gitea).