### PR TITLE
feature-mounts: honor CROW_HOME when mounting knowledge-base public routes

### DIFF
--- a/servers/gateway/boot/feature-mounts.js
+++ b/servers/gateway/boot/feature-mounts.js
@@ -127,7 +127,9 @@ export async function mountFeatureRoutes(app, deps) {
     const { join } = await import("node:path");
     const { pathToFileURL } = await import("node:url");
     const { homedir } = await import("node:os");
-    const installed = join(homedir(), ".crow", "bundles", "knowledge-base", "routes", "kb-public.js");
+    // Honor CROW_HOME so alternate instances mount their own installed copy
+    const crowHome = process.env.CROW_HOME || join(homedir(), ".crow");
+    const installed = join(crowHome, "bundles", "knowledge-base", "routes", "kb-public.js");
     // C3: re-anchored — boot/ is one level deeper, need ../../bundles
     const repo = join(__featureGatewayDir, "../../bundles/knowledge-base/routes/kb-public.js");
     const routesPath = existsSync(installed) ? installed : repo;


### PR DESCRIPTION
The installed-copy lookup for the knowledge-base public routes hardcoded `~/.crow`, so alternate instances (running with `CROW_HOME` pointed elsewhere) mounted the primary instance's installed copy — or fell back to the repo copy — instead of their own installed bundle. One-line fix following the same convention the panel registry already uses (`process.env.CROW_HOME || join(homedir(), ".crow")`).

No behavior change for default instances: with `CROW_HOME` unset the resolved path is identical.