### PR TITLE
fix(pm-workspace): reserve digest row before sending email

### DIFF
--- a/bundles/pm-workspace/server/digest/index.js
+++ b/bundles/pm-workspace/server/digest/index.js
@@ -103,6 +103,17 @@ export async function runDigest(db, config, { force = false } = {}) {
     digest.sections.map((s) => ({ title: s.title, available: s.available, reason: s.reason || null }))
   );
 
+  // Reserve today's row BEFORE sending: the cron's only resend gate is this row's
+  // existence, so a post-send write failure would mean a resend on every tick.
+  // If the reservation can't be written, skip sending entirely.
+  if (existing.rows.length === 0) {
+    await db.execute({
+      sql: `INSERT INTO pm_digests (digest_date, html, summary, sources_json, sent_at, sent_via)
+            VALUES (?, ?, ?, ?, NULL, NULL)`,
+      args: [date, rendered.html, rendered.summary, sourcesJson],
+    });
+  }
+
   let sentAt = null;
   let sentVia = null;
   let sendError = null;
@@ -124,18 +135,10 @@ export async function runDigest(db, config, { force = false } = {}) {
   const ntfy = await notifyNtfy(config, rendered.summary, date);
   if (ntfy.sent) sentVia = sentVia ? `${sentVia}+ntfy` : "ntfy";
 
-  if (existing.rows.length > 0) {
-    await db.execute({
-      sql: `UPDATE pm_digests SET html = ?, summary = ?, sources_json = ?, sent_at = ?, sent_via = ? WHERE digest_date = ?`,
-      args: [rendered.html, rendered.summary, sourcesJson, sentAt, sentVia, date],
-    });
-  } else {
-    await db.execute({
-      sql: `INSERT INTO pm_digests (digest_date, html, summary, sources_json, sent_at, sent_via)
-            VALUES (?, ?, ?, ?, ?, ?)`,
-      args: [date, rendered.html, rendered.summary, sourcesJson, sentAt, sentVia],
-    });
-  }
+  await db.execute({
+    sql: `UPDATE pm_digests SET html = ?, summary = ?, sources_json = ?, sent_at = ?, sent_via = ? WHERE digest_date = ?`,
+    args: [rendered.html, rendered.summary, sourcesJson, sentAt, sentVia, date],
+  });
 
   return {
     ok: true,


### PR DESCRIPTION
The digest cron's only resend gate is the existence of today's `pm_digests` row, which was written **after** the SMTP send. Any failure of that write (seen in the wild 2026-08-04 as `SQLITE_CORRUPT` after DB page damage in the `pm_digests` table) meant the email went out on **every 60-second tick** — 57 copies before intervention.

**Change:** insert the row (`sent_at` NULL) before sending, update it with send status after. If the reservation write fails, the run aborts without sending — worst case becomes a missed digest instead of a resend storm. The `UNIQUE` constraint on `digest_date` also dedupes concurrent runs.

**Tested:** one-off flow test against a temp libsql DB — (1) normal run writes exactly one row with html; (2) same-day rerun skips; (3) simulated `SQLITE_CORRUPT` on the reservation INSERT throws before any send path and leaves zero rows.