### PR TITLE
feat(migrations): per-instance migration registry

### DIFF
--- a/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
+++ b/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
@@ -20,6 +20,9 @@
 - **Foreground test runs with direct file capture.** Baseline is **2961 pass / 0 fail** on this worktree.
 - **Every test file that can reach `fireMigrationAlert` MUST call `_setAlertChannelsForTest`** with no-op channels, or the suite sends real ntfy pushes and emails.
 - **Every test that can reach `checkForUpdates` MUST call `_setAppRootForTest(<fixture>)` and restore it**, or it runs git against the real worktree.
+- **Every bare `node --test <file>` in this plan MUST be prefixed `CROW_DISABLE_CONVERGE=1`** unless the file pins its own `CROW_DATA_DIR`/`CROW_DB_PATH`. After Task 9, `checkForUpdates()` with no injected instance resolves paths from env — and `npm test` pins a scratch env (`run-suite.mjs`) but a bare run does **not**. `resolveDataDir()` then falls back to `~/.crow/data`, so the existing auto-update tests would `CREATE TABLE`/`ALTER TABLE` the **live primary gateway's** `crow.db` and `tasks.db` and drop a `convergence-pending.json` the live gateway would act on at its next boot. On a host that has lost databases twice this month, this is the single most dangerous line in the plan.
+- **Add `process.env.CROW_DISABLE_CONVERGE = "1"` at the top of `tests/auto-update-hardening.test.js`, `tests/auto-update-ci-gate.test.js`, and `tests/auto-update-tick-gate.test.js`** (beside their existing `delete process.env.INVOCATION_ID` scrub). Those files test the TREE half; the instance half has its own files.
+- **Restore, never delete, environment variables.** `run-suite.mjs` sets `CROW_DATA_DIR` for the whole child process; a test that does `delete process.env.CROW_DATA_DIR` in a `finally` makes every later test in that file resolve to `~/.crow/data`. Capture the previous value and put it back.
 - **Coordination:** `pibot-gateways@r4` is mid-soak from `~/crow` through ~2026-08-12 — log a timestamp for every pull touching `scripts/pi-bots/` and every restart. Don't touch `~/crow-wt-board` or `~/.crow/p4/harness-wt`.
 
 ---
@@ -109,9 +112,22 @@ primary_counts() {
     [ -f "$d" ] || { echo "$d MISSING"; continue; }
     cp "$d" "/tmp/pcheck.db"; [ -f "$d-wal" ] && cp "$d-wal" "/tmp/pcheck.db-wal"
     [ -f "$d-shm" ] && cp "$d-shm" "/tmp/pcheck.db-shm"
+    # Count USER ROWS in every table, not schema objects. Counting sqlite_master
+    # entries would be blind to exactly the leak this guard exists to catch: an
+    # env-leaked migration that INSERTs or DELETEs rows in the primary leaves the
+    # schema untouched and would print PASS.
     echo -n "$d "
-    sqlite3 /tmp/pcheck.db \
-      "SELECT (SELECT count(*) FROM sqlite_master)||':'||(SELECT coalesce(sum(1),0) FROM sqlite_master WHERE type='table');"
+    sqlite3 /tmp/pcheck.db "
+      SELECT group_concat(n, ',') FROM (
+        SELECT name || '=' || (SELECT count(*) FROM pragma_table_info(name)) AS n
+        FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name);" \
+      2>/dev/null
+    # Row counts require dynamic SQL; emit them per table.
+    for t in $(sqlite3 /tmp/pcheck.db \
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;"); do
+      echo -n " $t:$(sqlite3 /tmp/pcheck.db "SELECT count(*) FROM \"$t\";" 2>/dev/null)"
+    done
+    echo
     rm -f /tmp/pcheck.db /tmp/pcheck.db-wal /tmp/pcheck.db-shm
   done
 }
@@ -171,14 +187,10 @@ chmod +x /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh && ls -l /home/kh0pp/r4-tehcy
 The gate is a **regression** check, matching the gateway's. An absolute "all connected" gate would have failed every deploy during Aug 3–5, when `tasks` and `bots-sql-mcp` were legitimately down for an unrelated ABI reason, and demanded rollback of a good tree.
 
 ```bash
-addon_states() {  # id=status per line, from the CURRENT journal
-  journalctl -u crow-r4-gateway --since "-24h" --no-pager 2>/dev/null \
-    | grep -oE 'addon [a-z0-9-]+: (connected|disconnected)' \
-    | awk '{print $2$3}' | sed 's/://' | sort -u | awk -F: '{print}' | tail -50
-}
 BASELINE_CONNECTED=$(journalctl -u crow-r4-gateway --since "-24h" --no-pager 2>/dev/null \
   | grep -oE 'addon [a-z0-9-]+: connected' | awk '{print $2}' | tr -d ':' | sort -u)
-log "baseline connected addons: $(echo "$BASELINE_CONNECTED" | tr '\n' ' ')"
+BASELINE_COUNT=$(echo "$BASELINE_CONNECTED" | grep -c . || true)
+log "baseline connected addons ($BASELINE_COUNT): $(echo "$BASELINE_CONNECTED" | tr '\n' ' ')"
 ```
 
 - [ ] **Step 2: Native ABI rebuild, test-loaded**
@@ -203,12 +215,19 @@ done
 RESTART_AT=$(date -Is)
 run sudo systemctl restart crow-r4-gateway || fail "systemctl restart"
 if [ "$DRY_RUN" = 0 ]; then
-  log "waiting for the addon loop to settle (cap 10m)"
+  # Wait until EVERY baseline addon has reported a terminal state — not until the
+  # first one has. Addons connect sequentially at 60s each, so breaking on the
+  # first line exits while later addons have not even been ATTEMPTED; the
+  # regression gate below would then fail a perfectly healthy deploy.
+  log "waiting for all $BASELINE_COUNT baseline addon(s) to reach a terminal state (cap 10m)"
   for i in $(seq 1 120); do
-    journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null \
-      | grep -q "Loading .* addon server" && \
-    journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null \
-      | grep -qE "addon .*: (connected|failed to connect)" && sleep 5 && break
+    J=$(journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null || true)
+    settled=1
+    for a in $BASELINE_CONNECTED; do
+      echo "$J" | grep -qE "addon $a: (connected|failed to connect)" || { settled=0; break; }
+    done
+    [ "$settled" = 1 ] && { log "all baseline addons settled after $((i*5))s"; break; }
+    [ "$i" = 120 ] && log "WARNING: settle timeout — gating on what has reported so far"
     sleep 5
   done
 fi
@@ -487,7 +506,7 @@ git show --stat HEAD
 - [ ] **Step 1: Write the failing test (append)**
 
 ```js
-test("0001-board-stages: adds columns, DEFERS when every table is absent, idempotent", async () => {
+test("0001-board-stages: adds columns, DEFERS when ANY table is absent, idempotent", async () => {
   const dir = join(import.meta.dirname, "..", "scripts", "migrations");
 
   // (a) All targets absent → deferred, NOT recorded.
@@ -498,6 +517,26 @@ test("0001-board-stages: adds columns, DEFERS when every table is absent, idempo
       "a fresh instance has no tasks_items yet — recording this as applied is the original bug");
     assert.ok(!r.applied.includes("0001-board-stages"));
   } finally { rmSync(bare.root, { recursive: true, force: true }); }
+
+  // (a2) THE PRODUCTION SHAPE: crow.db tables present (init-db has run), tasks.db
+  // table absent (the bundle has not started). This is every real instance at boot,
+  // and an `all absent` rule would wrongly mark it applied here.
+  const mixed = fixture();
+  try {
+    const c = new Database(mixed.dbPath);
+    c.prepare("CREATE TABLE project_spaces (id INTEGER PRIMARY KEY)").run();
+    c.prepare("CREATE TABLE bot_sessions (id INTEGER PRIMARY KEY)").run();
+    c.close();
+    const r = await runMigrations({ migrationsDir: dir, dbPath: mixed.dbPath, tasksDbPath: mixed.tasksDbPath });
+    assert.ok(r.deferred.includes("0001-board-stages"),
+      "crow.db tables present + tasks_items absent MUST defer — this is the real-instance shape");
+    assert.ok(!r.applied.includes("0001-board-stages"),
+      "recording it here is exactly the bug: tasks_items gets created later WITHOUT the columns");
+    // The crow.db half still applied its columns — deferral is about the RECORD.
+    const c2 = new Database(mixed.dbPath);
+    assert.ok(c2.prepare("PRAGMA table_info(project_spaces)").all().map((x) => x.name).includes("repo_path"));
+    c2.close();
+  } finally { rmSync(mixed.root, { recursive: true, force: true }); }
 
   // (b) tasks_items present → applied, columns added, re-runnable.
   const f = fixture();
@@ -563,9 +602,16 @@ export function run({ dbPath, tasksDbPath, log = () => {} }) {
     }
   } finally { cdb.close(); }
 
-  // Every target table missing means this instance's stores do not exist YET —
-  // not that the work is done. Defer so the runner retries on the next boot.
-  if (results.every((r) => r === "absent")) return { deferred: true };
+  // ANY absent target means this instance's stores do not all exist YET — not
+  // that the work is done. Defer so the runner retries after the addons settle.
+  //
+  // `any`, NOT `all`. This migration spans two databases: project_spaces lives in
+  // crow.db and is created by init-db.js (so it is ALWAYS present by the time the
+  // boot registry runs), while tasks_items lives in tasks.db and is created by the
+  // tasks BUNDLE, which starts after the gateway boots. An `all` rule would never
+  // fire on a real instance — project_spaces alone would mark the whole migration
+  // applied and the tasks_items columns would never land. That is the original bug.
+  if (results.includes("absent")) return { deferred: true };
 }
 ```
 
@@ -683,7 +729,7 @@ CROW_HOME=$S CROW_DATA_DIR=$S/data CROW_DB_PATH=$S/data/crow.db \
 CROW_AUTO_UPDATE=0 CROW_ALLOW_ORPHAN=1 PORT=3099 \
 timeout 120 node servers/gateway/index.js --no-auth 2>&1 | tee $S/boot.log | head -60
 ```
-Expected: `[migrations] deferred (will retry): 0001-board-stages` — a wiped instance has no `tasks_items` yet, so **deferred is the correct outcome here, not applied**. Gateway reaches its listen line. Then confirm `~/.crow/data/crow.db` mtime is unchanged.
+Expected, in this order: `[migrations] deferred (will retry): 0001-board-stages` at boot (a wiped instance has no `tasks_items` yet, so **deferred is correct here, not applied**), the gateway's listen line, and then — only if a `tasks` bundle is installed — `[migrations:post-settle] applied: 0001-board-stages`. With no bundles installed, `[migrations:post-settle] STILL deferred` is the correct outcome. Then confirm `~/.crow/data/crow.db` mtime is unchanged.
 
 - [ ] **Step 7: Full suite** — `npm test > …/suite-partA.log 2>&1`, then `grep -E "^# (tests|pass|fail|cancelled)"`. Expected `# fail 0`, `# cancelled 0`.
 
@@ -779,14 +825,41 @@ export function healthSnapshot() {
 
 let _settledResolve;
 const _settled = new Promise((r) => { _settledResolve = r; });
-/** Resolves once initProxyServers' addon-connect loop has finished. Addons
- *  connect SEQUENTIALLY at CONNECT_TIMEOUT_MS each, so total time is unbounded
- *  in addon count and no fixed grace window is correct. */
+/** Resolves once addon loading has finished — however it finished. Addons connect
+ *  SEQUENTIALLY at CONNECT_TIMEOUT_MS each, so total time is unbounded in addon
+ *  count and no fixed grace window is correct. */
 export function addonsSettled() { return _settled; }
 export function _markAddonsSettled() { _settledResolve?.(); }
 ```
 
-Then call `_markAddonsSettled()` at the end of the addon `for` loop in `initProxyServers` (after the loop at `proxy.js:337-344`), and also on the `entries.length === 0` early return, so it always resolves.
+**Resolve it in a `finally` wrapping the whole body of `initProxyServers`** — NOT at the end of the addon loop. That loop lives in `loadAddonServers`, which returns early three different ways before ever reaching it (`proxy.js:323` no `mcp-addons.json` — the common case on a fresh instance; the `JSON.parse` catch; `entries.length === 0`), and `initProxyServers` is itself called fire-and-forget with a `.catch` at `post-listen.js:168`. Resolving only at the end of the loop means the signal never fires on any of those paths — the gate then awaits forever, the cookie is never cleared, and the *next* boot reads an expired cookie and quarantines a sha that was healthy all along.
+
+```js
+export async function initProxyServers() {
+  try {
+    // ...existing body unchanged...
+  } finally {
+    _markAddonsSettled();
+  }
+}
+```
+
+- [ ] **Step 3b: Write the test that would have caught this**
+
+```js
+test("addonsSettled resolves even when there is no mcp-addons.json", async () => {
+  const { addonsSettled, _markAddonsSettled } = await import("../servers/gateway/proxy.js");
+  let resolved = false;
+  addonsSettled().then(() => { resolved = true; });
+  await new Promise((r) => setImmediate(r));
+  assert.equal(resolved, false, "must not be resolved before the loader runs");
+  _markAddonsSettled();
+  await addonsSettled();
+  assert.equal(resolved, true);
+});
+```
+
+Then mutate: move `_markAddonsSettled()` from the `finally` to the end of the addon loop and run a gateway with no `mcp-addons.json` — `verifyPendingConvergence` must be seen to hang. That behavioral check is the real proof; the unit test above only pins the primitive.
 
 - [ ] **Step 4: Create convergence.js with the comparator**
 
@@ -932,9 +1005,15 @@ const PENDING_FILE = "convergence-pending.json";
 const QUARANTINE_FILE = ".crow-convergence-quarantine.json";
 
 /** Atomic: a crash mid-write must not leave torn JSON that readPending would
- *  silently swallow as "nothing pending". */
+ *  silently swallow as "nothing pending".
+ *
+ *  The tmp path is PER-PROCESS. The repo-root quarantine marker has three writers
+ *  (one per co-hosted gateway); a shared `${path}.tmp` lets P2's O_TRUNC land in
+ *  the middle of P1's write, and P1 then renames the resulting byte-salad into
+ *  place ATOMICALLY. Every peer's JSON.parse then throws, readConvQuarantine
+ *  returns null, and the canary's failure is silently discarded. */
 function writeAtomic(path, obj) {
-  const tmp = `${path}.tmp`;
+  const tmp = `${path}.tmp.${process.pid}`;
   writeFileSync(tmp, JSON.stringify(obj, null, 2));
   renameSync(tmp, path);
 }
@@ -1219,13 +1298,39 @@ Replace the lock-loss early return (lines 209-223) so it **falls through**:
       pulled = Boolean(treeResult?.updated);
     }
 
-    // The INSTANCE half — always, for every gateway, lock or no lock.
+    // The INSTANCE half — for every gateway, lock or no lock, EXCEPT when this
+    // process's own tree half explicitly refused a restart.
+    //
+    // runLockedUpdate returns updated:false on three branches whose entire purpose
+    // is to withhold the restart: "init-db failed — restart withheld", and both
+    // migration-guard loss paths. The tree has already moved on all three, so
+    // bootSha !== HEAD is true and a naive fall-through restarts anyway — into a
+    // sha whose init-db just failed. The boot guard then hits index.js:183
+    // process.exit(1), systemd restarts, same again, StartLimitBurst is exhausted,
+    // and the UNIT IS DEAD — on each co-hosted gateway as its own tick arrives.
+    // A peer may still converge (it refused nothing, and the quarantine markers
+    // guard the genuinely-bad shas); the process that refused does not.
+    if (treeResult?.converge === false) {
+      log("instance half skipped — this process's own update refused a restart");
+      return { ...treeResult, pulled, converged: false, skipped: "refused" };
+    }
     const { convergeInstance } = await import("./convergence.js");
-    const conv = await convergeInstance({ instance, pulled, log });
+    const conv = await convergeInstance({ appRoot: APP_ROOT, instance, pulled, log });
     return { ...treeResult, pulled, converged: conv.converged, applied: conv.applied };
 ```
 
 and change the signature to `export async function checkForUpdates({ instance = null } = {})`.
+
+Passing `APP_ROOT` is **required, not tidiness**: `convergeInstance`'s fallback derives the root from `import.meta.url`, which is the real worktree. Without this, the two-instance gate's tree half operates on the fixture while its instance half operates on `~/crow-wt-rolling` — reading the real `scripts/migrations/`, so the fixture's probe migration is never discovered and the gate can never pass, while `.crow-convergence-quarantine.json` gets written into a checkout three live gateways share.
+
+- [ ] **Step 3b: Mark every refusal branch in `runLockedUpdate`**
+
+Add `converge: false` to the three returns that withhold a restart — the `init-db failed (exit N)` return (~line 475), and both migration-guard loss returns (~line 441 and ~line 464). Leave every other return alone: a successful update, an "up to date", a CI-gate skip and a quarantine skip did **not** refuse anything.
+
+```js
+    return { updated: false, error: msg, converge: false };            // init-db failed
+    return { updated: false, error: msg, quarantined: true, converge: false };  // both loss paths
+```
 
 - [ ] **Step 4: Implement `convergeInstance`**
 
@@ -1274,8 +1379,15 @@ export async function convergeInstance({ appRoot, instance = null, pulled = fals
     return { pulled, converged: false, skipped: "quarantined", sha: head, applied: [] };
   }
 
+  // A null boot sha is a REFUSAL, not a licence. setBootSha is best-effort; if
+  // `git rev-parse` failed, treating null as "not current" would converge and
+  // restart on every tick forever, and the health gate could not stop it —
+  // classifyPending with a null bootSha returns "stale", which clears the cookie
+  // without ever verifying. Same for an empty head.
   const boot = getBootSha();
-  if (boot && boot === head) return { pulled, converged: false, skipped: "current", sha: head, applied: [] };
+  if (!head) return { pulled, converged: false, skipped: "no-head", sha: null, applied: [] };
+  if (!boot) return { pulled, converged: false, skipped: "no-boot-sha", sha: head, applied: [] };
+  if (boot === head) return { pulled, converged: false, skipped: "current", sha: head, applied: [] };
 
   const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
   const { join } = await import("node:path");
@@ -1284,10 +1396,22 @@ export async function convergeInstance({ appRoot, instance = null, pulled = fals
     dbPath: inst.dbPath, tasksDbPath: inst.tasksDbPath, sha: head, log,
   });
 
-  // Baseline BEFORE the restart, from the still-live process, then hand it
-  // across the restart in the cookie.
+  // Without a supervisor, scheduleSupervisedRestart is a SILENT no-op. Writing a
+  // deadline-bearing cookie and then not restarting means the deadline passes and
+  // the next boot — hours later, on code that ran fine the whole time — classifies
+  // it "failed" and quarantines a healthy sha for every instance sharing this
+  // checkout. Migrate, tell the operator, write nothing.
+  const { isSupervised } = await import("../shared/supervisor.js");
+  if (!isSupervised()) {
+    log(`migrations applied for ${head.slice(0, 9)}; no supervisor — restart manually to load the new code`);
+    return { pulled, converged: false, skipped: "unsupervised", sha: head, applied: res.applied };
+  }
+
+  // Baseline BEFORE the restart, from the still-live process, handed across the
+  // restart in the cookie. An empty baseline means "nothing was connected", which
+  // compareHealth treats as never-regresses — the correct fail-open reading.
   let baseline = {};
-  try { ({ healthSnapshot: baseline } = {}); const p = await import("./proxy.js"); baseline = p.healthSnapshot(); } catch {}
+  try { const p = await import("./proxy.js"); baseline = p.healthSnapshot(); } catch {}
   writePending(inst.dataDir, { sha: head, baseline });
 
   const au = await import("./auto-update.js");
@@ -1295,8 +1419,6 @@ export async function convergeInstance({ appRoot, instance = null, pulled = fals
   return { pulled, converged: true, sha: head, applied: res.applied };
 }
 ```
-
-Clean up the `baseline` line to a plain `try { const p = await import("./proxy.js"); baseline = p.healthSnapshot(); } catch {}` when implementing.
 
 - [ ] **Step 5: Capture the boot sha at gateway start**
 
@@ -1319,7 +1441,89 @@ try {
 1. Restore the early `return` in the lock-loss branch → **beta must fail.** *(Under the previous harness this mutation could not go red, because sequential calls never contended. If it stays green now, the gate is still worthless — stop and fix it.)*
 2. Guard the instance half with `if (pulled) { ... }` → beta must fail.
 3. Delete `assert.equal(b.skipped, "locked")` mentally and re-run mutation 1 — confirm the *probe-column* assertion also moves, so the gate does not rest on the status string alone.
-4. Make `convergeInstance` return before `writePending` → Task 10's verification tests fail.
+4. Remove the `converge: false` guard → the refusal test (Step 7b) must fail.
+5. Delete the `boot === head` short-circuit → the "current instance does not converge" test (Step 7b) must fail. **This is the most dangerous single line in the design** — without it, every tick migrates and restarts, forever.
+6. Leave `scheduleSupervisedRestart` on `runLockedUpdate`'s success path → the "restart is scheduled exactly once" assertion must fail.
+
+*(The previous revision claimed "make `convergeInstance` return before `writePending` → Task 10's tests fail". That was a false mutation claim: all three Task 10 tests call `writePending` directly in the test body and inject `snapshot`/`settled`, so none of them ever reaches `convergeInstance`'s write path. Step 7b below closes that gap for real.)*
+
+- [ ] **Step 7b: Tests for the seams no existing test covers**
+
+Each of these currently survives every mutation in the plan — they are the "silently dead seam" class that `healthSnapshot` was fixed for.
+
+```js
+test("convergeInstance writes the cookie with the REAL pre-restart baseline", async () => {
+  const f = twoInstanceFixture();
+  _setAppRootForTest(f.work);
+  const { convergeInstance, setBootSha, readPending } = await import("../servers/gateway/convergence.js");
+  const { connectedServers } = await import("../servers/gateway/proxy.js");
+  connectedServers.clear();
+  connectedServers.set("tasks", { status: "connected", isAddon: true });
+  process.env.CROW_SUPERVISED = "1";                    // else convergence refuses
+  setBootSha("older-than-head");
+  try {
+    f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+    await convergeInstance({ appRoot: f.work, instance: f.instances[0] });
+    const p = readPending(f.instances[0].dataDir);
+    assert.ok(p, "convergence MUST write the cookie before restarting");
+    assert.equal(p.sha, g(f.work, "rev-parse", "HEAD"));
+    assert.deepEqual(p.baseline, { tasks: "connected" },
+      "the baseline must be the live snapshot, not an empty object");
+  } finally { delete process.env.CROW_SUPERVISED; connectedServers.clear(); }
+});
+
+test("a CURRENT instance does not converge, and an UNSUPERVISED one writes no cookie", async () => {
+  const f = twoInstanceFixture();
+  const { convergeInstance, setBootSha, readPending } = await import("../servers/gateway/convergence.js");
+  const head = g(f.work, "rev-parse", "HEAD");
+
+  setBootSha(head);
+  const cur = await convergeInstance({ appRoot: f.work, instance: f.instances[0] });
+  assert.equal(cur.skipped, "current", "an up-to-date instance must not restart every tick");
+
+  setBootSha(null);
+  const nul = await convergeInstance({ appRoot: f.work, instance: f.instances[0] });
+  assert.equal(nul.skipped, "no-boot-sha", "a null boot sha must REFUSE, not converge forever");
+
+  setBootSha("older");
+  f.advanceOrigin("0003-probe2.mjs", MIGRATION_BODY.replace(/0002-converge-probe/g, "0003-probe2"));
+  delete process.env.INVOCATION_ID; delete process.env.CROW_SUPERVISED;   // unsupervised
+  const uns = await convergeInstance({ appRoot: f.work, instance: f.instances[1] });
+  assert.equal(uns.skipped, "unsupervised");
+  assert.equal(readPending(f.instances[1].dataDir), null,
+    "no supervisor means no restart — a cookie here would expire and quarantine a HEALTHY sha");
+});
+
+test("a tree half that refused a restart is not overridden by convergence", async () => {
+  // The crash-loop case: init-db failed post-pull, restart deliberately withheld.
+  // Convergence must NOT restart into that sha — index.js:183 exits 1, systemd
+  // retries, StartLimitBurst is exhausted, and the unit is dead.
+  const f = twoInstanceFixture();
+  _setAppRootForTest(f.work);
+  _setDbForTest(stubDb());
+  // Land a commit whose init-db.js exits nonzero.
+  writeFileSync(join(f.work, "scripts", "init-db.js"), "process.exit(3);\n");
+  g(f.work, "add", "-A"); g(f.work, "commit", "-m", "bad init-db");
+  g(f.work, "push", "origin", "main"); g(f.work, "reset", "--hard", "HEAD~1");
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
+
+  const r = await checkForUpdates({ instance: f.instances[0] });
+  assert.equal(r.converged, false, "the process that refused must not converge");
+  assert.equal(r.skipped, "refused");
+  assert.equal(hasProbe(f.instances[0].tasksDbPath), false, "no migrations after a refusal");
+});
+```
+
+Also add a source-anchor test for the post-listen wiring, mirroring Task 5's — without it, deleting that whole block leaves every test green while the health gate never runs:
+
+```js
+test("post-listen wires convergence verification after startAutoUpdate", () => {
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "boot", "post-listen.js"), "utf8");
+  const start = src.indexOf("startAutoUpdate(");
+  const verify = src.indexOf("verifyPendingConvergence");
+  assert.ok(start > 0 && verify > start, "verification must be wired, and after auto-update starts");
+});
+```
 
 - [ ] **Step 8: Existing auto-update tests** — `node --test tests/auto-update-hardening.test.js tests/auto-update-ci-gate.test.js tests/auto-update-tick-gate.test.js`. These call `checkForUpdates()` with no argument; the new optional-object signature must keep them passing. The lock-skip message changed — update any assertion to the new text and confirm it still asserts behavior, not just a string.
 
@@ -1477,12 +1681,42 @@ export async function verifyPendingConvergence({
     const { fileURLToPath } = await import("node:url");
     const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
     const inst = await conv.resolveInstance();
+
+    // SECOND registry pass, after the addons have settled. The boot pass (Task 5)
+    // runs before serving, when crow.db's tables exist but bundle-owned stores do
+    // NOT — the tasks bundle creates tasks_items only once it starts, which is
+    // after boot. A boot-only registry defers tasks_items and then never retries,
+    // because a current instance short-circuits its ticks on bootSha === HEAD:
+    // the Bot Board 500 this whole plan exists to fix would survive it. A store's
+    // owner having started is the only reliable happens-before for migrating it.
+    // Idempotent by construction: applied ids are skipped by record.
+    await addonsSettled();
+    try {
+      const { runMigrations } = await import("../../../scripts/migrations/runner.mjs");
+      const r2 = await runMigrations({
+        migrationsDir: join(appRoot, "scripts", "migrations"),
+        dbPath: inst.dbPath, tasksDbPath: inst.tasksDbPath,
+        log: (m) => console.log(`[migrations:post-settle] ${m}`),
+      });
+      if (r2.applied.length) console.log(`[migrations:post-settle] applied: ${r2.applied.join(", ")}`);
+      if (r2.deferred.length) console.warn(`[migrations:post-settle] STILL deferred: ${r2.deferred.join(", ")} — the owning bundle may not be installed`);
+    } catch (err) { console.warn("[migrations:post-settle] skipped:", err.message); }
+
     await conv.verifyPendingConvergence({
       dataDir: inst.dataDir, appRoot, bootSha: conv.getBootSha(),
-      snapshot: healthSnapshot, settled: addonsSettled,
+      snapshot: healthSnapshot, settled: async () => {},   // already awaited above
       log: (m) => console.log(`[convergence] ${m}`),
     });
   }).catch((err) => console.warn("[convergence] verification skipped:", err.message));
+```
+
+Give `addonsSettled()` a timeout at this call site so a loader that never settles cannot hang the gate forever — resolve after 10 min and proceed, which yields `unknown`/fail-open rather than `failed`:
+
+```js
+const settledOrTimeout = () => Promise.race([
+  addonsSettled(),
+  new Promise((r) => setTimeout(r, 10 * 60 * 1000).unref()),
+]);
 ```
 
 - [ ] **Step 5: Run** — `node --test tests/convergence-two-instance.test.js tests/migration-guard.test.js` → PASS (migration-guard is untouched by this design and must stay green).

--- a/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
+++ b/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
@@ -392,7 +392,7 @@ test("a throwing migration aborts the rest and records nothing", async () => {
 
 - [ ] **Step 2: Verify it fails**
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && CROW_DISABLE_CONVERGE=1 node --test tests/migration-registry.test.js`
 Expected: FAIL — `Cannot find module '../scripts/migrations/runner.mjs'`.
 
 - [ ] **Step 3: Implement**
@@ -470,7 +470,7 @@ export async function runMigrations({ migrationsDir, dbPath, tasksDbPath, sha = 
 }
 ```
 
-- [ ] **Step 4: Run** — `node --test tests/migration-registry.test.js` → PASS, 6 tests.
+- [ ] **Step 4: Run** — `CROW_DISABLE_CONVERGE=1 node --test tests/migration-registry.test.js` → PASS, 6 tests.
 
 - [ ] **Step 5: Mutation-test (assume vacuous until proven otherwise)**
 
@@ -557,7 +557,7 @@ test("0001-board-stages: adds columns, DEFERS when ANY table is absent, idempote
 });
 ```
 
-- [ ] **Step 2: Verify it fails** — `node --test tests/migration-registry.test.js` → FAIL, `0001-board-stages` not in `deferred`.
+- [ ] **Step 2: Verify it fails** — `CROW_DISABLE_CONVERGE=1 node --test tests/migration-registry.test.js` → FAIL, `0001-board-stages` not in `deferred`.
 
 - [ ] **Step 3: Implement**
 
@@ -628,12 +628,13 @@ const out = run({ dbPath: botsDbPath(), tasksDbPath: tasksDbPath(), log: (m) => 
 if (out?.deferred) console.log("  (deferred — target tables absent on this instance)");
 ```
 
-- [ ] **Step 5: Run** — `node --test tests/migration-registry.test.js tests/board-stages-migration.test.js` → PASS. If the pre-existing board-stages test asserts on the old script's internals, adapt it to the wrapper; do not weaken the assertion.
+- [ ] **Step 5: Run** — `CROW_DISABLE_CONVERGE=1 node --test tests/migration-registry.test.js tests/board-stages-migration.test.js` → PASS. If the pre-existing board-stages test asserts on the old script's internals, adapt it to the wrapper; do not weaken the assertion.
 
 - [ ] **Step 6: Mutation-test**
 1. `if (!t) return "absent"` → `throw` → the deferral assertion fails.
 2. Remove the `have.includes(column)` guard → the direct re-run fails with "duplicate column name".
-3. Delete the `results.every(...)` deferral return → test (a) fails.
+3. Delete the `results.includes("absent")` deferral return → tests (a) and (a2) fail.
+4. Change `results.includes("absent")` to `results.every((r) => r === "absent")` → test **(a2)** fails while (a) stays green. This is the exact defect round 2 caught: an `all` rule passes the both-bare fixture and silently fails every real instance.
 
 - [ ] **Step 7: Commit**
 
@@ -712,7 +713,7 @@ try {
 }
 ```
 
-- [ ] **Step 4: Run** — `node --test tests/migration-registry.test.js` → PASS.
+- [ ] **Step 4: Run** — `CROW_DISABLE_CONVERGE=1 node --test tests/migration-registry.test.js` → PASS.
 
 - [ ] **Step 5: Mutation-test the invariant** (the previous plan revision had no mutation here)
 1. Move the registry block *above* the schema-guard block → the `guardCall < registry` assertion must fail.
@@ -1525,7 +1526,7 @@ test("post-listen wires convergence verification after startAutoUpdate", () => {
 });
 ```
 
-- [ ] **Step 8: Existing auto-update tests** — `node --test tests/auto-update-hardening.test.js tests/auto-update-ci-gate.test.js tests/auto-update-tick-gate.test.js`. These call `checkForUpdates()` with no argument; the new optional-object signature must keep them passing. The lock-skip message changed — update any assertion to the new text and confirm it still asserts behavior, not just a string.
+- [ ] **Step 8: Existing auto-update tests** — `CROW_DISABLE_CONVERGE=1 node --test tests/auto-update-hardening.test.js tests/auto-update-ci-gate.test.js tests/auto-update-tick-gate.test.js`. These call `checkForUpdates()` with no argument; the new optional-object signature must keep them passing. The lock-skip message changed — update any assertion to the new text and confirm it still asserts behavior, not just a string.
 
 - [ ] **Step 9: Commit**
 

--- a/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
+++ b/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
@@ -4,290 +4,266 @@
 
 **Goal:** Make every co-hosted crow gateway converge itself to the shared checkout — running its own migrations with its own env and verifying its own health — instead of one instance winning a lock and the others silently starving.
 
-**Architecture:** Split the auto-updater's single operation into `updateTree()` (checkout-scoped, one winner, does the pull) and `convergeInstance()` (per-instance, no lock, always runs). A file-based ordered migration registry runs at gateway boot for the booting instance's own stores. A boot cookie carries a pre-convergence health baseline across the restart; the new boot compares against it and, on regression, quarantines that sha so peers never converge to it. The shared git tree is never mutated by a health failure.
+**Architecture:** `checkForUpdates()` is **restructured**, not supplemented: acquire the checkout lock, run the tree half only if held, release, then **always** run the instance half. The scheduled tick stays the single production path. Convergence owns the restart, writes a boot cookie carrying a pre-restart addon-health baseline, and on regression writes a convergence-specific quarantine marker that withholds *convergence* (never the pull) and hard-expires after 24 h.
 
 **Tech Stack:** Node 22 (ABI 127) ESM, `better-sqlite3` for raw short-lived migration handles, node built-in test runner, bash for the Phase 1 deploy script.
 
 ## Global Constraints
 
-- **Node 22 on every invocation:** `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH`. Default `node` on crow is v20 — `better-sqlite3` is built for 22 and a v20 run fails `NODE_MODULE_VERSION 127 vs 115`.
-- **`~/crow` stays on `main` always.** All work happens in the worktree `/home/kh0pp/crow-wt-rolling` on branch `feat/safe-rolling-updates` (already created, `node_modules` symlinked to `~/crow/node_modules`).
-- **Positional-path commits:** `git commit <path> -m "..."`, never `git add .` then a bare commit. Verify with `git show --stat HEAD` after every commit.
-- **NEVER attribute Claude** as author, co-author, or contributor on any commit or PR.
-- **PR flow only** — `enforce_admins` is TRUE. Green check-runs (`suite`, `static-checks`, `audit`) queried via `https://api.github.com/repos/kh0pper/crow/commits/<sha>/check-runs` before merge. Never the legacy commit-status API.
-- **No `SCHEMA_GENERATION` bump in this work.** `schema_migrations` is created lazily by the runner, never added to `scripts/init-db.js`.
-- **Never open a running gateway's `crow.db` with an external sqlite3 client.** Copy the `.db` plus `-wal` and `-shm`, query the copy.
-- **`scripts/init-db.js` without `CROW_DATA_DIR` writes the LIVE `~/.crow/data/crow.db`.** Pin `CROW_HOME`, `CROW_DATA_DIR`, and `CROW_DB_PATH` on every out-of-gateway invocation.
-- **Test runs are foregrounded with direct file capture** (`npm test > log 2>&1`). Piping a background run through `tail` produced 0-byte logs twice in the P2 arc.
-- **Baseline is 2961 tests / 2961 pass / 0 fail** (verified on this worktree, node v22.23.1). Any deviation is yours.
-- **Coordination:** `pibot-gateways@r4` is mid-soak from the `~/crow` working tree through ~2026-08-12. Log a timestamp for every `~/crow` pull touching `scripts/pi-bots/` and every restart of that unit. Keep `bridge.mjs`'s exported surface name-stable. Do not touch `~/crow-wt-board` or `~/.crow/p4/harness-wt`.
+- **Node 22 on every invocation:** `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH`. Default `node` is v20; `better-sqlite3` is built for 22 and a v20 run fails `NODE_MODULE_VERSION 127 vs 115`.
+- **`~/crow` stays on `main` always.** Work in `/home/kh0pp/crow-wt-rolling` on `feat/safe-rolling-updates` (`node_modules` symlinked).
+- **Positional-path commits**, verified with `git show --stat HEAD`. **NEVER attribute Claude.**
+- **PR flow only** (`enforce_admins` TRUE). Green `suite`/`static-checks`/`audit` via `/commits/<sha>/check-runs`, never commit-status.
+- **No `SCHEMA_GENERATION` bump.** `schema_migrations` is created lazily by the runner.
+- **Never open a running gateway's `crow.db` externally.** Copy `.db` + `-wal` + `-shm`, query the copy.
+- **Pin `CROW_HOME`, `CROW_DATA_DIR`, `CROW_DB_PATH`** on every out-of-gateway invocation — `init-db.js` without them writes the LIVE primary DB.
+- **Foreground test runs with direct file capture.** Baseline is **2961 pass / 0 fail** on this worktree.
+- **Every test file that can reach `fireMigrationAlert` MUST call `_setAlertChannelsForTest`** with no-op channels, or the suite sends real ntfy pushes and emails.
+- **Every test that can reach `checkForUpdates` MUST call `_setAppRootForTest(<fixture>)` and restore it**, or it runs git against the real worktree.
+- **Coordination:** `pibot-gateways@r4` is mid-soak from `~/crow` through ~2026-08-12 — log a timestamp for every pull touching `scripts/pi-bots/` and every restart. Don't touch `~/crow-wt-board` or `~/.crow/p4/harness-wt`.
 
 ---
 
 ## File Structure
 
-**Part 1 — Phase 1 (separate repo, no crow changes, uncommitted):**
-- Create: `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh` — supervised r4 deploy: pull, deps, migrations with explicit r4 env, bundle diff-sync, native rebuild, restart, health gate.
+**Part 1 — Phase 1 (separate repo, uncommitted):** `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
 
-**Part 2 — PR A (migration registry):**
-- Create: `scripts/migrations/runner.mjs` — discovery, ordering, `schema_migrations` bookkeeping, execution.
-- Create: `scripts/migrations/0001-board-stages.mjs` — the first registry entry.
-- Modify: `scripts/migrate-board-stages.mjs` — becomes a thin wrapper delegating to the registry entry.
-- Modify: `servers/gateway/index.js` — run the registry after the schema guard, before the first `createDbClient`.
-- Create: `tests/migration-registry.test.js`
+**Part 2 — migration registry:**
+- Create `scripts/migrations/runner.mjs`, `scripts/migrations/0001-board-stages.mjs`
+- Modify `scripts/migrate-board-stages.mjs` (thin wrapper), `servers/gateway/index.js` (boot call site)
+- Create `tests/migration-registry.test.js`
 
-**Part 3 — PR B (converge + health gate):**
-- Create: `servers/gateway/convergence.js` — boot-sha capture, health snapshot comparison, boot cookie, `convergeInstance()`.
-- Modify: `servers/gateway/proxy.js` — export `healthSnapshot()`.
-- Modify: `servers/gateway/auto-update.js` — split `updateTree()`/`convergeInstance()`, record real HEAD before the disabled return, jitter the first check.
-- Modify: `servers/shared/migration-guard.js` — `reason` field + `attemptsKey` on quarantine markers.
-- Modify: `servers/gateway/boot/post-listen.js` — boot-cookie verification hook.
-- Create: `tests/convergence-two-instance.test.js` — the executable gate.
-- Create: `tests/convergence-unit.test.js`
-- Modify: `docs/architecture/gateway.md` — document convergence + the kill switch.
+**Part 3 — converge + health gate:**
+- Create `servers/gateway/convergence.js` (health comparison, boot cookie, quarantine namespace, `convergeInstance`)
+- Modify `servers/gateway/proxy.js` (`healthSnapshot()`, addons-settled signal)
+- Modify `servers/gateway/auto-update.js` (restructure `checkForUpdates`, move the restart out, jitter, record real HEAD)
+- Modify `servers/gateway/boot/post-listen.js` (cookie verification)
+- Create `tests/convergence-two-instance.test.js`, `tests/convergence-unit.test.js`
+- Modify `docs/architecture/gateway.md`
 
 ---
 
 ## Part 1 — Phase 1: `r4-deploy.sh`
 
-### Task 1: Deploy script with dry-run
+### Task 1: Deploy script — pull, deps, migrations, sync
 
-**Files:**
-- Create: `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
+**Files:** Create `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
 
-**Interfaces:**
-- Consumes: nothing from other tasks.
-- Produces: a script invoked as `r4-deploy.sh [--dry-run] [REF]`. Exit 0 = PASS, non-zero = FAIL. Nothing in Part 2 or 3 depends on it.
+**Interfaces:** Produces `r4-deploy.sh [--dry-run] [REF]`; exit 0 = PASS. Nothing else consumes it.
 
-- [ ] **Step 1: Write the script skeleton with env pinning and dry-run**
+- [ ] **Step 1: Skeleton with env pinning and dry-run**
 
 ```bash
 #!/usr/bin/env bash
 # Supervised deploy for the crow-r4 instance from the shared ~/crow checkout.
-# Usage: r4-deploy.sh [--dry-run] [REF]
 set -Eeuo pipefail
-
 CROW_REPO=/home/kh0pp/crow
 NODE_BIN=/home/kh0pp/.nvm/versions/node/v22.23.1/bin
 export PATH="$NODE_BIN:$PATH"
-
-# Explicit r4 env — every out-of-gateway spawn MUST carry all three, or the
-# child silently resolves to the PRIMARY instance's ~/.crow/data/crow.db.
+# All three, always: a child missing any of them silently resolves to the
+# PRIMARY instance's ~/.crow/data/crow.db and nothing errors.
 export CROW_HOME=/home/kh0pp/.crow-r4
 export CROW_DATA_DIR=/home/kh0pp/.crow-r4/data
 export CROW_DB_PATH=/home/kh0pp/.crow-r4/data/crow.db
 
-DRY_RUN=0
-[ "${1:-}" = "--dry-run" ] && { DRY_RUN=1; shift; }
+DRY_RUN=0; [ "${1:-}" = "--dry-run" ] && { DRY_RUN=1; shift; }
 REF="${1:-}"
-
 PREV_COMMIT=$(git -C "$CROW_REPO" rev-parse HEAD)
-FAILED_CHECK=""
-
 log()  { printf '[r4-deploy %s] %s\n' "$(date -Is)" "$*"; }
 run()  { if [ "$DRY_RUN" = 1 ]; then log "DRY: $*"; else log "RUN: $*"; "$@"; fi; }
-fail() { FAILED_CHECK="$1"; log "FAIL: $1"; log "Roll back with: git -C $CROW_REPO reset --hard $PREV_COMMIT"; exit 1; }
-
+fail() { log "FAIL: $1"; log "Roll back: git -C $CROW_REPO reset --hard $PREV_COMMIT"; exit 1; }
 log "starting; previous commit $PREV_COMMIT; dry_run=$DRY_RUN"
 ```
 
-- [ ] **Step 2: Verify node pinning is correct before going further**
+- [ ] **Step 2: Verify node pinning before anything else**
 
 Run: `bash -c 'export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH; node -v'`
-Expected: `v22.23.1` — NOT v20.x. If v20, stop; every later step is invalid.
+Expected: `v22.23.1`. If v20, stop — every later step is invalid.
 
-- [ ] **Step 3: Add steps 1-2 (pull, conditional deps) with the pi-bots soak log line**
+- [ ] **Step 3: Pull + conditional deps + soak log line**
 
 ```bash
-# --- 1. pull ---------------------------------------------------------------
 LOCK_BEFORE=$(md5sum "$CROW_REPO/package-lock.json" | cut -d' ' -f1)
-if [ -n "$REF" ]; then
-  run git -C "$CROW_REPO" checkout "$REF"
-else
-  run git -C "$CROW_REPO" pull --ff-only || fail "git pull --ff-only"
-fi
+if [ -n "$REF" ]; then run git -C "$CROW_REPO" checkout "$REF"
+else run git -C "$CROW_REPO" pull --ff-only || fail "git pull --ff-only"; fi
 NEW_COMMIT=$(git -C "$CROW_REPO" rev-parse HEAD)
 log "now at $NEW_COMMIT"
-
-# Soak coordination: pibot-gateways@r4 runs from this working tree through
-# ~2026-08-12. Any pull touching scripts/pi-bots/ can produce a heartbeat gap;
-# this line is what makes that gap explainable afterwards.
+# pibot-gateways@r4 soaks from this tree until ~2026-08-12; this line is what
+# makes a heartbeat gap explainable afterwards.
 if git -C "$CROW_REPO" diff --name-only "$PREV_COMMIT..$NEW_COMMIT" | grep -q '^scripts/pi-bots/'; then
-  log "NOTE: this pull touched scripts/pi-bots/ — pibot-gateways@r4 soak may show a heartbeat gap here"
+  log "NOTE: pull touched scripts/pi-bots/ — pibot-gateways@r4 soak may show a heartbeat gap here"
 fi
-
-# --- 2. deps (only if the lockfile actually changed) ------------------------
 LOCK_AFTER=$(md5sum "$CROW_REPO/package-lock.json" | cut -d' ' -f1)
 if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
-  log "lockfile changed — installing"
   (cd "$CROW_REPO" && run npm ci --omit=dev) || fail "npm ci"
-else
-  log "lockfile unchanged — skipping npm ci"
-fi
+else log "lockfile unchanged — skipping npm ci"; fi
 ```
 
-- [ ] **Step 4: Add step 3 (migrations) with the both-DB guard**
+- [ ] **Step 4: Migrations with a WAL-aware both-DB guard**
+
+The guard must count rows, not hash the file. These stores are WAL-mode: writes land in `crow.db-wal` and the main file's checksum does not move, so a hash-only guard prints PASS over exactly the env-leak it exists to catch.
 
 ```bash
-# --- 3. migrations, explicit r4 env ----------------------------------------
-# Baseline the PRIMARY instance's stores. They must not change: a migration
-# that silently targeted ~/.crow instead of ~/.crow-r4 is the exact failure
-# mode this guard exists to catch.
-PRIMARY_BEFORE=$(md5sum /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db 2>/dev/null || true)
-
-run node "$CROW_REPO/scripts/init-db.js"              || fail "init-db.js"
+primary_counts() {
+  for d in /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db; do
+    [ -f "$d" ] || { echo "$d MISSING"; continue; }
+    cp "$d" "/tmp/pcheck.db"; [ -f "$d-wal" ] && cp "$d-wal" "/tmp/pcheck.db-wal"
+    [ -f "$d-shm" ] && cp "$d-shm" "/tmp/pcheck.db-shm"
+    echo -n "$d "
+    sqlite3 /tmp/pcheck.db \
+      "SELECT (SELECT count(*) FROM sqlite_master)||':'||(SELECT coalesce(sum(1),0) FROM sqlite_master WHERE type='table');"
+    rm -f /tmp/pcheck.db /tmp/pcheck.db-wal /tmp/pcheck.db-shm
+  done
+}
+PRIMARY_BEFORE=$(primary_counts)
+run node "$CROW_REPO/scripts/init-db.js" || fail "init-db.js"
 for m in "$CROW_REPO"/scripts/migrate-*.mjs; do
-  case "$(basename "$m")" in
-    migrate-data-dir.js|migrate-redirect-303.js) continue ;;  # one-shot legacy / codemod
-  esac
+  [ -e "$m" ] || continue
   run node "$m" || fail "$(basename "$m")"
 done
-
-PRIMARY_AFTER=$(md5sum /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db 2>/dev/null || true)
-if [ "$DRY_RUN" = 0 ] && [ "$PRIMARY_BEFORE" != "$PRIMARY_AFTER" ]; then
-  fail "PRIMARY instance DBs changed during an r4 migration run — env leak, investigate before restarting anything"
+if [ "$DRY_RUN" = 0 ] && [ "$PRIMARY_BEFORE" != "$(primary_counts)" ]; then
+  fail "PRIMARY instance DBs changed during an r4 migration run — env leak"
 fi
 ```
 
-- [ ] **Step 5: Add step 4 (bundle + panel diff-sync, changed files only)**
+Note the glob is `migrate-*.mjs`: `migrate-data-dir.js` (one-shot legacy install) and `migrate-redirect-303.js` (a codemod) are `.js` and correctly excluded.
+
+- [ ] **Step 5: Bundle + panel sync with the per-instance exclusions**
 
 ```bash
-# --- 4. bundle + panel diff-sync -------------------------------------------
-# NEVER rsync --delete: knowledge-base's server/db.js and server/app-root.js
-# are deliberately per-instance. Changed files only, then report.
+# Omitting --delete prevents DELETION, not OVERWRITE, and -c selects exactly the
+# files that differ — i.e. the deliberately per-instance ones. Exclude them by name.
 for bdir in "$CROW_HOME"/bundles/*/; do
-  id=$(basename "$bdir")
-  src="$CROW_REPO/bundles/$id"
+  id=$(basename "$bdir"); src="$CROW_REPO/bundles/$id"
   [ -d "$src" ] || { log "bundle $id: no repo source, skipping"; continue; }
   run rsync -rc --exclude node_modules --exclude data --exclude '*.db' \
+      --exclude 'server/db.js' --exclude 'server/app-root.js' \
       "$src/" "$bdir" || fail "bundle sync $id"
+  log "--- diff report for $id ---"
+  diff -rq --exclude node_modules --exclude data "$src" "$bdir" || true
 done
-
 for p in "$CROW_HOME"/panels/*.js; do
   [ -e "$p" ] || continue
-  name=$(basename "$p")
-  src=$(find "$CROW_REPO/bundles" -name "$name" -path '*/panel*' -print -quit 2>/dev/null || true)
+  src=$(find "$CROW_REPO/bundles" -name "$(basename "$p")" -path '*/panel*' -print -quit 2>/dev/null || true)
   [ -n "$src" ] && run rsync -c "$src" "$p"
 done
 ```
 
-- [ ] **Step 6: Run the dry-run and read every line**
+- [ ] **Step 6: Dry-run and read every line**
 
 Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh --dry-run`
-Expected: exits 0, prints `DRY:` for every mutating command, and prints the real current commit. Confirm no `RUN:` line appears for a mutating command. If any mutating command executed under `--dry-run`, fix before continuing — the next task runs this for real against a live instance.
+Expected: exit 0; every mutating command prefixed `DRY:`. If any mutating command actually ran, fix before Task 2 — that task runs this for real against a live instance.
 
-- [ ] **Step 7: Commit — NOT to git**
+- [ ] **Step 7: Make executable, do NOT commit**
 
-The r4-tehcy repo belongs to another workstream. Leave the file uncommitted and note it on card #120 (Task 14). Verify only that it is executable:
-
+The r4-tehcy repo belongs to another workstream; leave it uncommitted and note it on card #120 (Task 15).
 ```bash
-chmod +x /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh
-ls -l /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh
+chmod +x /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh && ls -l /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh
 ```
 
-### Task 2: Native rebuild, restart, and health gate
+### Task 2: Native rebuild, restart, regression-based health gate
 
-**Files:**
-- Modify: `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
+**Files:** Modify `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
+**Interfaces:** Consumes Task 1's helpers and `PREV_COMMIT`.
 
-**Interfaces:**
-- Consumes: Task 1's script (the `run`/`fail`/`log` helpers and `PREV_COMMIT`).
-- Produces: nothing consumed elsewhere.
+- [ ] **Step 1: Capture the pre-restart addon baseline**
 
-- [ ] **Step 1: Add step 5 (native ABI rebuild, test-loaded)**
+The gate is a **regression** check, matching the gateway's. An absolute "all connected" gate would have failed every deploy during Aug 3–5, when `tasks` and `bots-sql-mcp` were legitimately down for an unrelated ABI reason, and demanded rollback of a good tree.
 
 ```bash
-# --- 5. native modules must match the gateway's node (ABI 127) -------------
+addon_states() {  # id=status per line, from the CURRENT journal
+  journalctl -u crow-r4-gateway --since "-24h" --no-pager 2>/dev/null \
+    | grep -oE 'addon [a-z0-9-]+: (connected|disconnected)' \
+    | awk '{print $2$3}' | sed 's/://' | sort -u | awk -F: '{print}' | tail -50
+}
+BASELINE_CONNECTED=$(journalctl -u crow-r4-gateway --since "-24h" --no-pager 2>/dev/null \
+  | grep -oE 'addon [a-z0-9-]+: connected' | awk '{print $2}' | tr -d ':' | sort -u)
+log "baseline connected addons: $(echo "$BASELINE_CONNECTED" | tr '\n' ' ')"
+```
+
+- [ ] **Step 2: Native ABI rebuild, test-loaded**
+
+```bash
 for nb in tasks bots-sql-mcp; do
   nbdir="$CROW_HOME/bundles/$nb"
   [ -d "$nbdir/node_modules/better-sqlite3" ] || continue
   if ! "$NODE_BIN/node" -e "require('$nbdir/node_modules/better-sqlite3')" 2>/dev/null; then
-    log "$nb: better-sqlite3 ABI mismatch — rebuilding with the v22 npm"
+    log "$nb: ABI mismatch — rebuilding with the v22 npm"
     (cd "$nbdir" && run "$NODE_BIN/npm" rebuild better-sqlite3) || fail "rebuild $nb"
-    "$NODE_BIN/node" -e "require('$nbdir/node_modules/better-sqlite3')" \
-      || fail "$nb still fails to load after rebuild"
-  else
-    log "$nb: better-sqlite3 loads under node 22"
-  fi
+    "$NODE_BIN/node" -e "require('$nbdir/node_modules/better-sqlite3')" || fail "$nb still fails to load"
+  else log "$nb: loads under node 22"; fi
 done
 ```
 
-- [ ] **Step 2: Add step 6 (restart) and capture the restart timestamp**
+- [ ] **Step 3: Restart and wait on the SETTLE signal, not a clock**
+
+`initProxyServers` connects addons **sequentially** (`proxy.js:337`) at 60 s each, so total time is unbounded in addon count. A fixed sleep either truncates a healthy slow start or wastes minutes.
 
 ```bash
-# --- 6. restart -------------------------------------------------------------
 RESTART_AT=$(date -Is)
 run sudo systemctl restart crow-r4-gateway || fail "systemctl restart"
-[ "$DRY_RUN" = 1 ] || sleep 20   # let addons attempt their connects (proxy CONNECT_TIMEOUT_MS is 60s)
+if [ "$DRY_RUN" = 0 ]; then
+  log "waiting for the addon loop to settle (cap 10m)"
+  for i in $(seq 1 120); do
+    journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null \
+      | grep -q "Loading .* addon server" && \
+    journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null \
+      | grep -qE "addon .*: (connected|failed to connect)" && sleep 5 && break
+    sleep 5
+  done
+fi
 ```
 
-- [ ] **Step 3: Add step 7 (health gate)**
+- [ ] **Step 4: Regression gate**
 
 ```bash
-# --- 7. health gate ---------------------------------------------------------
-if [ "$DRY_RUN" = 1 ]; then log "DRY: skipping health gate"; log "PASS (dry-run)"; exit 0; fi
-
+if [ "$DRY_RUN" = 1 ]; then log "PASS (dry-run)"; exit 0; fi
 systemctl is-active --quiet crow-r4-gateway || fail "unit not active"
-
-JOURNAL=$(journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null || true)
-if echo "$JOURNAL" | grep -q "failed to connect"; then
-  echo "$JOURNAL" | grep "failed to connect"
-  fail "at least one addon failed to connect"
-fi
-for a in tasks bots-sql-mcp pm-workspace knowledge-base knowledge-base-mcp; do
-  echo "$JOURNAL" | grep -q "addon $a: connected" || fail "addon $a never reported connected"
+J=$(journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null || true)
+for a in $BASELINE_CONNECTED; do
+  echo "$J" | grep -q "addon $a: connected" \
+    || fail "REGRESSION: addon '$a' was connected before this deploy and is not now"
 done
-
 code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3008/s/family/)
 [ "$code" = "200" ] || fail "smoke route /s/family/ returned $code"
-
-log "PASS — r4 on $(git -C "$CROW_REPO" rev-parse --short HEAD), all addons connected, smoke route 200"
+log "PASS — r4 on $(git -C "$CROW_REPO" rev-parse --short HEAD); no addon regressed; smoke 200"
 ```
 
-- [ ] **Step 4: Dry-run again end to end**
+- [ ] **Step 5: Dry-run end to end**
 
-Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh --dry-run`
-Expected: exit 0, ends with `PASS (dry-run)`. No `sudo` executed, no restart.
+Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh --dry-run` → exit 0, ends `PASS (dry-run)`, no sudo, no restart.
 
-- [ ] **Step 5: Real supervised run in a tight window**
+- [ ] **Step 6: Real supervised run in a tight window**
 
-Announce the window first (two other workstreams restart this gateway). Then:
+Announce the window (two other workstreams restart this gateway). Then:
+`bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh 2>&1 | tee /tmp/r4-deploy-first.log`
+Expected: exit 0, final line `PASS`. On FAIL, roll back with the printed command — never leave r4 on unverified code.
 
-Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh 2>&1 | tee /tmp/r4-deploy-first.log`
-Expected: exit 0, final line `PASS`. If FAIL, the script prints the failing check and the rollback command — roll back and do not leave r4 on unverified code.
+- [ ] **Step 7: Verify the primary was untouched**
 
-- [ ] **Step 6: Verify the primary instance was untouched**
-
-```bash
-ls -l /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db
-```
-Expected: mtimes unchanged by the deploy. This is the both-DB check the standing rule requires.
+`ls -l /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db` — mtimes unchanged.
 
 ---
 
-## Part 2 — PR A: migration registry
+## Part 2 — migration registry
 
-### Task 3: Registry runner
+### Task 3: Registry runner with deferral
 
-**Files:**
-- Create: `scripts/migrations/runner.mjs`
-- Test: `tests/migration-registry.test.js`
+**Files:** Create `scripts/migrations/runner.mjs`; Test `tests/migration-registry.test.js`
 
-**Interfaces:**
-- Consumes: nothing from earlier tasks.
-- Produces:
-  - `runMigrations({ migrationsDir, dbPath, tasksDbPath, log }) → Promise<{ applied: string[], skipped: string[] }>`
-  - `discoverMigrations(migrationsDir) → string[]` (sorted absolute paths)
-  - Each migration module exports `id: string` and `run({ dbPath, tasksDbPath, log }): void | Promise<void>`.
-  - Bookkeeping table `schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL, sha TEXT)` in the crow.db at `dbPath`, created lazily.
+**Interfaces:** Produces
+- `discoverMigrations(dir) → string[]` (sorted absolute paths)
+- `runMigrations({ migrationsDir, dbPath, tasksDbPath, sha?, log? }) → Promise<{ applied: string[], skipped: string[], deferred: string[] }>`
+- Migration module contract: exports `id: string` and `run({ dbPath, tasksDbPath, log }) → void | { deferred: true }`
+- Table `schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL, sha TEXT)`, created lazily.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests**
 
 ```js
 // tests/migration-registry.test.js
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
@@ -295,113 +271,112 @@ import { runMigrations, discoverMigrations } from "../scripts/migrations/runner.
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "migreg-"));
-  const dir = join(root, "migrations");
-  mkdirSync(dir);
-  const dbPath = join(root, "crow.db");
-  const tasksDbPath = join(root, "tasks.db");
-  new Database(dbPath).close();
-  new Database(tasksDbPath).close();
+  const dir = join(root, "migrations"); mkdirSync(dir);
+  const dbPath = join(root, "crow.db"), tasksDbPath = join(root, "tasks.db");
+  new Database(dbPath).close(); new Database(tasksDbPath).close();
   return { root, dir, dbPath, tasksDbPath };
 }
+const wm = (dir, name, body) => writeFileSync(join(dir, name), body);
+// Fixture migrations import ONLY node: builtins — a bare specifier would not
+// resolve from os.tmpdir(), which has no node_modules on its path.
+const sideEffect = (id, file) =>
+  `import { appendFileSync } from "node:fs";
+   export const id = ${JSON.stringify(id)};
+   export function run() { appendFileSync(${JSON.stringify(file)}, ${JSON.stringify(id + "\n")}); }`;
 
-function writeMigration(dir, name, body) {
-  writeFileSync(join(dir, name), body);
-}
-
-test("runs migrations in filename order and records them", async () => {
+test("runs migrations in filename order, not creation order", async () => {
   const f = fixture();
   try {
-    // Migration bodies are real ESM modules — record order via a shared file.
-    const orderFile = join(f.root, "order.txt");
-    writeMigration(f.dir, "0001-first.mjs",
-      `import { appendFileSync } from "node:fs";
-       export const id = "0001-first";
-       export function run() { appendFileSync(${JSON.stringify(orderFile)}, "first\\n"); }`);
-    writeMigration(f.dir, "0002-second.mjs",
-      `import { appendFileSync } from "node:fs";
-       export const id = "0002-second";
-       export function run() { appendFileSync(${JSON.stringify(orderFile)}, "second\\n"); }`);
-
+    const order = join(f.root, "order.txt");
+    // Created out of order on purpose: readdirSync order is unspecified, so a
+    // test whose files happen to be created in sorted order proves nothing.
+    wm(f.dir, "0003-c.mjs", sideEffect("0003-c", order));
+    wm(f.dir, "0001-a.mjs", sideEffect("0001-a", order));
+    wm(f.dir, "0002-b.mjs", sideEffect("0002-b", order));
     const res = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
-    assert.deepEqual(res.applied, ["0001-first", "0002-second"]);
-
-    const { readFileSync } = await import("node:fs");
-    assert.equal(readFileSync(orderFile, "utf8"), "first\nsecond\n");
+    assert.deepEqual(res.applied, ["0001-a", "0002-b", "0003-c"]);
+    assert.equal(readFileSync(order, "utf8"), "0001-a\n0002-b\n0003-c\n");
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 
-test("is idempotent — a second run applies nothing", async () => {
+test("is idempotent — the body runs exactly once across two calls", async () => {
   const f = fixture();
   try {
     const hits = join(f.root, "hits.txt");
-    writeMigration(f.dir, "0001-once.mjs",
-      `import { appendFileSync } from "node:fs";
-       export const id = "0001-once";
-       export function run() { appendFileSync(${JSON.stringify(hits)}, "x"); }`);
-
+    wm(f.dir, "0001-once.mjs", sideEffect("0001-once", hits));
     const a = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
     const b = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
-
     assert.deepEqual(a.applied, ["0001-once"]);
     assert.deepEqual(b.applied, []);
     assert.deepEqual(b.skipped, ["0001-once"]);
+    assert.equal(readFileSync(hits, "utf8"), "0001-once\n");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
 
-    const { readFileSync } = await import("node:fs");
-    assert.equal(readFileSync(hits, "utf8"), "x", "migration body must run exactly once");
+test("a DEFERRED migration is NOT recorded and runs again next time", async () => {
+  const f = fixture();
+  try {
+    const hits = join(f.root, "deferred.txt");
+    wm(f.dir, "0001-defer.mjs",
+      `import { appendFileSync } from "node:fs";
+       export const id = "0001-defer";
+       export function run() { appendFileSync(${JSON.stringify(hits)}, "x"); return { deferred: true }; }`);
+    const a = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    const b = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    assert.deepEqual(a.deferred, ["0001-defer"]);
+    assert.deepEqual(a.applied, []);
+    assert.deepEqual(b.deferred, ["0001-defer"], "a deferred migration must retry, not be recorded");
+    assert.equal(readFileSync(hits, "utf8"), "xx", "body must run BOTH times");
+    const db = new Database(f.dbPath);
+    assert.deepEqual(db.prepare("SELECT id FROM schema_migrations").all(), []);
+    db.close();
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 
 test("creates schema_migrations lazily — never requires init-db", async () => {
   const f = fixture();
   try {
-    writeMigration(f.dir, "0001-noop.mjs",
-      `export const id = "0001-noop"; export function run() {}`);
+    wm(f.dir, "0001-noop.mjs", `export const id="0001-noop"; export function run(){}`);
     await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
     const db = new Database(f.dbPath);
     const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'").get();
     db.close();
-    assert.ok(t, "runner must CREATE TABLE IF NOT EXISTS its own bookkeeping table");
+    assert.ok(t, "runner must CREATE TABLE IF NOT EXISTS its own bookkeeping");
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 
-test("ignores files that do not match the NNNN-slug.mjs pattern", () => {
+test("ignores files that do not match NNNN-slug.mjs", () => {
   const f = fixture();
   try {
-    writeMigration(f.dir, "0001-real.mjs", `export const id="0001-real"; export function run(){}`);
-    writeMigration(f.dir, "README.md", "not a migration");
-    writeMigration(f.dir, "helper.mjs", "export const x = 1;");
-    writeMigration(f.dir, "0002-draft.mjs.bak", "stray");
-    const found = discoverMigrations(f.dir).map((p) => p.split("/").pop());
-    assert.deepEqual(found, ["0001-real.mjs"]);
+    wm(f.dir, "0001-real.mjs", `export const id="0001-real"; export function run(){}`);
+    wm(f.dir, "README.md", "x"); wm(f.dir, "helper.mjs", "export const x=1;");
+    wm(f.dir, "0002-draft.mjs.bak", "x");
+    assert.deepEqual(discoverMigrations(f.dir).map((p) => p.split("/").pop()), ["0001-real.mjs"]);
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 
-test("a throwing migration aborts the rest and does not record itself", async () => {
+test("a throwing migration aborts the rest and records nothing", async () => {
   const f = fixture();
   try {
-    writeMigration(f.dir, "0001-boom.mjs",
-      `export const id = "0001-boom"; export function run() { throw new Error("boom"); }`);
-    writeMigration(f.dir, "0002-after.mjs",
-      `export const id = "0002-after"; export function run() {}`);
-
+    const after = join(f.root, "after.txt");
+    wm(f.dir, "0001-boom.mjs", `export const id="0001-boom"; export function run(){ throw new Error("boom"); }`);
+    wm(f.dir, "0002-after.mjs", sideEffect("0002-after", after));   // observable side effect
     await assert.rejects(
-      () => runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath }),
-      /boom/,
-    );
+      () => runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath }), /boom/);
+    assert.equal(existsSync(after), false, "0002 must NOT run after 0001 throws");
     const db = new Database(f.dbPath);
-    const rows = db.prepare("SELECT id FROM schema_migrations").all();
+    assert.deepEqual(db.prepare("SELECT id FROM schema_migrations").all(), []);
     db.close();
-    assert.deepEqual(rows, [], "a failed migration must not be recorded, and 0002 must not run");
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 2: Verify it fails**
 
 Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
-Expected: FAIL — `Cannot find module '../scripts/migrations/runner.mjs'`
+Expected: FAIL — `Cannot find module '../scripts/migrations/runner.mjs'`.
 
-- [ ] **Step 3: Write the implementation**
+- [ ] **Step 3: Implement**
 
 ```js
 // scripts/migrations/runner.mjs
@@ -409,14 +384,13 @@ Expected: FAIL — `Cannot find module '../scripts/migrations/runner.mjs'`
 // Ordered, idempotent, per-instance migration registry.
 //
 // Bookkeeping lives in `schema_migrations` inside the instance's crow.db and is
-// created lazily here — DELIBERATELY NOT in scripts/init-db.js. Adding a table
+// created lazily HERE — deliberately not in scripts/init-db.js. Adding a table
 // there would bump SCHEMA_GENERATION, which re-runs all of init-db's DROP TABLE
-// statements against every live instance DB. This registry must be able to ship
-// without touching that rail at all.
+// statements against every live instance DB.
 //
 // Migrations must ALSO be safe to run with their record missing (a restored
-// backup can lose the record but keep the schema change), so every migration
-// body stays shape-checked and idempotent in its own right.
+// backup can lose the record but keep the change), so every body stays
+// shape-checked and idempotent in its own right.
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -424,80 +398,71 @@ import Database from "better-sqlite3";
 
 const FILENAME = /^\d{4}-[a-z0-9-]+\.mjs$/;
 
-/** Sorted absolute paths of every valid migration module in `dir`. */
 export function discoverMigrations(dir) {
   let names;
   try { names = readdirSync(dir); } catch { return []; }
   return names.filter((n) => FILENAME.test(n)).sort().map((n) => join(dir, n));
 }
 
-function open(p) {
-  const d = new Database(p);
-  d.pragma("busy_timeout = 10000");
-  return d;
-}
+function open(p) { const d = new Database(p); d.pragma("busy_timeout = 10000"); return d; }
 
 function ensureTable(db) {
   db.prepare(
     `CREATE TABLE IF NOT EXISTS schema_migrations (
-       id TEXT PRIMARY KEY,
-       applied_at TEXT NOT NULL,
-       sha TEXT
-     )`,
-  ).run();
+       id TEXT PRIMARY KEY, applied_at TEXT NOT NULL, sha TEXT)`).run();
 }
 
 /**
  * Run every not-yet-applied migration, in order, against ONE instance's stores.
- * Throws on the first failure without recording it — the caller decides whether
- * that is fatal.
+ * Throws on the first failure without recording it.
+ *
+ * A migration returning `{ deferred: true }` is NOT recorded — its target tables
+ * did not exist yet (bundle stores are created by their bundle, which may start
+ * after the gateway boots, and better-sqlite3 creates an empty file on open, so
+ * "absent" is the normal fresh-install state). Recording a deferral as applied
+ * would reproduce the original bug: the table gets created later WITHOUT the new
+ * columns and the migration never retries.
  */
 export async function runMigrations({ migrationsDir, dbPath, tasksDbPath, sha = null, log = () => {} }) {
-  const applied = [];
-  const skipped = [];
-
+  const applied = [], skipped = [], deferred = [];
   const book = open(dbPath);
   try {
     ensureTable(book);
     const done = new Set(book.prepare("SELECT id FROM schema_migrations").all().map((r) => r.id));
-
     for (const file of discoverMigrations(migrationsDir)) {
       const mod = await import(pathToFileURL(file).href);
       if (!mod.id || typeof mod.run !== "function") {
         throw new Error(`${file}: a migration must export \`id\` and \`run\``);
       }
       if (done.has(mod.id)) { skipped.push(mod.id); continue; }
-
       log(`applying ${mod.id}`);
-      await mod.run({ dbPath, tasksDbPath, log });
-
+      const outcome = await mod.run({ dbPath, tasksDbPath, log });
+      if (outcome && outcome.deferred) {
+        log(`${mod.id} deferred — target tables absent, will retry next boot`);
+        deferred.push(mod.id);
+        continue;
+      }
       book.prepare("INSERT INTO schema_migrations (id, applied_at, sha) VALUES (?, ?, ?)")
         .run(mod.id, new Date().toISOString(), sha);
       applied.push(mod.id);
     }
-  } finally {
-    book.close();
-  }
-  return { applied, skipped };
+  } finally { book.close(); }
+  return { applied, skipped, deferred };
 }
 ```
 
-- [ ] **Step 4: Run the tests**
+- [ ] **Step 4: Run** — `node --test tests/migration-registry.test.js` → PASS, 6 tests.
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
-Expected: PASS, 5 tests.
+- [ ] **Step 5: Mutation-test (assume vacuous until proven otherwise)**
 
-- [ ] **Step 5: Mutation-test every assertion**
-
-Assume these tests are vacuous until proven otherwise. Apply each mutation, confirm a test goes RED, then revert:
-
-1. Delete the `if (done.has(mod.id))` line → the idempotence test must fail on the `"x"` assertion.
-2. Change `.sort()` to `.reverse()` → the ordering test must fail.
-3. Change `FILENAME` to `/\.mjs$/` → the stray-file test must fail.
-4. Move the `INSERT INTO schema_migrations` above `await mod.run(...)` → the throwing-migration test must fail.
-5. Remove `ensureTable(book)` → the lazy-creation test must fail.
-
-If any mutation leaves all tests green, that assertion proves nothing — fix the test before continuing.
+Apply each, confirm the named test goes RED, revert:
+1. Delete `if (done.has(mod.id))` → idempotence test fails on the `"0001-once\n"` assertion.
+2. `.sort()` → `.sort().reverse()` → ordering test fails. (Plain `.reverse()` is *not* a valid mutation: `readdirSync` order is unspecified, so it can land correct by luck.)
+3. `FILENAME` → `/\.mjs$/` → stray-file test fails.
+4. Move the `INSERT` above `await mod.run(...)` → throwing-migration test fails.
+5. Wrap `await mod.run(...)` in `try { } catch { continue }` → throwing test fails on `existsSync(after) === false`.
+6. Treat `{deferred:true}` as applied (delete the `continue`) → deferral test fails on both the retry and the `"xx"` assertion.
+7. Remove `ensureTable` → lazy-creation test fails.
 
 - [ ] **Step 6: Commit**
 
@@ -507,60 +472,55 @@ git add scripts/migrations/runner.mjs tests/migration-registry.test.js
 git commit scripts/migrations/runner.mjs tests/migration-registry.test.js \
   -m "feat(migrations): ordered per-instance migration registry
 
-Bookkeeping table is created lazily by the runner rather than in
-init-db.js, so the registry ships without a SCHEMA_GENERATION bump."
+Bookkeeping is created lazily rather than in init-db.js, so the registry
+ships without a SCHEMA_GENERATION bump. A migration whose target tables are
+absent defers instead of recording itself as applied."
 git show --stat HEAD
 ```
 
-### Task 4: Convert board-stages into the first registry entry
+### Task 4: board-stages as registry entry 0001
 
-**Files:**
-- Create: `scripts/migrations/0001-board-stages.mjs`
-- Modify: `scripts/migrate-board-stages.mjs`
-- Test: `tests/migration-registry.test.js` (append)
+**Files:** Create `scripts/migrations/0001-board-stages.mjs`; Modify `scripts/migrate-board-stages.mjs`; Test append.
 
-**Interfaces:**
-- Consumes: `runMigrations` from Task 3.
-- Produces: migration id `"0001-board-stages"`, and an exported helper `addColumnIfMissing(db, table, column, ddl) → "added"|"no-op"|"skip (<table> absent)"` reused by future entries.
+**Interfaces:** Consumes `runMigrations`. Produces id `"0001-board-stages"` and `addColumnIfMissing(db, table, column, ddl) → "added"|"no-op"|"absent"`.
 
-- [ ] **Step 1: Write the failing test (append to the file)**
+- [ ] **Step 1: Write the failing test (append)**
 
 ```js
-test("0001-board-stages adds the columns, tolerates absent tables, and is idempotent", async () => {
+test("0001-board-stages: adds columns, DEFERS when every table is absent, idempotent", async () => {
+  const dir = join(import.meta.dirname, "..", "scripts", "migrations");
+
+  // (a) All targets absent → deferred, NOT recorded.
+  const bare = fixture();
+  try {
+    const r = await runMigrations({ migrationsDir: dir, dbPath: bare.dbPath, tasksDbPath: bare.tasksDbPath });
+    assert.ok(r.deferred.includes("0001-board-stages"),
+      "a fresh instance has no tasks_items yet — recording this as applied is the original bug");
+    assert.ok(!r.applied.includes("0001-board-stages"));
+  } finally { rmSync(bare.root, { recursive: true, force: true }); }
+
+  // (b) tasks_items present → applied, columns added, re-runnable.
   const f = fixture();
   try {
-    // tasks.db HAS the table; crow.db does NOT have project_spaces/bot_sessions.
     const t = new Database(f.tasksDbPath);
     t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
     t.close();
-
-    const dir = join(import.meta.dirname, "..", "scripts", "migrations");
-    const res = await runMigrations({
-      migrationsDir: dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath,
-    });
-    assert.ok(res.applied.includes("0001-board-stages"));
-
+    const r = await runMigrations({ migrationsDir: dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    assert.ok(r.applied.includes("0001-board-stages"));
     const t2 = new Database(f.tasksDbPath);
     const cols = t2.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
     t2.close();
-    for (const c of ["stage", "assigned_bot", "plan_ref"]) {
-      assert.ok(cols.includes(c), `tasks_items.${c} must exist`);
-    }
-
-    // Absent-table tolerance: crow.db had neither table and the run still succeeded.
-    // Idempotence at the SHAPE level: re-run the module directly, record bypassed.
+    for (const c of ["stage", "assigned_bot", "plan_ref"]) assert.ok(cols.includes(c), `tasks_items.${c}`);
+    // Shape-level idempotence: re-run directly, bypassing the record.
     const mod = await import(join(dir, "0001-board-stages.mjs"));
     await mod.run({ dbPath: f.dbPath, tasksDbPath: f.tasksDbPath, log: () => {} });
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 2: Verify it fails** — `node --test tests/migration-registry.test.js` → FAIL, `0001-board-stages` not in `deferred`.
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
-Expected: FAIL — no `0001-board-stages` in `applied`.
-
-- [ ] **Step 3: Write the migration entry**
+- [ ] **Step 3: Implement**
 
 ```js
 // scripts/migrations/0001-board-stages.mjs
@@ -573,7 +533,7 @@ export const id = "0001-board-stages";
 
 export function addColumnIfMissing(db, table, column, ddl) {
   const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
-  if (!t) return `skip (${table} absent)`;
+  if (!t) return "absent";
   const have = db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
   if (have.includes(column)) return "no-op";
   db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`).run();
@@ -583,45 +543,51 @@ export function addColumnIfMissing(db, table, column, ddl) {
 function open(p) { const d = new Database(p); d.pragma("busy_timeout = 10000"); return d; }
 
 export function run({ dbPath, tasksDbPath, log = () => {} }) {
+  const results = [];
   const tdb = open(tasksDbPath);
   try {
-    log(`  tasks_items.stage: ${addColumnIfMissing(tdb, "tasks_items", "stage", "TEXT")}`);
-    log(`  tasks_items.assigned_bot: ${addColumnIfMissing(tdb, "tasks_items", "assigned_bot", "TEXT")}`);
-    log(`  tasks_items.plan_ref: ${addColumnIfMissing(tdb, "tasks_items", "plan_ref", "TEXT")}`);
+    for (const [col, ddl] of [["stage", "TEXT"], ["assigned_bot", "TEXT"], ["plan_ref", "TEXT"]]) {
+      const r = addColumnIfMissing(tdb, "tasks_items", col, ddl);
+      log(`  tasks_items.${col}: ${r}`); results.push(r);
+    }
   } finally { tdb.close(); }
 
   const cdb = open(dbPath);
   try {
-    log(`  project_spaces.repo_path: ${addColumnIfMissing(cdb, "project_spaces", "repo_path", "TEXT")}`);
-    log(`  bot_sessions.kind: ${addColumnIfMissing(cdb, "bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'")}`);
+    for (const [tbl, col, ddl] of [
+      ["project_spaces", "repo_path", "TEXT"],
+      ["bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'"],
+    ]) {
+      const r = addColumnIfMissing(cdb, tbl, col, ddl);
+      log(`  ${tbl}.${col}: ${r}`); results.push(r);
+    }
   } finally { cdb.close(); }
+
+  // Every target table missing means this instance's stores do not exist YET —
+  // not that the work is done. Defer so the runner retries on the next boot.
+  if (results.every((r) => r === "absent")) return { deferred: true };
 }
 ```
 
 - [ ] **Step 4: Rewrite the old script as a thin wrapper**
 
-Phase 1 step 3 and any operator muscle memory still invoke this path, so it must keep working and must stay idempotent with the registry.
-
 ```js
 // scripts/migrate-board-stages.mjs
-// Thin wrapper — the migration itself now lives in the registry at
+// Thin wrapper — the migration lives in the registry at
 // scripts/migrations/0001-board-stages.mjs and runs automatically at gateway
-// boot. This entry point stays for manual/deploy-script invocation.
+// boot. This entry point stays for manual and deploy-script invocation.
 import { tasksDbPath, botsDbPath } from "./pi-bots/instance-paths.mjs";
 import { run } from "./migrations/0001-board-stages.mjs";
-
-run({ dbPath: botsDbPath(), tasksDbPath: tasksDbPath(), log: (m) => console.log(m) });
+const out = run({ dbPath: botsDbPath(), tasksDbPath: tasksDbPath(), log: (m) => console.log(m) });
+if (out?.deferred) console.log("  (deferred — target tables absent on this instance)");
 ```
 
-- [ ] **Step 5: Run the tests, including the pre-existing board-stages test**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js tests/board-stages-migration.test.js`
-Expected: PASS. `tests/board-stages-migration.test.js` already exists and must not regress — if it asserts on the old script's internals, adapt the test to the wrapper, do not weaken the assertion.
+- [ ] **Step 5: Run** — `node --test tests/migration-registry.test.js tests/board-stages-migration.test.js` → PASS. If the pre-existing board-stages test asserts on the old script's internals, adapt it to the wrapper; do not weaken the assertion.
 
 - [ ] **Step 6: Mutation-test**
-
-1. Change `addColumnIfMissing`'s `if (!t) return` to `if (!t) throw` → the absent-table tolerance assertion must fail.
-2. Remove the `have.includes(column)` guard → the direct re-run at the end of the test must fail with "duplicate column name".
+1. `if (!t) return "absent"` → `throw` → the deferral assertion fails.
+2. Remove the `have.includes(column)` guard → the direct re-run fails with "duplicate column name".
+3. Delete the `results.every(...)` deferral return → test (a) fails.
 
 - [ ] **Step 7: Commit**
 
@@ -629,65 +595,49 @@ Expected: PASS. `tests/board-stages-migration.test.js` already exists and must n
 cd /home/kh0pp/crow-wt-rolling
 git add scripts/migrations/0001-board-stages.mjs
 git commit scripts/migrations/0001-board-stages.mjs scripts/migrate-board-stages.mjs tests/migration-registry.test.js \
-  -m "feat(migrations): move board-stages into the registry as 0001
-
-The old entry point becomes a thin wrapper so deploy scripts and manual
-invocation keep working."
+  -m "feat(migrations): move board-stages into the registry as 0001"
 git show --stat HEAD
 ```
 
 ### Task 5: Run the registry at gateway boot
 
-**Files:**
-- Modify: `servers/gateway/index.js` (insert after the schema-guard block ending at line 195, before `await initOAuthTables()` at line 198)
-- Test: `tests/migration-registry.test.js` (append)
+**Files:** Modify `servers/gateway/index.js` (after the schema-guard block ending line 195, before `initOAuthTables()` line 198); Test append.
 
-**Interfaces:**
-- Consumes: `runMigrations` from Task 3.
-- Produces: the boot-time call site. Part 3 does not call it again — convergence relies on the restart passing through this block.
+**Interfaces:** Consumes `runMigrations`. Produces the boot call site.
 
 - [ ] **Step 1: Write the failing order-invariant test**
 
-This mirrors the existing source-order assertion in `tests/migration-guard.test.js`. It is a source-text check because the invariant is about ordering within a module that cannot be imported without booting a gateway.
-
 ```js
-test("ORDER INVARIANT: registry runs after the schema guard and before the first createDbClient", async () => {
-  const { readFileSync } = await import("node:fs");
+test("ORDER INVARIANT: registry runs after the schema guard, before the first createDbClient", async () => {
   const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "index.js"), "utf8");
-
-  const guard = src.indexOf("runGuardedInitDb");
-  const registry = src.indexOf("runMigrations");
+  // Anchor on the guard's CALL, not its import: `runGuardedInitDb` first appears
+  // in the dynamic-import destructure, so indexOf would match a registry block
+  // wrongly placed INSIDE the guard block.
+  const guardCall = src.indexOf("await runGuardedInitDb(");
+  const registry  = src.indexOf("runMigrations(");
   const firstClient = src.indexOf("initOAuthTables()");
-
-  assert.ok(guard > 0, "schema guard must be present");
-  assert.ok(registry > 0, "registry call must be present");
-  assert.ok(firstClient > 0, "initOAuthTables must be present");
-  assert.ok(guard < registry, "registry must run AFTER the schema guard");
+  assert.ok(guardCall > 0 && registry > 0 && firstClient > 0, "all three call sites must be present");
+  assert.ok(guardCall < registry, "registry must run AFTER the schema guard");
   assert.ok(registry < firstClient,
     "registry must run BEFORE the first createDbClient — createDbClient registers a " +
     "never-closed WAL keeper, and a later restore would swap the DB under a pinned inode");
 });
 ```
 
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
-Expected: FAIL — "registry call must be present".
+- [ ] **Step 2: Verify it fails** — FAIL, "all three call sites must be present".
 
 - [ ] **Step 3: Insert the call site**
 
-Insert immediately after the schema-guard `try { ... } catch { ... }` block (which ends at line 195) and before `await initOAuthTables();`:
+Fail-closed only on genuine breakage. A `SQLITE_BUSY` on a bundle-owned store (the `tasks` addon child holds `tasks.db` open) is transient — exiting on it would make gateway boot depend on a store the gateway does not control, and under systemd's `StartLimitBurst` a crash-loop leaves the unit permanently down.
 
 ```js
-// Per-instance migration registry (scripts/migrations/). Runs for THIS
-// instance with THIS instance's env-resolved paths, so co-hosted gateways
-// sharing one checkout each migrate their own stores. Covers changes that
-// carry no SCHEMA_GENERATION bump — additive columns and non-crow.db stores
-// like tasks.db — which the guard above deliberately does not.
+// Per-instance migration registry (scripts/migrations/). Runs for THIS instance
+// with THIS instance's env-resolved paths, so co-hosted gateways sharing one
+// checkout each migrate their own stores. Covers changes carrying no
+// SCHEMA_GENERATION bump — additive columns, and non-crow.db stores like tasks.db.
 //
 // ORDER INVARIANT: after the schema guard, before the first createDbClient
-// (initOAuthTables). See the guard block's note above; tests/migration-
-// registry.test.js asserts this ordering.
+// (initOAuthTables). tests/migration-registry.test.js asserts this ordering.
 try {
   const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
   const { resolveDataDir } = await import("../db.js");
@@ -695,7 +645,6 @@ try {
   const { tasksDbPath } = await import("../../scripts/pi-bots/instance-paths.mjs");
   const { dirname, join } = await import("node:path");
   const { fileURLToPath } = await import("node:url");
-
   const _root = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
   const res = await runMigrations({
     migrationsDir: join(_root, "scripts", "migrations"),
@@ -704,23 +653,26 @@ try {
     log: (m) => console.log(`[migrations] ${m}`),
   });
   if (res.applied.length) console.log(`[migrations] applied: ${res.applied.join(", ")}`);
+  if (res.deferred.length) console.log(`[migrations] deferred (will retry): ${res.deferred.join(", ")}`);
 } catch (e) {
-  // Fail closed, matching the schema guard's posture: serving on a
-  // half-migrated store is how the Bot Board 500'd on every drawer open.
-  console.error("ERROR: migration registry failed:", e.message);
-  console.error("  Run it manually with this instance's CROW_DATA_DIR/CROW_DB_PATH before starting the gateway.");
-  process.exit(1);
+  const transient = /SQLITE_BUSY|database is locked/i.test(e.message || "");
+  if (transient) {
+    console.warn(`[migrations] deferred — store busy (${e.message}); retrying next boot`);
+  } else {
+    console.error("ERROR: migration registry failed:", e.message);
+    console.error("  Run it manually with this instance's CROW_DATA_DIR/CROW_DB_PATH before starting.");
+    process.exit(1);
+  }
 }
 ```
 
-- [ ] **Step 4: Run the test**
+- [ ] **Step 4: Run** — `node --test tests/migration-registry.test.js` → PASS.
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
-Expected: PASS.
+- [ ] **Step 5: Mutation-test the invariant** (the previous plan revision had no mutation here)
+1. Move the registry block *above* the schema-guard block → the `guardCall < registry` assertion must fail.
+2. Move it *below* `await initOAuthTables()` → the `registry < firstClient` assertion must fail.
 
-- [ ] **Step 5: Verify a real gateway still boots**
-
-Never point a scratch gateway at a live data dir. Use a scratch home with BOTH vars pinned:
+- [ ] **Step 6: Verify a real gateway boots on a scratch home**
 
 ```bash
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
@@ -729,90 +681,417 @@ rm -rf $S && mkdir -p $S/data
 cd /home/kh0pp/crow-wt-rolling
 CROW_HOME=$S CROW_DATA_DIR=$S/data CROW_DB_PATH=$S/data/crow.db \
 CROW_AUTO_UPDATE=0 CROW_ALLOW_ORPHAN=1 PORT=3099 \
-timeout 90 node servers/gateway/index.js --no-auth 2>&1 | tee $S/boot.log | head -60
+timeout 120 node servers/gateway/index.js --no-auth 2>&1 | tee $S/boot.log | head -60
 ```
-Expected: `[migrations] applied: 0001-board-stages` appears, and the gateway reaches its listen line. Then confirm the live DBs were untouched: `ls -l /home/kh0pp/.crow/data/crow.db` mtime unchanged.
+Expected: `[migrations] deferred (will retry): 0001-board-stages` — a wiped instance has no `tasks_items` yet, so **deferred is the correct outcome here, not applied**. Gateway reaches its listen line. Then confirm `~/.crow/data/crow.db` mtime is unchanged.
 
-- [ ] **Step 6: Run the full suite**
+- [ ] **Step 7: Full suite** — `npm test > …/suite-partA.log 2>&1`, then `grep -E "^# (tests|pass|fail|cancelled)"`. Expected `# fail 0`, `# cancelled 0`.
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && npm test > /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-taskA.log 2>&1; grep -E "^# (tests|pass|fail|cancelled)" /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-taskA.log`
-Expected: `# fail 0`, `# cancelled 0`, and `# tests` ≥ 2961 + the new tests.
-
-- [ ] **Step 7: Commit and open PR A**
+- [ ] **Step 8: Commit**
 
 ```bash
 cd /home/kh0pp/crow-wt-rolling
 git commit servers/gateway/index.js tests/migration-registry.test.js \
-  -m "feat(gateway): run the per-instance migration registry at boot
-
-Co-hosted gateways sharing one checkout each migrate their own stores with
-their own env, covering changes that carry no SCHEMA_GENERATION bump."
+  -m "feat(gateway): run the per-instance migration registry at boot"
 git show --stat HEAD
-git pull --rebase origin main
-git push -u origin feat/safe-rolling-updates
 ```
-
-Open PR A titled `feat(migrations): per-instance migration registry`. Do NOT merge yet — Part 3 continues on the same branch, and the whole-branch review in Task 14 gates the merge.
 
 ---
 
-## Part 3 — PR B: converge + health gate
+## Part 3 — converge + health gate
 
-### Task 6: The executable gate — two instances, one checkout (MUST FAIL)
+### Task 6: Addon health snapshot and the settled signal
 
-This task writes the integration test that reproduces the starvation bug. It is expected to FAIL at the end of this task and to go green in Task 10. A review that only reads a diff cannot tell you whether a restart-into-newer-code actually migrates — this harness can.
+**Files:** Modify `servers/gateway/proxy.js`; Create `servers/gateway/convergence.js`; Test `tests/convergence-unit.test.js`
 
-**Files:**
-- Create: `tests/convergence-two-instance.test.js`
+**Interfaces:** Produces
+- `healthSnapshot() → Record<string,string>` in `proxy.js` — **addons only** (`entry.isAddon`)
+- `addonsSettled() → Promise<void>` in `proxy.js` — resolves when `initProxyServers`' connect loop finishes
+- `compareHealth(before, after) → { ok, regressions: [{id, was, now}] }` in `convergence.js`
 
-**Interfaces:**
-- Consumes: `_setAppRootForTest`, `_setDbForTest` from `auto-update.js` (existing test seams).
-- Produces: `twoInstanceFixture()` — reused by Task 12.
+- [ ] **Step 1: Write the failing tests**
 
-- [ ] **Step 1: Write the harness and the failing assertion**
+```js
+// tests/convergence-unit.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { connectedServers, healthSnapshot } from "../servers/gateway/proxy.js";
+import { compareHealth } from "../servers/gateway/convergence.js";
+
+delete process.env.INVOCATION_ID;
+delete process.env.CROW_SUPERVISED;
+
+test("healthSnapshot reports ADDONS ONLY, with their real status field", () => {
+  connectedServers.clear();
+  connectedServers.set("tasks", { status: "connected", isAddon: true });
+  connectedServers.set("bots-sql-mcp", { status: "error", isAddon: true });
+  connectedServers.set("instance-peer", { status: "offline", isRemote: true });   // federation peer
+  connectedServers.set("some-integration", { status: "connected" });              // integration
+  try {
+    assert.deepEqual(healthSnapshot(), { tasks: "connected", "bots-sql-mcp": "error" },
+      "a remote crow rebooting must never look like a LOCAL regression");
+  } finally { connectedServers.clear(); }
+});
+
+test("compareHealth flags only REGRESSIONS, never pre-existing breakage", () => {
+  // The Aug 3-5 state: tasks and bots-sql-mcp already down for an unrelated ABI
+  // reason. An absolute gate would quarantine every good sha for that whole window.
+  const before = { tasks: "error", "bots-sql-mcp": "error", "pm-workspace": "connected" };
+  assert.equal(compareHealth(before, { ...before }).ok, true, "already-broken is not a regression");
+  assert.equal(compareHealth(before, { ...before, tasks: "connected" }).ok, true, "improvement is not a regression");
+
+  const broke = compareHealth(before, { ...before, "pm-workspace": "error" });
+  assert.equal(broke.ok, false);
+  assert.deepEqual(broke.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
+
+  // disconnected is the transport.onclose path (proxy.js:180) — the likeliest real regression.
+  assert.equal(compareHealth(before, { ...before, "pm-workspace": "disconnected" }).ok, false);
+
+  const vanished = compareHealth(before, { tasks: "error", "bots-sql-mcp": "error" });
+  assert.deepEqual(vanished.regressions, [{ id: "pm-workspace", was: "connected", now: "missing" }]);
+
+  const multi = compareHealth({ a: "connected", b: "connected" }, { a: "error", b: "error" });
+  assert.equal(multi.regressions.length, 2);
+  assert.equal(compareHealth({}, { anything: "error" }).ok, true, "empty baseline never regresses");
+});
+```
+
+- [ ] **Step 2: Verify it fails** — `Cannot find module '../servers/gateway/convergence.js'`.
+
+- [ ] **Step 3: Add `healthSnapshot` and `addonsSettled` to proxy.js**
+
+Insert before `export function getProxyStatus()`:
+
+```js
+/**
+ * Addon id → connection status, for the convergence health gate.
+ *
+ * ADDONS ONLY. connectedServers also holds remote federation peers (whose status
+ * flips to "offline" whenever a crow on another machine reboots) and data
+ * backends. Including them would let a remote host's uptime quarantine this
+ * host's sha.
+ */
+export function healthSnapshot() {
+  const snap = {};
+  for (const [id, entry] of connectedServers) if (entry.isAddon) snap[id] = entry.status;
+  return snap;
+}
+
+let _settledResolve;
+const _settled = new Promise((r) => { _settledResolve = r; });
+/** Resolves once initProxyServers' addon-connect loop has finished. Addons
+ *  connect SEQUENTIALLY at CONNECT_TIMEOUT_MS each, so total time is unbounded
+ *  in addon count and no fixed grace window is correct. */
+export function addonsSettled() { return _settled; }
+export function _markAddonsSettled() { _settledResolve?.(); }
+```
+
+Then call `_markAddonsSettled()` at the end of the addon `for` loop in `initProxyServers` (after the loop at `proxy.js:337-344`), and also on the `entries.length === 0` early return, so it always resolves.
+
+- [ ] **Step 4: Create convergence.js with the comparator**
+
+```js
+// servers/gateway/convergence.js
+//
+// An instance's job is to converge to the tree, not to pull. Pulling is a TREE
+// operation (one winner among co-hosted gateways sharing a checkout); migrating
+// and restarting are INSTANCE operations every gateway must perform with its own env.
+
+/**
+ * A REGRESSION check, not an absolute one. "Every addon connected" would
+ * quarantine a perfectly good sha on any host that already had a broken addon —
+ * precisely crow's state Aug 3-5. The gate answers "did this update break
+ * something?", not "is everything perfect?".
+ */
+export function compareHealth(before, after) {
+  const regressions = [];
+  for (const [id, was] of Object.entries(before || {})) {
+    if (was !== "connected") continue;             // already unhealthy — not ours
+    const now = (after || {})[id] ?? "missing";
+    if (now !== "connected") regressions.push({ id, was, now });
+  }
+  return { ok: regressions.length === 0, regressions };
+}
+```
+
+- [ ] **Step 5: Run** — PASS.
+
+- [ ] **Step 6: Mutation-test**
+1. Drop the `entry.isAddon` filter → the federation-peer assertion fails.
+2. `snap[id] = entry.state` (wrong field) → the snapshot test fails with `{tasks: undefined}`. *(This is the mutation the previous revision lacked: without a `healthSnapshot` test, a wrong field name would have left the entire gate silently dead with every test green.)*
+3. Remove `if (was !== "connected") continue` → the already-broken and improvement assertions fail.
+4. `?? "missing"` → `?? "connected"` → the vanished assertion fails.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git add servers/gateway/convergence.js tests/convergence-unit.test.js
+git commit servers/gateway/convergence.js servers/gateway/proxy.js tests/convergence-unit.test.js \
+  -m "feat(convergence): addon-only health snapshot and regression comparison"
+git show --stat HEAD
+```
+
+### Task 7: Boot cookie and convergence-quarantine namespace
+
+**Files:** Modify `servers/gateway/convergence.js`; Test append.
+
+**Interfaces:** Produces `PENDING_TTL_MS = 900000`, `QUARANTINE_TTL_MS = 86400000`; `writePending`, `readPending`, `clearPending`, `classifyPending`; `writeConvQuarantine({ appRoot, dataDir, sha, regressions, why, now })`, `readConvQuarantine({ appRoot, dataDir, now })`. Cookie at `<dataDir>/convergence-pending.json`; markers at `<appRoot>/.crow-convergence-quarantine.json` and `<dataDir>/.crow-convergence-quarantine.json`.
+
+- [ ] **Step 1: Write the failing tests (append)**
+
+```js
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  writePending, readPending, clearPending, classifyPending,
+  writeConvQuarantine, readConvQuarantine, PENDING_TTL_MS, QUARANTINE_TTL_MS,
+} from "../servers/gateway/convergence.js";
+
+test("the tuned constants are pinned to their justified values", () => {
+  // Both sides of a `now + PENDING_TTL_MS` assertion use the same constant, so
+  // that form proves nothing. Pin the literals with their rationale.
+  assert.equal(PENDING_TTL_MS, 15 * 60 * 1000,
+    "must exceed a guarded SCHEMA_GENERATION migration plus a full SEQUENTIAL addon-connect pass");
+  assert.equal(QUARANTINE_TTL_MS, 24 * 60 * 60 * 1000,
+    "hard expiry so no failure mode ends in a host only manual file deletion recovers");
+});
+
+test("boot cookie round-trips, clears, and survives a torn write", () => {
+  const d = mkdtempSync(join(tmpdir(), "cookie-"));
+  try {
+    const now = Date.parse("2026-08-06T12:00:00Z");
+    writePending(d, { sha: "abc1234", baseline: { tasks: "connected" }, now });
+    const p = readPending(d);
+    assert.equal(p.sha, "abc1234");
+    assert.deepEqual(p.baseline, { tasks: "connected" });
+    assert.equal(Date.parse(p.deadline), now + 15 * 60 * 1000);   // literal, not the constant
+    assert.equal(existsSync(join(d, "convergence-pending.json.tmp")), false, "tmp must be renamed away");
+    clearPending(d);
+    assert.equal(readPending(d), null);
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test("classifyPending covers every boot case including the crash-loop", () => {
+  const now = Date.parse("2026-08-06T12:00:00Z");
+  const fresh   = { sha: "new1234", baseline: {}, deadline: new Date(now + 60_000).toISOString() };
+  const expired = { sha: "new1234", baseline: {}, deadline: new Date(now - 1).toISOString() };
+  const exact   = { sha: "new1234", baseline: {}, deadline: new Date(now).toISOString() };
+
+  assert.equal(classifyPending(null, "new1234", now), "none");
+  assert.equal(classifyPending(fresh, "new1234", now), "verify");
+  assert.equal(classifyPending(expired, "new1234", now), "failed",
+    "crash-loop: booted the target sha but died before verifying");
+  assert.equal(classifyPending(expired, "old9999", now), "failed",
+    "never booted the target sha at all");
+  assert.equal(classifyPending(fresh, "old9999", now), "stale");
+  assert.equal(classifyPending(exact, "new1234", now), "failed", "deadline boundary is inclusive");
+});
+
+test("convergence quarantine is its OWN namespace and hard-expires", () => {
+  const root = mkdtempSync(join(tmpdir(), "convq-"));
+  const dataDir = join(root, "data"); require("node:fs").mkdirSync(dataDir);
+  try {
+    const now = Date.parse("2026-08-06T12:00:00Z");
+    writeConvQuarantine({ appRoot: root, dataDir, sha: "bad1234", regressions: [{ id: "x" }], why: "broke x", now });
+
+    // It must NOT be written where migration-guard's readers look: index.js:141
+    // would make a gateway boot skipping init-db entirely on an empty database.
+    assert.equal(existsSync(join(root, ".crow-migration-quarantine.json")), false,
+      "convergence must never write a migration-guard marker");
+    assert.ok(existsSync(join(root, ".crow-convergence-quarantine.json")), "repo-level marker for peers");
+    assert.ok(existsSync(join(dataDir, ".crow-convergence-quarantine.json")), "data-level marker");
+
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 1000 }).sha, "bad1234");
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 23 * 3600_000 }).sha, "bad1234");
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 25 * 3600_000 }), null,
+      "a quarantine older than 24h must be ignored — no permanent wedge");
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+```
+
+- [ ] **Step 2: Verify it fails** — `writePending is not a function`.
+
+- [ ] **Step 3: Implement** (append to `convergence.js`)
+
+```js
+import { readFileSync, writeFileSync, unlinkSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+/** How long a convergence has to boot and verify before we call it failed.
+ *  Exceeds a guarded SCHEMA_GENERATION migration plus a full SEQUENTIAL
+ *  addon-connect pass (60s per addon, unbounded in count). */
+export const PENDING_TTL_MS = 15 * 60 * 1000;
+
+/** Hard expiry on a convergence quarantine. No failure mode may end in a state
+ *  only manual file deletion recovers from. */
+export const QUARANTINE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const PENDING_FILE = "convergence-pending.json";
+const QUARANTINE_FILE = ".crow-convergence-quarantine.json";
+
+/** Atomic: a crash mid-write must not leave torn JSON that readPending would
+ *  silently swallow as "nothing pending". */
+function writeAtomic(path, obj) {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(obj, null, 2));
+  renameSync(tmp, path);
+}
+const readJson = (p) => { try { return JSON.parse(readFileSync(p, "utf8")); } catch { return null; } };
+
+export function writePending(dataDir, { sha, baseline, now = Date.now() }) {
+  const rec = { sha, baseline, deadline: new Date(now + PENDING_TTL_MS).toISOString() };
+  writeAtomic(join(dataDir, PENDING_FILE), rec);
+  return rec;
+}
+export const readPending = (dataDir) => readJson(join(dataDir, PENDING_FILE));
+export function clearPending(dataDir) { try { unlinkSync(join(dataDir, PENDING_FILE)); } catch {} }
+
+/**
+ *   none   — nothing pending.
+ *   verify — we ARE the boot this cookie was written for, with time left.
+ *   failed — the deadline passed uncleared: either the target never booted, or
+ *            it booted and died before verifying.
+ *   stale  — a live cookie for a sha we are not running.
+ */
+export function classifyPending(pending, bootSha, now = Date.now()) {
+  if (!pending) return "none";
+  if (Date.parse(pending.deadline) <= now) return "failed";
+  return pending.sha === bootSha ? "verify" : "stale";
+}
+
+/**
+ * Convergence quarantine — its OWN namespace, deliberately NOT migration-guard's
+ * markers. Two existing readers consume those with no knowledge of why they were
+ * written: index.js:141 would boot a gateway skipping init-db (on an empty DB,
+ * that means serving with no tables), and auto-update.js:318 would block all
+ * updates host-wide while printing `gen undefined->undefined`. An addon flapping
+ * must not be able to disable schema initialization.
+ *
+ * Written at BOTH repo and data level: the repo-level file is what co-hosted
+ * peers sharing the checkout read.
+ */
+export function writeConvQuarantine({ appRoot, dataDir, sha, regressions = [], why = "", now = Date.now() }) {
+  const marker = { sha, why, regressions, at: new Date(now).toISOString() };
+  for (const p of [join(appRoot, QUARANTINE_FILE), join(dataDir, QUARANTINE_FILE)]) {
+    try { writeAtomic(p, marker); } catch {}
+  }
+  return marker;
+}
+
+/** The active marker, or null. Anything past QUARANTINE_TTL_MS is ignored. */
+export function readConvQuarantine({ appRoot, dataDir, now = Date.now() }) {
+  for (const p of [join(appRoot, QUARANTINE_FILE), join(dataDir, QUARANTINE_FILE)]) {
+    const m = readJson(p);
+    if (!m) continue;
+    if (now - Date.parse(m.at) > QUARANTINE_TTL_MS) continue;
+    return m;
+  }
+  return null;
+}
+export function clearConvQuarantine({ appRoot, dataDir }) {
+  for (const p of [join(appRoot, QUARANTINE_FILE), join(dataDir, QUARANTINE_FILE)]) {
+    try { unlinkSync(p); } catch {}
+  }
+}
+```
+
+Replace the `require("node:fs").mkdirSync` in the test with a top-level `mkdirSync` import.
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Mutation-test**
+1. Swap the deadline and sha checks in `classifyPending` → the `classifyPending(expired,"old9999") === "failed"` assertion fails. *(Note: the crash-loop assertion does NOT move under this mutation — naming it would be a false mutation claim.)*
+2. `<=` → `<` in the deadline check → the boundary assertion fails.
+3. Make `writeAtomic` a plain `writeFileSync` to `path` → the `.tmp` assertion still passes; instead assert it by mutating `renameSync` to a no-op → `readPending` returns null and the round-trip fails.
+4. Point `writeConvQuarantine` at `.crow-migration-quarantine.json` → the namespace assertion fails.
+5. Delete the TTL check in `readConvQuarantine` → the 25 h assertion fails.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/convergence.js tests/convergence-unit.test.js \
+  -m "feat(convergence): boot cookie and a convergence-specific quarantine namespace
+
+Its own marker files, hard-expiring after 24h, so an addon flap can never
+disable schema initialization or wedge the host permanently."
+git show --stat HEAD
+```
+
+### Task 8: The executable gate — two instances, one checkout (MUST FAIL)
+
+Reproduces the starvation through the **real production path** (`checkForUpdates`), not a side entry point. Expected RED until Task 9.
+
+**Files:** Create `tests/convergence-two-instance.test.js`
+
+- [ ] **Step 1: Write the harness**
 
 ```js
 // tests/convergence-two-instance.test.js
 //
-// The executable gate for co-hosted convergence. TWO instance data dirs share
-// ONE git checkout, exactly like crow-gateway / crow-mpa-gateway / crow-r4-gateway
-// share ~/crow. Moving the fixture's origin forward must leave BOTH instances
-// migrated — including the instance that loses the updater lock.
-import { test } from "node:test";
+// The executable gate. TWO instance data dirs share ONE git checkout, exactly as
+// crow-gateway / crow-mpa-gateway / crow-r4-gateway share ~/crow. Moving origin
+// forward must leave BOTH instances migrated — including the one that LOSES the
+// checkout lock.
+import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import Database from "better-sqlite3";
+import { checkForUpdates, _setAppRootForTest, _setDbForTest } from "../servers/gateway/auto-update.js";
+import { _setAlertChannelsForTest } from "../servers/shared/migration-guard.js";
 
-// This file drives the restart branch. Never let the suite believe it is supervised.
+// Never let the suite believe it is supervised — the restart branch would arm
+// this process's exit chain.
 delete process.env.INVOCATION_ID;
 delete process.env.CROW_SUPERVISED;
 
-const g = (cwd, ...args) => execFileSync("git", args, { cwd, stdio: "pipe" }).toString().trim();
+// The update failure paths call fireMigrationAlert. Unstubbed, the suite sends a
+// REAL ntfy push and email.
+_setAlertChannelsForTest({ sendNtfyNotification: async () => {}, sendEmailNotification: async () => {} });
+
+const REAL_APP_ROOT = join(import.meta.dirname, "..");
+const g = (cwd, ...a) => execFileSync("git", a, { cwd, stdio: "pipe" }).toString().trim();
+
+/** A DB stub matching the shape auto-update's saveSetting/getSettings expect. */
+function stubDb(rows = [{ key: "auto_update_enabled", value: "true" }]) {
+  const writes = [];
+  return { writes, execute: async ({ sql, args }) => {
+    if (/^SELECT/i.test(sql)) return { rows };
+    writes.push({ key: args?.[0], value: args?.[1] }); return { rows: [] };
+  } };
+}
+
+const _fixtures = [];
+after(() => {
+  _setAppRootForTest(REAL_APP_ROOT);      // MUST restore, even on failure
+  _setDbForTest(null);
+  for (const f of _fixtures) f.cleanup();
+  _fixtures.length = 0;
+});
 
 export function twoInstanceFixture() {
   const root = mkdtempSync(join(tmpdir(), "converge-"));
-  const origin = join(root, "origin.git");
-  const work = join(root, "work");                 // the ONE shared checkout
+  const origin = join(root, "origin.git"), work = join(root, "work");
   execFileSync("git", ["init", "--bare", "-b", "main", origin], { stdio: "pipe" });
   execFileSync("git", ["clone", origin, work], { stdio: "pipe" });
-  g(work, "config", "user.email", "t@t");
-  g(work, "config", "user.name", "t");
-
+  g(work, "config", "user.email", "t@t"); g(work, "config", "user.name", "t");
   mkdirSync(join(work, "scripts", "migrations"), { recursive: true });
-  writeFileSync(join(work, "seed"), "1");
-  g(work, "add", "-A");
-  g(work, "commit", "-m", "seed");
-  g(work, "push", "origin", "main");
+  // runLockedUpdate CHECKS init-db's exit code; without this the fixture update
+  // always reports failure and withholds the restart.
+  writeFileSync(join(work, "scripts", "init-db.js"), "process.exit(0);\n");
+  g(work, "add", "-A"); g(work, "commit", "-m", "seed"); g(work, "push", "origin", "main");
 
-  // TWO instances, each with its own data dir and its own stores.
   const instances = ["alpha", "beta"].map((name) => {
     const dataDir = join(root, name, "data");
     mkdirSync(dataDir, { recursive: true });
-    const dbPath = join(dataDir, "crow.db");
-    const tasksDbPath = join(dataDir, "tasks.db");
+    const dbPath = join(dataDir, "crow.db"), tasksDbPath = join(dataDir, "tasks.db");
     const t = new Database(tasksDbPath);
     t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
     t.close();
@@ -820,21 +1099,22 @@ export function twoInstanceFixture() {
     return { name, dataDir, dbPath, tasksDbPath };
   });
 
-  /** Land a new migration on origin, as a real deploy would. */
   const advanceOrigin = (filename, body) => {
     writeFileSync(join(work, "scripts", "migrations", filename), body);
-    g(work, "add", "-A");
-    g(work, "commit", "-m", `add ${filename}`);
-    g(work, "push", "origin", "main");
-    // Rewind the shared checkout so it is genuinely BEHIND origin.
-    g(work, "reset", "--hard", "HEAD~1");
+    g(work, "add", "-A"); g(work, "commit", "-m", `add ${filename}`); g(work, "push", "origin", "main");
+    g(work, "reset", "--hard", "HEAD~1");        // the shared checkout is now genuinely behind
   };
-
-  return { root, origin, work, instances, advanceOrigin, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  const f = { root, origin, work, instances, advanceOrigin,
+              cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  _fixtures.push(f);
+  return f;
 }
 
-const MIGRATION_BODY = `
-import Database from "better-sqlite3";
+// A bare `import Database from "better-sqlite3"` cannot resolve from os.tmpdir()
+// — there is no node_modules on that path. Bake in the resolved absolute URL.
+const BS3 = pathToFileURL(createRequire(import.meta.url).resolve("better-sqlite3")).href;
+export const MIGRATION_BODY = `
+import Database from ${JSON.stringify(BS3)};
 export const id = "0002-converge-probe";
 export function run({ tasksDbPath }) {
   const d = new Database(tasksDbPath);
@@ -843,49 +1123,47 @@ export function run({ tasksDbPath }) {
   d.close();
 }`;
 
-function hasProbe(tasksDbPath) {
+export function hasProbe(tasksDbPath) {
   const d = new Database(tasksDbPath);
   const cols = d.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
   d.close();
   return cols.includes("probe");
 }
 
-test("BOTH co-hosted instances converge — the lock loser must not starve", async (t) => {
+test("BOTH co-hosted instances converge — the lock loser must not starve", async () => {
   const f = twoInstanceFixture();
-  t.after(f.cleanup);
-
   f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
-
-  const { converge } = await import("../servers/gateway/convergence.js");
-  const { _setAppRootForTest } = await import("../servers/gateway/auto-update.js");
-
-  // Both instances share ONE checkout, so the tree half has ONE root. Retarget
-  // it at the fixture, and restore it to the real repo before finishing — even
-  // on failure — so no later test sees a mutating git command against ~/crow.
   _setAppRootForTest(f.work);
-  t.after(() => _setAppRootForTest(join(import.meta.dirname, "..")));
 
-  // alpha runs first and wins the checkout lock; beta runs second and loses it.
-  const a = await converge({ appRoot: f.work, ...f.instances[0] });
-  const b = await converge({ appRoot: f.work, ...f.instances[1] });
+  // alpha: no contention, wins the lock, pulls, converges.
+  _setDbForTest(stubDb());
+  const a = await checkForUpdates({ instance: f.instances[0] });
 
+  // beta: HOLD the lock so beta genuinely LOSES it. Sequential awaited calls do
+  // NOT contend — checkForUpdates releases in a finally, so without this beta
+  // would simply find "already up to date" and the gate would prove nothing.
+  const lockFile = join(f.work, ".git", "crow-auto-update.lock");
+  writeFileSync(lockFile, `${process.pid}\n${new Date().toISOString()}\n`);
+  _setDbForTest(stubDb());
+  const b = await checkForUpdates({ instance: f.instances[1] });
+  rmSync(lockFile, { force: true });
+
+  assert.equal(b.skipped, "locked", "beta must actually have taken the lock-loss path");
   assert.ok(hasProbe(f.instances[0].tasksDbPath), "alpha (lock winner) must be migrated");
   assert.ok(hasProbe(f.instances[1].tasksDbPath),
-    "beta LOST the updater lock and must STILL migrate its own stores — this is the starvation bug");
+    "beta LOST the lock and must STILL migrate its own stores — this is the starvation bug");
   assert.equal(a.pulled, true, "the lock winner performs the pull");
   assert.equal(b.pulled, false, "the lock loser must not pull — the tree is shared");
   assert.equal(b.converged, true, "the lock loser must still converge");
 });
 ```
 
-- [ ] **Step 2: Run it and confirm it fails for the RIGHT reason**
+- [ ] **Step 2: Confirm it fails for the RIGHT reason**
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
-Expected: FAIL with `Cannot find module '../servers/gateway/convergence.js'`. That module arrives in Task 10. Do not stub it to make this pass.
+Run: `node --test tests/convergence-two-instance.test.js`
+Expected: FAIL because `b.converged` is `undefined` and beta has no `probe` column — the lock loser returns early today. It must NOT fail on a missing module, a `better-sqlite3` resolution error, or an init-db exit code; if it does, fix the fixture first. Do not stub anything to make it pass.
 
-- [ ] **Step 3: Commit the failing gate**
-
-Committing a known-red test is deliberate here: it is the spec's executable gate, and the branch is not merged until Task 14.
+- [ ] **Step 3: Commit the failing gate** (deliberate — the branch is not merged until Task 12)
 
 ```bash
 cd /home/kh0pp/crow-wt-rolling
@@ -893,790 +1171,272 @@ git add tests/convergence-two-instance.test.js
 git commit tests/convergence-two-instance.test.js \
   -m "test(convergence): failing two-instance gate reproducing lock starvation
 
-Two instance data dirs share one checkout. Expected RED until the
-converge/updateTree split lands."
+Drives the real checkForUpdates path and holds the lock so the loser
+genuinely loses it. Expected RED until the converge restructure lands."
 git show --stat HEAD
 ```
 
-### Task 7: Record real HEAD even when auto-update is disabled
+### Task 9: Restructure checkForUpdates — the instance half always runs
 
-**Files:**
-- Modify: `servers/gateway/auto-update.js:559-570`
-- Test: `tests/convergence-unit.test.js`
+Turns Task 8's gate green.
 
-**Interfaces:**
-- Consumes: nothing.
-- Produces: no new exports; a behavior change in `startAutoUpdate()`.
+**Files:** Modify `servers/gateway/auto-update.js`, `servers/gateway/convergence.js`
 
-- [ ] **Step 1: Write the failing test**
+**Interfaces:** Produces
+- `convergeInstance({ appRoot, instance, pulled, log }) → Promise<{ pulled, converged, sha, applied, skipped? }>` in `convergence.js`
+- `checkForUpdates({ instance? })` now returns `{ ...treeResult, pulled, converged }`
+- `resolveInstance()` in `convergence.js` → `{ dataDir, dbPath, tasksDbPath }` from env (production default when no `instance` is injected)
 
-```js
-// tests/convergence-unit.test.js
-import { test } from "node:test";
-import assert from "node:assert/strict";
-import { startAutoUpdate, stopAutoUpdate, _setDbForTest } from "../servers/gateway/auto-update.js";
+- [ ] **Step 1: Confirm the gate is still red** — `b.converged === undefined`.
 
-delete process.env.INVOCATION_ID;
-delete process.env.CROW_SUPERVISED;
+- [ ] **Step 2: Move the restart OUT of runLockedUpdate's success path**
 
-function fakeDb(rows) {
-  const writes = [];
-  return {
-    writes,
-    execute: async ({ sql, args }) => {
-      if (/^SELECT/i.test(sql)) return { rows };
-      writes.push({ key: args[0], value: args[1] });
-      return { rows: [] };
-    },
-  };
-}
+In `runLockedUpdate`, delete the `scheduleSupervisedRestart(log, "Restarting gateway to apply update...")` call on the success path (~line 505). **Keep** the one on the migration-guard loss path (~line 463) — that exists to reopen a restored DB file and is unrelated. Convergence now owns the restart: otherwise the winner's 1.5 s exit timer fires while its own migrations are still running (an interrupted `ALTER` on a live store), and the boot cookie — which must be written *before* the restart — may never be written.
 
-test("a DISABLED instance still records its real running version", async () => {
-  const db = fakeDb([{ key: "auto_update_enabled", value: "false" }]);
-  await startAutoUpdate(db, {});
-  stopAutoUpdate();
+Export it so convergence can call it: `export function scheduleSupervisedRestart(log, message) { ... }`.
 
-  const v = db.writes.find((w) => w.key === "auto_update_current_version");
-  assert.ok(v, "current_version must be recorded even when auto-update is disabled — " +
-               "otherwise a disabled instance reports a version it has not run since it was enabled");
-  assert.match(v.value, /^[0-9a-f]{7,40}$/, "must be a real git sha");
-});
-```
+- [ ] **Step 3: Restructure `checkForUpdates`**
 
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: FAIL — "current_version must be recorded even when auto-update is disabled".
-
-- [ ] **Step 3: Move the version write above the disabled return**
-
-Replace lines 559-570 of `servers/gateway/auto-update.js`:
-
-```js
-  const settings = await getSettings();
-
-  // Record the sha this process is ACTUALLY running, before any early return.
-  // Previously this sat below the `disabled in settings` return, so a disabled
-  // instance froze its reported version at whatever it was when it was last
-  // enabled — while continuing to run whatever the shared checkout moved to.
-  // The bookkeeping and the running code disagreed and nothing detected it.
-  try {
-    const ref = await run("git", ["rev-parse", "--short", "HEAD"]);
-    if (ref.code === 0 && ref.stdout) await saveSetting("auto_update_current_version", ref.stdout);
-  } catch {}
-
-  if (settings.auto_update_enabled !== "true") {
-    console.log("[auto-update] Disabled in settings");
-    return;
-  }
-```
-
-- [ ] **Step 4: Run the test**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js tests/auto-update-hardening.test.js tests/auto-update-tick-gate.test.js`
-Expected: PASS, no regression in the two existing files.
-
-- [ ] **Step 5: Mutation-test**
-
-Move the version write back below the `return` → the new test must go RED. Revert.
-
-- [ ] **Step 6: Commit**
-
-```bash
-cd /home/kh0pp/crow-wt-rolling
-git add tests/convergence-unit.test.js
-git commit servers/gateway/auto-update.js tests/convergence-unit.test.js \
-  -m "fix(auto-update): record the running sha even when updates are disabled
-
-A disabled instance froze its reported version while continuing to run
-whatever the shared checkout moved to."
-git show --stat HEAD
-```
-
-### Task 8: Health snapshot and regression comparison
-
-**Files:**
-- Modify: `servers/gateway/proxy.js` (add export near `getProxyStatus`, line ~653)
-- Create: `servers/gateway/convergence.js` (first half — pure functions only)
-- Test: `tests/convergence-unit.test.js` (append)
-
-**Interfaces:**
-- Consumes: `connectedServers` from `proxy.js` (already exported at line 25).
-- Produces:
-  - `healthSnapshot() → Record<string, string>` in `proxy.js` — addon id → status.
-  - `compareHealth(before, after) → { ok: boolean, regressions: Array<{id, was, now}> }` in `convergence.js`.
-
-- [ ] **Step 1: Write the failing test (append)**
-
-```js
-import { compareHealth } from "../servers/gateway/convergence.js";
-
-test("compareHealth flags only REGRESSIONS, never pre-existing breakage", () => {
-  // The Aug 3-5 state: tasks and bots-sql-mcp were already down for an
-  // unrelated ABI reason. An absolute "all green" gate would have quarantined
-  // every good sha for as long as that lasted.
-  const before = { tasks: "error", "bots-sql-mcp": "error", "pm-workspace": "connected" };
-
-  const unchanged = compareHealth(before, { ...before });
-  assert.equal(unchanged.ok, true, "already-broken addons must NOT count as a regression");
-
-  const healed = compareHealth(before, { ...before, tasks: "connected" });
-  assert.equal(healed.ok, true, "an addon getting BETTER is not a regression");
-
-  const broke = compareHealth(before, { ...before, "pm-workspace": "error" });
-  assert.equal(broke.ok, false, "a connected addon going to error IS a regression");
-  assert.deepEqual(broke.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
-
-  const vanished = compareHealth(before, { tasks: "error", "bots-sql-mcp": "error" });
-  assert.equal(vanished.ok, false, "an addon that disappears entirely is a regression");
-  assert.deepEqual(vanished.regressions, [{ id: "pm-workspace", was: "connected", now: "missing" }]);
-});
-
-test("compareHealth on an empty baseline never regresses", () => {
-  assert.equal(compareHealth({}, { anything: "error" }).ok, true);
-});
-```
-
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: FAIL — `Cannot find module '../servers/gateway/convergence.js'`.
-
-- [ ] **Step 3: Add the snapshot export to proxy.js**
-
-Insert immediately before `export function getProxyStatus()`:
-
-```js
-/**
- * Addon id → connection status, for the convergence health gate. Deliberately
- * a flat map of the SAME statuses connectedServers already tracks, so the gate
- * compares like with like across a restart.
- */
-export function healthSnapshot() {
-  const snap = {};
-  for (const [id, entry] of connectedServers) snap[id] = entry.status;
-  return snap;
-}
-```
-
-- [ ] **Step 4: Create convergence.js with the comparator**
-
-```js
-// servers/gateway/convergence.js
-//
-// An instance's job is to converge to the tree, not to pull. Pulling is a
-// TREE operation (one winner among co-hosted gateways sharing a checkout);
-// migrating and restarting are INSTANCE operations that every gateway must
-// perform with its own env.
-
-/**
- * A REGRESSION check, not an absolute one. "Every addon connected" would
- * quarantine a perfectly good sha on any host that already had a broken addon
- * — precisely crow's state Aug 3-5, when tasks and bots-sql-mcp were down for
- * an unrelated native-ABI reason. The gate must answer "did this update break
- * something?", not "is everything perfect?".
- */
-export function compareHealth(before, after) {
-  const regressions = [];
-  for (const [id, was] of Object.entries(before || {})) {
-    if (was !== "connected") continue;              // was already unhealthy — not ours
-    const now = (after || {})[id] ?? "missing";
-    if (now !== "connected") regressions.push({ id, was, now });
-  }
-  return { ok: regressions.length === 0, regressions };
-}
-```
-
-- [ ] **Step 5: Run the tests**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: PASS.
-
-- [ ] **Step 6: Mutation-test**
-
-1. Remove the `if (was !== "connected") continue;` line → the "already-broken" and "getting better" assertions must fail.
-2. Change `?? "missing"` to `?? "connected"` → the vanished-addon assertion must fail.
-3. Change `now !== "connected"` to `now === "error"` → the vanished-addon assertion must fail.
-
-- [ ] **Step 7: Commit**
-
-```bash
-cd /home/kh0pp/crow-wt-rolling
-git add servers/gateway/convergence.js
-git commit servers/gateway/convergence.js servers/gateway/proxy.js tests/convergence-unit.test.js \
-  -m "feat(convergence): regression-based addon health comparison
-
-Compares against a pre-convergence baseline rather than an absolute
-all-green bar, so pre-existing breakage never quarantines a good sha."
-git show --stat HEAD
-```
-
-### Task 9: The boot cookie
-
-**Files:**
-- Modify: `servers/gateway/convergence.js`
-- Test: `tests/convergence-unit.test.js` (append)
-
-**Interfaces:**
-- Consumes: nothing from Task 8 beyond the same file.
-- Produces:
-  - `PENDING_TTL_MS = 10 * 60 * 1000`, `ADDON_GRACE_MS = 90 * 1000`
-  - `writePending(dataDir, { sha, baseline, now })`, `readPending(dataDir) → record|null`, `clearPending(dataDir)`
-  - `classifyPending(pending, bootSha, now) → "none" | "verify" | "failed" | "stale"`
-  - Record shape: `{ sha, baseline: Record<string,string>, deadline: ISO string }` at `<dataDir>/convergence-pending.json`.
-
-- [ ] **Step 1: Write the failing test (append)**
-
-```js
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import {
-  writePending, readPending, clearPending, classifyPending, PENDING_TTL_MS,
-} from "../servers/gateway/convergence.js";
-
-test("boot cookie round-trips and clears", () => {
-  const d = mkdtempSync(join(tmpdir(), "cookie-"));
-  try {
-    const now = Date.parse("2026-08-06T12:00:00Z");
-    writePending(d, { sha: "abc1234", baseline: { tasks: "connected" }, now });
-    const p = readPending(d);
-    assert.equal(p.sha, "abc1234");
-    assert.deepEqual(p.baseline, { tasks: "connected" });
-    assert.equal(Date.parse(p.deadline), now + PENDING_TTL_MS);
-
-    clearPending(d);
-    assert.equal(readPending(d), null);
-    assert.equal(existsSync(join(d, "convergence-pending.json")), false);
-  } finally { rmSync(d, { recursive: true, force: true }); }
-});
-
-test("classifyPending covers every boot case including the crash-loop", () => {
-  const now = Date.parse("2026-08-06T12:00:00Z");
-  const fresh = { sha: "new1234", baseline: {}, deadline: new Date(now + 60_000).toISOString() };
-  const expired = { sha: "new1234", baseline: {}, deadline: new Date(now - 1).toISOString() };
-
-  assert.equal(classifyPending(null, "new1234", now), "none");
-
-  // We are the boot the cookie was written for, and there is still time: verify.
-  assert.equal(classifyPending(fresh, "new1234", now), "verify");
-
-  // Crash-loop: same sha, but the deadline passed without anyone clearing it.
-  // The previous boot never got far enough to verify — treat as failure.
-  assert.equal(classifyPending(expired, "new1234", now), "failed",
-    "an expired cookie for the sha we are booting proves the last convergence never verified");
-
-  // Never booted into the target sha at all (it crashed before serving).
-  assert.equal(classifyPending(expired, "old9999", now), "failed");
-
-  // Cookie for some other sha that has not expired — unrelated, drop it.
-  assert.equal(classifyPending(fresh, "old9999", now), "stale");
-});
-```
-
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: FAIL — `writePending is not a function`.
-
-- [ ] **Step 3: Implement**
-
-Append to `servers/gateway/convergence.js`:
-
-```js
-import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
-
-/** How long a convergence has to boot and verify before we call it failed.
- *  Exceeds the worst realistic boot: a guarded SCHEMA_GENERATION migration
- *  plus ADDON_GRACE_MS. Too short quarantines healthy slow boots. */
-export const PENDING_TTL_MS = 10 * 60 * 1000;
-
-/** How long after boot to let addons connect before snapshotting health.
- *  MUST exceed proxy.js's own CONNECT_TIMEOUT_MS (60s), or a slow-but-healthy
- *  addon reads as a regression. */
-export const ADDON_GRACE_MS = 90 * 1000;
-
-const PENDING_FILE = "convergence-pending.json";
-const pendingPath = (dataDir) => join(dataDir, PENDING_FILE);
-
-export function writePending(dataDir, { sha, baseline, now = Date.now() }) {
-  const rec = { sha, baseline, deadline: new Date(now + PENDING_TTL_MS).toISOString() };
-  writeFileSync(pendingPath(dataDir), JSON.stringify(rec, null, 2));
-  return rec;
-}
-
-export function readPending(dataDir) {
-  try { return JSON.parse(readFileSync(pendingPath(dataDir), "utf8")); } catch { return null; }
-}
-
-export function clearPending(dataDir) {
-  try { unlinkSync(pendingPath(dataDir)); } catch {}
-}
-
-/**
- * What a booting process should do about the cookie it finds.
- *
- *   none   — nothing pending.
- *   verify — we ARE the boot this cookie was written for and there is time
- *            left; snapshot health after ADDON_GRACE_MS and compare.
- *   failed — the deadline passed with the cookie uncleared. Either the target
- *            never booted, or it booted and died before verifying. Both mean
- *            the convergence did not prove itself.
- *   stale  — a live cookie for a sha we are not running; unrelated, discard.
- */
-export function classifyPending(pending, bootSha, now = Date.now()) {
-  if (!pending) return "none";
-  if (Date.parse(pending.deadline) <= now) return "failed";
-  return pending.sha === bootSha ? "verify" : "stale";
-}
-```
-
-- [ ] **Step 4: Run the tests**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: PASS.
-
-- [ ] **Step 5: Mutation-test**
-
-1. Swap the order of the deadline check and the sha check in `classifyPending` → the crash-loop assertion must fail.
-2. Change `<=` to `<` in the deadline check → confirm which assertion moves; if none does, add a boundary case at exactly `deadline === now`.
-3. Make `clearPending` a no-op → the round-trip test must fail.
-
-- [ ] **Step 6: Commit**
-
-```bash
-cd /home/kh0pp/crow-wt-rolling
-git commit servers/gateway/convergence.js tests/convergence-unit.test.js \
-  -m "feat(convergence): boot cookie carrying the pre-restart health baseline
-
-Classifies every boot case including the crash-loop, where the target sha
-boots but dies before it can verify itself."
-git show --stat HEAD
-```
-
-### Task 10: Split updateTree and convergeInstance
-
-This is the task that turns Task 6's gate green.
-
-**Files:**
-- Modify: `servers/gateway/auto-update.js:196-231` (`checkForUpdates`)
-- Modify: `servers/gateway/convergence.js`
-- Test: `tests/convergence-two-instance.test.js` (already written, currently red)
-
-**Interfaces:**
-- Consumes: `runMigrations` (Task 3), `PENDING_TTL_MS`/`writePending` (Task 9), `compareHealth` (Task 8).
-- Produces: `converge({ appRoot, dataDir, dbPath, tasksDbPath, log }) → Promise<{ pulled: boolean, converged: boolean, sha: string, applied: string[] }>`
-
-- [ ] **Step 1: Confirm the gate is still red for the right reason**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
-Expected: FAIL — `converge is not a function` (the module now exists from Tasks 8-9, but not this export).
-
-- [ ] **Step 2: Implement `converge`**
-
-Append to `servers/gateway/convergence.js`:
-
-```js
-import { execFile } from "node:child_process";
-
-function git(cwd, args) {
-  return new Promise((resolve) => {
-    execFile("git", args, { cwd, timeout: 120000 }, (err, stdout, stderr) => {
-      resolve({ stdout: (stdout || "").trim(), stderr: (stderr || "").trim(), code: err ? err.code || 1 : 0 });
-    });
-  });
-}
-
-/**
- * Make ONE instance current with the checkout it runs from.
- *
- * The pull is a TREE operation and stays behind the checkout-scoped lock —
- * exactly one co-hosted gateway performs it. Everything after the pull is an
- * INSTANCE operation and runs unconditionally, including for the gateway that
- * lost the lock. Before this split the loser returned early and therefore never
- * migrated its own stores and never restarted into the new code; with all
- * gateways restarting together their 6h timers were phase-locked, so the same
- * instance lost every tick, forever.
- */
-export async function converge({ appRoot, dataDir, dbPath, tasksDbPath, log = () => {} }) {
-  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
-  const au = await import("./auto-update.js");
-
-  // --- tree half: at most one winner ---------------------------------------
-  const pulled = await au.updateTree({ appRoot, log });
-
-  // --- instance half: everyone, always -------------------------------------
-  const sha = (await git(appRoot, ["rev-parse", "HEAD"])).stdout;
-  const res = await runMigrations({
-    migrationsDir: join(appRoot, "scripts", "migrations"),
-    dbPath, tasksDbPath, sha, log,
-  });
-
-  return { pulled, converged: true, sha, applied: res.applied };
-}
-```
-
-- [ ] **Step 3: Extract `updateTree` in auto-update.js**
-
-Replace the lock-skip early return at lines 209-223 of `servers/gateway/auto-update.js`:
+Replace the lock-loss early return (lines 209-223) so it **falls through**:
 
 ```js
     const lock = await lockPath();
     const held = lock ? acquireLock(lock) : null;
+    let treeResult = { updated: false }, pulled = false;
     if (lock && !held) {
-      const info = readLock(lock);
-      // NOT an error, and NOT a reason to stop. The tree is shared: another
+      // NOT an error and NOT a reason to stop. The tree is shared: another
       // co-hosted gateway is pulling it, which is exactly right. This instance
-      // skips the PULL and still converges itself — see convergence.js.
+      // skips the PULL and still converges itself.
+      const info = readLock(lock);
       const msg = `Tree pull skipped: another instance holds the checkout lock (pid ${info?.pid ?? "unknown"})`;
       log(msg);
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
-      return { updated: false, skipped: "locked", pulled: false, message: msg };
+      treeResult = { updated: false, skipped: "locked", message: msg };
+    } else {
+      try { treeResult = await runLockedUpdate(log); }
+      finally { if (held) releaseLock(held); }
+      pulled = Boolean(treeResult?.updated);
     }
+
+    // The INSTANCE half — always, for every gateway, lock or no lock.
+    const { convergeInstance } = await import("./convergence.js");
+    const conv = await convergeInstance({ instance, pulled, log });
+    return { ...treeResult, pulled, converged: conv.converged, applied: conv.applied };
 ```
 
-Then add the exported wrapper near the end of the module:
+and change the signature to `export async function checkForUpdates({ instance = null } = {})`.
+
+- [ ] **Step 4: Implement `convergeInstance`**
 
 ```js
-/**
- * The TREE half of an update: fetch, CI gate, quarantine check, pull, deps.
- * Returns whether this process actually moved the checkout. A `false` return
- * from a lock loss is a normal, healthy outcome — the caller still converges.
- *
- * Operates on the module's APP_ROOT deliberately: co-hosted gateways share ONE
- * checkout, so there is exactly one tree to update and no per-call root to
- * thread through. Tests retarget it with the existing _setAppRootForTest seam.
- */
-export async function updateTree({ log = (m) => console.log(`[auto-update] ${m}`) } = {}) {
-  const res = await checkForUpdates();
-  return Boolean(res?.updated);
+import { execFile } from "node:child_process";
+function git(cwd, args) {
+  return new Promise((resolve) => execFile("git", args, { cwd, timeout: 120000 },
+    (err, so, se) => resolve({ stdout: (so||"").trim(), stderr: (se||"").trim(), code: err ? err.code||1 : 0 })));
 }
-```
 
-**Do NOT call `_setAppRootForTest` from `updateTree`.** It is documented
-test-only (`auto-update.js:20`), and having production code mutate a test seam
-would let a stray call silently retarget every later git operation in the
-process. `converge()` accepts `appRoot` for its own git and migration paths
-only; the tree half uses the module root.
-
-- [ ] **Step 4: Run the two-instance gate**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
-Expected: PASS — both alpha and beta have the `probe` column, `a.pulled === true`, `b.pulled === false`, `b.converged === true`.
-
-- [ ] **Step 5: Mutation-test the gate — this is the important one**
-
-The gate exists to catch starvation. Prove it can:
-
-1. In `converge`, wrap the `runMigrations` call in `if (pulled) { ... }` → the beta assertion must fail with "beta LOST the updater lock and must STILL migrate". If it stays green, the harness is not actually exercising the loser path and the gate is worthless — fix it before continuing.
-2. Restore the early `return` in the lock-loss branch of `checkForUpdates` → beta must fail.
-3. Make `advanceOrigin` skip its `reset --hard` → the test should fail because nothing was behind; confirms the fixture creates real skew.
-
-- [ ] **Step 6: Run the existing auto-update tests for regressions**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/auto-update-hardening.test.js tests/auto-update-ci-gate.test.js tests/auto-update-tick-gate.test.js`
-Expected: PASS. The lock-skip message text changed — if a test asserts on the old string, update the assertion to the new one, and confirm it still asserts the *behavior* and not just the text.
-
-- [ ] **Step 7: Commit**
-
-```bash
-cd /home/kh0pp/crow-wt-rolling
-git commit servers/gateway/convergence.js servers/gateway/auto-update.js tests/convergence-two-instance.test.js \
-  -m "feat(convergence): converge every instance, pull on only one
-
-Splits the updater into a tree half behind the checkout lock and an
-instance half that always runs. The lock loser no longer starves."
-git show --stat HEAD
-```
-
-### Task 11: De-phase-lock the update timers
-
-**Files:**
-- Modify: `servers/gateway/auto-update.js` (`startAutoUpdate`, line ~578)
-- Test: `tests/convergence-unit.test.js` (append)
-
-**Interfaces:**
-- Consumes: nothing.
-- Produces: `instanceJitterMs(key) → number` exported from `auto-update.js`, range `[0, 600000)`.
-
-- [ ] **Step 1: Write the failing test (append)**
-
-```js
-import { instanceJitterMs } from "../servers/gateway/auto-update.js";
-
-test("instanceJitterMs is stable per instance and differs between instances", () => {
-  const a = instanceJitterMs("/home/kh0pp/.crow/data");
-  const b = instanceJitterMs("/home/kh0pp/.crow-mpa/data");
-  const c = instanceJitterMs("/home/kh0pp/.crow-r4/data");
-
-  assert.equal(a, instanceJitterMs("/home/kh0pp/.crow/data"), "must be deterministic");
-  assert.notEqual(a, b, "co-hosted instances must not share a phase");
-  assert.notEqual(b, c);
-  for (const v of [a, b, c]) {
-    assert.ok(v >= 0 && v < 600000, `jitter ${v} must be within [0, 10min)`);
-    assert.ok(Number.isInteger(v));
-  }
-});
-```
-
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: FAIL — `instanceJitterMs is not a function`.
-
-- [ ] **Step 3: Implement and wire it in**
-
-Add to `servers/gateway/auto-update.js`:
-
-```js
-const JITTER_WINDOW_MS = 10 * 60 * 1000;
-
-/**
- * A stable per-instance offset for the first update check.
- *
- * Co-hosted gateways restart together, so a fixed 5-minute first check put all
- * of them on the same millisecond forever: their checks landed 475ms apart and
- * the same instance lost the lock every single tick. Deriving the offset from
- * the instance's data-dir path de-phases them permanently and survives restarts.
- *
- * This is robustness, not the fix — the fix is that the lock loser converges
- * anyway (see convergence.js). Jitter only makes contention rare.
- */
-export function instanceJitterMs(key) {
-  let h = 2166136261;
-  for (let i = 0; i < key.length; i++) {
-    h ^= key.charCodeAt(i);
-    h = Math.imul(h, 16777619) >>> 0;
-  }
-  return h % JITTER_WINDOW_MS;
-}
-```
-
-Then in `startAutoUpdate`, replace the fixed `5 * 60 * 1000`:
-
-```js
+/** This process's paths, from env, matching how the stores actually resolve. */
+export async function resolveInstance() {
   const { resolveDataDir } = await import("../db.js");
-  const firstDelay = 5 * 60 * 1000 + instanceJitterMs(resolveDataDir());
-  console.log(`[auto-update] Enabled — checking every ${hours}h (first check in ${Math.round(firstDelay / 1000)}s)`);
+  const { resolveGuardDbPath } = await import("../shared/migration-guard.js");
+  const { tasksDbPath } = await import("../../scripts/pi-bots/instance-paths.mjs");
+  return { dataDir: resolveDataDir(), dbPath: resolveGuardDbPath(resolveDataDir), tasksDbPath: tasksDbPath() };
+}
 
-  updateTimer = setTimeout(async () => {
-    await tickCheck();
-    updateTimer = setInterval(() => { tickCheck().catch(() => {}); }, intervalMs);
-  }, firstDelay);
+/** The sha this process booted on. Captured once — convergence compares against
+ *  it, NOT against `pulled`: runLockedUpdate returns updated:false on several
+ *  branches AFTER the tree has already moved (quarantine skip, init-db failure,
+ *  the loss-and-rollback path). Deciding on that flag would let peers converge
+ *  into code the winner had just explicitly refused. */
+let BOOT_SHA = null;
+export function setBootSha(sha) { BOOT_SHA = sha; }
+export function getBootSha() { return BOOT_SHA; }
+
+export async function convergeInstance({ appRoot, instance = null, pulled = false, log = () => {} } = {}) {
+  if (process.env.CROW_DISABLE_CONVERGE === "1" || process.env.CROW_DISABLE_CONVERGE === "true") {
+    log("convergence disabled via CROW_DISABLE_CONVERGE");
+    return { pulled, converged: false, skipped: "disabled", sha: null, applied: [] };
+  }
+  const root = appRoot || (await import("node:path")).dirname(
+    (await import("node:path")).dirname((await import("node:path")).dirname(
+      (await import("node:url")).fileURLToPath(import.meta.url))));
+  const inst = instance || (await resolveInstance());
+  const head = (await git(root, ["rev-parse", "HEAD"])).stdout;
+
+  // Quarantine gates the MIGRATE-AND-RESTART, never the pull, and the tree half
+  // has already run above. A guard placed before the pull is a fleet deadlock: a
+  // blocked peer never fetches, so the checkout never moves past the bad sha, so
+  // the escape can never fire.
+  const q = readConvQuarantine({ appRoot: root, dataDir: inst.dataDir });
+  if (q && q.sha === head) {
+    log(`refusing to converge: ${head.slice(0, 9)} is quarantined (${q.why})`);
+    return { pulled, converged: false, skipped: "quarantined", sha: head, applied: [] };
+  }
+
+  const boot = getBootSha();
+  if (boot && boot === head) return { pulled, converged: false, skipped: "current", sha: head, applied: [] };
+
+  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
+  const { join } = await import("node:path");
+  const res = await runMigrations({
+    migrationsDir: join(root, "scripts", "migrations"),
+    dbPath: inst.dbPath, tasksDbPath: inst.tasksDbPath, sha: head, log,
+  });
+
+  // Baseline BEFORE the restart, from the still-live process, then hand it
+  // across the restart in the cookie.
+  let baseline = {};
+  try { ({ healthSnapshot: baseline } = {}); const p = await import("./proxy.js"); baseline = p.healthSnapshot(); } catch {}
+  writePending(inst.dataDir, { sha: head, baseline });
+
+  const au = await import("./auto-update.js");
+  au.scheduleSupervisedRestart(log, `Restarting to run ${head.slice(0, 9)}...`);
+  return { pulled, converged: true, sha: head, applied: res.applied };
+}
 ```
 
-- [ ] **Step 4: Run the tests**
+Clean up the `baseline` line to a plain `try { const p = await import("./proxy.js"); baseline = p.healthSnapshot(); } catch {}` when implementing.
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js tests/auto-update-hardening.test.js`
-Expected: PASS.
+- [ ] **Step 5: Capture the boot sha at gateway start**
 
-- [ ] **Step 5: Mutation-test**
+In `servers/gateway/index.js`, immediately after the registry block, add:
+```js
+try {
+  const { execFileSync } = await import("node:child_process");
+  const { setBootSha } = await import("./convergence.js");
+  const { dirname, join } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const _r = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+  setBootSha(execFileSync("git", ["rev-parse", "HEAD"], { cwd: _r, timeout: 10000 }).toString().trim());
+} catch {}
+```
 
-1. `return 0` from `instanceJitterMs` → the differ-between-instances assertion must fail.
-2. `return h` without `% JITTER_WINDOW_MS` → the range assertion must fail.
+- [ ] **Step 6: Run the gate** — `node --test tests/convergence-two-instance.test.js` → PASS, with `b.skipped === "locked"` and beta migrated.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Mutation-test — the most important step in this plan**
+
+1. Restore the early `return` in the lock-loss branch → **beta must fail.** *(Under the previous harness this mutation could not go red, because sequential calls never contended. If it stays green now, the gate is still worthless — stop and fix it.)*
+2. Guard the instance half with `if (pulled) { ... }` → beta must fail.
+3. Delete `assert.equal(b.skipped, "locked")` mentally and re-run mutation 1 — confirm the *probe-column* assertion also moves, so the gate does not rest on the status string alone.
+4. Make `convergeInstance` return before `writePending` → Task 10's verification tests fail.
+
+- [ ] **Step 8: Existing auto-update tests** — `node --test tests/auto-update-hardening.test.js tests/auto-update-ci-gate.test.js tests/auto-update-tick-gate.test.js`. These call `checkForUpdates()` with no argument; the new optional-object signature must keep them passing. The lock-skip message changed — update any assertion to the new text and confirm it still asserts behavior, not just a string.
+
+- [ ] **Step 9: Commit**
 
 ```bash
 cd /home/kh0pp/crow-wt-rolling
-git commit servers/gateway/auto-update.js tests/convergence-unit.test.js \
-  -m "fix(auto-update): de-phase-lock co-hosted first checks
+git commit servers/gateway/auto-update.js servers/gateway/convergence.js servers/gateway/index.js \
+  -m "feat(convergence): every instance converges, only one pulls
 
-Gateways restart together, so a fixed first-check delay put them on the
-same millisecond permanently."
+Restructures checkForUpdates so the lock loser falls through to the instance
+half instead of returning. Convergence owns the restart so it cannot fire
+mid-migration or before the boot cookie is written."
 git show --stat HEAD
 ```
 
-### Task 12: Quarantine on failed convergence, and peers honor it
+### Task 10: Boot-time verification and quarantine on regression
 
-**Files:**
-- Modify: `servers/shared/migration-guard.js:353-368` (`writeQuarantine`)
-- Modify: `servers/gateway/convergence.js`
-- Modify: `servers/gateway/boot/post-listen.js` (after the `startAutoUpdate` call, line ~186)
-- Test: `tests/convergence-two-instance.test.js` (append)
+**Files:** Modify `servers/gateway/convergence.js`, `servers/gateway/boot/post-listen.js`; Test append (two-instance file).
 
-**Interfaces:**
-- Consumes: `writeQuarantine`, `evaluateQuarantine`, `fireMigrationAlert` from `migration-guard.js`; `compareHealth`, `classifyPending`, `writePending`, `readPending`, `clearPending`, `ADDON_GRACE_MS` from `convergence.js`.
-- Produces:
-  - `writeQuarantine` gains an optional `reason` (default `"migration"`) and an `attemptsKey` field on the marker.
-  - `verifyPendingConvergence({ dataDir, appRoot, dbPath, bootSha, snapshot, now, schedule })` in `convergence.js`.
+**Interfaces:** Produces `verifyPendingConvergence({ dataDir, appRoot, bootSha, snapshot, settled, now, log }) → Promise<{ verdict, regressions? }>`; verdicts `none|stale|ok|quarantined`.
 
-- [ ] **Step 1: Write the failing test (append to the two-instance file)**
+- [ ] **Step 1: Write the failing tests (append)**
 
 ```js
-test("quarantine attempts are keyed per convergence sha, not shared across shas", () => {
+import { verifyPendingConvergence, writePending, readPending,
+         readConvQuarantine } from "../servers/gateway/convergence.js";
+
+test("a health regression quarantines the sha; peers then refuse to converge", async () => {
   const f = twoInstanceFixture();
-  t2after(f);
-  const { dbPath } = f.instances[0];
-
-  const m1 = writeQuarantine({ appRoot: f.work, dbPath, sha: "aaa", reason: "convergence" });
-  const m2 = writeQuarantine({ appRoot: f.work, dbPath, sha: "bbb", reason: "convergence" });
-  const m3 = writeQuarantine({ appRoot: f.work, dbPath, sha: "aaa", reason: "convergence" });
-
-  assert.equal(m1.attempts, 1);
-  assert.equal(m2.attempts, 1, "a DIFFERENT bad sha must start its own attempt count — " +
-    "otherwise three unrelated failures ever would permanently stop auto-clearing");
-  assert.equal(m3.attempts, 2, "the SAME bad sha must carry its count forward");
-});
-
-test("a health regression quarantines the sha; peers then refuse to converge to it", async () => {
-  const f = twoInstanceFixture();
-  t2after(f);
   const [alpha, beta] = f.instances;
-
-  writePending(alpha.dataDir, {
-    sha: "bad1234",
-    baseline: { "pm-workspace": "connected" },
-    now: Date.now(),
-  });
+  _setAppRootForTest(f.work);
+  // Quarantine the fixture's ACTUAL head — in production the shared tree STAYS
+  // at the bad sha, which is the whole case this design has to handle.
+  const badSha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha: badSha, baseline: { "pm-workspace": "connected" } });
 
   const out = await verifyPendingConvergence({
-    dataDir: alpha.dataDir,
-    appRoot: f.work,
-    dbPath: alpha.dbPath,
-    bootSha: "bad1234",
-    snapshot: () => ({ "pm-workspace": "error" }),   // the regression
-    schedule: (fn) => fn(),                          // run the grace timer inline
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: badSha,
+    snapshot: () => ({ "pm-workspace": "error" }),
+    settled: async () => {},
   });
-
   assert.equal(out.verdict, "quarantined");
   assert.deepEqual(out.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
-  assert.equal(readPending(alpha.dataDir), null, "the cookie must be cleared either way");
+  assert.equal(readPending(alpha.dataDir), null, "cookie must be cleared either way");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }).sha, badSha);
 
-  // The repo-level marker is what a PEER sees — they share the checkout.
-  const marker = readMarker(repoMarkerPath(f.work));
-  assert.equal(marker.sha, "bad1234");
-  assert.equal(marker.reason, "convergence");
-
-  // beta must now refuse.
-  const { converge } = await import("../servers/gateway/convergence.js");
-  const r = await converge({ appRoot: f.work, ...beta });
+  const { convergeInstance, setBootSha } = await import("../servers/gateway/convergence.js");
+  setBootSha("something-older");
+  const r = await convergeInstance({ appRoot: f.work, instance: beta });
   assert.equal(r.converged, false, "a peer must not converge to a quarantined sha");
   assert.equal(r.skipped, "quarantined");
 });
 
 test("a healthy convergence clears the cookie and quarantines nothing", async () => {
   const f = twoInstanceFixture();
-  t2after(f);
   const [alpha] = f.instances;
-
-  writePending(alpha.dataDir, { sha: "good999", baseline: { tasks: "connected" }, now: Date.now() });
-
+  const sha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha, baseline: { tasks: "connected" } });
   const out = await verifyPendingConvergence({
-    dataDir: alpha.dataDir, appRoot: f.work, dbPath: alpha.dbPath,
-    bootSha: "good999",
-    snapshot: () => ({ tasks: "connected" }),
-    schedule: (fn) => fn(),
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    snapshot: () => ({ tasks: "connected" }), settled: async () => {},
   });
-
   assert.equal(out.verdict, "ok");
   assert.equal(readPending(alpha.dataDir), null);
-  assert.equal(readMarker(repoMarkerPath(f.work)), null, "a healthy convergence must not quarantine");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }), null);
+});
+
+test("a snapshot that throws FAILS OPEN and always settles", async () => {
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha, baseline: { tasks: "connected" } });
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    snapshot: () => { throw new Error("proxy not ready"); }, settled: async () => {},
+  });
+  // Spec: "health gate cannot determine status -> unknown, FAIL OPEN". An
+  // unhandled rejection here would crash the gateway on Node 22 and the outer
+  // promise would never settle.
+  assert.equal(out.verdict, "unknown");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }), null,
+    "an indeterminate gate must not quarantine");
 });
 ```
 
-Add these imports to the TOP of the file (ESM imports must be at module scope,
-not inside the appended tests), and this cleanup helper:
+- [ ] **Step 2: Verify it fails** — `verifyPendingConvergence is not a function`.
 
-```js
-import { test, after } from "node:test";     // replaces the existing `import { test }`
-import { writeQuarantine, readMarker, repoMarkerPath } from "../servers/shared/migration-guard.js";
-import { verifyPendingConvergence, writePending, readPending } from "../servers/gateway/convergence.js";
-import { _setAppRootForTest } from "../servers/gateway/auto-update.js";
-
-// These tests take no `t`, so they cannot use t.after — register centrally.
-// The app-root restore is NOT optional: converge() reaches updateTree(), which
-// operates on the module root. A test that leaves the root pointed at a deleted
-// fixture makes a LATER test run git against whatever is there.
-const _fixtures = [];
-function t2after(f) { _fixtures.push(f); }
-after(() => {
-  _setAppRootForTest(join(import.meta.dirname, ".."));
-  for (const f of _fixtures) f.cleanup();
-  _fixtures.length = 0;
-});
-```
-
-In the peer-refusal test, call `_setAppRootForTest(f.work)` before `converge`.
-The quarantine guard runs before `updateTree` and should short-circuit first,
-but do not rely on that ordering to keep git off the real repo.
-
-- [ ] **Step 2: Run to verify it fails**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
-Expected: FAIL — `verifyPendingConvergence is not a function`, and the attempts test fails because `writeQuarantine` keys attempts on the generation pair (both convergence markers pass `undefined`/`undefined`, so `bbb` inherits `aaa`'s count).
-
-- [ ] **Step 3: Add `reason` and `attemptsKey` to writeQuarantine**
-
-Replace `servers/shared/migration-guard.js:353-368`:
-
-```js
-export function writeQuarantine({ appRoot, dbPath, sha, fromGeneration, toGeneration, report, reason = "migration" }) {
-  // Attempts carry forward per DISTINCT cause. For a schema migration the cause
-  // is the (from,to) generation crossing; for a convergence failure it is the
-  // specific bad sha. Keying convergence failures on the generation pair would
-  // make every convergence failure share one counter — three unrelated bad shas
-  // ever would permanently stop the quarantine from auto-clearing.
-  const attemptsKey = reason === "convergence"
-    ? `convergence:${sha}`
-    : `migration:${fromGeneration}->${toGeneration}`;
-
-  let attempts = 1;
-  for (const p of [repoMarkerPath(appRoot), dataMarkerPath(dbPath)]) {
-    const prev = readMarker(p);
-    if (!prev) continue;
-    // Markers written before attemptsKey existed are migration markers; fall
-    // back to the original generation-pair comparison for them.
-    const prevKey = prev.attemptsKey
-      ?? `migration:${prev.fromGeneration}->${prev.toGeneration}`;
-    if (prevKey === attemptsKey) attempts = Math.max(attempts, (prev.attempts || 0) + 1);
-  }
-  const marker = { sha, fromGeneration, toGeneration, reason, attemptsKey, at: new Date().toISOString(), attempts, report };
-  for (const p of [repoMarkerPath(appRoot), dataMarkerPath(dbPath)]) {
-    try { writeFileSync(p, JSON.stringify(marker, null, 2)); } catch {}
-  }
-  return marker;
-}
-```
-
-- [ ] **Step 4: Implement `verifyPendingConvergence` and the peer guard**
-
-Append to `servers/gateway/convergence.js`:
+- [ ] **Step 3: Implement**
 
 ```js
 /**
- * Called at boot. Decides what the cookie left behind by the previous
- * convergence means, and quarantines the sha if that convergence did not prove
- * itself healthy.
- *
- * `snapshot` and `schedule` are injected so tests can drive the grace window
- * without waiting 90 real seconds.
+ * Called at boot. Decides what the cookie left by the previous convergence means.
+ * `snapshot` and `settled` are injected so tests need not wait on the real
+ * addon-connect loop.
  */
 export async function verifyPendingConvergence({
-  dataDir, appRoot, dbPath, bootSha,
-  snapshot, schedule = (fn) => setTimeout(fn, ADDON_GRACE_MS).unref(),
+  dataDir, appRoot, bootSha, snapshot, settled,
   now = Date.now(), log = () => {},
 }) {
   const pending = readPending(dataDir);
   const verdict = classifyPending(pending, bootSha, now);
-
   if (verdict === "none") return { verdict: "none" };
   if (verdict === "stale") { clearPending(dataDir); return { verdict: "stale" }; }
 
-  const guard = await import("../shared/migration-guard.js");
-
   const quarantine = async (sha, regressions, why) => {
-    guard.writeQuarantine({ appRoot, dbPath, sha, reason: "convergence", report: { regressions, why } });
+    writeConvQuarantine({ appRoot, dataDir, sha, regressions, why });
     clearPending(dataDir);
-    await guard.fireMigrationAlert({
-      title: "Crow update quarantined: convergence failed",
-      body: `The gateway converged to ${String(sha).slice(0, 9)} and ${why}. `
-          + `That sha is quarantined — no instance on this host will converge to it until the `
-          + `quarantine clears (automatically when main moves past it, or by deleting the marker files). `
-          + `The tree was NOT rolled back: co-hosted instances may be running it healthily.`,
-    });
+    try {
+      const { fireMigrationAlert } = await import("../shared/migration-guard.js");
+      await fireMigrationAlert({
+        title: "Crow update quarantined: convergence failed",
+        body: `This instance converged to ${String(sha).slice(0, 9)} and ${why}. That sha is `
+            + `quarantined for 24h — no gateway on this host will converge to it. The tree was `
+            + `NOT rolled back: co-hosted instances may be running it healthily.`,
+      });
+    } catch {}
     log(`convergence to ${String(sha).slice(0, 9)} quarantined — ${why}`);
     return { verdict: "quarantined", regressions };
   };
@@ -1685,263 +1445,301 @@ export async function verifyPendingConvergence({
     return quarantine(pending.sha, [], "never completed a healthy boot before its deadline");
   }
 
-  // verdict === "verify": we are the boot this cookie was written for.
-  return new Promise((resolve) => {
-    schedule(async () => {
-      const after = snapshot();
-      const cmp = compareHealth(pending.baseline, after);
-      if (cmp.ok) {
-        clearPending(dataDir);
-        log(`convergence to ${String(pending.sha).slice(0, 9)} verified healthy`);
-        resolve({ verdict: "ok" });
-        return;
-      }
-      resolve(await quarantine(pending.sha, cmp.regressions,
-        `broke ${cmp.regressions.map((r) => r.id).join(", ")}`));
-    });
-  });
+  // verdict === "verify". Everything below is wrapped: an unhandled rejection
+  // here would take the gateway down on Node 22, and the spec requires the gate
+  // to fail OPEN when it cannot determine status.
+  try {
+    await settled();
+    const after = snapshot();
+    const cmp = compareHealth(pending.baseline, after);
+    if (cmp.ok) {
+      clearPending(dataDir);
+      log(`convergence to ${String(pending.sha).slice(0, 9)} verified healthy`);
+      return { verdict: "ok" };
+    }
+    return await quarantine(pending.sha, cmp.regressions,
+      `broke ${cmp.regressions.map((r) => r.id).join(", ")}`);
+  } catch (err) {
+    clearPending(dataDir);
+    log(`health gate indeterminate (${err.message}) — failing open, not quarantining`);
+    return { verdict: "unknown" };
+  }
 }
 ```
 
-Then add the peer guard at the top of `converge()`, immediately after the imports:
+- [ ] **Step 4: Wire into post-listen.js** after the `startAutoUpdate(...)` call (~line 186):
 
 ```js
-  // Peers honor a quarantine written by whichever instance converged first.
-  // The marker is written at BOTH repo and data level; the repo-level one is
-  // what makes a shared checkout's other gateways see it. evaluateQuarantine
-  // auto-clears once main moves past the bad sha (attempts-capped).
-  const guard = await import("../shared/migration-guard.js");
-  const head = (await git(appRoot, ["rev-parse", "HEAD"])).stdout;
-  const q = guard.evaluateQuarantine({ appRoot, dbPath, originHeadSha: head });
-  if (q.blocked) {
-    log(`refusing to converge: ${q.marker.sha.slice(0, 9)} is quarantined (attempt ${q.marker.attempts})`);
-    return { pulled: false, converged: false, skipped: "quarantined", sha: head, applied: [] };
-  }
-```
-
-- [ ] **Step 5: Wire the boot-time verification into post-listen.js**
-
-Insert immediately after the `startAutoUpdate(...)` call at line ~186:
-
-```js
-  // Verify the convergence that caused this restart, if there was one. Runs
-  // after listen so the addon connects the gate measures have actually begun.
-  import("../convergence.js").then(async ({ verifyPendingConvergence }) => {
-    const { resolveDataDir } = await import("../../db.js");
-    const { resolveGuardDbPath } = await import("../../shared/migration-guard.js");
-    const { healthSnapshot } = await import("../proxy.js");
-    const { execFileSync } = await import("node:child_process");
+  // Verify the convergence that caused this restart, if there was one.
+  import("../convergence.js").then(async (conv) => {
+    const { healthSnapshot, addonsSettled } = await import("../proxy.js");
     const { dirname, join } = await import("node:path");
     const { fileURLToPath } = await import("node:url");
     const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
-    let bootSha = null;
-    try { bootSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: appRoot, timeout: 10000 }).toString().trim(); } catch {}
-    await verifyPendingConvergence({
-      dataDir: resolveDataDir(),
-      appRoot,
-      dbPath: resolveGuardDbPath(resolveDataDir),
-      bootSha,
-      snapshot: healthSnapshot,
+    const inst = await conv.resolveInstance();
+    await conv.verifyPendingConvergence({
+      dataDir: inst.dataDir, appRoot, bootSha: conv.getBootSha(),
+      snapshot: healthSnapshot, settled: addonsSettled,
       log: (m) => console.log(`[convergence] ${m}`),
     });
   }).catch((err) => console.warn("[convergence] verification skipped:", err.message));
 ```
 
-- [ ] **Step 6: Run the tests**
+- [ ] **Step 5: Run** — `node --test tests/convergence-two-instance.test.js tests/migration-guard.test.js` → PASS (migration-guard is untouched by this design and must stay green).
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js tests/migration-guard.test.js`
-Expected: PASS, including the pre-existing `migration-guard.test.js` — the `reason` default of `"migration"` keeps every existing caller behaving identically.
+- [ ] **Step 6: Mutation-test**
+1. Remove `clearPending` from the healthy path → the "clears the cookie" assertion fails.
+2. Make the peer guard in `convergeInstance` return `converged: true` → the peer-refusal assertion fails.
+3. `compareHealth(pending.baseline, after)` → `compareHealth({}, after)` → the regression test fails (it would make every convergence look healthy).
+4. Remove the `try/catch` around the verify branch → the fail-open test fails (and likely crashes the runner, which is the point).
+5. Point `writeConvQuarantine` at migration-guard's `writeQuarantine` → `migration-guard.test.js` or the namespace assertion in Task 7 fails.
 
-- [ ] **Step 7: Mutation-test**
-
-1. Change the `attemptsKey` for convergence to use the generation pair → the per-sha attempts assertion must fail.
-2. Remove `clearPending(dataDir)` from the healthy path → the "clears the cookie" assertion must fail.
-3. Make the peer guard return `converged: true` anyway → the peer-refusal assertion must fail.
-4. Change `compareHealth(pending.baseline, after)` to `compareHealth({}, after)` → the regression test must fail (it would make every convergence look healthy).
-5. Remove the `reason` default from `writeQuarantine` → `migration-guard.test.js` must fail, proving back-compat is actually asserted.
-
-- [ ] **Step 8: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 cd /home/kh0pp/crow-wt-rolling
-git commit servers/shared/migration-guard.js servers/gateway/convergence.js \
-  servers/gateway/boot/post-listen.js tests/convergence-two-instance.test.js \
-  -m "feat(convergence): quarantine a sha whose convergence regressed health
+git commit servers/gateway/convergence.js servers/gateway/boot/post-listen.js tests/convergence-two-instance.test.js \
+  -m "feat(convergence): boot-time health verification with quarantine on regression
 
-The shared tree is never rolled back — one instance's failed health check
-must not drag co-hosted peers that are running that sha healthily. Peers
-read the repo-level marker and refuse the bad sha instead."
+Gates convergence, never the pull, so the tree can always move past a bad
+sha. Fails open when the gate cannot determine status."
 git show --stat HEAD
 ```
 
-### Task 13: Kill switch and documentation
+### Task 11: De-phase-lock the timers, and record real HEAD when disabled
 
-**Files:**
-- Modify: `servers/gateway/convergence.js`
-- Modify: `docs/architecture/gateway.md`
-- Test: `tests/convergence-unit.test.js` (append)
+**Files:** Modify `servers/gateway/auto-update.js`; Test append (unit file).
 
-**Interfaces:**
-- Consumes: `converge` from Task 10.
-- Produces: `CROW_DISABLE_CONVERGE=1|true` short-circuits `converge()`.
+**Interfaces:** Produces `instanceJitterMs(key) → number` in `[0, 600000)`.
 
-- [ ] **Step 1: Write the failing test (append)**
+- [ ] **Step 1: Write the failing tests (append)**
+
+```js
+import { startAutoUpdate, stopAutoUpdate, _setDbForTest, instanceJitterMs }
+  from "../servers/gateway/auto-update.js";
+import { execFileSync } from "node:child_process";
+
+test("instanceJitterMs is stable per instance and differs between instances", () => {
+  const a = instanceJitterMs("/home/kh0pp/.crow/data");
+  const b = instanceJitterMs("/home/kh0pp/.crow-mpa/data");
+  const c = instanceJitterMs("/home/kh0pp/.crow-r4/data");
+  assert.equal(a, instanceJitterMs("/home/kh0pp/.crow/data"), "must be deterministic");
+  assert.notEqual(a, b); assert.notEqual(b, c); assert.notEqual(a, c);
+  for (const k of Array.from({ length: 500 }, (_, i) => `/tmp/inst-${i}/data`)) {
+    const v = instanceJitterMs(k);
+    assert.ok(Number.isInteger(v) && v >= 0 && v < 600000, `jitter ${v} out of range for ${k}`);
+  }
+});
+
+test("the jitter is actually WIRED IN — the first-check delay differs per instance", async () => {
+  // Without this the pure function could be perfect and the delay still fixed.
+  const seen = [];
+  const orig = console.log;
+  console.log = (...a) => seen.push(a.join(" "));
+  try {
+    for (const dir of ["/tmp/jit-a/data", "/tmp/jit-b/data"]) {
+      process.env.CROW_DATA_DIR = dir;
+      _setDbForTest({ execute: async ({ sql }) =>
+        /^SELECT/i.test(sql) ? { rows: [{ key: "auto_update_enabled", value: "true" }] } : { rows: [] } });
+      await startAutoUpdate({ execute: async () => ({ rows: [] }) }, {});
+      stopAutoUpdate();
+    }
+  } finally { console.log = orig; delete process.env.CROW_DATA_DIR; _setDbForTest(null); }
+  const delays = seen.filter((l) => l.includes("first check in")).map((l) => l.match(/in (\d+)s/)?.[1]);
+  assert.equal(delays.length, 2);
+  assert.notEqual(delays[0], delays[1], "two instances must not share a first-check phase");
+});
+
+test("a DISABLED instance still records its ACTUAL running sha", async () => {
+  delete process.env.CROW_AUTO_UPDATE;   // shouldStartAutoUpdate gates on this
+  const writes = [];
+  const db = { execute: async ({ sql, args }) => {
+    if (/^SELECT/i.test(sql)) return { rows: [{ key: "auto_update_enabled", value: "false" }] };
+    writes.push({ key: args[0], value: args[1] }); return { rows: [] };
+  } };
+  await startAutoUpdate(db, {});
+  stopAutoUpdate();
+  const v = writes.find((w) => w.key === "auto_update_current_version");
+  assert.ok(v, "must record even when disabled — Gap 4b is a version it has not run");
+  const real = execFileSync("git", ["rev-parse", "--short", "HEAD"],
+    { cwd: join(import.meta.dirname, "..") }).toString().trim();
+  assert.equal(v.value, real, "must be THIS checkout's sha, not merely sha-shaped");
+});
+```
+
+- [ ] **Step 2: Verify it fails** — `instanceJitterMs is not a function`.
+
+- [ ] **Step 3: Implement**
+
+```js
+const JITTER_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * A stable per-instance offset for the first update check. Co-hosted gateways
+ * restart together, so a fixed 5-minute first check put all of them on the same
+ * millisecond forever — their checks landed 475ms apart and the same instance
+ * lost the lock every tick. Robustness only: the real fix is that the loser
+ * converges anyway.
+ */
+export function instanceJitterMs(key) {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) { h ^= key.charCodeAt(i); h = Math.imul(h, 16777619) >>> 0; }
+  return h % JITTER_WINDOW_MS;
+}
+```
+
+In `startAutoUpdate`, move the version write **above** the disabled return:
+
+```js
+  const settings = await getSettings();
+  // Record the sha this process is ACTUALLY running, before any early return.
+  // Previously this sat below the disabled return, so a disabled instance froze
+  // its reported version while continuing to run whatever the tree moved to.
+  try {
+    const ref = await run("git", ["rev-parse", "--short", "HEAD"]);
+    if (ref.code === 0 && ref.stdout) await saveSetting("auto_update_current_version", ref.stdout);
+  } catch {}
+  if (settings.auto_update_enabled !== "true") { console.log("[auto-update] Disabled in settings"); return; }
+```
+
+and replace the fixed first delay:
+
+```js
+  const { resolveDataDir } = await import("../db.js");
+  const firstDelay = 5 * 60 * 1000 + instanceJitterMs(resolveDataDir());
+  console.log(`[auto-update] Enabled — checking every ${hours}h (first check in ${Math.round(firstDelay/1000)}s)`);
+  updateTimer = setTimeout(async () => {
+    await tickCheck().catch((e) => console.error("[auto-update] tick failed:", e.message));
+    updateTimer = setInterval(() => { tickCheck().catch(() => {}); }, intervalMs);
+  }, firstDelay);
+```
+
+The added `.catch` matters: `tickCheck` now reaches `runMigrations`, which **can** reject, and an unhandled rejection in that timer would take the gateway down.
+
+- [ ] **Step 4: Run** — PASS.
+
+- [ ] **Step 5: Mutation-test**
+1. `return 0` from `instanceJitterMs` → both the differ-between-instances and the wired-in assertions fail.
+2. Drop `% JITTER_WINDOW_MS` → the 500-key range assertion fails.
+3. Revert the version write below the `return` → the disabled-instance test fails.
+4. Record `origin/main`'s sha instead of HEAD → the equality assertion fails (a regex-shaped assertion would not have caught this).
+5. Restore the fixed `5 * 60 * 1000` delay → the wired-in test fails.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/auto-update.js tests/convergence-unit.test.js \
+  -m "fix(auto-update): de-phase-lock co-hosted checks; record the running sha when disabled"
+git show --stat HEAD
+```
+
+### Task 12: Kill switch test, docs, whole-branch review, acceptance, merge, report
+
+**Files:** Modify `docs/architecture/gateway.md`; Test append.
+
+- [ ] **Step 1: Kill-switch test (append to the unit file)**
 
 ```js
 test("CROW_DISABLE_CONVERGE short-circuits convergence entirely", async () => {
-  const { converge } = await import("../servers/gateway/convergence.js");
+  const { convergeInstance } = await import("../servers/gateway/convergence.js");
   process.env.CROW_DISABLE_CONVERGE = "1";
   try {
-    const r = await converge({ appRoot: "/nonexistent", dataDir: "/nonexistent", dbPath: "/nonexistent/x.db", tasksDbPath: "/nonexistent/t.db" });
+    // Bogus paths are deliberate: if the switch works, nothing touches the
+    // filesystem or git, so they cannot fail.
+    const r = await convergeInstance({ appRoot: "/nonexistent", instance:
+      { dataDir: "/nonexistent", dbPath: "/nonexistent/x.db", tasksDbPath: "/nonexistent/t.db" } });
     assert.equal(r.converged, false);
     assert.equal(r.skipped, "disabled");
   } finally { delete process.env.CROW_DISABLE_CONVERGE; }
 });
 ```
 
-The nonexistent paths are deliberate: if the kill switch works, nothing touches the filesystem, so bogus paths cannot fail.
+The switch is already the first statement in `convergeInstance` (Task 9), so this should pass immediately — confirm by mutating it to run second and watching the test error on ENOENT rather than assert cleanly.
 
-- [ ] **Step 2: Run to verify it fails**
+- [ ] **Step 2: Document** in `docs/architecture/gateway.md`: the converge-vs-pull split and why a lock loss is normal; the migration registry and how to add an entry (`scripts/migrations/NNNN-slug.mjs` exporting `id` and `run`, returning `{deferred:true}` when targets are absent); the health gate as a regression check waiting on the addon-settled signal; quarantine-not-rollback, its own namespace, the 24 h expiry, and how to clear a marker; `CROW_DISABLE_CONVERGE=1`. Check EN/ES parity if any user-facing string was added (the gate is live; architecture docs are EN-only).
 
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: FAIL — an ENOENT from git or better-sqlite3, not a clean `skipped: "disabled"`.
+- [ ] **Step 3: Full suite**
 
-- [ ] **Step 3: Add the kill switch as the very first statement in `converge()`**
-
-```js
-  if (process.env.CROW_DISABLE_CONVERGE === "1" || process.env.CROW_DISABLE_CONVERGE === "true") {
-    log("convergence disabled via CROW_DISABLE_CONVERGE");
-    return { pulled: false, converged: false, skipped: "disabled", sha: null, applied: [] };
-  }
-```
-
-- [ ] **Step 4: Run the test**
-
-Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
-Expected: PASS.
-
-- [ ] **Step 5: Document it**
-
-Add to `docs/architecture/gateway.md` a section covering: the converge-vs-pull split and why the tree is shared; that a lock loss is normal and the instance still converges; the migration registry and how to add an entry (`scripts/migrations/NNNN-slug.mjs` exporting `id` and `run`); the health gate being a regression check with the 90 s / 10 min constants and why each is what it is; quarantine-not-rollback and how to clear a marker; and `CROW_DISABLE_CONVERGE=1`.
-
-Check whether EN/ES i18n parity applies to anything you touched — the parity gate is live. Architecture docs are EN-only, but if any user-facing string was added, both locales must carry it.
-
-- [ ] **Step 6: Run the FULL suite**
-
-Run:
 ```bash
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
 cd /home/kh0pp/crow-wt-rolling
 npm test > /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-final.log 2>&1
-grep -E "^# (tests|suites|pass|fail|cancelled|skipped)" /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-final.log
+grep -E "^# (tests|suites|pass|fail|cancelled|skipped)" …/suite-final.log
 ```
-Expected: `# fail 0`, `# cancelled 0`, `# tests` ≥ 2961 plus every test added here. A `cancelled` count above zero is the known whole-file-cancel flake under load — re-run that file alone to confirm before treating it as a real failure.
+Expected `# fail 0`, `# cancelled 0`, `# tests` ≥ 2961 + the new ones. A nonzero `cancelled` is the known whole-file-cancel flake under load — re-run that file alone before treating it as real.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 4: Audit the branch**
 
 ```bash
-cd /home/kh0pp/crow-wt-rolling
-git commit servers/gateway/convergence.js docs/architecture/gateway.md tests/convergence-unit.test.js \
-  -m "feat(convergence): CROW_DISABLE_CONVERGE kill switch and architecture docs"
-git show --stat HEAD
+git log --format='%an <%ae>%n%b' origin/main..HEAD | grep -iE "claude|co-authored|anthropic" && echo "ATTRIBUTION — FIX" || echo clean
+git diff origin/main..HEAD | grep -iE "DROP TABLE|DELETE FROM" || echo "no new DROP/DELETE — migration-expectations.js unaffected"
+git diff origin/main..HEAD -- servers/shared/schema-version.js | head -1 || true   # must be empty: no gen bump
+git diff origin/main..HEAD | grep -iE "listen\(|PORT" || echo "no new host port — port-allocation.md unaffected"
 ```
+Also confirm `.crow-convergence-quarantine.json` is gitignored — `convergeInstance` writes it into the repo root, which three gateways and the `pibot-gateways@r4` soak share. Add it to `.gitignore` if absent.
 
-### Task 14: Whole-branch review, acceptance, merge, deploy, report
+- [ ] **Step 5: Adversarial whole-branch review**
 
-**Files:**
-- No new files. This task gates the merge.
+Named concerns: the fall-through under real concurrency; whether any quarantine path can wedge an instance past the 24 h expiry; whether `verifyPendingConvergence` can leak a promise; whether the boot-order invariant holds at runtime and not just in source text; whether the registry's tick-time run (outside the boot ordering) is safe against the WAL keeper; and whether any test is vacuous.
 
-**Interfaces:**
-- Consumes: everything above.
-- Produces: merged `main`, deployed fleet, updated card #120.
-
-- [ ] **Step 1: Audit the whole branch before review**
+- [ ] **Step 6: Wiped-scratch acceptance**
 
 ```bash
-cd /home/kh0pp/crow-wt-rolling
-git log --format='%an <%ae>%n%b' origin/main..HEAD | grep -iE "claude|co-authored|anthropic" && echo "ATTRIBUTION FOUND — FIX" || echo "clean"
-git diff origin/main..HEAD --stat
-```
-Expected: `clean`. Any attribution must be rewritten before pushing further.
-
-- [ ] **Step 2: Check the doctrine gates that CI does not cover**
-
-- No new host ports added → `docs/developers/port-allocation.md` needs no change. Confirm with `git diff origin/main..HEAD | grep -iE "PORT|listen\("`.
-- No new `DROP` or `DELETE` statements → `migration-expectations.js` needs no change. Confirm with `git diff origin/main..HEAD | grep -iE "DROP TABLE|DELETE FROM"`.
-- No `SCHEMA_GENERATION` bump → the dryrun rail does not apply. Confirm with `git diff origin/main..HEAD -- servers/shared/schema-version.js` returning empty.
-
-If any of those confirms are non-empty, stop and handle the corresponding rail before merging.
-
-- [ ] **Step 3: Adversarial whole-branch review**
-
-Request a code review covering the full diff, with these as the named areas of concern: the converge/pull split under real concurrency; whether the quarantine can wedge an instance permanently; whether `verifyPendingConvergence`'s promise can leak or never resolve; whether the boot-order invariant actually holds at runtime and not just in source text; and whether any test is vacuous.
-
-- [ ] **Step 4: Wiped-scratch acceptance**
-
-A fresh instance, never migrated, must boot correctly — this is the case the fixture harness cannot cover:
-
-```bash
-export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
-S=/tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/accept
-rm -rf $S && mkdir -p $S/data
-cd /home/kh0pp/crow-wt-rolling
+S=…/scratchpad/accept; rm -rf $S && mkdir -p $S/data
 CROW_HOME=$S CROW_DATA_DIR=$S/data CROW_DB_PATH=$S/data/crow.db \
 CROW_AUTO_UPDATE=0 CROW_ALLOW_ORPHAN=1 PORT=3099 \
 timeout 120 node servers/gateway/index.js --no-auth 2>&1 | tee $S/accept.log | head -80
 ```
-Expected: `[migrations] applied: 0001-board-stages`, gateway listens, no `[convergence]` quarantine. Then verify the live DBs were untouched (mtimes on `~/.crow/data/crow.db` and `~/.crow-r4/data/crow.db` unchanged).
+Expected: `[migrations] deferred (will retry): 0001-board-stages` (**deferred, not applied** — a wiped instance has no `tasks_items`), gateway listens, no `[convergence]` quarantine, live DB mtimes unchanged.
 
-- [ ] **Step 5: Push, verify CI via check-runs, merge**
+- [ ] **Step 7: Push, verify check-runs, merge**
 
 ```bash
-cd /home/kh0pp/crow-wt-rolling
-git pull --rebase origin main
-git push
+git pull --rebase origin main && git push
 SHA=$(git rev-parse HEAD)
 curl -s "https://api.github.com/repos/kh0pper/crow/commits/$SHA/check-runs" \
-  | python3 -c "import json,sys; d=json.load(sys.stdin); [print(r['name'], r['status'], r['conclusion']) for r in d['check_runs']]"
+ | python3 -c "import json,sys;d=json.load(sys.stdin);[print(r['name'],r['status'],r['conclusion']) for r in d['check_runs']]"
 ```
-Expected: `suite`, `static-checks`, `audit` each `completed success`. An empty result on a current sha means something is WRONG, not that checks are absent. Merge only when all three are green.
+All of `suite`/`static-checks`/`audit` `completed success`. An empty result on a current sha means something is WRONG.
 
-- [ ] **Step 6: Deploy and verify the fleet**
+- [ ] **Step 8: Deploy and verify the fleet**
 
-Deploy to all five instances. For the three co-hosted on crow, use the Phase 1 script for r4 and normal restarts for primary/MPA, in tight windows. After each restart confirm from DB **copies** (never open a running gateway's crow.db directly):
+Deploy to all five. Use `r4-deploy.sh` for r4, normal restarts for primary/MPA, tight windows. From DB **copies** confirm `auto_update_current_version` matches the real running sha on **every** instance including r4 (the Gap 4b fix proving itself). Confirm no `.crow-convergence-quarantine.json` exists. Confirm `pibot-gateways@r4` is still active and log a timestamp if the deploy touched `scripts/pi-bots/`.
 
-- `auto_update_current_version` now matches the real running sha on **every** instance, including r4 where auto-update is disabled. That is the Gap 4b fix proving itself in prod.
-- No `[convergence]` quarantine markers exist: `ls ~/crow/.crow-migration-quarantine* 2>/dev/null`.
-- `pibot-gateways@r4` is still active, and log a timestamp for its restart if the deploy touched `scripts/pi-bots/`.
+- [ ] **Step 9: Report on card #120** in `~/.crow-r4/data/tasks.db` (`tasks_items`) — syncs to Monday, keep it accurate. Record what shipped, that `r4-deploy.sh` is **uncommitted** for the PM session to fold into Gitea, verification results, and that Phase 3 was deliberately not built. Set `done` only after Step 8 passes.
 
-- [ ] **Step 7: Report on card #120**
-
-Update the card in `~/.crow-r4/data/tasks.db` (`tasks_items`) — it syncs to the Monday board, so keep it accurate. Record: what shipped (PR numbers and merge sha), that `r4-deploy.sh` is **uncommitted** at `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh` for the PM session to fold into the Gitea repo, the verification results, and that Phase 3 was deliberately not built. Set status to `done` only after the fleet verification in Step 6 passes.
-
-- [ ] **Step 8: Present the r4 auto-update question**
-
-With convergence merged, r4 could have `auto_update_enabled` turned back on — the starvation and migration-drift reasons for keeping it off are gone. This is the operator's call, not an assumption. Present it with the evidence from Step 6, and do not change the setting without an explicit yes.
+- [ ] **Step 10: Present the r4 auto-update question** — with convergence merged, `auto_update_enabled` could return for r4. Operator's call; present the Step 8 evidence and change nothing without an explicit yes.
 
 ---
 
 ## Self-Review
 
-**Spec coverage:**
-
 | Spec requirement | Task |
 |---|---|
 | Gap 1 — migrations travel with code | 3, 4, 5 |
-| Gap 2 — bundle copies travel | 1 (step 5), 2 |
-| Gap 3 — health verified | 8, 12 |
-| Gap 4 — lock starvation | 6, 10, 11 |
-| Gap 4b — disabled instance version lies | 7 |
-| Lazy `schema_migrations`, no generation bump | 3 (step 3), 14 (step 2) |
+| Gap 1 — deferral, not false "applied" | 3, 4 |
+| Gap 2 — bundle copies travel (with per-instance exclusions) | 1 |
+| Gap 3 — health verified | 6, 10 |
+| Gap 4 — lock starvation (fall-through, real path) | 8, 9 |
+| Gap 4b — disabled instance version lies | 11 |
+| Lazy `schema_migrations`, no generation bump | 3, 12 |
 | Registry scope = crow.db + tasks.db only | 3, 4 |
-| Order invariant | 5 |
-| Regression-not-absolute health gate | 8 |
-| 90 s addon grace / 10 min cookie deadline | 9 |
-| Quarantine, never `git reset --hard` | 12 |
-| Peers honor the marker / canary by construction | 12 |
-| `CROW_DISABLE_CONVERGE` kill switch | 13 |
-| Two-instance executable gate | 6, 10 (step 5), 12 |
+| Order invariant (+ mutation) | 5 |
+| Regression-not-absolute gate, addons only | 6 |
+| Settled signal, not a fixed grace window | 6, 10 |
+| Cookie 15 min, atomic write, constants pinned | 7 |
+| Own quarantine namespace, 24 h expiry | 7, 10 |
+| Quarantine gates convergence, never the pull | 9, 10 |
+| Fail open when the gate is indeterminate | 10 |
+| Convergence owns the restart | 9 |
+| Trigger is bootSha≠HEAD, never `pulled` | 9 |
+| `CROW_DISABLE_CONVERGE` kill switch | 9, 12 |
+| Two-instance executable gate, real lock contention | 8, 9 |
 | Phase 3 not built | — (deliberate) |
-| Report on card #120 | 14 |
+| Report on card #120 | 12 |
 
-**Known gap, stated rather than hidden:** if the new code crashes *before* `post-listen.js` runs, no boot ever reads the cookie in that process, and the quarantine only fires on the following boot via the expired-deadline path (`classifyPending → "failed"`, Task 9). That path is tested. A crash so early that systemd gives up before any boot reaches post-listen leaves the sha un-quarantined — detection then falls to the operator alert path, not to this mechanism. This is a real limit of self-verification without an external watchdog and is accepted rather than papered over.
+**Stated limits, not hidden:**
+- If new code crashes *before* `post-listen.js` runs, quarantine fires only on the following boot via the expired-deadline path (tested). A crash so early that systemd exhausts `StartLimitBurst` first leaves the sha un-quarantined; detection falls to the operator alert. This is the real limit of self-verification without an external watchdog.
+- The registry runs at tick time inside `convergeInstance` as well as at boot. The boot call site is ordered before the first `createDbClient`; the tick-time one is not, and runs while the WAL keeper is pinned. That is safe for additive `ALTER`s (no file swap) but a future migration that restores or replaces a DB file must not go in this registry.
+- Three unlocked processes can write markers concurrently; writes are tmp+rename so no reader sees torn JSON, but a lost update between two simultaneous quarantines is possible. Consequence is bounded: both write the same sha, and the 24 h expiry caps any divergence.

--- a/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
+++ b/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
@@ -538,12 +538,18 @@ test("0001-board-stages: adds columns, DEFERS when ANY table is absent, idempote
     c2.close();
   } finally { rmSync(mixed.root, { recursive: true, force: true }); }
 
-  // (b) tasks_items present → applied, columns added, re-runnable.
+  // (b) ALL targets present → applied, columns added, re-runnable.
+  // Both DBs must be seeded: under the `any absent` rule, leaving crow.db bare
+  // would defer and `applied` would not contain the id.
   const f = fixture();
   try {
     const t = new Database(f.tasksDbPath);
     t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
     t.close();
+    const c = new Database(f.dbPath);
+    c.prepare("CREATE TABLE project_spaces (id INTEGER PRIMARY KEY)").run();
+    c.prepare("CREATE TABLE bot_sessions (id INTEGER PRIMARY KEY)").run();
+    c.close();
     const r = await runMigrations({ migrationsDir: dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
     assert.ok(r.applied.includes("0001-board-stages"));
     const t2 = new Database(f.tasksDbPath);
@@ -730,7 +736,7 @@ CROW_HOME=$S CROW_DATA_DIR=$S/data CROW_DB_PATH=$S/data/crow.db \
 CROW_AUTO_UPDATE=0 CROW_ALLOW_ORPHAN=1 PORT=3099 \
 timeout 120 node servers/gateway/index.js --no-auth 2>&1 | tee $S/boot.log | head -60
 ```
-Expected, in this order: `[migrations] deferred (will retry): 0001-board-stages` at boot (a wiped instance has no `tasks_items` yet, so **deferred is correct here, not applied**), the gateway's listen line, and then — only if a `tasks` bundle is installed — `[migrations:post-settle] applied: 0001-board-stages`. With no bundles installed, `[migrations:post-settle] STILL deferred` is the correct outcome. Then confirm `~/.crow/data/crow.db` mtime is unchanged.
+Expected: `[migrations] deferred (will retry): 0001-board-stages` at boot — a wiped instance has no `tasks_items` yet, so **deferred is correct here, not applied** — then the gateway's listen line. No `[migrations:post-settle]` line yet: that second pass is added in Task 10. Then confirm `~/.crow/data/crow.db` mtime is unchanged.
 
 - [ ] **Step 7: Full suite** — `npm test > …/suite-partA.log 2>&1`, then `grep -E "^# (tests|pass|fail|cancelled)"`. Expected `# fail 0`, `# cancelled 0`.
 
@@ -1124,8 +1130,32 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
 import { checkForUpdates, _setAppRootForTest, _setDbForTest } from "../servers/gateway/auto-update.js";
 import { _setAlertChannelsForTest } from "../servers/shared/migration-guard.js";
+import {
+  setBootSha, _setRestartForTest, _setSupervisedForTest,
+  convergeInstance, verifyPendingConvergence,
+  writePending, readPending, readConvQuarantine,
+} from "../servers/gateway/convergence.js";
+
+// Captured restarts, asserted per test. Reset in beforeEach-style prologue.
+const restarts = [];
+
+// This file's tree half resolves its guard DB from env. Unpinned, a bare
+// `node --test` run resolves to ~/.crow/data/crow.db and would BACK UP and
+// PRUNE the live primary instance's data dir (migration-guard takeBackup +
+// sweepRetention). Pin scratch paths, and RESTORE rather than delete.
+const _prevEnv = {
+  CROW_HOME: process.env.CROW_HOME,
+  CROW_DATA_DIR: process.env.CROW_DATA_DIR,
+  CROW_DB_PATH: process.env.CROW_DB_PATH,
+};
+const _scratch = mkdtempSync(join(tmpdir(), "conv-env-"));
+mkdirSync(join(_scratch, "data"), { recursive: true });
+process.env.CROW_HOME = _scratch;
+process.env.CROW_DATA_DIR = join(_scratch, "data");
+process.env.CROW_DB_PATH = join(_scratch, "data", "crow.db");
 
 // Never let the suite believe it is supervised — the restart branch would arm
 // this process's exit chain.
@@ -1152,6 +1182,13 @@ const _fixtures = [];
 after(() => {
   _setAppRootForTest(REAL_APP_ROOT);      // MUST restore, even on failure
   _setDbForTest(null);
+  _setRestartForTest(null);
+  _setSupervisedForTest(null);
+  setBootSha(null);                       // module state — do not leak a fixture sha
+  for (const [k, v] of Object.entries(_prevEnv)) {
+    if (v === undefined) delete process.env[k]; else process.env[k] = v;
+  }
+  rmSync(_scratch, { recursive: true, force: true });
   for (const f of _fixtures) f.cleanup();
   _fixtures.length = 0;
 });
@@ -1212,8 +1249,18 @@ export function hasProbe(tasksDbPath) {
 
 test("BOTH co-hosted instances converge — the lock loser must not starve", async () => {
   const f = twoInstanceFixture();
+  // Capture the sha we are "running" BEFORE origin moves. Without this,
+  // getBootSha() is null and convergeInstance refuses with "no-boot-sha" before
+  // it ever reaches runMigrations — the gate would fail for the wrong reason.
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
   f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
   _setAppRootForTest(f.work);
+  // The suite runs deliberately unsupervised (run-suite.mjs scrubs the env), so
+  // convergence would otherwise stop at the unsupervised guard. Inject both
+  // seams rather than setting CROW_SUPERVISED, which would arm a real
+  // process.exit(1) inside this runner.
+  _setSupervisedForTest(() => true);
+  _setRestartForTest((_log, msg) => { restarts.push(msg); });
 
   // alpha: no contention, wins the lock, pulls, converges.
   _setDbForTest(stubDb());
@@ -1235,6 +1282,7 @@ test("BOTH co-hosted instances converge — the lock loser must not starve", asy
   assert.equal(a.pulled, true, "the lock winner performs the pull");
   assert.equal(b.pulled, false, "the lock loser must not pull — the tree is shared");
   assert.equal(b.converged, true, "the lock loser must still converge");
+  assert.equal(restarts.length, 2, "each converging instance restarts exactly once");
 });
 ```
 
@@ -1324,14 +1372,42 @@ and change the signature to `export async function checkForUpdates({ instance = 
 
 Passing `APP_ROOT` is **required, not tidiness**: `convergeInstance`'s fallback derives the root from `import.meta.url`, which is the real worktree. Without this, the two-instance gate's tree half operates on the fixture while its instance half operates on `~/crow-wt-rolling` — reading the real `scripts/migrations/`, so the fixture's probe migration is never discovered and the gate can never pass, while `.crow-convergence-quarantine.json` gets written into a checkout three live gateways share.
 
-- [ ] **Step 3b: Mark every refusal branch in `runLockedUpdate`**
+- [ ] **Step 3b: Mark ALL FOUR refusal branches in `runLockedUpdate`**
 
-Add `converge: false` to the three returns that withhold a restart — the `init-db failed (exit N)` return (~line 475), and both migration-guard loss returns (~line 441 and ~line 464). Leave every other return alone: a successful update, an "up to date", a CI-gate skip and a quarantine skip did **not** refuse anything.
+Identify them by **message text**, not line number — there are four, and two share a message shape:
+
+| Message | Context |
+|---|---|
+| `Migration quarantined: data loss detected, automatic restore NOT possible` | loss, restore impossible |
+| `Migration quarantined: data loss detected and rolled back` | loss, rolled back |
+| `Migration failed (init-db exit N) — restart withheld` | **armed** path (generation crossing or `init-db.js` touched) |
+| `init-db failed (exit N) — restart withheld` | **unarmed `else` path** — the MORE COMMON case |
+
+The fourth is the one that is easy to miss: a pull that crosses no schema generation and does not touch `scripts/init-db.js`, where init-db still fails (disk, a locked DB, a bad dependency). It carries identical "restart withheld" semantics. Unmarked, convergence restarts into it and the boot guard exits 1.
 
 ```js
-    return { updated: false, error: msg, converge: false };            // init-db failed
+    return { updated: false, error: msg, converge: false };                     // both init-db paths
     return { updated: false, error: msg, quarantined: true, converge: false };  // both loss paths
 ```
+
+- [ ] **Step 3c: Make the refusal visible to PEERS, not just this process**
+
+`converge: false` is process-local, but the hazard is fleet-wide. Peer P2's next tick finds `behindCount === 0` (P1 already pulled), so `runLockedUpdate` returns the bare `{ updated: false }` at `auto-update.js:354` — no refusal flag — and P2 converges, restarts, and hits `index.js:183` `process.exit(1)`. Marking only the refusing process protects one of three co-hosted gateways.
+
+The loss branches already write a migration-guard quarantine, which peers honor. The **init-db-failure branches write no marker at all**, so they need one. On both, before returning, record the sha as convergence-quarantined:
+
+```js
+      const { writeConvQuarantine } = await import("./convergence.js");
+      const { resolveInstance } = await import("./convergence.js");
+      const inst = await resolveInstance();
+      const badSha = (await run("git", ["rev-parse", "HEAD"])).stdout;
+      writeConvQuarantine({
+        appRoot: APP_ROOT, dataDir: inst.dataDir, sha: badSha,
+        why: `init-db exited ${initRes.code} after pulling this sha`,
+      });
+```
+
+Peers then read that marker in `convergeInstance` and refuse the same sha, and the 24 h expiry plus "clears when the tree moves past it" both still apply.
 
 - [ ] **Step 4: Implement `convergeInstance`**
 
@@ -1415,10 +1491,35 @@ export async function convergeInstance({ appRoot, instance = null, pulled = fals
   try { const p = await import("./proxy.js"); baseline = p.healthSnapshot(); } catch {}
   writePending(inst.dataDir, { sha: head, baseline });
 
-  const au = await import("./auto-update.js");
-  au.scheduleSupervisedRestart(log, `Restarting to run ${head.slice(0, 9)}...`);
+  await _restart(log, `Restarting to run ${head.slice(0, 9)}...`);
   return { pulled, converged: true, sha: head, applied: res.applied };
 }
+```
+
+Add the restart seam near the top of `convergence.js`. It is **required**, not a convenience: `scheduleSupervisedRestart` sets `process.exitCode = 1` and schedules a real `process.exit(1)` (`auto-update.js:523-528`), and it is reached through a frozen ESM namespace object, so it cannot be monkeypatched. `scripts/run-suite.mjs:105-108` deletes `INVOCATION_ID`/`CROW_SUPERVISED` suite-wide precisely so "code under test would [not] arm real restart/exit paths inside test processes" — a test that sets `CROW_SUPERVISED=1` to exercise this path would break that invariant and fail the whole file regardless of its assertions.
+
+```js
+let _restartImpl = null;
+async function _restart(log, msg) {
+  if (_restartImpl) return _restartImpl(log, msg);
+  const au = await import("./auto-update.js");
+  return au.scheduleSupervisedRestart(log, msg);
+}
+/** Test-only: capture restarts instead of arming a real process exit. */
+export function _setRestartForTest(fn) { _restartImpl = fn; }
+
+let _supervisedImpl = null;
+/** Test-only: the harness deliberately runs unsupervised, but the convergence
+ *  path must still be exercisable. */
+export function _setSupervisedForTest(fn) { _supervisedImpl = fn; }
+```
+
+and use `_supervisedImpl` in place of the direct `isSupervised()` call when it is set:
+
+```js
+  const { isSupervised } = await import("../shared/supervisor.js");
+  const supervised = _supervisedImpl ? _supervisedImpl() : isSupervised();
+  if (!supervised) { /* …unsupervised branch… */ }
 ```
 
 - [ ] **Step 5: Capture the boot sha at gateway start**
@@ -1444,7 +1545,7 @@ try {
 3. Delete `assert.equal(b.skipped, "locked")` mentally and re-run mutation 1 — confirm the *probe-column* assertion also moves, so the gate does not rest on the status string alone.
 4. Remove the `converge: false` guard → the refusal test (Step 7b) must fail.
 5. Delete the `boot === head` short-circuit → the "current instance does not converge" test (Step 7b) must fail. **This is the most dangerous single line in the design** — without it, every tick migrates and restarts, forever.
-6. Leave `scheduleSupervisedRestart` on `runLockedUpdate`'s success path → the "restart is scheduled exactly once" assertion must fail.
+6. Leave `scheduleSupervisedRestart` on `runLockedUpdate`'s success path → the gate's `assert.equal(restarts.length, 2)` must fail (the winner would restart twice).
 
 *(The previous revision claimed "make `convergeInstance` return before `writePending` → Task 10's tests fail". That was a false mutation claim: all three Task 10 tests call `writePending` directly in the test body and inject `snapshot`/`settled`, so none of them ever reaches `convergeInstance`'s write path. Step 7b below closes that gap for real.)*
 
@@ -1515,7 +1616,7 @@ test("a tree half that refused a restart is not overridden by convergence", asyn
 });
 ```
 
-Also add a source-anchor test for the post-listen wiring, mirroring Task 5's — without it, deleting that whole block leaves every test green while the health gate never runs:
+**Defer this next test to Task 10 Step 4b** — it asserts the `post-listen.js` wiring that Task 10 adds, so it would be red at the end of Task 9. Add it in Task 10, right after the wiring lands. Without it, deleting that whole block leaves every test green while the health gate never runs:
 
 ```js
 test("post-listen wires convergence verification after startAutoUpdate", () => {
@@ -1691,7 +1792,7 @@ export async function verifyPendingConvergence({
     // the Bot Board 500 this whole plan exists to fix would survive it. A store's
     // owner having started is the only reliable happens-before for migrating it.
     // Idempotent by construction: applied ids are skipped by record.
-    await addonsSettled();
+    await settledOrTimeout();
     try {
       const { runMigrations } = await import("../../../scripts/migrations/runner.mjs");
       const r2 = await runMigrations({
@@ -1711,14 +1812,28 @@ export async function verifyPendingConvergence({
   }).catch((err) => console.warn("[convergence] verification skipped:", err.message));
 ```
 
-Give `addonsSettled()` a timeout at this call site so a loader that never settles cannot hang the gate forever — resolve after 10 min and proceed, which yields `unknown`/fail-open rather than `failed`:
+Give `addonsSettled()` a timeout at this call site so a loader that never settles cannot hang the gate forever. **A timeout must NOT simply proceed to the snapshot** — every addon that has not yet connected would read as `missing`, i.e. a regression, and quarantine a healthy sha. That is the opposite of the intended fail-open. The race must report WHY it finished, and a timeout forces `unknown`:
 
 ```js
 const settledOrTimeout = () => Promise.race([
-  addonsSettled(),
-  new Promise((r) => setTimeout(r, 10 * 60 * 1000).unref()),
+  addonsSettled().then(() => "settled"),
+  new Promise((r) => setTimeout(() => r("timeout"), 10 * 60 * 1000).unref()),
 ]);
 ```
+
+and pass the outcome through, so `verifyPendingConvergence` skips the comparison entirely on a timeout:
+
+```js
+    const how = await settledOrTimeout();
+    await conv.verifyPendingConvergence({
+      ...,
+      snapshot: how === "timeout" ? () => { throw new Error("addon loading never settled"); }
+                                  : healthSnapshot,
+      settled: async () => {},
+    });
+```
+
+Throwing from `snapshot` routes into the existing fail-open `catch`, which clears the cookie and returns `unknown` without quarantining — exactly the intended behavior, reusing a path that is already tested.
 
 - [ ] **Step 5: Run** — `node --test tests/convergence-two-instance.test.js tests/migration-guard.test.js` → PASS (migration-guard is untouched by this design and must stay green).
 
@@ -1912,7 +2027,7 @@ git diff origin/main..HEAD | grep -iE "DROP TABLE|DELETE FROM" || echo "no new D
 git diff origin/main..HEAD -- servers/shared/schema-version.js | head -1 || true   # must be empty: no gen bump
 git diff origin/main..HEAD | grep -iE "listen\(|PORT" || echo "no new host port — port-allocation.md unaffected"
 ```
-Also confirm `.crow-convergence-quarantine.json` is gitignored — `convergeInstance` writes it into the repo root, which three gateways and the `pibot-gateways@r4` soak share. Add it to `.gitignore` if absent.
+Also confirm `.crow-convergence-quarantine.json*` is gitignored (a trailing wildcard: `writeAtomic` leaves `.tmp.<pid>` files on a crash, which an exact-name rule would miss). Add `.crow-migration-quarantine.json*` too — it is not ignored today either — `convergeInstance` writes it into the repo root, which three gateways and the `pibot-gateways@r4` soak share. Add it to `.gitignore` if absent.
 
 - [ ] **Step 5: Adversarial whole-branch review**
 

--- a/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
+++ b/docs/superpowers/plans/2026-08-06-safe-rolling-updates.md
@@ -1,0 +1,1947 @@
+# Safe Rolling Updates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every co-hosted crow gateway converge itself to the shared checkout — running its own migrations with its own env and verifying its own health — instead of one instance winning a lock and the others silently starving.
+
+**Architecture:** Split the auto-updater's single operation into `updateTree()` (checkout-scoped, one winner, does the pull) and `convergeInstance()` (per-instance, no lock, always runs). A file-based ordered migration registry runs at gateway boot for the booting instance's own stores. A boot cookie carries a pre-convergence health baseline across the restart; the new boot compares against it and, on regression, quarantines that sha so peers never converge to it. The shared git tree is never mutated by a health failure.
+
+**Tech Stack:** Node 22 (ABI 127) ESM, `better-sqlite3` for raw short-lived migration handles, node built-in test runner, bash for the Phase 1 deploy script.
+
+## Global Constraints
+
+- **Node 22 on every invocation:** `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH`. Default `node` on crow is v20 — `better-sqlite3` is built for 22 and a v20 run fails `NODE_MODULE_VERSION 127 vs 115`.
+- **`~/crow` stays on `main` always.** All work happens in the worktree `/home/kh0pp/crow-wt-rolling` on branch `feat/safe-rolling-updates` (already created, `node_modules` symlinked to `~/crow/node_modules`).
+- **Positional-path commits:** `git commit <path> -m "..."`, never `git add .` then a bare commit. Verify with `git show --stat HEAD` after every commit.
+- **NEVER attribute Claude** as author, co-author, or contributor on any commit or PR.
+- **PR flow only** — `enforce_admins` is TRUE. Green check-runs (`suite`, `static-checks`, `audit`) queried via `https://api.github.com/repos/kh0pper/crow/commits/<sha>/check-runs` before merge. Never the legacy commit-status API.
+- **No `SCHEMA_GENERATION` bump in this work.** `schema_migrations` is created lazily by the runner, never added to `scripts/init-db.js`.
+- **Never open a running gateway's `crow.db` with an external sqlite3 client.** Copy the `.db` plus `-wal` and `-shm`, query the copy.
+- **`scripts/init-db.js` without `CROW_DATA_DIR` writes the LIVE `~/.crow/data/crow.db`.** Pin `CROW_HOME`, `CROW_DATA_DIR`, and `CROW_DB_PATH` on every out-of-gateway invocation.
+- **Test runs are foregrounded with direct file capture** (`npm test > log 2>&1`). Piping a background run through `tail` produced 0-byte logs twice in the P2 arc.
+- **Baseline is 2961 tests / 2961 pass / 0 fail** (verified on this worktree, node v22.23.1). Any deviation is yours.
+- **Coordination:** `pibot-gateways@r4` is mid-soak from the `~/crow` working tree through ~2026-08-12. Log a timestamp for every `~/crow` pull touching `scripts/pi-bots/` and every restart of that unit. Keep `bridge.mjs`'s exported surface name-stable. Do not touch `~/crow-wt-board` or `~/.crow/p4/harness-wt`.
+
+---
+
+## File Structure
+
+**Part 1 — Phase 1 (separate repo, no crow changes, uncommitted):**
+- Create: `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh` — supervised r4 deploy: pull, deps, migrations with explicit r4 env, bundle diff-sync, native rebuild, restart, health gate.
+
+**Part 2 — PR A (migration registry):**
+- Create: `scripts/migrations/runner.mjs` — discovery, ordering, `schema_migrations` bookkeeping, execution.
+- Create: `scripts/migrations/0001-board-stages.mjs` — the first registry entry.
+- Modify: `scripts/migrate-board-stages.mjs` — becomes a thin wrapper delegating to the registry entry.
+- Modify: `servers/gateway/index.js` — run the registry after the schema guard, before the first `createDbClient`.
+- Create: `tests/migration-registry.test.js`
+
+**Part 3 — PR B (converge + health gate):**
+- Create: `servers/gateway/convergence.js` — boot-sha capture, health snapshot comparison, boot cookie, `convergeInstance()`.
+- Modify: `servers/gateway/proxy.js` — export `healthSnapshot()`.
+- Modify: `servers/gateway/auto-update.js` — split `updateTree()`/`convergeInstance()`, record real HEAD before the disabled return, jitter the first check.
+- Modify: `servers/shared/migration-guard.js` — `reason` field + `attemptsKey` on quarantine markers.
+- Modify: `servers/gateway/boot/post-listen.js` — boot-cookie verification hook.
+- Create: `tests/convergence-two-instance.test.js` — the executable gate.
+- Create: `tests/convergence-unit.test.js`
+- Modify: `docs/architecture/gateway.md` — document convergence + the kill switch.
+
+---
+
+## Part 1 — Phase 1: `r4-deploy.sh`
+
+### Task 1: Deploy script with dry-run
+
+**Files:**
+- Create: `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: a script invoked as `r4-deploy.sh [--dry-run] [REF]`. Exit 0 = PASS, non-zero = FAIL. Nothing in Part 2 or 3 depends on it.
+
+- [ ] **Step 1: Write the script skeleton with env pinning and dry-run**
+
+```bash
+#!/usr/bin/env bash
+# Supervised deploy for the crow-r4 instance from the shared ~/crow checkout.
+# Usage: r4-deploy.sh [--dry-run] [REF]
+set -Eeuo pipefail
+
+CROW_REPO=/home/kh0pp/crow
+NODE_BIN=/home/kh0pp/.nvm/versions/node/v22.23.1/bin
+export PATH="$NODE_BIN:$PATH"
+
+# Explicit r4 env — every out-of-gateway spawn MUST carry all three, or the
+# child silently resolves to the PRIMARY instance's ~/.crow/data/crow.db.
+export CROW_HOME=/home/kh0pp/.crow-r4
+export CROW_DATA_DIR=/home/kh0pp/.crow-r4/data
+export CROW_DB_PATH=/home/kh0pp/.crow-r4/data/crow.db
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && { DRY_RUN=1; shift; }
+REF="${1:-}"
+
+PREV_COMMIT=$(git -C "$CROW_REPO" rev-parse HEAD)
+FAILED_CHECK=""
+
+log()  { printf '[r4-deploy %s] %s\n' "$(date -Is)" "$*"; }
+run()  { if [ "$DRY_RUN" = 1 ]; then log "DRY: $*"; else log "RUN: $*"; "$@"; fi; }
+fail() { FAILED_CHECK="$1"; log "FAIL: $1"; log "Roll back with: git -C $CROW_REPO reset --hard $PREV_COMMIT"; exit 1; }
+
+log "starting; previous commit $PREV_COMMIT; dry_run=$DRY_RUN"
+```
+
+- [ ] **Step 2: Verify node pinning is correct before going further**
+
+Run: `bash -c 'export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH; node -v'`
+Expected: `v22.23.1` — NOT v20.x. If v20, stop; every later step is invalid.
+
+- [ ] **Step 3: Add steps 1-2 (pull, conditional deps) with the pi-bots soak log line**
+
+```bash
+# --- 1. pull ---------------------------------------------------------------
+LOCK_BEFORE=$(md5sum "$CROW_REPO/package-lock.json" | cut -d' ' -f1)
+if [ -n "$REF" ]; then
+  run git -C "$CROW_REPO" checkout "$REF"
+else
+  run git -C "$CROW_REPO" pull --ff-only || fail "git pull --ff-only"
+fi
+NEW_COMMIT=$(git -C "$CROW_REPO" rev-parse HEAD)
+log "now at $NEW_COMMIT"
+
+# Soak coordination: pibot-gateways@r4 runs from this working tree through
+# ~2026-08-12. Any pull touching scripts/pi-bots/ can produce a heartbeat gap;
+# this line is what makes that gap explainable afterwards.
+if git -C "$CROW_REPO" diff --name-only "$PREV_COMMIT..$NEW_COMMIT" | grep -q '^scripts/pi-bots/'; then
+  log "NOTE: this pull touched scripts/pi-bots/ — pibot-gateways@r4 soak may show a heartbeat gap here"
+fi
+
+# --- 2. deps (only if the lockfile actually changed) ------------------------
+LOCK_AFTER=$(md5sum "$CROW_REPO/package-lock.json" | cut -d' ' -f1)
+if [ "$LOCK_BEFORE" != "$LOCK_AFTER" ]; then
+  log "lockfile changed — installing"
+  (cd "$CROW_REPO" && run npm ci --omit=dev) || fail "npm ci"
+else
+  log "lockfile unchanged — skipping npm ci"
+fi
+```
+
+- [ ] **Step 4: Add step 3 (migrations) with the both-DB guard**
+
+```bash
+# --- 3. migrations, explicit r4 env ----------------------------------------
+# Baseline the PRIMARY instance's stores. They must not change: a migration
+# that silently targeted ~/.crow instead of ~/.crow-r4 is the exact failure
+# mode this guard exists to catch.
+PRIMARY_BEFORE=$(md5sum /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db 2>/dev/null || true)
+
+run node "$CROW_REPO/scripts/init-db.js"              || fail "init-db.js"
+for m in "$CROW_REPO"/scripts/migrate-*.mjs; do
+  case "$(basename "$m")" in
+    migrate-data-dir.js|migrate-redirect-303.js) continue ;;  # one-shot legacy / codemod
+  esac
+  run node "$m" || fail "$(basename "$m")"
+done
+
+PRIMARY_AFTER=$(md5sum /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db 2>/dev/null || true)
+if [ "$DRY_RUN" = 0 ] && [ "$PRIMARY_BEFORE" != "$PRIMARY_AFTER" ]; then
+  fail "PRIMARY instance DBs changed during an r4 migration run — env leak, investigate before restarting anything"
+fi
+```
+
+- [ ] **Step 5: Add step 4 (bundle + panel diff-sync, changed files only)**
+
+```bash
+# --- 4. bundle + panel diff-sync -------------------------------------------
+# NEVER rsync --delete: knowledge-base's server/db.js and server/app-root.js
+# are deliberately per-instance. Changed files only, then report.
+for bdir in "$CROW_HOME"/bundles/*/; do
+  id=$(basename "$bdir")
+  src="$CROW_REPO/bundles/$id"
+  [ -d "$src" ] || { log "bundle $id: no repo source, skipping"; continue; }
+  run rsync -rc --exclude node_modules --exclude data --exclude '*.db' \
+      "$src/" "$bdir" || fail "bundle sync $id"
+done
+
+for p in "$CROW_HOME"/panels/*.js; do
+  [ -e "$p" ] || continue
+  name=$(basename "$p")
+  src=$(find "$CROW_REPO/bundles" -name "$name" -path '*/panel*' -print -quit 2>/dev/null || true)
+  [ -n "$src" ] && run rsync -c "$src" "$p"
+done
+```
+
+- [ ] **Step 6: Run the dry-run and read every line**
+
+Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh --dry-run`
+Expected: exits 0, prints `DRY:` for every mutating command, and prints the real current commit. Confirm no `RUN:` line appears for a mutating command. If any mutating command executed under `--dry-run`, fix before continuing — the next task runs this for real against a live instance.
+
+- [ ] **Step 7: Commit — NOT to git**
+
+The r4-tehcy repo belongs to another workstream. Leave the file uncommitted and note it on card #120 (Task 14). Verify only that it is executable:
+
+```bash
+chmod +x /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh
+ls -l /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh
+```
+
+### Task 2: Native rebuild, restart, and health gate
+
+**Files:**
+- Modify: `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`
+
+**Interfaces:**
+- Consumes: Task 1's script (the `run`/`fail`/`log` helpers and `PREV_COMMIT`).
+- Produces: nothing consumed elsewhere.
+
+- [ ] **Step 1: Add step 5 (native ABI rebuild, test-loaded)**
+
+```bash
+# --- 5. native modules must match the gateway's node (ABI 127) -------------
+for nb in tasks bots-sql-mcp; do
+  nbdir="$CROW_HOME/bundles/$nb"
+  [ -d "$nbdir/node_modules/better-sqlite3" ] || continue
+  if ! "$NODE_BIN/node" -e "require('$nbdir/node_modules/better-sqlite3')" 2>/dev/null; then
+    log "$nb: better-sqlite3 ABI mismatch — rebuilding with the v22 npm"
+    (cd "$nbdir" && run "$NODE_BIN/npm" rebuild better-sqlite3) || fail "rebuild $nb"
+    "$NODE_BIN/node" -e "require('$nbdir/node_modules/better-sqlite3')" \
+      || fail "$nb still fails to load after rebuild"
+  else
+    log "$nb: better-sqlite3 loads under node 22"
+  fi
+done
+```
+
+- [ ] **Step 2: Add step 6 (restart) and capture the restart timestamp**
+
+```bash
+# --- 6. restart -------------------------------------------------------------
+RESTART_AT=$(date -Is)
+run sudo systemctl restart crow-r4-gateway || fail "systemctl restart"
+[ "$DRY_RUN" = 1 ] || sleep 20   # let addons attempt their connects (proxy CONNECT_TIMEOUT_MS is 60s)
+```
+
+- [ ] **Step 3: Add step 7 (health gate)**
+
+```bash
+# --- 7. health gate ---------------------------------------------------------
+if [ "$DRY_RUN" = 1 ]; then log "DRY: skipping health gate"; log "PASS (dry-run)"; exit 0; fi
+
+systemctl is-active --quiet crow-r4-gateway || fail "unit not active"
+
+JOURNAL=$(journalctl -u crow-r4-gateway --since "$RESTART_AT" --no-pager 2>/dev/null || true)
+if echo "$JOURNAL" | grep -q "failed to connect"; then
+  echo "$JOURNAL" | grep "failed to connect"
+  fail "at least one addon failed to connect"
+fi
+for a in tasks bots-sql-mcp pm-workspace knowledge-base knowledge-base-mcp; do
+  echo "$JOURNAL" | grep -q "addon $a: connected" || fail "addon $a never reported connected"
+done
+
+code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3008/s/family/)
+[ "$code" = "200" ] || fail "smoke route /s/family/ returned $code"
+
+log "PASS — r4 on $(git -C "$CROW_REPO" rev-parse --short HEAD), all addons connected, smoke route 200"
+```
+
+- [ ] **Step 4: Dry-run again end to end**
+
+Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh --dry-run`
+Expected: exit 0, ends with `PASS (dry-run)`. No `sudo` executed, no restart.
+
+- [ ] **Step 5: Real supervised run in a tight window**
+
+Announce the window first (two other workstreams restart this gateway). Then:
+
+Run: `bash /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh 2>&1 | tee /tmp/r4-deploy-first.log`
+Expected: exit 0, final line `PASS`. If FAIL, the script prints the failing check and the rollback command — roll back and do not leave r4 on unverified code.
+
+- [ ] **Step 6: Verify the primary instance was untouched**
+
+```bash
+ls -l /home/kh0pp/.crow/data/crow.db /home/kh0pp/.crow/data/tasks.db
+```
+Expected: mtimes unchanged by the deploy. This is the both-DB check the standing rule requires.
+
+---
+
+## Part 2 — PR A: migration registry
+
+### Task 3: Registry runner
+
+**Files:**
+- Create: `scripts/migrations/runner.mjs`
+- Test: `tests/migration-registry.test.js`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `runMigrations({ migrationsDir, dbPath, tasksDbPath, log }) → Promise<{ applied: string[], skipped: string[] }>`
+  - `discoverMigrations(migrationsDir) → string[]` (sorted absolute paths)
+  - Each migration module exports `id: string` and `run({ dbPath, tasksDbPath, log }): void | Promise<void>`.
+  - Bookkeeping table `schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL, sha TEXT)` in the crow.db at `dbPath`, created lazily.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// tests/migration-registry.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { runMigrations, discoverMigrations } from "../scripts/migrations/runner.mjs";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "migreg-"));
+  const dir = join(root, "migrations");
+  mkdirSync(dir);
+  const dbPath = join(root, "crow.db");
+  const tasksDbPath = join(root, "tasks.db");
+  new Database(dbPath).close();
+  new Database(tasksDbPath).close();
+  return { root, dir, dbPath, tasksDbPath };
+}
+
+function writeMigration(dir, name, body) {
+  writeFileSync(join(dir, name), body);
+}
+
+test("runs migrations in filename order and records them", async () => {
+  const f = fixture();
+  try {
+    // Migration bodies are real ESM modules — record order via a shared file.
+    const orderFile = join(f.root, "order.txt");
+    writeMigration(f.dir, "0001-first.mjs",
+      `import { appendFileSync } from "node:fs";
+       export const id = "0001-first";
+       export function run() { appendFileSync(${JSON.stringify(orderFile)}, "first\\n"); }`);
+    writeMigration(f.dir, "0002-second.mjs",
+      `import { appendFileSync } from "node:fs";
+       export const id = "0002-second";
+       export function run() { appendFileSync(${JSON.stringify(orderFile)}, "second\\n"); }`);
+
+    const res = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    assert.deepEqual(res.applied, ["0001-first", "0002-second"]);
+
+    const { readFileSync } = await import("node:fs");
+    assert.equal(readFileSync(orderFile, "utf8"), "first\nsecond\n");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("is idempotent — a second run applies nothing", async () => {
+  const f = fixture();
+  try {
+    const hits = join(f.root, "hits.txt");
+    writeMigration(f.dir, "0001-once.mjs",
+      `import { appendFileSync } from "node:fs";
+       export const id = "0001-once";
+       export function run() { appendFileSync(${JSON.stringify(hits)}, "x"); }`);
+
+    const a = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    const b = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+
+    assert.deepEqual(a.applied, ["0001-once"]);
+    assert.deepEqual(b.applied, []);
+    assert.deepEqual(b.skipped, ["0001-once"]);
+
+    const { readFileSync } = await import("node:fs");
+    assert.equal(readFileSync(hits, "utf8"), "x", "migration body must run exactly once");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("creates schema_migrations lazily — never requires init-db", async () => {
+  const f = fixture();
+  try {
+    writeMigration(f.dir, "0001-noop.mjs",
+      `export const id = "0001-noop"; export function run() {}`);
+    await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    const db = new Database(f.dbPath);
+    const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'").get();
+    db.close();
+    assert.ok(t, "runner must CREATE TABLE IF NOT EXISTS its own bookkeeping table");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("ignores files that do not match the NNNN-slug.mjs pattern", () => {
+  const f = fixture();
+  try {
+    writeMigration(f.dir, "0001-real.mjs", `export const id="0001-real"; export function run(){}`);
+    writeMigration(f.dir, "README.md", "not a migration");
+    writeMigration(f.dir, "helper.mjs", "export const x = 1;");
+    writeMigration(f.dir, "0002-draft.mjs.bak", "stray");
+    const found = discoverMigrations(f.dir).map((p) => p.split("/").pop());
+    assert.deepEqual(found, ["0001-real.mjs"]);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("a throwing migration aborts the rest and does not record itself", async () => {
+  const f = fixture();
+  try {
+    writeMigration(f.dir, "0001-boom.mjs",
+      `export const id = "0001-boom"; export function run() { throw new Error("boom"); }`);
+    writeMigration(f.dir, "0002-after.mjs",
+      `export const id = "0002-after"; export function run() {}`);
+
+    await assert.rejects(
+      () => runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath }),
+      /boom/,
+    );
+    const db = new Database(f.dbPath);
+    const rows = db.prepare("SELECT id FROM schema_migrations").all();
+    db.close();
+    assert.deepEqual(rows, [], "a failed migration must not be recorded, and 0002 must not run");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
+Expected: FAIL — `Cannot find module '../scripts/migrations/runner.mjs'`
+
+- [ ] **Step 3: Write the implementation**
+
+```js
+// scripts/migrations/runner.mjs
+//
+// Ordered, idempotent, per-instance migration registry.
+//
+// Bookkeeping lives in `schema_migrations` inside the instance's crow.db and is
+// created lazily here — DELIBERATELY NOT in scripts/init-db.js. Adding a table
+// there would bump SCHEMA_GENERATION, which re-runs all of init-db's DROP TABLE
+// statements against every live instance DB. This registry must be able to ship
+// without touching that rail at all.
+//
+// Migrations must ALSO be safe to run with their record missing (a restored
+// backup can lose the record but keep the schema change), so every migration
+// body stays shape-checked and idempotent in its own right.
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+
+const FILENAME = /^\d{4}-[a-z0-9-]+\.mjs$/;
+
+/** Sorted absolute paths of every valid migration module in `dir`. */
+export function discoverMigrations(dir) {
+  let names;
+  try { names = readdirSync(dir); } catch { return []; }
+  return names.filter((n) => FILENAME.test(n)).sort().map((n) => join(dir, n));
+}
+
+function open(p) {
+  const d = new Database(p);
+  d.pragma("busy_timeout = 10000");
+  return d;
+}
+
+function ensureTable(db) {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS schema_migrations (
+       id TEXT PRIMARY KEY,
+       applied_at TEXT NOT NULL,
+       sha TEXT
+     )`,
+  ).run();
+}
+
+/**
+ * Run every not-yet-applied migration, in order, against ONE instance's stores.
+ * Throws on the first failure without recording it — the caller decides whether
+ * that is fatal.
+ */
+export async function runMigrations({ migrationsDir, dbPath, tasksDbPath, sha = null, log = () => {} }) {
+  const applied = [];
+  const skipped = [];
+
+  const book = open(dbPath);
+  try {
+    ensureTable(book);
+    const done = new Set(book.prepare("SELECT id FROM schema_migrations").all().map((r) => r.id));
+
+    for (const file of discoverMigrations(migrationsDir)) {
+      const mod = await import(pathToFileURL(file).href);
+      if (!mod.id || typeof mod.run !== "function") {
+        throw new Error(`${file}: a migration must export \`id\` and \`run\``);
+      }
+      if (done.has(mod.id)) { skipped.push(mod.id); continue; }
+
+      log(`applying ${mod.id}`);
+      await mod.run({ dbPath, tasksDbPath, log });
+
+      book.prepare("INSERT INTO schema_migrations (id, applied_at, sha) VALUES (?, ?, ?)")
+        .run(mod.id, new Date().toISOString(), sha);
+      applied.push(mod.id);
+    }
+  } finally {
+    book.close();
+  }
+  return { applied, skipped };
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Mutation-test every assertion**
+
+Assume these tests are vacuous until proven otherwise. Apply each mutation, confirm a test goes RED, then revert:
+
+1. Delete the `if (done.has(mod.id))` line → the idempotence test must fail on the `"x"` assertion.
+2. Change `.sort()` to `.reverse()` → the ordering test must fail.
+3. Change `FILENAME` to `/\.mjs$/` → the stray-file test must fail.
+4. Move the `INSERT INTO schema_migrations` above `await mod.run(...)` → the throwing-migration test must fail.
+5. Remove `ensureTable(book)` → the lazy-creation test must fail.
+
+If any mutation leaves all tests green, that assertion proves nothing — fix the test before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git add scripts/migrations/runner.mjs tests/migration-registry.test.js
+git commit scripts/migrations/runner.mjs tests/migration-registry.test.js \
+  -m "feat(migrations): ordered per-instance migration registry
+
+Bookkeeping table is created lazily by the runner rather than in
+init-db.js, so the registry ships without a SCHEMA_GENERATION bump."
+git show --stat HEAD
+```
+
+### Task 4: Convert board-stages into the first registry entry
+
+**Files:**
+- Create: `scripts/migrations/0001-board-stages.mjs`
+- Modify: `scripts/migrate-board-stages.mjs`
+- Test: `tests/migration-registry.test.js` (append)
+
+**Interfaces:**
+- Consumes: `runMigrations` from Task 3.
+- Produces: migration id `"0001-board-stages"`, and an exported helper `addColumnIfMissing(db, table, column, ddl) → "added"|"no-op"|"skip (<table> absent)"` reused by future entries.
+
+- [ ] **Step 1: Write the failing test (append to the file)**
+
+```js
+test("0001-board-stages adds the columns, tolerates absent tables, and is idempotent", async () => {
+  const f = fixture();
+  try {
+    // tasks.db HAS the table; crow.db does NOT have project_spaces/bot_sessions.
+    const t = new Database(f.tasksDbPath);
+    t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
+    t.close();
+
+    const dir = join(import.meta.dirname, "..", "scripts", "migrations");
+    const res = await runMigrations({
+      migrationsDir: dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath,
+    });
+    assert.ok(res.applied.includes("0001-board-stages"));
+
+    const t2 = new Database(f.tasksDbPath);
+    const cols = t2.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+    t2.close();
+    for (const c of ["stage", "assigned_bot", "plan_ref"]) {
+      assert.ok(cols.includes(c), `tasks_items.${c} must exist`);
+    }
+
+    // Absent-table tolerance: crow.db had neither table and the run still succeeded.
+    // Idempotence at the SHAPE level: re-run the module directly, record bypassed.
+    const mod = await import(join(dir, "0001-board-stages.mjs"));
+    await mod.run({ dbPath: f.dbPath, tasksDbPath: f.tasksDbPath, log: () => {} });
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
+Expected: FAIL — no `0001-board-stages` in `applied`.
+
+- [ ] **Step 3: Write the migration entry**
+
+```js
+// scripts/migrations/0001-board-stages.mjs
+// Board–plan unification: guarded additive ALTERs. PRAGMA presence check,
+// additive, idempotent, absent-table tolerant. SQLite ADD COLUMN never rebuilds
+// the table, so existing CHECK constraints are unaffected.
+import Database from "better-sqlite3";
+
+export const id = "0001-board-stages";
+
+export function addColumnIfMissing(db, table, column, ddl) {
+  const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
+  if (!t) return `skip (${table} absent)`;
+  const have = db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
+  if (have.includes(column)) return "no-op";
+  db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`).run();
+  return "added";
+}
+
+function open(p) { const d = new Database(p); d.pragma("busy_timeout = 10000"); return d; }
+
+export function run({ dbPath, tasksDbPath, log = () => {} }) {
+  const tdb = open(tasksDbPath);
+  try {
+    log(`  tasks_items.stage: ${addColumnIfMissing(tdb, "tasks_items", "stage", "TEXT")}`);
+    log(`  tasks_items.assigned_bot: ${addColumnIfMissing(tdb, "tasks_items", "assigned_bot", "TEXT")}`);
+    log(`  tasks_items.plan_ref: ${addColumnIfMissing(tdb, "tasks_items", "plan_ref", "TEXT")}`);
+  } finally { tdb.close(); }
+
+  const cdb = open(dbPath);
+  try {
+    log(`  project_spaces.repo_path: ${addColumnIfMissing(cdb, "project_spaces", "repo_path", "TEXT")}`);
+    log(`  bot_sessions.kind: ${addColumnIfMissing(cdb, "bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'")}`);
+  } finally { cdb.close(); }
+}
+```
+
+- [ ] **Step 4: Rewrite the old script as a thin wrapper**
+
+Phase 1 step 3 and any operator muscle memory still invoke this path, so it must keep working and must stay idempotent with the registry.
+
+```js
+// scripts/migrate-board-stages.mjs
+// Thin wrapper — the migration itself now lives in the registry at
+// scripts/migrations/0001-board-stages.mjs and runs automatically at gateway
+// boot. This entry point stays for manual/deploy-script invocation.
+import { tasksDbPath, botsDbPath } from "./pi-bots/instance-paths.mjs";
+import { run } from "./migrations/0001-board-stages.mjs";
+
+run({ dbPath: botsDbPath(), tasksDbPath: tasksDbPath(), log: (m) => console.log(m) });
+```
+
+- [ ] **Step 5: Run the tests, including the pre-existing board-stages test**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js tests/board-stages-migration.test.js`
+Expected: PASS. `tests/board-stages-migration.test.js` already exists and must not regress — if it asserts on the old script's internals, adapt the test to the wrapper, do not weaken the assertion.
+
+- [ ] **Step 6: Mutation-test**
+
+1. Change `addColumnIfMissing`'s `if (!t) return` to `if (!t) throw` → the absent-table tolerance assertion must fail.
+2. Remove the `have.includes(column)` guard → the direct re-run at the end of the test must fail with "duplicate column name".
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git add scripts/migrations/0001-board-stages.mjs
+git commit scripts/migrations/0001-board-stages.mjs scripts/migrate-board-stages.mjs tests/migration-registry.test.js \
+  -m "feat(migrations): move board-stages into the registry as 0001
+
+The old entry point becomes a thin wrapper so deploy scripts and manual
+invocation keep working."
+git show --stat HEAD
+```
+
+### Task 5: Run the registry at gateway boot
+
+**Files:**
+- Modify: `servers/gateway/index.js` (insert after the schema-guard block ending at line 195, before `await initOAuthTables()` at line 198)
+- Test: `tests/migration-registry.test.js` (append)
+
+**Interfaces:**
+- Consumes: `runMigrations` from Task 3.
+- Produces: the boot-time call site. Part 3 does not call it again — convergence relies on the restart passing through this block.
+
+- [ ] **Step 1: Write the failing order-invariant test**
+
+This mirrors the existing source-order assertion in `tests/migration-guard.test.js`. It is a source-text check because the invariant is about ordering within a module that cannot be imported without booting a gateway.
+
+```js
+test("ORDER INVARIANT: registry runs after the schema guard and before the first createDbClient", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "index.js"), "utf8");
+
+  const guard = src.indexOf("runGuardedInitDb");
+  const registry = src.indexOf("runMigrations");
+  const firstClient = src.indexOf("initOAuthTables()");
+
+  assert.ok(guard > 0, "schema guard must be present");
+  assert.ok(registry > 0, "registry call must be present");
+  assert.ok(firstClient > 0, "initOAuthTables must be present");
+  assert.ok(guard < registry, "registry must run AFTER the schema guard");
+  assert.ok(registry < firstClient,
+    "registry must run BEFORE the first createDbClient — createDbClient registers a " +
+    "never-closed WAL keeper, and a later restore would swap the DB under a pinned inode");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
+Expected: FAIL — "registry call must be present".
+
+- [ ] **Step 3: Insert the call site**
+
+Insert immediately after the schema-guard `try { ... } catch { ... }` block (which ends at line 195) and before `await initOAuthTables();`:
+
+```js
+// Per-instance migration registry (scripts/migrations/). Runs for THIS
+// instance with THIS instance's env-resolved paths, so co-hosted gateways
+// sharing one checkout each migrate their own stores. Covers changes that
+// carry no SCHEMA_GENERATION bump — additive columns and non-crow.db stores
+// like tasks.db — which the guard above deliberately does not.
+//
+// ORDER INVARIANT: after the schema guard, before the first createDbClient
+// (initOAuthTables). See the guard block's note above; tests/migration-
+// registry.test.js asserts this ordering.
+try {
+  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
+  const { resolveDataDir } = await import("../db.js");
+  const { resolveGuardDbPath } = await import("../shared/migration-guard.js");
+  const { tasksDbPath } = await import("../../scripts/pi-bots/instance-paths.mjs");
+  const { dirname, join } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+
+  const _root = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+  const res = await runMigrations({
+    migrationsDir: join(_root, "scripts", "migrations"),
+    dbPath: resolveGuardDbPath(resolveDataDir),
+    tasksDbPath: tasksDbPath(),
+    log: (m) => console.log(`[migrations] ${m}`),
+  });
+  if (res.applied.length) console.log(`[migrations] applied: ${res.applied.join(", ")}`);
+} catch (e) {
+  // Fail closed, matching the schema guard's posture: serving on a
+  // half-migrated store is how the Bot Board 500'd on every drawer open.
+  console.error("ERROR: migration registry failed:", e.message);
+  console.error("  Run it manually with this instance's CROW_DATA_DIR/CROW_DB_PATH before starting the gateway.");
+  process.exit(1);
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/migration-registry.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Verify a real gateway still boots**
+
+Never point a scratch gateway at a live data dir. Use a scratch home with BOTH vars pinned:
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+S=/tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/bootcheck
+rm -rf $S && mkdir -p $S/data
+cd /home/kh0pp/crow-wt-rolling
+CROW_HOME=$S CROW_DATA_DIR=$S/data CROW_DB_PATH=$S/data/crow.db \
+CROW_AUTO_UPDATE=0 CROW_ALLOW_ORPHAN=1 PORT=3099 \
+timeout 90 node servers/gateway/index.js --no-auth 2>&1 | tee $S/boot.log | head -60
+```
+Expected: `[migrations] applied: 0001-board-stages` appears, and the gateway reaches its listen line. Then confirm the live DBs were untouched: `ls -l /home/kh0pp/.crow/data/crow.db` mtime unchanged.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && npm test > /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-taskA.log 2>&1; grep -E "^# (tests|pass|fail|cancelled)" /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-taskA.log`
+Expected: `# fail 0`, `# cancelled 0`, and `# tests` ≥ 2961 + the new tests.
+
+- [ ] **Step 7: Commit and open PR A**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/index.js tests/migration-registry.test.js \
+  -m "feat(gateway): run the per-instance migration registry at boot
+
+Co-hosted gateways sharing one checkout each migrate their own stores with
+their own env, covering changes that carry no SCHEMA_GENERATION bump."
+git show --stat HEAD
+git pull --rebase origin main
+git push -u origin feat/safe-rolling-updates
+```
+
+Open PR A titled `feat(migrations): per-instance migration registry`. Do NOT merge yet — Part 3 continues on the same branch, and the whole-branch review in Task 14 gates the merge.
+
+---
+
+## Part 3 — PR B: converge + health gate
+
+### Task 6: The executable gate — two instances, one checkout (MUST FAIL)
+
+This task writes the integration test that reproduces the starvation bug. It is expected to FAIL at the end of this task and to go green in Task 10. A review that only reads a diff cannot tell you whether a restart-into-newer-code actually migrates — this harness can.
+
+**Files:**
+- Create: `tests/convergence-two-instance.test.js`
+
+**Interfaces:**
+- Consumes: `_setAppRootForTest`, `_setDbForTest` from `auto-update.js` (existing test seams).
+- Produces: `twoInstanceFixture()` — reused by Task 12.
+
+- [ ] **Step 1: Write the harness and the failing assertion**
+
+```js
+// tests/convergence-two-instance.test.js
+//
+// The executable gate for co-hosted convergence. TWO instance data dirs share
+// ONE git checkout, exactly like crow-gateway / crow-mpa-gateway / crow-r4-gateway
+// share ~/crow. Moving the fixture's origin forward must leave BOTH instances
+// migrated — including the instance that loses the updater lock.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+
+// This file drives the restart branch. Never let the suite believe it is supervised.
+delete process.env.INVOCATION_ID;
+delete process.env.CROW_SUPERVISED;
+
+const g = (cwd, ...args) => execFileSync("git", args, { cwd, stdio: "pipe" }).toString().trim();
+
+export function twoInstanceFixture() {
+  const root = mkdtempSync(join(tmpdir(), "converge-"));
+  const origin = join(root, "origin.git");
+  const work = join(root, "work");                 // the ONE shared checkout
+  execFileSync("git", ["init", "--bare", "-b", "main", origin], { stdio: "pipe" });
+  execFileSync("git", ["clone", origin, work], { stdio: "pipe" });
+  g(work, "config", "user.email", "t@t");
+  g(work, "config", "user.name", "t");
+
+  mkdirSync(join(work, "scripts", "migrations"), { recursive: true });
+  writeFileSync(join(work, "seed"), "1");
+  g(work, "add", "-A");
+  g(work, "commit", "-m", "seed");
+  g(work, "push", "origin", "main");
+
+  // TWO instances, each with its own data dir and its own stores.
+  const instances = ["alpha", "beta"].map((name) => {
+    const dataDir = join(root, name, "data");
+    mkdirSync(dataDir, { recursive: true });
+    const dbPath = join(dataDir, "crow.db");
+    const tasksDbPath = join(dataDir, "tasks.db");
+    const t = new Database(tasksDbPath);
+    t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
+    t.close();
+    new Database(dbPath).close();
+    return { name, dataDir, dbPath, tasksDbPath };
+  });
+
+  /** Land a new migration on origin, as a real deploy would. */
+  const advanceOrigin = (filename, body) => {
+    writeFileSync(join(work, "scripts", "migrations", filename), body);
+    g(work, "add", "-A");
+    g(work, "commit", "-m", `add ${filename}`);
+    g(work, "push", "origin", "main");
+    // Rewind the shared checkout so it is genuinely BEHIND origin.
+    g(work, "reset", "--hard", "HEAD~1");
+  };
+
+  return { root, origin, work, instances, advanceOrigin, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+const MIGRATION_BODY = `
+import Database from "better-sqlite3";
+export const id = "0002-converge-probe";
+export function run({ tasksDbPath }) {
+  const d = new Database(tasksDbPath);
+  const have = d.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+  if (!have.includes("probe")) d.prepare("ALTER TABLE tasks_items ADD COLUMN probe TEXT").run();
+  d.close();
+}`;
+
+function hasProbe(tasksDbPath) {
+  const d = new Database(tasksDbPath);
+  const cols = d.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+  d.close();
+  return cols.includes("probe");
+}
+
+test("BOTH co-hosted instances converge — the lock loser must not starve", async (t) => {
+  const f = twoInstanceFixture();
+  t.after(f.cleanup);
+
+  f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+
+  const { converge } = await import("../servers/gateway/convergence.js");
+  const { _setAppRootForTest } = await import("../servers/gateway/auto-update.js");
+
+  // Both instances share ONE checkout, so the tree half has ONE root. Retarget
+  // it at the fixture, and restore it to the real repo before finishing — even
+  // on failure — so no later test sees a mutating git command against ~/crow.
+  _setAppRootForTest(f.work);
+  t.after(() => _setAppRootForTest(join(import.meta.dirname, "..")));
+
+  // alpha runs first and wins the checkout lock; beta runs second and loses it.
+  const a = await converge({ appRoot: f.work, ...f.instances[0] });
+  const b = await converge({ appRoot: f.work, ...f.instances[1] });
+
+  assert.ok(hasProbe(f.instances[0].tasksDbPath), "alpha (lock winner) must be migrated");
+  assert.ok(hasProbe(f.instances[1].tasksDbPath),
+    "beta LOST the updater lock and must STILL migrate its own stores — this is the starvation bug");
+  assert.equal(a.pulled, true, "the lock winner performs the pull");
+  assert.equal(b.pulled, false, "the lock loser must not pull — the tree is shared");
+  assert.equal(b.converged, true, "the lock loser must still converge");
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails for the RIGHT reason**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
+Expected: FAIL with `Cannot find module '../servers/gateway/convergence.js'`. That module arrives in Task 10. Do not stub it to make this pass.
+
+- [ ] **Step 3: Commit the failing gate**
+
+Committing a known-red test is deliberate here: it is the spec's executable gate, and the branch is not merged until Task 14.
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git add tests/convergence-two-instance.test.js
+git commit tests/convergence-two-instance.test.js \
+  -m "test(convergence): failing two-instance gate reproducing lock starvation
+
+Two instance data dirs share one checkout. Expected RED until the
+converge/updateTree split lands."
+git show --stat HEAD
+```
+
+### Task 7: Record real HEAD even when auto-update is disabled
+
+**Files:**
+- Modify: `servers/gateway/auto-update.js:559-570`
+- Test: `tests/convergence-unit.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: no new exports; a behavior change in `startAutoUpdate()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// tests/convergence-unit.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { startAutoUpdate, stopAutoUpdate, _setDbForTest } from "../servers/gateway/auto-update.js";
+
+delete process.env.INVOCATION_ID;
+delete process.env.CROW_SUPERVISED;
+
+function fakeDb(rows) {
+  const writes = [];
+  return {
+    writes,
+    execute: async ({ sql, args }) => {
+      if (/^SELECT/i.test(sql)) return { rows };
+      writes.push({ key: args[0], value: args[1] });
+      return { rows: [] };
+    },
+  };
+}
+
+test("a DISABLED instance still records its real running version", async () => {
+  const db = fakeDb([{ key: "auto_update_enabled", value: "false" }]);
+  await startAutoUpdate(db, {});
+  stopAutoUpdate();
+
+  const v = db.writes.find((w) => w.key === "auto_update_current_version");
+  assert.ok(v, "current_version must be recorded even when auto-update is disabled — " +
+               "otherwise a disabled instance reports a version it has not run since it was enabled");
+  assert.match(v.value, /^[0-9a-f]{7,40}$/, "must be a real git sha");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: FAIL — "current_version must be recorded even when auto-update is disabled".
+
+- [ ] **Step 3: Move the version write above the disabled return**
+
+Replace lines 559-570 of `servers/gateway/auto-update.js`:
+
+```js
+  const settings = await getSettings();
+
+  // Record the sha this process is ACTUALLY running, before any early return.
+  // Previously this sat below the `disabled in settings` return, so a disabled
+  // instance froze its reported version at whatever it was when it was last
+  // enabled — while continuing to run whatever the shared checkout moved to.
+  // The bookkeeping and the running code disagreed and nothing detected it.
+  try {
+    const ref = await run("git", ["rev-parse", "--short", "HEAD"]);
+    if (ref.code === 0 && ref.stdout) await saveSetting("auto_update_current_version", ref.stdout);
+  } catch {}
+
+  if (settings.auto_update_enabled !== "true") {
+    console.log("[auto-update] Disabled in settings");
+    return;
+  }
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js tests/auto-update-hardening.test.js tests/auto-update-tick-gate.test.js`
+Expected: PASS, no regression in the two existing files.
+
+- [ ] **Step 5: Mutation-test**
+
+Move the version write back below the `return` → the new test must go RED. Revert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git add tests/convergence-unit.test.js
+git commit servers/gateway/auto-update.js tests/convergence-unit.test.js \
+  -m "fix(auto-update): record the running sha even when updates are disabled
+
+A disabled instance froze its reported version while continuing to run
+whatever the shared checkout moved to."
+git show --stat HEAD
+```
+
+### Task 8: Health snapshot and regression comparison
+
+**Files:**
+- Modify: `servers/gateway/proxy.js` (add export near `getProxyStatus`, line ~653)
+- Create: `servers/gateway/convergence.js` (first half — pure functions only)
+- Test: `tests/convergence-unit.test.js` (append)
+
+**Interfaces:**
+- Consumes: `connectedServers` from `proxy.js` (already exported at line 25).
+- Produces:
+  - `healthSnapshot() → Record<string, string>` in `proxy.js` — addon id → status.
+  - `compareHealth(before, after) → { ok: boolean, regressions: Array<{id, was, now}> }` in `convergence.js`.
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```js
+import { compareHealth } from "../servers/gateway/convergence.js";
+
+test("compareHealth flags only REGRESSIONS, never pre-existing breakage", () => {
+  // The Aug 3-5 state: tasks and bots-sql-mcp were already down for an
+  // unrelated ABI reason. An absolute "all green" gate would have quarantined
+  // every good sha for as long as that lasted.
+  const before = { tasks: "error", "bots-sql-mcp": "error", "pm-workspace": "connected" };
+
+  const unchanged = compareHealth(before, { ...before });
+  assert.equal(unchanged.ok, true, "already-broken addons must NOT count as a regression");
+
+  const healed = compareHealth(before, { ...before, tasks: "connected" });
+  assert.equal(healed.ok, true, "an addon getting BETTER is not a regression");
+
+  const broke = compareHealth(before, { ...before, "pm-workspace": "error" });
+  assert.equal(broke.ok, false, "a connected addon going to error IS a regression");
+  assert.deepEqual(broke.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
+
+  const vanished = compareHealth(before, { tasks: "error", "bots-sql-mcp": "error" });
+  assert.equal(vanished.ok, false, "an addon that disappears entirely is a regression");
+  assert.deepEqual(vanished.regressions, [{ id: "pm-workspace", was: "connected", now: "missing" }]);
+});
+
+test("compareHealth on an empty baseline never regresses", () => {
+  assert.equal(compareHealth({}, { anything: "error" }).ok, true);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: FAIL — `Cannot find module '../servers/gateway/convergence.js'`.
+
+- [ ] **Step 3: Add the snapshot export to proxy.js**
+
+Insert immediately before `export function getProxyStatus()`:
+
+```js
+/**
+ * Addon id → connection status, for the convergence health gate. Deliberately
+ * a flat map of the SAME statuses connectedServers already tracks, so the gate
+ * compares like with like across a restart.
+ */
+export function healthSnapshot() {
+  const snap = {};
+  for (const [id, entry] of connectedServers) snap[id] = entry.status;
+  return snap;
+}
+```
+
+- [ ] **Step 4: Create convergence.js with the comparator**
+
+```js
+// servers/gateway/convergence.js
+//
+// An instance's job is to converge to the tree, not to pull. Pulling is a
+// TREE operation (one winner among co-hosted gateways sharing a checkout);
+// migrating and restarting are INSTANCE operations that every gateway must
+// perform with its own env.
+
+/**
+ * A REGRESSION check, not an absolute one. "Every addon connected" would
+ * quarantine a perfectly good sha on any host that already had a broken addon
+ * — precisely crow's state Aug 3-5, when tasks and bots-sql-mcp were down for
+ * an unrelated native-ABI reason. The gate must answer "did this update break
+ * something?", not "is everything perfect?".
+ */
+export function compareHealth(before, after) {
+  const regressions = [];
+  for (const [id, was] of Object.entries(before || {})) {
+    if (was !== "connected") continue;              // was already unhealthy — not ours
+    const now = (after || {})[id] ?? "missing";
+    if (now !== "connected") regressions.push({ id, was, now });
+  }
+  return { ok: regressions.length === 0, regressions };
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Mutation-test**
+
+1. Remove the `if (was !== "connected") continue;` line → the "already-broken" and "getting better" assertions must fail.
+2. Change `?? "missing"` to `?? "connected"` → the vanished-addon assertion must fail.
+3. Change `now !== "connected"` to `now === "error"` → the vanished-addon assertion must fail.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git add servers/gateway/convergence.js
+git commit servers/gateway/convergence.js servers/gateway/proxy.js tests/convergence-unit.test.js \
+  -m "feat(convergence): regression-based addon health comparison
+
+Compares against a pre-convergence baseline rather than an absolute
+all-green bar, so pre-existing breakage never quarantines a good sha."
+git show --stat HEAD
+```
+
+### Task 9: The boot cookie
+
+**Files:**
+- Modify: `servers/gateway/convergence.js`
+- Test: `tests/convergence-unit.test.js` (append)
+
+**Interfaces:**
+- Consumes: nothing from Task 8 beyond the same file.
+- Produces:
+  - `PENDING_TTL_MS = 10 * 60 * 1000`, `ADDON_GRACE_MS = 90 * 1000`
+  - `writePending(dataDir, { sha, baseline, now })`, `readPending(dataDir) → record|null`, `clearPending(dataDir)`
+  - `classifyPending(pending, bootSha, now) → "none" | "verify" | "failed" | "stale"`
+  - Record shape: `{ sha, baseline: Record<string,string>, deadline: ISO string }` at `<dataDir>/convergence-pending.json`.
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```js
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  writePending, readPending, clearPending, classifyPending, PENDING_TTL_MS,
+} from "../servers/gateway/convergence.js";
+
+test("boot cookie round-trips and clears", () => {
+  const d = mkdtempSync(join(tmpdir(), "cookie-"));
+  try {
+    const now = Date.parse("2026-08-06T12:00:00Z");
+    writePending(d, { sha: "abc1234", baseline: { tasks: "connected" }, now });
+    const p = readPending(d);
+    assert.equal(p.sha, "abc1234");
+    assert.deepEqual(p.baseline, { tasks: "connected" });
+    assert.equal(Date.parse(p.deadline), now + PENDING_TTL_MS);
+
+    clearPending(d);
+    assert.equal(readPending(d), null);
+    assert.equal(existsSync(join(d, "convergence-pending.json")), false);
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test("classifyPending covers every boot case including the crash-loop", () => {
+  const now = Date.parse("2026-08-06T12:00:00Z");
+  const fresh = { sha: "new1234", baseline: {}, deadline: new Date(now + 60_000).toISOString() };
+  const expired = { sha: "new1234", baseline: {}, deadline: new Date(now - 1).toISOString() };
+
+  assert.equal(classifyPending(null, "new1234", now), "none");
+
+  // We are the boot the cookie was written for, and there is still time: verify.
+  assert.equal(classifyPending(fresh, "new1234", now), "verify");
+
+  // Crash-loop: same sha, but the deadline passed without anyone clearing it.
+  // The previous boot never got far enough to verify — treat as failure.
+  assert.equal(classifyPending(expired, "new1234", now), "failed",
+    "an expired cookie for the sha we are booting proves the last convergence never verified");
+
+  // Never booted into the target sha at all (it crashed before serving).
+  assert.equal(classifyPending(expired, "old9999", now), "failed");
+
+  // Cookie for some other sha that has not expired — unrelated, drop it.
+  assert.equal(classifyPending(fresh, "old9999", now), "stale");
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: FAIL — `writePending is not a function`.
+
+- [ ] **Step 3: Implement**
+
+Append to `servers/gateway/convergence.js`:
+
+```js
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/** How long a convergence has to boot and verify before we call it failed.
+ *  Exceeds the worst realistic boot: a guarded SCHEMA_GENERATION migration
+ *  plus ADDON_GRACE_MS. Too short quarantines healthy slow boots. */
+export const PENDING_TTL_MS = 10 * 60 * 1000;
+
+/** How long after boot to let addons connect before snapshotting health.
+ *  MUST exceed proxy.js's own CONNECT_TIMEOUT_MS (60s), or a slow-but-healthy
+ *  addon reads as a regression. */
+export const ADDON_GRACE_MS = 90 * 1000;
+
+const PENDING_FILE = "convergence-pending.json";
+const pendingPath = (dataDir) => join(dataDir, PENDING_FILE);
+
+export function writePending(dataDir, { sha, baseline, now = Date.now() }) {
+  const rec = { sha, baseline, deadline: new Date(now + PENDING_TTL_MS).toISOString() };
+  writeFileSync(pendingPath(dataDir), JSON.stringify(rec, null, 2));
+  return rec;
+}
+
+export function readPending(dataDir) {
+  try { return JSON.parse(readFileSync(pendingPath(dataDir), "utf8")); } catch { return null; }
+}
+
+export function clearPending(dataDir) {
+  try { unlinkSync(pendingPath(dataDir)); } catch {}
+}
+
+/**
+ * What a booting process should do about the cookie it finds.
+ *
+ *   none   — nothing pending.
+ *   verify — we ARE the boot this cookie was written for and there is time
+ *            left; snapshot health after ADDON_GRACE_MS and compare.
+ *   failed — the deadline passed with the cookie uncleared. Either the target
+ *            never booted, or it booted and died before verifying. Both mean
+ *            the convergence did not prove itself.
+ *   stale  — a live cookie for a sha we are not running; unrelated, discard.
+ */
+export function classifyPending(pending, bootSha, now = Date.now()) {
+  if (!pending) return "none";
+  if (Date.parse(pending.deadline) <= now) return "failed";
+  return pending.sha === bootSha ? "verify" : "stale";
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-test**
+
+1. Swap the order of the deadline check and the sha check in `classifyPending` → the crash-loop assertion must fail.
+2. Change `<=` to `<` in the deadline check → confirm which assertion moves; if none does, add a boundary case at exactly `deadline === now`.
+3. Make `clearPending` a no-op → the round-trip test must fail.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/convergence.js tests/convergence-unit.test.js \
+  -m "feat(convergence): boot cookie carrying the pre-restart health baseline
+
+Classifies every boot case including the crash-loop, where the target sha
+boots but dies before it can verify itself."
+git show --stat HEAD
+```
+
+### Task 10: Split updateTree and convergeInstance
+
+This is the task that turns Task 6's gate green.
+
+**Files:**
+- Modify: `servers/gateway/auto-update.js:196-231` (`checkForUpdates`)
+- Modify: `servers/gateway/convergence.js`
+- Test: `tests/convergence-two-instance.test.js` (already written, currently red)
+
+**Interfaces:**
+- Consumes: `runMigrations` (Task 3), `PENDING_TTL_MS`/`writePending` (Task 9), `compareHealth` (Task 8).
+- Produces: `converge({ appRoot, dataDir, dbPath, tasksDbPath, log }) → Promise<{ pulled: boolean, converged: boolean, sha: string, applied: string[] }>`
+
+- [ ] **Step 1: Confirm the gate is still red for the right reason**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
+Expected: FAIL — `converge is not a function` (the module now exists from Tasks 8-9, but not this export).
+
+- [ ] **Step 2: Implement `converge`**
+
+Append to `servers/gateway/convergence.js`:
+
+```js
+import { execFile } from "node:child_process";
+
+function git(cwd, args) {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd, timeout: 120000 }, (err, stdout, stderr) => {
+      resolve({ stdout: (stdout || "").trim(), stderr: (stderr || "").trim(), code: err ? err.code || 1 : 0 });
+    });
+  });
+}
+
+/**
+ * Make ONE instance current with the checkout it runs from.
+ *
+ * The pull is a TREE operation and stays behind the checkout-scoped lock —
+ * exactly one co-hosted gateway performs it. Everything after the pull is an
+ * INSTANCE operation and runs unconditionally, including for the gateway that
+ * lost the lock. Before this split the loser returned early and therefore never
+ * migrated its own stores and never restarted into the new code; with all
+ * gateways restarting together their 6h timers were phase-locked, so the same
+ * instance lost every tick, forever.
+ */
+export async function converge({ appRoot, dataDir, dbPath, tasksDbPath, log = () => {} }) {
+  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
+  const au = await import("./auto-update.js");
+
+  // --- tree half: at most one winner ---------------------------------------
+  const pulled = await au.updateTree({ appRoot, log });
+
+  // --- instance half: everyone, always -------------------------------------
+  const sha = (await git(appRoot, ["rev-parse", "HEAD"])).stdout;
+  const res = await runMigrations({
+    migrationsDir: join(appRoot, "scripts", "migrations"),
+    dbPath, tasksDbPath, sha, log,
+  });
+
+  return { pulled, converged: true, sha, applied: res.applied };
+}
+```
+
+- [ ] **Step 3: Extract `updateTree` in auto-update.js**
+
+Replace the lock-skip early return at lines 209-223 of `servers/gateway/auto-update.js`:
+
+```js
+    const lock = await lockPath();
+    const held = lock ? acquireLock(lock) : null;
+    if (lock && !held) {
+      const info = readLock(lock);
+      // NOT an error, and NOT a reason to stop. The tree is shared: another
+      // co-hosted gateway is pulling it, which is exactly right. This instance
+      // skips the PULL and still converges itself — see convergence.js.
+      const msg = `Tree pull skipped: another instance holds the checkout lock (pid ${info?.pid ?? "unknown"})`;
+      log(msg);
+      await saveSetting("auto_update_last_check", new Date().toISOString());
+      await saveSetting("auto_update_last_result", msg);
+      return { updated: false, skipped: "locked", pulled: false, message: msg };
+    }
+```
+
+Then add the exported wrapper near the end of the module:
+
+```js
+/**
+ * The TREE half of an update: fetch, CI gate, quarantine check, pull, deps.
+ * Returns whether this process actually moved the checkout. A `false` return
+ * from a lock loss is a normal, healthy outcome — the caller still converges.
+ *
+ * Operates on the module's APP_ROOT deliberately: co-hosted gateways share ONE
+ * checkout, so there is exactly one tree to update and no per-call root to
+ * thread through. Tests retarget it with the existing _setAppRootForTest seam.
+ */
+export async function updateTree({ log = (m) => console.log(`[auto-update] ${m}`) } = {}) {
+  const res = await checkForUpdates();
+  return Boolean(res?.updated);
+}
+```
+
+**Do NOT call `_setAppRootForTest` from `updateTree`.** It is documented
+test-only (`auto-update.js:20`), and having production code mutate a test seam
+would let a stray call silently retarget every later git operation in the
+process. `converge()` accepts `appRoot` for its own git and migration paths
+only; the tree half uses the module root.
+
+- [ ] **Step 4: Run the two-instance gate**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
+Expected: PASS — both alpha and beta have the `probe` column, `a.pulled === true`, `b.pulled === false`, `b.converged === true`.
+
+- [ ] **Step 5: Mutation-test the gate — this is the important one**
+
+The gate exists to catch starvation. Prove it can:
+
+1. In `converge`, wrap the `runMigrations` call in `if (pulled) { ... }` → the beta assertion must fail with "beta LOST the updater lock and must STILL migrate". If it stays green, the harness is not actually exercising the loser path and the gate is worthless — fix it before continuing.
+2. Restore the early `return` in the lock-loss branch of `checkForUpdates` → beta must fail.
+3. Make `advanceOrigin` skip its `reset --hard` → the test should fail because nothing was behind; confirms the fixture creates real skew.
+
+- [ ] **Step 6: Run the existing auto-update tests for regressions**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/auto-update-hardening.test.js tests/auto-update-ci-gate.test.js tests/auto-update-tick-gate.test.js`
+Expected: PASS. The lock-skip message text changed — if a test asserts on the old string, update the assertion to the new one, and confirm it still asserts the *behavior* and not just the text.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/convergence.js servers/gateway/auto-update.js tests/convergence-two-instance.test.js \
+  -m "feat(convergence): converge every instance, pull on only one
+
+Splits the updater into a tree half behind the checkout lock and an
+instance half that always runs. The lock loser no longer starves."
+git show --stat HEAD
+```
+
+### Task 11: De-phase-lock the update timers
+
+**Files:**
+- Modify: `servers/gateway/auto-update.js` (`startAutoUpdate`, line ~578)
+- Test: `tests/convergence-unit.test.js` (append)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `instanceJitterMs(key) → number` exported from `auto-update.js`, range `[0, 600000)`.
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```js
+import { instanceJitterMs } from "../servers/gateway/auto-update.js";
+
+test("instanceJitterMs is stable per instance and differs between instances", () => {
+  const a = instanceJitterMs("/home/kh0pp/.crow/data");
+  const b = instanceJitterMs("/home/kh0pp/.crow-mpa/data");
+  const c = instanceJitterMs("/home/kh0pp/.crow-r4/data");
+
+  assert.equal(a, instanceJitterMs("/home/kh0pp/.crow/data"), "must be deterministic");
+  assert.notEqual(a, b, "co-hosted instances must not share a phase");
+  assert.notEqual(b, c);
+  for (const v of [a, b, c]) {
+    assert.ok(v >= 0 && v < 600000, `jitter ${v} must be within [0, 10min)`);
+    assert.ok(Number.isInteger(v));
+  }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: FAIL — `instanceJitterMs is not a function`.
+
+- [ ] **Step 3: Implement and wire it in**
+
+Add to `servers/gateway/auto-update.js`:
+
+```js
+const JITTER_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * A stable per-instance offset for the first update check.
+ *
+ * Co-hosted gateways restart together, so a fixed 5-minute first check put all
+ * of them on the same millisecond forever: their checks landed 475ms apart and
+ * the same instance lost the lock every single tick. Deriving the offset from
+ * the instance's data-dir path de-phases them permanently and survives restarts.
+ *
+ * This is robustness, not the fix — the fix is that the lock loser converges
+ * anyway (see convergence.js). Jitter only makes contention rare.
+ */
+export function instanceJitterMs(key) {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h % JITTER_WINDOW_MS;
+}
+```
+
+Then in `startAutoUpdate`, replace the fixed `5 * 60 * 1000`:
+
+```js
+  const { resolveDataDir } = await import("../db.js");
+  const firstDelay = 5 * 60 * 1000 + instanceJitterMs(resolveDataDir());
+  console.log(`[auto-update] Enabled — checking every ${hours}h (first check in ${Math.round(firstDelay / 1000)}s)`);
+
+  updateTimer = setTimeout(async () => {
+    await tickCheck();
+    updateTimer = setInterval(() => { tickCheck().catch(() => {}); }, intervalMs);
+  }, firstDelay);
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js tests/auto-update-hardening.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-test**
+
+1. `return 0` from `instanceJitterMs` → the differ-between-instances assertion must fail.
+2. `return h` without `% JITTER_WINDOW_MS` → the range assertion must fail.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/auto-update.js tests/convergence-unit.test.js \
+  -m "fix(auto-update): de-phase-lock co-hosted first checks
+
+Gateways restart together, so a fixed first-check delay put them on the
+same millisecond permanently."
+git show --stat HEAD
+```
+
+### Task 12: Quarantine on failed convergence, and peers honor it
+
+**Files:**
+- Modify: `servers/shared/migration-guard.js:353-368` (`writeQuarantine`)
+- Modify: `servers/gateway/convergence.js`
+- Modify: `servers/gateway/boot/post-listen.js` (after the `startAutoUpdate` call, line ~186)
+- Test: `tests/convergence-two-instance.test.js` (append)
+
+**Interfaces:**
+- Consumes: `writeQuarantine`, `evaluateQuarantine`, `fireMigrationAlert` from `migration-guard.js`; `compareHealth`, `classifyPending`, `writePending`, `readPending`, `clearPending`, `ADDON_GRACE_MS` from `convergence.js`.
+- Produces:
+  - `writeQuarantine` gains an optional `reason` (default `"migration"`) and an `attemptsKey` field on the marker.
+  - `verifyPendingConvergence({ dataDir, appRoot, dbPath, bootSha, snapshot, now, schedule })` in `convergence.js`.
+
+- [ ] **Step 1: Write the failing test (append to the two-instance file)**
+
+```js
+test("quarantine attempts are keyed per convergence sha, not shared across shas", () => {
+  const f = twoInstanceFixture();
+  t2after(f);
+  const { dbPath } = f.instances[0];
+
+  const m1 = writeQuarantine({ appRoot: f.work, dbPath, sha: "aaa", reason: "convergence" });
+  const m2 = writeQuarantine({ appRoot: f.work, dbPath, sha: "bbb", reason: "convergence" });
+  const m3 = writeQuarantine({ appRoot: f.work, dbPath, sha: "aaa", reason: "convergence" });
+
+  assert.equal(m1.attempts, 1);
+  assert.equal(m2.attempts, 1, "a DIFFERENT bad sha must start its own attempt count — " +
+    "otherwise three unrelated failures ever would permanently stop auto-clearing");
+  assert.equal(m3.attempts, 2, "the SAME bad sha must carry its count forward");
+});
+
+test("a health regression quarantines the sha; peers then refuse to converge to it", async () => {
+  const f = twoInstanceFixture();
+  t2after(f);
+  const [alpha, beta] = f.instances;
+
+  writePending(alpha.dataDir, {
+    sha: "bad1234",
+    baseline: { "pm-workspace": "connected" },
+    now: Date.now(),
+  });
+
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir,
+    appRoot: f.work,
+    dbPath: alpha.dbPath,
+    bootSha: "bad1234",
+    snapshot: () => ({ "pm-workspace": "error" }),   // the regression
+    schedule: (fn) => fn(),                          // run the grace timer inline
+  });
+
+  assert.equal(out.verdict, "quarantined");
+  assert.deepEqual(out.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
+  assert.equal(readPending(alpha.dataDir), null, "the cookie must be cleared either way");
+
+  // The repo-level marker is what a PEER sees — they share the checkout.
+  const marker = readMarker(repoMarkerPath(f.work));
+  assert.equal(marker.sha, "bad1234");
+  assert.equal(marker.reason, "convergence");
+
+  // beta must now refuse.
+  const { converge } = await import("../servers/gateway/convergence.js");
+  const r = await converge({ appRoot: f.work, ...beta });
+  assert.equal(r.converged, false, "a peer must not converge to a quarantined sha");
+  assert.equal(r.skipped, "quarantined");
+});
+
+test("a healthy convergence clears the cookie and quarantines nothing", async () => {
+  const f = twoInstanceFixture();
+  t2after(f);
+  const [alpha] = f.instances;
+
+  writePending(alpha.dataDir, { sha: "good999", baseline: { tasks: "connected" }, now: Date.now() });
+
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, dbPath: alpha.dbPath,
+    bootSha: "good999",
+    snapshot: () => ({ tasks: "connected" }),
+    schedule: (fn) => fn(),
+  });
+
+  assert.equal(out.verdict, "ok");
+  assert.equal(readPending(alpha.dataDir), null);
+  assert.equal(readMarker(repoMarkerPath(f.work)), null, "a healthy convergence must not quarantine");
+});
+```
+
+Add these imports to the TOP of the file (ESM imports must be at module scope,
+not inside the appended tests), and this cleanup helper:
+
+```js
+import { test, after } from "node:test";     // replaces the existing `import { test }`
+import { writeQuarantine, readMarker, repoMarkerPath } from "../servers/shared/migration-guard.js";
+import { verifyPendingConvergence, writePending, readPending } from "../servers/gateway/convergence.js";
+import { _setAppRootForTest } from "../servers/gateway/auto-update.js";
+
+// These tests take no `t`, so they cannot use t.after — register centrally.
+// The app-root restore is NOT optional: converge() reaches updateTree(), which
+// operates on the module root. A test that leaves the root pointed at a deleted
+// fixture makes a LATER test run git against whatever is there.
+const _fixtures = [];
+function t2after(f) { _fixtures.push(f); }
+after(() => {
+  _setAppRootForTest(join(import.meta.dirname, ".."));
+  for (const f of _fixtures) f.cleanup();
+  _fixtures.length = 0;
+});
+```
+
+In the peer-refusal test, call `_setAppRootForTest(f.work)` before `converge`.
+The quarantine guard runs before `updateTree` and should short-circuit first,
+but do not rely on that ordering to keep git off the real repo.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js`
+Expected: FAIL — `verifyPendingConvergence is not a function`, and the attempts test fails because `writeQuarantine` keys attempts on the generation pair (both convergence markers pass `undefined`/`undefined`, so `bbb` inherits `aaa`'s count).
+
+- [ ] **Step 3: Add `reason` and `attemptsKey` to writeQuarantine**
+
+Replace `servers/shared/migration-guard.js:353-368`:
+
+```js
+export function writeQuarantine({ appRoot, dbPath, sha, fromGeneration, toGeneration, report, reason = "migration" }) {
+  // Attempts carry forward per DISTINCT cause. For a schema migration the cause
+  // is the (from,to) generation crossing; for a convergence failure it is the
+  // specific bad sha. Keying convergence failures on the generation pair would
+  // make every convergence failure share one counter — three unrelated bad shas
+  // ever would permanently stop the quarantine from auto-clearing.
+  const attemptsKey = reason === "convergence"
+    ? `convergence:${sha}`
+    : `migration:${fromGeneration}->${toGeneration}`;
+
+  let attempts = 1;
+  for (const p of [repoMarkerPath(appRoot), dataMarkerPath(dbPath)]) {
+    const prev = readMarker(p);
+    if (!prev) continue;
+    // Markers written before attemptsKey existed are migration markers; fall
+    // back to the original generation-pair comparison for them.
+    const prevKey = prev.attemptsKey
+      ?? `migration:${prev.fromGeneration}->${prev.toGeneration}`;
+    if (prevKey === attemptsKey) attempts = Math.max(attempts, (prev.attempts || 0) + 1);
+  }
+  const marker = { sha, fromGeneration, toGeneration, reason, attemptsKey, at: new Date().toISOString(), attempts, report };
+  for (const p of [repoMarkerPath(appRoot), dataMarkerPath(dbPath)]) {
+    try { writeFileSync(p, JSON.stringify(marker, null, 2)); } catch {}
+  }
+  return marker;
+}
+```
+
+- [ ] **Step 4: Implement `verifyPendingConvergence` and the peer guard**
+
+Append to `servers/gateway/convergence.js`:
+
+```js
+/**
+ * Called at boot. Decides what the cookie left behind by the previous
+ * convergence means, and quarantines the sha if that convergence did not prove
+ * itself healthy.
+ *
+ * `snapshot` and `schedule` are injected so tests can drive the grace window
+ * without waiting 90 real seconds.
+ */
+export async function verifyPendingConvergence({
+  dataDir, appRoot, dbPath, bootSha,
+  snapshot, schedule = (fn) => setTimeout(fn, ADDON_GRACE_MS).unref(),
+  now = Date.now(), log = () => {},
+}) {
+  const pending = readPending(dataDir);
+  const verdict = classifyPending(pending, bootSha, now);
+
+  if (verdict === "none") return { verdict: "none" };
+  if (verdict === "stale") { clearPending(dataDir); return { verdict: "stale" }; }
+
+  const guard = await import("../shared/migration-guard.js");
+
+  const quarantine = async (sha, regressions, why) => {
+    guard.writeQuarantine({ appRoot, dbPath, sha, reason: "convergence", report: { regressions, why } });
+    clearPending(dataDir);
+    await guard.fireMigrationAlert({
+      title: "Crow update quarantined: convergence failed",
+      body: `The gateway converged to ${String(sha).slice(0, 9)} and ${why}. `
+          + `That sha is quarantined — no instance on this host will converge to it until the `
+          + `quarantine clears (automatically when main moves past it, or by deleting the marker files). `
+          + `The tree was NOT rolled back: co-hosted instances may be running it healthily.`,
+    });
+    log(`convergence to ${String(sha).slice(0, 9)} quarantined — ${why}`);
+    return { verdict: "quarantined", regressions };
+  };
+
+  if (verdict === "failed") {
+    return quarantine(pending.sha, [], "never completed a healthy boot before its deadline");
+  }
+
+  // verdict === "verify": we are the boot this cookie was written for.
+  return new Promise((resolve) => {
+    schedule(async () => {
+      const after = snapshot();
+      const cmp = compareHealth(pending.baseline, after);
+      if (cmp.ok) {
+        clearPending(dataDir);
+        log(`convergence to ${String(pending.sha).slice(0, 9)} verified healthy`);
+        resolve({ verdict: "ok" });
+        return;
+      }
+      resolve(await quarantine(pending.sha, cmp.regressions,
+        `broke ${cmp.regressions.map((r) => r.id).join(", ")}`));
+    });
+  });
+}
+```
+
+Then add the peer guard at the top of `converge()`, immediately after the imports:
+
+```js
+  // Peers honor a quarantine written by whichever instance converged first.
+  // The marker is written at BOTH repo and data level; the repo-level one is
+  // what makes a shared checkout's other gateways see it. evaluateQuarantine
+  // auto-clears once main moves past the bad sha (attempts-capped).
+  const guard = await import("../shared/migration-guard.js");
+  const head = (await git(appRoot, ["rev-parse", "HEAD"])).stdout;
+  const q = guard.evaluateQuarantine({ appRoot, dbPath, originHeadSha: head });
+  if (q.blocked) {
+    log(`refusing to converge: ${q.marker.sha.slice(0, 9)} is quarantined (attempt ${q.marker.attempts})`);
+    return { pulled: false, converged: false, skipped: "quarantined", sha: head, applied: [] };
+  }
+```
+
+- [ ] **Step 5: Wire the boot-time verification into post-listen.js**
+
+Insert immediately after the `startAutoUpdate(...)` call at line ~186:
+
+```js
+  // Verify the convergence that caused this restart, if there was one. Runs
+  // after listen so the addon connects the gate measures have actually begun.
+  import("../convergence.js").then(async ({ verifyPendingConvergence }) => {
+    const { resolveDataDir } = await import("../../db.js");
+    const { resolveGuardDbPath } = await import("../../shared/migration-guard.js");
+    const { healthSnapshot } = await import("../proxy.js");
+    const { execFileSync } = await import("node:child_process");
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+    let bootSha = null;
+    try { bootSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: appRoot, timeout: 10000 }).toString().trim(); } catch {}
+    await verifyPendingConvergence({
+      dataDir: resolveDataDir(),
+      appRoot,
+      dbPath: resolveGuardDbPath(resolveDataDir),
+      bootSha,
+      snapshot: healthSnapshot,
+      log: (m) => console.log(`[convergence] ${m}`),
+    });
+  }).catch((err) => console.warn("[convergence] verification skipped:", err.message));
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-two-instance.test.js tests/migration-guard.test.js`
+Expected: PASS, including the pre-existing `migration-guard.test.js` — the `reason` default of `"migration"` keeps every existing caller behaving identically.
+
+- [ ] **Step 7: Mutation-test**
+
+1. Change the `attemptsKey` for convergence to use the generation pair → the per-sha attempts assertion must fail.
+2. Remove `clearPending(dataDir)` from the healthy path → the "clears the cookie" assertion must fail.
+3. Make the peer guard return `converged: true` anyway → the peer-refusal assertion must fail.
+4. Change `compareHealth(pending.baseline, after)` to `compareHealth({}, after)` → the regression test must fail (it would make every convergence look healthy).
+5. Remove the `reason` default from `writeQuarantine` → `migration-guard.test.js` must fail, proving back-compat is actually asserted.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/shared/migration-guard.js servers/gateway/convergence.js \
+  servers/gateway/boot/post-listen.js tests/convergence-two-instance.test.js \
+  -m "feat(convergence): quarantine a sha whose convergence regressed health
+
+The shared tree is never rolled back — one instance's failed health check
+must not drag co-hosted peers that are running that sha healthily. Peers
+read the repo-level marker and refuse the bad sha instead."
+git show --stat HEAD
+```
+
+### Task 13: Kill switch and documentation
+
+**Files:**
+- Modify: `servers/gateway/convergence.js`
+- Modify: `docs/architecture/gateway.md`
+- Test: `tests/convergence-unit.test.js` (append)
+
+**Interfaces:**
+- Consumes: `converge` from Task 10.
+- Produces: `CROW_DISABLE_CONVERGE=1|true` short-circuits `converge()`.
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```js
+test("CROW_DISABLE_CONVERGE short-circuits convergence entirely", async () => {
+  const { converge } = await import("../servers/gateway/convergence.js");
+  process.env.CROW_DISABLE_CONVERGE = "1";
+  try {
+    const r = await converge({ appRoot: "/nonexistent", dataDir: "/nonexistent", dbPath: "/nonexistent/x.db", tasksDbPath: "/nonexistent/t.db" });
+    assert.equal(r.converged, false);
+    assert.equal(r.skipped, "disabled");
+  } finally { delete process.env.CROW_DISABLE_CONVERGE; }
+});
+```
+
+The nonexistent paths are deliberate: if the kill switch works, nothing touches the filesystem, so bogus paths cannot fail.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: FAIL — an ENOENT from git or better-sqlite3, not a clean `skipped: "disabled"`.
+
+- [ ] **Step 3: Add the kill switch as the very first statement in `converge()`**
+
+```js
+  if (process.env.CROW_DISABLE_CONVERGE === "1" || process.env.CROW_DISABLE_CONVERGE === "true") {
+    log("convergence disabled via CROW_DISABLE_CONVERGE");
+    return { pulled: false, converged: false, skipped: "disabled", sha: null, applied: [] };
+  }
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH && cd /home/kh0pp/crow-wt-rolling && node --test tests/convergence-unit.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Document it**
+
+Add to `docs/architecture/gateway.md` a section covering: the converge-vs-pull split and why the tree is shared; that a lock loss is normal and the instance still converges; the migration registry and how to add an entry (`scripts/migrations/NNNN-slug.mjs` exporting `id` and `run`); the health gate being a regression check with the 90 s / 10 min constants and why each is what it is; quarantine-not-rollback and how to clear a marker; and `CROW_DISABLE_CONVERGE=1`.
+
+Check whether EN/ES i18n parity applies to anything you touched — the parity gate is live. Architecture docs are EN-only, but if any user-facing string was added, both locales must carry it.
+
+- [ ] **Step 6: Run the FULL suite**
+
+Run:
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow-wt-rolling
+npm test > /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-final.log 2>&1
+grep -E "^# (tests|suites|pass|fail|cancelled|skipped)" /tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/suite-final.log
+```
+Expected: `# fail 0`, `# cancelled 0`, `# tests` ≥ 2961 plus every test added here. A `cancelled` count above zero is the known whole-file-cancel flake under load — re-run that file alone to confirm before treating it as a real failure.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git commit servers/gateway/convergence.js docs/architecture/gateway.md tests/convergence-unit.test.js \
+  -m "feat(convergence): CROW_DISABLE_CONVERGE kill switch and architecture docs"
+git show --stat HEAD
+```
+
+### Task 14: Whole-branch review, acceptance, merge, deploy, report
+
+**Files:**
+- No new files. This task gates the merge.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: merged `main`, deployed fleet, updated card #120.
+
+- [ ] **Step 1: Audit the whole branch before review**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git log --format='%an <%ae>%n%b' origin/main..HEAD | grep -iE "claude|co-authored|anthropic" && echo "ATTRIBUTION FOUND — FIX" || echo "clean"
+git diff origin/main..HEAD --stat
+```
+Expected: `clean`. Any attribution must be rewritten before pushing further.
+
+- [ ] **Step 2: Check the doctrine gates that CI does not cover**
+
+- No new host ports added → `docs/developers/port-allocation.md` needs no change. Confirm with `git diff origin/main..HEAD | grep -iE "PORT|listen\("`.
+- No new `DROP` or `DELETE` statements → `migration-expectations.js` needs no change. Confirm with `git diff origin/main..HEAD | grep -iE "DROP TABLE|DELETE FROM"`.
+- No `SCHEMA_GENERATION` bump → the dryrun rail does not apply. Confirm with `git diff origin/main..HEAD -- servers/shared/schema-version.js` returning empty.
+
+If any of those confirms are non-empty, stop and handle the corresponding rail before merging.
+
+- [ ] **Step 3: Adversarial whole-branch review**
+
+Request a code review covering the full diff, with these as the named areas of concern: the converge/pull split under real concurrency; whether the quarantine can wedge an instance permanently; whether `verifyPendingConvergence`'s promise can leak or never resolve; whether the boot-order invariant actually holds at runtime and not just in source text; and whether any test is vacuous.
+
+- [ ] **Step 4: Wiped-scratch acceptance**
+
+A fresh instance, never migrated, must boot correctly — this is the case the fixture harness cannot cover:
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+S=/tmp/claude-1000/-home-kh0pp-crow/6d3ccab0-b825-43c7-b8e4-dddc847b9be3/scratchpad/accept
+rm -rf $S && mkdir -p $S/data
+cd /home/kh0pp/crow-wt-rolling
+CROW_HOME=$S CROW_DATA_DIR=$S/data CROW_DB_PATH=$S/data/crow.db \
+CROW_AUTO_UPDATE=0 CROW_ALLOW_ORPHAN=1 PORT=3099 \
+timeout 120 node servers/gateway/index.js --no-auth 2>&1 | tee $S/accept.log | head -80
+```
+Expected: `[migrations] applied: 0001-board-stages`, gateway listens, no `[convergence]` quarantine. Then verify the live DBs were untouched (mtimes on `~/.crow/data/crow.db` and `~/.crow-r4/data/crow.db` unchanged).
+
+- [ ] **Step 5: Push, verify CI via check-runs, merge**
+
+```bash
+cd /home/kh0pp/crow-wt-rolling
+git pull --rebase origin main
+git push
+SHA=$(git rev-parse HEAD)
+curl -s "https://api.github.com/repos/kh0pper/crow/commits/$SHA/check-runs" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); [print(r['name'], r['status'], r['conclusion']) for r in d['check_runs']]"
+```
+Expected: `suite`, `static-checks`, `audit` each `completed success`. An empty result on a current sha means something is WRONG, not that checks are absent. Merge only when all three are green.
+
+- [ ] **Step 6: Deploy and verify the fleet**
+
+Deploy to all five instances. For the three co-hosted on crow, use the Phase 1 script for r4 and normal restarts for primary/MPA, in tight windows. After each restart confirm from DB **copies** (never open a running gateway's crow.db directly):
+
+- `auto_update_current_version` now matches the real running sha on **every** instance, including r4 where auto-update is disabled. That is the Gap 4b fix proving itself in prod.
+- No `[convergence]` quarantine markers exist: `ls ~/crow/.crow-migration-quarantine* 2>/dev/null`.
+- `pibot-gateways@r4` is still active, and log a timestamp for its restart if the deploy touched `scripts/pi-bots/`.
+
+- [ ] **Step 7: Report on card #120**
+
+Update the card in `~/.crow-r4/data/tasks.db` (`tasks_items`) — it syncs to the Monday board, so keep it accurate. Record: what shipped (PR numbers and merge sha), that `r4-deploy.sh` is **uncommitted** at `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh` for the PM session to fold into the Gitea repo, the verification results, and that Phase 3 was deliberately not built. Set status to `done` only after the fleet verification in Step 6 passes.
+
+- [ ] **Step 8: Present the r4 auto-update question**
+
+With convergence merged, r4 could have `auto_update_enabled` turned back on — the starvation and migration-drift reasons for keeping it off are gone. This is the operator's call, not an assumption. Present it with the evidence from Step 6, and do not change the setting without an explicit yes.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Gap 1 — migrations travel with code | 3, 4, 5 |
+| Gap 2 — bundle copies travel | 1 (step 5), 2 |
+| Gap 3 — health verified | 8, 12 |
+| Gap 4 — lock starvation | 6, 10, 11 |
+| Gap 4b — disabled instance version lies | 7 |
+| Lazy `schema_migrations`, no generation bump | 3 (step 3), 14 (step 2) |
+| Registry scope = crow.db + tasks.db only | 3, 4 |
+| Order invariant | 5 |
+| Regression-not-absolute health gate | 8 |
+| 90 s addon grace / 10 min cookie deadline | 9 |
+| Quarantine, never `git reset --hard` | 12 |
+| Peers honor the marker / canary by construction | 12 |
+| `CROW_DISABLE_CONVERGE` kill switch | 13 |
+| Two-instance executable gate | 6, 10 (step 5), 12 |
+| Phase 3 not built | — (deliberate) |
+| Report on card #120 | 14 |
+
+**Known gap, stated rather than hidden:** if the new code crashes *before* `post-listen.js` runs, no boot ever reads the cookie in that process, and the quarantine only fires on the following boot via the expired-deadline path (`classifyPending → "failed"`, Task 9). That path is tested. A crash so early that systemd gives up before any boot reaches post-listen leaves the sha un-quarantined — detection then falls to the operator alert path, not to this mechanism. This is a real limit of self-verification without an external watchdog and is accepted rather than papered over.

--- a/docs/superpowers/specs/2026-08-06-safe-rolling-updates-design.md
+++ b/docs/superpowers/specs/2026-08-06-safe-rolling-updates-design.md
@@ -110,8 +110,34 @@ path stays where it is: it exists to reopen a restored DB file, which is unrelat
 **The trigger is `bootSha !== HEAD`, never `pulled`.** `runLockedUpdate()` returns
 `updated: false` on several branches *after* the tree has already moved (quarantine
 skip, `init-db failed — restart withheld`, the loss-and-rollback path). Deciding
-convergence on that flag would let peers converge into code the winner had just
-explicitly refused. `pulled` is informational only.
+convergence on that flag would let a peer sit on stale code indefinitely just
+because *this* process did not pull. `pulled` is informational only.
+
+**But a process must honor its OWN refusal.** Three of those branches exist
+precisely to withhold a restart: `init-db failed — restart withheld`, and both
+migration-guard loss paths. `bootSha !== HEAD` is true on all of them, so a naive
+fall-through restarts anyway — into a sha whose `init-db` just failed. The boot guard
+then hits `index.js:183` `process.exit(1)`, systemd restarts, the same thing
+happens, `StartLimitBurst` is exhausted, and **the unit is dead** — on each
+co-hosted gateway as its own tick arrives. So `runLockedUpdate` returns an explicit
+`converge: false` on every refusal branch, and `checkForUpdates` skips the instance
+half when its own tree half said so. A *peer* may still converge (it did not refuse
+anything, and the quarantine markers already guard the genuinely-bad cases); the
+process that refused does not.
+
+**Convergence requires a supervisor.** `scheduleSupervisedRestart` is a silent no-op
+when `isSupervised()` is false. Writing a deadline-bearing cookie and then not
+restarting means the deadline passes, and the next boot — hours later, on code that
+ran fine the whole time — classifies it `failed` and quarantines a healthy sha for
+every instance sharing the checkout. So convergence checks `isSupervised()` **before**
+writing the cookie: unsupervised instances run migrations, log that a manual restart
+is needed to load the new code, and write nothing.
+
+**A null boot sha means "do not converge".** `setBootSha` is best-effort; if
+`git rev-parse` fails, `BOOT_SHA` stays null. Treating null as "not current" would
+converge and restart on every tick forever, and the health gate could not stop it
+(`classifyPending` with a null boot sha returns `stale`, which clears the cookie
+without verifying). Null must be a refusal, not a licence.
 
 ## Scope decision: which stores
 
@@ -207,15 +233,29 @@ month. Creating it lazily means no generation bump, no dryrun rail, no DROP risk
 Idempotence is therefore doubly enforced: by recorded id, and by each migration's
 own shape checks. A migration must be safe to run even if its record is missing.
 
-**A migration whose target tables were all absent is DEFERRED, not applied.** Bundle
-stores are created by their bundle, which may start after the gateway boots — and
+**A migration with ANY absent target table is DEFERRED, not applied.** Bundle stores
+are created by their bundle, which starts *after* the gateway boots — and
 `better-sqlite3` creates an empty DB file on open, so "the table is absent" is the
-normal state on a fresh instance, not an error. Recording such a run as applied
-reproduces Gap 1 exactly: the `tasks` addon later creates `tasks_items` **without**
+normal state at boot, not an error. Recording such a run as applied reproduces Gap 1
+exactly: the `tasks` addon later creates `tasks_items` **without**
 `stage`/`assigned_bot`/`plan_ref`, and the registry never retries because the id is
-already recorded. So `run()` returns `{ deferred: true }` when every operation
-skipped for an absent table, and the runner does not record it — it retries on the
-next boot. Absent-table tolerance means "do not crash", not "consider it done".
+already recorded. Absent-table tolerance means "do not crash", not "consider it done".
+
+The rule is **any**, not **all**. `0001-board-stages` spans two databases:
+`project_spaces` in `crow.db` (created by `init-db.js`, so always present after the
+boot guard) and `tasks_items` in `tasks.db` (created by the tasks bundle, so absent
+at boot). An "all absent" rule would never fire on a real instance — one present
+table would mark the whole migration applied and the `tasks_items` columns would
+never land.
+
+**The registry therefore runs TWICE per boot: once before serving, and again after
+the addon-settled signal.** The boot run covers `crow.db`, whose tables exist by
+then. The post-settle run covers bundle-owned stores, which only exist once their
+bundle has started — and a store's owner starting is the only reliable
+happens-before for migrating it. Running only at boot would defer `tasks_items`
+forever on a long-lived gateway, since a current instance short-circuits its ticks.
+The second pass is idempotent by construction: already-applied ids are skipped by
+record, and every body is shape-checked anyway.
 
 **ORDER INVARIANT:** the registry runs AFTER the schema guard and BEFORE the first
 `createDbClient()` in the process, for the same reason the guard block does —
@@ -263,9 +303,18 @@ must be covered the same way.
    Any fixed grace window is wrong: with two addons hung on their full timeout, a
    third has not yet been *attempted* and is simply absent from the map — which the
    comparator would read as `missing`, i.e. a regression, on a sha that is fine.
-   The gate therefore waits on an explicit "addon loop finished" signal from
-   `initProxyServers` before snapshotting, with the boot-cookie deadline as the only
-   backstop.
+   The gate therefore waits on an explicit "addon loop finished" signal before
+   snapshotting.
+
+   **That signal must be unmissable.** `loadAddonServers` returns early three
+   different ways before reaching its loop — no `mcp-addons.json` (the common case
+   on a fresh instance), unparseable JSON, or zero entries — and `initProxyServers`
+   is invoked fire-and-forget with a `.catch`. Resolving the signal only at the end
+   of the loop means it never resolves on those paths, the gate awaits forever, the
+   cookie is never cleared, and the *next* boot reads an expired cookie and
+   quarantines a sha that was healthy all along. So the signal resolves in a
+   `finally` around the whole of `initProxyServers`, and the wait carries its own
+   timeout that resolves to **unknown / fail open** — never to `failed`.
 6. **Boot cookie:** before restarting, convergence writes a `pending-verification`
    record into the instance data dir carrying the target sha, the **pre-convergence
    health snapshot** (the baseline item 5 compares against), and a deadline of

--- a/docs/superpowers/specs/2026-08-06-safe-rolling-updates-design.md
+++ b/docs/superpowers/specs/2026-08-06-safe-rolling-updates-design.md
@@ -83,6 +83,36 @@ env, then restarts. Trigger: `bootSha !== tree HEAD`.
 The lock loser stops returning early — it skips the pull it does not need and
 proceeds to convergence. This single split closes Gap 1 and Gap 4 together.
 
+**The split is a restructuring of `checkForUpdates()`, not a new entry point beside
+it.** The scheduled tick (`tickCheck → checkForUpdates`) stays the one production
+path; on lock loss it *falls through* to the instance half instead of returning.
+Adding a second entry point that the timer never calls would leave the whole
+mechanism as dead code while every test passed — the tests would be calling a
+function production never runs.
+
+```
+checkForUpdates():
+    branch guard
+    lock ← acquire(checkout lock)
+    if held:  pulled ← runLockedUpdate()      # tree half, one winner
+    else:     pulled ← false                  # normal, not an error
+    release(lock)
+    return convergeInstance()                 # instance half, ALWAYS
+```
+
+**Convergence owns the restart.** `runLockedUpdate()` currently schedules the
+supervised restart itself on the success path; that must move out, or the winner's
+1.5 s exit timer fires while its own migrations are still running — an interrupted
+`ALTER` on a live store — and the boot cookie, which must be written *before* the
+restart, may never be written at all. The restart on the migration-guard **loss**
+path stays where it is: it exists to reopen a restored DB file, which is unrelated.
+
+**The trigger is `bootSha !== HEAD`, never `pulled`.** `runLockedUpdate()` returns
+`updated: false` on several branches *after* the tree has already moved (quarantine
+skip, `init-db failed — restart withheld`, the loss-and-rollback path). Deciding
+convergence on that flag would let peers converge into code the winner had just
+explicitly refused. `pulled` is informational only.
+
 ## Scope decision: which stores
 
 Live core stores per instance are exactly two: `<data-dir>/crow.db` and
@@ -125,8 +155,21 @@ Additions beyond the original brief, each from a trap that has already cost time
   invocation — bare `node` is v20 (ABI 115) and silently mismatches.
 - Explicit r4 env on **every** out-of-gateway spawn.
 - A **both-DB check**: the primary's `~/.crow/data/*` stores must be unchanged
-  after the run. Bulk writes end with a both-DB count check before declaring
-  success.
+  after the run. This is a **row-count** check, not a hash of the `.db` file —
+  these stores are WAL-mode, so writes land in `crow.db-wal` and the main file's
+  checksum does not move. A hash-only guard would print PASS over exactly the
+  env-leak it exists to catch.
+- The bundle sync **explicitly excludes** `server/db.js` and `server/app-root.js`.
+  Omitting `--delete` prevents deletion, not overwrite, and `-c` selects precisely
+  the files that differ — i.e. the deliberately per-instance ones. (They happen to
+  be byte-identical today; that is luck, not a guarantee.) A `diff -r` report at
+  the end, as the brief asked.
+- The health gate is the **same regression check** the gateway uses, not an
+  absolute one. An absolute "every addon connected" gate would have failed every
+  deploy during Aug 3–5 and demanded rollback of a perfectly good tree — the exact
+  reasoning that makes the gateway's gate regression-based applies here unchanged.
+- Wait on addon settling rather than a fixed `sleep`, for the sequential-connect
+  reason above.
 - A timestamped log line whenever the pull touches `scripts/pi-bots/`, so the
   `pibot-gateways@r4` soak (7-day Phase 0, ends ~2026-08-12) has explainable
   heartbeat gaps.
@@ -164,6 +207,16 @@ month. Creating it lazily means no generation bump, no dryrun rail, no DROP risk
 Idempotence is therefore doubly enforced: by recorded id, and by each migration's
 own shape checks. A migration must be safe to run even if its record is missing.
 
+**A migration whose target tables were all absent is DEFERRED, not applied.** Bundle
+stores are created by their bundle, which may start after the gateway boots — and
+`better-sqlite3` creates an empty DB file on open, so "the table is absent" is the
+normal state on a fresh instance, not an error. Recording such a run as applied
+reproduces Gap 1 exactly: the `tasks` addon later creates `tasks_items` **without**
+`stage`/`assigned_bot`/`plan_ref`, and the registry never retries because the id is
+already recorded. So `run()` returns `{ deferred: true }` when every operation
+skipped for an absent table, and the runner does not record it — it retries on the
+next boot. Absent-table tolerance means "do not crash", not "consider it done".
+
 **ORDER INVARIANT:** the registry runs AFTER the schema guard and BEFORE the first
 `createDbClient()` in the process, for the same reason the guard block does —
 `createDbClient` registers a never-closed per-path WAL keeper, and a later restore
@@ -186,10 +239,11 @@ must be covered the same way.
    at the same millisecond, so lock contention becomes rare rather than certain.
    (Jitter is a robustness measure, not the fix — the fix is item 2.)
 5. **Health gate — a REGRESSION check, not an absolute one.** A health snapshot is
-   exported over `proxy.js`'s existing `connectedServers` Map (`proxy.js:170`,
-   which already carries per-addon `status: connected|disconnected|error`). After a
-   convergence restart the new process verifies: HTTP listener bound, DB readable,
-   and **no addon that was `connected` before the convergence is now failing**.
+   taken over `proxy.js`'s existing `connectedServers` Map (`proxy.js:170`, which
+   already carries per-addon `status: connected|disconnected|error`), **filtered to
+   `entry.isAddon`**. After a convergence restart the new process verifies: HTTP
+   listener bound, DB readable, and **no addon that was `connected` before the
+   convergence is now failing**.
 
    Comparing against "all addons green" would quarantine a perfectly good sha on
    any host that already had a broken addon — which is precisely the state crow was
@@ -197,30 +251,60 @@ must be covered the same way.
    reason. The gate must answer "did this update break something?", not "is
    everything perfect?". Fixes Gap 3.
 
-   Grace window for addon connect: **90 s** — `proxy.js`'s own
-   `CONNECT_TIMEOUT_MS` is 60 s, so the window must exceed one full connect attempt
-   or a slow-but-healthy addon reads as a regression.
+   **The `isAddon` filter is load-bearing, not tidiness.** `connectedServers` also
+   holds remote federation peers (`proxy.js:564,582`, statuses include `offline`)
+   and data backends. Without the filter, a peer crow on a different machine
+   rebooting during the window reads as a local regression — a remote host's uptime
+   would quarantine this host's sha.
+
+   **Timing is by completion signal, not by clock.** `initProxyServers` connects
+   addons **sequentially** (`proxy.js:337`, `for (...) { await connectAddonServer }`)
+   with a 60 s `CONNECT_TIMEOUT_MS` each, so the total is unbounded in addon count.
+   Any fixed grace window is wrong: with two addons hung on their full timeout, a
+   third has not yet been *attempted* and is simply absent from the map — which the
+   comparator would read as `missing`, i.e. a regression, on a sha that is fine.
+   The gate therefore waits on an explicit "addon loop finished" signal from
+   `initProxyServers` before snapshotting, with the boot-cookie deadline as the only
+   backstop.
 6. **Boot cookie:** before restarting, convergence writes a `pending-verification`
    record into the instance data dir carrying the target sha, the **pre-convergence
    health snapshot** (the baseline item 5 compares against), and a deadline of
-   **10 min** from the write. The new boot clears it on pass. A boot that finds a
+   **15 min** from the write. The new boot clears it on pass. A boot that finds a
    **past-deadline** pending record proves the previous convergence failed.
 
-   10 min is chosen to exceed the worst realistic boot: a `SCHEMA_GENERATION`
-   migration under the guard, plus the 90 s addon window. Too short quarantines
-   healthy slow boots; too long leaves a crash-looping instance undetected for that
-   window. Both defaults are constants, adjustable without a schema change.
-7. **On failure: quarantine, never rollback.** Write a quarantine marker for that
-   sha (reusing `servers/shared/migration-guard.js`'s existing marker machinery,
-   which already carries auto-clear-when-main-moves and an attempts cap), fire
-   ntfy, keep running degraded and observable. Peers read the marker and never
-   converge to that sha.
+   15 min exceeds the worst realistic boot: a `SCHEMA_GENERATION` migration under
+   the guard, plus a full sequential addon-connect pass where several addons burn
+   their 60 s timeout. Too short quarantines healthy slow boots; too long leaves a
+   crash-looping instance undetected. The write is tmp-then-rename so a crash
+   mid-write cannot leave torn JSON that `readPending` would silently read as
+   "nothing pending".
+7. **On failure: quarantine, never rollback.** Write a convergence-quarantine
+   marker for that sha, fire ntfy, keep running degraded and observable. Peers read
+   the marker and refuse to converge to that sha.
 
    **The tree is never touched.** `git reset --hard` on a shared checkout would
    let one instance's failed health check drag two healthy peers backward on their
    next boot — one instance's failure becoming a fleet-wide regression. Auto-
    rollback is safe for the single-instance install it was imagined for and unsafe
    for exactly the topology being fixed. (Operator decision, 2026-08-06.)
+
+   **Convergence quarantine gets its OWN marker namespace** —
+   `.crow-convergence-quarantine.json`, with its own reader. It does **not** reuse
+   `servers/shared/migration-guard.js`'s markers. Two existing call sites read those
+   markers with no knowledge of why they were written: `index.js:141` would make a
+   gateway boot **skipping `init-db` entirely** — on an empty database, that means
+   serving with no tables — and `auto-update.js:318` would block all updates
+   host-wide while printing `gen undefined->undefined` at the operator. An addon
+   flapping must not be able to disable schema initialization.
+
+   **The quarantine gates the migrate-and-restart, NOT the pull, and it is
+   time-bounded.** A guard placed before the tree update is a fleet deadlock: a
+   blocked peer never fetches, so the checkout never moves past the bad sha, so the
+   "clears when main moves" escape can never fire — all three gateways freeze until
+   an operator deletes files by hand. That is strictly worse than the starvation
+   being fixed. So: the tree half always runs; only convergence is withheld. The
+   marker also carries a hard **24 h expiry** — after that it is ignored regardless,
+   so no failure mode ends in a permanently wedged host.
 8. **Canary by construction:** because peers honor the quarantine marker, the first
    instance to converge absorbs a bad sha alone. This is what the operator already
    does by hand by treating the primary as canary — now it is structural.
@@ -274,8 +358,15 @@ The gate must be **executable** (Item 2a lesson).
   just crow's co-hosted trio. Mitigated by quarantine-not-rollback, canary-by-
   construction, and the kill switch.
 - **A wrong health gate is worse than none** — a false negative quarantines a good
-  sha fleet-wide. Mitigated by fail-open on unknown, and by the marker's existing
-  auto-clear-when-main-moves behavior, which bounds the damage to one sha.
+  sha fleet-wide. Mitigated by fail-open on unknown, the `isAddon` filter, waiting
+  on the addon-settled signal rather than a clock, and the marker's 24 h hard
+  expiry. No quarantine path may end in a state only manual file deletion recovers.
+- **Concurrency:** the instance half now runs unlocked in three processes against
+  one checkout, while a fourth may be mid-`git pull` or mid-`npm install`. Marker
+  and cookie writes are tmp-then-rename. The registry's boot failure is fail-closed
+  (`process.exit(1)`), which under a crash-loop plus systemd's `StartLimitBurst`
+  could hold a gateway down — so registry failures distinguish "transient, retry
+  next boot" (a locked store) from "genuinely broken" rather than exiting on both.
 - **Shared host, live workstreams:** two other sessions restart/deploy the r4
   gateway, and `pibot-gateways@r4` is mid-soak from the working tree. Deploys go in
   tight verified windows; every `scripts/pi-bots/` pull and every soak-unit restart

--- a/docs/superpowers/specs/2026-08-06-safe-rolling-updates-design.md
+++ b/docs/superpowers/specs/2026-08-06-safe-rolling-updates-design.md
@@ -1,0 +1,295 @@
+# Safe rolling updates for co-hosted gateways — design
+
+**Date:** 2026-08-06
+**Tracking:** R4 kanban card #120 (`~/.crow-r4/data/tasks.db`, `tasks_items`)
+**Baseline:** `~/crow` at `cbf7a343` (== `origin/main`), CI green
+(`suite`/`static-checks`/`audit` all `completed/success`)
+
+## Problem
+
+Three gateways — `crow-gateway` (`~/.crow`), `crow-mpa-gateway` (`~/.crow-mpa`),
+`crow-r4-gateway` (`~/.crow-r4`) — run from ONE shared `~/crow` checkout. crow's
+auto-updater treats "pull the tree" and "make this instance current" as a single
+operation. That is correct for a single-instance install and wrong for a shared
+checkout, and it produces four failure classes.
+
+### Gap 1 — migrations do not travel with code
+
+`scripts/migrate-board-stages.mjs` is documented "run on deploy, both instances" but
+has no runner. It reached the primary and never reached r4; r4's `tasks.db` lacked
+`stage`/`assigned_bot`/`plan_ref` and every Bot Board drawer open 500'd
+("no such column: stage") while the board list rendered fine.
+
+The boot-time schema guard in `servers/gateway/index.js:125-195` covers this for
+`crow.db` **only when `SCHEMA_GENERATION` is bumped**. Additive columns with no
+generation bump reach a host only via `guarded-init-db`, never via a gateway
+restart — and nothing at all covers `tasks.db`.
+
+### Gap 2 — installed bundle copies do not travel with code
+
+Gateways run bundle code from `~/.crow-<inst>/bundles/<id>`, synced by hand. A
+restart into newer gateway code can pair with stale bundle copies silently.
+Per-instance adaptations are deliberate (`knowledge-base`'s `server/db.js` and
+`server/app-root.js`), so a blind `rsync --delete` is not available.
+
+### Gap 3 — nothing verifies an update landed healthy
+
+The `tasks` and `bots-sql-mcp` addon children were dead Aug 3–5 (better-sqlite3 ABI
+115 vs the gateway's node v22 ABI 127), visible only in `journalctl`. Addon connect
+failures are silent at the dashboard level.
+
+### Gap 4 — the updater lock is checkout-scoped, and starves co-hosted instances
+
+`auto-update.js:126` places the lock at `<git-dir>/crow-auto-update.lock` — one lock
+per **checkout**, shared by all three gateways.
+
+Verified evidence (2026-08-06):
+
+- All gateways restarted at the same instant (`20:18:46 CDT`), so the
+  "+5 min, then every 6h" timers (`auto-update.js:578`) are **phase-locked**.
+- Last check: primary `01:23:48.545Z`, MPA `01:23:49.020Z` — **475 ms apart**.
+- MPA won (`last_result="Up to date"`, `latest=cbf7a343`). Primary lost:
+  `"Skipped: another updater is running (pid 1333991)"`, and pid 1333991 is
+  `crow-mpa-gateway`'s MainPID.
+- Primary's `auto_update_latest_version=9f5656a3` is **16 commits behind its own
+  `current`** — the bookkeeping is not merely stale, it is backwards, because the
+  loser never reaches the code that writes it.
+
+The loser does not just skip the pull (which would be correct — the tree is shared).
+It skips **everything**: its own migrations and its own restart-into-new-code. Same
+phase every tick means the same loser loses forever. This is deterministic
+starvation, not a race.
+
+### Gap 4b — a disabled instance never records its real running version
+
+`startAutoUpdate()` returns at `auto-update.js:561` ("Disabled in settings")
+**before** line 568 records real HEAD. r4 reports `current=5cc4daf8` while the
+process actually runs `cbf7a343` from the shared tree. The bookkeeping and the
+running code disagree and nothing detects it.
+
+## The model: converge to the tree, don't pull
+
+Split the single operation into two with different scopes:
+
+| Operation | Scope | Lock | Who runs it |
+|---|---|---|---|
+| `updateTree()` | the checkout | checkout-scoped, one winner | whichever instance wins |
+| `convergeInstance()` | one instance | none needed | **every** instance, always |
+
+`updateTree()` keeps today's semantics: fetch, CI gate, quarantine check, pull, npm.
+`convergeInstance()` runs the migration registry for its own instance with its own
+env, then restarts. Trigger: `bootSha !== tree HEAD`.
+
+The lock loser stops returning early — it skips the pull it does not need and
+proceeds to convergence. This single split closes Gap 1 and Gap 4 together.
+
+## Scope decision: which stores
+
+Live core stores per instance are exactly two: `<data-dir>/crow.db` and
+`<data-dir>/tasks.db` (`scripts/pi-bots/instance-paths.mjs` derives both from the
+same anchor: `CROW_DB_PATH` → `resolveDataDir()`).
+
+Bundle-owned DBs are **out of scope for v1**. They are heterogeneous and
+bundle-owned — `fed-gov-data` sits at `data/fed-gov-data/` on the primary and at
+`bundles/fed-gov-data/data/` on r4. Phase 1's diff-sync covers r4's bundle needs;
+generalizing bundle migrations is a separate design if it is ever needed (YAGNI).
+
+Noted, not fixed: `~/.crow/crow.db` and `~/.crow-r4/crow.db` both exist at **0
+bytes** — empty decoys of the silent-fallback shape. Harmless; out of scope.
+
+## Phase 1 — `r4-deploy.sh` (no crow changes)
+
+One script at `/home/kh0pp/r4-tehcy/scripts/r4-deploy.sh`. Steps in order,
+stop-on-fail:
+
+1. `git -C ~/crow pull --ff-only` (or check out an explicit ref argument).
+2. `npm ci --omit=dev` only if the lockfile changed.
+3. Run all guarded migrations with explicit r4 env
+   (`CROW_HOME`, `CROW_DATA_DIR`, `CROW_DB_PATH` → `~/.crow-r4/…`) and the v22 node:
+   `scripts/init-db.js`, `scripts/migrate-board-stages.mjs`, and any future
+   `scripts/migrate-*` siblings.
+4. Diff-sync repo bundle files into r4 installed copies for bundles present in
+   `~/.crow-r4/bundles/` — changed files only, **never** `rsync --delete`;
+   `diff -r` report at the end. Also sync panel files into `~/.crow-r4/panels/`
+   (`<id>.js` + `<id>-routes.js`).
+5. Rebuild native modules on ABI mismatch (better-sqlite3 in `tasks` and
+   `bots-sql-mcp`); test-load with the v22 node.
+6. `systemctl restart crow-r4-gateway`.
+7. Health gate: unit active; journal since restart shows every expected addon
+   "connected" and zero "failed to connect"; `curl 127.0.0.1:3008/s/family/` → 200;
+   authed `GET /dashboard/bot-board-api/card/<id>` → 200.
+
+Additions beyond the original brief, each from a trap that has already cost time:
+
+- v22 node pinned (`~/.nvm/versions/node/v22.23.1/bin`) on **every** npm/node
+  invocation — bare `node` is v20 (ABI 115) and silently mismatches.
+- Explicit r4 env on **every** out-of-gateway spawn.
+- A **both-DB check**: the primary's `~/.crow/data/*` stores must be unchanged
+  after the run. Bulk writes end with a both-DB count check before declaring
+  success.
+- A timestamped log line whenever the pull touches `scripts/pi-bots/`, so the
+  `pibot-gateways@r4` soak (7-day Phase 0, ends ~2026-08-12) has explainable
+  heartbeat gaps.
+- Prints PASS or FAIL with the failing check and the previous commit hash.
+
+Left **uncommitted**, with a note on card #120 for the r4-tehcy PM session to fold
+in — this design does not push to another workstream's Gitea repo.
+
+## Phase 2, PR A — migration registry
+
+`scripts/migrations/` — ordered modules, each exporting:
+
+```js
+export const id = "0001-board-stages";          // ordering key, stable forever
+export function describe() { return "…"; }
+export async function run({ dataDir, dbPath, tasksDbPath, log }) { … }
+```
+
+Every migration is idempotent and absent-table tolerant, in the existing
+`addColumnIfMissing` house style (PRAGMA presence check, additive ALTER, skip when
+the table is absent). `migrate-board-stages.mjs` becomes entry `0001`, kept as a
+thin wrapper so the manual invocation and Phase 1 step 3 keep working.
+
+The gateway runs the registry **for its own instance** at boot: after the existing
+`SCHEMA_GENERATION` guard block (`index.js:125-195`), before serving. Paths are
+env-resolved, so co-hosted instances each migrate their own stores.
+
+**Bookkeeping table:** `schema_migrations` (`id`, `applied_at`, `sha`) in the
+instance's `crow.db`, created lazily by the runner with
+`CREATE TABLE IF NOT EXISTS` — **deliberately NOT added to `scripts/init-db.js`**.
+Adding it there would bump `SCHEMA_GENERATION`, which re-runs all of init-db's
+8 `DROP TABLE`s across four live DBs, on a host that has lost databases twice this
+month. Creating it lazily means no generation bump, no dryrun rail, no DROP risk.
+
+Idempotence is therefore doubly enforced: by recorded id, and by each migration's
+own shape checks. A migration must be safe to run even if its record is missing.
+
+**ORDER INVARIANT:** the registry runs AFTER the schema guard and BEFORE the first
+`createDbClient()` in the process, for the same reason the guard block does —
+`createDbClient` registers a never-closed per-path WAL keeper, and a later restore
+would swap the DB file under a pinned inode. `index.js:118-124` documents this and
+`tests/migration-guard.test.js` asserts the source ordering; the registry call site
+must be covered the same way.
+
+## Phase 2, PR B — converge + health gate
+
+1. **Record real HEAD at boot** before the "Disabled in settings" return
+   (`auto-update.js:561`). Fixes Gap 4b; a disabled instance stops lying about its
+   version.
+2. **Split** `checkForUpdates()` into `updateTree()` and `convergeInstance()`. The
+   lock loser proceeds to convergence instead of returning at
+   `auto-update.js:211-218`. Fixes Gap 4.
+3. **Boot sha** captured as a module constant at process start; convergence
+   triggers on `bootSha !== tree HEAD`.
+4. **De-phase-lock:** the first-check delay becomes `5 min + jitter derived from a
+   stable hash of the instance's data-dir path`. Co-hosted gateways stop colliding
+   at the same millisecond, so lock contention becomes rare rather than certain.
+   (Jitter is a robustness measure, not the fix — the fix is item 2.)
+5. **Health gate — a REGRESSION check, not an absolute one.** A health snapshot is
+   exported over `proxy.js`'s existing `connectedServers` Map (`proxy.js:170`,
+   which already carries per-addon `status: connected|disconnected|error`). After a
+   convergence restart the new process verifies: HTTP listener bound, DB readable,
+   and **no addon that was `connected` before the convergence is now failing**.
+
+   Comparing against "all addons green" would quarantine a perfectly good sha on
+   any host that already had a broken addon — which is precisely the state crow was
+   in Aug 3–5, when `tasks` and `bots-sql-mcp` were down for an unrelated ABI
+   reason. The gate must answer "did this update break something?", not "is
+   everything perfect?". Fixes Gap 3.
+
+   Grace window for addon connect: **90 s** — `proxy.js`'s own
+   `CONNECT_TIMEOUT_MS` is 60 s, so the window must exceed one full connect attempt
+   or a slow-but-healthy addon reads as a regression.
+6. **Boot cookie:** before restarting, convergence writes a `pending-verification`
+   record into the instance data dir carrying the target sha, the **pre-convergence
+   health snapshot** (the baseline item 5 compares against), and a deadline of
+   **10 min** from the write. The new boot clears it on pass. A boot that finds a
+   **past-deadline** pending record proves the previous convergence failed.
+
+   10 min is chosen to exceed the worst realistic boot: a `SCHEMA_GENERATION`
+   migration under the guard, plus the 90 s addon window. Too short quarantines
+   healthy slow boots; too long leaves a crash-looping instance undetected for that
+   window. Both defaults are constants, adjustable without a schema change.
+7. **On failure: quarantine, never rollback.** Write a quarantine marker for that
+   sha (reusing `servers/shared/migration-guard.js`'s existing marker machinery,
+   which already carries auto-clear-when-main-moves and an attempts cap), fire
+   ntfy, keep running degraded and observable. Peers read the marker and never
+   converge to that sha.
+
+   **The tree is never touched.** `git reset --hard` on a shared checkout would
+   let one instance's failed health check drag two healthy peers backward on their
+   next boot — one instance's failure becoming a fleet-wide regression. Auto-
+   rollback is safe for the single-instance install it was imagined for and unsafe
+   for exactly the topology being fixed. (Operator decision, 2026-08-06.)
+8. **Canary by construction:** because peers honor the quarantine marker, the first
+   instance to converge absorbs a bad sha alone. This is what the operator already
+   does by hand by treating the primary as canary — now it is structural.
+9. **Kill switch:** `CROW_DISABLE_CONVERGE=1`, documented.
+
+Once merged and deployed, auto-update *could* be re-enabled for r4. That is the
+operator's call and is presented as an option, not assumed.
+
+## Phase 3 — not built
+
+Separate git worktree per instance. Costs a second `node_modules` and a second
+pull. Build only if Phases 1+2 demonstrably fail.
+
+## Error handling
+
+- Registry migration throws → abort the remaining registry, log loudly, do NOT
+  serve on a half-migrated store; the boot gate's existing fail-closed posture
+  applies.
+- Health gate cannot determine status (snapshot unavailable) → treat as
+  **unknown, fail open**, matching `classifyCheckRuns`' documented posture
+  (`auto-update.js:253-259`). The gate defends against a knowably-bad convergence,
+  not against unknowns.
+- Quarantine marker write fails → alert and do not restart; a quarantine we cannot
+  record must not be relied on.
+- Instances whose `auto_update_enabled='false'` still record real HEAD (item 1) but
+  do not converge. Disabled means disabled.
+
+## Testing
+
+Prose review cannot tell you whether a restart-into-newer-code actually migrates.
+The gate must be **executable** (Item 2a lesson).
+
+- A fixture harness standing up **two scratch instances against one fixture
+  checkout**, moving the fixture HEAD, and asserting that **both** converge and
+  **both** DBs migrate — including the case where one instance loses the lock.
+- The starvation case specifically: the loser must still migrate and restart.
+- The regression-vs-absolute distinction, both directions: an addon broken BEFORE
+  convergence and still broken after must **not** quarantine; an addon healthy
+  before and failing after **must**.
+- Mutation-test every test. Four vacuous tests were caught this way in the P2 arc;
+  assume a test is vacuous until a mutation proves otherwise.
+- Order-invariant assertion for the registry call site, matching the existing
+  `tests/migration-guard.test.js` source-order check.
+- Full suite green; `check-runs` on the head sha green
+  (`suite`/`static-checks`/`audit`) before any merge.
+- Wiped-scratch acceptance after deploy.
+
+## Risks
+
+- **Blast radius:** PR B changes the update path for all 5 fleet instances, not
+  just crow's co-hosted trio. Mitigated by quarantine-not-rollback, canary-by-
+  construction, and the kill switch.
+- **A wrong health gate is worse than none** — a false negative quarantines a good
+  sha fleet-wide. Mitigated by fail-open on unknown, and by the marker's existing
+  auto-clear-when-main-moves behavior, which bounds the damage to one sha.
+- **Shared host, live workstreams:** two other sessions restart/deploy the r4
+  gateway, and `pibot-gateways@r4` is mid-soak from the working tree. Deploys go in
+  tight verified windows; every `scripts/pi-bots/` pull and every soak-unit restart
+  is logged with a timestamp.
+
+## Constraints that bind this work
+
+- Public GitHub `kh0pper/crow`, PR flow, `enforce_admins` TRUE — green check-runs
+  before merge, queried via `/commits/<sha>/check-runs` (never commit-status).
+- `~/crow` stays on main always; branch work in a `git worktree` with
+  `ln -s ~/crow/node_modules`.
+- Positional-path commits. No Claude attribution on commits or PRs.
+- New `DROP`/`DELETE` → `migration-expectations.js`. New host ports →
+  `docs/developers/port-allocation.md`. EN/ES i18n parity gate is live.
+- Every out-of-gateway spawn passes explicit instance env; every bulk write ends
+  with a both-DB count check.
+- Report outcomes on card #120.

--- a/scripts/migrate-board-stages.mjs
+++ b/scripts/migrate-board-stages.mjs
@@ -1,34 +1,14 @@
 // scripts/migrate-board-stages.mjs
-// Board–plan unification Plan 1 Task 1: guarded ALTERs (init-pi-bots.mjs
-// pattern — PRAGMA presence check, additive, idempotent, absent-table
-// tolerant). Run on deploy, both instances. SQLite ADD COLUMN never rebuilds
-// the table, so existing CHECK constraints are unaffected.
-import Database from "better-sqlite3";
+//
+// Thin wrapper. The migration itself now lives in the registry at
+// scripts/migrations/0001-board-stages.mjs and runs automatically at gateway
+// boot for whichever instance is booting. This entry point stays for manual and
+// deploy-script invocation, and resolves the same per-instance paths it always
+// did.
 import { tasksDbPath, botsDbPath } from "./pi-bots/instance-paths.mjs";
+import { run } from "./migrations/0001-board-stages.mjs";
 
-function addColumnIfMissing(db, table, column, ddl) {
-  const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
-  if (!t) return "skip (" + table + " absent)";
-  const have = db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
-  if (have.includes(column)) return "no-op";
-  db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`).run();
-  return "added";
+const out = run({ dbPath: botsDbPath(), tasksDbPath: tasksDbPath(), log: (m) => console.log(m) });
+if (out?.deferred) {
+  console.log("  (deferred — a target table is absent on this instance; the registry will retry)");
 }
-
-function open(p) { const d = new Database(p); d.pragma("busy_timeout = 10000"); return d; }
-
-const out = [];
-{
-  const tdb = open(tasksDbPath());
-  out.push(["tasks_items.stage", addColumnIfMissing(tdb, "tasks_items", "stage", "TEXT")]);
-  out.push(["tasks_items.assigned_bot", addColumnIfMissing(tdb, "tasks_items", "assigned_bot", "TEXT")]);
-  out.push(["tasks_items.plan_ref", addColumnIfMissing(tdb, "tasks_items", "plan_ref", "TEXT")]);
-  tdb.close();
-}
-{
-  const cdb = open(botsDbPath());
-  out.push(["project_spaces.repo_path", addColumnIfMissing(cdb, "project_spaces", "repo_path", "TEXT")]);
-  out.push(["bot_sessions.kind", addColumnIfMissing(cdb, "bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'")]);
-  cdb.close();
-}
-for (const [what, r] of out) console.log("  " + what + ": " + r);

--- a/scripts/migrations/0001-board-stages.mjs
+++ b/scripts/migrations/0001-board-stages.mjs
@@ -1,0 +1,71 @@
+// scripts/migrations/0001-board-stages.mjs
+//
+// Board–plan unification: guarded additive ALTERs. PRAGMA presence check,
+// additive, idempotent, absent-table tolerant. SQLite ADD COLUMN never rebuilds
+// the table, so existing CHECK constraints are unaffected.
+//
+// Previously this lived in scripts/migrate-board-stages.mjs, documented "run on
+// deploy, both instances" — which meant it reached the primary and silently
+// skipped r4, whose tasks.db then lacked stage/assigned_bot/plan_ref and 500'd
+// every Bot Board drawer open. That is the drift this registry exists to end.
+import Database from "better-sqlite3";
+
+export const id = "0001-board-stages";
+
+/** "added" | "no-op" | "absent" — never throws on a missing table. */
+export function addColumnIfMissing(db, table, column, ddl) {
+  const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
+  if (!t) return "absent";
+  const have = db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
+  if (have.includes(column)) return "no-op";
+  db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`).run();
+  return "added";
+}
+
+function open(p) {
+  const d = new Database(p);
+  d.pragma("busy_timeout = 10000");
+  return d;
+}
+
+export function run({ dbPath, tasksDbPath, log = () => {} }) {
+  const results = [];
+
+  const tdb = open(tasksDbPath);
+  try {
+    for (const [col, ddl] of [["stage", "TEXT"], ["assigned_bot", "TEXT"], ["plan_ref", "TEXT"]]) {
+      const r = addColumnIfMissing(tdb, "tasks_items", col, ddl);
+      log(`  tasks_items.${col}: ${r}`);
+      results.push(r);
+    }
+  } finally {
+    tdb.close();
+  }
+
+  const cdb = open(dbPath);
+  try {
+    for (const [tbl, col, ddl] of [
+      ["project_spaces", "repo_path", "TEXT"],
+      ["bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'"],
+    ]) {
+      const r = addColumnIfMissing(cdb, tbl, col, ddl);
+      log(`  ${tbl}.${col}: ${r}`);
+      results.push(r);
+    }
+  } finally {
+    cdb.close();
+  }
+
+  // ANY absent target means this instance's stores do not all exist YET — not
+  // that the work is done. Defer so the runner retries once the owning bundle
+  // has started.
+  //
+  // `any`, NOT `all`: this migration spans two databases. project_spaces and
+  // bot_sessions live in crow.db and are created by init-db.js, so they are
+  // ALWAYS present by the time the boot registry runs. tasks_items lives in
+  // tasks.db and is created by the tasks BUNDLE, which starts after the gateway
+  // boots. An `all` rule would therefore never fire on a real instance — one
+  // present table would mark the whole migration applied and the tasks_items
+  // columns would never land. That is the original bug, reintroduced.
+  if (results.includes("absent")) return { deferred: true };
+}

--- a/scripts/migrations/runner.mjs
+++ b/scripts/migrations/runner.mjs
@@ -1,0 +1,115 @@
+// scripts/migrations/runner.mjs
+//
+// Ordered, idempotent, per-instance migration registry.
+//
+// Co-hosted gateways share one checkout but have their own data dirs, so each
+// runs this registry against its OWN stores with its own env-resolved paths.
+// It covers changes that carry no SCHEMA_GENERATION bump — additive columns,
+// and non-crow.db stores like tasks.db — which the boot schema guard in
+// servers/gateway/index.js deliberately does not.
+//
+// Bookkeeping lives in `schema_migrations` inside the instance's crow.db and is
+// created lazily HERE, deliberately NOT in scripts/init-db.js. Adding a table
+// there would bump SCHEMA_GENERATION, which re-runs all of init-db's DROP TABLE
+// statements against every live instance DB — a rail this change has no reason
+// to ride.
+//
+// Migrations must ALSO be safe to run with their record missing: a database
+// restored from backup can lose the row while keeping the schema change. So
+// every migration body stays shape-checked and idempotent in its own right, and
+// the record is an optimization, not the contract.
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+
+const FILENAME = /^\d{4}-[a-z0-9-]+\.mjs$/;
+
+/** Sorted absolute paths of every valid migration module in `dir`. */
+export function discoverMigrations(dir) {
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return []; // no registry directory yet is not an error
+  }
+  return names.filter((n) => FILENAME.test(n)).sort().map((n) => join(dir, n));
+}
+
+function open(p) {
+  const d = new Database(p);
+  d.pragma("busy_timeout = 10000");
+  return d;
+}
+
+function ensureTable(db) {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS schema_migrations (
+       id TEXT PRIMARY KEY,
+       applied_at TEXT NOT NULL,
+       sha TEXT
+     )`,
+  ).run();
+}
+
+/**
+ * Run every not-yet-applied migration, in order, against ONE instance's stores.
+ * Throws on the first failure without recording it — the caller decides whether
+ * that is fatal.
+ *
+ * A migration returning `{ deferred: true }` is NOT recorded. Its target tables
+ * did not exist yet: bundle-owned stores are created by their bundle, which
+ * starts after the gateway boots, and better-sqlite3 creates an empty DB file on
+ * open — so "absent" is the normal fresh-install state, not an error. Recording
+ * a deferral as applied would reproduce the bug this registry exists to fix: the
+ * table gets created later WITHOUT the new columns, and the migration never
+ * retries because its id is already on file.
+ *
+ * @returns {Promise<{applied: string[], skipped: string[], deferred: string[]}>}
+ */
+export async function runMigrations({
+  migrationsDir,
+  dbPath,
+  tasksDbPath,
+  sha = null,
+  log = () => {},
+}) {
+  const applied = [];
+  const skipped = [];
+  const deferred = [];
+
+  const book = open(dbPath);
+  try {
+    ensureTable(book);
+    const done = new Set(book.prepare("SELECT id FROM schema_migrations").all().map((r) => r.id));
+
+    for (const file of discoverMigrations(migrationsDir)) {
+      const mod = await import(pathToFileURL(file).href);
+      if (!mod.id || typeof mod.run !== "function") {
+        throw new Error(`${file}: a migration must export \`id\` and \`run\``);
+      }
+      if (done.has(mod.id)) {
+        skipped.push(mod.id);
+        continue;
+      }
+
+      log(`applying ${mod.id}`);
+      const outcome = await mod.run({ dbPath, tasksDbPath, log });
+
+      if (outcome && outcome.deferred) {
+        log(`${mod.id} deferred — target tables absent, will retry`);
+        deferred.push(mod.id);
+        continue;
+      }
+
+      book
+        .prepare("INSERT INTO schema_migrations (id, applied_at, sha) VALUES (?, ?, ?)")
+        .run(mod.id, new Date().toISOString(), sha);
+      applied.push(mod.id);
+    }
+  } finally {
+    book.close();
+  }
+
+  return { applied, skipped, deferred };
+}

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -194,6 +194,51 @@ try {
   process.exit(1);
 }
 
+// Per-instance migration registry (scripts/migrations/). Runs for THIS instance
+// with THIS instance's env-resolved paths, so co-hosted gateways sharing one
+// checkout each migrate their own stores. Covers changes that carry no
+// SCHEMA_GENERATION bump — additive columns, and non-crow.db stores like
+// tasks.db — which the guard above deliberately does not.
+//
+// ORDER INVARIANT: after the schema guard, before the first createDbClient
+// (initOAuthTables below), for the same reason the guard block documents —
+// createDbClient registers a never-closed per-path WAL keeper, and a later
+// restore would swap the DB file under a pinned inode.
+// tests/migration-registry.test.js asserts this ordering.
+try {
+  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
+  const { resolveDataDir: _rddReg } = await import("../db.js");
+  const { resolveGuardDbPath: _rgdpReg } = await import("../shared/migration-guard.js");
+  const { tasksDbPath: _tdpReg } = await import("../../scripts/pi-bots/instance-paths.mjs");
+  const { dirname: _dnReg, join: _joinReg } = await import("node:path");
+  const { fileURLToPath: _fupReg } = await import("node:url");
+
+  const _rootReg = _dnReg(_dnReg(_dnReg(_fupReg(import.meta.url))));
+  const _resReg = await runMigrations({
+    migrationsDir: _joinReg(_rootReg, "scripts", "migrations"),
+    dbPath: _rgdpReg(_rddReg),
+    tasksDbPath: _tdpReg(),
+    log: (m) => console.log(`[migrations] ${m}`),
+  });
+  if (_resReg.applied.length) console.log(`[migrations] applied: ${_resReg.applied.join(", ")}`);
+  if (_resReg.deferred.length) {
+    console.log(`[migrations] deferred (will retry): ${_resReg.deferred.join(", ")}`);
+  }
+} catch (e) {
+  // Fail closed on a genuine failure — serving on a half-migrated store is how
+  // the Bot Board 500'd on every drawer open. But a busy bundle-owned store is
+  // TRANSIENT: the tasks addon child holds tasks.db open, and exiting on that
+  // would make gateway boot depend on a store the gateway does not control,
+  // where a crash-loop plus systemd's StartLimitBurst leaves the unit down.
+  if (/SQLITE_BUSY|database is locked/i.test(e.message || "")) {
+    console.warn(`[migrations] deferred — store busy (${e.message}); retrying next boot`);
+  } else {
+    console.error("ERROR: migration registry failed:", e.message);
+    console.error("  Run it manually with this instance's CROW_DATA_DIR/CROW_DB_PATH before starting.");
+    process.exit(1);
+  }
+}
+
 // Initialize OAuth tables
 await initOAuthTables();
 

--- a/tests/migration-registry.test.js
+++ b/tests/migration-registry.test.js
@@ -201,3 +201,23 @@ test("0001-board-stages: adds columns, DEFERS when ANY target table is absent", 
     assert.deepEqual(after, cols, "a re-run must not change the column set");
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
+
+test("ORDER INVARIANT: registry runs after the schema guard, before the first createDbClient", () => {
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "index.js"), "utf8");
+
+  // Anchor on the guard's CALL, not its import: `runGuardedInitDb` first appears
+  // in the dynamic-import destructure, so a plain indexOf would also match a
+  // registry block wrongly placed INSIDE the guard block.
+  const guardCall = src.indexOf("await runGuardedInitDb(");
+  const registry = src.indexOf("runMigrations(");
+  const firstClient = src.indexOf("initOAuthTables()");
+
+  assert.ok(guardCall > 0, "the schema guard call must be present");
+  assert.ok(registry > 0, "the registry call must be present");
+  assert.ok(firstClient > 0, "initOAuthTables must be present");
+  assert.ok(guardCall < registry, "registry must run AFTER the schema guard");
+  assert.ok(registry < firstClient,
+    "registry must run BEFORE the first createDbClient — createDbClient registers a " +
+    "never-closed per-path WAL keeper, and a later migration-guard restore would " +
+    "swap the DB file under a pinned inode (split-brain)");
+});

--- a/tests/migration-registry.test.js
+++ b/tests/migration-registry.test.js
@@ -134,3 +134,70 @@ test("a throwing migration aborts the rest and records nothing", async () => {
     assert.deepEqual(rows, [], "a failed migration must not be recorded");
   } finally { rmSync(f.root, { recursive: true, force: true }); }
 });
+
+test("0001-board-stages: adds columns, DEFERS when ANY target table is absent", async () => {
+  const dir = join(import.meta.dirname, "..", "scripts", "migrations");
+
+  // (a) Every target absent → deferred, not recorded.
+  const bare = fixture();
+  try {
+    const r = await runMigrations({ migrationsDir: dir, dbPath: bare.dbPath, tasksDbPath: bare.tasksDbPath });
+    assert.ok(r.deferred.includes("0001-board-stages"),
+      "a fresh instance has no tasks_items yet — recording this as applied is the original bug");
+    assert.ok(!r.applied.includes("0001-board-stages"));
+  } finally { rmSync(bare.root, { recursive: true, force: true }); }
+
+  // (a2) THE PRODUCTION SHAPE: crow.db tables exist (init-db has run at boot),
+  // tasks_items does not (the tasks bundle has not started). This is every real
+  // instance at boot — an "all absent" rule would wrongly record it as applied
+  // here, and the tasks_items columns would never land.
+  const mixed = fixture();
+  try {
+    const c = new Database(mixed.dbPath);
+    c.prepare("CREATE TABLE project_spaces (id INTEGER PRIMARY KEY)").run();
+    c.prepare("CREATE TABLE bot_sessions (id INTEGER PRIMARY KEY)").run();
+    c.close();
+
+    const r = await runMigrations({ migrationsDir: dir, dbPath: mixed.dbPath, tasksDbPath: mixed.tasksDbPath });
+    assert.ok(r.deferred.includes("0001-board-stages"),
+      "crow.db tables present + tasks_items absent MUST defer — this is the real-instance shape");
+    assert.ok(!r.applied.includes("0001-board-stages"));
+
+    // The crow.db half still applied its column — deferral is about the RECORD.
+    const c2 = new Database(mixed.dbPath);
+    const cols = c2.prepare("PRAGMA table_info(project_spaces)").all().map((x) => x.name);
+    c2.close();
+    assert.ok(cols.includes("repo_path"), "present tables must still be migrated");
+  } finally { rmSync(mixed.root, { recursive: true, force: true }); }
+
+  // (b) All targets present → applied, columns added, re-runnable.
+  const f = fixture();
+  try {
+    const t = new Database(f.tasksDbPath);
+    t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
+    t.close();
+    const c = new Database(f.dbPath);
+    c.prepare("CREATE TABLE project_spaces (id INTEGER PRIMARY KEY)").run();
+    c.prepare("CREATE TABLE bot_sessions (id INTEGER PRIMARY KEY)").run();
+    c.close();
+
+    const r = await runMigrations({ migrationsDir: dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    assert.ok(r.applied.includes("0001-board-stages"), "all targets present → applied");
+
+    const t2 = new Database(f.tasksDbPath);
+    const cols = t2.prepare("PRAGMA table_info(tasks_items)").all().map((x) => x.name);
+    t2.close();
+    for (const col of ["stage", "assigned_bot", "plan_ref"]) {
+      assert.ok(cols.includes(col), `tasks_items.${col} must exist`);
+    }
+
+    // Shape-level idempotence: re-run directly, bypassing the record. A missing
+    // guard would throw "duplicate column name".
+    const mod = await import(join(dir, "0001-board-stages.mjs"));
+    await mod.run({ dbPath: f.dbPath, tasksDbPath: f.tasksDbPath, log: () => {} });
+    const t3 = new Database(f.tasksDbPath);
+    const after = t3.prepare("PRAGMA table_info(tasks_items)").all().map((x) => x.name);
+    t3.close();
+    assert.deepEqual(after, cols, "a re-run must not change the column set");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});

--- a/tests/migration-registry.test.js
+++ b/tests/migration-registry.test.js
@@ -1,0 +1,136 @@
+/**
+ * Per-instance migration registry (scripts/migrations/).
+ *
+ * Fixtures are real temp directories with real SQLite files, so the runner's
+ * actual import + bookkeeping path is exercised. Fixture migration bodies import
+ * ONLY node: builtins — a bare specifier like "better-sqlite3" cannot resolve
+ * from os.tmpdir(), which has no node_modules anywhere on its path.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { runMigrations, discoverMigrations } from "../scripts/migrations/runner.mjs";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "migreg-"));
+  const dir = join(root, "migrations");
+  mkdirSync(dir);
+  const dbPath = join(root, "crow.db");
+  const tasksDbPath = join(root, "tasks.db");
+  new Database(dbPath).close();
+  new Database(tasksDbPath).close();
+  return { root, dir, dbPath, tasksDbPath };
+}
+
+const wm = (dir, name, body) => writeFileSync(join(dir, name), body);
+
+const sideEffect = (id, file) =>
+  `import { appendFileSync } from "node:fs";
+   export const id = ${JSON.stringify(id)};
+   export function run() { appendFileSync(${JSON.stringify(file)}, ${JSON.stringify(id + "\n")}); }`;
+
+test("runs migrations in filename order, not creation order", async () => {
+  const f = fixture();
+  try {
+    const order = join(f.root, "order.txt");
+    // Created out of order deliberately: readdirSync order is unspecified, so a
+    // fixture whose files happen to be created in sorted order proves nothing.
+    wm(f.dir, "0003-c.mjs", sideEffect("0003-c", order));
+    wm(f.dir, "0001-a.mjs", sideEffect("0001-a", order));
+    wm(f.dir, "0002-b.mjs", sideEffect("0002-b", order));
+
+    const res = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+
+    assert.deepEqual(res.applied, ["0001-a", "0002-b", "0003-c"]);
+    assert.equal(readFileSync(order, "utf8"), "0001-a\n0002-b\n0003-c\n");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("is idempotent — the body runs exactly once across two calls", async () => {
+  const f = fixture();
+  try {
+    const hits = join(f.root, "hits.txt");
+    wm(f.dir, "0001-once.mjs", sideEffect("0001-once", hits));
+
+    const a = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    const b = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+
+    assert.deepEqual(a.applied, ["0001-once"]);
+    assert.deepEqual(b.applied, []);
+    assert.deepEqual(b.skipped, ["0001-once"]);
+    assert.equal(readFileSync(hits, "utf8"), "0001-once\n", "the body must run exactly once");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("a DEFERRED migration is NOT recorded and runs again next time", async () => {
+  const f = fixture();
+  try {
+    const hits = join(f.root, "deferred.txt");
+    wm(f.dir, "0001-defer.mjs",
+      `import { appendFileSync } from "node:fs";
+       export const id = "0001-defer";
+       export function run() { appendFileSync(${JSON.stringify(hits)}, "x"); return { deferred: true }; }`);
+
+    const a = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+    const b = await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+
+    assert.deepEqual(a.deferred, ["0001-defer"]);
+    assert.deepEqual(a.applied, []);
+    assert.deepEqual(b.deferred, ["0001-defer"], "a deferred migration must retry, not be recorded");
+    assert.equal(readFileSync(hits, "utf8"), "xx", "the body must run BOTH times");
+
+    const db = new Database(f.dbPath);
+    const rows = db.prepare("SELECT id FROM schema_migrations").all();
+    db.close();
+    assert.deepEqual(rows, [], "a deferral must leave no bookkeeping row behind");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("creates schema_migrations lazily — never requires init-db", async () => {
+  const f = fixture();
+  try {
+    wm(f.dir, "0001-noop.mjs", `export const id = "0001-noop"; export function run() {}`);
+    await runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath });
+
+    const db = new Database(f.dbPath);
+    const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'").get();
+    db.close();
+    assert.ok(t, "the runner must CREATE TABLE IF NOT EXISTS its own bookkeeping table");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("ignores files that do not match the NNNN-slug.mjs pattern", () => {
+  const f = fixture();
+  try {
+    wm(f.dir, "0001-real.mjs", `export const id = "0001-real"; export function run() {}`);
+    wm(f.dir, "README.md", "not a migration");
+    wm(f.dir, "helper.mjs", "export const x = 1;");
+    wm(f.dir, "0002-draft.mjs.bak", "stray");
+
+    const found = discoverMigrations(f.dir).map((p) => p.split("/").pop());
+    assert.deepEqual(found, ["0001-real.mjs"]);
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("a throwing migration aborts the rest and records nothing", async () => {
+  const f = fixture();
+  try {
+    const after = join(f.root, "after.txt");
+    wm(f.dir, "0001-boom.mjs", `export const id = "0001-boom"; export function run() { throw new Error("boom"); }`);
+    wm(f.dir, "0002-after.mjs", sideEffect("0002-after", after));   // observable side effect
+
+    await assert.rejects(
+      () => runMigrations({ migrationsDir: f.dir, dbPath: f.dbPath, tasksDbPath: f.tasksDbPath }),
+      /boom/,
+    );
+
+    assert.equal(existsSync(after), false, "0002 must NOT run after 0001 throws");
+    const db = new Database(f.dbPath);
+    const rows = db.prepare("SELECT id FROM schema_migrations").all();
+    db.close();
+    assert.deepEqual(rows, [], "a failed migration must not be recorded");
+  } finally { rmSync(f.root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Why

Three gateways (`crow-gateway`, `crow-mpa-gateway`, `crow-r4-gateway`) run from one shared `~/crow` checkout with three separate data dirs. Migrations do not travel with code: `scripts/migrate-board-stages.mjs` was documented "run on deploy, both instances", reached the primary, and silently skipped r4 — whose `tasks.db` then lacked `stage`/`assigned_bot`/`plan_ref`, 500ing every Bot Board drawer open while the board list rendered fine.

The boot schema guard in `servers/gateway/index.js` covers `crow.db` **only when `SCHEMA_GENERATION` is bumped**. Additive columns with no bump reach a host only via `guarded-init-db`, never via a restart — and nothing at all covers `tasks.db`.

## What this adds

An ordered, idempotent, per-instance migration registry at `scripts/migrations/`, run at gateway boot for the booting instance with its own env-resolved paths. Co-hosted gateways each migrate their own stores.

- `scripts/migrations/runner.mjs` — discovery (`NNNN-slug.mjs`), ordering, bookkeeping, execution
- `scripts/migrations/0001-board-stages.mjs` — the first entry; `scripts/migrate-board-stages.mjs` becomes a thin wrapper so deploy scripts and manual invocation keep working

## Two deliberate design points

**`schema_migrations` is created lazily by the runner, not in `init-db.js`.** Adding a table there would bump `SCHEMA_GENERATION`, which re-runs all of init-db's `DROP TABLE` statements against every live instance DB. This ships without riding that rail at all.

**A migration with ANY absent target table defers rather than recording itself as applied.** This migration spans two databases: `project_spaces` lives in `crow.db` and is created by `init-db.js` (always present at boot), while `tasks_items` lives in `tasks.db` and is created by the tasks *bundle*, which starts after the gateway boots. An "all absent" rule would never fire on a real instance — one present table would mark the whole migration applied and the `tasks_items` columns would never land. Verified on a real scratch gateway boot:

```
project_spaces.repo_path: added
tasks_items.*: absent
-> deferred (will retry)
```

## Ordering invariant

The registry runs after the schema guard and before the first `createDbClient`, for the same reason the guard block documents: `createDbClient` registers a never-closed per-path WAL keeper, and a later restore would swap the DB file under a pinned inode. Asserted by a source-anchor test.

Fails closed on a genuine error, but treats `SQLITE_BUSY` as transient — the tasks addon child holds `tasks.db` open, and exiting on that would make gateway boot depend on a store the gateway does not control.

## Verification

- Suite **2969 pass / 0 fail / 0 cancelled** (baseline 2961 + 8 new)
- **13/13 mutations killed** across the three tasks — every test proven non-vacuous
- Pre-existing `tests/board-stages-migration.test.js` passes unchanged against the wrapper
- Real gateway boot on a scratch home reaches listen; both live instance DBs verified untouched
- No `SCHEMA_GENERATION` bump, no new `DROP`/`DELETE`, no new host port; `check-ports` passes

Also includes the design spec and implementation plan for the follow-on convergence work (PR B), which is deliberately **not** in this PR — this change is additive and cannot restart anything, so it is safe to soak on its own first.

Card #120.
