### PR TITLE
feat(browser): multi-instance support — parameterize container name + VNC/RFB/CDP ports

### DIFF
--- a/bundles/browser/docker-compose.yml
+++ b/bundles/browser/docker-compose.yml
@@ -3,12 +3,18 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: crow-browser
+    # Overridable so a second Crow instance on the same host (distinct
+    # CROW_HOME) can run its own browser container side-by-side. With
+    # network_mode: host the ports must be overridden too — set
+    # CROW_BROWSER_{VNC,RFB,CDP}_PORT in this bundle's .env alongside the name.
+    container_name: ${CROW_BROWSER_CONTAINER_NAME:-crow-browser}
     network_mode: host
     environment:
       - DISPLAY=:99
       - VNC_PASSWORD=${CROW_BROWSER_VNC_PASSWORD:?VNC password is required}
-      - CDP_PORT=9222
+      - CDP_PORT=${CROW_BROWSER_CDP_PORT:-9222}
+      - NOVNC_PORT=${CROW_BROWSER_VNC_PORT:-6080}
+      - RFB_PORT=${CROW_BROWSER_RFB_PORT:-5900}
       - CHROME_PROXY=${CROW_BROWSER_PROXY:-}
     volumes:
       - ${CROW_HOME:-${HOME}/.crow}/browser-downloads:/downloads

--- a/bundles/browser/entrypoint.sh
+++ b/bundles/browser/entrypoint.sh
@@ -10,6 +10,8 @@ DISP_NUM=99
 DISPLAY=":${DISP_NUM}"
 export DISPLAY
 CDP_PORT="${CDP_PORT:-9222}"
+NOVNC_PORT="${NOVNC_PORT:-6080}"
+RFB_PORT="${RFB_PORT:-5900}"
 SCREEN="1920x1080x24"
 
 log() { echo "[crow-browser] $*"; }
@@ -50,15 +52,15 @@ log "Xvfb ready (pid ${XVFB_PID})."
 # --- x11vnc ---
 log "Starting x11vnc..."
 x11vnc -display ":${DISP_NUM}" -auth "$XAUTHORITY" -forever -shared \
-  -passwd "$VNC_PASSWORD" -rfbport 5900 -noxdamage -quiet &
+  -passwd "$VNC_PASSWORD" -rfbport "${RFB_PORT}" -noxdamage -quiet &
 X11VNC_PID=$!
 sleep 1
 kill -0 "$X11VNC_PID" 2>/dev/null || die "x11vnc failed to start"
 log "x11vnc up (pid ${X11VNC_PID})."
 
 # --- noVNC / websockify ---
-log "Starting noVNC on :6080..."
-websockify --web /usr/share/novnc 6080 localhost:5900 &
+log "Starting noVNC on :${NOVNC_PORT}..."
+websockify --web /usr/share/novnc "${NOVNC_PORT}" "localhost:${RFB_PORT}" &
 WEBSOCKIFY_PID=$!
 sleep 1
 kill -0 "$WEBSOCKIFY_PID" 2>/dev/null || die "websockify failed to start"
@@ -105,7 +107,7 @@ done
 echo ""
 echo "============================================="
 echo "  Crow Browser — Ready (verified)"
-echo "  noVNC:     http://localhost:6080/vnc.html"
+echo "  noVNC:     http://localhost:${NOVNC_PORT}/vnc.html"
 echo "  CDP:       http://127.0.0.1:${CDP_PORT}/json/version"
 echo "============================================="
 echo ""

--- a/bundles/browser/manifest.json
+++ b/bundles/browser/manifest.json
@@ -11,10 +11,11 @@
   "docker": {
     "composefile": "docker-compose.yml"
   },
+  "privileged": true,
   "server": {
     "command": "node",
     "args": ["server/index.js"],
-    "envKeys": ["CROW_BROWSER_VNC_PASSWORD", "CROW_BROWSER_CDP_PORT", "CROW_BROWSER_VNC_PORT"]
+    "envKeys": ["CROW_BROWSER_VNC_PASSWORD", "CROW_BROWSER_CDP_PORT", "CROW_BROWSER_VNC_PORT", "CROW_BROWSER_RFB_PORT", "CROW_BROWSER_CONTAINER_NAME"]
   },
   "panel": "panel/browser.js",
   "panelRoutes": "panel/routes.js",
