### PR TITLE
fix(pi-bots): a bot must never resolve another instance's Crow server

### DIFF
--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -514,6 +514,21 @@ test("optIn never survives into an active block", () => {
   assert.ok(!("optIn" in json.mcpServers.gws), "a copied optIn block would never load");
 });
 
+test("RESOLUTION ORDER: the catalog wins over canonical for the same name", () => {
+  const f = twoInstances();
+  // Make canonical's crow-memory STRUCTURALLY distinguishable. rebindBlock
+  // rewrites env and a `.crow*/bundles` cwd, but never `args` — so `args` is
+  // the only witness of WHICH SOURCE won. Without this, both paths yield an
+  // instance-correct block and reversing the order breaks no test, which is
+  // exactly the vacuum a mutation run found.
+  const canon = JSON.parse(readFileSync(f.canonicalPath, "utf8"));
+  canon.mcpServers["crow-memory"].args = ["CANONICAL-WINS.js"];
+  writeFileSync(f.canonicalPath, JSON.stringify(canon));
+  const { json } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  assert.deepEqual(json.mcpServers["crow-memory"].args, ["servers/memory/index.js"],
+    "args must come from the registry catalog, not from the canonical block");
+});
+
 test("a non-Crow server is carried through untouched", () => {
   const f = twoInstances();
   const { json } = write({ tools: { crow_mcp: ["brave-search"] } }, f);
@@ -1096,11 +1111,15 @@ Expected: pass/fail counts with **0 failures other than** `tests/models-panel-ui
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
 S=$(mktemp -d); mkdir -p $S/db $S/out
 for f in crow.db crow.db-wal crow.db-shm; do cp -a /home/kh0pp/.crow-r4/data/$f $S/db/ 2>/dev/null; done
-cd /home/kh0pp/crow
+cd /home/kh0pp/crow-wt-mcp-binding
+# CROW_DB_PATH names the LIVE instance because that is what instanceBinding()
+# turns into path strings — writeBotMcp never OPENS crow.db. The bot definition
+# is read from the COPY via PIBOT_DEF_DB. Pointing CROW_DB_PATH at the copy
+# instead would bind the output to the scratch dir and prove nothing.
 CROW_HOME=/home/kh0pp/.crow-r4 CROW_DATA_DIR=/home/kh0pp/.crow-r4/data \
-CROW_DB_PATH=$S/db/crow.db node -e "
+CROW_DB_PATH=/home/kh0pp/.crow-r4/data/crow.db PIBOT_DEF_DB=$S/db/crow.db node -e "
 const Database=require('better-sqlite3');
-const d=new Database(process.env.CROW_DB_PATH,{readonly:true});
+const d=new Database(process.env.PIBOT_DEF_DB,{readonly:true});
 const def=JSON.parse(d.prepare('SELECT definition FROM pi_bot_defs WHERE bot_id=?').get('r4-assistant').definition);
 d.close();
 import('./scripts/pi-bots/mcp_writer.mjs').then(m=>{

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -953,7 +953,8 @@ test("probe surface is the catalog plus NON-Crow canonical entries", () => {
   assert.equal(surface["crow-memory"].env.CROW_DB_PATH, join(home, "data", "crow.db"),
     "the catalog wins over the canonical entry");
   assert.equal(surface["brave-search"].env.BRAVE_API_KEY, "k", "non-Crow entries survive");
-  assert.ok(surface.tasks, "this instance's bundles are offered");
+  assert.ok(!surface.tasks,
+    "addons stay OUT — probeExtensions already owns them; folding them in double-lists every addon");
 });
 ```
 
@@ -986,12 +987,18 @@ Add this exported function immediately above `probeAll`:
  * function is what keeps the picker whole.
  */
 export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = {}) {
-  const { servers: catalog } = crowServerCatalog(crowHome, opts);
+  // CORE servers only. `probeExtensions` already owns the addon surface and is
+  // already instance-correct, so folding the catalog's mcp-addons half in here
+  // would render every installed addon TWICE in the editor's Tools tab and
+  // spawn each one twice per cold render.
+  const { servers: catalog, coreNames } = crowServerCatalog(crowHome, opts);
+  const core = {};
+  for (const name of coreNames) if (catalog[name]) core[name] = catalog[name];
   const out = {};
   for (const [name, block] of Object.entries(canonical.mcpServers || {})) {
-    if (!catalog[name]) out[name] = block;
+    if (!core[name]) out[name] = block;
   }
-  return Object.assign(out, catalog);
+  return Object.assign(out, core);
 }
 ```
 

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -987,7 +987,7 @@ Expected: FAIL — `serversForProbe` is not exported.
 In `scripts/pi-bots/ext_registry.mjs`, add to the imports:
 
 ```js
-import { crowServerCatalog } from "./crow-server-catalog.mjs";
+import { crowServerCatalog, instanceBinding, rebindBlock } from "./crow-server-catalog.mjs";
 ```
 
 Add this exported function immediately above `probeAll`:
@@ -1002,16 +1002,24 @@ Add this exported function immediately above `probeAll`:
  * function is what keeps the picker whole.
  */
 export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = {}) {
-  // CORE servers only. `probeExtensions` already owns the addon surface and is
-  // already instance-correct, so folding the catalog's mcp-addons half in here
-  // would render every installed addon TWICE in the editor's Tools tab and
-  // spawn each one twice per cold render.
+  // Two jobs. (1) The catalog OWNS every core name — `probeExtensions` owns the
+  // addon surface, so folding addons in here would double-list them.
+  // (2) Everything left in canonical is passed through `rebindBlock`, NOT
+  // verbatim: canonical is pinned to whichever instance authored it, so
+  // `crow-tasks`/`crow-bots-sql`/`crow-storage` would otherwise be probed —
+  // and SPAWNED — against another instance's bundles and databases on every
+  // cold Tools-tab render. A name whose bundle is absent here is dropped.
   const { servers: catalog, coreNames } = crowServerCatalog(crowHome, opts);
+  const binding = opts.binding || instanceBinding(crowHome, opts);
+  const coreSet = new Set(coreNames);
   const core = {};
   for (const name of coreNames) if (catalog[name]) core[name] = catalog[name];
   const out = {};
   for (const [name, block] of Object.entries(canonical.mcpServers || {})) {
-    if (!core[name]) out[name] = block;
+    if (coreSet.has(name)) continue; // the catalog owns it (or it is unconfigured here)
+    const r = rebindBlock(name, block, binding, crowHome);
+    if (r.disabled) continue;        // bundle not installed on this instance
+    out[name] = r.block;
   }
   return Object.assign(out, core);
 }
@@ -1264,6 +1272,11 @@ cp -a /home/kh0pp/r4-tehcy/.mcp.json /home/kh0pp/r4-tehcy/.mcp.json.bak.$D
 ```
 
 Then:
+
+**Order matters within this step.** Do the MPA bot-def rename (3) BEFORE stripping canonical (1),
+or do both in one window. In between, an MPA bot selecting `crow-tasks` resolves nowhere: the
+catalog has `tasks`, canonical no longer has `crow-tasks`, and `extraServersFromExtensions`
+looks up `crow-tasks` in `mcp-addons.json` and misses.
 
 **1. Strip the six Crow entries from the global config.** Leaves `google-workspace`,
 `brave-search`, `crow-browser`, `google-workspace-dayane`.

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -698,6 +698,17 @@ with:
   });
 ```
 
+Then forward the two new keys in `writeBotMcp`'s own `return {...}` — without this the
+function silently drops them and Step 1's closed-world test throws
+`Cannot read properties of undefined (reading 'includes')`:
+
+```js
+    journalGuarded: built.journalGuarded,
+    minted: built.minted,
+    rebound: built.rebound,
+    disabled: built.disabled,
+```
+
 - [ ] **Step 6: Run tests to verify they pass**
 
 ```bash

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -1072,6 +1072,7 @@ For each mutation below: apply it, run the named test file, confirm it FAILS, th
 | 5 | in `mcp_writer.mjs`, prefer `canonical` over `catalog` in the resolution order | `pibot-mcp-instance-binding` |
 | 6 | in `bridge.mjs`, restore `else if (tools)` | `pibot-tools-envelope` |
 | 7 | in `crow-server-catalog.mjs`, anchor the bundle regex on `/crow` instead of `/\.crow` | `pibot-crow-server-catalog` (the repo-cwd test) |
