### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Crow
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fkh0pper%2Fcrow.svg)](https://mcptoplist.com/server/glama%2Fkh0pper%2Fcrow)
+
 [![Tests](https://github.com/kh0pper/crow/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/kh0pper/crow/actions/workflows/test.yml)
 
 Crow is a modular, agentic framework and MCP platform that integrates with the services and AI tools you already use — run on hardware you own, with local or cloud models. It brings persistent memory, research, agents, P2P sharing, and a full self-hosted app ecosystem into one private interface that your AI clients can reach natively.


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **Crow** is currently ranked **#737**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fkh0pper%2Fcrow.svg)](https://mcptoplist.com/server/glama%2Fkh0pper%2Fcrow)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Crow!
