### PR TITLE
pm-workspace: dispatch rail hardening — overlapping-span redaction, poll-only delivery, quarantined files

### DIFF
--- a/bundles/pm-workspace/manifest.json
+++ b/bundles/pm-workspace/manifest.json
@@ -70,7 +70,8 @@
     { "name": "CROW_TASKS_DB_PATH", "description": "Path to the kanban tasks DB (default $CROW_DATA_DIR/tasks.db)", "required": false },
     { "name": "PLANNER_DRIVE_FOLDER_ID", "description": "Drive folder where approved planned-events feed files are written for an external agent (e.g. Power Automate) to create real calendar events", "required": false },
     { "name": "PLANNER_CATEGORY", "description": "Marker category stamped on planner-created calendar events; the reconcile loop-guard matches on it (default: Crow Plan)", "required": false },
-    { "name": "PLANNER_CRON", "description": "Cron expression for planner export/reconcile runs (default: */15 * * * *)", "required": false }
+    { "name": "PLANNER_CRON", "description": "Cron expression for planner export/reconcile runs (default: */15 * * * *)", "required": false },
+    { "name": "PM_SCAN_RULES_FILE", "description": "Path to the JSON rules file (regex secret/PII patterns) the bot dispatch rail scans output against before crow_pm_bot_result returns it; unset skips scanning, set-but-unloadable is a hard error (fail closed)", "required": false }
   ],
   "notes": "Notes (markdown + pressure-sensitive drawing with OCR), a daily digest, and deterministic Monday.com sync. Boards/kanban remain the job of the tasks bundle and Bot Board tracker tools — this bundle reads them for the digest and writes them only via the sync engine."
 }

