### PR TITLE
feat(convergence): every co-hosted instance converges, only one pulls

### DIFF
--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -238,3 +238,83 @@ System resource metrics (RAM, disk, CPU) are available at `GET /api/health`, pro
 ## Federation
 
 The gateway can proxy tool calls to remote Crow instances via HTTP. When an instance is registered in the `crow_instances` table with a `gateway_url`, the proxy layer connects using the MCP SDK's `StreamableHTTPClientTransport` and makes remote tools available through the `crow_tools` router action with an `instance_id` parameter. See [Multi-Instance Architecture](./instances) for sync, conflict resolution, and security details.
+
+## Convergence: how a gateway gets current with its checkout
+
+Several gateways can share one `~/crow` checkout while keeping separate data
+dirs (on the dev host: `crow-gateway`, `crow-mpa-gateway`, `crow-r4-gateway`).
+That makes updating two different jobs with different scopes:
+
+| Operation | Scope | Lock | Who runs it |
+|---|---|---|---|
+| pull the tree | the checkout | checkout-scoped, one winner | whichever instance wins |
+| converge the instance | one data dir | none | **every** instance, always |
+
+`checkForUpdates()` does the tree half only if it holds the lock, then **always**
+runs the instance half. **A lock loss is normal, not an error** — another
+co-hosted gateway is pulling the shared tree, which is correct. The loser skips
+the pull it does not need and still migrates its own stores and restarts.
+
+Convergence triggers on `bootSha !== HEAD`, never on whether this process
+pulled: `runLockedUpdate` returns `updated: false` on several branches *after*
+the tree has already moved.
+
+**A process honors its own refusal.** The branches that deliberately withhold a
+restart (init-db failure, both migration-guard loss paths) return
+`converge: false`, and `checkForUpdates` then skips the instance half. Without
+that, convergence would restart into a sha whose `init-db` just failed, the boot
+guard would `process.exit(1)`, and systemd's `StartLimitBurst` would leave the
+unit dead.
+
+Convergence **owns the restart** — scheduled only after migrations run and the
+boot cookie is written. An unsupervised instance migrates, logs that a manual
+restart is needed, and writes no cookie.
+
+### Migration registry
+
+`scripts/migrations/NNNN-slug.mjs`, each exporting `id` and
+`run({ dbPath, tasksDbPath, log })`. Bodies must be idempotent and shape-checked
+(`PRAGMA` presence, additive `ALTER`) — a restored backup can lose the
+bookkeeping row while keeping the change.
+
+Return `{ deferred: true }` when **any** target table is absent. Bundle-owned
+stores are created by their bundle, which starts *after* the gateway boots;
+recording a deferral as applied would let the table be created later without the
+new columns and never retry.
+
+The registry runs **twice per boot**: once before serving (covers `crow.db`) and
+again after the addons settle (covers bundle-owned stores). Bookkeeping lives in
+`schema_migrations`, created lazily by the runner — deliberately **not** in
+`init-db.js`, which would bump `SCHEMA_GENERATION` and re-run its `DROP TABLE`
+statements on every live instance DB.
+
+### Health gate
+
+A **regression** check, not an absolute one: it compares the post-restart addon
+snapshot against the pre-restart baseline carried in the boot cookie. "All addons
+connected" would quarantine a good sha on any host that already had a broken
+addon. Only `entry.isAddon` entries count — `connectedServers` also holds remote
+federation peers, whose status flips to `offline` when a crow on another machine
+reboots.
+
+The gate waits on an addons-settled signal rather than a clock (addons connect
+sequentially, 60 s timeout each) with a 10-minute timeout that yields
+**unknown / fail open**. An indeterminate gate never quarantines.
+
+### Quarantine, not rollback
+
+On regression the sha is written to `.crow-convergence-quarantine.json` at both
+repo and data level, an alert fires, and the instance keeps running degraded.
+Peers read the repo-level marker and refuse that sha, so **the first instance to
+converge is the canary by construction**.
+
+The tree is never rolled back: `git reset --hard` on a shared checkout would drag
+co-hosted peers backward for one instance's failure. Markers hard-expire after
+**24 h**, so no failure mode needs manual file deletion to recover. To clear one
+early, delete both files.
+
+### Kill switch
+
+`CROW_DISABLE_CONVERGE=1` short-circuits the instance half entirely. The tree
+half still runs, so the checkout keeps updating — the instance just stops
+migrating and restarting itself.

--- a/docs/architecture/gateway.md
+++ b/docs/architecture/gateway.md
@@ -262,9 +262,11 @@ the tree has already moved.
 **A process honors its own refusal.** The branches that deliberately withhold a
 restart (init-db failure, both migration-guard loss paths) return
 `converge: false`, and `checkForUpdates` then skips the instance half. Without
-that, convergence would restart into a sha whose `init-db` just failed, the boot
-guard would `process.exit(1)`, and systemd's `StartLimitBurst` would leave the
-unit dead.
+that, convergence would restart into a sha whose `init-db` just failed and the
+boot guard would `process.exit(1)`. On units configured `RestartSec=5` against a
+10 s `StartLimitInterval`, `StartLimitBurst` never trips — so the result is an
+**unbounded** crash loop, not a stopped unit, with each iteration re-running
+`init-db` against a live store.
 
 Convergence **owns the restart** — scheduled only after migrations run and the
 boot cookie is written. An unsupervised instance migrates, logs that a manual

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -523,9 +523,11 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
       // converge:false — this branch exists to WITHHOLD the restart. Without
-      // the flag, convergence restarts into a sha whose init-db just failed,
-      // the boot guard exits 1, systemd retries, StartLimitBurst is exhausted,
-      // and the unit is dead — on each co-hosted gateway as its tick arrives.
+      // the flag, convergence restarts into a sha whose init-db just failed and
+      // the boot guard exits 1. Note the units here run RestartSec=5 against a
+      // 10s StartLimitInterval, so StartLimitBurst=5 can never trip: the result
+      // is an UNBOUNDED crash loop, not a stopped unit. Each iteration re-enters
+      // the boot schema guard and re-runs init-db against a live store.
       return { updated: false, error: msg, converge: false };
     }
   } else {
@@ -540,9 +542,11 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
       // converge:false — this branch exists to WITHHOLD the restart. Without
-      // the flag, convergence restarts into a sha whose init-db just failed,
-      // the boot guard exits 1, systemd retries, StartLimitBurst is exhausted,
-      // and the unit is dead — on each co-hosted gateway as its tick arrives.
+      // the flag, convergence restarts into a sha whose init-db just failed and
+      // the boot guard exits 1. Note the units here run RestartSec=5 against a
+      // 10s StartLimitInterval, so StartLimitBurst=5 can never trip: the result
+      // is an UNBOUNDED crash loop, not a stopped unit. Each iteration re-enters
+      // the boot schema guard and re-runs init-db against a live store.
       return { updated: false, error: msg, converge: false };
     }
   }

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -193,7 +193,7 @@ export const _lockPrimitivesForTest = { acquireLock, releaseLock, lockIsStale };
  * Check for and apply updates
  * Returns { updated, from, to, error, skipped?, message?, branch? }
  */
-export async function checkForUpdates() {
+export async function checkForUpdates({ instance = null } = {}) {
   const log = (msg) => console.log(`[auto-update] ${msg}`);
   try {
     const branch = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
@@ -208,19 +208,47 @@ export async function checkForUpdates() {
     }
     const lock = await lockPath();
     const held = lock ? acquireLock(lock) : null;
+    let treeResult = { updated: false };
+    let pulled = false;
+
     if (lock && !held) {
+      // NOT an error, and NOT a reason to stop. The tree is shared: another
+      // co-hosted gateway is pulling it, which is exactly right. This instance
+      // skips the PULL and still converges itself below. Before this split it
+      // returned here — and since co-hosted gateways restart together, their
+      // timers are phase-locked and the same instance lost every tick forever,
+      // never migrating its own stores and never restarting into the new code.
       const info = readLock(lock);
-      const msg = `Skipped: another updater is running (pid ${info?.pid ?? "unknown"})`;
+      const msg = `Tree pull skipped: another instance holds the checkout lock (pid ${info?.pid ?? "unknown"})`;
       log(msg);
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
-      return { updated: false, skipped: "locked", message: msg };
+      treeResult = { updated: false, skipped: "locked", message: msg };
+    } else {
+      try {
+        treeResult = await runLockedUpdate(log);
+      } finally {
+        if (held) releaseLock(held);
+      }
+      pulled = Boolean(treeResult?.updated);
     }
-    try {
-      return await runLockedUpdate(log);
-    } finally {
-      if (held) releaseLock(held);
+
+    // A process must honor its OWN refusal. runLockedUpdate returns
+    // converge:false on the branches whose whole purpose is to withhold a
+    // restart; a peer may still converge (it refused nothing, and the
+    // quarantine markers guard the genuinely-bad shas), but this process
+    // must not restart into code it just declined.
+    if (treeResult?.converge === false) {
+      log("instance half skipped — this process's own update refused a restart");
+      return { ...treeResult, pulled, converged: false, skipped: "refused" };
     }
+
+    // The INSTANCE half — for every gateway, lock or no lock. APP_ROOT is
+    // passed explicitly: convergence's own fallback resolves from
+    // import.meta.url, which is the real worktree even under a test fixture.
+    const { convergeInstance } = await import("./convergence.js");
+    const conv = await convergeInstance({ appRoot: APP_ROOT, instance, pulled, log });
+    return { ...treeResult, pulled, converged: conv.converged, applied: conv.applied };
   } catch (err) {
     const msg = `Update error: ${err.message}`;
     console.error(`[auto-update] ${msg}`);
@@ -438,7 +466,7 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
         log(msg);
         await saveSetting("auto_update_last_check", new Date().toISOString());
         await saveSetting("auto_update_last_result", msg);
-        return { updated: false, error: msg, quarantined: true };
+        return { updated: false, error: msg, quarantined: true, converge: false };
       }
       // Fail closed: the guard restored the backup and quarantined the sha.
       // Roll the code back to match the restored schema — but never destroy
@@ -461,7 +489,7 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
       // The live process's DB handles still pin the pre-restore inode —
       // restart IMMEDIATELY so the process reopens the restored file.
       scheduleSupervisedRestart(log, "Restarting to reopen the restored database...");
-      return { updated: false, error: msg, quarantined: true };
+      return { updated: false, error: msg, quarantined: true, converge: false };
     }
     if (res.initDbExit !== 0) {
       const msg = `Migration failed (init-db exit ${res.initDbExit}) — restart withheld, running code unchanged`;
@@ -472,7 +500,11 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
       });
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
-      return { updated: false, error: msg };
+      // converge:false — this branch exists to WITHHOLD the restart. Without
+      // the flag, convergence restarts into a sha whose init-db just failed,
+      // the boot guard exits 1, systemd retries, StartLimitBurst is exhausted,
+      // and the unit is dead — on each co-hosted gateway as its tick arrives.
+      return { updated: false, error: msg, converge: false };
     }
   } else {
     const initRes = await run("node", ["scripts/init-db.js"]);
@@ -485,7 +517,11 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
       });
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
-      return { updated: false, error: msg };
+      // converge:false — this branch exists to WITHHOLD the restart. Without
+      // the flag, convergence restarts into a sha whose init-db just failed,
+      // the boot guard exits 1, systemd retries, StartLimitBurst is exhausted,
+      // and the unit is dead — on each co-hosted gateway as its tick arrives.
+      return { updated: false, error: msg, converge: false };
     }
   }
 
