### PR TITLE
release: v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Unlike hosted, auto-authoring bot platforms, Crow keeps the engine on your hardw
 | **Blog & publishing** | Markdown blog with RSS/Atom feeds, themes, and public URLs. Publish by telling your AI. |
 | **File storage** | S3-compatible storage with quotas and presigned URLs. |
 | **20+ integrations** | GitHub, Slack, Notion, Gmail, Trello, Discord, Google Workspace, and more, proxied through one authenticated gateway. |
+| **Local AI (Model Catalog)** | A curated model catalog with Hugging Face downloads, hardware-fit filtering, and a managed llama.cpp runtime — run your own AI locally with no cloud key. |
 | **Self-hosting add-ons** | Ollama, Nextcloud, Immich, Home Assistant, Jellyfin, and more, installable by asking your AI. |
 | **Multi-instance** | Run Crow on several devices and sync the pieces that should travel with you. |
 

--- a/docs/getting-started/managed-hosting.md
+++ b/docs/getting-started/managed-hosting.md
@@ -4,99 +4,17 @@
 Managed hosting is not an active offering right now. This page is kept for reference; for a working install today, see the [getting-started paths](./index.md).
 :::
 
-Skip the setup entirely. Get a fully configured Crow instance hosted by [Maestro Press](https://maestro.press) — $15/mo or $120/yr.
+Managed hosting is the planned zero-ops way to run Crow: a fully configured instance operated by [Maestro Press](https://maestro.press) on your own subdomain, with automatic updates, daily backups, HTTPS, mandatory two-factor authentication, and email-based password recovery — the same Crow features as self-hosting, without the server work.
 
-## What's Included
+There is no signup or checkout while the offering is inactive, and no pricing is published here until it is real.
 
-- **Your own subdomain** — `username.crow.maestro.press`
-- **Crow's Nest & blog** — Visual control panel and publishing platform, ready to go
-- **All AI integrations** — Connect Claude, ChatGPT, Gemini, Grok, Cursor, and more
-- **Public blog & podcast** — Your blog and podcast RSS feeds are publicly accessible with HTTPS — ready for monetization, podcast directories (Apple Podcasts, Spotify), and subscribers
-- **Daily backups** — Automatic daily backups of your data
-- **SSL included** — HTTPS enabled by default
-- **Automatic updates** — Always running the latest version of Crow
-- **No bandwidth limits** — No throttling or fair-use caps on your public content
+## In the meantime
 
-## How It Works
+Self-hosting is free and gives you full control — your data stays on infrastructure you choose:
 
-1. **Pick a username** — Choose your subdomain (e.g., `alice.crow.maestro.press`)
-2. **Check out** — $15/mo or $120/yr (4 months free with annual)
-3. **Visit your instance** — Your Crow's Nest is live immediately
-4. **Connect your AI** — Use the `/setup` page to connect Claude, ChatGPT, or any supported platform
+- [Oracle Cloud Free Tier](./oracle-cloud) — a permanent free server that never sleeps
+- [Raspberry Pi / Crow OS](./full-setup) — one-line installer on a Pi or any Debian/Ubuntu machine
+- [Desktop setup](./desktop-setup) — run Crow beside Claude Desktop on your own computer
+- [All getting-started paths](./index.md)
 
-> **[Get started at maestro.press/hosting →](https://maestro.press/hosting/)**
-
-## What Can I Do With It?
-
-Everything a self-hosted Crow instance can do:
-
-- **Persistent memory** — Your AI remembers across conversations and platforms
-- **Project management** — Organize projects, manage sources, generate APA citations, connect data backends
-- **Blog** — Publish posts with Markdown, RSS feeds, and custom themes
-- **File storage** — Upload and manage files with presigned URLs
-- **20+ integrations** — Gmail, GitHub, Slack, Notion, and more
-- **Encrypted P2P sharing** — Share memories and research with other Crow users
-- **Crow's Nest** — Visual control panel for messages, blog, files, and settings
-
-## Managed vs. Self-Hosted
-
-| | Managed Hosting | Self-Hosted (Free) |
-|---|---|---|
-| **Setup** | None — live in minutes | You deploy and configure |
-| **Maintenance** | Automatic updates and backups | You manage updates |
-| **Cost** | $15/mo or $120/yr | Free (Render, Oracle Cloud, Pi) |
-| **Control** | Hosted by Maestro Press | Full control over your server |
-| **Data** | Stored on Maestro Press infrastructure | Stored wherever you choose |
-| **Public blog/podcast** | Ready to go, no extra setup | Requires reverse proxy + domain |
-| **2FA** | Mandatory (TOTP) | Optional |
-| **Password reset** | Email-based | CLI (`npm run reset-password`) |
-| **Best for** | Users who want Crow without the ops work | Developers and tinkerers |
-
-Both options give you the same Crow features. Self-hosting is free and gives you full control. Managed hosting trades a small monthly cost for zero maintenance.
-
-::: tip Hybrid setup
-Managed hosting can be chained with a self-hosted instance for the best of both worlds — always-on cloud access plus a home server for heavy processing and data storage. See [Multi-Device Quick Start](./multi-device) to set it up.
-:::
-
-## Security
-
-Managed hosting includes additional security features that are automatically enabled:
-
-### Two-Factor Authentication (Required)
-
-On your first login, you'll be asked to set up two-factor authentication (2FA) using an authenticator app like Google Authenticator or Authy.
-
-1. Scan the QR code with your authenticator app
-2. Enter the 6-digit code to verify
-3. Save your 8 recovery codes in a safe place — they won't be shown again
-
-2FA is **mandatory** for managed hosting and cannot be disabled. You can optionally trust a device for 30 days to skip the code on future logins. Manage your 2FA settings (regenerate codes, revoke trusted devices) in **Settings → Two-Factor Auth**.
-
-### Password Reset
-
-If you forget your password, click **"Forgot password?"** on the login page. A reset link will be sent to the email address on your account (the one used during signup). The link expires after 1 hour.
-
-### Account Lockout
-
-After 5 failed login attempts, your account is locked for 15 minutes. When this happens:
-- You'll receive an email alert with the source IP address
-- The lockout screen shows a link to reset your password and contact support at **support@maestro.press**
-
-For the full security model, see the [Security Guide](https://github.com/kh0pper/crow/blob/main/SECURITY.md).
-
-## FAQ
-
-**Can I migrate to self-hosting later?**
-Yes. Your data can be exported and moved to a self-hosted instance at any time.
-
-**Can I use my own domain?**
-Custom domains are on the roadmap. For now, you get `username.crow.maestro.press`.
-
-**Is my data private?**
-Yes. Each managed instance has its own isolated database. Maestro Press does not access your data. See the [Security Guide](https://github.com/kh0pper/crow/blob/main/SECURITY.md) for details.
-
-**Can I monetize my blog or podcast?**
-Yes. Managed hosting includes public HTTPS URLs for your blog and podcast feeds — suitable for ad-supported content, paid subscriptions, and podcast directory submission. Self-hosted users can do this too, but need to set up a reverse proxy and custom domain (Tailscale Funnel is for personal/hobby use only).
-
-**What are the terms of service?**
-See the [Managed Hosting Terms of Service](/legal/managed-hosting-terms).
+A future managed instance will chain with a self-hosted one (always-on cloud access plus a home server for heavy processing) via [Multi-Device](./multi-device) — that mechanism works between any two instances today.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,14 +4,14 @@
 
 ## What v1 means
 
-Crow's version number stays at 0.x until all of the following are true:
+Crow was tagged **1.0.0 in July 2026**, when all of the following became true — each proven on a wiped scratch install, not asserted:
 
-- A newcomer on supported hardware reaches first value — a connected AI client using Crow's memory, or a working agent — within 30 minutes of starting the installer, without help from the maintainer.
-- CI defines what is mergeable: the full test suite runs on every pull request and every push to `main`, and a red run blocks merge for everyone.
+- A newcomer on supported hardware reaches first value — a connected AI client using Crow's memory, or a working agent — within 30 minutes of starting the installer, without help from the maintainer. (The timed walkthrough: under 2 minutes of interaction after the installer, zero terminal steps.)
+- CI defines what is mergeable: the full test suite runs on every pull request and every push to `main`, and a red run blocks merge for everyone, the maintainer included.
 - Every capability claim in the README and docs is demonstrably true on a fresh install, or explicitly labeled as planned.
 - The release is tagged 1.0.0.
 
-Everything aspirational — FERPA-specific tooling, education verticals, cloud web clients reaching self-hosted instances — is explicitly post-v1 or explicitly parked (see below).
+Everything aspirational — FERPA-specific tooling, education verticals — remains explicitly post-v1 or parked (see below).
 
 ## Shipped in 2026
 
@@ -24,13 +24,13 @@ The original 2026 roadmap on this page listed four education-focused milestones.
 - **Project spaces** — the shareable project redesign: membership, roles, per-member capability overrides, and an audit log.
 - **Engineering floor (July 2026)** — CI on every PR and push with branch protection that binds the maintainer too, a runtime database-migration guard with automatic backup and quarantine, and fleet auto-update that refuses to pull a red or unverified `main`.
 
-## Current focus: proving v1
+- **First value (July 2026)** — the setup wizard now carries a fresh install to a working AI: a curated **Model Catalog** with Hugging Face downloads (llama.cpp runtime, hardware-fit filtering — local-first, no cloud key required), starter memories that make the first conversation demonstrate recall, and the CLI post-install steps folded into the dashboard.
+- **Bot engine as an extension (July 2026)** — agent channels (Gmail, Discord) install their engine as a one-click bundle at the point of use instead of assuming a pre-provisioned machine; honest readiness states throughout.
 
-The active arc converts "works on the maintainer's fleet" into "works for a stranger":
+## Current focus: after v1
 
-- **Truth & identity** — reconcile every README/docs claim with reality (this page's rewrite is part of that work).
-- **First 30 minutes** — design work on reaching first value inside the setup wizard: a free-path AI provider quickstart, a guided first agent, and folding the remaining CLI post-install steps into the dashboard.
-- **Model catalog** — a curated local-model catalog with Hugging Face downloads (llama.cpp-first) instead of hardcoded model lists.
+- **Cloud web-client access** — claude.ai on the web, ChatGPT, and similar clients need a publicly reachable endpoint, which a private Crow deliberately does not expose today. A hardened opt-in path is the committed next arc, gated behind a dedicated security review (consent gate first). Until it ships, cloud web clients remain unsupported on self-hosted instances.
+- **Platform breadth** — the Windows path runs via WSL2 (documented; GPU currently falls back to CPU there — CUDA-in-WSL2 enablement is filed), and the macOS path predates the current wizard. Hardening both with real-hardware proof is next.
 
 ## Deliberately parked
 
@@ -38,7 +38,6 @@ These are conscious decisions, not TODOs:
 
 - **Education verticals (old Milestones 2–4)** — LMS course projects, Canvas backends, curriculum and institutional tooling. Parked until validated education users exist. The data-backend registry that would power them remains in place.
 - **FERPA enforcement** — Self-hosted Crow keeps data on infrastructure you control, which suits FERPA-sensitive contexts; Crow does not itself implement FERPA controls, and none are currently planned.
-- **Cloud web clients on self-hosted instances** — claude.ai on the web, ChatGPT, and similar clients require a publicly reachable endpoint, which a private Crow deliberately does not expose. Whether to offer a hardened public path is an open strategy decision, not a scheduled feature.
 - **Managed hosting** — not an active offering.
 - **crowdsec-firewall-bouncer bundle** — the one bundle from the 2026-04 MVP expansion that never shipped (upstream publishes no Docker image; a safe install needs the privileged-install consent gate plus a tested unwind path). Parked until that machinery has been exercised.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crow-platform",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crow-platform",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@libsql/client": "^0.17.2",
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crow-platform",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Self-hosted AI platform with persistent memory, encrypted P2P sharing, and 20+ integrations — works with Claude, ChatGPT, Gemini, and any MCP client",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Tags Crow 1.0.0 per the v1 Proving Arc exit review (2026-07-23). All exit criteria verified with fresh evidence:

- **First value in 30 minutes without help**: timed wiped-scratch walkthrough — under 2 minutes of interaction after the installer, zero terminal steps; local-AI free path (Model Catalog download → live completion) and bot-engine one-click install both acceptance-proven on wiped environments.
- **CI defines mergeable**: branch protection with `enforce_admins: true` and required contexts `suite`/`static-checks`/`audit`, verified live.
- **Every README claim true**: fresh top-to-bottom audit; the two cosmetic blemishes it found are fixed in this PR.

Changes:
- `package.json` / `package-lock.json`: 0.1.0 → 1.0.0
- `docs/roadmap.md`: "What v1 means" reflects criteria met; arc outcomes (Model Catalog, first-value wizard, bot-engine bundle) recorded as shipped; current focus now the post-v1 queue (cloud web-client access behind a dedicated security review, platform breadth)
- `docs/getting-started/managed-hosting.md`: trimmed to an honest reference page — banner kept, pricing/checkout/CTA removed while the offering is inactive
- `README.md`: Model Catalog capability row

After merge: tag `v1.0.0` on the merge commit + GitHub release.