### PR TITLE
knowledge-base panel: fix All-collections view and installed-copy db resolution

### DIFF
--- a/bundles/knowledge-base/panel/knowledge-base.js
+++ b/bundles/knowledge-base/panel/knowledge-base.js
@@ -65,19 +65,19 @@ export default {
 
     // ─── ARTICLES TAB ───
     if (tab === "articles") {
-      let articles = [];
-      if (activeCollectionId) {
-        const result = await db.execute({
-          sql: `SELECT a.id, a.title, a.slug, a.language, a.status, a.pair_id, a.tags,
-                a.updated_at, a.published_at, a.last_verified_at,
-                c.name AS collection_name
-                FROM kb_articles a JOIN kb_collections c ON a.collection_id = c.id
-                WHERE a.collection_id = ?
-                ORDER BY a.pair_id, a.language`,
-          args: [Number(activeCollectionId)],
-        });
-        articles = result.rows;
-      }
+      // No collection filter = all collections ("All" must never show an empty lie)
+      const filterSql = activeCollectionId ? "WHERE a.collection_id = ?" : "";
+      const filterArgs = activeCollectionId ? [Number(activeCollectionId)] : [];
+      const result = await db.execute({
+        sql: `SELECT a.id, a.title, a.slug, a.language, a.status, a.pair_id, a.tags,
+              a.updated_at, a.published_at, a.last_verified_at,
+              c.name AS collection_name
+              FROM kb_articles a JOIN kb_collections c ON a.collection_id = c.id
+              ${filterSql}
+              ORDER BY c.name, a.pair_id, a.language`,
+        args: filterArgs,
+      });
+      const articles = result.rows;
 
       // Group by pair_id for display
       const pairs = new Map();
@@ -97,7 +97,7 @@ export default {
           : '<span style="color:var(--crow-text-muted);font-size:0.8rem">Draft</span>';
         return `
           <tr>
-            <td><a href="/dashboard/knowledge-base?tab=edit&id=${primary.id}" style="color:var(--crow-text-primary)">${escapeHtml(primary.title)}</a></td>
+            <td><a href="/dashboard/knowledge-base?tab=edit&id=${primary.id}" style="color:var(--crow-text-primary)">${escapeHtml(primary.title)}</a>${!activeCollectionId ? `<div style="font-size:0.75rem;color:var(--crow-text-muted)">${escapeHtml(primary.collection_name || "")}</div>` : ""}</td>
             <td>${langBadges}</td>
             <td>${statusPill}</td>
             <td style="font-size:0.8rem;color:var(--crow-text-muted)">${primary.updated_at ? primary.updated_at.slice(0, 10) : ""}</td>

--- a/bundles/knowledge-base/panel/routes.js
+++ b/bundles/knowledge-base/panel/routes.js
@@ -6,18 +6,42 @@
  */
 
 import { Router } from "express";
-import { resolve, dirname } from "path";
+import { join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { pathToFileURL } from "url";
+import { homedir } from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-let createDbClient;
-try {
-  const dbMod = await import(pathToFileURL(resolve(__dirname, "../server/db.js")).href);
-  createDbClient = dbMod.createDbClient;
-} catch {
-  createDbClient = null;
+// The panel registry installs this file to <crow-home>/panels/, which breaks
+// bundle-relative imports. Resolve db.js from the installed bundle first, then
+// the dev layout, then fall back to a direct libsql client from env.
+async function loadCreateDbClient() {
+  const crowHome = process.env.CROW_HOME || join(homedir(), ".crow");
+  const candidates = [
+    join(crowHome, "bundles", "knowledge-base", "server", "db.js"),
+    resolve(__dirname, "../server/db.js"),
+  ];
+  for (const path of candidates) {
+    try {
+      const mod = await import(pathToFileURL(path).href);
+      if (mod.createDbClient) return mod.createDbClient;
+    } catch {
+      // try next candidate
+    }
+  }
+  try {
+    const { createClient } = await import("@libsql/client");
+    return (dbPath) => {
+      const filePath = dbPath || process.env.CROW_DB_PATH
+        || join(process.env.CROW_DATA_DIR || join(crowHome, "data"), "crow.db");
+      const client = createClient({ url: `file:${filePath}` });
+      client.execute("PRAGMA busy_timeout = 5000").catch(() => {});
+      return client;
+    };
+  } catch {
+    return null;
+  }
 }
 
 export default function kbDashboardRouter() {
@@ -25,7 +49,10 @@ export default function kbDashboardRouter() {
   let db;
 
   router.use(async (req, res, next) => {
-    if (!db && createDbClient) db = createDbClient();
+    if (!db) {
+      const createDbClient = await loadCreateDbClient();
+      if (createDbClient) db = createDbClient();
+    }
     if (!db) return res.status(500).json({ error: "Database not available" });
     next();
   });


### PR DESCRIPTION
Two defects that surface together the moment an instance has a second collection:

**1. All-collections view rendered an empty state over a populated database.** The articles tab only ran its query when a collection filter was active. With exactly one collection the filter auto-selected; with two or more, the default (All) view skipped the query entirely and showed "No articles yet." The query now runs unfiltered for All (ordered by collection, collection name shown under each title).

**2. Installed panel copies could not reach the database.** The panel registry installs panel files to `<crow-home>/panels/`, which breaks the bundle-relative `../server/db.js` import in `routes.js`. `createDbClient` silently became `null` and every `/api/kb/*` endpoint returned 500. Resolution now follows a candidate chain (installed bundle dir via `CROW_HOME`, then the dev-layout relative path) with a final inline `@libsql/client` fallback from `CROW_DB_PATH` — the same pattern the pm-workspace panel already uses for bundle imports.

Verified on a live instance with 2 collections / 13 articles: `/api/kb/articles` returns 200 with all rows from the installed location, and the All view renders both collections.