@@ -499,18 +535,20 @@ export async function runLockedUpdate(log = (m) => console.log(`[auto-update] ${
 
   log(`Updated: ${currentVersion} → ${newVersion}`);
 
-  // Restart to load the new code when supervised (systemd, launchd
-  // KeepAlive, Docker, etc.). Without a supervisor the pulled code only
-  // takes effect on the next manual restart.
-  scheduleSupervisedRestart(log, "Restarting gateway to apply update...");
-
+  // NOTE: the restart is NOT scheduled here. convergeInstance() owns it, and
+  // schedules it only AFTER running this instance's migrations and writing the
+  // boot cookie. Restarting here would fire a 1.5s exit timer while those
+  // migrations are still running — an interrupted ALTER on a live store — and
+  // the cookie, which must exist before the restart, might never be written.
+  // (The restart on the migration-guard LOSS path below stays: it exists to
+  // reopen a restored DB file and is unrelated to convergence.)
   return { updated: true, from: currentVersion, to: newVersion };
 }
 
 /** Supervised-restart machinery, shared by the normal update path and the
  *  migration-guard loss path (which must reopen the restored DB file).
  *  No-op without a supervisor. */
-function scheduleSupervisedRestart(log, message) {
+export function scheduleSupervisedRestart(log, message) {
   if (!isSupervised()) return;
   log(message);
   // Close the HTTP server first to release the port, then exit

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -145,8 +145,8 @@ function run(cmd, args, options = {}) {
 
 const LOCK_STALE_MS = 30 * 60 * 1000;
 
-async function lockPath() {
-  const r = await run("git", ["rev-parse", "--absolute-git-dir"]);
+async function lockPath(cwd) {
+  const r = await run("git", ["rev-parse", "--absolute-git-dir"], cwd ? { cwd } : {});
   if (r.code !== 0 || !r.stdout) return null; // not a git checkout → no lock possible
   return join(r.stdout, "crow-auto-update.lock");
 }
@@ -206,6 +206,37 @@ function releaseLock(path) {
   } catch {}
 }
 
+/**
+ * Acquire the checkout lock, waiting for a holder to finish.
+ *
+ * The instance half needs this: the lock-loss path is reached ONLY while
+ * another co-hosted gateway holds the lock, i.e. while it is between `git pull`
+ * and its `npm install --omit=dev` (up to 5 minutes of rewriting the SHARED
+ * node_modules) and its init-db. Converging and restarting into that window
+ * boots a gateway against a half-written dependency tree.
+ *
+ * Returns the lock path on success, or null if it could not be acquired within
+ * `waitMs` — in which case the caller must NOT converge; it retries next tick.
+ */
+export async function acquireCheckoutLock({ appRoot = null, waitMs = 6 * 60 * 1000, pollMs = 2000 } = {}) {
+  // Resolve against the caller's root, not the module's APP_ROOT: convergence
+  // is handed an explicit appRoot, and waiting on a lock for a DIFFERENT tree
+  // would silently defeat the serialization.
+  const lock = await lockPath(appRoot);
+  if (!lock) return null;
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    const held = acquireLock(lock);
+    if (held) return held;
+    if (Date.now() >= deadline) return null;
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+export function releaseCheckoutLock(path) {
+  if (path) releaseLock(path);
+}
+
 /** Test-only: the lock primitives, unit-tested directly (they are not
  *  exported for production use — checkForUpdates()/runLockedUpdate() are the
  *  real callers). */
@@ -246,6 +277,17 @@ export async function checkForUpdates({ instance = null } = {}) {
       await saveSetting("auto_update_last_check", new Date().toISOString());
       await saveSetting("auto_update_last_result", msg);
       treeResult = { updated: false, skipped: "locked", message: msg };
+
+      // Record what the tree is moving to even though we did not pull it.
+      // auto_update_latest_version is otherwise written ONLY inside
+      // runLockedUpdate, which the loser never enters — which is exactly why
+      // the primary's latest_version sat 16 commits BEHIND its own current
+      // while last_result read "another updater is running". The holder has
+      // just fetched, so origin/main is fresh.
+      try {
+        const om = await run("git", ["rev-parse", "--short", "origin/main"]);
+        if (om.code === 0 && om.stdout) await saveSetting("auto_update_latest_version", om.stdout);
+      } catch {}
     } else {
       try {
         treeResult = await runLockedUpdate(log);

--- a/servers/gateway/auto-update.js
+++ b/servers/gateway/auto-update.js
@@ -22,6 +22,28 @@ export function _setAppRootForTest(dir) {
   APP_ROOT = dir;
 }
 
+const JITTER_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * A stable per-instance offset for the first update check.
+ *
+ * Co-hosted gateways restart together, so a fixed 5-minute first check put all
+ * of them on the same millisecond forever: their checks landed 475ms apart and
+ * the same instance lost the lock every single tick. Deriving the offset from
+ * the instance's data dir de-phases them permanently and survives restarts.
+ *
+ * This is robustness, not the fix — the fix is that the lock loser converges
+ * anyway (see convergence.js). Jitter only makes contention rare.
+ */
+export function instanceJitterMs(key) {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h % JITTER_WINDOW_MS;
+}
+
 const DEFAULT_INTERVAL_HOURS = 6;
 const MIN_INTERVAL_HOURS = 1;
 
@@ -596,28 +618,36 @@ export async function startAutoUpdate(database, { noAuth = false } = {}) {
 
   const settings = await getSettings();
 
+  // Record the sha this process is ACTUALLY running, BEFORE any early return.
+  // This used to sit below the disabled-in-settings return, so a disabled
+  // instance froze its reported version at whatever it was when it was last
+  // enabled — while continuing to run whatever the shared checkout moved to.
+  // The bookkeeping and the running code disagreed and nothing detected it.
+  try {
+    const ref = await run("git", ["rev-parse", "--short", "HEAD"]);
+    if (ref.code === 0 && ref.stdout) await saveSetting("auto_update_current_version", ref.stdout);
+  } catch {}
+
   if (settings.auto_update_enabled !== "true") {
     console.log("[auto-update] Disabled in settings");
     return;
   }
 
-  // Save current version on startup
-  try {
-    const ref = await run("git", ["rev-parse", "--short", "HEAD"]);
-    await saveSetting("auto_update_current_version", ref.stdout);
-  } catch {}
-
   const hours = Math.max(MIN_INTERVAL_HOURS, parseInt(settings.auto_update_interval_hours, 10) || DEFAULT_INTERVAL_HOURS);
   const intervalMs = hours * 60 * 60 * 1000;
 
-  console.log(`[auto-update] Enabled — checking every ${hours}h`);
+  const { resolveDataDir } = await import("../db.js");
+  const firstDelay = 5 * 60 * 1000 + instanceJitterMs(resolveDataDir());
+  console.log(`[auto-update] Enabled — checking every ${hours}h (first check in ${Math.round(firstDelay / 1000)}s)`);
 
-  // First check after 5 minutes (let gateway fully start)
+  // First check after ~5 minutes plus a per-instance offset (let the gateway
+  // fully start, and keep co-hosted instances off the same millisecond).
   updateTimer = setTimeout(async () => {
-    await tickCheck();
-    // Then schedule recurring checks
+    // tickCheck now reaches runMigrations, which CAN reject; an unhandled
+    // rejection in this timer would take the gateway down.
+    await tickCheck().catch((e) => console.error("[auto-update] tick failed:", e.message));
     updateTimer = setInterval(() => { tickCheck().catch(() => {}); }, intervalMs);
-  }, 5 * 60 * 1000);
+  }, firstDelay);
 }
 
 /**

--- a/servers/gateway/boot/post-listen.js
+++ b/servers/gateway/boot/post-listen.js
@@ -187,6 +187,62 @@ export async function runPostListenSetup(server, app, deps) {
     console.error("[auto-update] Failed to start:", err.message);
   });
 
+  // Post-settle migration pass + verification of the convergence that caused
+  // this restart, if there was one.
+  import("../convergence.js").then(async (conv) => {
+    const { healthSnapshot, addonsSettled } = await import("../proxy.js");
+    const { dirname, join } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+    const appRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+    const inst = await conv.resolveInstance();
+
+    // Wait for addon loading to finish, but never forever: a loader that hangs
+    // must not strand the cookie, because the NEXT boot would read an expired
+    // cookie and quarantine a sha that was healthy all along. A timeout yields
+    // `unknown` (fail open), never `failed`.
+    const settledOrTimeout = () =>
+      Promise.race([
+        addonsSettled().then(() => "settled"),
+        new Promise((r) => setTimeout(() => r("timeout"), 10 * 60 * 1000).unref()),
+      ]);
+    const how = await settledOrTimeout();
+
+    // SECOND registry pass. The boot pass runs before serving, when crow.db's
+    // tables exist but bundle-owned stores do NOT — the tasks bundle creates
+    // tasks_items only once it starts, which is after boot. A boot-only
+    // registry defers tasks_items and then never retries, because a current
+    // instance short-circuits its ticks on bootSha === HEAD. Idempotent by
+    // construction: applied ids are skipped by record.
+    try {
+      const { runMigrations } = await import("../../../scripts/migrations/runner.mjs");
+      const r2 = await runMigrations({
+        migrationsDir: join(appRoot, "scripts", "migrations"),
+        dbPath: inst.dbPath,
+        tasksDbPath: inst.tasksDbPath,
+        log: (m) => console.log(`[migrations:post-settle] ${m}`),
+      });
+      if (r2.applied.length) console.log(`[migrations:post-settle] applied: ${r2.applied.join(", ")}`);
+      if (r2.deferred.length) {
+        console.warn(`[migrations:post-settle] still deferred: ${r2.deferred.join(", ")} — the owning bundle may not be installed`);
+      }
+    } catch (err) {
+      console.warn("[migrations:post-settle] skipped:", err.message);
+    }
+
+    await conv.verifyPendingConvergence({
+      dataDir: inst.dataDir,
+      appRoot,
+      bootSha: conv.getBootSha(),
+      // On timeout the gate cannot know: throwing routes into the fail-open
+      // catch rather than comparing against addons that were never attempted.
+      snapshot: how === "timeout"
+        ? () => { throw new Error("addon loading never settled"); }
+        : healthSnapshot,
+      settled: async () => {},
+      log: (m) => console.log(`[convergence] ${m}`),
+    });
+  }).catch((err) => console.warn("[convergence] verification skipped:", err.message));
+
   // Bring up alwaysResident vLLM bundles (embed, etc.) via gpu-orchestrator.
   // Non-fatal — if docker isn't available the gateway still runs; bundles
   // just have to be started manually.

--- a/servers/gateway/convergence.js
+++ b/servers/gateway/convergence.js
@@ -196,6 +196,10 @@ let _restartImpl = null;
  *  suite-wide precisely so code under test never arms those paths. */
 export function _setRestartForTest(fn) { _restartImpl = fn; }
 
+let _lockWaitOpts = null;
+/** Test-only: shorten the wait for the tree to go quiescent. */
+export function _setLockWaitForTest(opts) { _lockWaitOpts = opts; }
+
 let _supervisedImpl = null;
 /** Test-only: the harness deliberately runs unsupervised, but the convergence
  *  path still has to be exercisable. */
@@ -214,6 +218,45 @@ async function supervised() {
 }
 
 /* ------------------------------------------------------------- convergence */
+
+/**
+ * Can this instance safely restart into the code now on disk?
+ *
+ * Returns true when the store needs no schema init, or when a guarded init-db
+ * brings it current. Returns false when the schema is behind and cannot be
+ * migrated — the caller must then keep the live process rather than restart
+ * into a boot guard that will exit(1).
+ */
+async function schemaReadyForRestart({ appRoot, dbPath, log }) {
+  try {
+    const { SCHEMA_GENERATION, needsSchemaInit } = await import("../shared/schema-version.js");
+    const guard = await import("../shared/migration-guard.js");
+    const state = guard.readSchemaState(dbPath);
+    if (!needsSchemaInit({
+      coreTableCount: state.coreTableCount,
+      userVersion: state.userVersion,
+      schemaGeneration: SCHEMA_GENERATION,
+    })) return true;
+
+    log(`schema behind (user_version=${state.userVersion} < ${SCHEMA_GENERATION}) — running guarded init-db before restart`);
+    const res = await guard.runGuardedInitDb({
+      dbPath, appRoot, sha: null, newGeneration: SCHEMA_GENERATION,
+      log: (m) => log(`[migration-guard] ${m}`),
+    });
+    if (res.verdict === "loss" || res.initDbExit !== 0) return false;
+
+    const after = guard.readSchemaState(dbPath);
+    return !needsSchemaInit({
+      coreTableCount: after.coreTableCount,
+      userVersion: after.userVersion,
+      schemaGeneration: SCHEMA_GENERATION,
+    });
+  } catch (err) {
+    // Cannot determine: do not restart on a guess.
+    log(`schema pre-flight error (${err?.message}) — treating as not ready`);
+    return false;
+  }
+}
 
 /**
  * Make ONE instance current with the checkout it runs from.
@@ -258,15 +301,50 @@ export async function convergeInstance({ appRoot, instance = null, pulled = fals
     return { pulled, converged: false, skipped: "quarantined", sha: head, applied: [] };
   }
 
-  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
-  const { join: joinPath } = await import("node:path");
-  const res = await runMigrations({
-    migrationsDir: joinPath(root, "scripts", "migrations"),
-    dbPath: inst.dbPath,
-    tasksDbPath: inst.tasksDbPath,
-    sha: head,
-    log,
-  });
+  // Serialize the instance half against the TREE half. This path is reached
+  // only while another co-hosted gateway holds the checkout lock — i.e. while
+  // it is between `git pull` and its `npm install --omit=dev` (up to 5 minutes
+  // rewriting the SHARED node_modules) and its init-db. Migrating and
+  // restarting into that window boots a gateway against a half-written
+  // dependency tree, and `Restart=on-failure` with RestartSec=5 against a 10s
+  // StartLimitInterval means the resulting crash loop is UNBOUNDED.
+  //
+  // Failing to acquire is not an error: skip this tick and retry on the next.
+  const au = await import("./auto-update.js");
+  const lock = await au.acquireCheckoutLock({ appRoot: root, ...(_lockWaitOpts || {}) });
+  if (!lock) {
+    log("could not acquire the checkout lock — deferring convergence to the next tick");
+    return { pulled, converged: false, skipped: "tree-busy", sha: head, applied: [] };
+  }
+
+  try {
+    const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
+    const { join: joinPath } = await import("node:path");
+    var res = await runMigrations({
+      migrationsDir: joinPath(root, "scripts", "migrations"),
+      dbPath: inst.dbPath,
+      tasksDbPath: inst.tasksDbPath,
+      sha: head,
+      log,
+    });
+
+    // Schema pre-flight, BEFORE committing to a restart.
+    //
+    // The registry only handles additive changes. A SCHEMA_GENERATION bump is
+    // validated by whichever instance ran init-db — against ITS data. This
+    // instance's store may differ (a backfill or unique index that passed on a
+    // smaller dataset can fail here). Discovering that AFTER restarting means
+    // the boot guard exits 1 on a process we had just killed for no reason.
+    // Check now, and if the schema cannot be brought current, keep serving the
+    // live process instead.
+    const ok = await schemaReadyForRestart({ appRoot: root, dbPath: inst.dbPath, log });
+    if (!ok) {
+      log("schema pre-flight failed — restart withheld, this instance keeps running its current code");
+      return { pulled, converged: false, skipped: "schema-not-ready", sha: head, applied: res.applied };
+    }
+  } finally {
+    au.releaseCheckoutLock(lock);
+  }
 
   // Without a supervisor, the restart is a silent no-op. Writing a
   // deadline-bearing cookie and then not restarting means the deadline passes

--- a/servers/gateway/convergence.js
+++ b/servers/gateway/convergence.js
@@ -152,3 +152,142 @@ export function clearConvQuarantine({ appRoot, dataDir }) {
     try { unlinkSync(p); } catch {}
   }
 }
+
+/* --------------------------------------------------------- instance identity */
+
+import { execFile } from "node:child_process";
+
+function git(cwd, args) {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd, timeout: 120000 }, (err, so, se) =>
+      resolve({ stdout: (so || "").trim(), stderr: (se || "").trim(), code: err ? err.code || 1 : 0 }));
+  });
+}
+
+/** This process's store paths, resolved exactly as the stores themselves are. */
+export async function resolveInstance() {
+  const { resolveDataDir } = await import("../db.js");
+  const { resolveGuardDbPath } = await import("../shared/migration-guard.js");
+  const { tasksDbPath } = await import("../../scripts/pi-bots/instance-paths.mjs");
+  return {
+    dataDir: resolveDataDir(),
+    dbPath: resolveGuardDbPath(resolveDataDir),
+    tasksDbPath: tasksDbPath(),
+  };
+}
+
+/**
+ * The sha this process booted on. Convergence compares against THIS, never
+ * against `pulled`: runLockedUpdate returns updated:false on several branches
+ * AFTER the tree has already moved, so a peer deciding on that flag would sit
+ * on stale code indefinitely just because it did not personally pull.
+ */
+let BOOT_SHA = null;
+export function setBootSha(sha) { BOOT_SHA = sha || null; }
+export function getBootSha() { return BOOT_SHA; }
+
+/* ------------------------------------------------------------------- seams */
+
+let _restartImpl = null;
+/** Test-only: capture restarts instead of arming a real process exit.
+ *  scheduleSupervisedRestart sets process.exitCode = 1 and schedules a real
+ *  process.exit(1), and it is reached through a frozen ESM namespace object so
+ *  it cannot be monkeypatched. run-suite.mjs scrubs INVOCATION_ID/CROW_SUPERVISED
+ *  suite-wide precisely so code under test never arms those paths. */
+export function _setRestartForTest(fn) { _restartImpl = fn; }
+
+let _supervisedImpl = null;
+/** Test-only: the harness deliberately runs unsupervised, but the convergence
+ *  path still has to be exercisable. */
+export function _setSupervisedForTest(fn) { _supervisedImpl = fn; }
+
+async function restart(log, msg) {
+  if (_restartImpl) return _restartImpl(log, msg);
+  const au = await import("./auto-update.js");
+  return au.scheduleSupervisedRestart(log, msg);
+}
+
+async function supervised() {
+  if (_supervisedImpl) return _supervisedImpl();
+  const { isSupervised } = await import("../shared/supervisor.js");
+  return isSupervised();
+}
+
+/* ------------------------------------------------------------- convergence */
+
+/**
+ * Make ONE instance current with the checkout it runs from.
+ *
+ * The pull is a TREE operation and stays behind the checkout-scoped lock in
+ * auto-update.js — exactly one co-hosted gateway performs it. Everything here
+ * is an INSTANCE operation and runs unconditionally, including for the gateway
+ * that lost that lock. Before this split the loser returned early and therefore
+ * never migrated its own stores and never restarted into the new code; with all
+ * gateways restarting together their timers are phase-locked, so the same
+ * instance lost every tick, forever.
+ */
+export async function convergeInstance({ appRoot, instance = null, pulled = false, log = () => {} } = {}) {
+  if (process.env.CROW_DISABLE_CONVERGE === "1" || process.env.CROW_DISABLE_CONVERGE === "true") {
+    log("convergence disabled via CROW_DISABLE_CONVERGE");
+    return { pulled, converged: false, skipped: "disabled", sha: null, applied: [] };
+  }
+
+  const { dirname } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+  const root = appRoot || dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+  const inst = instance || (await resolveInstance());
+
+  const head = (await git(root, ["rev-parse", "HEAD"])).stdout;
+  const boot = getBootSha();
+
+  // A null sha is a REFUSAL, not a licence. setBootSha is best-effort; treating
+  // null as "not current" would converge and restart on every tick forever, and
+  // the health gate could not stop it (classifyPending with a null bootSha
+  // returns "stale", clearing the cookie without ever verifying).
+  if (!head) return { pulled, converged: false, skipped: "no-head", sha: null, applied: [] };
+  if (!boot) return { pulled, converged: false, skipped: "no-boot-sha", sha: head, applied: [] };
+  if (boot === head) return { pulled, converged: false, skipped: "current", sha: head, applied: [] };
+
+  // Peers honor a quarantine written by whichever instance converged first —
+  // that instance is the canary by construction. This gates the MIGRATE AND
+  // RESTART only; the tree half above has already run, so the checkout can
+  // always move past a bad sha and the marker's expiry can fire.
+  const q = readConvQuarantine({ appRoot: root, dataDir: inst.dataDir });
+  if (q && q.sha === head) {
+    log(`refusing to converge: ${head.slice(0, 9)} is quarantined (${q.why})`);
+    return { pulled, converged: false, skipped: "quarantined", sha: head, applied: [] };
+  }
+
+  const { runMigrations } = await import("../../scripts/migrations/runner.mjs");
+  const { join: joinPath } = await import("node:path");
+  const res = await runMigrations({
+    migrationsDir: joinPath(root, "scripts", "migrations"),
+    dbPath: inst.dbPath,
+    tasksDbPath: inst.tasksDbPath,
+    sha: head,
+    log,
+  });
+
+  // Without a supervisor, the restart is a silent no-op. Writing a
+  // deadline-bearing cookie and then not restarting means the deadline passes
+  // and the next boot — hours later, on code that ran fine the whole time —
+  // classifies it "failed" and quarantines a healthy sha for every instance
+  // sharing this checkout.
+  if (!(await supervised())) {
+    log(`migrations applied for ${head.slice(0, 9)}; no supervisor — restart manually to load the new code`);
+    return { pulled, converged: false, skipped: "unsupervised", sha: head, applied: res.applied };
+  }
+
+  // Baseline BEFORE the restart, from the still-live process, handed across in
+  // the cookie. An empty baseline never regresses — the correct fail-open read.
+  let baseline = {};
+  try {
+    const p = await import("./proxy.js");
+    baseline = p.healthSnapshot();
+  } catch { /* proxy not initialized — fail open */ }
+
+  writePending(inst.dataDir, { sha: head, baseline });
+  await restart(log, `Restarting to run ${head.slice(0, 9)}...`);
+
+  return { pulled, converged: true, sha: head, applied: res.applied };
+}

--- a/servers/gateway/convergence.js
+++ b/servers/gateway/convergence.js
@@ -291,3 +291,72 @@ export async function convergeInstance({ appRoot, instance = null, pulled = fals
 
   return { pulled, converged: true, sha: head, applied: res.applied };
 }
+
+/* -------------------------------------------------------- boot verification */
+
+/**
+ * Called at boot. Decides what the cookie left behind by the previous
+ * convergence means, and quarantines the sha if that convergence did not prove
+ * itself healthy.
+ *
+ * `snapshot` and `settled` are injected so tests need not wait on the real
+ * addon-connect loop.
+ */
+export async function verifyPendingConvergence({
+  dataDir, appRoot, bootSha, snapshot, settled,
+  now = Date.now(), log = () => {},
+}) {
+  const pending = readPending(dataDir);
+  const verdict = classifyPending(pending, bootSha, now);
+
+  if (verdict === "none") return { verdict: "none" };
+  if (verdict === "stale") { clearPending(dataDir); return { verdict: "stale" }; }
+
+  const quarantine = async (sha, regressions, why) => {
+    writeConvQuarantine({ appRoot, dataDir, sha, regressions, why });
+    clearPending(dataDir);
+    try {
+      const { fireMigrationAlert } = await import("../shared/migration-guard.js");
+      await fireMigrationAlert({
+        title: "Crow update quarantined: convergence failed",
+        body:
+          `This instance converged to ${String(sha).slice(0, 9)} and ${why}. That sha is ` +
+          `quarantined for 24h — no gateway on this host will converge to it, so the first ` +
+          `instance to try is the only one affected. The tree was NOT rolled back: ` +
+          `co-hosted instances may be running it healthily.`,
+      });
+    } catch { /* alerting must never turn a quarantine into a crash */ }
+    log(`convergence to ${String(sha).slice(0, 9)} quarantined — ${why}`);
+    return { verdict: "quarantined", regressions };
+  };
+
+  if (verdict === "failed") {
+    return quarantine(pending.sha, [], "never completed a healthy boot before its deadline");
+  }
+
+  // verdict === "verify". Everything below is wrapped: an unhandled rejection
+  // would take the gateway down on Node 22 and leave the outer promise
+  // unsettled, and the gate must fail OPEN when it cannot determine status —
+  // a false quarantine is worse than no gate at all.
+  try {
+    await settled();
+    const after = snapshot();
+    const cmp = compareHealth(pending.baseline, after);
+    if (cmp.ok) {
+      clearPending(dataDir);
+      // Clear any expired marker we may have left on a previous attempt, so
+      // stale files do not accumulate in a shared checkout.
+      clearConvQuarantine({ appRoot, dataDir });
+      log(`convergence to ${String(pending.sha).slice(0, 9)} verified healthy`);
+      return { verdict: "ok" };
+    }
+    return await quarantine(
+      pending.sha, cmp.regressions,
+      `broke ${cmp.regressions.map((r) => r.id).join(", ")}`,
+    );
+  } catch (err) {
+    clearPending(dataDir);
+    log(`health gate indeterminate (${err.message}) — failing open, not quarantining`);
+    return { verdict: "unknown" };
+  }
+}

--- a/servers/gateway/convergence.js
+++ b/servers/gateway/convergence.js
@@ -36,3 +36,119 @@ export function compareHealth(before, after) {
   }
   return { ok: regressions.length === 0, regressions };
 }
+
+import { readFileSync, writeFileSync, unlinkSync, renameSync } from "node:fs";
+import { join } from "node:path";
+
+/** How long a convergence has to boot and verify before we call it failed.
+ *  Must exceed the worst realistic boot: a guarded SCHEMA_GENERATION migration
+ *  plus a full SEQUENTIAL addon-connect pass (60s per addon, unbounded in
+ *  count). Too short quarantines healthy slow boots. */
+export const PENDING_TTL_MS = 15 * 60 * 1000;
+
+/** Hard expiry on a convergence quarantine. No failure mode may end in a state
+ *  recoverable only by deleting files by hand. */
+export const QUARANTINE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const PENDING_FILE = "convergence-pending.json";
+const QUARANTINE_FILE = ".crow-convergence-quarantine.json";
+
+/**
+ * Atomic write. Two properties matter:
+ *  - rename(2) is atomic, so a crash mid-write cannot leave torn JSON that
+ *    readPending would silently swallow as "nothing pending";
+ *  - the tmp path is PER-PROCESS. The repo-root quarantine marker has three
+ *    writers (one per co-hosted gateway). With a shared `${path}.tmp`, P2's
+ *    O_TRUNC can land in the middle of P1's write and P1 then renames the
+ *    resulting byte-salad into place atomically — every peer's JSON.parse
+ *    throws, readConvQuarantine returns null, and the canary's failure is
+ *    silently discarded.
+ */
+function writeAtomic(path, obj) {
+  const tmp = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(obj, null, 2));
+  renameSync(tmp, path);
+}
+
+function readJson(p) {
+  try { return JSON.parse(readFileSync(p, "utf8")); } catch { return null; }
+}
+
+/* ------------------------------------------------------------- boot cookie */
+
+export function writePending(dataDir, { sha, baseline, now = Date.now() }) {
+  const rec = { sha, baseline: baseline || {}, deadline: new Date(now + PENDING_TTL_MS).toISOString() };
+  writeAtomic(join(dataDir, PENDING_FILE), rec);
+  return rec;
+}
+
+export function readPending(dataDir) {
+  return readJson(join(dataDir, PENDING_FILE));
+}
+
+export function clearPending(dataDir) {
+  try { unlinkSync(join(dataDir, PENDING_FILE)); } catch {}
+}
+
+/**
+ * What a booting process should do about the cookie it finds.
+ *
+ *   none   — nothing pending.
+ *   verify — we ARE the boot this cookie was written for, with time left:
+ *            wait for addons to settle, snapshot, compare.
+ *   failed — the deadline passed with the cookie uncleared. Either the target
+ *            never booted, or it booted and died before verifying. Both mean
+ *            the convergence did not prove itself.
+ *   stale  — a live cookie for a sha we are not running; unrelated, discard.
+ *
+ * The deadline is checked FIRST and inclusively: a crash-looping gateway boots
+ * the target sha repeatedly, so "same sha" alone cannot distinguish healthy
+ * from wedged.
+ */
+export function classifyPending(pending, bootSha, now = Date.now()) {
+  if (!pending) return "none";
+  if (Date.parse(pending.deadline) <= now) return "failed";
+  return pending.sha === bootSha ? "verify" : "stale";
+}
+
+/* ------------------------------------------------------ convergence quarantine */
+
+/**
+ * Convergence quarantine — its OWN namespace, deliberately NOT the markers in
+ * servers/shared/migration-guard.js.
+ *
+ * Two existing readers consume those with no knowledge of why they were
+ * written: the boot guard in index.js would boot the gateway SKIPPING init-db
+ * (on an empty database, that means serving with no tables at all), and
+ * auto-update.js would block updates host-wide while printing
+ * `gen undefined->undefined` at the operator. An addon flapping must not be
+ * able to disable schema initialization.
+ *
+ * Written at BOTH repo and data level: the repo-level file is what co-hosted
+ * peers sharing the checkout read.
+ */
+export function writeConvQuarantine({ appRoot, dataDir, sha, regressions = [], why = "", now = Date.now() }) {
+  const marker = { sha, why, regressions, at: new Date(now).toISOString() };
+  for (const p of [join(appRoot, QUARANTINE_FILE), join(dataDir, QUARANTINE_FILE)]) {
+    try { writeAtomic(p, marker); } catch {}
+  }
+  return marker;
+}
+
+/** The active marker, or null. Anything past QUARANTINE_TTL_MS is ignored, so
+ *  no failure mode wedges the host permanently. */
+export function readConvQuarantine({ appRoot, dataDir, now = Date.now() }) {
+  for (const p of [join(appRoot, QUARANTINE_FILE), join(dataDir, QUARANTINE_FILE)]) {
+    const m = readJson(p);
+    if (!m) continue;
+    if (now - Date.parse(m.at) > QUARANTINE_TTL_MS) continue;
+    return m;
+  }
+  return null;
+}
+
+export function clearConvQuarantine({ appRoot, dataDir }) {
+  for (const p of [join(appRoot, QUARANTINE_FILE), join(dataDir, QUARANTINE_FILE)]) {
+    try { unlinkSync(p); } catch {}
+  }
+}

--- a/servers/gateway/convergence.js
+++ b/servers/gateway/convergence.js
@@ -1,0 +1,38 @@
+// servers/gateway/convergence.js
+//
+// An instance's job is to converge to the tree, not to pull.
+//
+// Three gateways (primary, MPA, r4) run from ONE shared ~/crow checkout with
+// three separate data dirs. Pulling is a TREE operation — exactly one winner,
+// guarded by the checkout-scoped lock in auto-update.js. Migrating and
+// restarting are INSTANCE operations that every gateway must perform with its
+// own env. Conflating the two is why the lock loser used to skip everything:
+// its own migrations and its own restart-into-new-code, forever, because
+// co-hosted gateways restart together and their 6h timers are phase-locked.
+
+/**
+ * A REGRESSION check, not an absolute one.
+ *
+ * "Every addon connected" would quarantine a perfectly good sha on any host
+ * that already had a broken addon — precisely crow's state Aug 3-5 2026, when
+ * `tasks` and `bots-sql-mcp` were down for an unrelated native-ABI reason. The
+ * gate must answer "did this update break something?", not "is everything
+ * perfect?".
+ *
+ * An addon that was already unhealthy is ignored. An addon that has vanished
+ * from the snapshot entirely counts as `missing`, which IS a regression when it
+ * was previously connected.
+ *
+ * @param {Record<string,string>|null} before pre-convergence snapshot
+ * @param {Record<string,string>|null} after  post-restart snapshot
+ * @returns {{ok: boolean, regressions: Array<{id: string, was: string, now: string}>}}
+ */
+export function compareHealth(before, after) {
+  const regressions = [];
+  for (const [id, was] of Object.entries(before || {})) {
+    if (was !== "connected") continue; // already unhealthy — not ours to blame
+    const now = (after || {})[id] ?? "missing";
+    if (now !== "connected") regressions.push({ id, was, now });
+  }
+  return { ok: regressions.length === 0, regressions };
+}

--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -239,6 +239,26 @@ try {
   }
 }
 
+// Record the sha this process booted on, for convergence. Captured once, here,
+// so every later comparison is against the code actually running rather than
+// whatever the shared checkout has since moved to. A null value makes
+// convergeInstance REFUSE (see convergence.js) — deliberately fail-safe, since
+// converging on an unknown baseline would restart on every tick forever.
+//
+// Full 40-char sha: convergeInstance compares against `git rev-parse HEAD`,
+// which is also full-length. A short sha here would make classifyPending see a
+// mismatch on every boot and silently discard the health-gate cookie.
+try {
+  const { execFileSync: _efsBoot } = await import("node:child_process");
+  const { setBootSha } = await import("./convergence.js");
+  const { dirname: _dnBoot } = await import("node:path");
+  const { fileURLToPath: _fupBoot } = await import("node:url");
+  const _rootBoot = _dnBoot(_dnBoot(_dnBoot(_fupBoot(import.meta.url))));
+  setBootSha(_efsBoot("git", ["rev-parse", "HEAD"], { cwd: _rootBoot, timeout: 10000 }).toString().trim());
+} catch (e) {
+  console.warn(`[convergence] could not record the boot sha (${e.message}) — this instance will not self-converge`);
+}
+
 // Initialize OAuth tables
 await initOAuthTables();
 

--- a/servers/gateway/proxy.js
+++ b/servers/gateway/proxy.js
@@ -266,6 +266,15 @@ function cleanupStaleAddonProcesses() {
  * Call this once at gateway startup; it spawns all configured servers.
  */
 export async function initProxyServers() {
+  // The settled signal MUST fire however this function exits — the early
+  // `configured.length === 0` return, a throw from any loader, or the normal
+  // path. initProxyServers is invoked fire-and-forget with a .catch in
+  // boot/post-listen.js, so a signal that only fires at the end of the addon
+  // loop would never resolve on a host with no mcp-addons.json (the common
+  // fresh-install case). The convergence health gate awaits this; an unresolved
+  // promise there means the boot cookie is never cleared and the NEXT boot
+  // quarantines a sha that was healthy all along.
+  try {
   cleanupStaleAddonProcesses();
 
   const configured = INTEGRATIONS.filter((i) => {
@@ -311,6 +320,9 @@ export async function initProxyServers() {
 
   // Load bundle-installed MCP servers from <crow-home>/mcp-addons.json
   await loadAddonServers();
+  } finally {
+    _markAddonsSettled();
+  }
 }
 
 /**
@@ -645,6 +657,40 @@ async function createRemoteInstanceClient(instance) {
   ]);
 
   return client;
+}
+
+/**
+ * Addon id → connection status, for the convergence health gate.
+ *
+ * ADDONS ONLY. connectedServers also holds remote federation peers (whose status
+ * flips to "offline" whenever a crow on another machine reboots) and dynamic
+ * data backends. Including them would let a remote host's uptime quarantine
+ * this host's sha — a regression that has nothing to do with the update.
+ */
+export function healthSnapshot() {
+  const snap = {};
+  for (const [id, entry] of connectedServers) {
+    if (entry.isAddon) snap[id] = entry.status;
+  }
+  return snap;
+}
+
+let _settledResolve = null;
+const _settled = new Promise((r) => { _settledResolve = r; });
+
+/**
+ * Resolves once addon loading has finished — however it finished.
+ *
+ * Addons connect SEQUENTIALLY with a 60s CONNECT_TIMEOUT_MS each, so the total
+ * is unbounded in addon count and no fixed grace window is correct: with two
+ * addons hung on their full timeout, a third has not yet been *attempted* and
+ * would read as "missing", i.e. a false regression, on a perfectly good sha.
+ */
+export function addonsSettled() { return _settled; }
+
+/** Marked from initProxyServers' `finally`. Idempotent. */
+export function _markAddonsSettled() {
+  if (_settledResolve) { _settledResolve(); _settledResolve = null; }
 }
 
 /**

--- a/tests/convergence-two-instance.test.js
+++ b/tests/convergence-two-instance.test.js
@@ -1,0 +1,183 @@
+/**
+ * The executable gate for co-hosted convergence.
+ *
+ * TWO instance data dirs share ONE git checkout, exactly as crow-gateway /
+ * crow-mpa-gateway / crow-r4-gateway share ~/crow. Moving origin forward must
+ * leave BOTH instances migrated — including the one that LOSES the checkout
+ * lock. A review that only reads the diff cannot tell you whether a
+ * restart-into-newer-code actually migrates; this can.
+ */
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+import { checkForUpdates, _setAppRootForTest, _setDbForTest } from "../servers/gateway/auto-update.js";
+import { _setAlertChannelsForTest } from "../servers/shared/migration-guard.js";
+import {
+  setBootSha, _setRestartForTest, _setSupervisedForTest, convergeInstance,
+} from "../servers/gateway/convergence.js";
+
+// Never let the suite believe it is supervised: a systemd-launched context
+// leaks INVOCATION_ID and the restart branch would arm this process's exit.
+delete process.env.INVOCATION_ID;
+delete process.env.CROW_SUPERVISED;
+
+// The update failure paths call fireMigrationAlert. Unstubbed, the suite sends
+// a REAL ntfy push and email.
+_setAlertChannelsForTest({ sendNtfyNotification: async () => {}, sendEmailNotification: async () => {} });
+
+// The TREE half resolves its guard DB from env. Unpinned, a bare `node --test`
+// run resolves to ~/.crow/data/crow.db and migration-guard would BACK UP and
+// PRUNE the live primary instance's data dir. Pin scratch paths; RESTORE (never
+// delete) in after(), since run-suite.mjs sets these for the whole process.
+const _prevEnv = {
+  CROW_HOME: process.env.CROW_HOME,
+  CROW_DATA_DIR: process.env.CROW_DATA_DIR,
+  CROW_DB_PATH: process.env.CROW_DB_PATH,
+};
+const _scratch = mkdtempSync(join(tmpdir(), "conv-env-"));
+mkdirSync(join(_scratch, "data"), { recursive: true });
+process.env.CROW_HOME = _scratch;
+process.env.CROW_DATA_DIR = join(_scratch, "data");
+process.env.CROW_DB_PATH = join(_scratch, "data", "crow.db");
+
+const REAL_APP_ROOT = join(import.meta.dirname, "..");
+const g = (cwd, ...a) => execFileSync("git", a, { cwd, stdio: "pipe" }).toString().trim();
+
+/** Captured restarts, so the gate can assert without arming a real exit. */
+const restarts = [];
+
+/** Matches the shape auto-update's getSettings/saveSetting expect. */
+function stubDb(rows = [{ key: "auto_update_enabled", value: "true" }]) {
+  return {
+    execute: async ({ sql }) => (/^SELECT/i.test(sql) ? { rows } : { rows: [] }),
+  };
+}
+
+const _fixtures = [];
+after(() => {
+  _setAppRootForTest(REAL_APP_ROOT);
+  _setDbForTest(null);
+  _setRestartForTest(null);
+  _setSupervisedForTest(null);
+  setBootSha(null);
+  for (const [k, v] of Object.entries(_prevEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(_scratch, { recursive: true, force: true });
+  for (const f of _fixtures) f.cleanup();
+  _fixtures.length = 0;
+});
+
+export function twoInstanceFixture() {
+  const root = mkdtempSync(join(tmpdir(), "converge-"));
+  const origin = join(root, "origin.git");
+  const work = join(root, "work"); // the ONE shared checkout
+  execFileSync("git", ["init", "--bare", "-b", "main", origin], { stdio: "pipe" });
+  execFileSync("git", ["clone", origin, work], { stdio: "pipe" });
+  g(work, "config", "user.email", "t@t");
+  g(work, "config", "user.name", "t");
+
+  mkdirSync(join(work, "scripts", "migrations"), { recursive: true });
+  // runLockedUpdate CHECKS init-db's exit code; without a runnable one the
+  // fixture update always reports failure and withholds the restart.
+  writeFileSync(join(work, "scripts", "init-db.js"), "process.exit(0);\n");
+  g(work, "add", "-A");
+  g(work, "commit", "-m", "seed");
+  g(work, "push", "origin", "main");
+
+  const instances = ["alpha", "beta"].map((name) => {
+    const dataDir = join(root, name, "data");
+    mkdirSync(dataDir, { recursive: true });
+    const dbPath = join(dataDir, "crow.db");
+    const tasksDbPath = join(dataDir, "tasks.db");
+    const t = new Database(tasksDbPath);
+    t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
+    t.close();
+    new Database(dbPath).close();
+    return { name, dataDir, dbPath, tasksDbPath };
+  });
+
+  /** Land a new migration on origin, then rewind the shared checkout so it is
+   *  genuinely BEHIND — the state a real deploy creates. */
+  const advanceOrigin = (filename, body) => {
+    writeFileSync(join(work, "scripts", "migrations", filename), body);
+    g(work, "add", "-A");
+    g(work, "commit", "-m", `add ${filename}`);
+    g(work, "push", "origin", "main");
+    g(work, "reset", "--hard", "HEAD~1");
+  };
+
+  const f = { root, origin, work, instances, advanceOrigin,
+              cleanup: () => rmSync(root, { recursive: true, force: true }) };
+  _fixtures.push(f);
+  return f;
+}
+
+// A bare `import Database from "better-sqlite3"` cannot resolve from
+// os.tmpdir() — there is no node_modules anywhere on that path. Bake in the
+// resolved absolute URL.
+const BS3 = pathToFileURL(createRequire(import.meta.url).resolve("better-sqlite3")).href;
+
+export const MIGRATION_BODY = `
+import Database from ${JSON.stringify(BS3)};
+export const id = "0002-converge-probe";
+export function run({ tasksDbPath }) {
+  const d = new Database(tasksDbPath);
+  const have = d.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+  if (!have.includes("probe")) d.prepare("ALTER TABLE tasks_items ADD COLUMN probe TEXT").run();
+  d.close();
+}`;
+
+export function hasProbe(tasksDbPath) {
+  const d = new Database(tasksDbPath);
+  const cols = d.prepare("PRAGMA table_info(tasks_items)").all().map((c) => c.name);
+  d.close();
+  return cols.includes("probe");
+}
+
+test("BOTH co-hosted instances converge — the lock loser must not starve", async () => {
+  const f = twoInstanceFixture();
+  restarts.length = 0;
+
+  // Capture the sha we are "running" BEFORE origin moves. Without this,
+  // getBootSha() is null and convergence refuses ("no-boot-sha") before it ever
+  // reaches runMigrations — the gate would fail for the wrong reason.
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
+  f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+  _setAppRootForTest(f.work);
+
+  // The suite runs deliberately unsupervised, so convergence would otherwise
+  // stop at its supervisor guard. Inject both seams rather than setting
+  // CROW_SUPERVISED, which would arm a real process.exit(1) in this runner.
+  _setSupervisedForTest(() => true);
+  _setRestartForTest((_log, msg) => { restarts.push(msg); });
+
+  // alpha: no contention — wins the lock, pulls, converges.
+  _setDbForTest(stubDb());
+  const a = await checkForUpdates({ instance: f.instances[0] });
+
+  // beta: HOLD the lock so beta genuinely LOSES it. Sequential awaited calls do
+  // NOT contend — checkForUpdates releases in a finally — so without this beta
+  // would simply find "already up to date" and the gate would prove nothing.
+  const lockFile = join(f.work, ".git", "crow-auto-update.lock");
+  writeFileSync(lockFile, `${process.pid}\n${new Date().toISOString()}\n`);
+  _setDbForTest(stubDb());
+  const b = await checkForUpdates({ instance: f.instances[1] });
+  rmSync(lockFile, { force: true });
+
+  assert.equal(b.skipped, "locked", "beta must actually have taken the lock-loss path");
+  assert.ok(hasProbe(f.instances[0].tasksDbPath), "alpha (lock winner) must be migrated");
+  assert.ok(hasProbe(f.instances[1].tasksDbPath),
+    "beta LOST the lock and must STILL migrate its own stores — this is the starvation bug");
+  assert.equal(a.pulled, true, "the lock winner performs the pull");
+  assert.equal(b.pulled, false, "the lock loser must not pull — the tree is shared");
+  assert.equal(b.converged, true, "the lock loser must still converge");
+  assert.equal(restarts.length, 2, "each converging instance restarts exactly once");
+});

--- a/tests/convergence-two-instance.test.js
+++ b/tests/convergence-two-instance.test.js
@@ -11,7 +11,7 @@ import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -20,6 +20,7 @@ import { checkForUpdates, _setAppRootForTest, _setDbForTest } from "../servers/g
 import { _setAlertChannelsForTest } from "../servers/shared/migration-guard.js";
 import {
   setBootSha, _setRestartForTest, _setSupervisedForTest, convergeInstance,
+  readPending,
 } from "../servers/gateway/convergence.js";
 
 // Never let the suite believe it is supervised: a systemd-launched context
@@ -180,4 +181,84 @@ test("BOTH co-hosted instances converge — the lock loser must not starve", asy
   assert.equal(b.pulled, false, "the lock loser must not pull — the tree is shared");
   assert.equal(b.converged, true, "the lock loser must still converge");
   assert.equal(restarts.length, 2, "each converging instance restarts exactly once");
+});
+
+test("convergeInstance writes the cookie with the REAL pre-restart baseline", async () => {
+  const f = twoInstanceFixture();
+  restarts.length = 0;
+  const { connectedServers } = await import("../servers/gateway/proxy.js");
+  connectedServers.clear();
+  connectedServers.set("tasks", { status: "connected", isAddon: true });
+  _setSupervisedForTest(() => true);
+  _setRestartForTest((_log, msg) => { restarts.push(msg); });
+  try {
+    setBootSha(g(f.work, "rev-parse", "HEAD"));
+    f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+    // Fast-forward the shared checkout the way the tree half would.
+    g(f.work, "pull", "--ff-only", "origin", "main");
+
+    await convergeInstance({ appRoot: f.work, instance: f.instances[0] });
+
+    const p = readPending(f.instances[0].dataDir);
+    assert.ok(p, "convergence MUST write the cookie before restarting");
+    assert.equal(p.sha, g(f.work, "rev-parse", "HEAD"));
+    assert.deepEqual(p.baseline, { tasks: "connected" },
+      "the baseline must be the live snapshot, not an empty object");
+    assert.equal(restarts.length, 1, "exactly one restart per convergence");
+  } finally { connectedServers.clear(); }
+});
+
+test("a CURRENT instance does not converge; a null boot sha REFUSES", async () => {
+  const f = twoInstanceFixture();
+  restarts.length = 0;
+  _setSupervisedForTest(() => true);
+  _setRestartForTest((_log, msg) => { restarts.push(msg); });
+  const head = g(f.work, "rev-parse", "HEAD");
+
+  setBootSha(head);
+  const cur = await convergeInstance({ appRoot: f.work, instance: f.instances[0] });
+  assert.equal(cur.skipped, "current",
+    "an up-to-date instance must not migrate and restart on every tick");
+
+  setBootSha(null);
+  const nul = await convergeInstance({ appRoot: f.work, instance: f.instances[0] });
+  assert.equal(nul.skipped, "no-boot-sha",
+    "a null boot sha must REFUSE — treating it as 'not current' converges forever");
+
+  assert.equal(restarts.length, 0, "neither case may restart");
+});
+
+test("an UNSUPERVISED instance migrates but writes NO cookie", async () => {
+  const f = twoInstanceFixture();
+  restarts.length = 0;
+  _setSupervisedForTest(() => false);
+  _setRestartForTest((_log, msg) => { restarts.push(msg); });
+
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
+  f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+  g(f.work, "pull", "--ff-only", "origin", "main");
+
+  const r = await convergeInstance({ appRoot: f.work, instance: f.instances[1] });
+  assert.equal(r.skipped, "unsupervised");
+  assert.equal(readPending(f.instances[1].dataDir), null,
+    "no supervisor means no restart — a cookie here would expire and quarantine a HEALTHY sha");
+  assert.equal(restarts.length, 0);
+  assert.ok(hasProbe(f.instances[1].tasksDbPath), "migrations still ran");
+});
+
+test("the restart is scheduled by convergence ONLY, never by the update's success path", () => {
+  // The success path returning without a restart is not observable from a test
+  // (scheduleSupervisedRestart no-ops unsupervised), so anchor on the source —
+  // the same technique the boot ORDER INVARIANT test uses. A restart there
+  // fires a 1.5s exit timer while convergence is still migrating.
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "auto-update.js"), "utf8");
+  const successReturn = src.indexOf("return { updated: true, from: currentVersion, to: newVersion };");
+  assert.ok(successReturn > 0, "the success return must be present");
+
+  const before = src.slice(0, successReturn);
+  const lastRestart = before.lastIndexOf("scheduleSupervisedRestart(");
+  const lossPath = before.lastIndexOf("Restarting to reopen the restored database");
+  assert.ok(lastRestart < lossPath,
+    "the only scheduleSupervisedRestart before the success return must be the " +
+    "migration-guard LOSS path (which reopens a restored DB file); convergence owns the rest");
 });

--- a/tests/convergence-two-instance.test.js
+++ b/tests/convergence-two-instance.test.js
@@ -20,7 +20,7 @@ import { checkForUpdates, _setAppRootForTest, _setDbForTest } from "../servers/g
 import { _setAlertChannelsForTest } from "../servers/shared/migration-guard.js";
 import {
   setBootSha, _setRestartForTest, _setSupervisedForTest, convergeInstance,
-  readPending,
+  readPending, writePending, verifyPendingConvergence, readConvQuarantine,
 } from "../servers/gateway/convergence.js";
 
 // Never let the suite believe it is supervised: a systemd-launched context
@@ -261,4 +261,120 @@ test("the restart is scheduled by convergence ONLY, never by the update's succes
   assert.ok(lastRestart < lossPath,
     "the only scheduleSupervisedRestart before the success return must be the " +
     "migration-guard LOSS path (which reopens a restored DB file); convergence owns the rest");
+});
+
+test("a health regression quarantines the sha; peers then refuse to converge to it", async () => {
+  const f = twoInstanceFixture();
+  const [alpha, beta] = f.instances;
+  _setSupervisedForTest(() => true);
+  _setRestartForTest(() => {});
+
+  // Quarantine the fixture's ACTUAL head: in production the shared tree STAYS
+  // at the bad sha, which is the case this design has to survive.
+  const badSha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha: badSha, baseline: { "pm-workspace": "connected" } });
+
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: badSha,
+    snapshot: () => ({ "pm-workspace": "error" }),
+    settled: async () => {},
+  });
+
+  assert.equal(out.verdict, "quarantined");
+  assert.deepEqual(out.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
+  assert.equal(readPending(alpha.dataDir), null, "the cookie must be cleared either way");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }).sha, badSha);
+
+  // beta shares the checkout and must now refuse that sha.
+  setBootSha("something-older");
+  const r = await convergeInstance({ appRoot: f.work, instance: beta });
+  assert.equal(r.converged, false, "a peer must not converge to a quarantined sha");
+  assert.equal(r.skipped, "quarantined");
+});
+
+test("a healthy convergence clears the cookie and quarantines nothing", async () => {
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha, baseline: { tasks: "connected" } });
+
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    snapshot: () => ({ tasks: "connected" }), settled: async () => {},
+  });
+
+  assert.equal(out.verdict, "ok");
+  assert.equal(readPending(alpha.dataDir), null);
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }), null,
+    "a healthy convergence must not quarantine");
+});
+
+test("an EXPIRED cookie quarantines — the crash-loop case", async () => {
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sha = g(f.work, "rev-parse", "HEAD");
+
+  // Written 20 minutes ago with a 15-minute TTL: the previous convergence
+  // booted the target sha and died before it could verify itself.
+  writePending(alpha.dataDir, { sha, baseline: {}, now: Date.now() - 20 * 60 * 1000 });
+
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    snapshot: () => ({}), settled: async () => {},
+  });
+
+  assert.equal(out.verdict, "quarantined", "an expired cookie means the convergence failed");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }).sha, sha);
+  assert.equal(readPending(alpha.dataDir), null);
+});
+
+test("a STALE cookie just clears, and never quarantines", async () => {
+  // A SEPARATE fixture: the quarantine marker is written at the REPO level so
+  // co-hosted peers see it, which means a fixture carrying an earlier
+  // quarantine would leak into this assertion.
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sha = g(f.work, "rev-parse", "HEAD");
+
+  writePending(alpha.dataDir, { sha: "some-other-sha", baseline: {} });
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    snapshot: () => ({}), settled: async () => {},
+  });
+
+  assert.equal(out.verdict, "stale");
+  assert.equal(readPending(alpha.dataDir), null, "a stale cookie is cleared");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }), null,
+    "a stale cookie must NOT quarantine");
+});
+
+test("a snapshot that throws FAILS OPEN and always settles", async () => {
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha, baseline: { tasks: "connected" } });
+
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    snapshot: () => { throw new Error("proxy not ready"); },
+    settled: async () => {},
+  });
+
+  // An unhandled rejection here would take the gateway down on Node 22, and the
+  // outer promise would never settle. The gate must fail OPEN when it cannot
+  // determine status — a false quarantine is worse than no gate.
+  assert.equal(out.verdict, "unknown");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }), null,
+    "an indeterminate gate must not quarantine");
+  assert.equal(readPending(alpha.dataDir), null);
+});
+
+test("post-listen wires convergence verification after startAutoUpdate", () => {
+  // Without this anchor, deleting the whole wiring block leaves every other
+  // test green while the health gate never runs in production.
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "boot", "post-listen.js"), "utf8");
+  const start = src.indexOf("startAutoUpdate(");
+  const verify = src.indexOf("verifyPendingConvergence");
+  assert.ok(start > 0, "startAutoUpdate must be present");
+  assert.ok(verify > start, "convergence verification must be wired, and after auto-update starts");
 });

--- a/tests/convergence-two-instance.test.js
+++ b/tests/convergence-two-instance.test.js
@@ -16,11 +16,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import Database from "better-sqlite3";
+import { SCHEMA_GENERATION } from "../servers/shared/schema-version.js";
 import { checkForUpdates, _setAppRootForTest, _setDbForTest } from "../servers/gateway/auto-update.js";
 import { _setAlertChannelsForTest } from "../servers/shared/migration-guard.js";
 import {
+  _setLockWaitForTest,
   setBootSha, _setRestartForTest, _setSupervisedForTest, convergeInstance,
-  readPending, writePending, verifyPendingConvergence, readConvQuarantine,
+  readPending, writePending, verifyPendingConvergence, readConvQuarantine, writeConvQuarantine,
 } from "../servers/gateway/convergence.js";
 
 // Never let the suite believe it is supervised: a systemd-launched context
@@ -60,12 +62,16 @@ function stubDb(rows = [{ key: "auto_update_enabled", value: "true" }]) {
   };
 }
 
+// Production waits up to 6 minutes for the tree to go quiescent; tests must not.
+_setLockWaitForTest({ waitMs: 5000, pollMs: 50 });
+
 const _fixtures = [];
 after(() => {
   _setAppRootForTest(REAL_APP_ROOT);
   _setDbForTest(null);
   _setRestartForTest(null);
   _setSupervisedForTest(null);
+  _setLockWaitForTest(null);
   setBootSha(null);
   for (const [k, v] of Object.entries(_prevEnv)) {
     if (v === undefined) delete process.env[k];
@@ -101,7 +107,16 @@ export function twoInstanceFixture() {
     const t = new Database(tasksDbPath);
     t.prepare("CREATE TABLE tasks_items (id INTEGER PRIMARY KEY, title TEXT)").run();
     t.close();
-    new Database(dbPath).close();
+    // Model a REAL instance's crow.db: the three tables the boot guard counts
+    // as "core", and a current user_version. A bare empty file would read as
+    // "schema behind", and convergence would correctly refuse to restart into
+    // a boot guard that is about to exit(1) — masking what this gate tests.
+    const c = new Database(dbPath);
+    for (const tbl of ["memories", "dashboard_settings", "crow_context"]) {
+      c.prepare(`CREATE TABLE ${tbl} (id INTEGER PRIMARY KEY)`).run();
+    }
+    c.pragma(`user_version = ${SCHEMA_GENERATION}`);
+    c.close();
     return { name, dataDir, dbPath, tasksDbPath };
   });
 
@@ -167,11 +182,16 @@ test("BOTH co-hosted instances converge — the lock loser must not starve", asy
   // beta: HOLD the lock so beta genuinely LOSES it. Sequential awaited calls do
   // NOT contend — checkForUpdates releases in a finally — so without this beta
   // would simply find "already up to date" and the gate would prove nothing.
+  // Then RELEASE it while beta is mid-flight, modelling the winner finishing
+  // its pull and npm install. Beta must WAIT for the tree to go quiescent and
+  // only then converge — restarting into a half-written node_modules is the
+  // failure this serialization exists to prevent.
   const lockFile = join(f.work, ".git", "crow-auto-update.lock");
   writeFileSync(lockFile, `${process.pid}\n${new Date().toISOString()}\n`);
   _setDbForTest(stubDb());
-  const b = await checkForUpdates({ instance: f.instances[1] });
-  rmSync(lockFile, { force: true });
+  const betaPromise = checkForUpdates({ instance: f.instances[1] });
+  setTimeout(() => rmSync(lockFile, { force: true }), 200);
+  const b = await betaPromise;
 
   assert.equal(b.skipped, "locked", "beta must actually have taken the lock-loss path");
   assert.ok(hasProbe(f.instances[0].tasksDbPath), "alpha (lock winner) must be migrated");
@@ -403,4 +423,114 @@ test("WIRING: setBootSha is called at gateway boot, before serving", () => {
   const call = src.slice(setBoot - 400, setBoot + 200);
   assert.ok(!/rev-parse["\s,]+.*--short/.test(call),
     "the boot sha must be the full 40-char form to match convergeInstance's comparison");
+});
+
+test("the health gate WAITS for addons to settle before snapshotting", async () => {
+  // Without this, `await settled()` is deletable and every test still passes —
+  // yet deleting it snapshots before addons connect, so every addon reads
+  // "missing", compareHealth reports a full-board regression, and a HEALTHY sha
+  // is quarantined for 24h across every co-hosted gateway.
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sha = g(f.work, "rev-parse", "HEAD");
+  writePending(alpha.dataDir, { sha, baseline: { tasks: "connected" } });
+
+  let settledYet = false;
+  const out = await verifyPendingConvergence({
+    dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+    settled: async () => { settledYet = true; },
+    snapshot: () => (settledYet ? { tasks: "connected" } : {}),  // empty until settled
+  });
+
+  assert.equal(out.verdict, "ok",
+    "the snapshot must be taken AFTER settling — otherwise addons read as missing and a good sha is quarantined");
+  assert.equal(readConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir }), null);
+});
+
+test("a quarantine for a DIFFERENT sha does not block converging to the fix", async () => {
+  // Matching any marker rather than `q.sha === head` would make a bad sha block
+  // its own fix for 24h across every gateway sharing the checkout.
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  _setSupervisedForTest(() => true);
+  _setRestartForTest(() => {});
+
+  // Quarantine an OLD sha, then move the tree forward to the "fix".
+  writeConvQuarantine({ appRoot: f.work, dataDir: alpha.dataDir, sha: "deadbee", why: "test" });
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
+  f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+  g(f.work, "pull", "--ff-only", "origin", "main");
+
+  const r = await convergeInstance({ appRoot: f.work, instance: alpha });
+  assert.equal(r.converged, true,
+    "a quarantine on a DIFFERENT sha must not block convergence to the fix");
+  assert.ok(hasProbe(alpha.tasksDbPath));
+});
+
+test("quarantine actually ALERTS the operator", async () => {
+  // The alert channels are stubbed suite-wide to avoid real pushes; without
+  // asserting they fire, the whole notification can be deleted and a silent
+  // 24h host-wide quarantine looks identical in the tests.
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const sent = [];
+  _setAlertChannelsForTest({
+    sendNtfyNotification: async (t) => { sent.push(["ntfy", t]); },
+    sendEmailNotification: async (t) => { sent.push(["email", t]); },
+  });
+  try {
+    const sha = g(f.work, "rev-parse", "HEAD");
+    writePending(alpha.dataDir, { sha, baseline: { "pm-workspace": "connected" } });
+    const out = await verifyPendingConvergence({
+      dataDir: alpha.dataDir, appRoot: f.work, bootSha: sha,
+      snapshot: () => ({ "pm-workspace": "error" }), settled: async () => {},
+    });
+    assert.equal(out.verdict, "quarantined");
+    assert.ok(sent.length > 0, "a quarantine MUST notify the operator — it is a silent 24h fleet block otherwise");
+  } finally {
+    _setAlertChannelsForTest({ sendNtfyNotification: async () => {}, sendEmailNotification: async () => {} });
+  }
+});
+
+test("convergence DEFERS while the tree is busy", async () => {
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const restarted = [];
+  _setSupervisedForTest(() => true);
+  _setRestartForTest((_l, m) => restarted.push(m));
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
+  f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+  g(f.work, "pull", "--ff-only", "origin", "main");
+
+  const lockFile = join(f.work, ".git", "crow-auto-update.lock");
+  writeFileSync(lockFile, `${process.pid}\n${new Date().toISOString()}\n`);
+  const busy = await convergeInstance({ appRoot: f.work, instance: alpha });
+  rmSync(lockFile, { force: true });
+
+  assert.equal(busy.skipped, "tree-busy",
+    "converging while the winner rewrites shared node_modules boots against a torn dependency tree");
+  assert.deepEqual(restarted, [], "a deferred convergence must not restart");
+});
+
+test("convergence WITHHOLDS the restart when this instance's schema is not ready", async () => {
+  const f = twoInstanceFixture();
+  const [alpha] = f.instances;
+  const restarted = [];
+  _setSupervisedForTest(() => true);
+  _setRestartForTest((_l, m) => restarted.push(m));
+  setBootSha(g(f.work, "rev-parse", "HEAD"));
+  f.advanceOrigin("0002-converge-probe.mjs", MIGRATION_BODY);
+  g(f.work, "pull", "--ff-only", "origin", "main");
+
+  // This store is behind, and the fixture's init-db is a no-op, so it cannot be
+  // brought current. The winner validated init-db against ITS data; discovering
+  // the failure AFTER restarting means the boot guard exits 1 on a process we
+  // just killed for no reason.
+  const c = new Database(alpha.dbPath);
+  c.pragma("user_version = 0");
+  c.close();
+
+  const r = await convergeInstance({ appRoot: f.work, instance: alpha });
+  assert.equal(r.skipped, "schema-not-ready");
+  assert.deepEqual(restarted, [], "the live process must keep running instead");
 });

--- a/tests/convergence-two-instance.test.js
+++ b/tests/convergence-two-instance.test.js
@@ -378,3 +378,29 @@ test("post-listen wires convergence verification after startAutoUpdate", () => {
   assert.ok(start > 0, "startAutoUpdate must be present");
   assert.ok(verify > start, "convergence verification must be wired, and after auto-update starts");
 });
+
+test("WIRING: setBootSha is called at gateway boot, before serving", () => {
+  // This is the test whose absence let a fully inert feature ship green. Every
+  // other convergence test supplies the boot sha itself as a seam, so the
+  // production wiring was never exercised: convergeInstance returned
+  // skipped:"no-boot-sha" on every tick, and because the restart had moved out
+  // of runLockedUpdate's success path, the gateways would have stopped applying
+  // updates entirely while reporting success.
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "index.js"), "utf8");
+
+  const setBoot = src.indexOf("setBootSha(");
+  assert.ok(setBoot > 0, "index.js MUST call setBootSha — without it convergence is a no-op fleet-wide");
+
+  // It has to run before the server starts serving, so the very first tick
+  // already has a baseline.
+  const listen = src.indexOf("app.listen(");
+  assert.ok(listen > 0, "app.listen must be present");
+  assert.ok(setBoot < listen, "the boot sha must be recorded before the gateway starts serving");
+
+  // Full sha, not --short: convergeInstance compares against `git rev-parse
+  // HEAD`. A short sha would mismatch on every boot and silently discard the
+  // health-gate cookie as "stale".
+  const call = src.slice(setBoot - 400, setBoot + 200);
+  assert.ok(!/rev-parse["\s,]+.*--short/.test(call),
+    "the boot sha must be the full 40-char form to match convergeInstance's comparison");
+});

--- a/tests/convergence-unit.test.js
+++ b/tests/convergence-unit.test.js
@@ -235,3 +235,22 @@ test("a DISABLED instance still records its ACTUAL running sha", async () => {
   assert.equal(v.value, real,
     "must be THIS checkout's sha, not merely sha-shaped — a stale or origin/main sha would pass a regex");
 });
+
+test("CROW_DISABLE_CONVERGE short-circuits convergence entirely", async () => {
+  const { convergeInstance } = await import("../servers/gateway/convergence.js");
+  const prev = process.env.CROW_DISABLE_CONVERGE;
+  process.env.CROW_DISABLE_CONVERGE = "1";
+  try {
+    // Bogus paths are deliberate: if the switch works, nothing touches the
+    // filesystem or git, so they cannot fail.
+    const r = await convergeInstance({
+      appRoot: "/nonexistent",
+      instance: { dataDir: "/nonexistent", dbPath: "/nonexistent/x.db", tasksDbPath: "/nonexistent/t.db" },
+    });
+    assert.equal(r.converged, false);
+    assert.equal(r.skipped, "disabled");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_DISABLE_CONVERGE;
+    else process.env.CROW_DISABLE_CONVERGE = prev;
+  }
+});

--- a/tests/convergence-unit.test.js
+++ b/tests/convergence-unit.test.js
@@ -6,7 +6,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { connectedServers, healthSnapshot, addonsSettled, _markAddonsSettled } from "../servers/gateway/proxy.js";
-import { compareHealth } from "../servers/gateway/convergence.js";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  compareHealth,
+  writePending, readPending, clearPending, classifyPending,
+  writeConvQuarantine, readConvQuarantine, clearConvQuarantine,
+  PENDING_TTL_MS, QUARANTINE_TTL_MS,
+} from "../servers/gateway/convergence.js";
 
 // The suite must never believe it is supervised — code under test would arm
 // real restart/exit paths inside this process.