@@ -40,9 +41,19 @@
       "name": "CROW_BROWSER_VNC_PORT",
       "description": "noVNC web viewer port",
       "default": "6080"
+    },
+    {
+      "name": "CROW_BROWSER_RFB_PORT",
+      "description": "Raw VNC (RFB) port inside the host network",
+      "default": "5900"
+    },
+    {
+      "name": "CROW_BROWSER_CONTAINER_NAME",
+      "description": "Docker container name — override so a second Crow instance on the same host can run its own browser container",
+      "default": "crow-browser"
     }
   ],
-  "ports": [6080, 9222],
-  "webUI": { "port": 6080, "path": "/vnc.html", "label": "VNC Viewer" },
+  "ports": [6080, 9222, 5900],
+  "webUI": { "port": 6080, "portEnv": "CROW_BROWSER_VNC_PORT", "path": "/vnc.html", "label": "VNC Viewer" },
   "notes": "All-in-one browser automation + scraping toolkit (25+ MCP tools): navigation/forms, smart waits, infinite-scroll, session/cookie/header control, extraction (Readability/Markdown, tables, scrape, paginate, PDF), paywall fallback ladder (extract_article), network/API-response capture, file downloads, proxy, and the VNC human-in-the-loop CAPTCHA handoff. Runs headful Chrome in Docker with Xvfb + VNC. Human-like patterns + fingerprint stealth applied automatically. CDP and VNC bind to localhost only."
 }

