### PR TITLE
fix(init-db): bot_sessions.kind was never in the schema — fresh installs crashed on their first bot turn

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -2530,10 +2530,19 @@ await initTable("job_search_sites table", `
 `);
 
 // --- Bot Builder tables (F3: moved from scripts/init-pi-bots.mjs) ---
-// Full current shape: pi_bot_defs.project_id and bot_sessions.model/escalated
-// are in the CREATE body here (init-pi-bots.mjs adds them via guarded ALTER on
-// pre-F3 DBs). CREATE ... IF NOT EXISTS — a no-op on the live MPA crow.db.
-// init-pi-bots.mjs remains the MPA-only JSON->column project_id backfill + guard.
+// Full current shape: pi_bot_defs.project_id and bot_sessions.model/escalated/
+// kind are in the CREATE body here (init-pi-bots.mjs adds model/escalated via
+// guarded ALTER on pre-F3 DBs). CREATE ... IF NOT EXISTS — a no-op on the live
+// MPA crow.db. init-pi-bots.mjs remains the MPA-only JSON->column project_id
+// backfill + guard.
+// bot_sessions.kind (C4 acceptance fix, 2026-07-22): bridge.mjs upsertSession()
+// writes/reads this on every bot turn (default "chat"; also "planning" for the
+// plan-authoring session — see pi-bots/bridge.mjs ~:807). It was writing to a
+// column that only existed on prod via an uncaptured manual ALTER TABLE — a
+// truly fresh install crashed on its first bot turn ("no column named kind").
+// Added to the CREATE body (fresh installs) AND via addColumnIfMissing right
+// after this initTable call (pre-existing installs, same idiom as every other
+// post-hoc column in this file) — additive-only, no SCHEMA_GENERATION bump.
 await initTable("pi_bot_defs table", `
   CREATE TABLE IF NOT EXISTS pi_bot_defs (
     bot_id        TEXT PRIMARY KEY,
@@ -2566,6 +2575,7 @@ await initTable("bot_sessions table", `
                         CHECK (control IN ('run','stop')),
     model             TEXT,
     escalated         INTEGER DEFAULT 0,
+    kind              TEXT NOT NULL DEFAULT 'chat',
     created_at        TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
   );
@@ -2575,6 +2585,11 @@ await initTable("bot_sessions table", `
   CREATE INDEX IF NOT EXISTS idx_bot_sessions_status
     ON bot_sessions (status);
 `);