@@ -75,4 +83,75 @@ test("compareHealth flags only REGRESSIONS, never pre-existing breakage", () => 
   assert.equal(compareHealth({}, { anything: "error" }).ok, true,
     "an empty baseline never regresses — the correct fail-open reading");
   assert.equal(compareHealth(null, null).ok, true, "null inputs must not throw");
+});
+
+test("the tuned constants are pinned to their justified values", () => {
+  // Asserting `now + PENDING_TTL_MS` uses the same constant on both sides and
+  // proves nothing. Pin the literals, with the reasoning in the message.
+  assert.equal(PENDING_TTL_MS, 15 * 60 * 1000,
+    "must exceed a guarded SCHEMA_GENERATION migration plus a full SEQUENTIAL addon-connect pass");
+  assert.equal(QUARANTINE_TTL_MS, 24 * 60 * 60 * 1000,
+    "hard expiry so no failure mode ends in a host recoverable only by manual file deletion");
+});
+
+test("boot cookie round-trips atomically and clears", () => {
+  const d = mkdtempSync(join(tmpdir(), "cookie-"));
+  try {
+    const now = Date.parse("2026-08-06T12:00:00Z");
+    writePending(d, { sha: "abc1234", baseline: { tasks: "connected" }, now });
+
+    const p = readPending(d);
+    assert.equal(p.sha, "abc1234");
+    assert.deepEqual(p.baseline, { tasks: "connected" });
+    assert.equal(Date.parse(p.deadline), now + 15 * 60 * 1000); // literal, not the constant
+
+    // The tmp file must be renamed away, never left behind.
+    assert.deepEqual(readdirSync(d), ["convergence-pending.json"]);
+
+    clearPending(d);
+    assert.equal(readPending(d), null);
+    assert.equal(existsSync(join(d, "convergence-pending.json")), false);
+  } finally { rmSync(d, { recursive: true, force: true }); }
+});
+
+test("classifyPending covers every boot case including the crash-loop", () => {
+  const now = Date.parse("2026-08-06T12:00:00Z");
+  const fresh   = { sha: "new1234", baseline: {}, deadline: new Date(now + 60_000).toISOString() };
+  const expired = { sha: "new1234", baseline: {}, deadline: new Date(now - 1).toISOString() };
+  const exact   = { sha: "new1234", baseline: {}, deadline: new Date(now).toISOString() };
+
+  assert.equal(classifyPending(null, "new1234", now), "none");
+  assert.equal(classifyPending(fresh, "new1234", now), "verify");
+  assert.equal(classifyPending(expired, "new1234", now), "failed",
+    "crash-loop: booted the target sha but died before verifying");
+  assert.equal(classifyPending(expired, "old9999", now), "failed",
+    "never booted the target sha at all");
+  assert.equal(classifyPending(fresh, "old9999", now), "stale");
+  assert.equal(classifyPending(exact, "new1234", now), "failed", "the deadline boundary is inclusive");
+});
+
+test("convergence quarantine is its OWN namespace and hard-expires", () => {
+  const root = mkdtempSync(join(tmpdir(), "convq-"));
+  const dataDir = join(root, "data");
+  mkdirSync(dataDir);
+  try {
+    const now = Date.parse("2026-08-06T12:00:00Z");
+    writeConvQuarantine({ appRoot: root, dataDir, sha: "bad1234", regressions: [{ id: "x" }], why: "broke x", now });
+
+    // It must NOT land where migration-guard's readers look: index.js reads that
+    // marker and would boot the gateway SKIPPING init-db entirely — on an empty
+    // database, that means serving with no tables at all.
+    assert.equal(existsSync(join(root, ".crow-migration-quarantine.json")), false,
+      "convergence must never write a migration-guard marker");
+    assert.ok(existsSync(join(root, ".crow-convergence-quarantine.json")), "repo-level marker for peers");
+    assert.ok(existsSync(join(dataDir, ".crow-convergence-quarantine.json")), "data-level marker");
+
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 1000 }).sha, "bad1234");
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 23 * 3600_000 }).sha, "bad1234");
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 25 * 3600_000 }), null,
+      "a quarantine older than 24h must be ignored — no permanent wedge");
+
+    clearConvQuarantine({ appRoot: root, dataDir });
+    assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 1000 }), null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
 });

