### PR TITLE
ops: ed-jobs-scraper stack migrated to grackle

### DIFF
--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -62,6 +62,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 6080 | 127.0.0.1 | browser (noVNC, existing) — overridable via `CROW_BROWSER_VNC_PORT`; RFB 5900 via `CROW_BROWSER_RFB_PORT`, CDP 9222 via `CROW_BROWSER_CDP_PORT`. Secondary instances on one host pick +1 offsets (6081/5901/9223) | existing |
 | 6875 | 127.0.0.1 | bookstack (existing) | existing |
 | 8000 | 127.0.0.1 | paperless (existing) | existing |
+| 8002 | tailscale IP | ~~ed-jobs-scraper backend~~ — freed 2026-07-26 (stack migrated to grackle :8002) | external, freed |
 | 8004 | 127.0.0.1 | faster-whisper-server (local STT) | existing |
 | 8007 | 127.0.0.1 | llamacpp-cpu-qwen3-embed (CPU embeddings) | PR #111 |
 | 8080 | 127.0.0.1 | localai (existing) — **also nextcloud, conflict** | existing |
@@ -71,6 +72,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 8085 | 127.0.0.1 | miniflux (existing) | existing |
 | 8086 | 127.0.0.1 | shiori (existing) | existing |
 | 8088 | 127.0.0.1 | trilium (existing) | existing |
+| 8089 | 127.0.0.1 + tailscale IP | edjobs nominatim (external, ~/ed-jobs-scraper) — R4 GIS tools + grackle scraper stack (ufw-scoped) | external |
 | 8090 | 127.0.0.1 | capstone-tracker | shipped |
 | 8091 | 127.0.0.1 | crowdsec (LAPI) | MVP PR 4 |
 | 8092 | 127.0.0.1 | stirling-pdf | MVP PR 1 |

--- a/scripts/bots/sync_edjobs_to_candidates.mjs
+++ b/scripts/bots/sync_edjobs_to_candidates.mjs
@@ -286,11 +286,24 @@ function main() {
     }
   });
 
-  const child = spawn(
-    "docker",
-    ["exec", "-i", PG_CONTAINER, "psql", "-U", PG_USER, "-d", PG_DB, "-q", "-c", PG_COPY],
-    { stdio: ["ignore", "pipe", "pipe"] },
-  );
+  // The edjobs stack moved to grackle (2026-07-26): reach its postgres via
+  // ssh docker-exec. Set EDJOBS_PG_SSH_HOST="" to restore the local-container
+  // path (e.g. if the stack ever moves back).
+  const PG_SSH_HOST = process.env.EDJOBS_PG_SSH_HOST ?? "kh0pp@100.121.254.89";
+  const pgArgs = ["exec", "-i", PG_CONTAINER, "psql", "-U", PG_USER, "-d", PG_DB, "-q", "-c"];
+  const shellQuote = (s) => `'${s.replace(/'/g, `'\\''`)}'`;
+  const child = PG_SSH_HOST
+    ? spawn(
+        "ssh",
+        ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15", PG_SSH_HOST,
+         ["docker", ...pgArgs].join(" ") + " " + shellQuote(PG_COPY)],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      )
+    : spawn(
+        "docker",
+        [...pgArgs, PG_COPY],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
 
   let stderr = "";
   child.stdout.setEncoding("utf8");
@@ -301,7 +314,7 @@ function main() {
   });
 
   child.on("error", (err) => {
-    console.error(`[sync-edjobs] failed to spawn docker: ${err.message}`);
+    console.error(`[sync-edjobs] failed to spawn docker/ssh: ${err.message}`);
     db.close();
     process.exit(1);
   });


### PR DESCRIPTION
The edjobs compose stack (backend, celery workers/beat, postgres, redis) now runs on grackle (100.121.254.89:8002); nominatim stays on crow :8089 (17GB volume + R4 GIS dependency) with a tailnet binding ufw-scoped to grackle.

- sync_edjobs_to_candidates.mjs reaches grackle's postgres over ssh docker-exec (EDJOBS_PG_SSH_HOST override; empty string restores the local-container path)
- Verified live: dry-run + real run — 27,182 postings fetched, 10,058 candidates updated
- Port registry: crow 8002 freed, 8089 documented (external, dual-bound, ufw-scoped)
- Crow-side containers stopped with restart=no; volumes kept as backup