### PR TITLE
fix(pi-bots): tolerate non-array gateways in bot defs when arming the runtime

### DIFF
--- a/scripts/pi-bots/gateways/gateway_runner.mjs
+++ b/scripts/pi-bots/gateways/gateway_runner.mjs
@@ -54,7 +54,11 @@ function loadGatewayJobs() {
   for (const row of rows) {
     let def;
     try { def = JSON.parse(row.definition || "{}"); } catch { continue; }
-    for (const gw of def.gateways || []) {
+    // Legacy defs carry `gateways: {}` (an empty object, not an array); `for...of`
+    // on a non-array throws. One malformed def must never abort runtime arming
+    // for the whole instance, so a non-array value is tolerated as "no gateways".
+    const gws = Array.isArray(def.gateways) ? def.gateways : [];
+    for (const gw of gws) {
       if (gw && isHostManaged(gw.type)) jobs.push({ bot_id: row.bot_id, gw });
     }
   }


### PR DESCRIPTION
`gateway_runner.mjs`'s `loadGatewayJobs()` did `for (const gw of def.gateways || [])`. A def with `gateways: {}` (an empty object rather than an empty array) is truthy, so `|| []` never substitutes, and `for...of` on a plain object throws `TypeError: object is not iterable`.

That throw happens inside `startAll()`, which `runtime-gate.mjs` awaits as the first step of its `start()` callback (`await startAll(); startJobs(); startSchedules();`). Because the exception aborts the whole callback, one malformed def blocks the background-job runner and the bot-cron scheduler from arming for the *entire* instance, not just its own gateway adapters — discovered live when flipping `feature_flags.bot_runtime` on an instance where four legacy bot defs predate the convention of `gateways: []`.

Fix: coerce a non-array `gateways` to `[]` before iterating, with a comment explaining why. One-line behavioral change, no new dependencies.

Testing: `loadGatewayJobs` isn't exported, and the module runs a `main()` IIFE at import time that opens the live `CROW_DB` and starts the runtime-gate poller — importing it in a test would carry that side effect. Unit-testing it directly would need either exporting the function or gating the IIFE behind an entrypoint check, which is more than this fix's scope. Skipping a new test per the task's own fallback for heavy scaffolding; ran the existing gateway/runtime-gate suite instead (`node --test tests/runtime-gate.test.js tests/bot-builder-gateway-draft.test.js tests/gateway-shutdown.test.js tests/kill-orphan-gateways.test.js tests/bot-builder-gateway-fields.test.js tests/gateway-delegate-tools.test.js`) before and after the change: same 37 pass / 22 fail split both times (the 22 failures are pre-existing on `main`, unrelated to this file). `runtime-gate.test.js` itself is fully green in both runs. `node --check` passes on the changed file.