--- a/tests/convergence-unit.test.js
+++ b/tests/convergence-unit.test.js
@@ -6,6 +6,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { connectedServers, healthSnapshot, addonsSettled, _markAddonsSettled } from "../servers/gateway/proxy.js";
+import { execFileSync } from "node:child_process";
+import { startAutoUpdate, stopAutoUpdate, _setDbForTest, instanceJitterMs } from "../servers/gateway/auto-update.js";
 import { mkdtempSync, mkdirSync, rmSync, existsSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -154,4 +156,82 @@ test("convergence quarantine is its OWN namespace and hard-expires", () => {
     clearConvQuarantine({ appRoot: root, dataDir });
     assert.equal(readConvQuarantine({ appRoot: root, dataDir, now: now + 1000 }), null);
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("instanceJitterMs is stable per instance and differs between instances", () => {
+  const a = instanceJitterMs("/home/kh0pp/.crow/data");
+  const b = instanceJitterMs("/home/kh0pp/.crow-mpa/data");
+  const c = instanceJitterMs("/home/kh0pp/.crow-r4/data");
+
+  assert.equal(a, instanceJitterMs("/home/kh0pp/.crow/data"), "must be deterministic across calls");
+  assert.notEqual(a, b, "co-hosted instances must not share a phase");
+  assert.notEqual(b, c);
+  assert.notEqual(a, c);
+
+  // Range over many keys, not just the three above — a missing modulo would
+  // pass a three-key check by luck.
+  for (let i = 0; i < 500; i++) {
+    const v = instanceJitterMs(`/tmp/inst-${i}/data`);
+    assert.ok(Number.isInteger(v) && v >= 0 && v < 600000, `jitter ${v} out of range for key ${i}`);
+  }
+});
+
+test("the jitter is actually WIRED IN — the first-check delay differs per instance", async () => {
+  // Without this, instanceJitterMs could be perfect and startAutoUpdate could
+  // still use a fixed delay, leaving the de-phase-locking fix dead.
+  const prevDataDir = process.env.CROW_DATA_DIR;
+  const prevAuto = process.env.CROW_AUTO_UPDATE;
+  delete process.env.CROW_AUTO_UPDATE;
+  const seen = [];
+  const origLog = console.log;
+  console.log = (...a) => seen.push(a.join(" "));
+  try {
+    for (const dir of ["/tmp/jit-a/data", "/tmp/jit-b/data"]) {
+      process.env.CROW_DATA_DIR = dir;
+      await startAutoUpdate({
+        execute: async ({ sql }) =>
+          /^SELECT/i.test(sql) ? { rows: [{ key: "auto_update_enabled", value: "true" }] } : { rows: [] },
+      }, {});
+      stopAutoUpdate();
+    }
+  } finally {
+    console.log = origLog;
+    // RESTORE, never delete: run-suite.mjs sets CROW_DATA_DIR for the whole
+    // process, and deleting it would make every later test resolve to ~/.crow.
+    if (prevDataDir === undefined) delete process.env.CROW_DATA_DIR;
+    else process.env.CROW_DATA_DIR = prevDataDir;
+    if (prevAuto !== undefined) process.env.CROW_AUTO_UPDATE = prevAuto;
+    _setDbForTest(null);
+  }
+
+  const delays = seen.filter((l) => l.includes("first check in")).map((l) => l.match(/in (\d+)s/)?.[1]);
+  assert.equal(delays.length, 2, "both starts must have logged a first-check delay");
+  assert.notEqual(delays[0], delays[1], "two instances must not share a first-check phase");
+});
+
+test("a DISABLED instance still records its ACTUAL running sha", async () => {
+  const prevAuto = process.env.CROW_AUTO_UPDATE;
+  delete process.env.CROW_AUTO_UPDATE; // shouldStartAutoUpdate gates on this
+  const writes = [];
+  const db = {
+    execute: async ({ sql, args }) => {
+      if (/^SELECT/i.test(sql)) return { rows: [{ key: "auto_update_enabled", value: "false" }] };
+      writes.push({ key: args[0], value: args[1] });
+      return { rows: [] };
+    },
+  };
+  try {
+    await startAutoUpdate(db, {});
+    stopAutoUpdate();
+  } finally {
+    if (prevAuto !== undefined) process.env.CROW_AUTO_UPDATE = prevAuto;
+    _setDbForTest(null);
+  }
+
+  const v = writes.find((w) => w.key === "auto_update_current_version");
+  assert.ok(v, "must record even when disabled — the r4 instance reported a version it had not run");
+  const real = execFileSync("git", ["rev-parse", "--short", "HEAD"],
+    { cwd: join(import.meta.dirname, "..") }).toString().trim();
+  assert.equal(v.value, real,
+    "must be THIS checkout's sha, not merely sha-shaped — a stale or origin/main sha would pass a regex");
 });

--- a/tests/convergence-unit.test.js
+++ b/tests/convergence-unit.test.js
@@ -8,13 +8,13 @@ import assert from "node:assert/strict";
 import { connectedServers, healthSnapshot, addonsSettled, _markAddonsSettled } from "../servers/gateway/proxy.js";
 import { execFileSync } from "node:child_process";
 import { startAutoUpdate, stopAutoUpdate, _setDbForTest, instanceJitterMs } from "../servers/gateway/auto-update.js";
-import { mkdtempSync, mkdirSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   compareHealth,
   writePending, readPending, clearPending, classifyPending,
-  writeConvQuarantine, readConvQuarantine, clearConvQuarantine,
+  writeConvQuarantine, readConvQuarantine, clearConvQuarantine, resolveInstance,
   PENDING_TTL_MS, QUARANTINE_TTL_MS,
 } from "../servers/gateway/convergence.js";
 
@@ -239,7 +239,7 @@ test("a DISABLED instance still records its ACTUAL running sha", async () => {
 test("CROW_DISABLE_CONVERGE short-circuits convergence entirely", async () => {
   const { convergeInstance } = await import("../servers/gateway/convergence.js");
   const prev = process.env.CROW_DISABLE_CONVERGE;
-  process.env.CROW_DISABLE_CONVERGE = "1";
+  process.env.CROW_DISABLE_CONVERGE = "true";  // the documented word form, not just "1"
   try {
     // Bogus paths are deliberate: if the switch works, nothing touches the
     // filesystem or git, so they cannot fail.
@@ -253,4 +253,74 @@ test("CROW_DISABLE_CONVERGE short-circuits convergence entirely", async () => {
     if (prev === undefined) delete process.env.CROW_DISABLE_CONVERGE;
     else process.env.CROW_DISABLE_CONVERGE = prev;
   }
+});
+
+test("resolveInstance resolves the PRODUCTION paths from env", async () => {
+  // Nothing else exercises this: every other test injects `instance` explicitly,
+  // yet production always goes through here (checkForUpdates defaults it to
+  // null). Swapping dbPath/tasksDbPath would put schema_migrations bookkeeping
+  // in tasks.db and migrate crow.db, with no test failing.
+  const prev = {
+    CROW_HOME: process.env.CROW_HOME,
+    CROW_DATA_DIR: process.env.CROW_DATA_DIR,
+    CROW_DB_PATH: process.env.CROW_DB_PATH,
+  };
+  const dir = mkdtempSync(join(tmpdir(), "resolve-inst-"));
+  mkdirSync(join(dir, "data"), { recursive: true });
+  process.env.CROW_HOME = dir;
+  process.env.CROW_DATA_DIR = join(dir, "data");
+  process.env.CROW_DB_PATH = join(dir, "data", "crow.db");
+  try {
+    const inst = await resolveInstance();
+    assert.equal(inst.dataDir, join(dir, "data"), "dataDir comes from CROW_DATA_DIR");
+    assert.ok(inst.dbPath.endsWith("crow.db"), `dbPath must be the crow store, got ${inst.dbPath}`);
+    assert.ok(inst.tasksDbPath.endsWith("tasks.db"), `tasksDbPath must be the tasks store, got ${inst.tasksDbPath}`);
+    assert.notEqual(inst.dbPath, inst.tasksDbPath, "the two stores must not resolve to the same file");
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a tree half that REFUSED a restart is not overridden by convergence", async () => {
+  // The crash-loop guard: init-db failed post-pull and the restart was
+  // deliberately withheld. Nothing else in the suite covers `converge:false`.
+  const { _setDbForTest: setDb } = await import("../servers/gateway/auto-update.js");
+  const au = await import("../servers/gateway/auto-update.js");
+  const conv = await import("../servers/gateway/convergence.js");
+
+  let converged = false;
+  conv._setRestartForTest(() => { converged = true; });
+  setDb({ execute: async ({ sql }) => (/^SELECT/i.test(sql) ? { rows: [] } : { rows: [] }) });
+  try {
+    // Drive the decision directly: a treeResult carrying converge:false must
+    // short-circuit before the instance half.
+    const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "auto-update.js"), "utf8");
+    assert.ok(src.includes("treeResult?.converge === false"),
+      "checkForUpdates must honor its own tree half's refusal");
+    assert.equal((src.match(/converge: false/g) || []).length, 4,
+      "all FOUR restart-withholding branches must be marked (2 loss paths + 2 init-db failures)");
+    assert.equal(converged, false);
+  } finally {
+    conv._setRestartForTest(null);
+    setDb(null);
+  }
+});
+
+test("WIRING: initProxyServers marks addons settled in a finally", () => {
+  // Losing this call means addonsSettled() never resolves, post-listen's race
+  // hits its 10-minute timeout on every boot, and the health gate silently
+  // disables itself — with every log line still looking correct.
+  const src = readFileSync(join(import.meta.dirname, "..", "servers", "gateway", "proxy.js"), "utf8");
+  const fn = src.indexOf("export async function initProxyServers()");
+  assert.ok(fn > 0, "initProxyServers must be present");
+  const body = src.slice(fn, src.indexOf("\n}\n", fn));
+
+  assert.ok(body.includes("_markAddonsSettled()"),
+    "initProxyServers MUST mark addons settled — otherwise the health gate never runs");
+  assert.ok(/finally\s*\{[^}]*_markAddonsSettled\(\)/.test(body),
+    "it must be in a finally: loadAddonServers returns early three ways (no mcp-addons.json, " +
+    "bad JSON, zero entries) and initProxyServers is called fire-and-forget with a .catch");
 });

--- a/tests/convergence-unit.test.js
+++ b/tests/convergence-unit.test.js
@@ -1,0 +1,78 @@
+/**
+ * Convergence unit tests — pure functions and module primitives.
+ *
+ * The two-instance integration gate lives in convergence-two-instance.test.js.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { connectedServers, healthSnapshot, addonsSettled, _markAddonsSettled } from "../servers/gateway/proxy.js";
+import { compareHealth } from "../servers/gateway/convergence.js";
+
+// The suite must never believe it is supervised — code under test would arm
+// real restart/exit paths inside this process.
+delete process.env.INVOCATION_ID;
+delete process.env.CROW_SUPERVISED;
+
+// NOTE: addonsSettled() is module state that resolves ONCE. This test must run
+// before anything else marks it, so it is deliberately first in the file.
+test("addonsSettled starts pending and resolves when marked", async () => {
+  let resolved = false;
+  addonsSettled().then(() => { resolved = true; });
+  await new Promise((r) => setImmediate(r));
+  assert.equal(resolved, false, "must not be resolved before the addon loader finishes");
+
+  _markAddonsSettled();
+  await addonsSettled();
+  assert.equal(resolved, true, "must resolve once marked");
+
+  // Idempotent: marking again must not throw or hang.
+  _markAddonsSettled();
+  await addonsSettled();
+});
+
+test("healthSnapshot reports ADDONS ONLY, reading the real status field", () => {
+  connectedServers.clear();
+  connectedServers.set("tasks", { status: "connected", isAddon: true });
+  connectedServers.set("bots-sql-mcp", { status: "error", isAddon: true });
+  connectedServers.set("instance-peer", { status: "offline", isRemote: true }); // federation peer
+  connectedServers.set("some-integration", { status: "connected" });            // integration
+  try {
+    assert.deepEqual(
+      healthSnapshot(),
+      { tasks: "connected", "bots-sql-mcp": "error" },
+      "a remote crow rebooting must never look like a LOCAL regression",
+    );
+  } finally {
+    connectedServers.clear();
+  }
+});
+
+test("compareHealth flags only REGRESSIONS, never pre-existing breakage", () => {
+  // The Aug 3-5 state: tasks and bots-sql-mcp were already down for an unrelated
+  // native-ABI reason. An absolute "all green" gate would have quarantined every
+  // good sha for that entire window.
+  const before = { tasks: "error", "bots-sql-mcp": "error", "pm-workspace": "connected" };
+
+  assert.equal(compareHealth(before, { ...before }).ok, true,
+    "already-broken addons must NOT count as a regression");
+  assert.equal(compareHealth(before, { ...before, tasks: "connected" }).ok, true,
+    "an addon getting BETTER is not a regression");
+
+  const broke = compareHealth(before, { ...before, "pm-workspace": "error" });
+  assert.equal(broke.ok, false, "a connected addon going to error IS a regression");
+  assert.deepEqual(broke.regressions, [{ id: "pm-workspace", was: "connected", now: "error" }]);
+
+  // "disconnected" is the transport.onclose path — the likeliest real regression.
+  assert.equal(compareHealth(before, { ...before, "pm-workspace": "disconnected" }).ok, false);
+
+  const vanished = compareHealth(before, { tasks: "error", "bots-sql-mcp": "error" });
+  assert.equal(vanished.ok, false, "an addon that disappears entirely is a regression");
+  assert.deepEqual(vanished.regressions, [{ id: "pm-workspace", was: "connected", now: "missing" }]);
+
+  const multi = compareHealth({ a: "connected", b: "connected" }, { a: "error", b: "error" });
+  assert.equal(multi.regressions.length, 2, "every regression must be reported, not just the first");
+
+  assert.equal(compareHealth({}, { anything: "error" }).ok, true,
+    "an empty baseline never regresses — the correct fail-open reading");
+  assert.equal(compareHealth(null, null).ok, true, "null inputs must not throw");
+});


### PR DESCRIPTION
Follow-on to #273. That PR made migrations travel with code; this one makes the *update path* correct for co-hosted gateways.

## The bug, with evidence

Three gateways run from one shared `~/crow` checkout. The updater's lock lives at `<git-dir>/crow-auto-update.lock` — one lock per **checkout**, shared by all three. They restart together, so their "+5min then every 6h" timers are phase-locked. Measured on the dev host:

- primary last check `01:23:48.545Z`, MPA `01:23:49.020Z` — **475 ms apart**, colliding every tick
- MPA won; primary got `Skipped: another updater is running (pid 1333991)` — which is MPA's MainPID
- primary's `auto_update_latest_version` sat **16 commits behind its own `current`** — not merely stale, backwards, because the loser never reaches the code that writes it

The loser did not just skip the pull (correct — the tree is shared). It skipped **everything**: its own migrations and its own restart-into-new-code. Same phase every tick means the same loser loses forever. Deterministic starvation, not a race.

## The model

`checkForUpdates()` is restructured, not supplemented — the scheduled tick stays the one production path:

```
lock ← acquire(checkout lock)
if held:  treeResult ← runLockedUpdate()   # tree half, one winner
else:     log, continue                    # normal, not an error
release(lock)
convergeInstance()                         # instance half, ALWAYS
```

## Design points worth review

**Convergence owns the restart.** Scheduling it in `runLockedUpdate`'s success path fired a 1.5 s exit timer while migrations were still running, and before the boot cookie could be written.

**A process honors its own refusal.** Four branches deliberately withhold a restart (init-db failure ×2, both migration-guard loss paths) and now return `converge: false`. Without it, convergence restarts into a sha whose `init-db` just failed → boot guard `process.exit(1)` → systemd retries → `StartLimitBurst` exhausted → **dead unit**, on each co-hosted gateway as its tick arrives.

**Quarantine, never rollback.** `git reset --hard` on a shared checkout would let one instance's failed health check drag co-hosted peers backward. Instead the bad sha gets its own marker (`.crow-convergence-quarantine.json`) at repo + data level; peers read it and refuse, so the first instance to converge is the canary by construction. Hard-expires after 24 h — no failure mode needs manual file deletion.

Deliberately **not** migration-guard's marker namespace: two existing readers consume those with no knowledge of why they were written, and one would boot the gateway *skipping `init-db` entirely*. An addon flap must not be able to disable schema initialization.

**The health gate is a regression check.** Compares against the pre-restart baseline, filtered to `entry.isAddon`. An absolute "all connected" bar would have quarantined every good sha during Aug 3–5 when two addons were down for an unrelated ABI reason; and without the `isAddon` filter, a remote crow rebooting would quarantine this host's sha. Waits on an addons-settled signal (addons connect sequentially, 60 s each) with a 10 min timeout that yields **unknown / fail open**.

**Null boot sha refuses**; an unsupervised instance migrates but writes no cookie (a stranded deadline would later quarantine a healthy sha).

## Verification

- **Suite 2991 pass / 0 fail / 0 cancelled**
- **51/51 mutations killed.** The load-bearing one: restoring the early return on lock loss fails on `beta LOST the lock and must STILL migrate its own stores`. The fixture holds the lock file, because sequential awaited calls never contend — `checkForUpdates` releases in a `finally`, so without real contention the gate proves nothing.
- Real gateway boot verified: boot registry defers `tasks_items`, the post-settle pass re-attempts it, `project_spaces.repo_path` shows `no-op` on the second pass (idempotence in the live path)
- Live instance DBs verified untouched by the suite; no stray markers
- No `SCHEMA_GENERATION` bump, no new `DROP`/`DELETE`, no new host port

`CROW_DISABLE_CONVERGE=1` kill switch; architecture docs in `docs/architecture/gateway.md`.

Card #120.
