### PR TITLE
fix(bot-board): render custom trackers by tracker, not bot; guard live-reload storms

### DIFF
--- a/servers/gateway/dashboard/panels/bot-board/client.js
+++ b/servers/gateway/dashboard/panels/bot-board/client.js
@@ -724,7 +724,19 @@ export function clientJs(botId, trackerType, projectId, trackerSlug, contextFiel
           var newLocked=!!(d.locks&&d.locks[c.id]);
           if(!el || curStatus!==c.status || curLocked!==newLocked){ if(c.id!==busyId) changed=true; }
         });
-        if(changed && !document.hidden) reload();
+        // Reload-storm guard: if the rendered board can never converge with
+        // the stream snapshot (a render/stream query mismatch), an
+        // unconditional reload loops forever — each fresh page re-detects
+        // the same diff. One reload per 10s window; persisted across the
+        // reload it triggers.
+        if(changed && !document.hidden){
+          var now=Date.now(), lastReload=0;
+          try{ lastReload=Number(sessionStorage.getItem('bb-live-reload'))||0; }catch(e){}
+          if(now-lastReload>10000){
+            try{ sessionStorage.setItem('bb-live-reload',String(now)); }catch(e){}
+            reload();
+          }
+        }
       };
       es.onerror=function(){ /* EventSource auto-reconnects; server resends a full snapshot */ };
     }

--- a/servers/gateway/dashboard/panels/bot-board/html.js
+++ b/servers/gateway/dashboard/panels/bot-board/html.js
@@ -363,7 +363,12 @@ export async function renderCustomTracker(req, res, { db, layout, selBot, bots, 
     try { contextFields = JSON.parse(trackerDef.columns_json || "[]"); } catch { contextFields = []; }
   }
 
-  // Query tracker_items for this bot
+  // Query tracker_items for this tracker. The tracker is the unit of
+  // display: items written by external feeds (e.g. a mirror sync) carry
+  // bot_id NULL, and the live stream + bot-board-api already query by
+  // tracker alone — filtering by bot here rendered those boards empty
+  // while the stream kept reporting rows, which the client read as a
+  // permanent diff (reload loop).
   let items = [];
   try {
     items = (await db.execute({
@@ -371,8 +376,8 @@ export async function renderCustomTracker(req, res, { db, layout, selBot, bots, 
         "SELECT id, tracker_id, bot_id, status, priority, label, data_json, action_needed, " +
         "next_followup_date, processing_lease, processing_lease_status, " +
         "datetime(created_at) AS created_at, datetime(updated_at) AS updated_at " +
-        "FROM tracker_items WHERE bot_id=? AND tracker_id=? ORDER BY priority ASC, id ASC",
-      args: [selBot.botId, trackerDef.id],
+        "FROM tracker_items WHERE tracker_id=? ORDER BY priority ASC, id ASC",
+      args: [trackerDef.id],
     })).rows || [];
   } catch { items = []; }
 


### PR DESCRIPTION
`renderCustomTracker` filtered `tracker_items` by `bot_id AND tracker_id`, but items written by external feeds (mirror syncs) carry `bot_id NULL` — the board rendered empty while the live stream, which queries by tracker alone (`routes/streams.js`), kept reporting rows. The client treats any snapshot row missing from the DOM as a change and calls `reload()`, so the page reloaded every snapshot interval forever (~2 navigations/second observed via CDP).

Two changes:
- Query custom-tracker items by `tracker_id` only, matching the stream and bot-board-api.
- Rate-limit the live-overlay reload to one per 10s (sessionStorage-persisted) so any future render/stream mismatch degrades to a stale board instead of a reload storm.