+
+// Pre-existing installs (table already present without `kind`, e.g. any host
+// that ran init-db.js between F3 and this fix): idempotent guarded ALTER,
+// matching prod's manual column def (TEXT NOT NULL DEFAULT 'chat').
+await addColumnIfMissing("bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'");
 
 await initTable("bot_skill_events table", `
   CREATE TABLE IF NOT EXISTS bot_skill_events (

--- a/tests/init-db-bot-tables.test.js
+++ b/tests/init-db-bot-tables.test.js
@@ -34,3 +34,109 @@ test("bot_sessions exists with model + escalated columns", () => {
 test("bot_skill_events exists with action column", () => {
   assert.ok(cols("bot_skill_events").includes("action"));
 });
+
+// C4 acceptance fix (2026-07-22): bridge.mjs upsertSession() writes/reads
+// bot_sessions.kind on EVERY bot turn (default "chat"), but init-db.js never
+// created or migrated that column — a truly fresh install crashed on its
+// first bot turn with "table bot_sessions has no column named kind". Prod
+// only worked via an uncaptured manual ALTER TABLE. See the fix comment
+// above the bot_sessions initTable() call in scripts/init-db.js.
+test("bot_sessions (fresh install) has a kind column, NOT NULL DEFAULT 'chat'", () => {
+  const info = db.prepare("PRAGMA table_info(bot_sessions)").all();
+  const kind = info.find((c) => c.name === "kind");
+  assert.ok(kind, "bot_sessions.kind must exist on a freshly init-db'd DB");
+  assert.equal(kind.notnull, 1, "kind must be NOT NULL, matching prod's manual ALTER");
+  assert.equal(kind.dflt_value, "'chat'", "kind must default to 'chat', matching bridge.mjs's null-default");
+});
+
+test("bot_sessions accepts the exact INSERT bridge.mjs's upsertSession() issues (fresh install)", () => {
+  // Mirrors scripts/pi-bots/bridge.mjs upsertSession()'s INSERT verbatim —
+  // this is the literal statement that crashed a fresh install pre-fix.
+  const rw = new Database(join(dir, "crow.db"));
+  try {
+    const info = rw
+      .prepare(
+        "INSERT INTO bot_sessions (bot_id,pi_session_id,pi_session_dir,gateway_type,gateway_thread_id,project_id,card_id,plan_path,status,control,model,escalated,kind) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)"
+      )
+      .run("test-bot", null, null, "gmail", "thread-1", null, null, null, "active", "run", null, 0, "chat");
+    assert.ok(info.lastInsertRowid > 0);
+    const row = rw.prepare("SELECT kind FROM bot_sessions WHERE id=?").get(info.lastInsertRowid);
+    assert.equal(row.kind, "chat");
+    // Clean up so this test doesn't leak state into the read-only assertions above.
+    rw.prepare("DELETE FROM bot_sessions WHERE id=?").run(info.lastInsertRowid);
+  } finally {
+    rw.close();
+  }
+});
+
+// Migration path: an existing DB that already has bot_sessions WITHOUT `kind`
+// (any host that ran init-db.js between F3 and this fix) must converge via
+// addColumnIfMissing on the NEXT init-db.js run — no SCHEMA_GENERATION bump,
+// same idiom as every other post-hoc column in this file.
+test("bot_sessions pre-existing WITHOUT kind: re-running init-db.js adds it", () => {
+  const migDir = mkdtempSync(join(tmpdir(), "f3-initdb-mig-"));
+  try {
+    // First pass: build the full current shape (so every OTHER table/column
+    // this migration depends on already exists), then drop back to the
+    // pre-fix bot_sessions shape by rebuilding the table without `kind`.
+    execFileSync(process.execPath, ["scripts/init-db.js"], {
+      env: { ...process.env, CROW_DATA_DIR: migDir },
+      stdio: "pipe",
+    });
+    const pre = new Database(join(migDir, "crow.db"));
+    try {
+      pre.exec(`
+        CREATE TABLE bot_sessions_old (
+          id                INTEGER PRIMARY KEY AUTOINCREMENT,
+          bot_id            TEXT NOT NULL,
+          pi_session_id     TEXT,
+          pi_session_dir    TEXT,
+          gateway_type      TEXT,
+          gateway_thread_id TEXT,
+          project_id        INTEGER,
+          card_id           INTEGER,
+          plan_path         TEXT,
+          status            TEXT NOT NULL DEFAULT 'active'
+                              CHECK (status IN ('active','waiting-user','stopped','done','error')),
+          control           TEXT NOT NULL DEFAULT 'run'
+                              CHECK (control IN ('run','stop')),
+          model             TEXT,
+          escalated         INTEGER DEFAULT 0,
+          created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO bot_sessions_old
+          (id,bot_id,pi_session_id,pi_session_dir,gateway_type,gateway_thread_id,
+           project_id,card_id,plan_path,status,control,model,escalated,created_at,updated_at)
+          SELECT id,bot_id,pi_session_id,pi_session_dir,gateway_type,gateway_thread_id,
+                 project_id,card_id,plan_path,status,control,model,escalated,created_at,updated_at
+          FROM bot_sessions;
+        DROP TABLE bot_sessions;
+        ALTER TABLE bot_sessions_old RENAME TO bot_sessions;
+      `);
+      const preCols = pre.prepare("PRAGMA table_info(bot_sessions)").all().map((c) => c.name);
+      assert.ok(!preCols.includes("kind"), "test setup sanity: pre-fix shape must not have kind");
+    } finally {
+      pre.close();
+    }
+
+    // Re-run init-db.js against the same data dir — the guarded ALTER path
+    // (addColumnIfMissing) must add `kind` without a SCHEMA_GENERATION bump
+    // and without touching any other column.
+    execFileSync(process.execPath, ["scripts/init-db.js"], {
+      env: { ...process.env, CROW_DATA_DIR: migDir },
+      stdio: "pipe",
+    });
+    const post = new Database(join(migDir, "crow.db"), { readonly: true });
+    try {
+      const postCols = post.prepare("PRAGMA table_info(bot_sessions)").all().map((c) => c.name);
+      assert.ok(postCols.includes("kind"), "kind must be added by a second init-db.js run");
+      assert.ok(postCols.includes("model") && postCols.includes("escalated"),
+        "pre-existing columns must survive the migration");
+    } finally {
+      post.close();
+    }
+  } finally {
+    rmSync(migDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Found by C4's live acceptance on a wiped scratch install: `bridge.mjs` `upsertSession()` writes `bot_sessions.kind` on every bot turn, but `scripts/init-db.js` never created the column — a truly fresh install crashes with `SqliteError: table bot_sessions has no column named kind` on its first turn. Fleet DBs only carried the column via the one-off `scripts/migrate-board-stages.mjs` deploy script, which was never folded back into init-db.

- Adds `kind TEXT NOT NULL DEFAULT 'chat'` to the CREATE TABLE shape + an `addColumnIfMissing` backfill (identical definition to the one-off script — byte-parity with what the fleet already carries, so re-running init-db anywhere is a no-op).
- **No SCHEMA_GENERATION bump**: additive, unconditional-idempotent per the ~40 existing `addColumnIfMissing` precedents; migration guard treats column gains as benign (verified against `migration-expectations.js` classification).
- Tests: fresh-DB shape assert, old-shape→re-run migration, and a literal-INSERT driver using bridge.mjs's exact SQL proving the crash is fixed. Sibling audit: `kind` was the only bridge-written column missing.
- Full suite in-worktree: **2685/2685**.