### PR TITLE
test(perch): allocate loopback ports without collisions

### DIFF
--- a/tests/perch-runtime.test.js
+++ b/tests/perch-runtime.test.js
@@ -385,18 +385,63 @@ test("the default bound is 5s and is exported so both callers share one number",
 // defaults and never the lab's live pi-hub on 4200/4201.
 
 /** Bind :0 on loopback, note the port the kernel handed out, release it. */
-function freeLoopbackPort() {
-  return new Promise((resolve, reject) => {
-    const srv = createServer();
-    srv.once("error", reject);
-    srv.listen(0, "127.0.0.1", () => {
-      const { port } = srv.address();
-      srv.close(() => resolve(port));
+/**
+ * Reserve `n` DISTINCT free loopback ports.
+ *
+ * Binding port 0, reading the port, closing, and repeating does NOT guarantee
+ * distinct results: once the first socket closes the kernel may hand the same
+ * ephemeral port straight back to the next call. That produced a real
+ * intermittent failure here — two sequential calls both returned 33605 (inside
+ * this host's 32768-60999 ephemeral range) and the `assert.notEqual` guard
+ * below tripped under full-suite load.
+ *
+ * Holding every socket open until all of them are bound makes a collision
+ * structurally impossible rather than merely unlikely, because no port is
+ * released until all have been chosen.
+ */
+function freeLoopbackPorts(n) {
+  const servers = [];
+  const openOne = () =>
+    new Promise((resolve, reject) => {
+      const srv = createServer();
+      srv.once("error", reject);
+      srv.listen(0, "127.0.0.1", () => {
+        servers.push(srv);
+        resolve(srv.address().port);
+      });
     });
-  });
+
+  return (async () => {
+    try {
+      const ports = [];
+      for (let i = 0; i < n; i++) ports.push(await openOne());
+      return ports;
+    } finally {
+      // Release only after every port has been chosen.
+      await Promise.all(servers.map((s) => new Promise((r) => s.close(r))));
+    }
+  })();
+}
+
+async function freeLoopbackPort() {
+  const [p] = await freeLoopbackPorts(1);
+  return p;
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+test("freeLoopbackPorts hands out distinct ports", async () => {
+  // Regression guard for a rare, load-dependent collision: the previous helper
+  // closed each socket before returning, so the kernel could reuse the port on
+  // the very next call. NOTE the honest limit — this asserts the property, but
+  // cannot deterministically reproduce the old bug (it did not collide in 3600
+  // synthetic pairs). It catches a gross regression; the real protection is
+  // that the new helper cannot collide by construction.
+  const ports = await freeLoopbackPorts(12);
+  assert.equal(ports.length, 12);
+  assert.equal(new Set(ports).size, 12, `ports must be distinct, got ${ports.join(",")}`);
+  for (const p of ports) assert.ok(p > 1024 && p < 65536, `implausible port ${p}`);
+});
 
 /** Lay out a scratch CROW_HOME exactly as a real bundle install would. */
 function installRealPayload(home) {
@@ -461,8 +506,7 @@ test("E2E: the vendored payload installs, boots under the real supervisor, and s
   );
   assert.equal(manifest.draft, false, "the bundle must be published for anyone to install it");
 
-  const port = await freeLoopbackPort();
-  const registryPort = await freeLoopbackPort();
+  const [port, registryPort] = await freeLoopbackPorts(2);
   for (const p of [port, registryPort]) {
     assert.ok(p > 10000, `refusing to bind low port ${p}`);
     assert.ok(![4200, 4201, 4210, 4211].includes(p), `port ${p} is reserved`);


### PR DESCRIPTION
## The bug

`freeLoopbackPort()` bound port 0, read the assigned port, **closed the socket**, then resolved. Once that socket closes the kernel is free to hand the same ephemeral port straight back to the next call, so two sequential calls can return the same port.

Observed once in a full-suite run: both allocations returned **33605** (inside this host's `32768-60999` ephemeral range) and `assert.notEqual(port, registryPort)` tripped.

```
not ok 2368 - E2E: the vendored payload installs, boots under the real supervisor, and serves /bots
  error: 'Expected "actual" to be strictly unequal to: 33605'
```

## The fix

`freeLoopbackPorts(n)` holds every socket open until all `n` are bound, releasing them only once all ports have been chosen. Collision becomes impossible **by construction** rather than merely unlikely. The two call sites now allocate together:

```js
const [port, registryPort] = await freeLoopbackPorts(2);
```

`freeLoopbackPort()` is kept as a one-port wrapper.

## Honest limits of the test

The added test asserts the distinctness property over a batch of 12, but it does **not** deterministically reproduce the old bug — the previous helper did not collide in 3600 synthetic pairs I ran, quiet or under concurrency. It only failed under real full-suite load.

So the test guards against a gross regression, not the race itself; the real protection is the structural argument above. That caveat is in the test comment and the commit message rather than left implicit.

## Verification

- Suite **3001 pass / 0 fail / 0 cancelled**
- `tests/perch-runtime.test.js` 14/14 in isolation
- Diagnosis verified rather than assumed: line 470 is the `notEqual` guard, and 33605 is in this host's ephemeral range

Test-only change; no production code touched.