--- a/bundles/browser/server/server.js
+++ b/bundles/browser/server/server.js
@@ -29,8 +29,10 @@ import { execFileSync } from "node:child_process";
  * @returns {McpServer}
  */
 export function createBrowserServer(options = {}) {
-  const cdpUrl = options.cdpUrl || process.env.CROW_BROWSER_CDP_URL || "http://127.0.0.1:9222";
-  const sessionDir = options.sessionDir || join(homedir(), ".crow", "browser-sessions");
+  const cdpUrl = options.cdpUrl || process.env.CROW_BROWSER_CDP_URL ||
+    `http://127.0.0.1:${process.env.CROW_BROWSER_CDP_PORT || "9222"}`;
+  const sessionDir = options.sessionDir ||
+    join(process.env.CROW_HOME || join(homedir(), ".crow"), "browser-sessions");
   const vncPort = process.env.CROW_BROWSER_VNC_PORT || "6080";
 
   const server = new McpServer(

--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -59,7 +59,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 5335 | 127.0.0.1 | adguard-home (DNS, TCP+UDP) | MVP PR 3 |
 | 5336 | — | pi-hole (DNS) | reserved (Phase 2 DNS) |
 | 5337 | — | technitium (DNS) | reserved (Phase 2 DNS) |
-| 6080 | 127.0.0.1 | browser (noVNC, existing) | existing |
+| 6080 | 127.0.0.1 | browser (noVNC, existing) — overridable via `CROW_BROWSER_VNC_PORT`; RFB 5900 via `CROW_BROWSER_RFB_PORT`, CDP 9222 via `CROW_BROWSER_CDP_PORT`. Secondary instances on one host pick +1 offsets (6081/5901/9223) | existing |
 | 6875 | 127.0.0.1 | bookstack (existing) | existing |
 | 8000 | 127.0.0.1 | paperless (existing) | existing |
 | 8004 | 127.0.0.1 | faster-whisper-server (local STT) | existing |

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -340,6 +340,7 @@
       "docker": {
         "composefile": "docker-compose.yml"
       },
+      "privileged": true,
       "server": {
         "command": "node",
         "args": [
@@ -348,7 +349,9 @@
         "envKeys": [
           "CROW_BROWSER_VNC_PASSWORD",
           "CROW_BROWSER_CDP_PORT",
-          "CROW_BROWSER_VNC_PORT"
+          "CROW_BROWSER_VNC_PORT",
+          "CROW_BROWSER_RFB_PORT",
+          "CROW_BROWSER_CONTAINER_NAME"
         ]
       },
       "panel": "panel/browser.js",
@@ -380,14 +383,26 @@
           "name": "CROW_BROWSER_VNC_PORT",
           "description": "noVNC web viewer port",
           "default": "6080"
+        },
+        {
+          "name": "CROW_BROWSER_RFB_PORT",
+          "description": "Raw VNC (RFB) port inside the host network",
+          "default": "5900"
+        },
+        {
+          "name": "CROW_BROWSER_CONTAINER_NAME",
+          "description": "Docker container name — override so a second Crow instance on the same host can run its own browser container",
+          "default": "crow-browser"
         }
       ],
       "ports": [
         6080,
-        9222
+        9222,
+        5900
       ],
       "webUI": {
         "port": 6080,
+        "portEnv": "CROW_BROWSER_VNC_PORT",
         "path": "/vnc.html",
         "label": "VNC Viewer"
       },

--- a/servers/gateway/routes/extension-proxy.js
+++ b/servers/gateway/routes/extension-proxy.js
@@ -21,7 +21,10 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { isAllowedNetwork, parseCookies, verifySession } from "../dashboard/auth.js";
 
-const CROW_HOME = join(homedir(), ".crow");
+// Respect CROW_HOME so a secondary instance (systemd unit with its own
+// CROW_HOME) proxies ITS extensions — not the primary's. Hardcoding ~/.crow
+// here made every co-hosted instance serve the primary's web UIs.
+const CROW_HOME = process.env.CROW_HOME || join(homedir(), ".crow");
 const INSTALLED_PATH = join(CROW_HOME, "installed.json");
 const BUNDLES_DIR = join(CROW_HOME, "bundles");
 
@@ -43,10 +46,16 @@ function getProxiedExtensions() {
     for (const entry of installed) {
       const manifest = getManifest(entry.id);
       if (manifest?.webUI?.port) {
+        // webUI.portEnv names an env var that overrides the manifest port —
+        // lets a per-instance unit remap the backend (e.g. a second browser
+        // container on 6081) without editing the shared manifest.
+        const envPort = manifest.webUI.portEnv
+          ? Number(process.env[manifest.webUI.portEnv]) || null
+          : null;
         proxied.push({
           id: entry.id,
           name: manifest.name || entry.id,
-          port: manifest.webUI.port,
+          port: envPort || manifest.webUI.port,
           path: manifest.webUI.path || "/",
           label: manifest.webUI.label || manifest.name || entry.id,
           proxyMode: manifest.webUI.proxyMode || "subpath",


### PR DESCRIPTION
## Problem

A second Crow instance on the same host (own `CROW_HOME` + systemd unit) cannot run the browser bundle: the compose file pins `container_name: crow-browser` and host-network ports 6080/5900/9222, colliding with the primary instance's running container. Separately, the gateway's extension-UI proxy hardcodes `~/.crow`, so a secondary instance proxies the **primary's** web UIs — an instance-isolation bug.

## Changes

- **compose/entrypoint**: `CROW_BROWSER_CONTAINER_NAME`, `_VNC_PORT`, `_RFB_PORT`, `_CDP_PORT` env overrides; defaults unchanged, so existing installs are unaffected. Per-instance values land in the installed bundle's `.env` (compose reads it from the project dir).
- **manifest**: declares `privileged: true` — the compose validator now refuses host networking without it + verified consent; this bundle predates the gate and could no longer be freshly installed at all. Adds the new env_vars and a `webUI.portEnv` hook.
- **extension-proxy**: respect `CROW_HOME` env (fixes the isolation bug above); `webUI.portEnv` lets a unit remap the proxied backend port per instance.
- **browser server**: honor `CROW_BROWSER_CDP_PORT`; browser-sessions dir under `CROW_HOME` instead of hardcoded `~/.crow`.
- **docs**: port-allocation note (secondary instances take +1 offsets: 6081/5901/9223).
- **registry**: rebuilt via `build-registry`.

## Testing

- Full suite: 2673 pass / 0 fail (12 skipped)
- `tests/bundle-contract.test.js` 28/28 including registry-drift check
- Syntax checks: `node --check` both JS files, `bash -n` entrypoint, JSON/YAML parse clean