### PR TITLE
pm-workspace: deterministic output scan (module + CLI) for bot-output pickup

### DIFF
--- a/bundles/pm-workspace/manifest.json
+++ b/bundles/pm-workspace/manifest.json
@@ -35,7 +35,8 @@
       "CROW_TASKS_DB_PATH",
       "PLANNER_DRIVE_FOLDER_ID",
       "PLANNER_CATEGORY",
-      "PLANNER_CRON"
+      "PLANNER_CRON",
+      "PM_SCAN_RULES_FILE"
     ]
   },
   "panel": "panel/pm-workspace.js",

--- a/bundles/pm-workspace/server/config.js
+++ b/bundles/pm-workspace/server/config.js
@@ -80,6 +80,7 @@ const KEYS = [
   "CROW_TASKS_DB_PATH",
   "CROW_DATA_DIR",
   "CROW_DB_PATH",
+  "PM_SCAN_RULES_FILE",
 ];
 
 /**

--- a/bundles/pm-workspace/server/output-scan-cli.js
+++ b/bundles/pm-workspace/server/output-scan-cli.js
@@ -1,0 +1,23 @@
+// CLI wrapper: exit 0 clean, 1 findings, 2 usage/error.
+import { loadRules, scanText, scanFiles } from "./output-scan.js";
+
+const args = process.argv.slice(2);
+const ri = args.indexOf("--rules");
+if (ri < 0 || !args[ri + 1]) { console.error("usage: output-scan-cli.js --rules FILE [--stdin] [files...]"); process.exit(2); }
+const rules = loadRules(args[ri + 1]);
+const files = args.filter((a, i) => i !== ri && i !== ri + 1 && a !== "--stdin");
+let total = 0;
+if (args.includes("--stdin")) {
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  const f = scanText(Buffer.concat(chunks).toString("utf8"), rules);
+  total += f.length;
+  for (const x of f) console.log(`stdin: ${x.name} (${x.severity}) at ${x.index}`);
+}
+const byFile = scanFiles(files, rules);
+for (const [p, f] of Object.entries(byFile)) {
+  total += f.length;
+  for (const x of f) console.log(`${p}: ${x.name} (${x.severity})${x.index != null ? " at " + x.index : ""}`);
+}
+console.log(total === 0 ? "CLEAN" : `FINDINGS: ${total}`);
+process.exit(total === 0 ? 0 : 1);

--- a/bundles/pm-workspace/server/output-scan.js
+++ b/bundles/pm-workspace/server/output-scan.js
@@ -1,0 +1,55 @@
+// Deterministic secret/PII scan over bot output. Pure functions; the rules
+// file is operator-supplied (PM_SCAN_RULES_FILE) and never ships in the repo.
+import { readFileSync, statSync } from "node:fs";
+
+export function loadRules(path) {
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  const list = Array.isArray(raw) ? raw : raw.rules || [];
+  return list.map((r) => ({
+    name: String(r.name),
+    severity: r.severity || "secret",
+    pattern: new RegExp(r.pattern, r.flags || "g"),
+  }));
+}
+
+export function scanText(text, rules) {
+  const findings = [];
+  const s = String(text || "");
+  for (const r of rules) {
+    r.pattern.lastIndex = 0;
+    let m;
+    while ((m = r.pattern.exec(s)) !== null) {
+      findings.push({ name: r.name, severity: r.severity, index: m.index, length: m[0].length });
+      if (m.index === r.pattern.lastIndex) r.pattern.lastIndex++;
+    }
+  }
+  return findings.sort((a, b) => a.index - b.index);
+}
+
+const MAX_SCAN_BYTES = 5 * 1024 * 1024;
+
+export function scanFiles(paths, rules) {
+  const out = {};
+  for (const p of paths) {
+    try {
+      if (statSync(p).size > MAX_SCAN_BYTES) {
+        // Fail closed: an unscannable file counts as a finding, never a pass.
+        out[p] = [{ name: "unscannable-large", severity: "error" }];
+        continue;
+      }
+      out[p] = scanText(readFileSync(p, "utf8"), rules);
+    }
+    catch (e) { out[p] = [{ name: "unreadable", severity: "error", error: String(e.message || e) }]; }
+  }
+  return out;
+}
+
+export function redact(text, findings) {
+  let s = String(text || "");
+  // Replace from the end so earlier indexes stay valid.
+  for (const f of [...findings].sort((a, b) => b.index - a.index)) {
+    if (typeof f.index !== "number") continue;
+    s = s.slice(0, f.index) + `[REDACTED:${f.name}]` + s.slice(f.index + f.length);
+  }
+  return s;
+}

--- a/bundles/pm-workspace/test/output-scan.test.js
+++ b/bundles/pm-workspace/test/output-scan.test.js
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loadRules, scanText, redact } from "../server/output-scan.js";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Compiled rules, the shape loadRules() produces (string patterns are the
+// FILE format only; scanText takes compiled RegExp — review round 1 finding 3).
+const RULES = [
+  { name: "github-token", pattern: /ghp_[A-Za-z0-9]{36}/g, severity: "secret" },
+  { name: "ssh-key-block", pattern: /BEGIN (OPENSSH|RSA) PRIVATE KEY/g, severity: "secret" },
+];
+const FILE_RULES = [
+  { name: "github-token", pattern: "ghp_[A-Za-z0-9]{36}", severity: "secret" },
+  { name: "ssh-key-block", pattern: "BEGIN (OPENSSH|RSA) PRIVATE KEY", severity: "secret" },
+];
+
+test("clean text passes", () => {
+  assert.equal(scanText("A perfectly ordinary draft paragraph.", RULES).length, 0);
+});
+
+test("seeded token is caught and redacted", () => {
+  const text = "leaked: ghp_" + "a".repeat(36) + " end";
+  const findings = scanText(text, RULES);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].name, "github-token");
+  const red = redact(text, findings);
+  assert.ok(!red.includes("ghp_" + "a".repeat(36)));
+  assert.ok(red.includes("[REDACTED:github-token]"));
+});
+
+test("loadRules compiles patterns from a JSON file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "scan-"));
+  const p = join(dir, "rules.json");
+  writeFileSync(p, JSON.stringify({ rules: FILE_RULES }));
+  const rules = loadRules(p);
+  assert.equal(rules.length, 2);
+  assert.ok(rules[0].pattern instanceof RegExp);
+  assert.equal(scanText("token ghp_" + "b".repeat(36), rules).length, 1);
+});

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4896,7 +4896,8 @@
           "CROW_TASKS_DB_PATH",
           "PLANNER_DRIVE_FOLDER_ID",
           "PLANNER_CATEGORY",
-          "PLANNER_CRON"
+          "PLANNER_CRON",
+          "PM_SCAN_RULES_FILE"
         ]
       },
       "panel": "panel/pm-workspace.js",


### PR DESCRIPTION
## Summary

Adds a deterministic secret/PII scan over bot output for pickup-time gating,
plus a small CLI wrapper. Pure functions, no new dependencies. The rules file
itself is operator-supplied at runtime via `PM_SCAN_RULES_FILE` and is never
part of this repo.

- `server/output-scan.js` — `loadRules(path)`, `scanText(text, rules)`,
  `scanFiles(paths, rules)`, `redact(text, findings)`.
- `server/output-scan-cli.js` — `node server/output-scan-cli.js --rules FILE
  [--stdin] [files...]`. Exit 0 clean, 1 on findings, 2 on usage/error.
- `test/output-scan.test.js` — node:test coverage for the module.
- `manifest.json` — `PM_SCAN_RULES_FILE` added to `envKeys`.
- `server/config.js` — `PM_SCAN_RULES_FILE` added to the `KEYS` allowlist, so
  the env-file route and the `process.env` overlay agree for stdio wrappers
  and tests.

## Rules file shape

`loadRules()` accepts either a bare array or `{ "rules": [...] }`. Each entry:

```json
{
  "rules": [
    { "name": "aws-key", "pattern": "AKIA[0-9A-Z]{16}" },
    { "name": "jwt", "pattern": "eyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{10,}", "severity": "secret" },
    { "name": "ssh-private-key", "pattern": "BEGIN (OPENSSH|RSA|EC) PRIVATE KEY", "flags": "g" }
  ]
}
```

- `pattern` is a JS regex source string (compiled with `new RegExp(pattern, flags || "g")`).
- `severity` is free-form, defaults to `"secret"`.
- `flags` is optional, defaults to `"g"`.

`scanText`/`scanFiles` take *compiled* rules (`pattern` is a `RegExp`), matching
what `loadRules()` produces — callers building rules programmatically (e.g. tests)
pass already-compiled `RegExp` objects directly.

## Test plan

- [x] `node --test bundles/pm-workspace/test/output-scan.test.js` — 3/3 pass
- [x] Confirmed the module has zero new dependencies (only `node:fs`)