### PR TITLE
docs: Node 20 → 22 sweep (EN+ES)

### DIFF
--- a/docs/architecture/crow-os.md
+++ b/docs/architecture/crow-os.md
@@ -81,7 +81,7 @@ All Crow data lives in `~/.crow/`, making the entire installation portable:
 `scripts/crow-install.sh` performs these steps:
 
 1. **System updates** — `apt update && apt upgrade`
-2. **Node.js 20** — via NodeSource repository
+2. **Node.js 22** — via NodeSource repository
 3. **Docker + Docker Compose** — official install script
 4. **Caddy** — reverse proxy with automatic TLS
 5. **Avahi** — mDNS for `crow.local` hostname

--- a/docs/es/architecture/crow-os.md
+++ b/docs/es/architecture/crow-os.md
@@ -82,7 +82,7 @@ Todos los datos de Crow viven en `~/.crow/`, lo que hace que la instalación com
 `scripts/crow-install.sh` realiza estos pasos:
 
 1. **Actualizaciones del sistema** — `apt update && apt upgrade`
-2. **Node.js 20** — vía el repositorio de NodeSource
+2. **Node.js 22** — vía el repositorio de NodeSource
 3. **Docker + Docker Compose** — script de instalación oficial
 4. **Caddy** — reverse proxy con TLS automático
 5. **Avahi** — mDNS para el hostname `crow.local`

--- a/docs/es/getting-started/desktop-install.md
+++ b/docs/es/getting-started/desktop-install.md
@@ -22,8 +22,8 @@ brew install node git
 ```
 
 ```bash [Linux (Ubuntu/Debian)]
-# Instalar Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Instalar Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt install -y nodejs git
 ```
 

--- a/docs/es/getting-started/google-cloud.md
+++ b/docs/es/getting-started/google-cloud.md
@@ -55,8 +55,8 @@ ssh your-username@<EXTERNAL_IP>
 ## Paso 4: Instala Crow
 
 ```bash
-# Instalar Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Instalar Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt-get install -y nodejs git
 
 # Clonar y configurar Crow

--- a/docs/es/getting-started/home-server.md
+++ b/docs/es/getting-started/home-server.md
@@ -36,7 +36,7 @@ bash crow-install.sh   # Ejecutarlo
 :::
 
 El instalador tarda 5-10 minutos y configura:
-- Node.js 20, Docker, Caddy, Avahi (mDNS)
+- Node.js 22, Docker, Caddy, Avahi (mDNS)
 - Plataforma Crow con base de datos SQLite local
 - Identidad criptográfica (Crow ID)
 - Servicio systemd para inicio automático

--- a/docs/es/getting-started/oracle-cloud.md
+++ b/docs/es/getting-started/oracle-cloud.md
@@ -49,8 +49,8 @@ ssh ubuntu@<tu-ip-publica>
 # Actualizar paquetes del sistema
 sudo apt update && sudo apt upgrade -y
 
-# Instalar Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Instalar Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt install -y nodejs git
 
 # Verificar

--- a/docs/es/getting-started/raspberry-pi.md
+++ b/docs/es/getting-started/raspberry-pi.md
@@ -56,7 +56,7 @@ bash crow-install.sh   # Ejecutarlo
 :::
 
 El instalador tarda 5-10 minutos y configura:
-- Node.js 20, Docker, Caddy, Avahi (mDNS)
+- Node.js 22, Docker, Caddy, Avahi (mDNS)
 - Plataforma Crow con base de datos SQLite
 - Identidad criptográfica (Crow ID)
 - Servicio systemd para inicio automático

--- a/docs/getting-started/desktop-install.md
+++ b/docs/getting-started/desktop-install.md
@@ -22,8 +22,8 @@ brew install node git
 ```
 
 ```bash [Linux (Ubuntu/Debian)]
-# Install Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Install Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt install -y nodejs git
 ```
 

--- a/docs/getting-started/google-cloud.md
+++ b/docs/getting-started/google-cloud.md
@@ -55,8 +55,8 @@ ssh your-username@<EXTERNAL_IP>
 ## Step 4: Install Crow
 
 ```bash
-# Install Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Install Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt-get install -y nodejs git
 
 # Clone and set up Crow

--- a/docs/getting-started/home-server.md
+++ b/docs/getting-started/home-server.md
@@ -40,7 +40,7 @@ bash crow-install.sh   # Run it
 :::
 
 The installer takes 5-10 minutes and sets up:
-- Node.js 20, Docker, Caddy, Avahi (mDNS)
+- Node.js 22, Docker, Caddy, Avahi (mDNS)
 - Crow platform with local SQLite database
 - Cryptographic identity (Crow ID)
 - systemd service for auto-start

--- a/docs/getting-started/oracle-cloud.md
+++ b/docs/getting-started/oracle-cloud.md
@@ -53,8 +53,8 @@ ssh ubuntu@<your-public-ip>
 # Update system packages
 sudo apt update && sudo apt upgrade -y
 
-# Install Node.js 20
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+# Install Node.js 22
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 sudo apt install -y nodejs git
 
 # Verify

--- a/docs/getting-started/raspberry-pi.md
+++ b/docs/getting-started/raspberry-pi.md
@@ -56,7 +56,7 @@ bash crow-install.sh   # Run it
 :::
 
 The installer takes 5-10 minutes and sets up:
-- Node.js 20, Docker, Caddy, Avahi (mDNS)
+- Node.js 22, Docker, Caddy, Avahi (mDNS)
 - Crow platform with SQLite database
 - Cryptographic identity (Crow ID)
 - systemd service for auto-start


### PR DESCRIPTION
Follow-up to #255: the getting-started pages (desktop, Oracle Cloud, Google Cloud, Raspberry Pi, home server) and the Crow OS architecture page still instructed strangers to install Node 20 / `setup_20.x`. Now that the installer provisions Node 22 and `engines` is ≥22.19.0, those were truth defects. Swept EN + ES. (The one remaining "Node.js 20+" hit is inside a sample user prompt in guide/customization.md — user example text, not a claim about Crow — left as is.)