### PR TITLE
fix(db): one SQLite implementation per process — eliminate in-gateway @libsql

### DIFF
--- a/bundles/campaigns/server/app-root.js
+++ b/bundles/campaigns/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/campaigns/server/db.js
+++ b/bundles/campaigns/server/db.js
@@ -5,7 +5,7 @@
  * Enables foreign keys for cascading deletes.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync } from "fs";
 import { resolve } from "path";
 
@@ -25,14 +25,59 @@ export function resolveDataDir() {
   return resolve(home || ".", "data");
 }
 
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[campaigns db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[campaigns db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
+// Lazy @libsql fallback: never statically load a second SQLite build into a
+// process that may already hold better-sqlite3 connections (see app-root.js
+// header — 2026-08-04 corruption root cause).
+function libsqlProxy(filePath, extraPragmas = []) {
+  const clientPromise = import("@libsql/client").then(({ createClient }) => {
+    const client = createClient({ url: `file:${filePath}` });
+    for (const p of ["PRAGMA busy_timeout = 5000", ...extraPragmas]) {
+      client.execute(p).catch(err => console.warn("[campaigns db]", p, "failed:", err.message));
+    }
+    return client;
+  });
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
+}
+
 export function createDbClient(dbPath) {
   const filePath = dbPath || process.env.CROW_DB_PATH || resolve(resolveDataDir(), "crow.db");
-  const client = createClient({ url: `file:${filePath}` });
-  client.execute("PRAGMA busy_timeout = 5000").catch(err =>
-    console.warn("[campaigns-db] Failed to set busy_timeout:", err.message)
-  );
-  client.execute("PRAGMA foreign_keys = ON").catch(err =>
-    console.warn("[campaigns-db] Failed to enable foreign_keys:", err.message)
-  );
-  return client;
+  const core = tryCoreClient(filePath);
+  if (core) {
+    core.execute("PRAGMA foreign_keys = ON").catch(err =>
+      console.warn("[campaigns-db] Failed to enable foreign_keys:", err.message)
+    );
+    return core;
+  }
+  return libsqlProxy(filePath, ["PRAGMA foreign_keys = ON"]);
 }

--- a/bundles/iptv/server/app-root.js
+++ b/bundles/iptv/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/iptv/server/db.js
+++ b/bundles/iptv/server/db.js
@@ -6,7 +6,7 @@
  * Subset of servers/db.js — excludes verifyDb, auditLog, isSqliteVecAvailable.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -32,11 +32,54 @@ export function resolveDataDir() {
   return resolve(home || ".", "data");
 }
 
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[iptv db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[iptv db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
+// Lazy @libsql fallback: never statically load a second SQLite build into a
+// process that may already hold better-sqlite3 connections (see app-root.js
+// header — 2026-08-04 corruption root cause).
+function libsqlProxy(filePath, extraPragmas = []) {
+  const clientPromise = import("@libsql/client").then(({ createClient }) => {
+    const client = createClient({ url: `file:${filePath}` });
+    for (const p of ["PRAGMA busy_timeout = 5000", ...extraPragmas]) {
+      client.execute(p).catch(err => console.warn("[iptv db]", p, "failed:", err.message));
+    }
+    return client;
+  });
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
+}
+
 export function createDbClient(dbPath) {
   const filePath = dbPath || process.env.CROW_DB_PATH || resolve(resolveDataDir(), "crow.db");
-  const client = createClient({ url: `file:${filePath}` });
-  client.execute("PRAGMA busy_timeout = 5000").catch(err =>
-    console.warn("[db] Failed to set busy_timeout:", err.message)
-  );
-  return client;
+  const core = tryCoreClient(filePath);
+  if (core) return core;
+  return libsqlProxy(filePath);
 }

--- a/bundles/knowledge-base/panel/routes.js
+++ b/bundles/knowledge-base/panel/routes.js
@@ -15,13 +15,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // The panel registry installs this file to <crow-home>/panels/, which breaks
 // bundle-relative imports. Resolve db.js from the installed bundle first, then
-// the dev layout, then fall back to a direct libsql client from env.
+// the dev layout, then the core repo's shared client directly.
+//
+// NEVER fall back to a raw @libsql/client here: this file runs INSIDE the
+// gateway process, which already holds better-sqlite3 connections. A second
+// SQLite implementation in the same PID defeats last-closer detection (POSIX
+// locks never conflict within one process) and unlinks the live WAL —
+// the 2026-08-04 crow.db corruption root cause. Failing to find a safe
+// client must fail the panel, not corrupt the database.
 async function loadCreateDbClient() {
   const crowHome = process.env.CROW_HOME || join(homedir(), ".crow");
   const candidates = [
     join(crowHome, "bundles", "knowledge-base", "server", "db.js"),
     resolve(__dirname, "../server/db.js"),
-  ];
+    process.env.CROW_APP_ROOT && join(process.env.CROW_APP_ROOT, "servers", "db.js"),
+    join(homedir(), "crow", "servers", "db.js"),
+  ].filter(Boolean);
   for (const path of candidates) {
     try {
       const mod = await import(pathToFileURL(path).href);
@@ -30,18 +39,8 @@ async function loadCreateDbClient() {
       // try next candidate
     }
   }
-  try {
-    const { createClient } = await import("@libsql/client");
-    return (dbPath) => {
-      const filePath = dbPath || process.env.CROW_DB_PATH
-        || join(process.env.CROW_DATA_DIR || join(crowHome, "data"), "crow.db");
-      const client = createClient({ url: `file:${filePath}` });
-      client.execute("PRAGMA busy_timeout = 5000").catch(() => {});
-      return client;
-    };
-  } catch {
-    return null;
-  }
+  console.error("[knowledge-base panel] no safe DB client available (core db.js unresolvable) — panel DB routes disabled");
+  return null;
 }
 
 export default function kbDashboardRouter() {

--- a/bundles/knowledge-base/server/app-root.js
+++ b/bundles/knowledge-base/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/knowledge-base/server/db.js
+++ b/bundles/knowledge-base/server/db.js
@@ -1,12 +1,19 @@
 /**
  * Crow Database Client Factory (Bundle Edition)
  *
- * Creates a @libsql/client instance for local SQLite files.
+ * Delegates to the core repo's better-sqlite3 client (libsql-shaped surface).
+ * One SQLite implementation per process is a CORRECTNESS requirement: this
+ * module is imported into the gateway process by panel/routes.js, and a
+ * second SQLite build (@libsql) opening crow.db there defeats last-closer
+ * detection and unlinks the live WAL (see app-root.js header — 2026-08-04
+ * corruption root cause). @libsql remains only as a LAZY fallback for
+ * standalone contexts where the core client cannot load; cross-process
+ * libsql is lock-safe, in-process mixing is not.
  *
  * Subset of servers/db.js — excludes verifyDb, auditLog, isSqliteVecAvailable.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -64,11 +71,48 @@ export function resolveDataDir() {
   return resolve(home || ".", "data");
 }
 
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[knowledge-base db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[knowledge-base db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
 export function createDbClient(dbPath) {
   const filePath = dbPath || process.env.CROW_DB_PATH || resolve(resolveDataDir(), "crow.db");
-  const client = createClient({ url: `file:${filePath}` });
-  client.execute("PRAGMA busy_timeout = 5000").catch(err =>
-    console.warn("[db] Failed to set busy_timeout:", err.message)
-  );
-  return client;
+  const core = tryCoreClient(filePath);
+  if (core) return core;
+  // Lazy fallback: never statically load a second SQLite build.
+  const clientPromise = import("@libsql/client").then(({ createClient }) => {
+    const client = createClient({ url: `file:${filePath}` });
+    client.execute("PRAGMA busy_timeout = 5000").catch(err =>
+      console.warn("[db] Failed to set busy_timeout:", err.message)
+    );
+    return client;
+  });
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
 }

--- a/bundles/media/server/app-root.js
+++ b/bundles/media/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/media/server/db.js
+++ b/bundles/media/server/db.js
@@ -6,7 +6,7 @@
  * Subset of servers/db.js — excludes verifyDb, auditLog, isSqliteVecAvailable.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -87,11 +87,54 @@ export async function ensureColumn(db, table, column, type) {
   }
 }
 
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[media db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[media db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
+// Lazy @libsql fallback: never statically load a second SQLite build into a
+// process that may already hold better-sqlite3 connections (see app-root.js
+// header — 2026-08-04 corruption root cause).
+function libsqlProxy(filePath, extraPragmas = []) {
+  const clientPromise = import("@libsql/client").then(({ createClient }) => {
+    const client = createClient({ url: `file:${filePath}` });
+    for (const p of ["PRAGMA busy_timeout = 5000", ...extraPragmas]) {
+      client.execute(p).catch(err => console.warn("[media db]", p, "failed:", err.message));
+    }
+    return client;
+  });
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
+}
+
 export function createDbClient(dbPath) {
   const filePath = dbPath || process.env.CROW_DB_PATH || resolve(resolveDataDir(), "crow.db");
-  const client = createClient({ url: `file:${filePath}` });
-  client.execute("PRAGMA busy_timeout = 5000").catch(err =>
-    console.warn("[db] Failed to set busy_timeout:", err.message)
-  );
-  return client;
+  const core = tryCoreClient(filePath);
+  if (core) return core;
+  return libsqlProxy(filePath);
 }

--- a/bundles/pm-workspace/server/app-root.js
+++ b/bundles/pm-workspace/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/pm-workspace/server/db.js
+++ b/bundles/pm-workspace/server/db.js
@@ -11,7 +11,7 @@
  * are always literal-term safe.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync } from "node:fs";
 import { resolve, join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -68,14 +68,77 @@ export function resolveDbPath(dbPath) {
   return dbPath || process.env.CROW_DB_PATH || join(resolveDataDir(), "crow.db");
 }
 
-/** Create a libsql client for the main crow DB. */
-export function createDbClient(dbPath) {
-  const filePath = resolveDbPath(dbPath);
+/**
+ * Shared better-sqlite3 client factory from the core repo (libsql-shaped
+ * surface: execute/batch/executeMultiple/close). Loaded once at module init.
+ *
+ * A single SQLite implementation per process is a CORRECTNESS requirement,
+ * not a preference: this module is imported into the gateway process by the
+ * panel routes, and a second SQLite build (@libsql) opening crow.db there
+ * defeats last-closer detection and unlinks the live WAL (see app-root.js
+ * header — 2026-08-04 corruption root cause).
+ *
+ * Fallback: only when the core client cannot load (standalone install with
+ * no repo checkout, or a node whose ABI can't load the repo's
+ * better-sqlite3 — e.g. an externally spawned stdio MCP copy on an older
+ * node). @libsql is imported LAZILY there so gateway-hosted code never even
+ * maps the second SQLite library. Cross-process libsql is lock-safe; only
+ * in-process mixing is not, and in-process always resolves the core client.
+ */
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[pm-workspace db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[pm-workspace db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
+async function libsqlClient(filePath, label) {
+  const { createClient } = await import("@libsql/client");
   const client = createClient({ url: `file:${filePath}` });
   client.execute("PRAGMA busy_timeout = 10000").catch((err) =>
-    console.warn("[pm-workspace db] Failed to set busy_timeout:", err.message)
+    console.warn(`[pm-workspace db] ${label} busy_timeout:`, err.message)
   );
   return client;
+}
+
+/** Create a client for the main crow DB (core better-sqlite3 wrapper). */
+export function createDbClient(dbPath) {
+  const filePath = resolveDbPath(dbPath);
+  return tryCoreClient(filePath) || libsqlProxy(filePath, "crow.db");
+}
+
+/**
+ * Wrap the async libsql fallback in a lazily-resolving proxy so the factory
+ * keeps its synchronous signature. Every method awaits the underlying
+ * client's creation first.
+ */
+function libsqlProxy(filePath, label) {
+  const clientPromise = libsqlClient(filePath, label);
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
 }
 
 /** Resolve the kanban tasks DB path (tasks bundle). */
@@ -87,13 +150,9 @@ export function resolveTasksDbPath(config = {}) {
   );
 }
 
-/** Create a libsql client for the tasks DB. Returns null if the file is absent. */
+/** Create a client for the tasks DB. Returns null if the file is absent. */
 export function createTasksDbClient(config = {}) {
   const filePath = resolveTasksDbPath(config);
   if (!existsSync(filePath)) return null;
-  const client = createClient({ url: `file:${filePath}` });
-  client.execute("PRAGMA busy_timeout = 10000").catch((err) =>
-    console.warn("[pm-workspace db] tasks.db busy_timeout:", err.message)
-  );
-  return client;
+  return tryCoreClient(filePath) || libsqlProxy(filePath, "tasks.db");
 }

--- a/bundles/tax/server/app-root.js
+++ b/bundles/tax/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/tax/server/db.js
+++ b/bundles/tax/server/db.js
@@ -4,7 +4,7 @@
  * Reuses the standard Crow DB pattern.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,11 +25,54 @@ function resolveDataDir() {
   return resolve(home || ".", "data");
 }
 
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[tax db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[tax db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
+// Lazy @libsql fallback: never statically load a second SQLite build into a
+// process that may already hold better-sqlite3 connections (see app-root.js
+// header — 2026-08-04 corruption root cause).
+function libsqlProxy(filePath, extraPragmas = []) {
+  const clientPromise = import("@libsql/client").then(({ createClient }) => {
+    const client = createClient({ url: `file:${filePath}` });
+    for (const p of ["PRAGMA busy_timeout = 5000", ...extraPragmas]) {
+      client.execute(p).catch(err => console.warn("[tax db]", p, "failed:", err.message));
+    }
+    return client;
+  });
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
+}
+
 export function createDbClient(dbPath) {
   const filePath = dbPath || process.env.CROW_TAX_DB_PATH || process.env.CROW_DB_PATH || resolve(resolveDataDir(), "crow.db");
-  const client = createClient({ url: `file:${filePath}` });
-  client.execute("PRAGMA busy_timeout = 5000").catch(err =>
-    console.warn("[db] Failed to set busy_timeout:", err.message)
-  );
-  return client;
+  const core = tryCoreClient(filePath);
+  if (core) return core;
+  return libsqlProxy(filePath);
 }

--- a/servers/db.js
+++ b/servers/db.js
@@ -24,7 +24,7 @@
 
 import Database from "better-sqlite3";
 import os from "node:os";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -299,6 +299,66 @@ export function resolveJournalMode() {
 
 export const _dbKeepers = new Map();
 
+/* ------------------------------------------------------- WAL tripwire */
+
+/**
+ * WAL-generation tripwire. While this process holds live connections, the
+ * -wal file's inode must NEVER change: SQLite only replaces it via
+ * unlink+recreate, which orphans every already-attached connection (they
+ * keep writing through the old, deleted generation — no mutual exclusion
+ * with the new one → torn multi-page commits → "database disk image is
+ * malformed"). That is exactly the 2026-08-04 corruption mechanism (a
+ * second in-process SQLite build, @libsql via panel routes, unlinked the
+ * live WAL: POSIX locks never conflict within one PID, so its last-closer
+ * check "won" against our own connections).
+ *
+ * The tripwire stats the -wal path on an interval and screams into the
+ * journal on an inode change, turning the next silent generation split
+ * into a diagnosable event within seconds instead of a corrupt DB an hour
+ * later. Detection only — no automatic restart.
+ *
+ * CROW_WAL_TRIPWIRE_MS overrides the interval (default 30000; 0 disables).
+ */
+export const _walTripwires = new Map(); // filePath → {baselineIno, trips, timer}
+
+export function checkWalCoherence(filePath) {
+  const tw = _walTripwires.get(filePath);
+  if (!tw) return { armed: false };
+  let currentIno = null;
+  try { currentIno = statSync(filePath + "-wal").ino; } catch { /* missing */ }
+  if (tw.baselineIno === null && currentIno !== null) {
+    // WAL appeared after arming (first real write) — adopt it as baseline.
+    tw.baselineIno = currentIno;
+  }
+  const ok = tw.baselineIno === null || currentIno === tw.baselineIno;
+  return { armed: true, ok, baselineIno: tw.baselineIno, currentIno };
+}
+
+function armWalTripwire(filePath) {
+  if (_walTripwires.has(filePath)) return;
+  const intervalMs = Number(process.env.CROW_WAL_TRIPWIRE_MS ?? 30000);
+  if (!intervalMs) return;
+  let baselineIno = null;
+  try { baselineIno = statSync(filePath + "-wal").ino; } catch { /* not yet */ }
+  const tw = { baselineIno, trips: 0, timer: null };
+  _walTripwires.set(filePath, tw);
+  tw.timer = setInterval(() => {
+    const res = checkWalCoherence(filePath);
+    if (res.armed && !res.ok) {
+      tw.trips += 1;
+      console.error(
+        `[db] WAL GENERATION SPLIT DETECTED for ${filePath}: -wal inode changed ` +
+        `${res.baselineIno} -> ${res.currentIno ?? "(missing)"} while this process holds ` +
+        `connections. Connections in this process may now write through a dead WAL and ` +
+        `CORRUPT the database. Restart this service and find the unlinker ` +
+        `(strace -f -e unlink,unlinkat). See servers/db.js WAL tripwire notes.`
+      );
+      tw.baselineIno = res.currentIno; // re-baseline so a further split logs again
+    }
+  }, intervalMs);
+  tw.timer.unref?.();
+}
+
 /**
  * Ensure a WAL-mode keeper handle exists for filePath.
  *
@@ -321,6 +381,7 @@ function ensureKeeper(filePath, requestedMode) {
   if (typeof actualMode === "string" && actualMode.toLowerCase() === "wal") {
     try { keeper.pragma("busy_timeout = 30000"); } catch {}
     _dbKeepers.set(filePath, keeper);
+    armWalTripwire(filePath);
   } else {
     // Non-WAL or unreadable — close without registering.
     try { keeper.close(); } catch {}

--- a/servers/gateway/dashboard/auth.js
+++ b/servers/gateway/dashboard/auth.js
@@ -251,13 +251,27 @@ export async function attemptLogin(password, ip) {
           }
         }
       }
-      await setLockout(db, ip, a);
+      // Best-effort: lockout bookkeeping must never take the gateway down.
+      // A DB-layer error here (2026-08-03: SQLITE_IOERR_SHORT_READ from a
+      // stale in-process WAL index) previously escaped as an unhandled
+      // rejection, crashed the gateway on every login POST, and the
+      // resulting crash-restart churn corrupted crow.db.
+      try {
+        await setLockout(db, ip, a);
+      } catch (err) {
+        console.error("[auth] setLockout failed (continuing):", err.message);
+      }
       await auditLog(db, 'auth_login_failure', { ip });
       return { error: "Invalid password." };
     }
 
-    // Reset attempts on success + clean expired lockouts
-    await clearLockout(db, ip);
+    // Reset attempts on success + clean expired lockouts (best-effort, same
+    // never-crash rule as setLockout above).
+    try {
+      await clearLockout(db, ip);
+    } catch (err) {
+      console.error("[auth] clearLockout failed (continuing):", err.message);
+    }
 
     // Check if 2FA is enabled
     const twoFaEnabled = await is2faEnabled();
@@ -286,6 +300,12 @@ export async function attemptLogin(password, ip) {
     });
 
     return { token };
+  } catch (err) {
+    // Never let a DB-layer failure escape as an unhandled rejection — the
+    // 2026-08-03 incident showed that crashing here puts systemd into a
+    // crash-restart loop whose overlapping boots corrupt crow.db.
+    console.error("[auth] attemptLogin database failure (returning soft error):", err.message);
+    return { error: "Login temporarily unavailable (server database error). Check gateway logs." };
   } finally {
     db.close();
   }

--- a/tests/bundle-db-single-sqlite.test.js
+++ b/tests/bundle-db-single-sqlite.test.js
@@ -1,0 +1,69 @@
+/**
+ * Single-SQLite-per-process invariant for bundle DB factories.
+ *
+ * 2026-08-04 root cause: bundle code imported @libsql/client (a second
+ * SQLite build) into the gateway process alongside better-sqlite3. POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "won" its last-closer check against the gateway's own connections and
+ * unlinked the live crow.db-wal/-shm — splitting WAL generations and
+ * corrupting the database (r4 x3, main x4 incidents).
+ *
+ * Guards:
+ *  1. No bundle db factory (or the knowledge-base panel routes, which run
+ *     INSIDE the gateway) may STATICALLY import @libsql/client — only a
+ *     lazy dynamic import inside an explicit fallback is allowed.
+ *  2. In-repo, every bundle factory must resolve the core better-sqlite3
+ *     client and round-trip through it without loading @libsql.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const FACTORY_FILES = [
+  "bundles/pm-workspace/server/db.js",
+  "bundles/knowledge-base/server/db.js",
+  "bundles/knowledge-base/panel/routes.js",
+  "bundles/maker-lab/server/db.js",
+  "bundles/tax/server/db.js",
+  "bundles/media/server/db.js",
+  "bundles/campaigns/server/db.js",
+  "bundles/iptv/server/db.js",
+];
+
+test("no static @libsql/client import in bundle db factories or in-gateway panel routes", () => {
+  for (const rel of FACTORY_FILES) {
+    const src = readFileSync(join(repo, rel), "utf8");
+    assert.ok(
+      !/^\s*import\s+[^;]*from\s+["']@libsql\/client["']/m.test(src),
+      `${rel} must not statically import @libsql/client (second SQLite build in-process unlinks the live WAL)`
+    );
+  }
+});
+
+test("knowledge-base panel routes have no @libsql fallback at all (gateway-resident)", () => {
+  const src = readFileSync(join(repo, "bundles/knowledge-base/panel/routes.js"), "utf8");
+  assert.ok(
+    !/import\s*\(\s*["']@libsql\/client["']\s*\)/.test(src) &&
+    !/from\s+["']@libsql\/client["']/.test(src),
+    "panel routes run inside the gateway; no libsql import path may exist (comments are fine)"
+  );
+});
+
+for (const bundle of ["pm-workspace", "knowledge-base", "tax", "media", "campaigns", "iptv"]) {
+  test(`${bundle} factory resolves the core client and round-trips in-repo`, async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), `crow-bundledb-${bundle}-`));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    const mod = await import(`../bundles/${bundle}/server/db.js`);
+    const db = mod.createDbClient(join(dir, "t.db"));
+    await db.execute("CREATE TABLE roundtrip (id INTEGER PRIMARY KEY, v TEXT)");
+    await db.execute({ sql: "INSERT INTO roundtrip (v) VALUES (?)", args: ["x"] });
+    const r = await db.execute("SELECT count(*) AS c FROM roundtrip");
+    assert.equal(Number(r.rows[0].c), 1);
+    db.close();
+  });
+}

--- a/tests/db-wal-tripwire.test.js
+++ b/tests/db-wal-tripwire.test.js
@@ -1,0 +1,65 @@
+/**
+ * WAL-generation tripwire (servers/db.js).
+ *
+ * While a process holds connections, the -wal inode must never change; a
+ * change means something unlinked the live WAL (the 2026-08-04 corruption
+ * mechanism). checkWalCoherence() must report ok while the inode is stable
+ * and !ok after an unlink+recreate.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, statSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.CROW_WAL_TRIPWIRE_MS = process.env.CROW_WAL_TRIPWIRE_MS || "30000";
+
+const { createDbClient, checkWalCoherence, _walTripwires } = await import("../servers/db.js");
+
+test("tripwire arms on WAL keeper and detects a wal inode swap", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "crow-tripwire-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const dbPath = join(dir, "trip.db");
+
+  const db = createDbClient(dbPath);
+  await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+  await db.execute({ sql: "INSERT INTO t (v) VALUES (?)", args: ["a"] });
+
+  assert.ok(existsSync(dbPath + "-wal"), "WAL file exists after a write");
+  const armed = checkWalCoherence(dbPath);
+  assert.equal(armed.armed, true, "tripwire armed for the keeper path");
+  assert.equal(armed.ok, true, "coherent while the wal inode is stable");
+  assert.equal(armed.baselineIno, statSync(dbPath + "-wal").ino);
+
+  // Simulate the failure: unlink + recreate the wal behind the process's back.
+  rmSync(dbPath + "-wal");
+  writeFileSync(dbPath + "-wal", "not a real wal");
+  const after = checkWalCoherence(dbPath);
+  assert.equal(after.armed, true);
+  assert.equal(after.ok, false, "inode swap must be detected");
+  assert.notEqual(after.currentIno, after.baselineIno);
+
+  db.close();
+});
+
+test("tripwire adopts a late-appearing wal as baseline", async () => {
+  // A keeper on a path whose wal is missing at arm time must adopt the
+  // first observed inode instead of tripping forever.
+  const dir = mkdtempSync(join(tmpdir(), "crow-tripwire2-"));
+  const dbPath = join(dir, "late.db");
+  const db = createDbClient(dbPath);
+  try {
+    // Force the recorded baseline to "missing" regardless of arm timing.
+    const tw = _walTripwires.get(dbPath);
+    if (tw) tw.baselineIno = null;
+    await db.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    await db.execute("INSERT INTO t DEFAULT VALUES");
+    const res = checkWalCoherence(dbPath);
+    assert.equal(res.armed, true);
+    assert.equal(res.ok, true, "first observed inode becomes the baseline");
+    assert.equal(res.baselineIno, statSync(dbPath + "-wal").ino);
+  } finally {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Root cause (recurring crow.db corruption: main ×4, r4 ×3 + the 2026-08-03 login-crash loop)

Bundle panel routes imported `@libsql/client` — a **second SQLite build** — into the gateway process alongside better-sqlite3. POSIX fcntl locks never conflict within one PID, so when a libsql connection closed, its "am I the last user?" check succeeded automatically against the gateway's own better-sqlite3 connections and it **unlinked the live `crow.db-wal`/`-shm`** (attributed by `strace -f -e unlink,unlinkat` during a controlled r4 boot: the gateway main PID unlinks shm then wal — SQLite's exact close order). Every already-attached connection then kept writing through the dead WAL generation with no mutual exclusion against the new generation → torn multi-page commits → `database disk image is malformed`. The same stale in-process shared WAL index made the first login write fail with `SQLITE_IOERR_SHORT_READ` — deterministically, and only in-gateway-process (CLI/standalone repros always passed).

Forensic confirmation on r4 (2026-08-04): 15 gateway fds on a deleted wal inode (a single unlink event at boot), last write into the deleted wal at 08:07:25 and into the deleted shm at 09:19:24 — bracketing the first `SQLITE_CORRUPT` at 09:15:30.

## Fix
- Bundle db factories (pm-workspace, knowledge-base, tax, media, campaigns, iptv) delegate to the core better-sqlite3 client via `app-root.js` (maker-lab's proven pattern). `@libsql` survives only as a **lazy** fallback for contexts that can't load the core client (checked at call time — better-sqlite3 binds its native module at construction, so an ABI mismatch throws there), where it's cross-process and lock-safe.
- knowledge-base panel routes (gateway-resident) lose the raw @libsql fallback entirely: no safe client → panel DB routes disabled, never corruption.
- `auth.js`: lockout writes best-effort + `attemptLogin` returns a soft error on DB failure — a DB error can no longer crash the gateway into the corrupting restart churn.
- `servers/db.js`: WAL-generation tripwire — keeper paths stat the `-wal` inode every 30s and log loudly on a generation split (`CROW_WAL_TRIPWIRE_MS`, 0 disables).
- Tests: static single-SQLite invariant, per-bundle factory round-trips (verified under node 22 and the node 20 fallback), tripwire detection.

Suite: 2853/2853 pass.

Follow-ups (not in this PR): data-dashboard/nominatim direct libsql use (child-process only, aux DBs), `recover-crow-db.mjs` bundle-table salvage gap + init-db seeded-row completeness false positive, nightly backup TARGETS gap (main instance never backed up).