### PR TITLE
Gateway: env-configurable rate-limit skip prefixes for shared-NAT deployments

### DIFF
--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -325,7 +325,13 @@ app.use(cors({
   credentials: true,
 }));
 
-// Rate limiting — general (skip for --no-auth since it's a local-only bridge)
+// Rate limiting — general (skip for --no-auth since it's a local-only bridge).
+// GATEWAY_RATE_LIMIT_SKIP_PREFIXES: comma-separated extra path prefixes exempted
+// from the general limiter, for deployments where many clients share one NAT IP
+// behind an already-allowlisted reverse proxy (per-IP buckets collapse to a
+// single shared bucket there).
+const rateLimitSkipPrefixes = (process.env.GATEWAY_RATE_LIMIT_SKIP_PREFIXES || "")
+  .split(",").map((s) => s.trim()).filter(Boolean);
 if (!noAuth) {
   app.use(rateLimit({
     windowMs: 15 * 60 * 1000,
@@ -333,7 +339,8 @@ if (!noAuth) {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: "Too many requests, please try again later" },
-    skip: (req) => req.path.startsWith("/dashboard") || req.path.startsWith("/api/meta-glasses/") || req.path.startsWith("/llm"),
+    skip: (req) => req.path.startsWith("/dashboard") || req.path.startsWith("/api/meta-glasses/") || req.path.startsWith("/llm")
+      || rateLimitSkipPrefixes.some((p) => req.path.startsWith(p)),
   }));
 }
 


### PR DESCRIPTION
The gateway general limiter keys per IP (200 req / 15 min). Where many clients share one NAT egress IP and arrive through an allowlisted reverse proxy, every client lands in the same bucket, and a burst of legitimate traffic 429s everyone at once (observed live: a training room of phones first-loading a public surface exhausted the shared bucket in seconds).

Adds GATEWAY_RATE_LIMIT_SKIP_PREFIXES: comma-separated extra path prefixes the general limiter skips, alongside the existing hardcoded skips. Default unset; behavior unchanged unless a deployment opts in. Auth and dashboard limiters untouched.

Verified live on the affected deployment: 300 consecutive burst requests to an exempted surface return 200; non-exempted paths keep existing limits.