### PR TITLE
fix(data-dashboard): route user-db opens through the core SQLite client

### DIFF
--- a/bundles/data-dashboard/server/app-root.js
+++ b/bundles/data-dashboard/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/data-dashboard/server/query-engine.js
+++ b/bundles/data-dashboard/server/query-engine.js
@@ -6,7 +6,7 @@
  * Write queries go through a separate path with explicit safety checks.
  */
 
-import { createClient } from "@libsql/client";
+import { appImport } from "./app-root.js";
 import { existsSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -30,8 +30,45 @@ export function getProjectDbDir(projectId) {
  * @param {string} dbPath - Absolute path to the .db file
  * @returns {import("@libsql/client").Client}
  */
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[data-dashboard db] core db client unavailable (${err.message}) -- ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch throws HERE, not at
+ *  import. A second SQLite build (@libsql) must NEVER load in-process next
+ *  to better-sqlite3 (see app-root.js header -- 2026-08-04 corruption root
+ *  cause), so @libsql is only a lazy fallback for standalone contexts. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[data-dashboard db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
 export function openUserDb(dbPath) {
-  return createClient({ url: `file:${dbPath}` });
+  const core = tryCoreClient(dbPath);
+  if (core) return core;
+  const clientPromise = import("@libsql/client").then(({ createClient }) =>
+    createClient({ url: `file:${dbPath}` })
+  );
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
 }
 
 /**

--- a/bundles/data-dashboard/server/server.js
+++ b/bundles/data-dashboard/server/server.js
@@ -201,7 +201,7 @@ export async function createDataDashboardServer(dbPath, options = {}) {
       }
 
       // Create empty database (libsql creates on first connect)
-      const userDb = (await import("@libsql/client")).createClient({ url: `file:${dbPath}` });
+      const userDb = (await import("./query-engine.js")).openUserDb(dbPath);
       await userDb.execute("SELECT 1"); // Force creation
       userDb.close();
 


### PR DESCRIPTION
Follow-up to #264: data-dashboard's query engine still imported `@libsql/client` statically, loading a second SQLite build into any process that mounts its panel (observed live on grackle's gateway and mcp-bridge after #264 deployed). Its user-project databases can also be held by core better-sqlite3 connections, so the same same-PID lock-blindness WAL-unlink hazard applies.

`openUserDb` now delegates to the core client via `app-root.js` with the same lazy, cross-process-safe `@libsql` fallback; `server.js` reuses `openUserDb` instead of its own inline libsql client.

Verified: round-trip under node 22 (core path) and node 20 (fallback path); single-sqlite + tripwire guard tests pass.