+| 8 | in `ext_registry.mjs`, revert `serversForProbe` to fold the whole catalog (`Object.assign(out, catalog)`) | `pibot-crow-server-catalog` (the addon double-listing test) |
 
 ```bash
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -1,0 +1,1270 @@
+# MCP Instance Binding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it structurally impossible for a Crow bot to resolve an MCP server bound to a different instance.
+
+**Architecture:** Crow servers stop being read out of the user-global `~/.pi/agent/mcp.json` and are instead derived per-instance from the repo registry (core servers) and the instance's own `mcp-addons.json` (bundle servers). The per-bot `<sessionDir>/.mcp.json` becomes closed-world: it names every server the bot may use with instance-correct bindings, and explicitly `{"disabled": true}`s everything else pi would otherwise inherit.
+
+**Tech Stack:** Node 22 ESM, `node:test` built-in runner, `better-sqlite3`, pi 0.82.0 + pi-lab `main`.
+
+**Spec:** `docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md`
+
+## Global Constraints
+
+- **Node 22 on every invocation:** `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH`
+- **Tests:** `npm test` runs the full suite in a scratch env. Single file: `npm test -- tests/<file>.test.js`
+- **Bridge export stability is mandatory.** `pibot-gateways@r4` runs from the `~/crow` working tree in a soak ending ~2026-08-12 and `job_runner.mjs` imports from `bridge.mjs`. Every export in `scripts/pi-bots/bridge.mjs` — `db`, `CROW_DB`, `TASKS_DB`, `PiRpc`, `toolAllowlist`, `applySessionNarrowing`, `readRemoteInvocationEnabled`, `readPeerGatewayUrls` — keeps its name and signature. Only function bodies change.
+- **Never open a running gateway's `crow.db`/`tasks.db` directly.** Copy `.db` + `-wal` + `-shm`, query the copy.
+- **Commit with a positional path arg:** `git commit <path> -m "..."`. `git add <exact path>` first only when the file is new. Never a bare `git add`. Verify with `git show --stat HEAD` after every commit.
+- **`git pull --rebase` before pushing.** Parallel sessions push to `main`.
+- **CI is a hard gate.** Query `https://api.github.com/repos/kh0pper/crow/commits/<sha>/check-runs`, never the legacy commit-status API. Contexts: `suite`, `static-checks`, `audit`. `enforce_admins` is TRUE.
+- **`gh` is not installed.** Use the GitHub MCP tools.
+- **Never attribute Claude. No `Co-Authored-By` trailer.**
+- **No schema changes in this plan.** `SCHEMA_GENERATION` is not touched, so the migration rail does not apply.
+
+## File Structure
+
+| file | responsibility |
+|---|---|
+| `scripts/pi-bots/crow-server-catalog.mjs` | **new.** Owns "what Crow servers exist on this instance and how are they bound." Imports only `server-registry.js` and `instance-paths.mjs` — no `ext_registry`, no `mcp_writer` — so there is no import cycle. |
+| `scripts/pi-bots/mcp_writer.mjs` | modified. Consumes the catalog; writes the closed-world per-bot file. Already 447 lines, so the catalog deliberately does not live here. |
+| `scripts/pi-bots/bridge.mjs` | modified, one line in the `PiRpc` constructor. |
+| `scripts/pi-bots/ext_registry.mjs` | modified, `probeAll()` only. |
+| `tests/pibot-crow-server-catalog.test.js` | **new.** Catalog derivation and rebinding. |
+| `tests/pibot-mcp-instance-binding.test.js` | **new.** The invariant, closed-world, `optIn`, and the empty-envelope spawn arg. |
+
+---
+
+### Task 1: The instance catalog module
+
+**Files:**
+- Create: `scripts/pi-bots/crow-server-catalog.mjs`
+- Test: `tests/pibot-crow-server-catalog.test.js`
+
+**Interfaces:**
+- Consumes: `CORE_SERVERS`, `CONDITIONAL_SERVERS`, `ROOT`, `loadEnv`, `resolveEnvValue` from `scripts/server-registry.js`; `botsDbPath`, `tasksDbPath`, `resolveSqlitePath` from `scripts/pi-bots/instance-paths.mjs`.
+- Produces:
+  - `INSTANCE_ENV_KEYS: string[]` — exactly `["CROW_HOME", "CROW_DATA_DIR", "CROW_DB_PATH", "CROW_TASKS_DB_PATH"]`
+  - `instanceBinding(crowHome: string, opts?: {tasksDbPath?: string}) -> {CROW_HOME, CROW_DATA_DIR, CROW_DB_PATH, CROW_TASKS_DB_PATH}`
+  - `rebindBlock(name: string, block: object, binding: object, crowHome: string) -> {block, rebound: string[]} | {disabled: true, reason: string}`
+  - `crowServerCatalog(crowHome: string, opts?: {binding?, node?}) -> {servers: {[name]: block}, unconfigured: {[name]: string}}`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/pibot-crow-server-catalog.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  INSTANCE_ENV_KEYS,
+  instanceBinding,
+  rebindBlock,
+  crowServerCatalog,
+} from "../scripts/pi-bots/crow-server-catalog.mjs";
+
+/** An instance home with a tasks bundle dir and an mcp-addons.json. */
+function instanceB() {
+  const dir = mkdtempSync(join(tmpdir(), "instB-"));
+  const home = join(dir, ".crow-b");
+  mkdirSync(join(home, "bundles", "tasks"), { recursive: true });
+  mkdirSync(join(home, "data"), { recursive: true });
+  writeFileSync(join(home, "mcp-addons.json"), JSON.stringify({
+    tasks: { command: "node", args: ["server/index.js"], env: { CROW_TASKS_DB_PATH: "/wrong/tasks.db" } },
+    ghost: { command: "node", args: ["server/index.js"] },
+  }));
+  return { dir, home };
+}
+
+const BINDING_B = (home) => ({
+  CROW_HOME: home,
+  CROW_DATA_DIR: join(home, "data"),
+  CROW_DB_PATH: join(home, "data", "crow.db"),
+  CROW_TASKS_DB_PATH: join(home, "data", "tasks.db"),
+});
+
+test("INSTANCE_ENV_KEYS is exactly the four instance-scoped vars", () => {
+  assert.deepEqual([...INSTANCE_ENV_KEYS].sort(),
+    ["CROW_DATA_DIR", "CROW_DB_PATH", "CROW_HOME", "CROW_TASKS_DB_PATH"]);
+});
+
+test("instanceBinding normalizes a file: tasks URI", () => {
+  const b = instanceBinding("/home/x/.crow-r4", { tasksDbPath: "file:/home/x/.crow-r4/data/tasks.db" });
+  assert.equal(b.CROW_TASKS_DB_PATH, "/home/x/.crow-r4/data/tasks.db");
+});
+
+test("rebindBlock rewrites every instance-scoped env key", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["a.js"], cwd: "/repo",
+    env: { CROW_DB_PATH: "/home/x/.crow-mpa/data/crow.db", UNRELATED: "keep" } };
+  const r = rebindBlock("crow-memory", block, BINDING_B(home), home);
+  assert.equal(r.env, undefined, "returns a wrapper, not a bare block");
+  assert.equal(r.block.env.CROW_DB_PATH, join(home, "data", "crow.db"));
+  assert.equal(r.block.env.UNRELATED, "keep");
+  assert.equal(r.block.env.CROW_JOURNAL_MODE, "DELETE", "WAL scar guard applied");
+  assert.deepEqual(r.rebound, ["CROW_DB_PATH"]);
+});
+
+test("rebindBlock retargets a cross-instance bundle cwd that exists here", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["server/index.js"], cwd: "/home/x/.crow-mpa/bundles/tasks", env: {} };
+  const r = rebindBlock("crow-tasks", block, BINDING_B(home), home);
+  assert.equal(r.block.cwd, join(home, "bundles", "tasks"));
+  assert.ok(r.rebound.includes("cwd"));
+});
+
+test("rebindBlock disables a bundle absent on this instance, with a reason", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["server/index.js"], cwd: "/home/x/.crow-mpa/bundles/rookery", env: {} };
+  const r = rebindBlock("crow-rookery", block, BINDING_B(home), home);
+  assert.equal(r.disabled, true);
+  assert.match(r.reason, /rookery/);
+  assert.match(r.reason, /not installed/);
+});
+
+test("rebindBlock leaves the repo cwd alone — the repo is instance-neutral", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["x.js"], cwd: "/home/kh0pp/crow/bundles/browser", env: {} };
+  const r = rebindBlock("crow-browser", block, BINDING_B(home), home);
+  assert.equal(r.block.cwd, "/home/kh0pp/crow/bundles/browser");
+  assert.deepEqual(r.rebound, []);
+});
+
+test("rebindBlock strips optIn — selection is the opt-in", () => {
+  const { home } = instanceB();
+  const r = rebindBlock("gws", { command: "n", args: [], optIn: true, env: {} }, BINDING_B(home), home);
+  assert.ok(!("optIn" in r.block));
+});
+
+test("catalog binds core servers to this instance and serves them from the repo", () => {
+  const { home } = instanceB();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  const mem = servers["crow-memory"];
+  assert.ok(mem, "crow-memory catalogued");
+  assert.equal(mem.env.CROW_DB_PATH, join(home, "data", "crow.db"));
+  assert.equal(mem.env.CROW_JOURNAL_MODE, "DELETE");
+  assert.match(mem.cwd, /crow$/, "core servers run from the repo root");
+});
+
+test("catalog binds bundle servers from this instance's mcp-addons.json", () => {
+  const { home } = instanceB();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.equal(servers.tasks.cwd, join(home, "bundles", "tasks"), "cwd defaulted under this instance");
+  assert.equal(servers.tasks.env.CROW_TASKS_DB_PATH, join(home, "data", "tasks.db"),
+    "the addon's own wrong path is rebound, not trusted");
+});
+
+test("catalog reports an addon whose bundle dir is missing as unconfigured", () => {
+  const { home } = instanceB();
+  const { servers, unconfigured } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.ok(!servers.ghost, "ghost is not offered as spawnable");
+  assert.match(unconfigured.ghost, /not installed/);
+});
+
+test("crow-storage is catalogued as unconfigured when MinIO env is absent", () => {
+  const { home } = instanceB();
+  const { servers, unconfigured } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.ok(!servers["crow-storage"], "not offered as spawnable without MinIO settings");
+  assert.match(unconfigured["crow-storage"], /MINIO_ENDPOINT/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: FAIL — `Cannot find module '../scripts/pi-bots/crow-server-catalog.mjs'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/pi-bots/crow-server-catalog.mjs`:
+
+```js
+#!/usr/bin/env node
+/**
+ * Crow Bot Builder — the per-instance Crow server catalog.
+ *
+ * THE INVARIANT: a bot must never resolve a Crow server bound to an instance
+ * other than its own. Stated structurally, which is how this module achieves
+ * it: no file that can name an instance may describe a Crow server.
+ *
+ * So Crow servers are DERIVED, never copied out of the user-global
+ * ~/.pi/agent/mcp.json:
+ *   - core servers  -> scripts/server-registry.js, run from the repo root,
+ *                      env bound to THIS instance
+ *   - bundle servers -> <crowHome>/mcp-addons.json, cwd under THIS instance
+ * The homedir config keeps only third-party servers, which carry credentials
+ * rather than instance identity.
+ *
+ * Imports are deliberately limited to server-registry.js and instance-paths.mjs
+ * so neither ext_registry.mjs nor mcp_writer.mjs can form a cycle through here.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import {
+  CORE_SERVERS,
+  CONDITIONAL_SERVERS,
+  ROOT,
+  loadEnv,
+  resolveEnvValue,
+} from "../server-registry.js";
+import { botsDbPath, tasksDbPath, resolveSqlitePath } from "./instance-paths.mjs";
+
+/**
+ * The env vars that name an instance. r4-deploy.sh warns that a child missing
+ * any of these silently resolves to the PRIMARY instance, which is exactly the
+ * failure this list exists to prevent.
+ */
+export const INSTANCE_ENV_KEYS = [
+  "CROW_HOME",
+  "CROW_DATA_DIR",
+  "CROW_DB_PATH",
+  "CROW_TASKS_DB_PATH",
+];
+
+/**
+ * This instance's canonical values for the four instance-scoped env vars.
+ *
+ * The tasks path is normalized through resolveSqlitePath(): production stores
+ * `file:` URIs in project_spaces.tasks_db_uri and better-sqlite3 has no URI
+ * support, so an un-normalized value reaches a bundle as an unopenable
+ * filename (the PR #278 defect).
+ */
+export function instanceBinding(crowHome, opts = {}) {
+  const dbPath = opts.dbPath || botsDbPath();
+  return {
+    CROW_HOME: crowHome,
+    CROW_DATA_DIR: dirname(dbPath),
+    CROW_DB_PATH: dbPath,
+    CROW_TASKS_DB_PATH: resolveSqlitePath(opts.tasksDbPath || tasksDbPath()),
+  };
+}
+
+/** A bundle cwd under SOME instance home: /…/.crow<suffix>/bundles/<id>. */
+const INSTANCE_BUNDLE_CWD = /\/\.crow[^/]*\/bundles\/([^/]+)\/?$/;
+
+function applyJournalGuard(env) {
+  // The WAL-unlink scar: every server touching a crow.db runs journal DELETE.
+  if (env && env.CROW_DB_PATH) env.CROW_JOURNAL_MODE = "DELETE";
+  return env;
+}
+
+/**
+ * Rebind a server block that did NOT come from the catalog — a third-party or
+ * `crow-browser` entry out of the homedir config — onto this instance.
+ *
+ * Returns {block, rebound} or {disabled, reason}. `optIn` is stripped: pi
+ * activates an optIn server only when a project file says {"enabled": true},
+ * so a verbatim copy of an optIn block silently never loads. Selecting the
+ * server IS the opt-in.
+ *
+ * The /.crow anchor is deliberate. `/home/kh0pp/crow/bundles/browser` and
+ * `/home/kh0pp/crow` do not match, so the repo is left alone — it is
+ * instance-neutral, correctly.
+ */
+export function rebindBlock(name, block, binding, crowHome) {
+  const clone = JSON.parse(JSON.stringify(block));
+  delete clone.optIn;
+  const rebound = [];
+  if (clone.env) {
+    for (const k of INSTANCE_ENV_KEYS) {
+      if (k in clone.env && clone.env[k] !== binding[k]) {
+        clone.env[k] = binding[k];
+        rebound.push(k);
+      }
+    }
+  }
+  const m = clone.cwd ? INSTANCE_BUNDLE_CWD.exec(clone.cwd) : null;
+  if (m) {
+    const target = join(crowHome, "bundles", m[1]);
+    if (!existsSync(target)) {
+      return {
+        disabled: true,
+        reason: `bundle '${m[1]}' is not installed on this instance (${target})`,
+      };
+    }
+    if (clone.cwd !== target) {
+      clone.cwd = target;
+      rebound.push("cwd");
+    }
+  }
+  applyJournalGuard(clone.env);
+  return { block: clone, rebound };
+}
+
+function readAddons(crowHome) {
+  try {
+    return JSON.parse(readFileSync(join(crowHome, "mcp-addons.json"), "utf8")) || {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Build a core-server block from its registry entry. Instance-scoped env keys
+ * come from the binding; everything else resolves against the repo .env.
+ * Returns {block, missing} — `missing` names required templates (no `:-`
+ * default) that resolved empty.
+ */
+function coreBlock(spec, binding, repoEnv, node) {
+  const env = {};
+  const missing = [];
+  for (const [k, tmpl] of Object.entries(spec.mcpEnv || {})) {
+    if (INSTANCE_ENV_KEYS.includes(k)) {
+      env[k] = binding[k];
+      continue;
+    }
+    const v = resolveEnvValue(tmpl, repoEnv);
+    if (!v && /\$\{\w+\}/.test(tmpl)) missing.push(k);
+    else env[k] = v;
+  }
+  applyJournalGuard(env);
+  return { block: { command: node, args: [...spec.args], cwd: ROOT, env }, missing };
+}
+
+/**
+ * Every Crow server available to THIS instance, plus the ones that exist but
+ * cannot be spawned here and why.
+ *
+ * `unconfigured` is not an error channel — it is what the GUI renders so an
+ * operator sees "crow-storage: unconfigured, missing MINIO_ENDPOINT" instead
+ * of an opaque spawn failure.
+ */
+export function crowServerCatalog(crowHome = process.env.CROW_HOME || join(homedir(), ".crow"), opts = {}) {
+  const binding = opts.binding || instanceBinding(crowHome, opts);
+  const node = opts.node || process.execPath;
+  const repoEnv = loadEnv();
+  const servers = {};
+  const unconfigured = {};
+
+  for (const spec of CORE_SERVERS) {
+    const { block } = coreBlock(spec, binding, repoEnv, node);
+    servers[spec.name] = block;
+  }
+  for (const spec of CONDITIONAL_SERVERS) {
+    const { block, missing } = coreBlock(spec, binding, repoEnv, node);
+    if (missing.length) unconfigured[spec.name] = `unconfigured: missing ${missing.join(", ")}`;
+    else servers[spec.name] = block;
+  }
+  for (const [id, addon] of Object.entries(readAddons(crowHome))) {
+    const cwd = resolve(addon.cwd || join(crowHome, "bundles", id));
+    if (!existsSync(cwd)) {
+      unconfigured[id] = `bundle not installed on this instance (${cwd})`;
+      continue;
+    }
+    const r = rebindBlock(id, { ...addon, cwd }, binding, crowHome);
+    if (r.disabled) unconfigured[id] = r.reason;
+    else servers[id] = r.block;
+  }
+  return { servers, unconfigured };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pi-bots/crow-server-catalog.mjs tests/pibot-crow-server-catalog.test.js
+git commit scripts/pi-bots/crow-server-catalog.mjs tests/pibot-crow-server-catalog.test.js \
+  -m "feat(pi-bots): derive Crow MCP servers per instance instead of copying them
+
+Core servers come from the repo registry bound to this instance's env; bundle
+servers come from this instance's mcp-addons.json with cwd under its own home.
+A bundle absent here is reported, never minted into a guaranteed spawn failure.
+
+No file that can name an instance describes a Crow server."
+git show --stat HEAD
+```
+
+---
+
+### Task 2: Closed-world per-bot config
+
+**Files:**
+- Modify: `scripts/pi-bots/mcp_writer.mjs` (header comment, `extraServersFromExtensions` comment, `buildBotMcp`, `writeBotMcp`)
+- Test: `tests/pibot-mcp-instance-binding.test.js`
+
+**Interfaces:**
+- Consumes: `crowServerCatalog`, `instanceBinding`, `rebindBlock` from Task 1.
+- Produces: `buildBotMcp(def, canonical, opts)` gains `opts.catalog`, `opts.unconfigured`, `opts.binding`, `opts.crowHome`; its return gains `rebound: Array<{name, keys}>` and `disabled: string[]`, and `servers` now lists **active** names only. `writeBotMcp(def, opts)` gains the same passthrough plus `opts.binding`. All existing keys and signatures are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/pibot-mcp-instance-binding.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeBotMcp } from "../scripts/pi-bots/mcp_writer.mjs";
+
+/**
+ * A canonical config pinned to instance A, and a crowHome of instance B.
+ * The invariant is that nothing active in the output may reference A.
+ */
+function twoInstances() {
+  const dir = mkdtempSync(join(tmpdir(), "twoinst-"));
+  const A = join(dir, ".crow-a");
+  const B = join(dir, ".crow-b");
+  mkdirSync(join(A, "bundles", "tasks"), { recursive: true });
+  mkdirSync(join(A, "bundles", "rookery"), { recursive: true });
+  mkdirSync(join(B, "bundles", "tasks"), { recursive: true });
+  mkdirSync(join(B, "data"), { recursive: true });
+  writeFileSync(join(B, "mcp-addons.json"), JSON.stringify({
+    tasks: { command: "node", args: ["server/index.js"], env: { CROW_TASKS_DB_PATH: join(A, "data", "tasks.db") } },
+  }));
+  const canonicalPath = join(dir, "canonical.json");
+  writeFileSync(canonicalPath, JSON.stringify({ mcpServers: {
+    "crow-memory":  { command: "n", args: ["servers/memory/index.js"], cwd: "/repo", env: { CROW_DB_PATH: join(A, "data", "crow.db") } },
+    "crow-tasks":   { command: "n", args: ["server/index.js"], cwd: join(A, "bundles", "tasks"), env: { CROW_TASKS_DB_PATH: join(A, "data", "tasks.db") } },
+    "crow-rookery": { command: "n", args: ["server/index.js"], cwd: join(A, "bundles", "rookery"), env: {} },
+    "brave-search": { command: "npx", args: ["-y", "srv"], cwd: "/home/x", env: { BRAVE_API_KEY: "k" } },
+    "gws":          { command: "g", args: [], optIn: true, env: {} },
+  } }));
+  const sessionDir = join(dir, "session");
+  mkdirSync(sessionDir, { recursive: true });
+  const binding = {
+    CROW_HOME: B,
+    CROW_DATA_DIR: join(B, "data"),
+    CROW_DB_PATH: join(B, "data", "crow.db"),
+    CROW_TASKS_DB_PATH: join(B, "data", "tasks.db"),
+  };
+  return { dir, A, B, canonicalPath, sessionDir, binding };
+}
+
+function write(def, f) {
+  const res = writeBotMcp(def, {
+    sessionDir: f.sessionDir, canonicalPath: f.canonicalPath, crowHome: f.B, binding: f.binding,
+  });
+  return { res, json: JSON.parse(readFileSync(join(f.sessionDir, ".mcp.json"), "utf8")) };
+}
+
+/** Every string anywhere in a block — cwd, command, args, env values. */
+function strings(block) {
+  const out = [];
+  const walk = (v) => {
+    if (typeof v === "string") out.push(v);
+    else if (Array.isArray(v)) v.forEach(walk);
+    else if (v && typeof v === "object") Object.values(v).forEach(walk);
+  };
+  walk(block);
+  return out;
+}
+
+test("THE INVARIANT: no active block references the other instance", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["crow-memory", "tasks", "brave-search"] } }, f);
+  for (const [name, block] of Object.entries(json.mcpServers)) {
+    if (block && block.disabled === true) continue;
+    for (const s of strings(block)) {
+      assert.ok(!s.includes("/.crow-a"), `${name} leaks instance A via ${s}`);
+    }
+  }
+});
+
+test("a selected core server is rebound to this instance's database", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  assert.equal(json.mcpServers["crow-memory"].env.CROW_DB_PATH, join(f.B, "data", "crow.db"));
+  assert.equal(json.mcpServers["crow-memory"].env.CROW_JOURNAL_MODE, "DELETE");
+});
+
+test("closed-world: every unselected canonical server is disabled", () => {
+  const f = twoInstances();
+  const { json, res } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  for (const name of ["crow-tasks", "crow-rookery", "brave-search", "gws"]) {
+    assert.deepEqual(json.mcpServers[name], { disabled: true }, `${name} must be disabled`);
+  }
+  assert.ok(res.disabled.includes("brave-search"));
+  assert.deepEqual(res.servers, ["crow-memory"], "servers lists ACTIVE names only");
+});
+
+test("a selected bundle absent on this instance is disabled with a reason", () => {
+  const f = twoInstances();
+  const { json, res } = write({ tools: { crow_mcp: ["crow-rookery"] } }, f);
+  assert.deepEqual(json.mcpServers["crow-rookery"], { disabled: true });
+  assert.ok(res.warnings.some((w) => /rookery/.test(w) && /not installed/.test(w)),
+    "the reason is surfaced, not swallowed: " + JSON.stringify(res.warnings));
+});
+
+test("optIn never survives into an active block", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["gws"] } }, f);
+  assert.ok(!("optIn" in json.mcpServers.gws), "a copied optIn block would never load");
+});
+
+test("a non-Crow server is carried through untouched", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["brave-search"] } }, f);
+  assert.equal(json.mcpServers["brave-search"].env.BRAVE_API_KEY, "k");
+  assert.equal(json.mcpServers["brave-search"].cwd, "/home/x");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-mcp-instance-binding.test.js
+```
+
+Expected: FAIL. `THE INVARIANT` fails because `crow-memory` still carries instance A's `CROW_DB_PATH`; `closed-world` fails because unselected servers are absent rather than disabled.
+
+- [ ] **Step 3: Correct the two stale precedence comments**
+
+In `scripts/pi-bots/mcp_writer.mjs`, replace the first paragraph of the file header (the block beginning `S2/D finding (plan §5, "Verified Claims")`) with:
+
+```js
+/**
+ * Crow Bot Builder — per-bot MCP config writer + tool-list prober.
+ *
+ * PRECEDENCE (verified live against pi 0.82.0 + pi-lab main, 2026-08-08):
+ * pi-lab/extensions/mcp-client.ts merges ~/.pi/agent/mcp.json FIRST, then every
+ * cwd-ancestor .mcp.json from the filesystem root down to cwd — the NEAREST
+ * project file WINS. pi-lab commit 671e116 (2026-07-04) changed this; the old
+ * "homedir wins on collision" rule this file used to assert is FALSE, and
+ * believing it hid three live bugs for a month. A project file may also delete
+ * an inherited server with {"name": {"disabled": true}}.
+ *
+ * So the per-bot <session_dir>/.mcp.json is AUTHORITATIVE, and this writer
+ * writes it CLOSED-WORLD: the bot's selected servers with instance-correct
+ * bindings, plus {"disabled": true} for every other server pi would inherit.
+ * Omission is NOT narrowing — an unmentioned homedir server still loads.
+ *
+ * Crow servers are never copied out of the homedir file; they are derived
+ * per-instance by crow-server-catalog.mjs. See
+ * docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md.
+ */
+```
+
+In `extraServersFromExtensions`, replace the line
+
+```js
+    if (canonical.mcpServers[name]) continue; // canonical present -> homedir wins, no mint
+```
+
+with:
+
+```js
+    // The catalog (crow-server-catalog.mjs) already covers every Crow server on
+    // this instance and is consulted first by buildBotMcp, so this path only
+    // ever fills a NON-Crow name absent from canonical. Kept as a seam for
+    // callers that pass their own canonical without a catalog.
+    if (canonical.mcpServers[name]) continue;
+```
+
+- [ ] **Step 4: Rewrite `buildBotMcp` closed-world**
+
+In `scripts/pi-bots/mcp_writer.mjs`, add to the imports at the top:
+
+```js
+import { crowServerCatalog, instanceBinding, rebindBlock } from "./crow-server-catalog.mjs";
+```
+
+Replace the whole of `buildBotMcp` with:
+
+```js
+/**
+ * Build the per-bot `.mcp.json` object. CLOSED-WORLD — see the file header.
+ *
+ * Resolution order for a selected name:
+ *   1. catalog   — instance-derived, always correct. Wins.
+ *   2. canonical — for names the catalog does not know (third-party servers,
+ *                  crow-browser). Rebound onto this instance as a belt.
+ *   3. extraServers — the mcp-addons seam retained for callers without a catalog.
+ * Then every OTHER canonical name is emitted as {"disabled": true}, because
+ * canonical is exactly what pi would otherwise inherit.
+ *
+ * @returns {{ json, servers, warnings, journalGuarded, minted, rebound, disabled }}
+ *   `servers` lists ACTIVE names only; disabled names are in `disabled`.
+ */
+export function buildBotMcp(def, canonical, opts = {}) {
+  const want = serversForBot(def);
+  const catalog = opts.catalog || {};
+  const unconfigured = opts.unconfigured || {};
+  const binding = opts.binding;
+  const crowHome = opts.crowHome;
+  const extra = opts.extraServers || {};
+  const out = { mcpServers: {} };
+  const warnings = [];
+  const journalGuarded = [];
+  const minted = [];
+  const rebound = [];
+  const disabled = [];
+  const active = [];
+
+  const disable = (name, reason) => {
+    out.mcpServers[name] = { disabled: true };
+    disabled.push(name);
+    if (reason) warnings.push(`server '${name}' ${reason}`);
+  };
+
+  for (const name of want) {
+    if (catalog[name]) {
+      out.mcpServers[name] = catalog[name];
+      active.push(name);
+      minted.push(name);
+      continue;
+    }
+    if (unconfigured[name]) {
+      disable(name, unconfigured[name]);
+      continue;
+    }
+    const source = canonical.mcpServers[name] || extra[name];
+    if (!source) {
+      warnings.push(
+        "server '" + name + "' is selected but absent from the instance catalog, " +
+        "canonical mcp.json AND mcp-addons.json — pi will NOT have it"
+      );
+      continue;
+    }
+    // No binding means a caller that predates instance binding (tests, CLI):
+    // fall back to the old verbatim copy + journal guard rather than crash.
+    if (!binding) {
+      const clone = JSON.parse(JSON.stringify(source));
+      if (touchesCrowDb(clone)) {
+        clone.env = clone.env || {};
+        if (clone.env.CROW_JOURNAL_MODE !== "DELETE") {
+          clone.env.CROW_JOURNAL_MODE = "DELETE";
+          journalGuarded.push(name);
+        }
+      }
+      out.mcpServers[name] = clone;
+      active.push(name);
+      if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+      continue;
+    }
+    const r = rebindBlock(name, source, binding, crowHome);
+    if (r.disabled) {
+      disable(name, r.reason);
+      continue;
+    }
+    if (r.rebound.length) rebound.push({ name, keys: r.rebound });
+    if (touchesCrowDb(r.block)) journalGuarded.push(name);
+    out.mcpServers[name] = r.block;
+    active.push(name);
+    if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+  }
+
+  // Closed-world. Sorted so the written file is diffable.
+  const selected = new Set(want);
+  for (const name of Object.keys(canonical.mcpServers).sort()) {
+    if (selected.has(name)) continue;
+    disable(name, null);
+  }
+
+  return { json: out, servers: active, warnings, journalGuarded, minted, rebound, disabled };
+}
+```
+
+- [ ] **Step 5: Thread the catalog through `writeBotMcp`**
+
+In `scripts/pi-bots/mcp_writer.mjs`, inside `writeBotMcp`, replace the two lines
+
+```js
+  const extraServers = opts.extraServers || extraServersFromExtensions(def, crowHome, { canonical });
+  const built = buildBotMcp(def, canonical, { extraServers });
+```
+
+with:
+
+```js
+  const extraServers = opts.extraServers || extraServersFromExtensions(def, crowHome, { canonical });
+  // The instance catalog is the FIRST source for any Crow server. opts.binding
+  // lets tests and the panel pin an instance without mutating process.env.
+  const binding = opts.binding || instanceBinding(crowHome, opts);
+  const { servers: catalog, unconfigured } = crowServerCatalog(crowHome, { binding });
+  const built = buildBotMcp(def, canonical, {
+    extraServers, catalog, unconfigured, binding, crowHome,
+  });
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-mcp-instance-binding.test.js
+npm test -- tests/remote-mcp-writer.test.js
+```
+
+Expected: both PASS. `remote-mcp-writer.test.js` exercises the no-binding fallback path and must be unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/pibot-mcp-instance-binding.test.js
+git commit scripts/pi-bots/mcp_writer.mjs tests/pibot-mcp-instance-binding.test.js \
+  -m "fix(pi-bots): write the per-bot .mcp.json closed-world
+
+pi's NEAREST-file-wins precedence (pi-lab 671e116, 2026-07-04) means the per-bot
+file is authoritative and can delete an inherited server. This writer believed
+the opposite, so it copied core-server blocks verbatim out of a homedir config
+pinned to one instance and stayed silent about everything else pi inherits.
+
+An r4 bot's crow_store_memory resolved to MPA's crow.db. Six MPA-pinned servers
+were spawned into every r4 turn. A copied optIn block never activated at all."
+git show --stat HEAD
+```
+
+---
+
+### Task 3: Pin `--tools` for an empty envelope
+
+**Files:**
+- Modify: `scripts/pi-bots/bridge.mjs` (`PiRpc` constructor, the `--tools` branch)
+- Test: `tests/pibot-mcp-instance-binding.test.js` (append)
+
+**Interfaces:**
+- Consumes: `toolAllowlist`, `applySessionNarrowing` from `bridge.mjs` — both already exported, neither changes.
+- Produces: nothing new. `PiRpc`'s spawn args gain `--tools ""` where the flag was previously omitted.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pibot-mcp-instance-binding.test.js`:
+
+```js
+import { toolAllowlist, applySessionNarrowing } from "../scripts/pi-bots/bridge.mjs";
+
+/**
+ * Mirrors the --tools branch in the PiRpc constructor. A bot with no builtin
+ * and no MCP tools yields "", and omitting the flag hands pi
+ * defaultActiveToolNames — bash, edit, write, and every tool registered by
+ * every inherited server (pi dist/cli/args.js:85-89 -> dist/core/sdk.js:133-136).
+ */
+function toolsArgs(def, narrowedTools) {
+  const tools = toolAllowlist(def);
+  const narrowed = applySessionNarrowing(tools, narrowedTools);
+  const args = [];
+  if (narrowed !== tools) args.push("--tools", narrowed);
+  else args.push("--tools", tools);
+  return args;
+}
+
+test("an empty tool envelope pins --tools \"\" instead of omitting the flag", () => {
+  const def = { tools: { pi_builtin: [], crow_mcp: [] } };
+  assert.equal(toolAllowlist(def), "", "precondition: the envelope really is empty");
+  assert.deepEqual(toolsArgs(def), ["--tools", ""],
+    "omitting the flag would WIDEN an empty envelope to pi's full default surface");
+});
+
+test("a normal envelope still pins its allowlist", () => {
+  const def = { tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } };
+  assert.deepEqual(toolsArgs(def), ["--tools", "read,mcp__tasks__tasks_list"]);
+});
+
+test("narrowing to nothing still pins --tools \"\"", () => {
+  const def = { tools: { pi_builtin: ["read"], crow_mcp: [] } };
+  assert.deepEqual(toolsArgs(def, JSON.stringify(["read"])), ["--tools", ""]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-mcp-instance-binding.test.js
+```
+
+Expected: FAIL on the first new test — the helper mirrors the current branch, which produces `[]`.
+
+Note: this test asserts the *intended* behavior of the helper. Step 3 changes `bridge.mjs`; Step 4 changes the helper to mirror it again. If the helper and `bridge.mjs` ever diverge, Step 5's grep catches it.
+
+- [ ] **Step 3: Change the branch in `bridge.mjs`**
+
+In `scripts/pi-bots/bridge.mjs`, in the `PiRpc` constructor, replace:
+
+```js
+    if (narrowedTools !== tools) {
+      // A narrowing that removes EVERY tool must STILL pin `--tools ""`: pi
+      // parses that to an empty allowlist (dist/cli/args.js:85-89 →
+      // core/sdk.js:133-136, verified on 0.82.0), whereas omitting the flag
+      // hands pi its full default surface — narrowing would widen.
+      args.push("--tools", narrowedTools);
+    } else if (tools) {
+      args.push("--tools", tools);
+    }
+```
+
+with:
+
+```js
+    // `--tools` is ALWAYS pinned. pi parses "" to an empty allowlist
+    // (dist/cli/args.js:85-89 → core/sdk.js:133-136, verified on 0.82.0),
+    // whereas OMITTING the flag hands pi defaultActiveToolNames — bash, edit,
+    // write, and every tool registered by every inherited MCP server.
+    //
+    // The narrowing case was already guarded. The EMPTY-ENVELOPE case fell
+    // through the same hole: toolAllowlist() returns "" for a bot with no
+    // builtin and no MCP tools, `else if (tools)` is falsy on "", and three
+    // enabled r4 bots were running with pi's entire default surface.
+    // An empty envelope is a real answer, not an absent one.
+    args.push("--tools", narrowedTools);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-mcp-instance-binding.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify bridge exports are unchanged — the soak requires it**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+git diff scripts/pi-bots/bridge.mjs | grep -E '^[-+].*export ' || echo "OK: no export line changed"
+node -e "import('./scripts/pi-bots/bridge.mjs').then(m=>console.log(Object.keys(m).sort().join(' ')))"
+```
+
+Expected: `OK: no export line changed`, and the export list contains at least `CROW_DB PiRpc TASKS_DB applySessionNarrowing db readPeerGatewayUrls readRemoteInvocationEnabled toolAllowlist`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit scripts/pi-bots/bridge.mjs tests/pibot-mcp-instance-binding.test.js \
+  -m "fix(pi-bots): always pin --tools, so an empty envelope means no tools
+
+toolAllowlist() returns \"\" for a bot with no builtin and no MCP tools, and
+\`else if (tools)\` is falsy on \"\", so the flag was omitted and pi fell back to
+defaultActiveToolNames. Three enabled r4 bots were running with bash, edit,
+write and every inherited MCP tool.
+
+The comment above the branch already stated the rule for the narrowing case.
+The empty-envelope case fell through the same hole."
+git show --stat HEAD
+```
+
+---
+
+### Task 4: The GUI picker keeps every server, correctly bound
+
+**Files:**
+- Modify: `scripts/pi-bots/ext_registry.mjs` (`probeAll` only)
+- Test: `tests/pibot-crow-server-catalog.test.js` (append)
+
+**Interfaces:**
+- Consumes: `crowServerCatalog` from Task 1.
+- Produces: `probeAll(crowHome?)` — gains an optional first argument. Existing zero-arg callers keep working.
+
+This task is what makes the host cleanup in Task 6 survivable: once the six Crow entries leave `~/.pi/agent/mcp.json`, a picker that renders canonical alone would stop offering Crow's own tools.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/pibot-crow-server-catalog.test.js`:
+
+```js
+import { serversForProbe } from "../scripts/pi-bots/ext_registry.mjs";
+
+test("probe surface is the catalog plus NON-Crow canonical entries", () => {
+  const { home } = instanceB();
+  const canonical = { mcpServers: {
+    "crow-memory": { command: "n", args: [], env: { CROW_DB_PATH: "/elsewhere/crow.db" } },
+    "brave-search": { command: "npx", args: ["-y", "s"], env: { BRAVE_API_KEY: "k" } },
+  } };
+  const surface = serversForProbe(canonical, home, { binding: BINDING_B(home) });
+  assert.equal(surface["crow-memory"].env.CROW_DB_PATH, join(home, "data", "crow.db"),
+    "the catalog wins over the canonical entry");
+  assert.equal(surface["brave-search"].env.BRAVE_API_KEY, "k", "non-Crow entries survive");
+  assert.ok(surface.tasks, "this instance's bundles are offered");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: FAIL — `serversForProbe` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `scripts/pi-bots/ext_registry.mjs`, add to the imports:
+
+```js
+import { crowServerCatalog } from "./crow-server-catalog.mjs";
+```
+
+Add this exported function immediately above `probeAll`:
+
+```js
+/**
+ * The set of servers the Tools tab probes: this instance's Crow catalog, plus
+ * the NON-Crow entries from the homedir config. The catalog wins on name, so a
+ * homedir entry pinned to another instance is never probed or offered.
+ *
+ * Once the Crow entries are removed from ~/.pi/agent/mcp.json entirely, this
+ * function is what keeps the picker whole.
+ */
+export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = {}) {
+  const { servers: catalog } = crowServerCatalog(crowHome, opts);
+  const out = {};
+  for (const [name, block] of Object.entries(canonical.mcpServers || {})) {
+    if (!catalog[name]) out[name] = block;
+  }
+  return Object.assign(out, catalog);
+}
+```
+
+In `probeAll`, replace:
+
+```js
+  const names = Object.keys(canonical.mcpServers);
+  await Promise.all(
+    names.map(async (n) => {
+      try {
+        out[n] = await probeServerTools(canonical.mcpServers[n], { timeoutMs: 12000 });
+```
+
+with:
+
+```js
+  const surface = serversForProbe(canonical, crowHome);
+  const names = Object.keys(surface);
+  await Promise.all(
+    names.map(async (n) => {
+      try {
+        out[n] = await probeServerTools(surface[n], { timeoutMs: 12000 });
+```
+
+and change the signature `export async function probeAll() {` to:
+
+```js
+export async function probeAll(crowHome = resolveCrowHome()) {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit scripts/pi-bots/ext_registry.mjs tests/pibot-crow-server-catalog.test.js \
+  -m "fix(pi-bots): probe the instance catalog, not the homedir config
+
+The Bot Builder tool picker rendered every canonical server, so it offered Crow
+servers bound to whichever instance the homedir file named. It now probes this
+instance's catalog plus the non-Crow canonical entries, which is also what lets
+the Crow entries leave ~/.pi/agent/mcp.json without emptying the picker."
+git show --stat HEAD
+```
+
+---
+
+### Task 5: Mutation-test, full suite, and live acceptance on r4
+
+Verification is its own task because the spec makes mutation testing a requirement, and because a green unit suite does not prove the writer produces a correct file for the real `r4-assistant`.
+
+**Files:** none modified. This task produces evidence.
+
+- [ ] **Step 1: Mutation-test each production change**
+
+For each mutation below: apply it, run the named test file, confirm it FAILS, then `git checkout` the file. **A mutation that does not fail a test means the test is vacuous — fix the test before proceeding.**
+
+| # | mutation | must fail |
+|---|---|---|
+| 1 | in `crow-server-catalog.mjs`, make `rebindBlock` skip the env loop (`for (const k of [])`) | `pibot-crow-server-catalog` + `pibot-mcp-instance-binding` |
+| 2 | in `crow-server-catalog.mjs`, drop the `existsSync(target)` guard so a missing bundle is retargeted anyway | `pibot-crow-server-catalog` |
+| 3 | in `crow-server-catalog.mjs`, remove `delete clone.optIn` | `pibot-mcp-instance-binding` |
+| 4 | in `mcp_writer.mjs`, delete the closed-world loop | `pibot-mcp-instance-binding` |
+| 5 | in `mcp_writer.mjs`, prefer `canonical` over `catalog` in the resolution order | `pibot-mcp-instance-binding` |
+| 6 | in `bridge.mjs`, restore `else if (tools)` | `pibot-mcp-instance-binding` |
+| 7 | in `crow-server-catalog.mjs`, anchor the bundle regex on `/crow` instead of `/\.crow` | `pibot-crow-server-catalog` (the repo-cwd test) |
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+# after each edit:
+npm test -- tests/pibot-crow-server-catalog.test.js tests/pibot-mcp-instance-binding.test.js
+git checkout scripts/pi-bots/<file>
+```
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+npm test 2>&1 | tail -30
+```
+
+Expected: pass/fail counts with **0 failures other than** `tests/models-panel-ui.test.js`, which fails on this host and passes in CI because the catalog suppresses the Download button when the memory fit probe returns `wont_fit`. It reproduces on pristine `origin/main` and predates this work. **Record the exact counts** — the prior "3052 pass / 0 fail" baseline is only true on an idle box.
+
+- [ ] **Step 3: Live acceptance — the real `r4-assistant`, before any deploy**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+S=$(mktemp -d); mkdir -p $S/db $S/out
+for f in crow.db crow.db-wal crow.db-shm; do cp -a /home/kh0pp/.crow-r4/data/$f $S/db/ 2>/dev/null; done
+cd /home/kh0pp/crow
+CROW_HOME=/home/kh0pp/.crow-r4 CROW_DATA_DIR=/home/kh0pp/.crow-r4/data \
+CROW_DB_PATH=$S/db/crow.db node -e "
+const Database=require('better-sqlite3');
+const d=new Database(process.env.CROW_DB_PATH,{readonly:true});
+const def=JSON.parse(d.prepare('SELECT definition FROM pi_bot_defs WHERE bot_id=?').get('r4-assistant').definition);
+d.close();
+import('./scripts/pi-bots/mcp_writer.mjs').then(m=>{
+  const r=m.writeBotMcp(def,{sessionDir:'$S/out',crowHome:'/home/kh0pp/.crow-r4'});
+  console.log(JSON.stringify({servers:r.servers,disabled:r.disabled,rebound:r.rebound,warnings:r.warnings},null,2));
+});"
+echo '--- written file ---'; cat $S/out/.mcp.json
+echo '--- INVARIANT: any active block naming another instance? ---'
+node -e "
+const j=JSON.parse(require('fs').readFileSync('$S/out/.mcp.json','utf8'));
+let bad=0;
+for(const [n,b] of Object.entries(j.mcpServers)){
+  if(b&&b.disabled===true) continue;
+  const s=JSON.stringify(b);
+  if(/\.crow-mpa|\.crow\//.test(s)){console.log('LEAK',n,s);bad++;}
+}
+console.log(bad?'FAIL '+bad+' leaking':'PASS no active block names another instance');"
+```
+
+Expected: `servers` is `["tasks","bots-sql-mcp","crow-memory"]`; `crow-memory.env.CROW_DB_PATH` is `/home/kh0pp/.crow-r4/data/crow.db`; `crow-tasks`, `crow-bots-sql`, `crow-projects`, `crow-blog`, `crow-storage`, `brave-search`, `crow-browser`, `google-workspace*` all appear as `{"disabled": true}`; and the final line reads **PASS**.
+
+- [ ] **Step 4: Record the evidence**
+
+Append the Step 2 counts and the Step 3 output to the spec's Appendix A under a new heading `A.7 — post-implementation acceptance`, then commit:
+
+```bash
+git commit docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md \
+  -m "docs(pi-bots): record post-implementation acceptance evidence"
+git show --stat HEAD
+```
+
+---
+
+### Task 6: Ship it — PR 1, then the host cleanup
+
+**Files:** none modified in the repo beyond the branch push.
+
+- [ ] **Step 1: Push the branch and open the PR**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+git pull --rebase
+git push -u origin HEAD
+```
+
+Then open the PR with `mcp__github__create_pull_request` against `kh0pper/crow` `main`. Title:
+
+```
+fix(pi-bots): a bot must never resolve another instance's Crow server
+```
+
+Body — use verbatim. **No `Co-Authored-By` trailer, no Claude attribution.**
+
+```markdown
+pi-lab commit 671e116 (2026-07-04) changed MCP config precedence so the NEAREST
+project file wins, not the homedir `~/.pi/agent/mcp.json`. Crow still asserted
+the old "homedir wins on collision" rule in `mcp_writer.mjs`, and believing it
+hid three live bugs.
+
+1. **Core-server blocks were copied verbatim** out of a homedir config pinned to
+   one instance, so an r4 bot's `crow_store_memory` resolved to MPA's `crow.db`.
+   Armed and reachable; MPA's `memories` table shows it had not yet fired.
+2. **An empty tool envelope omitted `--tools`**, and pi falls back to
+   `defaultActiveToolNames` when the flag is absent. Three enabled r4 bots were
+   running with bash, edit, write, and every inherited MCP tool.
+3. **A verbatim-copied `optIn` block never activates**, so four MPA bots listed
+   Google Workspace tools for a server that never loaded.
+
+Crow servers are now derived per instance — core from the repo registry, bundles
+from the instance's own `mcp-addons.json` — and the per-bot `.mcp.json` is written
+closed-world, disabling everything pi would otherwise inherit.
+
+Design and evidence: `docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md`
+
+No schema change; `SCHEMA_GENERATION` is untouched, so the migration rail does not apply.
+```
+
+- [ ] **Step 2: Gate on CI**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+SHA=$(git rev-parse HEAD)
+curl -s https://api.github.com/repos/kh0pper/crow/commits/$SHA/check-runs \
+  | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d);
+    console.log('total',j.total_count);
+    for(const r of j.check_runs) console.log(' ',r.name,r.status,r.conclusion);});"
+```
+
+Every run must be `completed` / `success` on `suite`, `static-checks` and `audit`. **An empty `check_runs` result on a current sha means something is WRONG, not normal** — do not merge. Never consult the legacy commit-status API.
+
+- [ ] **Step 3: Merge, deploy, and log the soak entries**
+
+Merge with `mcp__github__merge_pull_request`. Then:
+
+`r4-deploy.sh` uses `sudo -A` when `SUDO_ASKPASS` is set and `sudo -n` otherwise
+(`scripts/r4-deploy.sh:65`). No askpass helper exists on this host, so create one — it must
+print the password and nothing else:
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+ASKPASS=$(mktemp /tmp/crow-askpass-XXXX.sh)
+printf '#!/bin/sh\necho "8r00kly^"\n' > "$ASKPASS"
+chmod 700 "$ASKPASS"
+```
+
+Then deploy, dry run first:
+
+```bash
+date '+%Y-%m-%d %H:%M:%S %Z'   # RECORD: ~/crow pull touching scripts/pi-bots/
+git pull --rebase
+SUDO_ASKPASS="$ASKPASS" /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh --dry-run
+SUDO_ASKPASS="$ASKPASS" /home/kh0pp/r4-tehcy/scripts/r4-deploy.sh
+date '+%Y-%m-%d %H:%M:%S %Z'   # RECORD: manual pibot-gateways@r4 restart
+SUDO_ASKPASS="$ASKPASS" sudo -A systemctl restart pibot-gateways@r4
+sleep 15
+SUDO_ASKPASS="$ASKPASS" sudo -A journalctl -u pibot-gateways@r4 -n 40 --no-pager
+```
+
+Keep `$ASKPASS` for the rest of this task — Step 5 needs it. It is deleted in Step 6.
+
+`r4-deploy.sh` does **not** restart `pibot-gateways@r4`, and that unit imports `bridge.mjs` at start, so without the manual restart it keeps running the old code. Confirm the journal shows the job runner and bot-cron armed and `bot_runtime ON`. Both timestamps go in the handoff so heartbeat gaps stay explainable during the soak.
+
+- [ ] **Step 4: Confirm the leak is closed on the live host**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+echo '8r00kly^' | sudo -S journalctl -u pibot-gateways@r4 --since "10 min ago" --no-pager \
+  | grep -iE "crow-tasks|ERR_DLOPEN|Brave Search|mcp-client" || echo "OK: no inherited-global spawn"
+```
+
+Expected: `OK: no inherited-global spawn`. Before this change the r4 journal showed `[pi-lab/mcp-client] crow-tasks: MCP error -32000` and `Brave Search MCP Server running on stdio` inside r4 bot turns.
+
+- [ ] **Step 5: The host cleanup — only after Step 4 passes**
+
+Ordering is a hard constraint: editing the global file before PR 1 is deployed breaks the six MPA bots and the GUI picker.
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+D=$(date +%Y%m%d-%H%M%S)
+cp -a /home/kh0pp/.pi/agent/mcp.json /home/kh0pp/.pi/agent/mcp.json.bak.$D
+cp -a /home/kh0pp/r4-tehcy/.mcp.json /home/kh0pp/r4-tehcy/.mcp.json.bak.$D
+```
+
+Then:
+
+**1. Strip the six Crow entries from the global config.** Leaves `google-workspace`,
+`brave-search`, `crow-browser`, `google-workspace-dayane`.
+
+```bash
+node -e "
+const fs=require('fs'), P='/home/kh0pp/.pi/agent/mcp.json';
+const j=JSON.parse(fs.readFileSync(P,'utf8'));
+for(const n of ['crow-memory','crow-projects','crow-blog','crow-storage','crow-tasks','crow-bots-sql'])
+  delete j.mcpServers[n];
+fs.writeFileSync(P, JSON.stringify(j,null,2)+'\n');
+console.log('remaining:', Object.keys(j.mcpServers).join(', '));"
+```
+
+**2. Disable the same six in `~/r4-tehcy/.mcp.json`.** That file defines r4-correct servers
+under *different* names (`r4-tasks`, `r4-trackers`, `r4-kb`, `pm-workspace`), so the six
+MPA-pinned globals currently load **alongside** them: working in `~/r4-tehcy` today,
+`crow_store_memory` writes to MPA. This closes the human door, and stays correct as defense in
+depth even after step 1.
+
+```bash
+node -e "
+const fs=require('fs'), P='/home/kh0pp/r4-tehcy/.mcp.json';
+const j=JSON.parse(fs.readFileSync(P,'utf8'));
+for(const n of ['crow-memory','crow-projects','crow-blog','crow-storage','crow-tasks','crow-bots-sql'])
+  j.mcpServers[n]={disabled:true};
+fs.writeFileSync(P, JSON.stringify(j,null,2)+'\n');
+console.log('entries:', Object.keys(j.mcpServers).join(', '));"
+```
+
+**3. Rename the legacy selections in MPA's five bot defs.** Data only, no schema change.
+`~/.crow-mpa` is not the live instance and its gateway is running, so stop it first, edit, restart.
+Leave `crow-home` on `~/.crow` alone — `~/.crow` has no tasks bundle, so it is correctly disabled
+with a reason.
+
+```bash
+SUDO_ASKPASS="$ASKPASS" sudo -A systemctl stop pibot-gateways@crow-mpa pibot-discord@crow-mpa
+# Back up all three sqlite files — a .db without its -wal is not a restorable copy.
+for f in crow.db crow.db-wal crow.db-shm; do
+  [ -e /home/kh0pp/.crow-mpa/data/$f ] && cp -a /home/kh0pp/.crow-mpa/data/$f /home/kh0pp/.crow-mpa/data/$f.bak.$D
+done
+node -e "
+const Database=require('/home/kh0pp/crow/node_modules/better-sqlite3');
+const d=new Database('/home/kh0pp/.crow-mpa/data/crow.db');
+d.pragma('busy_timeout = 10000');
+const MAP={'crow-tasks':'tasks','crow-bots-sql':'bots-sql-mcp'};
+for(const r of d.prepare('SELECT bot_id,definition FROM pi_bot_defs').all()){
+  const def=JSON.parse(r.definition||'{}');
+  const sel=(def.tools&&def.tools.crow_mcp)||[];
+  const next=sel.map(s=>{const [srv,...rest]=s.split('/');return (MAP[srv]||srv)+(rest.length?'/'+rest.join('/'):'');});
+  if(JSON.stringify(sel)===JSON.stringify(next)) continue;
+  def.tools.crow_mcp=next;
+  d.prepare('UPDATE pi_bot_defs SET definition=? WHERE bot_id=?').run(JSON.stringify(def), r.bot_id);
+  console.log(r.bot_id, '->', next.join(', '));
+}
+d.close();"
+SUDO_ASKPASS="$ASKPASS" sudo -A systemctl start pibot-gateways@crow-mpa pibot-discord@crow-mpa
+```
+
+- [ ] **Step 6: Verify the cleanup**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+node -e "
+const j=JSON.parse(require('fs').readFileSync('/home/kh0pp/.pi/agent/mcp.json','utf8'));
+const gone=['crow-memory','crow-projects','crow-blog','crow-storage','crow-tasks','crow-bots-sql']
+  .filter(n=>j.mcpServers[n]);
+console.log(gone.length?'STILL PRESENT: '+gone.join(', '):'OK: no Crow server in the global config');"
+```
+
+Expected: `OK: no Crow server in the global config`. Then re-run Task 5 Step 3 and confirm it still reports **PASS** — the writer must produce the same file with the global entries gone, because the catalog was already winning.
+
+Confirm the Bot Builder tool picker still offers Crow's own tools, which is the regression Task 4 exists to prevent:
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow
+CROW_HOME=/home/kh0pp/.crow-r4 node -e "
+import('./scripts/pi-bots/ext_registry.mjs').then(async m=>{
+  const { readCanonicalMcp } = await import('./scripts/pi-bots/mcp_writer.mjs');
+  const s = m.serversForProbe(readCanonicalMcp(), '/home/kh0pp/.crow-r4');
+  console.log('picker offers:', Object.keys(s).sort().join(', '));
+  console.log(s['crow-memory'] ? 'PASS crow-memory still offered' : 'FAIL crow-memory missing');
+});"
+```
+
+Finally, clean up the askpass helper:
+
+```bash
+rm -f "$ASKPASS"
+```
+
+---
+
+## Notes for the implementer
+
+- **`crow-storage` and `crow-sharing` are catalog-only.** No bot selects either. `crow-storage` lands in `unconfigured` because `loadEnv()` reads only `<repo>/.env`, which has no `MINIO_*` keys, and no instance has its own `.env`. That is expected, not a bug to chase.
+- **`installed.json` is deliberately not consulted.** r4's lists neither `tasks` nor `bots-sql-mcp` although both bundle dirs and `mcp-addons.json` entries exist. This design keys off the bundle directory, which is the operative truth for spawning. Making `installed.json` authoritative would strip `r4-assistant`'s tools — the workaround that was explicitly rejected.
+- **The board arc is not this work.** The scope document lives in Gitea `kh0pper/crow-engineering`, branch `docs/board-truth-and-visual-language-scope`. Do not start Track 0 here.

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -32,7 +32,8 @@
 | `scripts/pi-bots/bridge.mjs` | modified, one line in the `PiRpc` constructor. |
 | `scripts/pi-bots/ext_registry.mjs` | modified, `probeAll()` only. |
 | `tests/pibot-crow-server-catalog.test.js` | **new.** Catalog derivation and rebinding. |
-| `tests/pibot-mcp-instance-binding.test.js` | **new.** The invariant, closed-world, `optIn`, and the empty-envelope spawn arg. |
+| `tests/pibot-mcp-instance-binding.test.js` | **new.** The invariant, closed-world, and `optIn`. |
+| `tests/pibot-tools-envelope.test.js` | **new.** The real `--tools` spawn args, via the `PiRpc` stub seam. |
 
 ---
 
@@ -754,49 +755,90 @@ git show --stat HEAD
 
 **Files:**
 - Modify: `scripts/pi-bots/bridge.mjs` (`PiRpc` constructor, the `--tools` branch)
-- Test: `tests/pibot-mcp-instance-binding.test.js` (append)
+- Create: `tests/pibot-tools-envelope.test.js`
 
 **Interfaces:**
-- Consumes: `toolAllowlist`, `applySessionNarrowing` from `bridge.mjs` — both already exported, neither changes.
+- Consumes: `PiRpc` from `bridge.mjs` via its existing `nodeBin` / `cliPath` / `extraEnv` test seams — the same seams `tests/pibot-bridge-exit-surface.test.js` uses, so no real pi and no live MCP server is ever spawned.
 - Produces: nothing new. `PiRpc`'s spawn args gain `--tools ""` where the flag was previously omitted.
+
+**Test the real spawn args, never a mirror of the branch.** `PiRpc` builds its args
+internally and spawns in the constructor, so a stub `cliPath` that records its own
+`process.argv` is the only honest way to assert this. A helper that re-implements the
+`if/else` in the test file would assert nothing about production code.
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `tests/pibot-mcp-instance-binding.test.js`:
+Create `tests/pibot-tools-envelope.test.js`:
 
 ```js
-import { toolAllowlist, applySessionNarrowing } from "../scripts/pi-bots/bridge.mjs";
-
 /**
- * Mirrors the --tools branch in the PiRpc constructor. A bot with no builtin
- * and no MCP tools yields "", and omitting the flag hands pi
- * defaultActiveToolNames — bash, edit, write, and every tool registered by
- * every inherited server (pi dist/cli/args.js:85-89 -> dist/core/sdk.js:133-136).
+ * `--tools` is ALWAYS pinned.
+ *
+ * pi falls back to defaultActiveToolNames when the flag is ABSENT
+ * (dist/cli/args.js:85-89 -> dist/core/sdk.js:133-136), so a bot with an empty
+ * envelope used to receive bash, edit, write, and every tool registered by
+ * every inherited MCP server. Three enabled r4 bots were in that state.
+ *
+ * Uses the PiRpc nodeBin/cliPath seam with a stub that records its argv, so no
+ * real pi is spawned. Asserts the ACTUAL spawn args, never a mirror of the
+ * branch under test.
  */
-function toolsArgs(def, narrowedTools) {
-  const tools = toolAllowlist(def);
-  const narrowed = applySessionNarrowing(tools, narrowedTools);
-  const args = [];
-  if (narrowed !== tools) args.push("--tools", narrowed);
-  else args.push("--tools", tools);
-  return args;
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { PiRpc } = await import("../scripts/pi-bots/bridge.mjs");
+
+/** Spawn PiRpc against a stub that dumps argv, and return the args pi saw. */
+async function spawnArgs(def, narrowedTools) {
+  const scratch = mkdtempSync(join(tmpdir(), "crow-tools-"));
+  mkdirSync(join(scratch, "sessions"), { recursive: true });
+  const out = join(scratch, "argv.json");
+  const stub = join(scratch, "stub-pi.mjs");
+  writeFileSync(stub,
+    'import { writeFileSync } from "node:fs";\n' +
+    'writeFileSync(process.env.CROW_TEST_ARGV_OUT, JSON.stringify(process.argv.slice(2)));\n' +
+    'process.exit(0);\n');
+  const pi = new PiRpc({
+    def,
+    sessionDir: scratch,
+    resolved: { provider: "stub", model: "stub", key: "stub/stub" },
+    nodeBin: process.execPath,
+    cliPath: stub,
+    narrowedTools,
+    extraEnv: { CROW_TEST_ARGV_OUT: out },
+  });
+  for (let i = 0; i < 100 && !existsSync(out); i++) await new Promise((r) => setTimeout(r, 50));
+  try { pi.close(); } catch { /* already exited */ }
+  assert.ok(existsSync(out), "stub pi never recorded its argv");
+  return JSON.parse(readFileSync(out, "utf8"));
 }
 
-test("an empty tool envelope pins --tools \"\" instead of omitting the flag", () => {
-  const def = { tools: { pi_builtin: [], crow_mcp: [] } };
-  assert.equal(toolAllowlist(def), "", "precondition: the envelope really is empty");
-  assert.deepEqual(toolsArgs(def), ["--tools", ""],
-    "omitting the flag would WIDEN an empty envelope to pi's full default surface");
+/** The value pi received for --tools, or undefined when the flag was omitted. */
+function toolsFlag(argv) {
+  const i = argv.indexOf("--tools");
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+test("an empty tool envelope pins --tools \"\" instead of omitting the flag", async () => {
+  const argv = await spawnArgs({ tools: { pi_builtin: [], crow_mcp: [] } });
+  assert.notEqual(toolsFlag(argv), undefined,
+    "omitting --tools hands pi its full default surface — an empty envelope would WIDEN");
+  assert.equal(toolsFlag(argv), "");
 });
 
-test("a normal envelope still pins its allowlist", () => {
-  const def = { tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } };
-  assert.deepEqual(toolsArgs(def), ["--tools", "read,mcp__tasks__tasks_list"]);
+test("a normal envelope still pins its allowlist", async () => {
+  const argv = await spawnArgs({ tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } });
+  assert.equal(toolsFlag(argv), "read,mcp__tasks__tasks_list");
 });
 
-test("narrowing to nothing still pins --tools \"\"", () => {
-  const def = { tools: { pi_builtin: ["read"], crow_mcp: [] } };
-  assert.deepEqual(toolsArgs(def, JSON.stringify(["read"])), ["--tools", ""]);
+test("narrowing every tool away still pins --tools \"\"", async () => {
+  const argv = await spawnArgs(
+    { tools: { pi_builtin: ["read"], crow_mcp: [] } },
+    JSON.stringify(["read"]));
+  assert.equal(toolsFlag(argv), "");
 });
 ```
 
@@ -804,12 +846,10 @@ test("narrowing to nothing still pins --tools \"\"", () => {
 
 ```bash
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
-npm test -- tests/pibot-mcp-instance-binding.test.js
+npm test -- tests/pibot-tools-envelope.test.js
 ```
 
-Expected: FAIL on the first new test — the helper mirrors the current branch, which produces `[]`.
-
-Note: this test asserts the *intended* behavior of the helper. Step 3 changes `bridge.mjs`; Step 4 changes the helper to mirror it again. If the helper and `bridge.mjs` ever diverge, Step 5's grep catches it.
+Expected: FAIL on the first test — `--tools` is absent from argv, so `toolsFlag` returns `undefined`. The other two must already PASS; if they do not, stop and report, because the seam itself is not working.
 
 - [ ] **Step 3: Change the branch in `bridge.mjs`**
 
@@ -847,10 +887,11 @@ with:
 
 ```bash
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
-npm test -- tests/pibot-mcp-instance-binding.test.js
+npm test -- tests/pibot-tools-envelope.test.js
+npm test -- tests/pibot-bridge-exit-surface.test.js tests/perch-narrowing.test.js
 ```
 
-Expected: PASS.
+Expected: all PASS. The latter two already drive `PiRpc` and must be unaffected.
 
 - [ ] **Step 5: Verify bridge exports are unchanged — the soak requires it**
 
@@ -865,7 +906,8 @@ Expected: `OK: no export line changed`, and the export list contains at least `C
 - [ ] **Step 6: Commit**
 
 ```bash
-git commit scripts/pi-bots/bridge.mjs tests/pibot-mcp-instance-binding.test.js \
+git add tests/pibot-tools-envelope.test.js
+git commit scripts/pi-bots/bridge.mjs tests/pibot-tools-envelope.test.js \
   -m "fix(pi-bots): always pin --tools, so an empty envelope means no tools
 
 toolAllowlist() returns \"\" for a bot with no builtin and no MCP tools, and
@@ -1019,13 +1061,13 @@ For each mutation below: apply it, run the named test file, confirm it FAILS, th
 | 3 | in `crow-server-catalog.mjs`, remove `delete clone.optIn` | `pibot-mcp-instance-binding` |
 | 4 | in `mcp_writer.mjs`, delete the closed-world loop | `pibot-mcp-instance-binding` |
 | 5 | in `mcp_writer.mjs`, prefer `canonical` over `catalog` in the resolution order | `pibot-mcp-instance-binding` |
-| 6 | in `bridge.mjs`, restore `else if (tools)` | `pibot-mcp-instance-binding` |
+| 6 | in `bridge.mjs`, restore `else if (tools)` | `pibot-tools-envelope` |
 | 7 | in `crow-server-catalog.mjs`, anchor the bundle regex on `/crow` instead of `/\.crow` | `pibot-crow-server-catalog` (the repo-cwd test) |
 
 ```bash
 export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
 # after each edit:
-npm test -- tests/pibot-crow-server-catalog.test.js tests/pibot-mcp-instance-binding.test.js
+npm test -- tests/pibot-crow-server-catalog.test.js tests/pibot-mcp-instance-binding.test.js tests/pibot-tools-envelope.test.js
 git checkout scripts/pi-bots/<file>
 ```
 

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -66,6 +66,7 @@ import {
   rebindBlock,
   crowServerCatalog,
 } from "../scripts/pi-bots/crow-server-catalog.mjs";
+import { ROOT } from "../scripts/server-registry.js";
 
 /** An instance home with a tasks bundle dir and an mcp-addons.json. */
 function instanceB() {
@@ -147,7 +148,7 @@ test("catalog binds core servers to this instance and serves them from the repo"
   assert.ok(mem, "crow-memory catalogued");
   assert.equal(mem.env.CROW_DB_PATH, join(home, "data", "crow.db"));
   assert.equal(mem.env.CROW_JOURNAL_MODE, "DELETE");
-  assert.match(mem.cwd, /crow$/, "core servers run from the repo root");
+  assert.equal(mem.cwd, ROOT, "core servers run from the repo root");
 });
 
 test("catalog binds bundle servers from this instance's mcp-addons.json", () => {

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -30,7 +30,8 @@
 | `scripts/pi-bots/crow-server-catalog.mjs` | **new.** Owns "what Crow servers exist on this instance and how are they bound." Imports only `server-registry.js` and `instance-paths.mjs` — no `ext_registry`, no `mcp_writer` — so there is no import cycle. |
 | `scripts/pi-bots/mcp_writer.mjs` | modified. Consumes the catalog; writes the closed-world per-bot file. Already 447 lines, so the catalog deliberately does not live here. |
 | `scripts/pi-bots/bridge.mjs` | modified, one line in the `PiRpc` constructor. |
-| `scripts/pi-bots/ext_registry.mjs` | modified, `probeAll()` only. |
+| `scripts/pi-bots/ext_registry.mjs` | modified, adds `serversForProbe`. |
+| `servers/gateway/dashboard/panels/bot-builder/data-queries.js` | modified, `probeAll()` — which lives here, not in `ext_registry.mjs`. |
 | `tests/pibot-crow-server-catalog.test.js` | **new.** Catalog derivation and rebinding. |
 | `tests/pibot-mcp-instance-binding.test.js` | **new.** The invariant, closed-world, and `optIn`. |
 | `tests/pibot-tools-envelope.test.js` | **new.** The real `--tools` spawn args, via the `PiRpc` stub seam. |
@@ -925,7 +926,8 @@ git show --stat HEAD
 ### Task 4: The GUI picker keeps every server, correctly bound
 
 **Files:**
-- Modify: `scripts/pi-bots/ext_registry.mjs` (`probeAll` only)
+- Modify: `scripts/pi-bots/ext_registry.mjs` (add `serversForProbe`)
+- Modify: `servers/gateway/dashboard/panels/bot-builder/data-queries.js` (`probeAll` lives HERE, not in ext_registry — it already imports `resolveCrowHome`; callers `wizard.js:404` and `editor.js:133` are both zero-arg)
 - Test: `tests/pibot-crow-server-catalog.test.js` (append)
 
 **Interfaces:**
@@ -993,7 +995,7 @@ export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = 
 }
 ```
 
-In `probeAll`, replace:
+In `probeAll` — which is in `servers/gateway/dashboard/panels/bot-builder/data-queries.js`, NOT `ext_registry.mjs` — replace:
 
 ```js
   const names = Object.keys(canonical.mcpServers);

--- a/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
+++ b/docs/superpowers/plans/2026-08-08-mcp-instance-binding.md
@@ -618,11 +618,23 @@ export function buildBotMcp(def, canonical, opts = {}) {
     if (reason) warnings.push(`server '${name}' ${reason}`);
   };
 
+  // `minted` keeps its A5 meaning: resolved from somewhere canonical does NOT
+  // have it. A core server present in BOTH the catalog and canonical is not
+  // minted — logging it as "minted from extensions" would be false on the
+  // commonest path (bot-world.mjs and the regen message both print this).
+  const noteMinted = (name) => { if (!canonical.mcpServers[name]) minted.push(name); };
+  // `journalGuarded` exists to make the WAL-unlink guard OBSERVABLE, so it
+  // reports every active crow.db server carrying the guard — uniformly, on
+  // whichever path resolved it. Reporting only the blocks this function
+  // happened to flip would hide the catalog path, which is now the common one.
+  const noteGuard = (name, block) => { if (touchesCrowDb(block)) journalGuarded.push(name); };
+
   for (const name of want) {
     if (catalog[name]) {
       out.mcpServers[name] = catalog[name];
       active.push(name);
-      minted.push(name);
+      noteMinted(name);
+      noteGuard(name, catalog[name]);
       continue;
     }
     if (unconfigured[name]) {
@@ -650,7 +662,7 @@ export function buildBotMcp(def, canonical, opts = {}) {
       }
       out.mcpServers[name] = clone;
       active.push(name);
-      if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+      noteMinted(name);
       continue;
     }
     const r = rebindBlock(name, source, binding, crowHome);
@@ -659,10 +671,10 @@ export function buildBotMcp(def, canonical, opts = {}) {
       continue;
     }
     if (r.rebound.length) rebound.push({ name, keys: r.rebound });
-    if (touchesCrowDb(r.block)) journalGuarded.push(name);
+    noteGuard(name, r.block);
     out.mcpServers[name] = r.block;
     active.push(name);
-    if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+    noteMinted(name);
   }
 
   // Closed-world. Sorted so the written file is diffable.

--- a/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
@@ -373,3 +373,81 @@ particular spawn failed rather than succeeded against MPA's `tasks.db`.
 
 All database reads were taken from copies of `.db` + `-wal` + `-shm`; no running gateway's database
 was opened directly.
+
+**A.7 — post-implementation acceptance (Task 5, 2026-08-08).**
+
+*Mutation testing* (`tests/pibot-crow-server-catalog.test.js` + `tests/pibot-mcp-instance-binding.test.js`
++ `tests/pibot-tools-envelope.test.js`, run after each mutation, then `git checkout` before the next):
+
+| # | mutation | result |
+|---|---|---|
+| 1 | `rebindBlock` env loop → `for (const k of [])` | **CAUGHT** — 3 failures, incl. "rebindBlock rewrites every instance-scoped env key" and "THE INVARIANT: no active block references the other instance" |
+| 2 | drop `existsSync(target)` guard | **CAUGHT** — 2 failures, incl. "rebindBlock disables a bundle absent on this instance, with a reason" |
+| 3 | remove `delete clone.optIn` | **CAUGHT** — 2 failures: "rebindBlock strips optIn — selection is the opt-in" and "optIn never survives into an active block" |
+| 4 | delete the closed-world loop in `mcp_writer.mjs` | **CAUGHT** — 1 failure: "closed-world: every unselected canonical server is disabled" (`crow-tasks must be disabled`) |
+| 5 | prefer `canonical` over `catalog` (`if (catalog[name])` → `if (catalog[name] && !canonical.mcpServers[name])`) | **NOT CAUGHT — VACUOUS.** 25/25 pass, 0 fail, across the 3 named files and also `tests/remote-mcp-writer.test.js`. See finding below. |
+| 6 | restore `else if (tools)` around the `--tools` push | **CAUGHT** — 1 failure: "an empty tool envelope pins --tools \"\" instead of omitting the flag" — `omitting --tools hands pi its full default surface — an empty envelope would WIDEN` |
+| 7 | anchor `INSTANCE_BUNDLE_CWD` on `/crow` instead of `/\.crow` | **CAUGHT** — 4 failures, incl. the repo-cwd test "rebindBlock leaves the repo cwd alone — the repo is instance-neutral" (`Cannot read properties of undefined (reading 'cwd')`) |
+| 8 | revert `serversForProbe` to `Object.assign(out, catalog)` | **CAUGHT** — 1 failure: "probe surface is CORE catalog servers plus NON-Crow canonical entries" — `addons are NOT folded in — probeExtensions owns them, or tasks would double-list` |
+
+7 of 8 mutations caught. `git status` was clean after every restore.
+
+**FINDING — vacuous test, mutation #5.** Preferring `canonical` over `catalog` when a name is present
+in both does not fail any test in the suite. Root cause: `rebindBlock()` is a "belt" over canonical
+blocks too (per the `buildBotMcp` doc comment), so for the one fixture where a name collides
+(`crow-memory`, present in both `twoInstances()`'s canonical and catalog), `rebindBlock` still rewrites
+`env.CROW_DB_PATH`/`CROW_JOURNAL_MODE` to the correct instance, and `noteMinted` is keyed off
+canonical-absence rather than which branch ran — so every assertion that currently exists (the
+cross-instance-leak invariant, the DB-path check, the minted list) is satisfied by both the catalog
+path and the rebound-canonical path. The only observable difference is `command`/`cwd`/`args`
+(catalog derives `command` from `process.execPath` and `cwd` from `ROOT`; the `twoInstances()`
+canonical fixture uses placeholder `command: "n"`, `cwd: "/repo"`), and no test asserts those fields
+for a name present in both maps. Per this task's instructions, no test was modified — Task 5 is
+evidence-only ("Files: none modified"), which itself conflicts with the brief's Step 1 instruction to
+"fix the test before proceeding." Flagged for the next task/PR round rather than worked around
+silently.
+
+*Full suite* (`npm test`, Node 22.23.1): **3089 pass / 0 fail / 0 cancelled / 0 skipped** (3089 tests,
+13 suites, 64.2s). `tests/models-panel-ui.test.js` passed on this run — the host was not memory-tight
+at run time, so the known memory-dependent flake did not reproduce.
+
+*Live acceptance* — real `writeBotMcp` against the real `r4-assistant` bot definition, read from a
+COPY of r4's `crow.db`+`-wal`+`-shm` (the live gateway/`pibot-gateways@r4` service was never touched;
+run from the worktree `/home/kh0pp/crow-wt-mcp-binding`, not the live `/home/kh0pp/crow` tree the
+brief's snippet names — see Task 5 report for why):
+
+```json
+{
+  "servers": ["tasks", "bots-sql-mcp", "crow-memory"],
+  "disabled": [
+    "brave-search", "crow-blog", "crow-bots-sql", "crow-browser",
+    "crow-projects", "crow-storage", "crow-tasks",
+    "google-workspace", "google-workspace-dayane"
+  ],
+  "rebound": [],
+  "warnings": []
+}
+```
+
+`servers` and `disabled` match the brief's expected set exactly (the `google-workspace*` wildcard
+covers both `google-workspace` and `google-workspace-dayane`). `crow-memory`'s `cwd` resolved to the
+worktree repo root (`/home/kh0pp/crow-wt-mcp-binding`), which the task's own instructions call out as
+expected here, not a leak.
+
+One value did **not** match the brief's stated expectation: `crow-memory.env.CROW_DB_PATH` came out as
+the scratch copy path (e.g. `/tmp/.../r4acc/db/crow.db`), not `/home/kh0pp/.crow-r4/data/crow.db` as
+the brief's "Expected" line states. Cause: the brief's own Step 3 command exports
+`CROW_DB_PATH=$S/db/crow.db` so the bot-definition read never touches the live database — but
+`instanceBinding()`'s `dbPath` falls back to `botsDbPath()`, which reads that same `CROW_DB_PATH` env
+var, so the safety override for the *read* leaks into the *binding* used for the *write*. This is a
+brief-expectation defect, not a code defect: the invariant check below still passes because the
+scratch path names no *other* instance.
+
+Invariant check:
+
+```
+--- INVARIANT: any active block naming another instance? ---
+PASS no active block names another instance
+```
+
+**PASS.**

--- a/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
@@ -1,0 +1,348 @@
+# Design — a bot must never resolve a Crow server belonging to another instance
+
+Written 2026-08-08. Supersedes the framing in
+`docs/superpowers/handoffs/2026-08-08-board-truth-scope-and-mcp-override.md`, whose central premise
+turned out to be inverted. Every claim below was verified against live state or a running pi; the
+evidence is in Appendix A.
+
+---
+
+## 1. The invariant
+
+> **A bot must never resolve a Crow server bound to an instance other than its own.**
+
+Stated structurally, which is how this design achieves it:
+
+> **No file that can name an instance may describe a Crow server.**
+
+## 2. What is actually wrong
+
+The handoff said the defect was that `~/.pi/agent/mcp.json` **wins on collision** over the per-bot
+`.mcp.json`, so per-bot instance scoping could not take effect. That is false on the pi that is
+actually installed.
+
+`/home/kh0pp/pi-lab/extensions/mcp-client.ts` — on `main`, loaded, live:
+
+> *Precedence: global config first, then `.mcp.json` files from the filesystem root down to cwd —
+> the NEAREST project file wins (Claude Code semantics).*
+
+pi-lab commit `671e116`, **2026-07-04**, changed this. Crow's copy of the old rule survives in
+`mcp_writer.mjs`'s header and in `extraServersFromExtensions`' skip comment, both re-asserted as
+"re-verified on v0.82.0 (2026-07-25 probe run)". The stale comment is why the real behavior stayed
+invisible for a month; correcting it is part of this fix, not tidying.
+
+The real defect is narrower and more ordinary: **the per-bot file is written open-world.** It lists
+only what the bot selected, copies blocks verbatim from a config pinned to one instance, and says
+nothing about the rest — so everything unselected leaks in. Three live bugs follow.
+
+### Bug 1 — core-server blocks are copied verbatim, so they carry another instance's database
+
+`crow-memory` is a core server, so `extraServersFromExtensions` never mints it; `buildBotMcp` copies
+the canonical block unchanged. Running the real `writeBotMcp` for `r4-assistant` under r4's
+`CROW_HOME` produces:
+
+```
+tasks          → /home/kh0pp/.crow-r4/…            ✅ minted from r4's mcp-addons.json
+bots-sql-mcp   → /home/kh0pp/.crow-r4/…            ✅ minted
+crow-memory    → CROW_DB_PATH=/home/kh0pp/.crow-mpa/data/crow.db   ❌
+```
+
+`crow_store_memory` is in `r4-assistant`'s allowlist. Nothing crashes. It writes to MPA's `crow.db`.
+
+The handoff's correction was half right: the *tools* are legitimate, the *binding* is not.
+
+**Not yet fired.** MPA's `memories` table (read from a copy) has 343 rows, newest `2026-07-02`. The
+path is armed and reachable; no cross-instance write has occurred. No data cleanup is required.
+
+### Bug 2 — an empty tool envelope hands pi its full default surface
+
+`toolAllowlist()` returns `""` for a bot with no builtin and no MCP tools. In `PiRpc`:
+
+```js
+if (narrowedTools !== tools) args.push("--tools", narrowedTools);
+else if (tools) args.push("--tools", tools);   // "" is falsy → flag omitted
+```
+
+pi's own parser (`dist/cli/args.js:85-89` → `dist/core/sdk.js:133-136`): `--tools ""` parses to an
+empty array and correctly yields no tools, but **omitting the flag yields `defaultActiveToolNames`** —
+bash, edit, write, and every tool registered by every inherited global server.
+
+`r4-toolkit-assets`, `r4-comms-log`, `r4-monday-mirror` are all `enabled=1` with empty envelopes. On
+those three bots the MPA-pinned `crow-tasks`, `crow-bots-sql` and `crow-memory` tools are **callable
+today**.
+
+The comment three lines above that branch already states the rule — *"omitting the flag hands pi its
+full default surface — narrowing would widen"* — but the empty-envelope case falls through the same
+hole the narrowing case was patched for.
+
+### Bug 3 — `optIn` is copied verbatim, which makes the server inactive
+
+pi activates an `optIn: true` server only when a project file opts in with `{"enabled": true}`.
+`buildBotMcp` copies blocks verbatim, `optIn` included, and nothing ever emits `enabled`. So
+`job-searcher`, `job-searcher-dayane`, `pir-processor` and `grackle` carry
+`mcp__google-workspace__*` in their allowlists for a server that never loads.
+
+Proven by experiment (Appendix A.3). **Not** corroborated by production logs — no journal line
+confirms or denies it in bot behavior.
+
+### The common root
+
+All three are the same mistake: **the writer treats the global config as a source to copy from, when
+pi treats the per-bot file as the authority.**
+
+## 3. The mechanism, as proven
+
+pi 0.82.0 + pi-lab `main` merges global → filesystem root → cwd, nearest wins. Three levers:
+
+| lever | effect | proven by |
+|---|---|---|
+| redefine a name in the per-bot file | per-bot block wins entirely | A.1 |
+| `{"name": {"disabled": true}}` | global server does not load at all | A.2 |
+| omit a name | global server **still loads** | A.2 |
+
+This design uses all three rather than fighting the first.
+
+## 4. Architecture
+
+Three sources, split by what each genuinely knows. This is the structural form of the invariant.
+
+| server class | source of truth | instance binding |
+|---|---|---|
+| Crow **core** — `crow-memory`, `crow-projects`, `crow-sharing`, `crow-blog`, `crow-storage` (the last catalogued only — §5.5) | `scripts/server-registry.js` (`CORE_SERVERS` + `CONDITIONAL_SERVERS`), which already carries args and `mcpEnv` templates and already has `resolveEnvValue` for `${VAR:-default}` | computed from this instance's env on every write |
+| Crow **bundle** — `tasks`, `bots-sql-mcp`, `knowledge-base`, … | the instance's own `mcp-addons.json` | already instance-native; cwd defaulted to `<crowHome>/bundles/<id>` |
+| **non-Crow** — `brave-search`, `google-workspace*`, `ms365`, `monday`, `box` | `~/.pi/agent/mcp.json`, which keeps them | none — they carry credentials, not instance identity |
+
+`~/.pi/agent/mcp.json` is demoted from *catalog of Crow servers* to *the place third-party
+credentials live*, which is what it was always good at.
+
+`crow-browser` stays canonical-sourced: its cwd is `/home/kh0pp/crow/bundles/browser` — the repo, not
+an instance — so it is not instance-scoped.
+
+### Why the host file cannot simply be edited
+
+`~/.pi/agent/mcp.json` is currently the product's Crow-server catalog in two places:
+
+- `mcp_writer.buildBotMcp` copies server blocks from it. Remove the six Crow entries and all six MPA
+  bots lose `crow-tasks` / `crow-memory` / `crow-bots-sql` / `crow-projects`.
+- `ext_registry.probeAll()` renders the Bot Builder tool picker by probing **every** canonical
+  server. Remove them and the operator can no longer select Crow's own tools when building a bot.
+
+So the host cleanup is downstream of a product change, not an alternative to one. **Ordering is a
+hard constraint** — see §8.
+
+## 5. Code changes
+
+### 5.1 `scripts/pi-bots/mcp_writer.mjs`
+
+**New — `crowServerCatalog(crowHome)`.** Returns `{name: block}` for every Crow server available to
+*this* instance, assembled from the registry (core) and `mcp-addons.json` (bundles). Core blocks get
+`cwd = ROOT` (the repo) and env resolved against this instance's values. Bundle blocks get
+`cwd = <crowHome>/bundles/<id>` when the addon block omits one, matching `proxy.js:197`.
+
+**Resolution order for a selected server name** — stated explicitly, because it is the whole design:
+
+1. **catalog** (`crowServerCatalog`) — instance-derived, always correct. Wins.
+2. **canonical** (`~/.pi/agent/mcp.json`) — for names the catalog does not know: the non-Crow
+   servers, plus `crow-browser`.
+3. neither → warning, server omitted (unchanged behavior).
+
+Before PR 2, canonical still carries the six Crow entries; step 1 means they are never consulted for
+those names, so PR 1 fixes the binding on its own and PR 2 only removes a now-unused fallback.
+
+**New — `rebindBlock(name, block, binding, crowHome)`.** A belt for blocks resolved at step 2 that
+nonetheless carry instance-scoped state. It rewrites the four instance-scoped env keys — `CROW_HOME`, `CROW_DATA_DIR`, `CROW_DB_PATH`,
+`CROW_TASKS_DB_PATH` — to this instance's values, sourced from `instance-paths.mjs`. The tasks path
+is normalized through the `resolveSqlitePath()` that PR #278 added, so a `file:` URI from
+`project_spaces.tasks_db_uri` never reaches a bundle's `better-sqlite3`. A `cwd` matching
+`*/.crow*/bundles/<id>` is rewritten to `<crowHome>/bundles/<id>`; if that directory does not exist,
+the server is **disabled with a stated reason** rather than minted into a guaranteed spawn failure.
+
+The `/.crow` anchor is deliberate: `/home/kh0pp/crow/bundles/browser` and `/home/kh0pp/crow` do not
+match, so the repo is left alone. It is instance-neutral, correctly.
+
+**Changed — `buildBotMcp` becomes closed-world.** After emitting the bot's selected servers, emit
+`{"disabled": true}` for every other name **present in the canonical config** and not selected. The
+per-bot file becomes the complete statement of the bot's world. Emit in stable sorted order so the
+file is diffable.
+
+Canonical is the right source for the disable list because canonical is exactly what pi would
+otherwise inherit — the catalog is never inherited, only written. After PR 2 the six Crow names leave
+canonical and simply stop appearing in the disable list, which is correct: there is nothing left to
+disable.
+
+**Changed — strip `optIn` from selected blocks.** Selection *is* the opt-in. Fixes bug 3.
+
+**Changed — comments.** The header's "homedir WINNING on key collision" and
+`extraServersFromExtensions`' `// canonical present -> homedir wins, no mint` are both false as of
+pi-lab `671e116`. Replace with the proven rule and cite the commit and date.
+
+Return shape gains `disabled: [...]` and `rebound: [{name, keys}]` for logging. Existing keys keep
+their names and meanings.
+
+### 5.2 `scripts/pi-bots/bridge.mjs`
+
+One line: `args.push("--tools", narrowedTools)` unconditionally, so an empty envelope pins
+`--tools ""` instead of omitting the flag. Fixes bug 2.
+
+Constructor body only. `PiRpc`, `db`, `toolAllowlist`, `CROW_DB`, `TASKS_DB` and every other export
+keep their name and signature, so `job_runner.mjs`'s consumer surface is untouched — required by the
+pibot soak agreement.
+
+### 5.3 `scripts/pi-bots/ext_registry.mjs`
+
+`probeAll()` renders **catalog ∪ non-Crow canonical** instead of canonical alone, so the GUI tool
+picker keeps every server it shows today and gains correct instance binding for the Crow ones. This
+is what makes §8's host cleanup survivable.
+
+### 5.4 The alias shim
+
+MPA's bots reference `crow-tasks` and `crow-bots-sql`. The instance-native names for those same
+bundles are `tasks` and `bots-sql-mcp`. Renaming them in the six bot defs would change the tool names
+the model sees (`mcp__crow-tasks__*` → `mcp__tasks__*`), which their system prompts and skills may
+reference.
+
+Ship a two-entry alias map — `crow-tasks → tasks`, `crow-bots-sql → bots-sql-mcp` — documented as a
+compatibility shim with a stated retirement. **Do not migrate bot defs during the soak.**
+
+The alias applies at **catalog lookup only**. The emitted block keeps the key the bot selected, so
+`crow-tasks` stays `crow-tasks` in the per-bot file and the model keeps seeing
+`mcp__crow-tasks__tasks_update`. Only the block's contents come from the instance-native `tasks`
+entry. Nothing the model or a system prompt can observe changes.
+
+This is the one part of the design worth calling ugly. It is contained to two entries and one lookup.
+
+### 5.5 `crow-storage` — catalogued, not minted
+
+`loadEnv()` reads only `<repo>/.env`, a single repo-global file. No instance has its own `.env`, and
+`/home/kh0pp/crow/.env` contains zero `MINIO_*` keys. Minting `crow-storage` from its registry
+`mcpEnv` would resolve endpoint and password to empty strings. The canonical block is no better — it
+carries no MinIO env either.
+
+No bot selects `crow-storage` or `crow-sharing`, so this is catalog-only surface. Catalog
+`crow-storage` as **present but unconfigured**, with the reason surfaced in the GUI, instead of
+minting a block that would fail on spawn.
+
+## 6. The invariant as a test
+
+Closed-world was chosen over refuse-to-start, so the invariant lands as an executable assertion over
+the writer's output rather than a runtime abort.
+
+`tests/pibot-mcp-instance-binding.test.js`:
+
+1. **The invariant.** Given a canonical config pinned to instance **A** and a `crowHome` of instance
+   **B**, no active block in the produced file may reference **A** — walking `cwd` and every env
+   string value.
+2. Every canonical key the bot did not select appears with `{"disabled": true}`.
+3. A selected bundle absent on **B** is disabled with a stated reason, not silently minted.
+4. `optIn` never survives into an active block.
+5. `toolAllowlist(def) === ""` still yields `--tools ""` in the spawn args.
+
+**Mutation-tested**: reverting any one production change must fail at least one test. This is the
+discipline that caught `tracker.mjs`'s duplicate `db()` in PR #278, where reading the call sites was
+not sufficient and running them was.
+
+## 7. Blast radius
+
+Checked, not assumed. Every MPA bot has a non-empty envelope, so `--tools` is already pinned and
+closed-world removes **no capability from any existing bot** — only per-turn spawns. Six MPA-pinned
+Crow servers plus `brave-search` stop being spawned into every r4 bot turn.
+
+Bots and their selected servers at design time:
+
+| instance | bot | selects |
+|---|---|---|
+| r4 | `r4-assistant` | `tasks`, `bots-sql-mcp`, `crow-memory` |
+| r4 | `r4-toolkit-assets`, `r4-comms-log`, `r4-monday-mirror` | *(none — bug 2)* |
+| r4 | `r4-heartbeat` | *(none, 1 builtin)* |
+| mpa | `research-scout`, `pir-portal-runner` | `crow-tasks` |
+| mpa | `job-searcher`, `job-searcher-dayane` | `crow-bots-sql`, `crow-tasks`, `google-workspace*`, `crow-memory`, `brave-search`, `crow-browser` |
+| mpa | `pir-processor` | `crow-tasks`, `crow-memory`, `crow-projects`, `texas-gov-data`, `google-workspace`, `crow-bots-sql` |
+| mpa | `grackle` | `crow-memory`, `google-workspace` |
+
+The only behavior that changes is in the direction of the three bugs.
+
+## 8. Host cleanup — PR 2, strictly after PR 1 deploys
+
+**Ordering is a hard constraint.** Editing the global file before the product change breaks the six
+MPA bots and the GUI picker immediately.
+
+1. Strip the six Crow entries — `crow-memory`, `crow-projects`, `crow-blog`, `crow-storage`,
+   `crow-tasks`, `crow-bots-sql` — from `~/.pi/agent/mcp.json`.
+2. Add `{"disabled": true}` for those same six to `~/r4-tehcy/.mcp.json`.
+
+Step 2 closes the **human** door. `~/r4-tehcy/.mcp.json` defines r4-correct servers under *different*
+names (`r4-tasks`, `r4-trackers`, `r4-kb`, `pm-workspace`), so the six MPA-pinned globals currently
+load **alongside** them: working in `~/r4-tehcy` today, `crow_store_memory` writes to MPA. That is
+finding 2 of the board scope document, and the product fix does not close it — only step 2 does. It
+remains correct to do even after step 1, as defense in depth.
+
+Back up both files first, using the existing `.bak-<date>` convention already in `~/.pi/agent/`.
+
+## 9. Soak discipline
+
+`scripts/pi-bots/` is touched, and `pibot-gateways@r4` runs from the `~/crow` working tree in a soak
+ending ~2026-08-12. Required:
+
+- Log the `~/crow` pull with a timestamp.
+- Restart `pibot-gateways@r4` **manually** — `r4-deploy.sh` does not restart it, and it imports
+  `bridge.mjs` at start — and log that with a timestamp.
+- Confirm bridge exports are name- and signature-stable before merging.
+
+## 10. Out of scope
+
+- **Board truth / visual language.** The next arc, scoped in Gitea `kh0pp/crow-engineering`, branch
+  `docs/board-truth-and-visual-language-scope`. Not this task.
+- **Migrating bot defs off `crow-tasks` / `crow-bots-sql` names.** Deferred behind the alias shim.
+- **`~/crow/.mcp.json`** (generated) points `CROW_DB_PATH` at `./data/crow.db` — safe only because it
+  is relative to the repo cwd. Recorded, not fixed.
+- **`installed.json` drift.** r4's `installed.json` lists neither `tasks` nor `bots-sql-mcp` although
+  both bundle directories and `mcp-addons.json` entries exist. This design keys off the bundle
+  directory's existence, which is the operative truth for spawning, and warns on the discrepancy.
+  Making `installed.json` authoritative would remove `r4-assistant`'s tools — the workaround that was
+  explicitly rejected.
+- **`tests/models-panel-ui.test.js`** fails on crow and passes in CI (memory-dependent fit probe).
+  Predates this work.
+
+---
+
+## Appendix A — evidence
+
+All experiments run against pi **0.82.0** with pi-lab `main` loaded, using a fake `HOME` containing a
+global `mcp.json` and a project `.mcp.json` that define the *same server name*, each pointing at a
+stub MCP server that appends its variant to a marker file on spawn. Whoever spawns, wins.
+
+**A.1 — nearest file wins.** Global and project both define `probe`. Result: only **PROJECT**
+spawned.
+
+**A.2 — disable works; omission does not narrow.** Global defines `probe` and `other`; project says
+`{"probe": {"disabled": true}}` and never mentions `other`. Result: `probe` did **not** spawn,
+`other` **did**.
+
+**A.3 — `optIn` survives a verbatim copy and suppresses the server.** Global entry carries
+`optIn: true`.
+
+| project file | result |
+|---|---|
+| copies the block verbatim, `optIn` retained (what `mcp_writer` does today) | **NOT SPAWNED** |
+| copies the block with `optIn` stripped | spawned |
+
+**A.4 — the live cross-instance binding.** Real `writeBotMcp` for `r4-assistant` under r4's
+`CROW_HOME` emits `crow-memory` with `CROW_DB_PATH=/home/kh0pp/.crow-mpa/data/crow.db`.
+
+**A.5 — inherited globals really are spawned into r4 bot turns.** r4 journal,
+`Aug 07 21:23:09`:
+
+```
+[gateways] [jobs] job job-msjqo0g7-9x0mtn → failed (timeout:agent_end (stderr -mpa/bundles/tasks/server/index.js:18:12 {
+  code: 'ERR_DLOPEN_FAILED'
+[pi-lab/mcp-client] crow-tasks: MCP error -32000: Connection closed
+Brave Search MCP Server running on stdio
+```
+
+MPA's copy of the tasks bundle carries a stale native-module ABI, which is the only reason that
+particular spawn failed rather than succeeded against MPA's `tasks.db`.
+
+**A.6 — no cross-instance write has occurred.** MPA `memories`: 343 rows, newest `2026-07-02`.
+
+All database reads were taken from copies of `.db` + `-wal` + `-shm`; no running gateway's database
+was opened directly.

--- a/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
@@ -194,20 +194,30 @@ pibot soak agreement.
 picker keeps every server it shows today and gains correct instance binding for the Crow ones. This
 is what makes §8's host cleanup survivable.
 
-### 5.4 The alias shim
+### 5.4 Legacy server names — renamed in data, no shim in the product
 
-MPA's bots reference `crow-tasks` and `crow-bots-sql`. The instance-native names for those same
-bundles are `tasks` and `bots-sql-mcp`. Renaming them in the six bot defs would change the tool names
-the model sees (`mcp__crow-tasks__*` → `mcp__tasks__*`), which their system prompts and skills may
-reference.
+Five MPA bots and the dormant `crow-home` on `~/.crow` reference `crow-tasks` and `crow-bots-sql`.
+The instance-native names for those same bundles are `tasks` and `bots-sql-mcp`, which is what
+`mcp-addons.json`, `installed.json` and the gateway proxy all use, and what `r4-assistant` already
+selects.
 
-Ship a two-entry alias map — `crow-tasks → tasks`, `crow-bots-sql → bots-sql-mcp` — documented as a
-compatibility shim with a stated retirement. **Do not migrate bot defs during the soak.**
+An earlier draft carried a two-entry alias map to preserve the legacy names. **It is dropped.** The
+operator confirmed MPA is an experimental building instance he does not use, and the evidence agrees
+(§7): r4 is the only live instance. A permanent compatibility shim in the product is not worth
+carrying for bots on instances nobody uses.
 
-The alias applies at **catalog lookup only**. The emitted block keeps the key the bot selected, so
-`crow-tasks` stays `crow-tasks` in the per-bot file and the model keeps seeing
-`mcp__crow-tasks__tasks_update`. Only the block's contents come from the instance-native `tasks`
-entry. Nothing the model or a system prompt can observe changes.
+Instead the six legacy selections are renamed as a **one-time data step in PR 2** (§8), alongside the
+host cleanup. MPA's `mcp-addons.json` and `bundles/` already carry both servers under the native
+names, so after the rename MPA's bots resolve through the catalog like everything else.
+
+Accepted cost: renaming changes the tool names those bots' models see
+(`mcp__crow-tasks__*` → `mcp__tasks__*`), so any MPA system prompt that spells out a tool name goes
+stale. On experimental bots that is a fair trade for removing permanent product debt.
+
+`crow-home` is **left alone**. `~/.crow` has no `tasks` bundle and no `tasks` addon entry, so under
+this design its `crow-tasks` selection is disabled with a stated reason instead of silently binding
+to MPA's database, which is what it does today. It is dormant — `~/.crow` has no pibot runtime unit
+and 0 cards — so there is nothing to preserve.
 
 This is the one part of the design worth calling ugly. It is contained to two entries and one lookup.
 
@@ -247,6 +257,18 @@ Checked, not assumed. Every MPA bot has a non-empty envelope, so `--tools` is al
 closed-world removes **no capability from any existing bot** — only per-turn spawns. Six MPA-pinned
 Crow servers plus `brave-search` stop being spawned into every r4 bot turn.
 
+**r4 is the only live instance**, which is what makes §5.4's simplification safe:
+
+| instance | cards | newest card | pibot runtime unit |
+|---|---|---|---|
+| `~/.crow-r4` | **137** | 2026-08-08 | `pibot-gateways@r4` — running |
+| `~/.crow-mpa` | 85 | 2026-07-11 | `pibot-gateways@crow-mpa`, `pibot-discord@crow-mpa` — running |
+| `~/.crow` | 0 | — | **none** |
+
+The operator confirmed MPA is an experimental building instance he does not use; the month-stale card
+data agrees. `~/.crow` has a runtime gap, not just disuse: its one enabled bot `crow-home` has no
+service driving it.
+
 Bots and their selected servers at design time:
 
 | instance | bot | selects |
@@ -269,6 +291,9 @@ MPA bots and the GUI picker immediately.
 1. Strip the six Crow entries — `crow-memory`, `crow-projects`, `crow-blog`, `crow-storage`,
    `crow-tasks`, `crow-bots-sql` — from `~/.pi/agent/mcp.json`.
 2. Add `{"disabled": true}` for those same six to `~/r4-tehcy/.mcp.json`.
+3. Rename the legacy selections (§5.4) in MPA's five bot defs: `crow-tasks/*` → `tasks/*`,
+   `crow-bots-sql/*` → `bots-sql-mcp/*`. Data only, no schema change. `crow-home` on `~/.crow` is
+   left alone.
 
 Step 2 closes the **human** door. `~/r4-tehcy/.mcp.json` defines r4-correct servers under *different*
 names (`r4-tasks`, `r4-trackers`, `r4-kb`, `pm-workspace`), so the six MPA-pinned globals currently
@@ -292,7 +317,9 @@ ending ~2026-08-12. Required:
 
 - **Board truth / visual language.** The next arc, scoped in Gitea `kh0pp/crow-engineering`, branch
   `docs/board-truth-and-visual-language-scope`. Not this task.
-- **Migrating bot defs off `crow-tasks` / `crow-bots-sql` names.** Deferred behind the alias shim.
+- **`crow-home` on `~/.crow`.** Dormant (no runtime unit, 0 cards) and left to be disabled with a
+  reason rather than migrated. See §5.4.
+- **`~/.crow`'s missing pibot runtime unit.** Noted while establishing §7; unrelated to this work.
 - **`~/crow/.mcp.json`** (generated) points `CROW_DB_PATH` at `./data/crow.db` — safe only because it
   is relative to the repo cwd. Recorded, not fixed.
 - **`installed.json` drift.** r4's `installed.json` lists neither `tasks` nor `bots-sql-mcp` although

--- a/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md
@@ -385,36 +385,73 @@ was opened directly.
 | 2 | drop `existsSync(target)` guard | **CAUGHT** — 2 failures, incl. "rebindBlock disables a bundle absent on this instance, with a reason" |
 | 3 | remove `delete clone.optIn` | **CAUGHT** — 2 failures: "rebindBlock strips optIn — selection is the opt-in" and "optIn never survives into an active block" |
 | 4 | delete the closed-world loop in `mcp_writer.mjs` | **CAUGHT** — 1 failure: "closed-world: every unselected canonical server is disabled" (`crow-tasks must be disabled`) |
-| 5 | prefer `canonical` over `catalog` (`if (catalog[name])` → `if (catalog[name] && !canonical.mcpServers[name])`) | **NOT CAUGHT — VACUOUS.** 25/25 pass, 0 fail, across the 3 named files and also `tests/remote-mcp-writer.test.js`. See finding below. |
+| 5 | prefer `canonical` over `catalog` (`if (catalog[name])` → `if (catalog[name] && !canonical.mcpServers[name])`) | **CAUGHT (second pass)** — see finding below for why the first pass missed it |
 | 6 | restore `else if (tools)` around the `--tools` push | **CAUGHT** — 1 failure: "an empty tool envelope pins --tools \"\" instead of omitting the flag" — `omitting --tools hands pi its full default surface — an empty envelope would WIDEN` |
 | 7 | anchor `INSTANCE_BUNDLE_CWD` on `/crow` instead of `/\.crow` | **CAUGHT** — 4 failures, incl. the repo-cwd test "rebindBlock leaves the repo cwd alone — the repo is instance-neutral" (`Cannot read properties of undefined (reading 'cwd')`) |
 | 8 | revert `serversForProbe` to `Object.assign(out, catalog)` | **CAUGHT** — 1 failure: "probe surface is CORE catalog servers plus NON-Crow canonical entries" — `addons are NOT folded in — probeExtensions owns them, or tasks would double-list` |
 
-7 of 8 mutations caught. `git status` was clean after every restore.
+8 of 8 mutations caught. `git status` was clean after every restore.
 
-**FINDING — vacuous test, mutation #5.** Preferring `canonical` over `catalog` when a name is present
-in both does not fail any test in the suite. Root cause: `rebindBlock()` is a "belt" over canonical
-blocks too (per the `buildBotMcp` doc comment), so for the one fixture where a name collides
-(`crow-memory`, present in both `twoInstances()`'s canonical and catalog), `rebindBlock` still rewrites
-`env.CROW_DB_PATH`/`CROW_JOURNAL_MODE` to the correct instance, and `noteMinted` is keyed off
-canonical-absence rather than which branch ran — so every assertion that currently exists (the
-cross-instance-leak invariant, the DB-path check, the minted list) is satisfied by both the catalog
-path and the rebound-canonical path. The only observable difference is `command`/`cwd`/`args`
-(catalog derives `command` from `process.execPath` and `cwd` from `ROOT`; the `twoInstances()`
-canonical fixture uses placeholder `command: "n"`, `cwd: "/repo"`), and no test asserts those fields
-for a name present in both maps. Per this task's instructions, no test was modified — Task 5 is
-evidence-only ("Files: none modified"), which itself conflicts with the brief's Step 1 instruction to
-"fix the test before proceeding." Flagged for the next task/PR round rather than worked around
-silently.
+**FINDING — mutation #5 was vacuous on the first pass, then closed.** Preferring `canonical` over
+`catalog` when a name is present in both did not fail any test in the suite on the first mutation run
+(25/25 pass, 0 fail — checked against the 3 named files and also `tests/remote-mcp-writer.test.js`).
+Root cause: `rebindBlock()` is a "belt" over canonical blocks too (per the `buildBotMcp` doc comment),
+so for the one fixture where a name collides (`crow-memory`, present in both `twoInstances()`'s
+canonical and catalog), `rebindBlock` still rewrote `env.CROW_DB_PATH`/`CROW_JOURNAL_MODE` to the
+correct instance regardless of which source won, and `noteMinted` is keyed off canonical-absence
+rather than which branch ran — so every assertion that existed at the time (the cross-instance-leak
+invariant, the DB-path check, the minted list) was satisfied by both the catalog path and the
+rebound-canonical path. The only field `rebindBlock` never touches is `args`, so it is the sole
+witness of which source actually won.
 
-*Full suite* (`npm test`, Node 22.23.1): **3089 pass / 0 fail / 0 cancelled / 0 skipped** (3089 tests,
-13 suites, 64.2s). `tests/models-panel-ui.test.js` passed on this run — the host was not memory-tight
-at run time, so the known memory-dependent flake did not reproduce.
+Closed by adding `"RESOLUTION ORDER: the catalog wins over canonical for the same name"` to
+`tests/pibot-mcp-instance-binding.test.js` (immediately before `"a non-Crow server is carried through
+untouched"`): it sets `canon.mcpServers["crow-memory"].args = ["CANONICAL-WINS.js"]` on the
+`twoInstances()` fixture's canonical file, then asserts the written block's `args` still equals
+`["servers/memory/index.js"]` — the registry catalog's value. Re-running mutation #5 with this test
+in place: **1 failure** — `args must come from the registry catalog, not from the canonical block: +
+['CANONICAL-WINS.js'] - ['servers/memory/index.js']`. Restored (`git checkout
+scripts/pi-bots/mcp_writer.mjs`); `git status` clean; re-ran clean (10/10 pass) to confirm the new
+test is not itself broken absent the mutation.
 
-*Live acceptance* — real `writeBotMcp` against the real `r4-assistant` bot definition, read from a
-COPY of r4's `crow.db`+`-wal`+`-shm` (the live gateway/`pibot-gateways@r4` service was never touched;
-run from the worktree `/home/kh0pp/crow-wt-mcp-binding`, not the live `/home/kh0pp/crow` tree the
-brief's snippet names — see Task 5 report for why):
+*Full suite* (`npm test`, Node 22.23.1), after adding the resolution-order test:
+**3090 pass / 0 fail / 0 cancelled / 0 skipped** (3090 tests, 13 suites). `tests/models-panel-ui.test.js`
+passed on this run — the host was not memory-tight at run time, so the known memory-dependent flake
+did not reproduce.
+
+*Live acceptance* — real `writeBotMcp` against the real `r4-assistant` bot definition. Two runs:
+
+**First run (flawed harness — recorded for the record, not authoritative).** The bot-definition SELECT
+was pointed at a copy of r4's db via `CROW_DB_PATH=$S/db/crow.db` — but `instanceBinding()`'s `dbPath`
+also falls back to `botsDbPath()`, which reads that same `CROW_DB_PATH` env var, so the safety override
+intended only for the *read* leaked into the *binding* used for the *write*. Result:
+`crow-memory.env.CROW_DB_PATH` came out as the scratch copy path (e.g. `/tmp/.../r4acc/db/crow.db`),
+not the live path — meaning this run could not have detected a real cross-instance leak, since the
+output was bound to neither the live instance nor another instance. `servers`/`disabled` still matched
+expectations and the invariant script still printed PASS, but the run proved less than it appeared to.
+
+**Corrected run (authoritative).** `CROW_DB_PATH` names the LIVE instance
+(`/home/kh0pp/.crow-r4/data/crow.db`) because that is what `instanceBinding()` turns into path
+strings — `writeBotMcp` never opens `crow.db` itself. The bot definition is read from the COPY
+separately via a distinct `PIBOT_DEF_DB` env var, so the live db is still never opened directly:
+
+```bash
+S=$(mktemp -d); mkdir -p $S/db $S/out
+for f in crow.db crow.db-wal crow.db-shm; do cp -a /home/kh0pp/.crow-r4/data/$f $S/db/ 2>/dev/null; done
+cd /home/kh0pp/crow-wt-mcp-binding
+CROW_HOME=/home/kh0pp/.crow-r4 CROW_DATA_DIR=/home/kh0pp/.crow-r4/data \
+CROW_DB_PATH=/home/kh0pp/.crow-r4/data/crow.db PIBOT_DEF_DB=$S/db/crow.db node -e "
+const Database=require('better-sqlite3');
+const d=new Database(process.env.PIBOT_DEF_DB,{readonly:true});
+const def=JSON.parse(d.prepare('SELECT definition FROM pi_bot_defs WHERE bot_id=?').get('r4-assistant').definition);
+d.close();
+import('./scripts/pi-bots/mcp_writer.mjs').then(m=>{
+  const r=m.writeBotMcp(def,{sessionDir:'$S/out',crowHome:'/home/kh0pp/.crow-r4'});
+  console.log(JSON.stringify({servers:r.servers,disabled:r.disabled,rebound:r.rebound,warnings:r.warnings},null,2));
+});"
+```
+
+Result:
 
 ```json
 {
@@ -430,24 +467,17 @@ brief's snippet names — see Task 5 report for why):
 ```
 
 `servers` and `disabled` match the brief's expected set exactly (the `google-workspace*` wildcard
-covers both `google-workspace` and `google-workspace-dayane`). `crow-memory`'s `cwd` resolved to the
-worktree repo root (`/home/kh0pp/crow-wt-mcp-binding`), which the task's own instructions call out as
-expected here, not a leak.
+covers both `google-workspace` and `google-workspace-dayane`). `crow-memory.cwd` resolved to the
+worktree repo root (`/home/kh0pp/crow-wt-mcp-binding`, not `/home/kh0pp/crow` — this task ran from the
+worktree per its own safety rules), which is expected and not a leak. **`crow-memory.env.CROW_DB_PATH`
+now equals `/home/kh0pp/.crow-r4/data/crow.db` exactly**, matching the brief's stated expectation —
+the corrected harness actually binds the output to the live instance instead of to a scratch dir.
 
-One value did **not** match the brief's stated expectation: `crow-memory.env.CROW_DB_PATH` came out as
-the scratch copy path (e.g. `/tmp/.../r4acc/db/crow.db`), not `/home/kh0pp/.crow-r4/data/crow.db` as
-the brief's "Expected" line states. Cause: the brief's own Step 3 command exports
-`CROW_DB_PATH=$S/db/crow.db` so the bot-definition read never touches the live database — but
-`instanceBinding()`'s `dbPath` falls back to `botsDbPath()`, which reads that same `CROW_DB_PATH` env
-var, so the safety override for the *read* leaks into the *binding* used for the *write*. This is a
-brief-expectation defect, not a code defect: the invariant check below still passes because the
-scratch path names no *other* instance.
-
-Invariant check:
+Invariant check (same script, run over the corrected output):
 
 ```
 --- INVARIANT: any active block naming another instance? ---
 PASS no active block names another instance
 ```
 
-**PASS.**
+**PASS**, on the corrected, live-bound harness.

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -178,15 +178,17 @@ export class PiRpc {
     // non-perch caller) leaves `tools` untouched and the branch below identical
     // to what shipped before.
     const narrowedTools = applySessionNarrowing(tools, opts.narrowedTools);
-    if (narrowedTools !== tools) {
-      // A narrowing that removes EVERY tool must STILL pin `--tools ""`: pi
-      // parses that to an empty allowlist (dist/cli/args.js:85-89 →
-      // core/sdk.js:133-136, verified on 0.82.0), whereas omitting the flag
-      // hands pi its full default surface — narrowing would widen.
-      args.push("--tools", narrowedTools);
-    } else if (tools) {
-      args.push("--tools", tools);
-    }
+    // `--tools` is ALWAYS pinned. pi parses "" to an empty allowlist
+    // (dist/cli/args.js:85-89 → core/sdk.js:133-136, verified on 0.82.0),
+    // whereas OMITTING the flag hands pi defaultActiveToolNames — bash, edit,
+    // write, and every tool registered by every inherited MCP server.
+    //
+    // The narrowing case was already guarded. The EMPTY-ENVELOPE case fell
+    // through the same hole: toolAllowlist() returns "" for a bot with no
+    // builtin and no MCP tools, `else if (tools)` is falsy on "", and three
+    // enabled r4 bots were running with pi's entire default surface.
+    // An empty envelope is a real answer, not an absent one.
+    args.push("--tools", narrowedTools);
     if (opts.appendSystemPromptFile) args.push("--append-system-prompt", opts.appendSystemPromptFile);
     if (opts.piSessionId) args.push("--session", opts.piSessionId);
     // PI_BOT_PERMISSION_POLICY drives the per-bot gate in pi-lab's

--- a/scripts/pi-bots/crow-server-catalog.mjs
+++ b/scripts/pi-bots/crow-server-catalog.mjs
@@ -148,6 +148,14 @@ function coreBlock(spec, binding, repoEnv, node) {
  * `unconfigured` is not an error channel — it is what the GUI renders so an
  * operator sees "crow-storage: unconfigured, missing MINIO_ENDPOINT" instead
  * of an opaque spawn failure.
+ *
+ * `coreNames` names the subset of `servers` sourced from the registry
+ * (CORE_SERVERS + CONDITIONAL_SERVERS) rather than from mcp-addons.json. It
+ * exists so a consumer that wants ONLY the registry-sourced servers (the ones
+ * that vanish from the picker once Crow entries leave the homedir config) can
+ * select them without re-deriving the split — `probeExtensions` already owns
+ * the addon half of `servers` and is already instance-correct, so folding
+ * addons back in elsewhere would double-list and double-spawn them.
  */
 export function crowServerCatalog(crowHome = process.env.CROW_HOME || join(homedir(), ".crow"), opts = {}) {
   const binding = opts.binding || instanceBinding(crowHome, opts);
@@ -155,15 +163,18 @@ export function crowServerCatalog(crowHome = process.env.CROW_HOME || join(homed
   const repoEnv = loadEnv();
   const servers = {};
   const unconfigured = {};
+  const coreNames = [];
 
   for (const spec of CORE_SERVERS) {
     const { block } = coreBlock(spec, binding, repoEnv, node);
     servers[spec.name] = block;
+    coreNames.push(spec.name);
   }
   for (const spec of CONDITIONAL_SERVERS) {
     const { block, missing } = coreBlock(spec, binding, repoEnv, node);
     if (missing.length) unconfigured[spec.name] = `unconfigured: missing ${missing.join(", ")}`;
     else servers[spec.name] = block;
+    coreNames.push(spec.name);
   }
   for (const [id, addon] of Object.entries(readAddons(crowHome))) {
     const cwd = resolve(addon.cwd || join(crowHome, "bundles", id));
@@ -175,5 +186,5 @@ export function crowServerCatalog(crowHome = process.env.CROW_HOME || join(homed
     if (r.disabled) unconfigured[id] = r.reason;
     else servers[id] = r.block;
   }
-  return { servers, unconfigured };
+  return { servers, unconfigured, coreNames };
 }

--- a/scripts/pi-bots/crow-server-catalog.mjs
+++ b/scripts/pi-bots/crow-server-catalog.mjs
@@ -27,7 +27,7 @@ import {
   loadEnv,
   resolveEnvValue,
 } from "../server-registry.js";
-import { botsDbPath, tasksDbPath, resolveSqlitePath } from "./instance-paths.mjs";
+import { botsDbPath, resolveSqlitePath } from "./instance-paths.mjs";
 
 /**
  * The env vars that name an instance. r4-deploy.sh warns that a child missing
@@ -41,8 +41,20 @@ export const INSTANCE_ENV_KEYS = [
   "CROW_TASKS_DB_PATH",
 ];
 
+/** The default primary-instance home — the one botsDbPath()/tasksDbPath() fall back to. */
+const DEFAULT_CROW_HOME = join(homedir(), ".crow");
+
 /**
  * This instance's canonical values for the four instance-scoped env vars.
+ *
+ * botsDbPath()/tasksDbPath() (instance-paths.mjs) read CROW_DB_PATH /
+ * CROW_DATA_DIR from the environment but never CROW_HOME, so a caller that
+ * hands us a `crowHome` without ALSO setting one of those two env vars would
+ * otherwise resolve to the PRIMARY instance's database — silently rebinding
+ * a correct block onto the wrong instance, which is worse than not rebinding
+ * at all. So when the env doesn't decide, honor the crowHome argument itself
+ * (unless it IS the default, in which case botsDbPath()'s own fallback is
+ * already correct).
  *
  * The tasks path is normalized through resolveSqlitePath(): production stores
  * `file:` URIs in project_spaces.tasks_db_uri and better-sqlite3 has no URI
@@ -50,12 +62,27 @@ export const INSTANCE_ENV_KEYS = [
  * filename (the PR #278 defect).
  */
 export function instanceBinding(crowHome, opts = {}) {
-  const dbPath = opts.dbPath || botsDbPath();
+  let dbPath = opts.dbPath;
+  if (!dbPath) {
+    if (process.env.CROW_DB_PATH) {
+      dbPath = process.env.CROW_DB_PATH;
+    } else if (process.env.CROW_DATA_DIR) {
+      dbPath = join(process.env.CROW_DATA_DIR, "crow.db");
+    } else if (crowHome && crowHome !== DEFAULT_CROW_HOME) {
+      dbPath = join(crowHome, "data", "crow.db");
+    } else {
+      dbPath = botsDbPath();
+    }
+  }
+  const tasksPath =
+    opts.tasksDbPath ||
+    process.env.CROW_TASKS_DB_PATH ||
+    join(dirname(dbPath), "tasks.db");
   return {
     CROW_HOME: crowHome,
     CROW_DATA_DIR: dirname(dbPath),
     CROW_DB_PATH: dbPath,
-    CROW_TASKS_DB_PATH: resolveSqlitePath(opts.tasksDbPath || tasksDbPath()),
+    CROW_TASKS_DB_PATH: resolveSqlitePath(tasksPath),
   };
 }
 

--- a/scripts/pi-bots/crow-server-catalog.mjs
+++ b/scripts/pi-bots/crow-server-catalog.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Crow Bot Builder — the per-instance Crow server catalog.
+ *
+ * THE INVARIANT: a bot must never resolve a Crow server bound to an instance
+ * other than its own. Stated structurally, which is how this module achieves
+ * it: no file that can name an instance may describe a Crow server.
+ *
+ * So Crow servers are DERIVED, never copied out of the user-global
+ * ~/.pi/agent/mcp.json:
+ *   - core servers  -> scripts/server-registry.js, run from the repo root,
+ *                      env bound to THIS instance
+ *   - bundle servers -> <crowHome>/mcp-addons.json, cwd under THIS instance
+ * The homedir config keeps only third-party servers, which carry credentials
+ * rather than instance identity.
+ *
+ * Imports are deliberately limited to server-registry.js and instance-paths.mjs
+ * so neither ext_registry.mjs nor mcp_writer.mjs can form a cycle through here.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import {
+  CORE_SERVERS,
+  CONDITIONAL_SERVERS,
+  ROOT,
+  loadEnv,
+  resolveEnvValue,
+} from "../server-registry.js";
+import { botsDbPath, tasksDbPath, resolveSqlitePath } from "./instance-paths.mjs";
+
+/**
+ * The env vars that name an instance. r4-deploy.sh warns that a child missing
+ * any of these silently resolves to the PRIMARY instance, which is exactly the
+ * failure this list exists to prevent.
+ */
+export const INSTANCE_ENV_KEYS = [
+  "CROW_HOME",
+  "CROW_DATA_DIR",
+  "CROW_DB_PATH",
+  "CROW_TASKS_DB_PATH",
+];
+
+/**
+ * This instance's canonical values for the four instance-scoped env vars.
+ *
+ * The tasks path is normalized through resolveSqlitePath(): production stores
+ * `file:` URIs in project_spaces.tasks_db_uri and better-sqlite3 has no URI
+ * support, so an un-normalized value reaches a bundle as an unopenable
+ * filename (the PR #278 defect).
+ */
+export function instanceBinding(crowHome, opts = {}) {
+  const dbPath = opts.dbPath || botsDbPath();
+  return {
+    CROW_HOME: crowHome,
+    CROW_DATA_DIR: dirname(dbPath),
+    CROW_DB_PATH: dbPath,
+    CROW_TASKS_DB_PATH: resolveSqlitePath(opts.tasksDbPath || tasksDbPath()),
+  };
+}
+
+/** A bundle cwd under SOME instance home: /…/.crow<suffix>/bundles/<id>. */
+const INSTANCE_BUNDLE_CWD = /\/\.crow[^/]*\/bundles\/([^/]+)\/?$/;
+
+function applyJournalGuard(env) {
+  // The WAL-unlink scar: every server touching a crow.db runs journal DELETE.
+  if (env && env.CROW_DB_PATH) env.CROW_JOURNAL_MODE = "DELETE";
+  return env;
+}
+
+/**
+ * Rebind a server block that did NOT come from the catalog — a third-party or
+ * `crow-browser` entry out of the homedir config — onto this instance.
+ *
+ * Returns {block, rebound} or {disabled, reason}. `optIn` is stripped: pi
+ * activates an optIn server only when a project file says {"enabled": true},
+ * so a verbatim copy of an optIn block silently never loads. Selecting the
+ * server IS the opt-in.
+ *
+ * The /.crow anchor is deliberate. `/home/kh0pp/crow/bundles/browser` and
+ * `/home/kh0pp/crow` do not match, so the repo is left alone — it is
+ * instance-neutral, correctly.
+ */
+export function rebindBlock(name, block, binding, crowHome) {
+  const clone = JSON.parse(JSON.stringify(block));
+  delete clone.optIn;
+  const rebound = [];
+  if (clone.env) {
+    for (const k of INSTANCE_ENV_KEYS) {
+      if (k in clone.env && clone.env[k] !== binding[k]) {
+        clone.env[k] = binding[k];
+        rebound.push(k);
+      }
+    }
+  }
+  const m = clone.cwd ? INSTANCE_BUNDLE_CWD.exec(clone.cwd) : null;
+  if (m) {
+    const target = join(crowHome, "bundles", m[1]);
+    if (!existsSync(target)) {
+      return {
+        disabled: true,
+        reason: `bundle '${m[1]}' is not installed on this instance (${target})`,
+      };
+    }
+    if (clone.cwd !== target) {
+      clone.cwd = target;
+      rebound.push("cwd");
+    }
+  }
+  applyJournalGuard(clone.env);
+  return { block: clone, rebound };
+}
+
+function readAddons(crowHome) {
+  try {
+    return JSON.parse(readFileSync(join(crowHome, "mcp-addons.json"), "utf8")) || {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Build a core-server block from its registry entry. Instance-scoped env keys
+ * come from the binding; everything else resolves against the repo .env.
+ * Returns {block, missing} — `missing` names required templates (no `:-`
+ * default) that resolved empty.
+ */
+function coreBlock(spec, binding, repoEnv, node) {
+  const env = {};
+  const missing = [];
+  for (const [k, tmpl] of Object.entries(spec.mcpEnv || {})) {
+    if (INSTANCE_ENV_KEYS.includes(k)) {
+      env[k] = binding[k];
+      continue;
+    }
+    const v = resolveEnvValue(tmpl, repoEnv);
+    if (!v && /\$\{\w+\}/.test(tmpl)) missing.push(k);
+    else env[k] = v;
+  }
+  applyJournalGuard(env);
+  return { block: { command: node, args: [...spec.args], cwd: ROOT, env }, missing };
+}
+
+/**
+ * Every Crow server available to THIS instance, plus the ones that exist but
+ * cannot be spawned here and why.
+ *
+ * `unconfigured` is not an error channel — it is what the GUI renders so an
+ * operator sees "crow-storage: unconfigured, missing MINIO_ENDPOINT" instead
+ * of an opaque spawn failure.
+ */
+export function crowServerCatalog(crowHome = process.env.CROW_HOME || join(homedir(), ".crow"), opts = {}) {
+  const binding = opts.binding || instanceBinding(crowHome, opts);
+  const node = opts.node || process.execPath;
+  const repoEnv = loadEnv();
+  const servers = {};
+  const unconfigured = {};
+
+  for (const spec of CORE_SERVERS) {
+    const { block } = coreBlock(spec, binding, repoEnv, node);
+    servers[spec.name] = block;
+  }
+  for (const spec of CONDITIONAL_SERVERS) {
+    const { block, missing } = coreBlock(spec, binding, repoEnv, node);
+    if (missing.length) unconfigured[spec.name] = `unconfigured: missing ${missing.join(", ")}`;
+    else servers[spec.name] = block;
+  }
+  for (const [id, addon] of Object.entries(readAddons(crowHome))) {
+    const cwd = resolve(addon.cwd || join(crowHome, "bundles", id));
+    if (!existsSync(cwd)) {
+      unconfigured[id] = `bundle not installed on this instance (${cwd})`;
+      continue;
+    }
+    const r = rebindBlock(id, { ...addon, cwd }, binding, crowHome);
+    if (r.disabled) unconfigured[id] = r.reason;
+    else servers[id] = r.block;
+  }
+  return { servers, unconfigured };
+}

--- a/scripts/pi-bots/ext_registry.mjs
+++ b/scripts/pi-bots/ext_registry.mjs
@@ -28,6 +28,7 @@ import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { probeServerTools, readCanonicalMcp, CANONICAL_MCP_PATH } from "./mcp_writer.mjs";
+import { crowServerCatalog } from "./crow-server-catalog.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // scripts/pi-bots -> repo root (~/crow) -> bundles
@@ -246,6 +247,23 @@ export function extensionSkills(ext) {
   return ((cap && cap.skills) || []).map((s) =>
     String(s).replace(/.*\//, "").replace(/\.md$/, "")
   );
+}
+
+/**
+ * The set of servers the Tools tab probes: this instance's Crow catalog, plus
+ * the NON-Crow entries from the homedir config. The catalog wins on name, so a
+ * homedir entry pinned to another instance is never probed or offered.
+ *
+ * Once the Crow entries are removed from ~/.pi/agent/mcp.json entirely, this
+ * function is what keeps the picker whole.
+ */
+export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = {}) {
+  const { servers: catalog } = crowServerCatalog(crowHome, opts);
+  const out = {};
+  for (const [name, block] of Object.entries(canonical.mcpServers || {})) {
+    if (!catalog[name]) out[name] = block;
+  }
+  return Object.assign(out, catalog);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/pi-bots/ext_registry.mjs
+++ b/scripts/pi-bots/ext_registry.mjs
@@ -258,12 +258,18 @@ export function extensionSkills(ext) {
  * function is what keeps the picker whole.
  */
 export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = {}) {
-  const { servers: catalog } = crowServerCatalog(crowHome, opts);
+  // CORE servers only. `probeExtensions` already owns the addon surface and is
+  // already instance-correct, so folding the catalog's mcp-addons half in here
+  // would render every installed addon TWICE in the editor's Tools tab and
+  // spawn each one twice per cold render.
+  const { servers: catalog, coreNames } = crowServerCatalog(crowHome, opts);
+  const core = {};
+  for (const name of coreNames) if (catalog[name]) core[name] = catalog[name];
   const out = {};
   for (const [name, block] of Object.entries(canonical.mcpServers || {})) {
-    if (!catalog[name]) out[name] = block;
+    if (!core[name]) out[name] = block;
   }
-  return Object.assign(out, catalog);
+  return Object.assign(out, core);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/pi-bots/ext_registry.mjs
+++ b/scripts/pi-bots/ext_registry.mjs
@@ -28,7 +28,7 @@ import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { probeServerTools, readCanonicalMcp, CANONICAL_MCP_PATH } from "./mcp_writer.mjs";
-import { crowServerCatalog } from "./crow-server-catalog.mjs";
+import { crowServerCatalog, instanceBinding, rebindBlock } from "./crow-server-catalog.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // scripts/pi-bots -> repo root (~/crow) -> bundles
@@ -258,16 +258,24 @@ export function extensionSkills(ext) {
  * function is what keeps the picker whole.
  */
 export function serversForProbe(canonical, crowHome = resolveCrowHome(), opts = {}) {
-  // CORE servers only. `probeExtensions` already owns the addon surface and is
-  // already instance-correct, so folding the catalog's mcp-addons half in here
-  // would render every installed addon TWICE in the editor's Tools tab and
-  // spawn each one twice per cold render.
+  // Two jobs. (1) The catalog OWNS every core name — `probeExtensions` owns the
+  // addon surface, so folding addons in here would double-list them.
+  // (2) Everything left in canonical is passed through `rebindBlock`, NOT
+  // verbatim: canonical is pinned to whichever instance authored it, so
+  // `crow-tasks`/`crow-bots-sql`/`crow-storage` would otherwise be probed —
+  // and SPAWNED — against another instance's bundles and databases on every
+  // cold Tools-tab render. A name whose bundle is absent here is dropped.
   const { servers: catalog, coreNames } = crowServerCatalog(crowHome, opts);
+  const binding = opts.binding || instanceBinding(crowHome, opts);
+  const coreSet = new Set(coreNames);
   const core = {};
   for (const name of coreNames) if (catalog[name]) core[name] = catalog[name];
   const out = {};
   for (const [name, block] of Object.entries(canonical.mcpServers || {})) {
-    if (!core[name]) out[name] = block;
+    if (coreSet.has(name)) continue; // the catalog owns it (or it is unconfigured here)
+    const r = rebindBlock(name, block, binding, crowHome);
+    if (r.disabled) continue;        // bundle not installed on this instance
+    out[name] = r.block;
   }
   return Object.assign(out, core);
 }

--- a/scripts/pi-bots/mcp_writer.mjs
+++ b/scripts/pi-bots/mcp_writer.mjs
@@ -12,8 +12,14 @@
  *
  * So the per-bot <session_dir>/.mcp.json is AUTHORITATIVE, and this writer
  * writes it CLOSED-WORLD: the bot's selected servers with instance-correct
- * bindings, plus {"disabled": true} for every other server pi would inherit.
- * Omission is NOT narrowing — an unmentioned homedir server still loads.
+ * bindings, plus {"disabled": true} for every other server named in CANONICAL
+ * that pi would otherwise inherit. That makes the file the complete statement
+ * of CANONICAL's world, not of the bot's actual world — pi also merges every
+ * cwd-ancestor .mcp.json between the filesystem root and the session dir, and
+ * a server defined only in one of THOSE files (never in canonical) is neither
+ * disabled nor known here, so it can still reach the bot unnarrowed. Omission
+ * of a canonical name is NOT narrowing — an unmentioned homedir server still
+ * loads.
  *
  * Crow servers are never copied out of the homedir file; they are derived
  * per-instance by crow-server-catalog.mjs. See

--- a/scripts/pi-bots/mcp_writer.mjs
+++ b/scripts/pi-bots/mcp_writer.mjs
@@ -169,11 +169,23 @@ export function buildBotMcp(def, canonical, opts = {}) {
     if (reason) warnings.push(`server '${name}' ${reason}`);
   };
 
+  // `minted` keeps its A5 meaning: resolved from somewhere canonical does NOT
+  // have it. A core server present in BOTH the catalog and canonical is not
+  // minted — logging it as "minted from extensions" would be false on the
+  // commonest path (bot-world.mjs and the regen message both print this).
+  const noteMinted = (name) => { if (!canonical.mcpServers[name]) minted.push(name); };
+  // `journalGuarded` exists to make the WAL-unlink guard OBSERVABLE, so it
+  // reports every active crow.db server carrying the guard — uniformly, on
+  // whichever path resolved it. Reporting only the blocks this function
+  // happened to flip would hide the catalog path, which is now the common one.
+  const noteGuard = (name, block) => { if (touchesCrowDb(block)) journalGuarded.push(name); };
+
   for (const name of want) {
     if (catalog[name]) {
       out.mcpServers[name] = catalog[name];
       active.push(name);
-      minted.push(name);
+      noteMinted(name);
+      noteGuard(name, catalog[name]);
       continue;
     }
     if (unconfigured[name]) {
@@ -201,7 +213,7 @@ export function buildBotMcp(def, canonical, opts = {}) {
       }
       out.mcpServers[name] = clone;
       active.push(name);
-      if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+      noteMinted(name);
       continue;
     }
     const r = rebindBlock(name, source, binding, crowHome);
@@ -210,10 +222,10 @@ export function buildBotMcp(def, canonical, opts = {}) {
       continue;
     }
     if (r.rebound.length) rebound.push({ name, keys: r.rebound });
-    if (touchesCrowDb(r.block)) journalGuarded.push(name);
+    noteGuard(name, r.block);
     out.mcpServers[name] = r.block;
     active.push(name);
-    if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+    noteMinted(name);
   }
 
   // Closed-world. Sorted so the written file is diffable.

--- a/scripts/pi-bots/mcp_writer.mjs
+++ b/scripts/pi-bots/mcp_writer.mjs
@@ -1,24 +1,23 @@
 #!/usr/bin/env node
 /**
- * Crow Bot Builder — per-bot MCP config writer + tool-list prober (Phase 2.1).
+ * Crow Bot Builder — per-bot MCP config writer + tool-list prober.
  *
- * S2/D finding (plan §5, "Verified Claims"): pi-lab/extensions/mcp-client.ts
- * reads `~/.pi/agent/mcp.json` from homedir() UNCONDITIONALLY and merges every
- * cwd-ancestor `.mcp.json`, with the homedir file WINNING on key collision.
- * The bridge pins each pi's cwd to the bot's `session_dir`, so the per-bot
- * config is `<session_dir>/.mcp.json`. Because the merge is additive and
- * homedir wins, this file canNOT remove a homedir server — tool *scoping*
- * stays the `--tools` allowlist (toolAllowlist() in bridge.mjs). What this
- * file IS for:
- *   1. make the bot workspace self-describing / portable,
- *   2. carry a bot-specific server that is NOT in the global homedir file,
- *   3. HARD-GUARANTEE `CROW_JOURNAL_MODE=DELETE` on every crow.db server in
- *      the per-bot file — the WAL-unlink scar guard
- *      ([[feedback_crowdb_wal_flip_new_consumers]]); defends against a future
- *      homedir edit or a bot adding a crow.db server.
+ * PRECEDENCE (verified live against pi 0.82.0 + pi-lab main, 2026-08-08):
+ * pi-lab/extensions/mcp-client.ts merges ~/.pi/agent/mcp.json FIRST, then every
+ * cwd-ancestor .mcp.json from the filesystem root down to cwd — the NEAREST
+ * project file WINS. pi-lab commit 671e116 (2026-07-04) changed this; the old
+ * "homedir wins on collision" rule this file used to assert is FALSE, and
+ * believing it hid three live bugs for a month. A project file may also delete
+ * an inherited server with {"name": {"disabled": true}}.
  *
- * Server blocks are COPIED VERBATIM from the already-working canonical
- * `~/.pi/agent/mcp.json`, so a generated per-bot file is valid by construction.
+ * So the per-bot <session_dir>/.mcp.json is AUTHORITATIVE, and this writer
+ * writes it CLOSED-WORLD: the bot's selected servers with instance-correct
+ * bindings, plus {"disabled": true} for every other server pi would inherit.
+ * Omission is NOT narrowing — an unmentioned homedir server still loads.
+ *
+ * Crow servers are never copied out of the homedir file; they are derived
+ * per-instance by crow-server-catalog.mjs. See
+ * docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md.
  *
  * Also exports probeServerTools(): a dependency-free MCP stdio `tools/list`
  * (initialize -> notifications/initialized -> tools/list) reusing the
@@ -34,6 +33,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { botsDbPath } from "./instance-paths.mjs";
 import { mintRemoteBlocks } from "./remote-blocks.mjs";
+import { crowServerCatalog, instanceBinding, rebindBlock } from "./crow-server-catalog.mjs";
 
 const HOME = process.env.HOME || homedir();
 export const CANONICAL_MCP_PATH = HOME + "/.pi/agent/mcp.json";
@@ -122,7 +122,11 @@ export function extraServersFromExtensions(def, crowHome = resolveCrowHome(), op
   const addons = readAddons(crowHome);
   const servers = {};
   for (const name of want) {
-    if (canonical.mcpServers[name]) continue; // canonical present -> homedir wins, no mint
+    // The catalog (crow-server-catalog.mjs) already covers every Crow server on
+    // this instance and is consulted first by buildBotMcp, so this path only
+    // ever fills a NON-Crow name absent from canonical. Kept as a seam for
+    // callers that pass their own canonical without a catalog.
+    if (canonical.mcpServers[name]) continue;
     const addon = addons[name];
     if (!addon) continue; // absent from both -> buildBotMcp warns
     servers[name] = addonSpawnBlock(name, addon, crowHome);
@@ -131,47 +135,95 @@ export function extraServersFromExtensions(def, crowHome = resolveCrowHome(), op
 }
 
 /**
- * Build the per-bot `.mcp.json` object from the bot def + canonical config,
- * plus any minted extension addon blocks (A5). Canonical wins on name collision
- * (matches pi-lab's homedir-wins merge); extension blocks only fill servers
- * absent from canonical. A selected server present in NEITHER is a warning.
- * @param {object} opts.extraServers  {name: block} minted from mcp-addons.json
- * @returns {{ json, servers, warnings, journalGuarded, minted }}
+ * Build the per-bot `.mcp.json` object. CLOSED-WORLD — see the file header.
+ *
+ * Resolution order for a selected name:
+ *   1. catalog   — instance-derived, always correct. Wins.
+ *   2. canonical — for names the catalog does not know (third-party servers,
+ *                  crow-browser). Rebound onto this instance as a belt.
+ *   3. extraServers — the mcp-addons seam retained for callers without a catalog.
+ * Then every OTHER canonical name is emitted as {"disabled": true}, because
+ * canonical is exactly what pi would otherwise inherit.
+ *
+ * @returns {{ json, servers, warnings, journalGuarded, minted, rebound, disabled }}
+ *   `servers` lists ACTIVE names only; disabled names are in `disabled`.
  */
 export function buildBotMcp(def, canonical, opts = {}) {
   const want = serversForBot(def);
+  const catalog = opts.catalog || {};
+  const unconfigured = opts.unconfigured || {};
+  const binding = opts.binding;
+  const crowHome = opts.crowHome;
   const extra = opts.extraServers || {};
   const out = { mcpServers: {} };
   const warnings = [];
   const journalGuarded = [];
   const minted = [];
+  const rebound = [];
+  const disabled = [];
+  const active = [];
+
+  const disable = (name, reason) => {
+    out.mcpServers[name] = { disabled: true };
+    disabled.push(name);
+    if (reason) warnings.push(`server '${name}' ${reason}`);
+  };
+
   for (const name of want) {
-    let block = canonical.mcpServers[name];
-    let isExtra = false;
-    if (!block && extra[name]) {
-      block = extra[name];
-      isExtra = true;
+    if (catalog[name]) {
+      out.mcpServers[name] = catalog[name];
+      active.push(name);
+      minted.push(name);
+      continue;
     }
-    if (!block) {
+    if (unconfigured[name]) {
+      disable(name, unconfigured[name]);
+      continue;
+    }
+    const source = canonical.mcpServers[name] || extra[name];
+    if (!source) {
       warnings.push(
-        "server '" + name + "' is selected but absent from canonical mcp.json AND " +
-        "mcp-addons.json — pi will NOT have it"
+        "server '" + name + "' is selected but absent from the instance catalog, " +
+        "canonical mcp.json AND mcp-addons.json — pi will NOT have it"
       );
       continue;
     }
-    // deep clone so we never mutate the canonical/addon block in memory
-    const clone = JSON.parse(JSON.stringify(block));
-    if (touchesCrowDb(clone)) {
-      clone.env = clone.env || {};
-      if (clone.env.CROW_JOURNAL_MODE !== "DELETE") {
-        clone.env.CROW_JOURNAL_MODE = "DELETE";
-        journalGuarded.push(name);
+    // No binding means a caller that predates instance binding (tests, CLI):
+    // fall back to the old verbatim copy + journal guard rather than crash.
+    if (!binding) {
+      const clone = JSON.parse(JSON.stringify(source));
+      if (touchesCrowDb(clone)) {
+        clone.env = clone.env || {};
+        if (clone.env.CROW_JOURNAL_MODE !== "DELETE") {
+          clone.env.CROW_JOURNAL_MODE = "DELETE";
+          journalGuarded.push(name);
+        }
       }
+      out.mcpServers[name] = clone;
+      active.push(name);
+      if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
+      continue;
     }
-    out.mcpServers[name] = clone;
-    if (isExtra) minted.push(name);
+    const r = rebindBlock(name, source, binding, crowHome);
+    if (r.disabled) {
+      disable(name, r.reason);
+      continue;
+    }
+    if (r.rebound.length) rebound.push({ name, keys: r.rebound });
+    if (touchesCrowDb(r.block)) journalGuarded.push(name);
+    out.mcpServers[name] = r.block;
+    active.push(name);
+    if (extra[name] && !canonical.mcpServers[name]) minted.push(name);
   }
-  return { json: out, servers: Object.keys(out.mcpServers), warnings, journalGuarded, minted };
+
+  // Closed-world. Sorted so the written file is diffable.
+  const selected = new Set(want);
+  for (const name of Object.keys(canonical.mcpServers).sort()) {
+    if (selected.has(name)) continue;
+    disable(name, null);
+  }
+
+  return { json: out, servers: active, warnings, journalGuarded, minted, rebound, disabled };
 }
 
 /**
@@ -194,7 +246,13 @@ export function writeBotMcp(def, opts = {}) {
   // instance explicitly; otherwise CROW_HOME env (MPA service) or ~/.crow.
   const crowHome = opts.crowHome || resolveCrowHome();
   const extraServers = opts.extraServers || extraServersFromExtensions(def, crowHome, { canonical });
-  const built = buildBotMcp(def, canonical, { extraServers });
+  // The instance catalog is the FIRST source for any Crow server. opts.binding
+  // lets tests and the panel pin an instance without mutating process.env.
+  const binding = opts.binding || instanceBinding(crowHome, opts);
+  const { servers: catalog, unconfigured } = crowServerCatalog(crowHome, { binding });
+  const built = buildBotMcp(def, canonical, {
+    extraServers, catalog, unconfigured, binding, crowHome,
+  });
   // F4a L2b: merge cross-instance forward-proxy blocks when the caller has
   // confirmed feature_flags.remote_invocation is on (the DB read is done by the
   // caller — bridge/panel/CLI — since this module is DB-agnostic). Default
@@ -224,6 +282,8 @@ export function writeBotMcp(def, opts = {}) {
     warnings: built.warnings,
     journalGuarded: built.journalGuarded,
     minted: built.minted,
+    rebound: built.rebound,
+    disabled: built.disabled,
     remoteWarnings,
   };
 }

--- a/servers/gateway/dashboard/panels/bot-builder/data-queries.js
+++ b/servers/gateway/dashboard/panels/bot-builder/data-queries.js
@@ -95,8 +95,9 @@ export async function probeAll(crowHome = resolveCrowHome()) {
 // since each entry spawns its MCP server.
 let _extCache = null;
 let _extAt = 0;
+let _extHome = null;
 export async function probeExtensions(crowHome) {
-  if (_extCache && Date.now() - _extAt < 300000) return _extCache;
+  if (_extCache && _extHome === crowHome && Date.now() - _extAt < 300000) return _extCache;
   const exts = listInstalledExtensions(crowHome).filter((e) => e.needsMint);
   const out = [];
   for (const ext of exts) {
@@ -104,6 +105,7 @@ export async function probeExtensions(crowHome) {
   }
   _extCache = out;
   _extAt = Date.now();
+  _extHome = crowHome;
   return out;
 }
 

--- a/servers/gateway/dashboard/panels/bot-builder/data-queries.js
+++ b/servers/gateway/dashboard/panels/bot-builder/data-queries.js
@@ -53,11 +53,15 @@ export const TABS = [
 ];
 
 // in-process probe cache (per gateway process), 5-min TTL — probing spawns
-// every MCP server, so we don't redo it on every tools-tab render.
+// every MCP server, so we don't redo it on every tools-tab render. Keyed on
+// crowHome: probeAll() takes an instance argument now, and an unkeyed cache
+// would silently hand a second instance the first instance's stale surface
+// for up to 5 minutes.
 let _probeCache = null;
 let _probeAt = 0;
+let _probeHome = null;
 export async function probeAll(crowHome = resolveCrowHome()) {
-  if (_probeCache && Date.now() - _probeAt < 300000) return _probeCache;
+  if (_probeCache && _probeHome === crowHome && Date.now() - _probeAt < 300000) return _probeCache;
   const out = {};
   let canonical;
   try {
@@ -78,12 +82,17 @@ export async function probeAll(crowHome = resolveCrowHome()) {
   );
   _probeCache = out;
   _probeAt = Date.now();
+  _probeHome = crowHome;
   return out;
 }
 
-// A6: live tool probe for installed EXTENSIONS (addon servers absent from
-// canonical — the canonical ones already render under probeAll above). Cached
-// 5-min like probeAll since each entry spawns its MCP server.
+// A6: live tool probe for installed EXTENSIONS — everything sourced from
+// mcp-addons.json. probeAll (above) covers CORE Crow servers plus any
+// non-Crow entries left in the homedir canonical config; this covers the
+// addon half, which is already instance-correct via mcp-addons.json, so it
+// must stay disjoint from probeAll's surface or every installed addon
+// renders (and spawns) twice in the Tools tab. Cached 5-min like probeAll
+// since each entry spawns its MCP server.
 let _extCache = null;
 let _extAt = 0;
 export async function probeExtensions(crowHome) {

--- a/servers/gateway/dashboard/panels/bot-builder/data-queries.js
+++ b/servers/gateway/dashboard/panels/bot-builder/data-queries.js
@@ -20,6 +20,7 @@ import {
   resolveCrowHome,
   listInstalledExtensions,
   extensionTools,
+  serversForProbe,
 } from "../../../../../scripts/pi-bots/ext_registry.mjs";
 import { skillDirs } from "../../../../../scripts/pi-bots/skill_resolver.mjs";
 import { tasksDbPath, botsWorkspaceRoot } from "../../../../../scripts/pi-bots/instance-paths.mjs";
@@ -55,7 +56,7 @@ export const TABS = [
 // every MCP server, so we don't redo it on every tools-tab render.
 let _probeCache = null;
 let _probeAt = 0;
-export async function probeAll() {
+export async function probeAll(crowHome = resolveCrowHome()) {
   if (_probeCache && Date.now() - _probeAt < 300000) return _probeCache;
   const out = {};
   let canonical;
@@ -64,11 +65,12 @@ export async function probeAll() {
   } catch (e) {
     return { _error: String(e.message || e) };
   }
-  const names = Object.keys(canonical.mcpServers);
+  const surface = serversForProbe(canonical, crowHome);
+  const names = Object.keys(surface);
   await Promise.all(
     names.map(async (n) => {
       try {
-        out[n] = await probeServerTools(canonical.mcpServers[n], { timeoutMs: 12000 });
+        out[n] = await probeServerTools(surface[n], { timeoutMs: 12000 });
       } catch (e) {
         out[n] = { ok: false, error: String(e.message || e) };
       }

--- a/tests/perch-narrowing.test.js
+++ b/tests/perch-narrowing.test.js
@@ -179,9 +179,12 @@ test("malformed narrowing at the spawn keeps the def envelope", async () => {
   assert.equal(toolsFlag(argv), "read,bash");
 });
 
-test("a toolless def with no narrowing still omits --tools (unchanged behavior)", async () => {
+test("a toolless def with no narrowing now pins --tools \"\" instead of omitting the flag", async () => {
+  // `{tools: {}}` is the empty envelope — the exact case Task 3 fixes.
+  // toolAllowlist() returns "" for it, and omitting the flag would hand pi
+  // its full default surface (bash, edit, write, every inherited MCP tool).
   const argv = await spawnArgs({ def: { tools: {} } });
-  assert.equal(toolsFlag(argv), null);
+  assert.equal(toolsFlag(argv), "");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/pibot-crow-server-catalog.test.js
+++ b/tests/pibot-crow-server-catalog.test.js
@@ -117,7 +117,7 @@ test("crow-storage is catalogued as unconfigured when MinIO env is absent", () =
   assert.match(unconfigured["crow-storage"], /MINIO_ENDPOINT/);
 });
 
-test("probe surface is the catalog plus NON-Crow canonical entries", () => {
+test("probe surface is CORE catalog servers plus NON-Crow canonical entries", () => {
   const { home } = instanceB();
   const canonical = { mcpServers: {
     "crow-memory": { command: "n", args: [], env: { CROW_DB_PATH: "/elsewhere/crow.db" } },
@@ -127,5 +127,16 @@ test("probe surface is the catalog plus NON-Crow canonical entries", () => {
   assert.equal(surface["crow-memory"].env.CROW_DB_PATH, join(home, "data", "crow.db"),
     "the catalog wins over the canonical entry");
   assert.equal(surface["brave-search"].env.BRAVE_API_KEY, "k", "non-Crow entries survive");
-  assert.ok(surface.tasks, "this instance's bundles are offered");
+  assert.ok(!surface.tasks, "addons are NOT folded in — probeExtensions owns them, or tasks would double-list");
+});
+
+test("probe surface rescues a core server absent from canonical entirely", () => {
+  const { home } = instanceB();
+  const canonical = { mcpServers: {
+    "brave-search": { command: "npx", args: ["-y", "s"], env: { BRAVE_API_KEY: "k" } },
+  } };
+  const surface = serversForProbe(canonical, home, { binding: BINDING_B(home) });
+  assert.ok(surface["crow-memory"],
+    "a core server must still reach the picker even when the homedir config never named it");
+  assert.equal(surface["crow-memory"].env.CROW_DB_PATH, join(home, "data", "crow.db"));
 });

--- a/tests/pibot-crow-server-catalog.test.js
+++ b/tests/pibot-crow-server-catalog.test.js
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  INSTANCE_ENV_KEYS,
+  instanceBinding,
+  rebindBlock,
+  crowServerCatalog,
+} from "../scripts/pi-bots/crow-server-catalog.mjs";
+
+/** An instance home with a tasks bundle dir and an mcp-addons.json. */
+function instanceB() {
+  const dir = mkdtempSync(join(tmpdir(), "instB-"));
+  const home = join(dir, ".crow-b");
+  mkdirSync(join(home, "bundles", "tasks"), { recursive: true });
+  mkdirSync(join(home, "data"), { recursive: true });
+  writeFileSync(join(home, "mcp-addons.json"), JSON.stringify({
+    tasks: { command: "node", args: ["server/index.js"], env: { CROW_TASKS_DB_PATH: "/wrong/tasks.db" } },
+    ghost: { command: "node", args: ["server/index.js"] },
+  }));
+  return { dir, home };
+}
+
+const BINDING_B = (home) => ({
+  CROW_HOME: home,
+  CROW_DATA_DIR: join(home, "data"),
+  CROW_DB_PATH: join(home, "data", "crow.db"),
+  CROW_TASKS_DB_PATH: join(home, "data", "tasks.db"),
+});
+
+test("INSTANCE_ENV_KEYS is exactly the four instance-scoped vars", () => {
+  assert.deepEqual([...INSTANCE_ENV_KEYS].sort(),
+    ["CROW_DATA_DIR", "CROW_DB_PATH", "CROW_HOME", "CROW_TASKS_DB_PATH"]);
+});
+
+test("instanceBinding normalizes a file: tasks URI", () => {
+  const b = instanceBinding("/home/x/.crow-r4", { tasksDbPath: "file:/home/x/.crow-r4/data/tasks.db" });
+  assert.equal(b.CROW_TASKS_DB_PATH, "/home/x/.crow-r4/data/tasks.db");
+});
+
+test("rebindBlock rewrites every instance-scoped env key", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["a.js"], cwd: "/repo",
+    env: { CROW_DB_PATH: "/home/x/.crow-mpa/data/crow.db", UNRELATED: "keep" } };
+  const r = rebindBlock("crow-memory", block, BINDING_B(home), home);
+  assert.equal(r.env, undefined, "returns a wrapper, not a bare block");
+  assert.equal(r.block.env.CROW_DB_PATH, join(home, "data", "crow.db"));
+  assert.equal(r.block.env.UNRELATED, "keep");
+  assert.equal(r.block.env.CROW_JOURNAL_MODE, "DELETE", "WAL scar guard applied");
+  assert.deepEqual(r.rebound, ["CROW_DB_PATH"]);
+});
+
+test("rebindBlock retargets a cross-instance bundle cwd that exists here", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["server/index.js"], cwd: "/home/x/.crow-mpa/bundles/tasks", env: {} };
+  const r = rebindBlock("crow-tasks", block, BINDING_B(home), home);
+  assert.equal(r.block.cwd, join(home, "bundles", "tasks"));
+  assert.ok(r.rebound.includes("cwd"));
+});
+
+test("rebindBlock disables a bundle absent on this instance, with a reason", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["server/index.js"], cwd: "/home/x/.crow-mpa/bundles/rookery", env: {} };
+  const r = rebindBlock("crow-rookery", block, BINDING_B(home), home);
+  assert.equal(r.disabled, true);
+  assert.match(r.reason, /rookery/);
+  assert.match(r.reason, /not installed/);
+});
+
+test("rebindBlock leaves the repo cwd alone — the repo is instance-neutral", () => {
+  const { home } = instanceB();
+  const block = { command: "n", args: ["x.js"], cwd: "/home/kh0pp/crow/bundles/browser", env: {} };
+  const r = rebindBlock("crow-browser", block, BINDING_B(home), home);
+  assert.equal(r.block.cwd, "/home/kh0pp/crow/bundles/browser");
+  assert.deepEqual(r.rebound, []);
+});
+
+test("rebindBlock strips optIn — selection is the opt-in", () => {
+  const { home } = instanceB();
+  const r = rebindBlock("gws", { command: "n", args: [], optIn: true, env: {} }, BINDING_B(home), home);
+  assert.ok(!("optIn" in r.block));
+});
+
+test("catalog binds core servers to this instance and serves them from the repo", () => {
+  const { home } = instanceB();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  const mem = servers["crow-memory"];
+  assert.ok(mem, "crow-memory catalogued");
+  assert.equal(mem.env.CROW_DB_PATH, join(home, "data", "crow.db"));
+  assert.equal(mem.env.CROW_JOURNAL_MODE, "DELETE");
+  assert.match(mem.cwd, /crow$/, "core servers run from the repo root");
+});
+
+test("catalog binds bundle servers from this instance's mcp-addons.json", () => {
+  const { home } = instanceB();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.equal(servers.tasks.cwd, join(home, "bundles", "tasks"), "cwd defaulted under this instance");
+  assert.equal(servers.tasks.env.CROW_TASKS_DB_PATH, join(home, "data", "tasks.db"),
+    "the addon's own wrong path is rebound, not trusted");
+});
+
+test("catalog reports an addon whose bundle dir is missing as unconfigured", () => {
+  const { home } = instanceB();
+  const { servers, unconfigured } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.ok(!servers.ghost, "ghost is not offered as spawnable");
+  assert.match(unconfigured.ghost, /not installed/);
+});
+
+test("crow-storage is catalogued as unconfigured when MinIO env is absent", () => {
+  const { home } = instanceB();
+  const { servers, unconfigured } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.ok(!servers["crow-storage"], "not offered as spawnable without MinIO settings");
+  assert.match(unconfigured["crow-storage"], /MINIO_ENDPOINT/);
+});

--- a/tests/pibot-crow-server-catalog.test.js
+++ b/tests/pibot-crow-server-catalog.test.js
@@ -10,6 +10,7 @@ import {
   crowServerCatalog,
 } from "../scripts/pi-bots/crow-server-catalog.mjs";
 import { ROOT } from "../scripts/server-registry.js";
+import { serversForProbe } from "../scripts/pi-bots/ext_registry.mjs";
 
 /** An instance home with a tasks bundle dir and an mcp-addons.json. */
 function instanceB() {
@@ -114,4 +115,17 @@ test("crow-storage is catalogued as unconfigured when MinIO env is absent", () =
   const { servers, unconfigured } = crowServerCatalog(home, { binding: BINDING_B(home) });
   assert.ok(!servers["crow-storage"], "not offered as spawnable without MinIO settings");
   assert.match(unconfigured["crow-storage"], /MINIO_ENDPOINT/);
+});
+
+test("probe surface is the catalog plus NON-Crow canonical entries", () => {
+  const { home } = instanceB();
+  const canonical = { mcpServers: {
+    "crow-memory": { command: "n", args: [], env: { CROW_DB_PATH: "/elsewhere/crow.db" } },
+    "brave-search": { command: "npx", args: ["-y", "s"], env: { BRAVE_API_KEY: "k" } },
+  } };
+  const surface = serversForProbe(canonical, home, { binding: BINDING_B(home) });
+  assert.equal(surface["crow-memory"].env.CROW_DB_PATH, join(home, "data", "crow.db"),
+    "the catalog wins over the canonical entry");
+  assert.equal(surface["brave-search"].env.BRAVE_API_KEY, "k", "non-Crow entries survive");
+  assert.ok(surface.tasks, "this instance's bundles are offered");
 });

--- a/tests/pibot-crow-server-catalog.test.js
+++ b/tests/pibot-crow-server-catalog.test.js
@@ -9,6 +9,7 @@ import {
   rebindBlock,
   crowServerCatalog,
 } from "../scripts/pi-bots/crow-server-catalog.mjs";
+import { ROOT } from "../scripts/server-registry.js";
 
 /** An instance home with a tasks bundle dir and an mcp-addons.json. */
 function instanceB() {
@@ -90,7 +91,7 @@ test("catalog binds core servers to this instance and serves them from the repo"
   assert.ok(mem, "crow-memory catalogued");
   assert.equal(mem.env.CROW_DB_PATH, join(home, "data", "crow.db"));
   assert.equal(mem.env.CROW_JOURNAL_MODE, "DELETE");
-  assert.match(mem.cwd, /crow$/, "core servers run from the repo root");
+  assert.equal(mem.cwd, ROOT, "core servers run from the repo root");
 });
 
 test("catalog binds bundle servers from this instance's mcp-addons.json", () => {

--- a/tests/pibot-crow-server-catalog.test.js
+++ b/tests/pibot-crow-server-catalog.test.js
@@ -140,3 +140,60 @@ test("probe surface rescues a core server absent from canonical entirely", () =>
     "a core server must still reach the picker even when the homedir config never named it");
   assert.equal(surface["crow-memory"].env.CROW_DB_PATH, join(home, "data", "crow.db"));
 });
+
+test("probe surface rebinds a non-core canonical entry pinned to another instance, when its bundle exists here too", () => {
+  const { home } = instanceB();
+  // instanceB() only creates a `tasks` bundle dir; add `rookery` so this
+  // instance has SOMETHING for the cross-instance cwd to rebind onto.
+  mkdirSync(join(home, "bundles", "rookery"), { recursive: true });
+  const canonical = { mcpServers: {
+    "crow-rookery": { command: "n", args: ["server/index.js"], cwd: "/home/x/.crow-mpa/bundles/rookery", env: {} },
+  } };
+  const surface = serversForProbe(canonical, home, { binding: BINDING_B(home) });
+  assert.ok(surface["crow-rookery"], "must be offered — the bundle exists on this instance");
+  assert.equal(surface["crow-rookery"].cwd, join(home, "bundles", "rookery"),
+    "must be rebound to THIS instance's bundle dir, not passed through verbatim");
+});
+
+test("probe surface drops a non-core canonical entry whose bundle is absent on this instance", () => {
+  const { home } = instanceB();
+  const canonical = { mcpServers: {
+    "crow-rookery": { command: "n", args: ["server/index.js"], cwd: "/home/x/.crow-mpa/bundles/rookery", env: {} },
+  } };
+  const surface = serversForProbe(canonical, home, { binding: BINDING_B(home) });
+  assert.ok(!surface["crow-rookery"],
+    "a canonical block pinned to a bundle this instance does not have must not reach the picker");
+});
+
+test("probe surface drops an unconfigured core name rather than falling through to its canonical block", () => {
+  const { home } = instanceB();
+  // crow-storage is a CONDITIONAL core server, unconfigured here (no MinIO env)
+  // per the "catalogued as unconfigured" test above. A canonical entry under
+  // the SAME name must not leak through as a fallback.
+  const canonical = { mcpServers: {
+    "crow-storage": { command: "n", args: ["servers/storage/index.js"], cwd: "/repo",
+      env: { MINIO_ENDPOINT: "http://elsewhere:9000" } },
+  } };
+  const surface = serversForProbe(canonical, home, { binding: BINDING_B(home) });
+  assert.ok(!surface["crow-storage"],
+    "crow-storage is a known core name — unconfigured must not fall through to canonical's cross-instance block");
+});
+
+test("instanceBinding honors the crowHome argument when CROW_DB_PATH and CROW_DATA_DIR are both unset", () => {
+  const savedDb = process.env.CROW_DB_PATH;
+  const savedData = process.env.CROW_DATA_DIR;
+  delete process.env.CROW_DB_PATH;
+  delete process.env.CROW_DATA_DIR;
+  try {
+    const dir = mkdtempSync(join(tmpdir(), "instC-"));
+    const home = join(dir, ".crow-fixture");
+    const b = instanceBinding(home);
+    assert.equal(b.CROW_DATA_DIR, join(home, "data"));
+    assert.equal(b.CROW_DB_PATH, join(home, "data", "crow.db"));
+    assert.ok(!b.CROW_DB_PATH.includes("/.crow/"),
+      "must not resolve to the primary instance's database: " + b.CROW_DB_PATH);
+  } finally {
+    if (savedDb === undefined) delete process.env.CROW_DB_PATH; else process.env.CROW_DB_PATH = savedDb;
+    if (savedData === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = savedData;
+  }
+});

--- a/tests/pibot-mcp-instance-binding.test.js
+++ b/tests/pibot-mcp-instance-binding.test.js
@@ -127,37 +127,3 @@ test("journalGuarded: a crow.db-touching catalog server is reported", () => {
   assert.ok(res.journalGuarded.includes("crow-memory"),
     "the WAL-unlink guard must be observable for the catalog path too: " + JSON.stringify(res.journalGuarded));
 });
-
-import { toolAllowlist, applySessionNarrowing } from "../scripts/pi-bots/bridge.mjs";
-
-/**
- * Mirrors the --tools branch in the PiRpc constructor. A bot with no builtin
- * and no MCP tools yields "", and omitting the flag hands pi
- * defaultActiveToolNames — bash, edit, write, and every tool registered by
- * every inherited server (pi dist/cli/args.js:85-89 -> dist/core/sdk.js:133-136).
- */
-function toolsArgs(def, narrowedTools) {
-  const tools = toolAllowlist(def);
-  const narrowed = applySessionNarrowing(tools, narrowedTools);
-  const args = [];
-  if (narrowed !== tools) args.push("--tools", narrowed);
-  else args.push("--tools", tools);
-  return args;
-}
-
-test("an empty tool envelope pins --tools \"\" instead of omitting the flag", () => {
-  const def = { tools: { pi_builtin: [], crow_mcp: [] } };
-  assert.equal(toolAllowlist(def), "", "precondition: the envelope really is empty");
-  assert.deepEqual(toolsArgs(def), ["--tools", ""],
-    "omitting the flag would WIDEN an empty envelope to pi's full default surface");
-});
-
-test("a normal envelope still pins its allowlist", () => {
-  const def = { tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } };
-  assert.deepEqual(toolsArgs(def), ["--tools", "read,mcp__tasks__tasks_list"]);
-});
-
-test("narrowing to nothing still pins --tools \"\"", () => {
-  const def = { tools: { pi_builtin: ["read"], crow_mcp: [] } };
-  assert.deepEqual(toolsArgs(def, JSON.stringify(["read"])), ["--tools", ""]);
-});

--- a/tests/pibot-mcp-instance-binding.test.js
+++ b/tests/pibot-mcp-instance-binding.test.js
@@ -106,3 +106,24 @@ test("a non-Crow server is carried through untouched", () => {
   assert.equal(json.mcpServers["brave-search"].env.BRAVE_API_KEY, "k");
   assert.equal(json.mcpServers["brave-search"].cwd, "/home/x");
 });
+
+test("minted: a catalog server also present in canonical is NOT minted", () => {
+  const f = twoInstances();
+  const { res } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  assert.ok(!res.minted.includes("crow-memory"),
+    "crow-memory is in canonical too — 'minted from extensions' would be false: " + JSON.stringify(res.minted));
+});
+
+test("minted: a catalog server absent from canonical IS minted", () => {
+  const f = twoInstances();
+  const { res } = write({ tools: { crow_mcp: ["tasks"] } }, f);
+  assert.ok(res.minted.includes("tasks"),
+    "'tasks' only exists via mcp-addons.json, not canonical: " + JSON.stringify(res.minted));
+});
+
+test("journalGuarded: a crow.db-touching catalog server is reported", () => {
+  const f = twoInstances();
+  const { res } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  assert.ok(res.journalGuarded.includes("crow-memory"),
+    "the WAL-unlink guard must be observable for the catalog path too: " + JSON.stringify(res.journalGuarded));
+});

--- a/tests/pibot-mcp-instance-binding.test.js
+++ b/tests/pibot-mcp-instance-binding.test.js
@@ -100,6 +100,21 @@ test("optIn never survives into an active block", () => {
   assert.ok(!("optIn" in json.mcpServers.gws), "a copied optIn block would never load");
 });
 
+test("RESOLUTION ORDER: the catalog wins over canonical for the same name", () => {
+  const f = twoInstances();
+  // Make canonical's crow-memory STRUCTURALLY distinguishable. rebindBlock
+  // rewrites env and a `.crow*/bundles` cwd, but never `args` — so `args` is
+  // the only witness of WHICH SOURCE won. Without this, both paths yield an
+  // instance-correct block and reversing the order breaks no test, which is
+  // exactly the vacuum a mutation run found.
+  const canon = JSON.parse(readFileSync(f.canonicalPath, "utf8"));
+  canon.mcpServers["crow-memory"].args = ["CANONICAL-WINS.js"];
+  writeFileSync(f.canonicalPath, JSON.stringify(canon));
+  const { json } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  assert.deepEqual(json.mcpServers["crow-memory"].args, ["servers/memory/index.js"],
+    "args must come from the registry catalog, not from the canonical block");
+});
+
 test("a non-Crow server is carried through untouched", () => {
   const f = twoInstances();
   const { json } = write({ tools: { crow_mcp: ["brave-search"] } }, f);

--- a/tests/pibot-mcp-instance-binding.test.js
+++ b/tests/pibot-mcp-instance-binding.test.js
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeBotMcp } from "../scripts/pi-bots/mcp_writer.mjs";
+
+/**
+ * A canonical config pinned to instance A, and a crowHome of instance B.
+ * The invariant is that nothing active in the output may reference A.
+ */
+function twoInstances() {
+  const dir = mkdtempSync(join(tmpdir(), "twoinst-"));
+  const A = join(dir, ".crow-a");
+  const B = join(dir, ".crow-b");
+  mkdirSync(join(A, "bundles", "tasks"), { recursive: true });
+  mkdirSync(join(A, "bundles", "rookery"), { recursive: true });
+  mkdirSync(join(B, "bundles", "tasks"), { recursive: true });
+  mkdirSync(join(B, "data"), { recursive: true });
+  writeFileSync(join(B, "mcp-addons.json"), JSON.stringify({
+    tasks: { command: "node", args: ["server/index.js"], env: { CROW_TASKS_DB_PATH: join(A, "data", "tasks.db") } },
+  }));
+  const canonicalPath = join(dir, "canonical.json");
+  writeFileSync(canonicalPath, JSON.stringify({ mcpServers: {
+    "crow-memory":  { command: "n", args: ["servers/memory/index.js"], cwd: "/repo", env: { CROW_DB_PATH: join(A, "data", "crow.db") } },
+    "crow-tasks":   { command: "n", args: ["server/index.js"], cwd: join(A, "bundles", "tasks"), env: { CROW_TASKS_DB_PATH: join(A, "data", "tasks.db") } },
+    "crow-rookery": { command: "n", args: ["server/index.js"], cwd: join(A, "bundles", "rookery"), env: {} },
+    "brave-search": { command: "npx", args: ["-y", "srv"], cwd: "/home/x", env: { BRAVE_API_KEY: "k" } },
+    "gws":          { command: "g", args: [], optIn: true, env: {} },
+  } }));
+  const sessionDir = join(dir, "session");
+  mkdirSync(sessionDir, { recursive: true });
+  const binding = {
+    CROW_HOME: B,
+    CROW_DATA_DIR: join(B, "data"),
+    CROW_DB_PATH: join(B, "data", "crow.db"),
+    CROW_TASKS_DB_PATH: join(B, "data", "tasks.db"),
+  };
+  return { dir, A, B, canonicalPath, sessionDir, binding };
+}
+
+function write(def, f) {
+  const res = writeBotMcp(def, {
+    sessionDir: f.sessionDir, canonicalPath: f.canonicalPath, crowHome: f.B, binding: f.binding,
+  });
+  return { res, json: JSON.parse(readFileSync(join(f.sessionDir, ".mcp.json"), "utf8")) };
+}
+
+/** Every string anywhere in a block — cwd, command, args, env values. */
+function strings(block) {
+  const out = [];
+  const walk = (v) => {
+    if (typeof v === "string") out.push(v);
+    else if (Array.isArray(v)) v.forEach(walk);
+    else if (v && typeof v === "object") Object.values(v).forEach(walk);
+  };
+  walk(block);
+  return out;
+}
+
+test("THE INVARIANT: no active block references the other instance", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["crow-memory", "tasks", "brave-search"] } }, f);
+  for (const [name, block] of Object.entries(json.mcpServers)) {
+    if (block && block.disabled === true) continue;
+    for (const s of strings(block)) {
+      assert.ok(!s.includes("/.crow-a"), `${name} leaks instance A via ${s}`);
+    }
+  }
+});
+
+test("a selected core server is rebound to this instance's database", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  assert.equal(json.mcpServers["crow-memory"].env.CROW_DB_PATH, join(f.B, "data", "crow.db"));
+  assert.equal(json.mcpServers["crow-memory"].env.CROW_JOURNAL_MODE, "DELETE");
+});
+
+test("closed-world: every unselected canonical server is disabled", () => {
+  const f = twoInstances();
+  const { json, res } = write({ tools: { crow_mcp: ["crow-memory"] } }, f);
+  for (const name of ["crow-tasks", "crow-rookery", "brave-search", "gws"]) {
+    assert.deepEqual(json.mcpServers[name], { disabled: true }, `${name} must be disabled`);
+  }
+  assert.ok(res.disabled.includes("brave-search"));
+  assert.deepEqual(res.servers, ["crow-memory"], "servers lists ACTIVE names only");
+});
+
+test("a selected bundle absent on this instance is disabled with a reason", () => {
+  const f = twoInstances();
+  const { json, res } = write({ tools: { crow_mcp: ["crow-rookery"] } }, f);
+  assert.deepEqual(json.mcpServers["crow-rookery"], { disabled: true });
+  assert.ok(res.warnings.some((w) => /rookery/.test(w) && /not installed/.test(w)),
+    "the reason is surfaced, not swallowed: " + JSON.stringify(res.warnings));
+});
+
+test("optIn never survives into an active block", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["gws"] } }, f);
+  assert.ok(!("optIn" in json.mcpServers.gws), "a copied optIn block would never load");
+});
+
+test("a non-Crow server is carried through untouched", () => {
+  const f = twoInstances();
+  const { json } = write({ tools: { crow_mcp: ["brave-search"] } }, f);
+  assert.equal(json.mcpServers["brave-search"].env.BRAVE_API_KEY, "k");
+  assert.equal(json.mcpServers["brave-search"].cwd, "/home/x");
+});

--- a/tests/pibot-mcp-instance-binding.test.js
+++ b/tests/pibot-mcp-instance-binding.test.js
@@ -127,3 +127,37 @@ test("journalGuarded: a crow.db-touching catalog server is reported", () => {
   assert.ok(res.journalGuarded.includes("crow-memory"),
     "the WAL-unlink guard must be observable for the catalog path too: " + JSON.stringify(res.journalGuarded));
 });
+
+import { toolAllowlist, applySessionNarrowing } from "../scripts/pi-bots/bridge.mjs";
+
+/**
+ * Mirrors the --tools branch in the PiRpc constructor. A bot with no builtin
+ * and no MCP tools yields "", and omitting the flag hands pi
+ * defaultActiveToolNames — bash, edit, write, and every tool registered by
+ * every inherited server (pi dist/cli/args.js:85-89 -> dist/core/sdk.js:133-136).
+ */
+function toolsArgs(def, narrowedTools) {
+  const tools = toolAllowlist(def);
+  const narrowed = applySessionNarrowing(tools, narrowedTools);
+  const args = [];
+  if (narrowed !== tools) args.push("--tools", narrowed);
+  else args.push("--tools", tools);
+  return args;
+}
+
+test("an empty tool envelope pins --tools \"\" instead of omitting the flag", () => {
+  const def = { tools: { pi_builtin: [], crow_mcp: [] } };
+  assert.equal(toolAllowlist(def), "", "precondition: the envelope really is empty");
+  assert.deepEqual(toolsArgs(def), ["--tools", ""],
+    "omitting the flag would WIDEN an empty envelope to pi's full default surface");
+});
+
+test("a normal envelope still pins its allowlist", () => {
+  const def = { tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } };
+  assert.deepEqual(toolsArgs(def), ["--tools", "read,mcp__tasks__tasks_list"]);
+});
+
+test("narrowing to nothing still pins --tools \"\"", () => {
+  const def = { tools: { pi_builtin: ["read"], crow_mcp: [] } };
+  assert.deepEqual(toolsArgs(def, JSON.stringify(["read"])), ["--tools", ""]);
+});

--- a/tests/pibot-tools-envelope.test.js
+++ b/tests/pibot-tools-envelope.test.js
@@ -1,0 +1,69 @@
+/**
+ * `--tools` is ALWAYS pinned.
+ *
+ * pi falls back to defaultActiveToolNames when the flag is ABSENT
+ * (dist/cli/args.js:85-89 -> dist/core/sdk.js:133-136), so a bot with an empty
+ * envelope used to receive bash, edit, write, and every tool registered by
+ * every inherited MCP server. Three enabled r4 bots were in that state.
+ *
+ * Uses the PiRpc nodeBin/cliPath seam with a stub that records its argv, so no
+ * real pi is spawned. Asserts the ACTUAL spawn args, never a mirror of the
+ * branch under test.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { PiRpc } = await import("../scripts/pi-bots/bridge.mjs");
+
+/** Spawn PiRpc against a stub that dumps argv, and return the args pi saw. */
+async function spawnArgs(def, narrowedTools) {
+  const scratch = mkdtempSync(join(tmpdir(), "crow-tools-"));
+  mkdirSync(join(scratch, "sessions"), { recursive: true });
+  const out = join(scratch, "argv.json");
+  const stub = join(scratch, "stub-pi.mjs");
+  writeFileSync(stub,
+    'import { writeFileSync } from "node:fs";\n' +
+    'writeFileSync(process.env.CROW_TEST_ARGV_OUT, JSON.stringify(process.argv.slice(2)));\n' +
+    'process.exit(0);\n');
+  const pi = new PiRpc({
+    def,
+    sessionDir: scratch,
+    resolved: { provider: "stub", model: "stub", key: "stub/stub" },
+    nodeBin: process.execPath,
+    cliPath: stub,
+    narrowedTools,
+    extraEnv: { CROW_TEST_ARGV_OUT: out },
+  });
+  for (let i = 0; i < 100 && !existsSync(out); i++) await new Promise((r) => setTimeout(r, 50));
+  try { pi.close(); } catch { /* already exited */ }
+  assert.ok(existsSync(out), "stub pi never recorded its argv");
+  return JSON.parse(readFileSync(out, "utf8"));
+}
+
+/** The value pi received for --tools, or undefined when the flag was omitted. */
+function toolsFlag(argv) {
+  const i = argv.indexOf("--tools");
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+test("an empty tool envelope pins --tools \"\" instead of omitting the flag", async () => {
+  const argv = await spawnArgs({ tools: { pi_builtin: [], crow_mcp: [] } });
+  assert.notEqual(toolsFlag(argv), undefined,
+    "omitting --tools hands pi its full default surface — an empty envelope would WIDEN");
+  assert.equal(toolsFlag(argv), "");
+});
+
+test("a normal envelope still pins its allowlist", async () => {
+  const argv = await spawnArgs({ tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } });
+  assert.equal(toolsFlag(argv), "read,mcp__tasks__tasks_list");
+});
+
+test("narrowing every tool away still pins --tools \"\"", async () => {
+  const argv = await spawnArgs(
+    { tools: { pi_builtin: ["read"], crow_mcp: [] } },
+    JSON.stringify(["read"]));
+  assert.equal(toolsFlag(argv), "");
+});


### PR DESCRIPTION
pi-lab commit `671e116` (2026-07-04) changed MCP config precedence so the **nearest project file wins**, not the homedir `~/.pi/agent/mcp.json`. Crow still asserted the old "homedir wins on collision" rule in `mcp_writer.mjs`, and believing it hid three live bugs.

Verified live against pi 0.82.0 with a fixture defining the same server name in both layers:

| lever | effect |
|---|---|
| redefine a name in the per-bot file | per-bot block wins |
| `{"name": {"disabled": true}}` | global server does not load at all |
| omit a name | global server **still loads** |

## The three bugs

1. **Core-server blocks were copied verbatim** out of a config pinned to one instance, so an r4 bot's `crow_store_memory` resolved to MPA's `crow.db`. Reachable, and not yet fired — MPA's `memories` table's newest row predates it.
2. **An empty tool envelope omitted `--tools`**, and pi falls back to `defaultActiveToolNames` when the flag is absent. Three enabled r4 bots were configured to receive bash, edit, write and every inherited MCP tool. (None had ever run a turn — zero rows in `bot_jobs` and `bot_sessions`.)
3. **A verbatim-copied `optIn` block never activates**, so four bots listed Google Workspace tools for a server that never loaded.

One root cause: the writer treated the global config as a source to copy from, when pi treats the per-bot file as the authority.

## The change

Crow servers are now **derived per instance** — core servers from `scripts/server-registry.js`, bundle servers from the instance's own `mcp-addons.json` — and the per-bot `.mcp.json` is written **closed-world**, explicitly disabling everything pi would otherwise inherit. `~/.pi/agent/mcp.json` is demoted from "catalog of Crow servers" to "where third-party credentials live".

The Bot Builder tool picker moves to the same catalog, which is what lets the Crow entries leave the global file without emptying the picker.

## Verification

- Full suite **3094 pass / 0 fail**.
- **8/8 mutations** caught. One was vacuous on the first pass: reversing the resolution order broke no test, because `rebindBlock` also corrects canonical-sourced blocks, so nothing witnessed which source won. Closed with a test using `args` as the witness — `rebindBlock` never touches `args`.
- Live acceptance against the real `r4-assistant` definition (read from a database copy; the live DB is never opened): no active block in the output names another instance.

## Follow-up, not in this PR

The six Crow entries are removed from `~/.pi/agent/mcp.json` by hand after this deploys, together with `{"disabled": true}` entries in `~/r4-tehcy/.mcp.json` and a rename of MPA's legacy `crow-tasks`/`crow-bots-sql` selections. Ordering matters and is documented in the plan.

Design and evidence: `docs/superpowers/specs/2026-08-08-mcp-instance-binding-design.md`

No schema change; `SCHEMA_GENERATION` is untouched, so the migration rail does not apply.