--- a/bundles/pm-workspace/server/dispatch.js
+++ b/bundles/pm-workspace/server/dispatch.js
@@ -2,7 +2,7 @@
 // record dispatch telemetry, and gate result pickup behind the output scan.
 // Kanban cards stay with the tasks bundle; callers pass card_id in.
 import { statSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { loadRules, scanText, scanFiles, redact } from "./output-scan.js";
 import { loadConfig } from "./config.js";
 
@@ -15,7 +15,12 @@ function resolveRulesPath() {
 }
 
 // Mirror of scripts/pi-bots/bot-jobs-schema.mjs (the bundle cannot import
-// across the repo boundary at runtime; keep in sync with that file).
+// across the repo boundary at runtime; keep in sync with that file). The
+// runtime's copy also creates idx_bot_jobs_status and idx_bot_jobs_bot,
+// intentionally omitted here (ensureDispatchTables runs this as a single
+// db.execute() statement, not executeMultiple, and the runtime self-heals
+// those indexes on its own first use — this table only needs to EXIST for
+// the dispatch rail's own inserts/updates, not be independently indexed).
 const BOT_JOBS_DDL = `
   CREATE TABLE IF NOT EXISTS bot_jobs (
     job_id TEXT PRIMARY KEY, bot_id TEXT NOT NULL, goal TEXT NOT NULL,
@@ -66,7 +71,16 @@ function composeGoal({ dispatchTag, duty, goal, card_id }) {
   ].join("\n");
 }
 
-export async function dispatch(db, { bot_id, duty, goal, card_id = null, deliver = null }) {
+// deliver_to is always the poll literal — review round 1, IMPORTANT 2. The
+// pi-bots runtime supports other delivery kinds (gmail, gateway threads, …)
+// that route a job's raw output out of band, around the crow_pm_bot_result
+// scan gate entirely. This rail's whole safety property depends on every
+// dispatched job's output being picked up (and scanned) through
+// crow_pm_bot_result, so callers cannot choose a delivery kind that bypasses
+// it — there is no `deliver` parameter to plumb through.
+const POLL_DELIVER_TO = JSON.stringify({ kind: "poll" });
+
+export async function dispatch(db, { bot_id, duty, goal, card_id = null }) {
   await ensureDispatchTables(db);
   const bot = (await db.execute({
     sql: "SELECT bot_id, definition FROM pi_bot_defs WHERE bot_id=? AND enabled=1", args: [bot_id],
@@ -75,12 +89,10 @@ export async function dispatch(db, { bot_id, duty, goal, card_id = null, deliver
   let model = null;
   try { model = JSON.parse(bot.definition).models?.default || null; } catch {}
   const job_id = generateJobId();
-  const deliver_to = deliver == null ? JSON.stringify({ kind: "poll" })
-    : (typeof deliver === "string" ? deliver : JSON.stringify(deliver));
   const fullGoal = composeGoal({ dispatchTag: job_id, duty, goal, card_id });
   await db.execute({
     sql: "INSERT INTO bot_jobs (job_id, bot_id, goal, status, deliver_to, source) VALUES (?,?,?,'queued',?,?)",
-    args: [job_id, bot_id, fullGoal, deliver_to, "chat"],
+    args: [job_id, bot_id, fullGoal, POLL_DELIVER_TO, "chat"],
   });
   await db.execute({
     sql: "INSERT INTO pm_bot_dispatches (job_id, bot_id, duty, card_id, model) VALUES (?,?,?,?,?)",
@@ -92,9 +104,25 @@ export async function dispatch(db, { bot_id, duty, goal, card_id = null, deliver
   return { job_id, dispatch_id };
 }
 
-function workspaceFilesSince(bot_id, startedAt) {
+// Mirror of scripts/pi-bots/instance-paths.mjs botsWorkspaceRoot() (review
+// round 1, IMPORTANT 5): when CROW_DB_PATH is set, the workspace root is the
+// sibling "pi-bots" dir of the data dir holding THAT db
+// (dirname(dirname(CROW_DB_PATH))/pi-bots) — the same anchor the pi-bots
+// runtime itself uses, so a per-instance CROW_DB_PATH always finds the right
+// workspace even when it points somewhere other than CROW_HOME/data. Falls
+// back to CROW_HOME/pi-bots (then ~/.crow/pi-bots) when CROW_DB_PATH isn't
+// set, matching this bundle's other CROW_HOME fallbacks. Not a real import
+// of instance-paths.mjs — the bundle cannot reach across the repo boundary
+// at runtime; keep this in sync with that file's botsWorkspaceRoot().
+function workspaceRoot() {
+  const dbPath = process.env.CROW_DB_PATH;
+  if (dbPath) return join(dirname(dirname(dbPath)), "pi-bots");
   const home = process.env.CROW_HOME || join(process.env.HOME || "", ".crow");
-  const dir = join(home, "pi-bots", bot_id);
+  return join(home, "pi-bots");
+}
+
+function workspaceFilesSince(bot_id, startedAt) {
+  const dir = join(workspaceRoot(), bot_id);
   const cutoff = Date.parse(String(startedAt).endsWith("Z") ? startedAt : startedAt + "Z");
   const out = [];
   const walk = (d) => {
@@ -115,32 +143,58 @@ export async function result(db, { job_id }) {
   const job = (await db.execute({ sql: "SELECT * FROM bot_jobs WHERE job_id=?", args: [job_id] })).rows[0];
   if (!job) throw new Error(`no such job: ${job_id}`);
   const rulesPath = resolveRulesPath();
-  if (job.status !== "completed") {
-    // Failed-job error text is bot output too (Safety measure 8) — scan it.
+
+  if (job.status === "queued" || job.status === "running") {
+    return { job_id, status: job.status };
+  }
+
+  if (job.status === "failed") {
+    // Failed-job error text is bot output too (Safety measure 8) — scan it,
+    // and stamp scan_status on the dispatch row the same way the completed
+    // path does (review round 1, MINOR 10), so crow_pm_bot_telemetry can
+    // tell a scanned-clean failure apart from a scanned-and-flagged one
+    // instead of every failed job looking identically un-stamped.
     let err = job.error || null;
-    if (err && rulesPath) {
-      const rules = loadRules(rulesPath);
-      const f = scanText(err, rules);
+    let scan_status = "skipped";
+    if (rulesPath) {
+      const rules = loadRules(rulesPath); // throws if set but unloadable: fail closed
+      const f = err ? scanText(err, rules) : [];
+      scan_status = f.length ? "findings" : "pass";
       if (f.length) err = redact(err, f);
     }
-    return { job_id, status: job.status, error: err };
+    await db.execute({ sql: "UPDATE pm_bot_dispatches SET scan_status=? WHERE job_id=?", args: [scan_status, job_id] });
+    return { job_id, status: "failed", scan_status, error: err };
   }
+
+  // completed
   if (!rulesPath) {
     await db.execute({ sql: "UPDATE pm_bot_dispatches SET scan_status='skipped' WHERE job_id=?", args: [job_id] });
-    return { job_id, status: "completed", scan_status: "skipped", result: job.result, files: [] };
+    return { job_id, status: "completed", scan_status: "skipped", result: job.result, files: [], quarantined: [] };
   }
   const rules = loadRules(rulesPath); // throws if set but unloadable: fail closed
   const textFindings = scanText(job.result || "", rules);
-  const files = job.started_at ? workspaceFilesSince(job.bot_id, job.started_at) : [];
+  // started_at can be NULL between a job being claimed and actually starting
+  // work; created_at is NOT NULL in the DDL, so falling back to it means the
+  // workspace scan always runs for a completed job instead of silently
+  // skipping (review round 1, IMPORTANT 4 — fail-open on a NULL timestamp).
+  const cutoff = job.started_at || job.created_at;
+  const files = cutoff ? workspaceFilesSince(job.bot_id, cutoff) : [];
   const fileFindings = scanFiles(files, rules);
-  const fileHits = Object.entries(fileFindings).filter(([, f]) => f.length > 0);
-  const scan_status = textFindings.length || fileHits.length ? "findings" : "pass";
+  const fileEntries = Object.entries(fileFindings);
+  // Files with findings are quarantined, never surfaced as an openable path
+  // (review round 1, IMPORTANT 3) — only their rule-name findings are
+  // returned, under findings.files, same as before. `files` now lists ONLY
+  // paths that scanned clean.
+  const clean = fileEntries.filter(([, f]) => f.length === 0).map(([p]) => p);
+  const flagged = fileEntries.filter(([, f]) => f.length > 0);
+  const scan_status = textFindings.length || flagged.length ? "findings" : "pass";
   await db.execute({ sql: "UPDATE pm_bot_dispatches SET scan_status=? WHERE job_id=?", args: [scan_status, job_id] });
   return {
     job_id, status: "completed", scan_status,
     result: scan_status === "pass" ? job.result : redact(job.result || "", textFindings),
-    findings: { text: textFindings, files: Object.fromEntries(fileHits.map(([p, f]) => [p, f.map(x => x.name)])) },
-    files,
+    findings: { text: textFindings, files: Object.fromEntries(flagged.map(([p, f]) => [p, f.map(x => x.name)])) },
+    files: clean,
+    quarantined: flagged.map(([p]) => p),
   };
 }
 

--- a/bundles/pm-workspace/server/output-scan.js
+++ b/bundles/pm-workspace/server/output-scan.js
@@ -45,11 +45,36 @@ export function scanFiles(paths, rules) {
 }
 
 export function redact(text, findings) {
-  let s = String(text || "");
-  // Replace from the end so earlier indexes stay valid.
-  for (const f of [...findings].sort((a, b) => b.index - a.index)) {
-    if (typeof f.index !== "number") continue;
-    s = s.slice(0, f.index) + `[REDACTED:${f.name}]` + s.slice(f.index + f.length);
+  const s = String(text || "");
+  const numeric = findings.filter((f) => typeof f.index === "number" && typeof f.length === "number");
+  if (numeric.length === 0) return s;
+
+  // Coalesce overlapping/adjacent spans BEFORE replacing (review round 1,
+  // CRITICAL 1). Two findings can legitimately overlap — e.g. an SSN-shaped
+  // rule matching a substring inside a longer slack-token match — and
+  // replacing them independently corrupts offsets: the inner replacement
+  // shifts the string, so the outer span's stale end index slices the wrong
+  // place and raw secret bytes survive in the "redacted" output. Merging
+  // first means every replacement below operates on a set of disjoint spans,
+  // so replacing from the end (descending start) never invalidates an
+  // index computed for a span still to be processed.
+  const sorted = [...numeric].sort((a, b) => a.index - b.index);
+  const merged = [];
+  for (const f of sorted) {
+    const start = f.index;
+    const end = f.index + f.length;
+    const last = merged[merged.length - 1];
+    if (last && start <= last.end) {
+      if (end > last.end) last.end = end;
+      if (!last.names.includes(f.name)) last.names.push(f.name);
+    } else {
+      merged.push({ start, end, names: [f.name] });
+    }
   }
-  return s;
+
+  let out = s;
+  for (const span of [...merged].sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, span.start) + `[REDACTED:${span.names.join("+")}]` + out.slice(span.end);
+  }
+  return out;
 }

--- a/bundles/pm-workspace/server/server.js
+++ b/bundles/pm-workspace/server/server.js
@@ -293,17 +293,16 @@ export function createPmWorkspaceServer(db, options = {}) {
 
   server.tool(
     "crow_pm_bot_dispatch",
-    "Dispatch a duty to an enabled pi-bot: enqueues a bot_jobs row (source 'chat', deliver_to defaults to poll-only) and a pm_bot_dispatches telemetry row at dispatch time. This tool does NOT create kanban cards — call tasks_create first and pass its id as card_id so the dispatch is linked to a card. Pick up the outcome later with crow_pm_bot_result, which is scan-gated (see that tool's description).",
+    "Dispatch a duty to an enabled pi-bot: enqueues a bot_jobs row (source 'chat', deliver_to always {kind:'poll'} — there is no way to route delivery around the scan gate) and a pm_bot_dispatches telemetry row at dispatch time. This tool does NOT create kanban cards — call tasks_create first and pass its id as card_id so the dispatch is linked to a card. Pick up the outcome later with crow_pm_bot_result, which is scan-gated (see that tool's description).",
     {
       bot_id: z.string().min(1).max(200).describe("Enabled pi-bot id (pi_bot_defs.bot_id)"),
       duty: z.string().min(1).max(200).describe("Short duty label, e.g. 'doc-revision'"),
       goal: z.string().min(1).max(20_000).describe("The task goal text; wrapped in the dispatch/deliverable-contract template"),
       card_id: z.number().int().positive().optional().describe("Kanban card id from tasks_create, if this dispatch is tracking a card"),
-      deliver: z.union([z.string(), z.record(z.any())]).optional().describe("Delivery target for the bot_jobs row; defaults to {kind:'poll'}"),
     },
-    async ({ bot_id, duty, goal, card_id, deliver }) => {
+    async ({ bot_id, duty, goal, card_id }) => {
       try {
-        const row = await dispatchRail.dispatch(db, { bot_id, duty, goal, card_id, deliver });
+        const row = await dispatchRail.dispatch(db, { bot_id, duty, goal, card_id });
         return text(JSON.stringify(row, null, 2));
       } catch (err) {
         return errorText(err.message);
@@ -313,7 +312,7 @@ export function createPmWorkspaceServer(db, options = {}) {
 
   server.tool(
     "crow_pm_bot_result",
-    "Pick up a dispatched job's outcome. While queued/running, returns status only. On failed, the error text is scanned like any other bot output (Safety measure 8 covers every channel). On completed, the result text plus any workspace files changed since the job started are scanned with the output-scan rules from PM_SCAN_RULES_FILE: findings return REDACTED text plus the findings list and set scan_status='findings' (raw content never crosses this tool boundary); clean sets scan_status='pass'. If PM_SCAN_RULES_FILE is unset, scan_status='skipped'; if it's set but the rules file can't be loaded, this call errors (fail closed) rather than returning unscanned content.",
+    "Pick up a dispatched job's outcome. While queued/running, returns status only. On failed, the error text is scanned like any other bot output (Safety measure 8 covers every channel). On completed, the result text plus any workspace files changed since the job started (or, if not yet marked started, since it was created) are scanned with the output-scan rules from PM_SCAN_RULES_FILE: findings return REDACTED text plus the findings list and set scan_status='findings' (raw content never crosses this tool boundary); clean sets scan_status='pass'. Any workspace file WITH findings is listed under `quarantined` (names only, from findings.files) — never under `files` and never returned as an openable path; only files that scanned clean appear in `files`. If PM_SCAN_RULES_FILE is unset, scan_status='skipped'; if it's set but the rules file can't be loaded, this call errors (fail closed) rather than returning unscanned content.",
     {
       job_id: z.string().min(1).max(200).describe("bot_jobs.job_id returned by crow_pm_bot_dispatch"),
     },
@@ -353,8 +352,12 @@ export function createPmWorkspaceServer(db, options = {}) {
       since: z.string().max(50).optional().describe("ISO datetime; only count dispatches at or after this time"),
     },
     async ({ since }) => {
-      const row = await dispatchRail.telemetry(db, { since });
-      return text(JSON.stringify(row, null, 2));
+      try {
+        const row = await dispatchRail.telemetry(db, { since });
+        return text(JSON.stringify(row, null, 2));
+      } catch (err) {
+        return errorText(err.message);
+      }
     }
   );
 

--- a/bundles/pm-workspace/test/dispatch.test.js
+++ b/bundles/pm-workspace/test/dispatch.test.js
@@ -26,6 +26,12 @@ test("dispatch refuses an unknown or disabled bot", async () => {
   await assert.rejects(dispatch(db, { bot_id: "nope", duty: "d", goal: "g" }), /unknown or disabled/);
 });
 
+test("dispatch always sets deliver_to to the poll literal (review round 1, IMPORTANT 2 — no bypass of the scan gate)", async () => {
+  const r = await dispatch(db, { bot_id: "t-bot", duty: "d-poll", goal: "g" });
+  const job = (await db.execute({ sql: "SELECT deliver_to FROM bot_jobs WHERE job_id=?", args: [r.job_id] })).rows[0];
+  assert.equal(job.deliver_to, JSON.stringify({ kind: "poll" }));
+});
+
 test("result on a completed job scans and redacts", async (t) => {
   const r = await dispatch(db, { bot_id: "t-bot", duty: "d2", goal: "g2" });
   await db.execute({ sql: "UPDATE bot_jobs SET status='completed', result=?, started_at=datetime('now') WHERE job_id=?",
@@ -39,6 +45,110 @@ test("result on a completed job scans and redacts", async (t) => {
   const out = await result(db, { job_id: r.job_id });
   assert.equal(out.scan_status, "findings");
   assert.ok(!out.result.includes("ghp_" + "a".repeat(36)));
+});
+
+test("failed jobs stamp scan_status on the dispatch row, same as completed jobs (review round 1, MINOR 10)", async (t) => {
+  stashEnv(t, ["PM_SCAN_RULES_FILE"]);
+  const r = await dispatch(db, { bot_id: "t-bot", duty: "d-failed", goal: "g" });
+  process.env.PM_SCAN_RULES_FILE = writeTmpRules();
+  await db.execute({
+    sql: "UPDATE bot_jobs SET status='failed', error=? WHERE job_id=?",
+    args: ["boom: leaked ghp_" + "a".repeat(36), r.job_id],
+  });
+
+  const out = await result(db, { job_id: r.job_id });
+  assert.equal(out.status, "failed");
+  assert.equal(out.scan_status, "findings");
+  assert.ok(!out.error.includes("ghp_" + "a".repeat(36)));
+
+  const row = (await db.execute({ sql: "SELECT scan_status FROM pm_bot_dispatches WHERE job_id=?", args: [r.job_id] })).rows[0];
+  assert.equal(row.scan_status, "findings");
+});
+
+test("workspace files with findings are quarantined, not returned as files (review round 1, IMPORTANT 3)", async (t) => {
+  stashEnv(t, ["CROW_HOME", "CROW_DB_PATH", "PM_SCAN_RULES_FILE"]);
+  const bot_id = "t-bot";
+  const r = await dispatch(db, { bot_id, duty: "d-quarantine", goal: "g" });
+
+  const crowHome = mkdtempSync(join(tmpdir(), "crow-home-"));
+  const wsDir = join(crowHome, "pi-bots", bot_id);
+  mkdirSync(wsDir, { recursive: true });
+  const secretFile = join(wsDir, "draft.txt");
+  writeFileSync(secretFile, "leaked token ghp_" + "a".repeat(36));
+  const cleanFile = join(wsDir, "clean.txt");
+  writeFileSync(cleanFile, "nothing sensitive here");
+
+  process.env.CROW_HOME = crowHome;
+  delete process.env.CROW_DB_PATH;
+  process.env.PM_SCAN_RULES_FILE = writeTmpRules();
+
+  await db.execute({
+    sql: "UPDATE bot_jobs SET status='completed', result=?, started_at='2020-01-01T00:00:00.000Z' WHERE job_id=?",
+    args: ["clean result text", r.job_id],
+  });
+
+  const out = await result(db, { job_id: r.job_id });
+  assert.equal(out.scan_status, "findings");
+  assert.ok(out.quarantined.includes(secretFile), "flagged file should be quarantined");
+  assert.ok(!out.files.includes(secretFile), "flagged file must not appear in files");
+  assert.ok(out.files.includes(cleanFile), "clean file should still appear in files");
+});
+
+test("NULL started_at falls back to created_at so the workspace scan still runs (review round 1, IMPORTANT 4)", async (t) => {
+  stashEnv(t, ["CROW_HOME", "CROW_DB_PATH", "PM_SCAN_RULES_FILE"]);
+  const bot_id = "t-bot";
+  const r = await dispatch(db, { bot_id, duty: "d-null-started", goal: "g" });
+  // started_at is left NULL (never set); created_at is stamped by the DDL default.
+  await db.execute({
+    sql: "UPDATE bot_jobs SET status='completed', result=? WHERE job_id=?",
+    args: ["clean result text", r.job_id],
+  });
+  const job = (await db.execute({ sql: "SELECT started_at, created_at FROM bot_jobs WHERE job_id=?", args: [r.job_id] })).rows[0];
+  assert.equal(job.started_at, null);
+  assert.ok(job.created_at);
+
+  const crowHome = mkdtempSync(join(tmpdir(), "crow-home-"));
+  const wsDir = join(crowHome, "pi-bots", bot_id);
+  mkdirSync(wsDir, { recursive: true });
+  const secretFile = join(wsDir, "late.txt");
+  writeFileSync(secretFile, "token ghp_" + "a".repeat(36));
+
+  process.env.CROW_HOME = crowHome;
+  delete process.env.CROW_DB_PATH;
+  process.env.PM_SCAN_RULES_FILE = writeTmpRules();
+
+  const out = await result(db, { job_id: r.job_id });
+  assert.equal(out.scan_status, "findings");
+  assert.ok(out.quarantined.includes(secretFile), "workspace scan must run off created_at when started_at is NULL");
+});
+
+test("workspace root follows CROW_DB_PATH parity with instance-paths.mjs when set (review round 1, IMPORTANT 5)", async (t) => {
+  stashEnv(t, ["CROW_HOME", "CROW_DB_PATH", "PM_SCAN_RULES_FILE"]);
+  const bot_id = "t-bot";
+  const r = await dispatch(db, { bot_id, duty: "d-db-path", goal: "g" });
+
+  const instanceRoot = mkdtempSync(join(tmpdir(), "instance-"));
+  const dataDir = join(instanceRoot, "data");
+  mkdirSync(dataDir, { recursive: true });
+  const dbPath = join(dataDir, "crow.db");
+  writeFileSync(dbPath, ""); // dispatch.js only reads the PATH, never opens this file
+  const wsDir = join(instanceRoot, "pi-bots", bot_id); // sibling of the data dir, per instance-paths.mjs
+  mkdirSync(wsDir, { recursive: true });
+  const secretFile = join(wsDir, "draft.txt");
+  writeFileSync(secretFile, "token ghp_" + "a".repeat(36));
+
+  process.env.CROW_DB_PATH = dbPath;
+  delete process.env.CROW_HOME; // CROW_DB_PATH must win even without CROW_HOME set
+  process.env.PM_SCAN_RULES_FILE = writeTmpRules();
+
+  await db.execute({
+    sql: "UPDATE bot_jobs SET status='completed', result=?, started_at='2020-01-01T00:00:00.000Z' WHERE job_id=?",
+    args: ["clean result text", r.job_id],
+  });
+
+  const out = await result(db, { job_id: r.job_id });
+  assert.equal(out.scan_status, "findings");
+  assert.ok(out.quarantined.includes(secretFile));
 });
 
 test("disposition + telemetry math (edit counts as a miss)", async () => {
@@ -55,11 +165,23 @@ test("disposition + telemetry math (edit counts as a miss)", async () => {
   assert.equal(s.per_bot["t-bot"].decided, 3);
 });
 
-import { writeFileSync, mkdtempSync } from "node:fs";
+import { writeFileSync, mkdtempSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 function writeTmpRules() {
   const p = join(mkdtempSync(join(tmpdir(), "rules-")), "r.json");
   writeFileSync(p, JSON.stringify({ rules: [{ name: "github-token", pattern: "ghp_[A-Za-z0-9]{36}" }] }));
   return p;
+}
+
+// Restores a set of env vars to their pre-test values via t.after, whether
+// they were set, unset, or overwritten mid-test.
+function stashEnv(t, keys) {
+  const prev = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  t.after(() => {
+    for (const k of keys) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  });
 }

--- a/bundles/pm-workspace/test/output-scan.test.js
+++ b/bundles/pm-workspace/test/output-scan.test.js
@@ -30,6 +30,24 @@ test("seeded token is caught and redacted", () => {
   assert.ok(red.includes("[REDACTED:github-token]"));
 });
 
+test("redact coalesces overlapping spans (review round 1, CRITICAL 1)", () => {
+  // The ssn-shaped rule matches a substring INSIDE the slack-token match —
+  // a naive per-finding replace-from-the-end corrupts the outer span's
+  // stale offset once the inner one has already shifted the string, and
+  // raw tail bytes of the token survive. This must not happen.
+  const text = "note xoxb-1234567890-345-67-8901-SECRETTAILXYZ end";
+  const rules = [
+    { name: "slack-token", pattern: /xoxb-1234567890-345-67-8901-SECRETTAILXYZ/g, severity: "secret" },
+    { name: "ssn", pattern: /345-67-8901/g, severity: "secret" },
+  ];
+  const findings = scanText(text, rules);
+  assert.equal(findings.length, 2);
+  const out = redact(text, findings);
+  assert.ok(!/xoxb|345-67-8901|SECRETTAIL/.test(out), `raw token bytes leaked: ${out}`);
+  const markers = out.match(/\[REDACTED:[^\]]*\]/g) || [];
+  assert.equal(markers.length, 1, `expected exactly one merged marker, got: ${out}`);
+});
+
 test("loadRules compiles patterns from a JSON file", () => {
   const dir = mkdtempSync(join(tmpdir(), "scan-"));
   const p = join(dir, "rules.json");

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -5032,6 +5032,11 @@
           "name": "PLANNER_CRON",
           "description": "Cron expression for planner export/reconcile runs (default: */15 * * * *)",
           "required": false
+        },
+        {
+          "name": "PM_SCAN_RULES_FILE",
+          "description": "Path to the JSON rules file (regex secret/PII patterns) the bot dispatch rail scans output against before crow_pm_bot_result returns it; unset skips scanning, set-but-unloadable is a hard error (fail closed)",
+          "required": false
         }
       ],
       "notes": "Notes (markdown + pressure-sensitive drawing with OCR), a daily digest, and deterministic Monday.com sync. Boards/kanban remain the job of the tasks bundle and Bot Board tracker tools — this bundle reads them for the digest and writes them only via the sync engine.",


### PR DESCRIPTION
## Summary

Fix round on the bot dispatch rail (#269), in priority order from a review pass.

**CRITICAL — `redact()` could leak raw secret bytes on overlapping findings.** Two rules can
legitimately match overlapping spans in the same text (e.g. an SSN-shaped pattern matching a
substring inside a longer slack-token match). The old `redact()` replaced each finding
independently, sorted by descending index, "so earlier indexes stay valid" — but that
invariant only holds for *disjoint* spans. When an inner span's replacement changes the
string's length, an outer span's index computed against the *original* string no longer points
at the right place in the *now-shorter-or-longer* string, and the slice for the outer
replacement can cut short of the actual secret, leaving raw tail bytes in the "redacted"
output. Fixed by merging overlapping/adjacent spans into disjoint ranges (union of rule names)
*before* any replacement happens, then replacing those merged spans from the end. New test in
`output-scan.test.js` seeds a slack-token match containing a nested ssn match and asserts the
output contains none of the original token's bytes and exactly one `[REDACTED:...]` marker.

**`crow_pm_bot_dispatch` dropped the `deliver` parameter.** The pi-bots runtime supports
delivery kinds (gmail, gateway threads, …) that route a job's raw output out of band, entirely
around the `crow_pm_bot_result` scan gate. Since this rail's safety property depends on every
job's output being picked up through that one scanned tool, there's no parameter for a caller
to opt into a different delivery target — `deliver_to` is now always the poll literal,
unconditionally.

**`crow_pm_bot_result` quarantines flagged workspace files instead of returning their paths.**
Files that scan clean are listed in `files`; any file with findings now appears (name only)
under a new `quarantined` list and never under `files` — the tool description says explicitly
that a quarantined path must never be opened raw.

**`started_at` NULL no longer fail-opens the workspace scan.** A job can be `completed` with
`started_at` still NULL (only ever set on the "started" transition, not required for
completion); the old code used `job.started_at ? scan : []`, silently skipping the workspace
scan whenever that happened. Cutoff is now `job.started_at || job.created_at` — `created_at` is
`NOT NULL` in the DDL, so the scan always runs for a completed job.

**Workspace root now has instance parity.** Derives from `CROW_DB_PATH` the same way
`scripts/pi-bots/instance-paths.mjs`'s `botsWorkspaceRoot()` does
(`dirname(dirname(CROW_DB_PATH))/pi-bots`) when it's set, falling back to `CROW_HOME/pi-bots`
otherwise — so a per-instance `CROW_DB_PATH` pointing somewhere other than `CROW_HOME/data`
still finds the right per-bot workspace.

**Minor:** `crow_pm_bot_telemetry` now uses the same try/catch → `errorText` pattern as the
other three tools · failed jobs stamp `scan_status` on their `pm_bot_dispatches` row too (was
completed-only), so telemetry can tell a scanned-clean failure from a scanned-and-flagged one ·
the `BOT_JOBS_DDL` mirror comment now notes the runtime's two indexes are intentionally omitted
here (single-statement `execute`, not `executeMultiple`; the runtime self-heals them on first
use) · `manifest.json`'s `env_vars` documentation array now includes `PM_SCAN_RULES_FILE` (it
was already in `envKeys` from #268, just missing from the human-readable docs array);
`registry/add-ons.json` regenerated to match (scoped 5-line diff, the same generated-artifact
step #268 needed).

**Parked, not changed:** `pm_bot_dispatches.verdict` stays as-is — Phase 2's reviewer verdict
writes it.

## Test plan

- [x] `bundles/pm-workspace/test/dispatch.test.js` — 9 tests (5 new: poll-only `deliver_to`,
      failed-job `scan_status` stamping, quarantined-vs-clean file split, NULL-`started_at`
      fallback, `CROW_DB_PATH` workspace-root parity).
- [x] `bundles/pm-workspace/test/output-scan.test.js` — 4 tests (1 new: overlapping-span
      redaction).
- [x] Both files together: 13/13 pass.
- [x] `node scripts/build-registry.mjs --check` clean after regenerating
      `registry/add-ons.json`.
- [x] `tests/bundle-contract.test.js` (28/28) and `tests/bundle-provider-audit.test.js`
      (15/15) pass.
- [x] Full local suite (`node scripts/run-suite.mjs`, 2853 tests) run before and after this
      change: identical 8 pre-existing failures both times (unrelated CLI/schema-migration
      tests) — no regression from this change.
