### PR TITLE
pm-workspace: bot dispatch rail (crow_pm_bot_* tools) with scan-gated pickup + dispatch telemetry

### DIFF
--- a/bundles/pm-workspace/server/dispatch.js
+++ b/bundles/pm-workspace/server/dispatch.js
@@ -1,0 +1,189 @@
+// Day-track delegation rail: enqueue a bot_jobs row for the pi-bots runtime,
+// record dispatch telemetry, and gate result pickup behind the output scan.
+// Kanban cards stay with the tasks bundle; callers pass card_id in.
+import { statSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { loadRules, scanText, scanFiles, redact } from "./output-scan.js";
+import { loadConfig } from "./config.js";
+
+// Rules-path resolution (finding 11): the gateway child's process env never
+// carries this key; loadConfig() reads it from $CROW_HOME/env/pm-workspace.env.
+// process.env is the fallback for stdio wrappers and tests.
+function resolveRulesPath() {
+  try { const c = loadConfig(); if (c.PM_SCAN_RULES_FILE) return c.PM_SCAN_RULES_FILE; } catch {}
+  return process.env.PM_SCAN_RULES_FILE || null;
+}
+
+// Mirror of scripts/pi-bots/bot-jobs-schema.mjs (the bundle cannot import
+// across the repo boundary at runtime; keep in sync with that file).
+const BOT_JOBS_DDL = `
+  CREATE TABLE IF NOT EXISTS bot_jobs (
+    job_id TEXT PRIMARY KEY, bot_id TEXT NOT NULL, goal TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'queued', deliver_to TEXT, source TEXT,
+    schedule_id INTEGER, escalate INTEGER NOT NULL DEFAULT 0,
+    attempts INTEGER NOT NULL DEFAULT 0, result TEXT, error TEXT,
+    pi_session_id TEXT, tool_calls INTEGER, worker_pid INTEGER, claimed_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), started_at TEXT, ended_at TEXT
+  )`;
+
+// Keep in sync with the identical DDL string in init-tables.js.
+const DISPATCH_DDL = `
+  CREATE TABLE IF NOT EXISTS pm_bot_dispatches (
+    dispatch_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL UNIQUE,
+    bot_id TEXT NOT NULL,
+    duty TEXT NOT NULL,
+    card_id INTEGER,
+    model TEXT,
+    verdict TEXT,
+    scan_status TEXT,
+    disposition TEXT,
+    boundary_violation INTEGER NOT NULL DEFAULT 0,
+    disposition_notes TEXT,
+    dispatched_at TEXT NOT NULL DEFAULT (datetime('now')),
+    disposition_at TEXT
+  )`;
+
+export async function ensureDispatchTables(db) {
+  await db.execute(BOT_JOBS_DDL);
+  await db.execute(DISPATCH_DDL);
+}
+
+function generateJobId() {
+  return "job-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+}
+
+function composeGoal({ dispatchTag, duty, goal, card_id }) {
+  return [
+    `DISPATCH ${dispatchTag} — duty: ${duty}` + (card_id ? ` — card #${card_id}` : ""),
+    goal,
+    "",
+    "Deliverable contract:",
+    "- Write your draft(s) under your session workspace outbox directory as NEW files",
+    "  (never edit an existing shared file).",
+    "- End your reply with one line per draft file: DRAFT_FILE: <absolute path>",
+    "- Then a short self-contained summary of what you produced.",
+  ].join("\n");
+}
+
+export async function dispatch(db, { bot_id, duty, goal, card_id = null, deliver = null }) {
+  await ensureDispatchTables(db);
+  const bot = (await db.execute({
+    sql: "SELECT bot_id, definition FROM pi_bot_defs WHERE bot_id=? AND enabled=1", args: [bot_id],
+  })).rows[0];
+  if (!bot) throw new Error(`unknown or disabled bot: ${bot_id}`);
+  let model = null;
+  try { model = JSON.parse(bot.definition).models?.default || null; } catch {}
+  const job_id = generateJobId();
+  const deliver_to = deliver == null ? JSON.stringify({ kind: "poll" })
+    : (typeof deliver === "string" ? deliver : JSON.stringify(deliver));
+  const fullGoal = composeGoal({ dispatchTag: job_id, duty, goal, card_id });
+  await db.execute({
+    sql: "INSERT INTO bot_jobs (job_id, bot_id, goal, status, deliver_to, source) VALUES (?,?,?,'queued',?,?)",
+    args: [job_id, bot_id, fullGoal, deliver_to, "chat"],
+  });
+  await db.execute({
+    sql: "INSERT INTO pm_bot_dispatches (job_id, bot_id, duty, card_id, model) VALUES (?,?,?,?,?)",
+    args: [job_id, bot_id, duty, card_id, model],
+  });
+  const dispatch_id = (await db.execute({
+    sql: "SELECT dispatch_id FROM pm_bot_dispatches WHERE job_id=?", args: [job_id],
+  })).rows[0].dispatch_id;
+  return { job_id, dispatch_id };
+}
+
+function workspaceFilesSince(bot_id, startedAt) {
+  const home = process.env.CROW_HOME || join(process.env.HOME || "", ".crow");
+  const dir = join(home, "pi-bots", bot_id);
+  const cutoff = Date.parse(String(startedAt).endsWith("Z") ? startedAt : startedAt + "Z");
+  const out = [];
+  const walk = (d) => {
+    let entries = [];
+    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else { try { if (statSync(p).mtimeMs >= cutoff) out.push(p); } catch {} }
+    }
+  };
+  if (!Number.isNaN(cutoff)) walk(dir);
+  return out;
+}
+
+export async function result(db, { job_id }) {
+  await ensureDispatchTables(db);
+  const job = (await db.execute({ sql: "SELECT * FROM bot_jobs WHERE job_id=?", args: [job_id] })).rows[0];
+  if (!job) throw new Error(`no such job: ${job_id}`);
+  const rulesPath = resolveRulesPath();
+  if (job.status !== "completed") {
+    // Failed-job error text is bot output too (Safety measure 8) — scan it.
+    let err = job.error || null;
+    if (err && rulesPath) {
+      const rules = loadRules(rulesPath);
+      const f = scanText(err, rules);
+      if (f.length) err = redact(err, f);
+    }
+    return { job_id, status: job.status, error: err };
+  }
+  if (!rulesPath) {
+    await db.execute({ sql: "UPDATE pm_bot_dispatches SET scan_status='skipped' WHERE job_id=?", args: [job_id] });
+    return { job_id, status: "completed", scan_status: "skipped", result: job.result, files: [] };
+  }
+  const rules = loadRules(rulesPath); // throws if set but unloadable: fail closed
+  const textFindings = scanText(job.result || "", rules);
+  const files = job.started_at ? workspaceFilesSince(job.bot_id, job.started_at) : [];
+  const fileFindings = scanFiles(files, rules);
+  const fileHits = Object.entries(fileFindings).filter(([, f]) => f.length > 0);
+  const scan_status = textFindings.length || fileHits.length ? "findings" : "pass";
+  await db.execute({ sql: "UPDATE pm_bot_dispatches SET scan_status=? WHERE job_id=?", args: [scan_status, job_id] });
+  return {
+    job_id, status: "completed", scan_status,
+    result: scan_status === "pass" ? job.result : redact(job.result || "", textFindings),
+    findings: { text: textFindings, files: Object.fromEntries(fileHits.map(([p, f]) => [p, f.map(x => x.name)])) },
+    files,
+  };
+}
+
+export async function disposition(db, { job_id, disposition: d, boundary_violation = false, notes = null }) {
+  await ensureDispatchTables(db);
+  if (!["accepted", "edited", "rejected"].includes(d)) throw new Error(`bad disposition: ${d}`);
+  const r = await db.execute({
+    sql: "UPDATE pm_bot_dispatches SET disposition=?, boundary_violation=?, disposition_notes=?, disposition_at=datetime('now') WHERE job_id=?",
+    args: [d, boundary_violation ? 1 : 0, notes, job_id],
+  });
+  if (!r.rowsAffected) throw new Error(`no dispatch row for job: ${job_id}`);
+  return { job_id, disposition: d };
+}
+
+export async function telemetry(db, { since = null }) {
+  await ensureDispatchTables(db);
+  // dispatched_at is sqlite datetime('now') format (space-separated, no
+  // milliseconds, no Z); normalize caller ISO so comparison is lexicographic.
+  const norm = since ? String(since).replace("T", " ").replace(/(\.\d+)?Z?$/, "") : null;
+  const where = norm ? "WHERE dispatched_at >= ?" : "";
+  const args = norm ? [norm] : [];
+  const rows = (await db.execute({
+    sql: `SELECT bot_id, disposition, boundary_violation FROM pm_bot_dispatches ${where}`, args,
+  })).rows;
+  const summarize = (subset) => {
+    const decided = subset.filter((r) => r.disposition);
+    const accepted = decided.filter((r) => r.disposition === "accepted").length;
+    return {
+      dispatched: subset.length,
+      decided: decided.length,
+      accepted,
+      edited: decided.filter((r) => r.disposition === "edited").length,
+      rejected: decided.filter((r) => r.disposition === "rejected").length,
+      boundary_violations: subset.filter((r) => r.boundary_violation).length,
+      accept_rate: decided.length ? accepted / decided.length : null,
+    };
+  };
+  // Per-bot breakdown: the Gemma bake-off adds a second drafter into this
+  // table, and surface flips cite these rows per bot (design Trust measurement).
+  const per_bot = {};
+  for (const r of rows) (per_bot[r.bot_id] ||= []).push(r);
+  return {
+    ...summarize(rows),
+    per_bot: Object.fromEntries(Object.entries(per_bot).map(([b, rs]) => [b, summarize(rs)])),
+  };
+}

--- a/bundles/pm-workspace/server/init-tables.js
+++ b/bundles/pm-workspace/server/init-tables.js
@@ -118,6 +118,25 @@ export async function initPmTables(db) {
     CREATE INDEX IF NOT EXISTS idx_pm_planned_events_status ON pm_planned_events(status, start_utc);
   `);
 
+  // Keep in sync with the identical DDL string in dispatch.js (DISPATCH_DDL).
+  await initTable(db, "pm_bot_dispatches", `
+    CREATE TABLE IF NOT EXISTS pm_bot_dispatches (
+      dispatch_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_id TEXT NOT NULL UNIQUE,
+      bot_id TEXT NOT NULL,
+      duty TEXT NOT NULL,
+      card_id INTEGER,
+      model TEXT,
+      verdict TEXT,
+      scan_status TEXT,
+      disposition TEXT,
+      boundary_violation INTEGER NOT NULL DEFAULT 0,
+      disposition_notes TEXT,
+      dispatched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      disposition_at TEXT
+    );
+  `);
+
   await initTable(db, "pm_sync_log", `
     CREATE TABLE IF NOT EXISTS pm_sync_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/bundles/pm-workspace/server/server.js
+++ b/bundles/pm-workspace/server/server.js
@@ -4,7 +4,10 @@
  * Factory: createPmWorkspaceServer(db, options?)
  * Tools: crow_pm_note_create, crow_pm_note_get, crow_pm_note_list,
  *        crow_pm_search, crow_pm_digest_preview, crow_pm_digest_send,
- *        crow_pm_sync_run, crow_pm_sync_status, crow_pm_status
+ *        crow_pm_sync_run, crow_pm_sync_status, crow_pm_plan_propose,
+ *        crow_pm_plan_list, crow_pm_plan_decide, crow_pm_plan_export,
+ *        crow_pm_plan_reconcile, crow_pm_bot_dispatch, crow_pm_bot_result,
+ *        crow_pm_bot_disposition, crow_pm_bot_telemetry, crow_pm_status
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -20,6 +23,7 @@ import { preview, runDigest } from "./digest/index.js";
 import { runSync } from "./sync/monday.js";
 import { loadSyncConfig } from "./sync/mapping.js";
 import * as planner from "./planner.js";
+import * as dispatchRail from "./dispatch.js";
 
 function text(t) {
   return { content: [{ type: "text", text: t }] };
@@ -282,6 +286,75 @@ export function createPmWorkspaceServer(db, options = {}) {
       } catch (err) {
         return errorText(err.message);
       }
+    }
+  );
+
+  // ── Bot dispatch rail (day-track delegation to the pi-bots runtime) ──
+
+  server.tool(
+    "crow_pm_bot_dispatch",
+    "Dispatch a duty to an enabled pi-bot: enqueues a bot_jobs row (source 'chat', deliver_to defaults to poll-only) and a pm_bot_dispatches telemetry row at dispatch time. This tool does NOT create kanban cards — call tasks_create first and pass its id as card_id so the dispatch is linked to a card. Pick up the outcome later with crow_pm_bot_result, which is scan-gated (see that tool's description).",
+    {
+      bot_id: z.string().min(1).max(200).describe("Enabled pi-bot id (pi_bot_defs.bot_id)"),
+      duty: z.string().min(1).max(200).describe("Short duty label, e.g. 'doc-revision'"),
+      goal: z.string().min(1).max(20_000).describe("The task goal text; wrapped in the dispatch/deliverable-contract template"),
+      card_id: z.number().int().positive().optional().describe("Kanban card id from tasks_create, if this dispatch is tracking a card"),
+      deliver: z.union([z.string(), z.record(z.any())]).optional().describe("Delivery target for the bot_jobs row; defaults to {kind:'poll'}"),
+    },
+    async ({ bot_id, duty, goal, card_id, deliver }) => {
+      try {
+        const row = await dispatchRail.dispatch(db, { bot_id, duty, goal, card_id, deliver });
+        return text(JSON.stringify(row, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
+  server.tool(
+    "crow_pm_bot_result",
+    "Pick up a dispatched job's outcome. While queued/running, returns status only. On failed, the error text is scanned like any other bot output (Safety measure 8 covers every channel). On completed, the result text plus any workspace files changed since the job started are scanned with the output-scan rules from PM_SCAN_RULES_FILE: findings return REDACTED text plus the findings list and set scan_status='findings' (raw content never crosses this tool boundary); clean sets scan_status='pass'. If PM_SCAN_RULES_FILE is unset, scan_status='skipped'; if it's set but the rules file can't be loaded, this call errors (fail closed) rather than returning unscanned content.",
+    {
+      job_id: z.string().min(1).max(200).describe("bot_jobs.job_id returned by crow_pm_bot_dispatch"),
+    },
+    async ({ job_id }) => {
+      try {
+        const row = await dispatchRail.result(db, { job_id });
+        return text(JSON.stringify(row, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
+  server.tool(
+    "crow_pm_bot_disposition",
+    "Record the human decision on a dispatched job's output: accepted | edited | rejected. Stamps disposition_at. 'edited' counts against the bot's accept rate the same as 'rejected' does — crow_pm_bot_telemetry's accept_rate is accepted / decided, so anything short of taking the draft as-is is a miss.",
+    {
+      job_id: z.string().min(1).max(200).describe("bot_jobs.job_id"),
+      disposition: z.enum(["accepted", "edited", "rejected"]),
+      boundary_violation: z.boolean().default(false).describe("Flag if the bot's output crossed a boundary it shouldn't have (e.g. edited a shared file instead of writing a new one)"),
+      notes: z.string().max(5000).optional().describe("Optional free-text notes on the decision"),
+    },
+    async ({ job_id, disposition: d, boundary_violation, notes }) => {
+      try {
+        const row = await dispatchRail.disposition(db, { job_id, disposition: d, boundary_violation, notes });
+        return text(JSON.stringify(row, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
+    }
+  );
+
+  server.tool(
+    "crow_pm_bot_telemetry",
+    "Dispatch-rail telemetry: totals by disposition, accept rate (accepted / decided — edits and rejections both count against it), boundary violation count, and a per-bot breakdown of the same numbers.",
+    {
+      since: z.string().max(50).optional().describe("ISO datetime; only count dispatches at or after this time"),
+    },
+    async ({ since }) => {
+      const row = await dispatchRail.telemetry(db, { since });
+      return text(JSON.stringify(row, null, 2));
     }
   );
 

--- a/bundles/pm-workspace/test/dispatch.test.js
+++ b/bundles/pm-workspace/test/dispatch.test.js
@@ -1,0 +1,65 @@
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { ensureDispatchTables, dispatch, result, disposition, telemetry } from "../server/dispatch.js";
+
+let db;
+before(async () => {
+  db = createClient({ url: "file::memory:" });
+  await db.execute("CREATE TABLE pi_bot_defs (bot_id TEXT PRIMARY KEY, definition TEXT, enabled INTEGER)");
+  await db.execute("INSERT INTO pi_bot_defs VALUES ('t-bot', '{\"models\":{\"default\":\"m1\"}}', 1)");
+  await ensureDispatchTables(db);
+});
+
+test("dispatch inserts a queued job row and a telemetry row", async () => {
+  const r = await dispatch(db, { bot_id: "t-bot", duty: "doc-revision", goal: "Revise X", card_id: 7 });
+  assert.ok(r.job_id.startsWith("job-"));
+  const job = (await db.execute({ sql: "SELECT * FROM bot_jobs WHERE job_id=?", args: [r.job_id] })).rows[0];
+  assert.equal(job.status, "queued");
+  assert.match(String(job.goal), /DISPATCH .* duty: doc-revision/);
+  const t = (await db.execute({ sql: "SELECT * FROM pm_bot_dispatches WHERE job_id=?", args: [r.job_id] })).rows[0];
+  assert.equal(t.duty, "doc-revision");
+  assert.equal(t.card_id, 7);
+});
+
+test("dispatch refuses an unknown or disabled bot", async () => {
+  await assert.rejects(dispatch(db, { bot_id: "nope", duty: "d", goal: "g" }), /unknown or disabled/);
+});
+
+test("result on a completed job scans and redacts", async (t) => {
+  const r = await dispatch(db, { bot_id: "t-bot", duty: "d2", goal: "g2" });
+  await db.execute({ sql: "UPDATE bot_jobs SET status='completed', result=?, started_at=datetime('now') WHERE job_id=?",
+    args: ["fine text plus ghp_" + "a".repeat(36), r.job_id] });
+  const prev = process.env.PM_SCAN_RULES_FILE;
+  process.env.PM_SCAN_RULES_FILE = writeTmpRules();
+  t.after(() => {
+    if (prev === undefined) delete process.env.PM_SCAN_RULES_FILE;
+    else process.env.PM_SCAN_RULES_FILE = prev;
+  });
+  const out = await result(db, { job_id: r.job_id });
+  assert.equal(out.scan_status, "findings");
+  assert.ok(!out.result.includes("ghp_" + "a".repeat(36)));
+});
+
+test("disposition + telemetry math (edit counts as a miss)", async () => {
+  const ids = [];
+  for (let i = 0; i < 3; i++) ids.push((await dispatch(db, { bot_id: "t-bot", duty: "d3", goal: "g" })).job_id);
+  await disposition(db, { job_id: ids[0], disposition: "accepted" });
+  await disposition(db, { job_id: ids[1], disposition: "edited" });
+  await disposition(db, { job_id: ids[2], disposition: "rejected" });
+  const s = await telemetry(db, {});
+  assert.equal(s.decided, 3);
+  assert.equal(s.accepted, 1);
+  assert.ok(Math.abs(s.accept_rate - 1 / 3) < 1e-9);
+  assert.ok(s.per_bot["t-bot"]);
+  assert.equal(s.per_bot["t-bot"].decided, 3);
+});
+
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+function writeTmpRules() {
+  const p = join(mkdtempSync(join(tmpdir(), "rules-")), "r.json");
+  writeFileSync(p, JSON.stringify({ rules: [{ name: "github-token", pattern: "ghp_[A-Za-z0-9]{36}" }] }));
+  return p;
+}


### PR DESCRIPTION
## Summary

Adds a delegation rail to the pm-workspace bundle: four MCP tools for dispatching a duty to an enabled pi-bot, picking up its result, recording a human disposition, and reporting telemetry. New `pm_bot_dispatches` table records one row per dispatch.

### The four-tool contract

- **`crow_pm_bot_dispatch({bot_id, duty, goal, card_id?, deliver?})`** — validates the bot exists and is enabled, composes the job goal (wraps it in a deliverable-contract template: draft files go under the bot's own session workspace outbox as new files, never edits to a shared file, and the reply ends with `DRAFT_FILE:` lines), inserts a `bot_jobs` row (`source: "chat"`, `deliver_to` defaults to `{"kind":"poll"}`), and inserts the `pm_bot_dispatches` telemetry row at dispatch time. Returns `{job_id, dispatch_id}`. **It does not create kanban cards** — the caller runs `tasks_create` first and passes the resulting id as `card_id`, so the dispatch is linked without this tool reaching into the tasks bundle's schema.

- **`crow_pm_bot_result({job_id})`** — while `queued`/`running`, returns status only. On `failed`, the error text passes through the same output scan before it's returned (Safety measure 8 covers every channel a bot's output can reach, error strings included). On `completed`, scans the result text plus any workspace files changed since `started_at` with the output-scan module: findings return **REDACTED** text plus the findings list and set `scan_status='findings'` — raw content never crosses the tool boundary; clean sets `scan_status='pass'`.

- **`crow_pm_bot_disposition({job_id, disposition, boundary_violation?, notes?})`** — `disposition ∈ accepted|edited|rejected`, stamps `disposition_at`.

- **`crow_pm_bot_telemetry({since?})`** — totals by disposition, accept rate (`accepted / decided`; both `edited` and `rejected` count against it), boundary violation count, and a per-bot breakdown.

### `PM_SCAN_RULES_FILE` fail-closed rule

The rules path resolves through `loadConfig().PM_SCAN_RULES_FILE` first (the gateway child's process env doesn't carry this key; `loadConfig()` reads the instance's env file), then falls back to `process.env.PM_SCAN_RULES_FILE` for stdio wrappers and tests.

- **Unset in both** → `scan_status='skipped'` (generic default; no rules configured, nothing to gate on).
- **Set but unloadable** (missing file, bad JSON) → hard error. The call fails rather than returning unscanned content — fail closed, not fail open.

### Other notes

- `pm_bot_dispatches` DDL lives in both `dispatch.js` (used at call time via `ensureDispatchTables`) and `init-tables.js` (server startup); both copies carry a "keep in sync" comment pointing at the other.
- No new `manifest.json` envKeys — `PM_SCAN_RULES_FILE` was already added in #268.

## Test plan

- [x] `bundles/pm-workspace/test/dispatch.test.js` (new, 4 tests): dispatch inserts a queued `bot_jobs` row + telemetry row; dispatch refuses an unknown/disabled bot; `result` on a completed job scans and redacts a seeded token; disposition + telemetry math (edited counts as a miss).
- [x] `bundles/pm-workspace/test/output-scan.test.js` (existing, 3 tests) still passes unchanged.
- [x] `tests/bundle-contract.test.js` (28/28) and `tests/bundle-provider-audit.test.js` (15/15) pass — no manifest/registry drift from this change.
- [x] Full local suite (`node scripts/run-suite.mjs`, 2853 tests) run before and after this change: same 8 pre-existing failures both times (unrelated CLI/schema-migration tests), confirming nothing here regresses the floor.
