### PR TITLE
fix(browser): each instance gets its own browser

### DIFF
--- a/bundles/browser/.env.example
+++ b/bundles/browser/.env.example
@@ -1,3 +1,9 @@
 CROW_BROWSER_VNC_PASSWORD=changeme
 CROW_BROWSER_CDP_PORT=9222
 CROW_BROWSER_VNC_PORT=6080
+
+# Required. The Crow instance this browser belongs to — decides where downloads,
+# exports and saved sessions land. The gateway sets it automatically when you
+# install through the Extensions panel; set it here if you run docker compose by
+# hand, or the mount will refuse to start.
+CROW_HOME=/home/youruser/.crow

--- a/bundles/browser/docker-compose.yml
+++ b/bundles/browser/docker-compose.yml
@@ -17,7 +17,9 @@ services:
       - RFB_PORT=${CROW_BROWSER_RFB_PORT:-5900}
       - CHROME_PROXY=${CROW_BROWSER_PROXY:-}
     volumes:
-      - ${CROW_HOME:-${HOME}/.crow}/browser-downloads:/downloads
+      # No default: a second instance whose CROW_HOME is unset must fail here rather
+      # than silently mount the primary's downloads directory into its container.
+      - ${CROW_HOME:?CROW_HOME is required so each instance writes downloads to its own directory}/browser-downloads:/downloads
     init: true
     mem_limit: 2g
     shm_size: 1g

--- a/bundles/browser/manifest.json
+++ b/bundles/browser/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "browser",
   "name": "Browser Automation",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Stealth browser automation — navigate, fill forms, take screenshots, extract content via Chrome DevTools Protocol with VNC viewing",
   "type": "bundle",
   "author": "Crow",

--- a/bundles/browser/server/instance.js
+++ b/bundles/browser/server/instance.js
@@ -1,0 +1,20 @@
+/**
+ * Which Crow instance is this browser server bound to?
+ *
+ * One module, one answer. server.js used to disagree with itself: browser-sessions
+ * honored CROW_HOME while browser-exports and browser-downloads hardcoded ~/.crow,
+ * so a second instance on the same host wrote its downloads into the primary's
+ * directory. Everything instance-scoped resolves here now.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** This instance's home. Falls back to the primary, which is correct only for the primary. */
+export function stateRoot() {
+  return process.env.CROW_HOME || join(homedir(), ".crow");
+}
+
+/** A state directory under this instance's home, e.g. stateDir("browser-downloads"). */
+export function stateDir(name) {
+  return join(stateRoot(), name);
+}

--- a/bundles/browser/server/instance.js
+++ b/bundles/browser/server/instance.js
@@ -18,3 +18,15 @@ export function stateRoot() {
 export function stateDir(name) {
   return join(stateRoot(), name);
 }
+
+/**
+ * The docker container this instance's browser runs in.
+ *
+ * manifest.json declares CROW_BROWSER_CONTAINER_NAME and r4's addon sets it, but
+ * server.js used to hardcode "crow-browser" in all four of its docker calls — one
+ * of which is `docker restart`, so a secondary instance restarting "its" browser
+ * killed the primary's Chrome and every session logged into it.
+ */
+export function containerName() {
+  return process.env.CROW_BROWSER_CONTAINER_NAME || "crow-browser";
+}

--- a/bundles/browser/server/server.js
+++ b/bundles/browser/server/server.js
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSy
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
-import { stateDir } from "./instance.js";
+import { stateDir, stateRoot, containerName } from "./instance.js";
 
 /**
  * Create and configure the crow-browser MCP server.
@@ -33,6 +33,7 @@ export function createBrowserServer(options = {}) {
     `http://127.0.0.1:${process.env.CROW_BROWSER_CDP_PORT || "9222"}`;
   const sessionDir = options.sessionDir || stateDir("browser-sessions");
   const vncPort = process.env.CROW_BROWSER_VNC_PORT || "6080";
+  const container = containerName();
 
   const server = new McpServer(
     { name: "crow-browser", version: "0.1.0" },
@@ -121,9 +122,9 @@ export function createBrowserServer(options = {}) {
           if (browser) { await browser.close().catch(() => {}); browser = null; context = null; page = null; cdpSession = null; }
           let vncpw = "", composeFile = "";
           try {
-            const env = execFileSync("docker", ["inspect", "crow-browser", "--format", "{{range .Config.Env}}{{println .}}{{end}}"], { timeout: 10000 }).toString();
+            const env = execFileSync("docker", ["inspect", container, "--format", "{{range .Config.Env}}{{println .}}{{end}}"], { timeout: 10000 }).toString();
             vncpw = (env.split("\n").find((l) => l.startsWith("VNC_PASSWORD=")) || "").slice("VNC_PASSWORD=".length);
-            composeFile = execFileSync("docker", ["inspect", "crow-browser", "--format", '{{index .Config.Labels "com.docker.compose.project.config_files"}}'], { timeout: 10000 }).toString().trim();
+            composeFile = execFileSync("docker", ["inspect", container, "--format", '{{index .Config.Labels "com.docker.compose.project.config_files"}}'], { timeout: 10000 }).toString().trim();
           } catch { /* fall through to error */ }
           if (!vncpw) return { content: [{ type: "text", text: "Could not read VNC password from the running container — set CROW_BROWSER_PROXY in the environment and recreate the container manually." }], isError: true };
           // Fallback: this bundle's own compose file, derived from our location
@@ -151,7 +152,7 @@ export function createBrowserServer(options = {}) {
             cdpSession = null;
           }
           try {
-            execFileSync("docker", ["restart", "crow-browser"], { timeout: 30000 });
+            execFileSync("docker", ["restart", container], { timeout: 30000 });
             // Wait for Chrome to be ready
             await new Promise((r) => setTimeout(r, 5000));
           } catch {
@@ -196,7 +197,7 @@ export function createBrowserServer(options = {}) {
     async () => {
       const containerRunning = (() => {
         try {
-          const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", "crow-browser"], { encoding: "utf-8", timeout: 5000 }).trim();
+          const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", container], { encoding: "utf-8", timeout: 5000 }).trim();
           return out === "true";
         } catch {
           return false;
@@ -210,8 +211,11 @@ export function createBrowserServer(options = {}) {
         content: [{
           type: "text",
           text: JSON.stringify({
+            container,
             container_running: containerRunning,
+            cdp_url: cdpUrl,
             cdp_connected: cdpConnected,
+            state_root: stateRoot(),
             current_url: currentUrl,
             vnc_url: containerRunning ? `http://localhost:${vncPort}/vnc.html` : null,
           }, null, 2),

--- a/bundles/browser/server/server.js
+++ b/bundles/browser/server/server.js
@@ -15,9 +15,9 @@ import { buildStealthScript, getContextOptions, humanType, humanClick, delay } f
 import { getRandomProfile } from "./profiles.js";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
+import { stateDir } from "./instance.js";
 
 /**
  * Create and configure the crow-browser MCP server.
@@ -31,8 +31,7 @@ import { execFileSync } from "node:child_process";
 export function createBrowserServer(options = {}) {
   const cdpUrl = options.cdpUrl || process.env.CROW_BROWSER_CDP_URL ||
     `http://127.0.0.1:${process.env.CROW_BROWSER_CDP_PORT || "9222"}`;
-  const sessionDir = options.sessionDir ||
-    join(process.env.CROW_HOME || join(homedir(), ".crow"), "browser-sessions");
+  const sessionDir = options.sessionDir || stateDir("browser-sessions");
   const vncPort = process.env.CROW_BROWSER_VNC_PORT || "6080";
 
   const server = new McpServer(
@@ -953,11 +952,11 @@ export function createBrowserServer(options = {}) {
     {
       data: z.array(z.record(z.string(), z.any())).describe("Array of data objects to export"),
       format: z.enum(["csv", "json"]).describe("Export format"),
-      filename: z.string().optional().describe("Output filename (saved to ~/.crow/browser-exports/)"),
+      filename: z.string().optional().describe("Output filename (saved to this instance's browser-exports/ directory — see crow_browser_status for the resolved path)"),
     },
     async ({ data, format, filename }) => {
       try {
-        const exportDir = join(homedir(), ".crow", "browser-exports");
+        const exportDir = stateDir("browser-exports");
         if (!existsSync(exportDir)) mkdirSync(exportDir, { recursive: true });
 
         const ts = new Date().toISOString().replace(/[:.]/g, "-").substring(0, 19);
@@ -1400,7 +1399,7 @@ export function createBrowserServer(options = {}) {
   // Tool: crow_browser_download
   server.tool(
     "crow_browser_download",
-    "Trigger a file download by clicking an element, and save it to the host at ~/.crow/browser-downloads/. Uses a container bind mount + CDP download behavior.",
+    "Trigger a file download by clicking an element, and save it to this instance's browser-downloads/ directory on the host (see crow_browser_status for the resolved path). Uses a container bind mount + CDP download behavior.",
     {
       selector: z.string().describe("CSS selector of the link/button that starts the download"),
       timeout_ms: z.number().optional().describe("Max wait for the file to finish (default: 30000)"),
@@ -1408,7 +1407,7 @@ export function createBrowserServer(options = {}) {
     async ({ selector, timeout_ms }) => {
       try {
         const p = await getPage();
-        const hostDir = join(homedir(), ".crow", "browser-downloads");
+        const hostDir = stateDir("browser-downloads");
         if (!existsSync(hostDir)) mkdirSync(hostDir, { recursive: true });
 
         // Container writes to /downloads, bind-mounted to hostDir.

--- a/docs/superpowers/plans/2026-08-09-per-instance-browser.md
+++ b/docs/superpowers/plans/2026-08-09-per-instance-browser.md
@@ -278,8 +278,17 @@ test("no docker call in server.js hardcodes a container name", () => {
 
 test("crow_browser_status reports what the server bound to", () => {
   const src = readFileSync(SERVER_JS, "utf8");
+  // Scope to the status handler. A whole-file substring search is vacuous here:
+  // `container:` also matches an unrelated Zod field on crow_browser_scrape and
+  // `cdp_url:` a pre-existing field in the reconnect response, so a file-wide
+  // check passes even when the status payload never gained either.
+  const start = src.indexOf('"crow_browser_status"');
+  assert.ok(start > 0, "could not locate the crow_browser_status registration");
+  const next = src.indexOf("server.tool(", start);
+  const handler = src.slice(start, next > start ? next : undefined);
+  assert.ok(handler.length > 0, "the crow_browser_status slice is empty — the slicing logic broke");
   for (const field of ["container:", "cdp_url:", "state_root:"]) {
-    assert.ok(src.includes(field), `crow_browser_status must report ${field} so a deploy can be verified by running it`);
+    assert.ok(handler.includes(field), `crow_browser_status must report ${field} so a deploy can be verified by running it`);
   }
 });
 ```

--- a/docs/superpowers/plans/2026-08-09-per-instance-browser.md
+++ b/docs/superpowers/plans/2026-08-09-per-instance-browser.md
@@ -688,6 +688,7 @@ git show --stat HEAD
 
 **Files:**
 - Modify: `bundles/browser/manifest.json` (`version`)
+- Modify: `registry/add-ons.json` (regenerated — it is a generated snapshot that pins each bundle's version, so bumping the manifest without rebuilding it drifts and reddens both `tests/bundle-contract.test.js` and `tests/bundle-provider-audit.test.js`, plus the `static-checks` CI job)
 
 **Interfaces:**
 - Consumes: Tasks 1-4.
@@ -703,6 +704,17 @@ In `bundles/browser/manifest.json`, change `"version": "1.0.0",` to:
   "version": "1.1.0",
 ```
 
+- [ ] **Step 1b: Regenerate the add-ons registry**
+
+`registry/add-ons.json` is generated and checked in, and it carries `"version": "1.0.0"` for the `browser` bundle. Bumping the manifest alone leaves the two out of step.
+
+```bash
+cd /home/kh0pp/crow-wt-browser && npm run build-registry
+git diff --stat registry/add-ons.json
+```
+
+Expected: `registry/add-ons.json` changes, and the browser entry's `version` now reads `1.1.0`. Confirm the diff touches only version-related fields for this bundle — if it rewrites unrelated entries, stop and report, because that means the checked-in snapshot was already stale for some other reason.
+
 - [ ] **Step 2: Run the full suite**
 
 ```bash
@@ -717,7 +729,7 @@ Expected: all pass, 0 failures. Baseline before this change was 2961 passing; th
 ```bash
 cd /home/kh0pp/crow-wt-browser
 node scripts/check-port-allocation.js && echo "PORTS OK"
-node scripts/build-registry.js --check && echo "REGISTRY OK"
+node scripts/build-registry.mjs --check && echo "REGISTRY OK"
 ```
 
 Expected: both OK. `check-ports` only scans `bundles/*/docker-compose.yml` for `host:container` mappings and the browser bundle uses `network_mode: host` with no `ports:` list, so it should be unaffected — but run it rather than assume.
@@ -725,11 +737,12 @@ Expected: both OK. `check-ports` only scans `bundles/*/docker-compose.yml` for `
 - [ ] **Step 4: Commit the bump and push**
 
 ```bash
-git commit bundles/browser/manifest.json -m "chore(browser): 1.0.0 -> 1.1.0 so installed bundles refresh
+git commit bundles/browser/manifest.json registry/add-ons.json -m "chore(browser): 1.0.0 -> 1.1.0 so installed bundles refresh
 
 repairInstalledBundleAssets only re-copies server/ when the manifest versions
 differ, so without this the instance fixes never reach ~/.crow/bundles/browser
-or ~/.crow-r4/bundles/browser."
+or ~/.crow-r4/bundles/browser. registry/add-ons.json is generated and pins the
+same version, so it is regenerated in the same commit."
 git show --stat HEAD
 git push -u origin fix/per-instance-browser
 ```

--- a/docs/superpowers/plans/2026-08-09-per-instance-browser.md
+++ b/docs/superpowers/plans/2026-08-09-per-instance-browser.md
@@ -278,20 +278,35 @@ test("no docker call in server.js hardcodes a container name", () => {
 
 test("crow_browser_status reports what the server bound to", () => {
   const src = readFileSync(SERVER_JS, "utf8");
-  // Scope to the status handler. A whole-file substring search is vacuous here:
-  // `container:` also matches an unrelated Zod field on crow_browser_scrape and
-  // `cdp_url:` a pre-existing field in the reconnect response, so a file-wide
-  // check passes even when the status payload never gained either.
-  const start = src.indexOf('"crow_browser_status"');
-  assert.ok(start > 0, "could not locate the crow_browser_status registration");
-  const next = src.indexOf("server.tool(", start);
-  const handler = src.slice(start, next > start ? next : undefined);
-  assert.ok(handler.length > 0, "the crow_browser_status slice is empty — the slicing logic broke");
-  for (const field of ["container:", "cdp_url:", "state_root:"]) {
-    assert.ok(handler.includes(field), `crow_browser_status must report ${field} so a deploy can be verified by running it`);
+
+  // Scope to the crow_browser_status handler only — checking the whole file lets
+  // unrelated matches (e.g. a Zod field named `container` on a different tool, or
+  // a pre-existing `cdp_url` in the reconnect response) pass the assertion even
+  // when this handler's own payload never mentions the field.
+  const statusStart = src.indexOf('"crow_browser_status"');
+  assert.ok(statusStart !== -1, "could not find the crow_browser_status tool registration");
+  const nextToolStart = src.indexOf("server.tool(", statusStart);
+  const handlerSlice = nextToolStart === -1 ? src.slice(statusStart) : src.slice(statusStart, nextToolStart);
+  assert.ok(handlerSlice.length > 0, "crow_browser_status handler slice must be non-empty");
+
+  // Narrow further to the JSON.stringify(...) payload object itself, so the tool's
+  // own description text ("Check browser container...") can't satisfy the check.
+  const payloadStart = handlerSlice.indexOf("JSON.stringify(");
+  assert.ok(payloadStart !== -1, "could not find the JSON.stringify(...) status payload inside the handler");
+  const payloadEnd = handlerSlice.indexOf("}, null, 2)", payloadStart);
+  assert.ok(payloadEnd !== -1, "could not find the end of the status payload object");
+  const payloadSlice = handlerSlice.slice(payloadStart, payloadEnd);
+  assert.ok(payloadSlice.length > 0, "crow_browser_status payload slice must be non-empty");
+
+  for (const field of ["container", "cdp_url", "state_root"]) {
+    // Word-boundary match: "container" must not be satisfied by "container_running".
+    const re = new RegExp(`\\b${field}\\b`);
+    assert.ok(re.test(payloadSlice), `crow_browser_status payload must report ${field} so a deploy can be verified by running it`);
   }
 });
 ```
+
+Field names carry no trailing colon here on purpose: the payload writes `container` as an ES6 shorthand property (`container,`), so a `"container:"` search would be false against the real file.
 
 - [ ] **Step 2: Run and confirm failure**
 

--- a/docs/superpowers/plans/2026-08-09-per-instance-browser.md
+++ b/docs/superpowers/plans/2026-08-09-per-instance-browser.md
@@ -192,7 +192,13 @@ Line 1403, currently `"Trigger a file download by clicking an element, and save 
     "Trigger a file download by clicking an element, and save it to this instance's browser-downloads/ directory on the host (see crow_browser_status for the resolved path). Uses a container bind mount + CDP download behavior.",
 ```
 
-Leave the `homedir` import in place — it is still used elsewhere in the file. If a lint run reports it unused, remove it then, not speculatively.
+**Remove the now-dead `homedir` import.** Those three lines were its only uses in `server.js` (verified 2026-08-09), and `node:os` is imported for nothing else, so delete the whole line at 18:
+
+```js
+import { homedir } from "node:os";
+```
+
+Keep the `join` import — it is still used throughout the file. After the edit, `grep -n 'homedir' bundles/browser/server/server.js` must return nothing.
 
 - [ ] **Step 6: Run the tests and confirm all three pass**
 

--- a/docs/superpowers/plans/2026-08-09-per-instance-browser.md
+++ b/docs/superpowers/plans/2026-08-09-per-instance-browser.md
@@ -1,0 +1,1093 @@
+# Per-Instance Browser Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make each independent Crow instance own its browser — its own container, port triple and state directories — so no instance's browser server can read, write, or restart another instance's Chrome.
+
+**Architecture:** One new module, `bundles/browser/server/instance.js`, answers "which instance am I bound to" (`stateRoot`, `stateDir`, `containerName`); `server.js` routes every path and every `docker` call through it. The compose mount loses its `~/.crow` fallback so a mis-run `docker compose up` fails loudly instead of borrowing the primary's directory. `crowServerCatalog` stamps `CROW_HOME` onto every bundle block it derives, so a bundle server is told its instance rather than inheriting it from the caller's shell. The rest is host configuration, executed in an order where nothing ever references a name that is about to disappear.
+
+**Tech Stack:** Node 22 (ESM), `node:test` + `node:assert/strict`, playwright + Chrome DevTools Protocol, Docker Compose (`network_mode: host`), pi 0.82.0 with pi-lab's `mcp-client` extension.
+
+**Spec:** `docs/superpowers/specs/2026-08-08-per-instance-browser-design.md` (read the Addendum — it adds finding 8 and renames the module).
+
+## Global Constraints
+
+- **Node 22 on every invocation:** `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH`
+- **Work in the worktree** `/home/kh0pp/crow-wt-browser`, branch `fix/per-instance-browser`, branched from `origin/main` (`53efc76a`). Never switch branches in `/home/kh0pp/crow` — it runs live services.
+- **`0aad37e8 fix(35b)` is unpushed on local `main` and is not ours.** The worktree is branched from `origin/main` precisely so it cannot ride along. Never cherry-pick or rebase it in.
+- **Commit with a positional path:** `git commit <exact/path> -m "..."`. For a new file, `git add <exact/path>` first, never bare `git add`. Verify with `git show --stat HEAD` after every commit.
+- **Never attribute Claude.** No `Co-Authored-By` trailer, no "generated with" line.
+- **Never open a running gateway's `crow.db` / `tasks.db`.** Copy the `.db` plus `-wal` and `-shm`, query the copy. The only exception is Task 7, which stops the gateways first.
+- **CI:** query `https://api.github.com/repos/kh0pper/crow/commits/<sha>/check-runs`. Never the legacy commit-status API. Contexts are `suite`, `static-checks`, `audit`. `enforce_admins` is TRUE — a red check blocks the merge, including yours.
+- **`gh` is not installed.** Use the GitHub MCP tools (`mcp__github__*`).
+- **`pibot-gateways@r4` is soaking from the `/home/kh0pp/crow` working tree until ~2026-08-12.** It consumes `bridge.mjs` exports via `job_runner.mjs` — this plan does not touch `bridge.mjs`, and must not. **Log every `~/crow` pull that touches `scripts/pi-bots/` and every restart of that unit** (Task 6). `r4-deploy.sh` does not restart it.
+- **A pre-existing unstaged change to `scripts/bench/h2-35b-overnight/compose-prod-snapshot.yml` lives in `~/crow` and blocks `git pull --rebase`.** Scoped-stash it, pull, pop. It is not ours.
+- **Live values:** primary gateway port 3001, MPA 3006, r4 3008 (`:8449`, dashboard password `H0ust0nTX_2026`). sudo `8r00kly^`. Ports: primary browser CDP 9222 / noVNC 6080 / RFB 5900; r4 CDP 9223 / noVNC 6081 / RFB 5901.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `bundles/browser/server/instance.js` | **New.** The single source of "which instance is this server bound to": state root, state directories, container name. No I/O, no side effects, so tests import it without pulling in playwright. |
+| `bundles/browser/server/server.js` | **Modified.** Routes all three state directories and all four `docker` calls through `instance.js`. Reports what it bound to via `crow_browser_status`. |
+| `bundles/browser/docker-compose.yml` | **Modified.** The downloads mount requires `CROW_HOME` instead of defaulting to `~/.crow`. |
+| `bundles/browser/.env.example` | **Modified.** Documents `CROW_HOME` and why it is required. |
+| `bundles/browser/manifest.json` | **Modified.** Version bump — the only thing that makes `repairInstalledBundleAssets` re-copy `server/` into installed bundles. |
+| `scripts/pi-bots/crow-server-catalog.mjs` | **Modified.** Stamps `CROW_HOME` on every block derived from `mcp-addons.json`. |
+| `tests/browser-bundle-instance.test.js` | **New.** The browser bundle's instance-isolation contract: paths, container name, compose. |
+| `tests/pibot-crow-server-catalog.test.js` | **Modified.** Adds the `CROW_HOME`-stamping assertions. |
+
+---
+
+## Task 1: The instance module and one state root
+
+**Files:**
+- Create: `bundles/browser/server/instance.js`
+- Create: `tests/browser-bundle-instance.test.js`
+- Modify: `bundles/browser/server/server.js` (imports at 16-20; `sessionDir` at 34-35; export tool at 956 and 960; download tool at 1403 and 1411)
+
+**Interfaces:**
+- Produces: `stateRoot(): string` and `stateDir(name: string): string`, both from `bundles/browser/server/instance.js`. Task 2 adds `containerName(): string` to the same module. Task 8's verification reads the `state_root` field Task 2 adds to `crow_browser_status`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/browser-bundle-instance.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { stateRoot, stateDir } from "../bundles/browser/server/instance.js";
+
+const SERVER_JS = new URL("../bundles/browser/server/server.js", import.meta.url);
+
+/** Run `fn` with CROW_HOME forced to `value` (or unset when value is null). */
+function withCrowHome(value, fn) {
+  const prev = process.env.CROW_HOME;
+  if (value === null) delete process.env.CROW_HOME;
+  else process.env.CROW_HOME = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.CROW_HOME;
+    else process.env.CROW_HOME = prev;
+  }
+}
+
+test("every state directory derives from CROW_HOME", () => {
+  withCrowHome("/tmp/scratch-crow-r4", () => {
+    assert.equal(stateRoot(), "/tmp/scratch-crow-r4");
+    assert.equal(stateDir("browser-sessions"), "/tmp/scratch-crow-r4/browser-sessions");
+    assert.equal(stateDir("browser-downloads"), "/tmp/scratch-crow-r4/browser-downloads");
+    assert.equal(stateDir("browser-exports"), "/tmp/scratch-crow-r4/browser-exports");
+  });
+});
+
+test("state directories fall back to ~/.crow when CROW_HOME is unset", () => {
+  withCrowHome(null, () => {
+    assert.equal(stateRoot(), join(homedir(), ".crow"));
+    assert.equal(stateDir("browser-downloads"), join(homedir(), ".crow", "browser-downloads"));
+  });
+});
+
+test("server.js never hardcodes the primary's home", () => {
+  const src = readFileSync(SERVER_JS, "utf8");
+  assert.ok(
+    !/join\(\s*homedir\(\)\s*,\s*"\.crow"/.test(src),
+    "server.js must resolve state through stateDir(), not join(homedir(), \".crow\", ...)",
+  );
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow-wt-browser && npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: FAIL — `Cannot find module '.../bundles/browser/server/instance.js'`.
+
+- [ ] **Step 3: Create the module**
+
+`bundles/browser/server/instance.js`:
+
+```js
+/**
+ * Which Crow instance is this browser server bound to?
+ *
+ * One module, one answer. server.js used to disagree with itself: browser-sessions
+ * honored CROW_HOME while browser-exports and browser-downloads hardcoded ~/.crow,
+ * so a second instance on the same host wrote its downloads into the primary's
+ * directory. Everything instance-scoped resolves here now.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** This instance's home. Falls back to the primary, which is correct only for the primary. */
+export function stateRoot() {
+  return process.env.CROW_HOME || join(homedir(), ".crow");
+}
+
+/** A state directory under this instance's home, e.g. stateDir("browser-downloads"). */
+export function stateDir(name) {
+  return join(stateRoot(), name);
+}
+```
+
+- [ ] **Step 4: Run the tests — two pass, the third still fails**
+
+```bash
+npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: the two `stateDir` tests PASS; `server.js never hardcodes the primary's home` still FAILS. That failure is the point — it is the real defect, and Step 5 fixes it.
+
+- [ ] **Step 5: Route server.js through the module**
+
+Add the import alongside the existing ones (after the `homedir` import at line 18):
+
+```js
+import { stateDir } from "./instance.js";
+```
+
+Replace the `sessionDir` default (lines 34-35), currently:
+
+```js
+  const sessionDir = options.sessionDir ||
+    join(process.env.CROW_HOME || join(homedir(), ".crow"), "browser-sessions");
+```
+
+with:
+
+```js
+  const sessionDir = options.sessionDir || stateDir("browser-sessions");
+```
+
+Replace the export directory (line 960), currently `const exportDir = join(homedir(), ".crow", "browser-exports");`, with:
+
+```js
+        const exportDir = stateDir("browser-exports");
+```
+
+Replace the download directory (line 1411), currently `const hostDir = join(homedir(), ".crow", "browser-downloads");`, with:
+
+```js
+        const hostDir = stateDir("browser-downloads");
+```
+
+Fix the two descriptions that assert a path they no longer control. Line 956, currently `filename: z.string().optional().describe("Output filename (saved to ~/.crow/browser-exports/)"),`:
+
+```js
+      filename: z.string().optional().describe("Output filename (saved to this instance's browser-exports/ directory — see crow_browser_status for the resolved path)"),
+```
+
+Line 1403, currently `"Trigger a file download by clicking an element, and save it to the host at ~/.crow/browser-downloads/. Uses a container bind mount + CDP download behavior.",`:
+
+```js
+    "Trigger a file download by clicking an element, and save it to this instance's browser-downloads/ directory on the host (see crow_browser_status for the resolved path). Uses a container bind mount + CDP download behavior.",
+```
+
+Leave the `homedir` import in place — it is still used elsewhere in the file. If a lint run reports it unused, remove it then, not speculatively.
+
+- [ ] **Step 6: Run the tests and confirm all three pass**
+
+```bash
+npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: PASS, 3/3.
+
+- [ ] **Step 7: Confirm the server still starts**
+
+```bash
+cd /home/kh0pp/crow-wt-browser/bundles/browser && node server/index.js
+```
+
+Expected: starts without throwing, then hangs on stdio waiting for a client. Ctrl-C to exit. A `Cannot find module` or a thrown error here means the import path is wrong.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-browser
+git add bundles/browser/server/instance.js tests/browser-bundle-instance.test.js
+git commit bundles/browser/server/instance.js tests/browser-bundle-instance.test.js bundles/browser/server/server.js -m "fix(browser): resolve every state directory from CROW_HOME
+
+server.js disagreed with itself: browser-sessions honored CROW_HOME while
+browser-exports and browser-downloads hardcoded ~/.crow, so a second instance
+on the same host wrote into the primary's directories. One module now answers
+which instance the server is bound to."
+git show --stat HEAD
+```
+
+---
+
+## Task 2: Target this instance's container, not the primary's
+
+**Files:**
+- Modify: `bundles/browser/server/instance.js`
+- Modify: `bundles/browser/server/server.js` (lines 125, 127, 155, 200; status payload at 210-219)
+- Modify: `tests/browser-bundle-instance.test.js`
+
+**Interfaces:**
+- Consumes: `stateRoot()` from Task 1.
+- Produces: `containerName(): string` from `bundles/browser/server/instance.js`, and three new fields on the `crow_browser_status` JSON payload — `container` (string), `cdp_url` (string), `state_root` (string). Task 8 verifies the deployment by reading exactly those three fields.
+
+**Why this task exists:** `manifest.json:18` declares `CROW_BROWSER_CONTAINER_NAME` as configurable and r4's addon sets it to `crow-browser-r4`, but `server.js` never reads it. Line 155 is `docker restart crow-browser` — so r4's browser server, asked to restart its own browser, restarts the primary's container and destroys every session logged into it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/browser-bundle-instance.test.js`:
+
+```js
+test("containerName honors CROW_BROWSER_CONTAINER_NAME and defaults to crow-browser", async () => {
+  const { containerName } = await import("../bundles/browser/server/instance.js");
+  const prev = process.env.CROW_BROWSER_CONTAINER_NAME;
+  try {
+    process.env.CROW_BROWSER_CONTAINER_NAME = "crow-browser-r4";
+    assert.equal(containerName(), "crow-browser-r4");
+    delete process.env.CROW_BROWSER_CONTAINER_NAME;
+    assert.equal(containerName(), "crow-browser");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_BROWSER_CONTAINER_NAME;
+    else process.env.CROW_BROWSER_CONTAINER_NAME = prev;
+  }
+});
+
+test("no docker call in server.js hardcodes a container name", () => {
+  const src = readFileSync(SERVER_JS, "utf8");
+  const dockerLines = src.split("\n").filter((l) => l.includes('execFileSync("docker"'));
+  assert.ok(dockerLines.length >= 4, `expected the docker calls to still exist, found ${dockerLines.length}`);
+  for (const line of dockerLines) {
+    assert.ok(
+      !line.includes('"crow-browser"'),
+      `docker call targets the primary's container by name: ${line.trim()}`,
+    );
+  }
+});
+
+test("crow_browser_status reports what the server bound to", () => {
+  const src = readFileSync(SERVER_JS, "utf8");
+  for (const field of ["container:", "cdp_url:", "state_root:"]) {
+    assert.ok(src.includes(field), `crow_browser_status must report ${field} so a deploy can be verified by running it`);
+  }
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow-wt-browser && npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: FAIL on all three new tests — `containerName is not a function`, four hardcoded docker lines, and the three missing status fields.
+
+- [ ] **Step 3: Add containerName to the module**
+
+Append to `bundles/browser/server/instance.js`:
+
+```js
+/**
+ * The docker container this instance's browser runs in.
+ *
+ * manifest.json declares CROW_BROWSER_CONTAINER_NAME and r4's addon sets it, but
+ * server.js used to hardcode "crow-browser" in all four of its docker calls — one
+ * of which is `docker restart`, so a secondary instance restarting "its" browser
+ * killed the primary's Chrome and every session logged into it.
+ */
+export function containerName() {
+  return process.env.CROW_BROWSER_CONTAINER_NAME || "crow-browser";
+}
+```
+
+- [ ] **Step 4: Use it in server.js**
+
+Extend the Task 1 import to:
+
+```js
+import { stateDir, containerName } from "./instance.js";
+```
+
+Add a resolved constant next to `cdpUrl` in `createBrowserServer` (after the `vncPort` line, line 36):
+
+```js
+  const container = containerName();
+```
+
+Replace the four hardcoded names. Line 125:
+
+```js
+            const env = execFileSync("docker", ["inspect", container, "--format", "{{range .Config.Env}}{{println .}}{{end}}"], { timeout: 10000 }).toString();
+```
+
+Line 127:
+
+```js
+            composeFile = execFileSync("docker", ["inspect", container, "--format", '{{index .Config.Labels "com.docker.compose.project.config_files"}}'], { timeout: 10000 }).toString().trim();
+```
+
+Line 155:
+
+```js
+            execFileSync("docker", ["restart", container], { timeout: 30000 });
+```
+
+Line 200:
+
+```js
+          const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", container], { encoding: "utf-8", timeout: 5000 }).trim();
+```
+
+Leave line 39 (`{ name: "crow-browser", version: "0.1.0" }`) alone — that is the MCP protocol server name, not a container.
+
+Extend the `crow_browser_status` payload (lines 213-218) to name what it bound to:
+
+```js
+          text: JSON.stringify({
+            container,
+            container_running: containerRunning,
+            cdp_url: cdpUrl,
+            cdp_connected: cdpConnected,
+            state_root: stateRoot(),
+            current_url: currentUrl,
+            vnc_url: containerRunning ? `http://localhost:${vncPort}/vnc.html` : null,
+          }, null, 2),
+```
+
+That needs `stateRoot` in the import too:
+
+```js
+import { stateDir, stateRoot, containerName } from "./instance.js";
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: PASS, 6/6.
+
+- [ ] **Step 6: Confirm the server still starts**
+
+```bash
+cd /home/kh0pp/crow-wt-browser/bundles/browser && node server/index.js
+```
+
+Expected: starts clean, hangs on stdio. Ctrl-C.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/kh0pp/crow-wt-browser
+git commit bundles/browser/server/instance.js bundles/browser/server/server.js tests/browser-bundle-instance.test.js -m "fix(browser): act on this instance's container, never a hardcoded one
+
+CROW_BROWSER_CONTAINER_NAME was declared in the manifest and set by r4's addon
+but never read. Four docker calls named \"crow-browser\" outright, including a
+restart — so r4's browser server restarted the primary's container. Status now
+reports the container, CDP endpoint and state root it resolved, which is what
+makes a deploy verifiable by running it rather than reading it."
+git show --stat HEAD
+```
+
+---
+
+## Task 3: Make a mis-run compose fail loudly
+
+**Files:**
+- Modify: `bundles/browser/docker-compose.yml` (the `volumes:` entry)
+- Modify: `bundles/browser/.env.example`
+- Modify: `tests/browser-bundle-instance.test.js`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: nothing consumed by later tasks. Task 8 relies on the guard being present when it recreates r4's container.
+
+**Why this task exists:** `crow-browser-r4`'s `/downloads` is bind-mounted to `/home/kh0pp/.crow/browser-downloads` — the primary's. Not a product defect: `runCompose` inherits the gateway's env (`routes/bundles.js:702-712, 743-746`) and `crow-r4-gateway.service` sets `CROW_HOME`. The container was created by hand from the bundle directory, where `CROW_HOME` was unset and `${CROW_HOME:-${HOME}/.crow}` silently fell back.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/browser-bundle-instance.test.js`:
+
+```js
+test("the downloads mount requires CROW_HOME instead of defaulting to the primary", () => {
+  const compose = readFileSync(new URL("../bundles/browser/docker-compose.yml", import.meta.url), "utf8");
+  assert.ok(
+    !compose.includes("${CROW_HOME:-"),
+    "a CROW_HOME default lets a hand-run compose mount the primary's downloads into a second instance's container",
+  );
+  assert.match(compose, /\$\{CROW_HOME:\?/, "the mount must fail loudly when CROW_HOME is unset");
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow-wt-browser && npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: FAIL — "a CROW_HOME default lets a hand-run compose mount…".
+
+- [ ] **Step 3: Change the mount**
+
+In `bundles/browser/docker-compose.yml`, replace:
+
+```yaml
+      - ${CROW_HOME:-${HOME}/.crow}/browser-downloads:/downloads
+```
+
+with:
+
+```yaml
+      # No default: a second instance whose CROW_HOME is unset must fail here rather
+      # than silently mount the primary's downloads directory into its container.
+      - ${CROW_HOME:?CROW_HOME is required so each instance writes downloads to its own directory}/browser-downloads:/downloads
+```
+
+Do not put `}`, `{` or `:` inside the error message — Compose's `${VAR:?err}` parsing ends at the first `}`.
+
+- [ ] **Step 4: Document it in `.env.example`**
+
+Append to `bundles/browser/.env.example`:
+
+```
+# Required. The Crow instance this browser belongs to — decides where downloads,
+# exports and saved sessions land. The gateway sets it automatically when you
+# install through the Extensions panel; set it here if you run docker compose by
+# hand, or the mount will refuse to start.
+CROW_HOME=/home/youruser/.crow
+```
+
+- [ ] **Step 5: Verify Compose still parses, and that the guard actually bites**
+
+```bash
+cd /home/kh0pp/crow-wt-browser/bundles/browser
+CROW_HOME=/tmp/scratch-crow CROW_BROWSER_VNC_PASSWORD=x docker compose config >/dev/null && echo "PARSES OK"
+env -u CROW_HOME CROW_BROWSER_VNC_PASSWORD=x docker compose config >/dev/null 2>&1 && echo "GUARD FAILED TO BITE" || echo "GUARD BITES OK"
+```
+
+Expected: `PARSES OK` then `GUARD BITES OK`. This is a config parse only — it starts nothing and touches no running container.
+
+- [ ] **Step 6: Run the tests**
+
+```bash
+cd /home/kh0pp/crow-wt-browser && npm test -- tests/browser-bundle-instance.test.js
+```
+
+Expected: PASS, 7/7.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit bundles/browser/docker-compose.yml bundles/browser/.env.example tests/browser-bundle-instance.test.js -m "fix(browser): require CROW_HOME for the downloads mount
+
+The :- default is how crow-browser-r4 ended up bind-mounted to the primary's
+browser-downloads: created by hand from the bundle dir, where CROW_HOME was
+unset. Installing through the Extensions panel was always correct, since
+runCompose inherits the gateway's env. Now the hand path fails instead of
+borrowing."
+git show --stat HEAD
+```
+
+---
+
+## Task 4: Stamp CROW_HOME on every derived bundle block
+
+**Files:**
+- Modify: `scripts/pi-bots/crow-server-catalog.mjs` (the `readAddons` loop, lines 206-215)
+- Modify: `tests/pibot-crow-server-catalog.test.js`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: every block in `crowServerCatalog().servers` that came from `mcp-addons.json` now carries `env.CROW_HOME === crowHome`. Task 7's operator blocks set `CROW_HOME` explicitly and do not depend on this; bots do.
+
+**Why this task exists:** `rebindBlock` rewrites instance env keys only when they are *already present*. r4's `browser` addon carries none of the four, so the spawned server's `CROW_HOME` came from whatever ambient environment pi happened to have.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/pibot-crow-server-catalog.test.js`, add `homedir` to the existing `node:os` import so it reads:
+
+```js
+import { tmpdir, homedir } from "node:os";
+```
+
+Then add a fixture and two tests. Put the fixture next to `instanceB()` near the top of the file:
+
+```js
+/** An instance home with a browser bundle whose addon names no instance env at all. */
+function instanceBrowser() {
+  const dir = mkdtempSync(join(tmpdir(), "instBrowser-"));
+  const home = join(dir, ".crow-r4");
+  mkdirSync(join(home, "bundles", "browser"), { recursive: true });
+  mkdirSync(join(home, "data"), { recursive: true });
+  writeFileSync(join(home, "mcp-addons.json"), JSON.stringify({
+    browser: {
+      command: "node",
+      args: ["server/index.js"],
+      env: { CROW_BROWSER_CDP_PORT: "9223", CROW_BROWSER_CONTAINER_NAME: "crow-browser-r4" },
+    },
+  }));
+  return { dir, home };
+}
+```
+
+And the tests at the end of the file:
+
+```js
+test("catalog stamps CROW_HOME on every bundle server it derives", () => {
+  const { home } = instanceB();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.equal(servers.tasks.env.CROW_HOME, home,
+    "a bundle server must be TOLD its instance, not inherit it from the caller's shell");
+});
+
+test("a derived browser block names its own instance and never the primary", () => {
+  const { home } = instanceBrowser();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  const block = servers.browser;
+  assert.ok(block, "the browser addon should be in the catalog");
+  assert.equal(block.env.CROW_HOME, home);
+  assert.equal(block.env.CROW_BROWSER_CDP_PORT, "9223", "the addon's own port must survive the stamp");
+  assert.equal(block.env.CROW_BROWSER_CONTAINER_NAME, "crow-browser-r4");
+  assert.equal(block.cwd, join(home, "bundles", "browser"));
+
+  const primary = join(homedir(), ".crow");
+  for (const [k, v] of Object.entries(block.env)) {
+    assert.ok(v !== primary && !String(v).startsWith(primary + "/"),
+      `browser block env ${k} points at the primary instance: ${v}`);
+  }
+  assert.ok(!block.cwd.startsWith(primary + "/"), `browser block cwd points at the primary: ${block.cwd}`);
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow-wt-browser && npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: FAIL on both new tests — `expected undefined to equal '<home>'`.
+
+- [ ] **Step 3: Stamp the block**
+
+In `scripts/pi-bots/crow-server-catalog.mjs`, the addon loop currently reads:
+
+```js
+    const r = rebindBlock(id, { ...addon, cwd }, binding, crowHome);
+    if (r.disabled) unconfigured[id] = r.reason;
+    else servers[id] = r.block;
+```
+
+Replace with:
+
+```js
+    const r = rebindBlock(id, { ...addon, cwd }, binding, crowHome);
+    if (r.disabled) {
+      unconfigured[id] = r.reason;
+    } else {
+      // A bundle server runs UNDER this instance, so it must be told which one.
+      // rebindBlock only rewrites instance keys a block already carries, and most
+      // addon blocks carry none — which left CROW_HOME to whatever ambient
+      // environment the caller happened to have (the browser bundle wrote its
+      // sessions wherever that pointed). CROW_HOME only: injecting CROW_DB_PATH
+      // would trip touchesCrowDb() and apply the journal guard to bundles that
+      // never open crow.db.
+      r.block.env = { ...(r.block.env || {}), CROW_HOME: crowHome };
+      servers[id] = r.block;
+    }
+```
+
+Deliberately here and not inside `rebindBlock`: that function is also used for third-party canonical blocks, which have no business carrying an instance.
+
+- [ ] **Step 4: Run and confirm the tests pass**
+
+```bash
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: PASS, whole file.
+
+- [ ] **Step 5: Mutation check — prove the tests can actually fail**
+
+This step is mandatory, not optional. The previous session in this defect family shipped a design whose central claim had no executable protection, and an acceptance harness bound to a scratch copy that could not have detected a real leak. A test that passes without the mechanism it names is worse than no test.
+
+Comment out the stamping line:
+
+```js
+      // r.block.env = { ...(r.block.env || {}), CROW_HOME: crowHome };
+```
+
+Then:
+
+```bash
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: FAIL on both new tests. If either still passes, the test is vacuous — fix the test before restoring the line.
+
+Restore the line and re-run:
+
+```bash
+npm test -- tests/pibot-crow-server-catalog.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit scripts/pi-bots/crow-server-catalog.mjs tests/pibot-crow-server-catalog.test.js -m "fix(pi-bots): a derived bundle block must name its own instance
+
+rebindBlock only rewrites instance env keys a block already carries, and most
+addon blocks carry none — so a bundle server's CROW_HOME came from whatever
+ambient environment pi happened to have. Stamp it in the addon loop, not in
+rebindBlock, which also serves third-party blocks that carry no instance."
+git show --stat HEAD
+```
+
+---
+
+## Task 5: Version bump, full suite, PR, green CI, merge
+
+**Files:**
+- Modify: `bundles/browser/manifest.json` (`version`)
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: a merge commit on `main`. Task 6 deploys it.
+
+**Why the version bump:** `repairInstalledBundleAssets` runs on every gateway start, but `refreshVersionedBundle` returns early unless the repo and installed `manifest.json` versions differ (`routes/bundles.js:497`). Without the bump the `server/` fix never reaches `~/.crow/bundles/browser` or `~/.crow-r4/bundles/browser`, and the whole change is inert on the host.
+
+- [ ] **Step 1: Bump the version**
+
+In `bundles/browser/manifest.json`, change `"version": "1.0.0",` to:
+
+```json
+  "version": "1.1.0",
+```
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow-wt-browser && npm test 2>&1 | tail -30
+```
+
+Expected: all pass, 0 failures. Baseline before this change was 2961 passing; this plan adds 7 in `browser-bundle-instance.test.js` and 2 in `pibot-crow-server-catalog.test.js`. Record the actual numbers — do not assert a count you did not see.
+
+- [ ] **Step 3: Run the static checks CI will run**
+
+```bash
+cd /home/kh0pp/crow-wt-browser
+node scripts/check-port-allocation.js && echo "PORTS OK"
+node scripts/build-registry.js --check && echo "REGISTRY OK"
+```
+
+Expected: both OK. `check-ports` only scans `bundles/*/docker-compose.yml` for `host:container` mappings and the browser bundle uses `network_mode: host` with no `ports:` list, so it should be unaffected — but run it rather than assume.
+
+- [ ] **Step 4: Commit the bump and push**
+
+```bash
+git commit bundles/browser/manifest.json -m "chore(browser): 1.0.0 -> 1.1.0 so installed bundles refresh
+
+repairInstalledBundleAssets only re-copies server/ when the manifest versions
+differ, so without this the instance fixes never reach ~/.crow/bundles/browser
+or ~/.crow-r4/bundles/browser."
+git show --stat HEAD
+git push -u origin fix/per-instance-browser
+```
+
+- [ ] **Step 5: Open the PR**
+
+Use `mcp__github__create_pull_request` — `gh` is not installed. Owner `kh0pper`, repo `crow`, base `main`, head `fix/per-instance-browser`.
+
+Title: `fix(browser): each instance gets its own browser`
+
+Body: summarize the nine findings, the four repo changes, and state explicitly that the host sequence (Tasks 6-8) follows separately and that r4's container is recreated in an operator window. No `Co-Authored-By` trailer, no "generated with" line.
+
+- [ ] **Step 6: Wait for CI and verify every check**
+
+```bash
+SHA=$(git rev-parse HEAD)
+curl -s "https://api.github.com/repos/kh0pper/crow/commits/$SHA/check-runs" \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('total', d['total_count']); [print(r['name'], r['status'], r['conclusion']) for r in d['check_runs']]"
+```
+
+Expected: `total 3` or more, every run `completed` / `success`, covering `suite`, `static-checks`, `audit`. An empty `check_runs` on a current sha means something is **wrong**, not that CI is idle — the `Tests` workflow has no path filters and every commit gets check-runs. Never use the legacy commit-status API; it omits Actions and can read green while a check is red.
+
+- [ ] **Step 7: Merge**
+
+Merge with `mcp__github__merge_pull_request` once every check is green. `enforce_admins` is TRUE, so a red check blocks the merge — do not try to work around it.
+
+---
+
+## Task 6: Deploy to both instances
+
+**Files:** none in the repo. This task changes the host.
+
+**Interfaces:**
+- Consumes: the merged `main` from Task 5.
+- Produces: `~/.crow/bundles/browser/server/instance.js` and `~/.crow-r4/bundles/browser/server/instance.js` present on disk, with the fixed `server.js` beside them. Task 7 points MCP config at those directories.
+
+**Soak coordination:** this pull touches `scripts/pi-bots/crow-server-catalog.mjs`, inside `pibot-gateways@r4`'s blast radius. `bridge.mjs` is untouched, so its exports stay name-stable for `job_runner.mjs`. Log the pull and the restart.
+
+- [ ] **Step 1: Log the pull before making it**
+
+Append to the soak log the operator keeps for this unit, or create `~/crow-soak-log.md` if absent:
+
+```
+2026-08-09 <HH:MM> CDT — ~/crow pull for PR "fix(browser): each instance gets its own browser".
+Touches scripts/pi-bots/crow-server-catalog.mjs (adds a CROW_HOME stamp in the
+mcp-addons loop; additive). bridge.mjs UNTOUCHED — job_runner exports unchanged.
+pibot-gateways@r4 restarted at <HH:MM> to pick it up.
+```
+
+- [ ] **Step 2: Pull into the live tree, working around the pre-existing dirty file**
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow
+git stash push -m "not-ours: 35b compose snapshot" scripts/bench/h2-35b-overnight/compose-prod-snapshot.yml
+git pull --rebase
+git stash pop
+git log --oneline -3
+```
+
+Expected: the merge commit from Task 5 is present, and `0aad37e8 fix(35b)` is still sitting unpushed on top or rebased above it — either is fine, it is not ours to ship. Confirm `git status --short` shows the compose snapshot modified again after the pop.
+
+- [ ] **Step 3: Restart both gateways so `repairInstalledBundleAssets` refreshes the bundles**
+
+```bash
+echo 8r00kly^ | sudo -S systemctl restart crow-gateway crow-r4-gateway
+sleep 10
+systemctl is-active crow-gateway crow-r4-gateway
+```
+
+Expected: `active` twice. This restarts the gateways, not the browser containers — Chrome is untouched.
+
+- [ ] **Step 4: Verify both installed bundles actually refreshed**
+
+```bash
+for d in /home/kh0pp/.crow /home/kh0pp/.crow-r4; do
+  echo "== $d"
+  ls -la $d/bundles/browser/server/instance.js 2>&1
+  grep -c 'stateDir(' $d/bundles/browser/server/server.js 2>/dev/null
+  python3 -c "import json;print('installed version', json.load(open('$d/bundles/browser/manifest.json'))['version'])"
+done
+```
+
+Expected for both: `instance.js` exists, `server.js` contains 3 `stateDir(` calls, manifest version `1.1.0`. If a bundle did not refresh, check the gateway's startup log for the `refreshed 1.0.0 -> 1.1.0` line before touching anything by hand — the product path is the one that has to work.
+
+- [ ] **Step 5: Restart the soaking bot unit and confirm it comes back**
+
+```bash
+echo 8r00kly^ | sudo -S systemctl restart pibot-gateways@r4
+sleep 10
+systemctl is-active pibot-gateways@r4
+journalctl -u pibot-gateways@r4 -n 30 --no-pager
+```
+
+Expected: `active`, no errors about missing exports from `bridge.mjs`. Record the restart time in the soak log from Step 1.
+
+---
+
+## Task 7: The host MCP configuration sequence
+
+**Files:** none in the repo. This task changes `~/.pi/agent/mcp.json`, `~/r4-tehcy/.mcp.json`, two bundle `.env` files, and two bot definitions in MPA's database.
+
+**Interfaces:**
+- Consumes: Task 6's refreshed bundles at `~/.crow/bundles/browser` and `~/.crow-r4/bundles/browser`.
+- Produces: `browser` resolving to 9222 in `~/crow` and 9223 in `~/r4-tehcy`; no `crow-browser` anywhere.
+
+**Order is load-bearing.** Nothing may reference a name that is about to disappear — the trap from the previous session, where the rename had to precede the strip.
+
+- [ ] **Step 1: Back everything up**
+
+```bash
+TS=$(date +%Y%m%d-%H%M%S)
+cp ~/.pi/agent/mcp.json ~/.pi/agent/mcp.json.bak.$TS
+cp ~/r4-tehcy/.mcp.json ~/r4-tehcy/.mcp.json.bak.$TS
+echo 8r00kly^ | sudo -S systemctl stop crow-mpa-gateway pibot-gateways@crow-mpa pibot-discord@crow-mpa
+sleep 3
+for f in ~/.crow-mpa/data/crow.db ~/.crow-mpa/data/crow.db-wal ~/.crow-mpa/data/crow.db-shm; do
+  [ -f "$f" ] && cp "$f" "$f.bak.$TS"
+done
+echo "backed up with suffix .bak.$TS"
+```
+
+MPA's gateways must be **stopped** before its database is written — this is the one place in the plan that opens a real `crow.db` for writing, and it is safe only because nothing is serving it.
+
+- [ ] **Step 2: Drop the dead `crow-browser` selections from MPA's two bots**
+
+Per finding 5 these resolve to zero tools today (`router: true` means pi registers only `mcp__crow-browser`, while the allowlist names `mcp__crow-browser__<tool>` and pi's `--tools` filter is exact-match). This removes a lie, not a capability.
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+node -e '
+const D = require("/home/kh0pp/crow/node_modules/better-sqlite3");
+const db = new D("/home/kh0pp/.crow-mpa/data/crow.db");
+const rows = db.prepare("select bot_id, definition from pi_bot_defs").all();
+let changed = 0;
+for (const r of rows) {
+  const d = JSON.parse(r.definition);
+  const sel = d.tools && d.tools.crow_mcp;
+  if (!Array.isArray(sel)) continue;
+  const kept = sel.filter((s) => s.split("/")[0] !== "crow-browser");
+  if (kept.length === sel.length) continue;
+  d.tools.crow_mcp = kept;
+  db.prepare("update pi_bot_defs set definition = ?, updated_at = datetime(\"now\") where bot_id = ?")
+    .run(JSON.stringify(d), r.bot_id);
+  console.log(r.bot_id, sel.length, "->", kept.length);
+  changed++;
+}
+console.log("bots changed:", changed);
+'
+```
+
+Expected: `job-searcher 34 -> 29`, `job-searcher-dayane` similarly, `bots changed: 2`. If any other bot appears, stop and re-read — only those two should select `crow-browser`.
+
+- [ ] **Step 3: Verify no selection of `crow-browser` remains anywhere**
+
+```bash
+for i in .crow .crow-r4 .crow-mpa; do
+  node -e "
+const D = require(\"/home/kh0pp/crow/node_modules/better-sqlite3\");
+const db = new D(\"/home/kh0pp/$i/data/crow.db\", { readonly: true });
+for (const r of db.prepare(\"select bot_id, definition from pi_bot_defs\").all()) {
+  if (/crow-browser/.test(r.definition)) console.log(\"$i\", r.bot_id, \"STILL SELECTS crow-browser\");
+}
+console.log(\"$i checked\");
+"
+done
+```
+
+Expected: three `checked` lines and no `STILL SELECTS`. Read `.crow` and `.crow-r4` directly only because their gateways are running and this is a **readonly** open of a file nothing is mid-write on — if this makes you uneasy, copy the db plus `-wal` and `-shm` first and query the copies.
+
+- [ ] **Step 4: Restart MPA's services**
+
+```bash
+echo 8r00kly^ | sudo -S systemctl start crow-mpa-gateway pibot-gateways@crow-mpa pibot-discord@crow-mpa
+sleep 8
+systemctl is-active crow-mpa-gateway pibot-gateways@crow-mpa pibot-discord@crow-mpa
+```
+
+Expected: `active` three times.
+
+- [ ] **Step 5: Rename `crow-browser` to `browser` in the homedir config, bound to the primary**
+
+Edit `~/.pi/agent/mcp.json`. Remove the `crow-browser` entry entirely and add, in its place:
+
+```json
+    "browser": {
+      "command": "/home/kh0pp/.nvm/versions/node/v22.23.1/bin/node",
+      "args": ["server/index.js"],
+      "cwd": "/home/kh0pp/.crow/bundles/browser",
+      "env": {
+        "CROW_HOME": "/home/kh0pp/.crow",
+        "CROW_BROWSER_CDP_PORT": "9222",
+        "CROW_BROWSER_CONTAINER_NAME": "crow-browser"
+      },
+      "router": true
+    }
+```
+
+Three deliberate choices. `cwd` is the **installed** bundle, not `/home/kh0pp/crow/bundles/browser` — the repo tree gets branch-switched under running services, which is Item H's complaint. `router: true` stays because this serves interactive shells, which have no `--tools` allowlist and would otherwise carry 28 tool schemas. And this is an instance-bound Crow server living in the homedir config, which PR #279's rule reserves for third-party servers — an accepted, approved exception, because `generate-mcp-config.js:135` rewrites `~/crow/.mcp.json` wholesale and a hand-added block there would not survive.
+
+Validate before moving on:
+
+```bash
+python3 -c "import json; d=json.load(open('/home/kh0pp/.pi/agent/mcp.json')); print(sorted(d['mcpServers']))"
+```
+
+Expected: `['brave-search', 'browser', 'google-workspace', 'google-workspace-dayane']` — no `crow-browser`.
+
+- [ ] **Step 6: Add the r4-bound override**
+
+Edit `~/r4-tehcy/.mcp.json` and add, alongside the existing `r4-tasks` / `r4-trackers` / `crow-memory` entries:
+
+```json
+    "browser": {
+      "command": "/home/kh0pp/.nvm/versions/node/v22.23.1/bin/node",
+      "args": ["server/index.js"],
+      "cwd": "/home/kh0pp/.crow-r4/bundles/browser",
+      "env": {
+        "CROW_HOME": "/home/kh0pp/.crow-r4",
+        "CROW_BROWSER_CDP_PORT": "9223",
+        "CROW_BROWSER_CONTAINER_NAME": "crow-browser-r4"
+      },
+      "router": true
+    }
+```
+
+pi merges the homedir config first and then every cwd-ancestor `.mcp.json` from the filesystem root down, so the nearest file wins on collision — this block is authoritative anywhere under `~/r4-tehcy`. No VNC password here: `crow_browser_launch` reads it from the running container when it needs it, so there is no reason to spread the credential.
+
+Validate:
+
+```bash
+python3 -c "
+import json
+d = json.load(open('/home/kh0pp/r4-tehcy/.mcp.json'))['mcpServers']['browser']
+print(d['cwd'], d['env']['CROW_BROWSER_CDP_PORT'], d['env']['CROW_HOME'])"
+```
+
+Expected: `/home/kh0pp/.crow-r4/bundles/browser 9223 /home/kh0pp/.crow-r4`.
+
+- [ ] **Step 7: Give both bundle `.env` files a CROW_HOME**
+
+Task 3's guard makes a hand-run compose fail without it.
+
+```bash
+grep -q '^CROW_HOME=' /home/kh0pp/.crow/bundles/browser/.env || echo 'CROW_HOME=/home/kh0pp/.crow' >> /home/kh0pp/.crow/bundles/browser/.env
+grep -q '^CROW_HOME=' /home/kh0pp/.crow-r4/bundles/browser/.env || echo 'CROW_HOME=/home/kh0pp/.crow-r4' >> /home/kh0pp/.crow-r4/bundles/browser/.env
+tail -3 /home/kh0pp/.crow/bundles/browser/.env /home/kh0pp/.crow-r4/bundles/browser/.env
+```
+
+Expected: each file ends with its own instance's `CROW_HOME`. Note `~/.crow/bundles/browser/.env` currently has no `CROW_BROWSER_CONTAINER_NAME`; the default is `crow-browser`, which is correct, so leave it.
+
+- [ ] **Step 8: Verify by running, not by reading**
+
+For each tree, start pi, call the browser gateway's status action, and read what it says it bound to. From `~/crow`:
+
+```bash
+export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH
+cd /home/kh0pp/crow
+node /home/kh0pp/.crow/bundles/browser/server/index.js < /dev/null &
+```
+
+That only proves the file runs. The real check spawns the server exactly as pi would and calls the tool. Write a throwaway probe at `/tmp/browser-probe.mjs`:
+
+```js
+import { spawn } from "node:child_process";
+const [cwd, ...envPairs] = process.argv.slice(2);
+const env = { ...process.env };
+for (const p of envPairs) { const i = p.indexOf("="); env[p.slice(0, i)] = p.slice(i + 1); }
+const child = spawn("node", ["server/index.js"], { cwd, env, stdio: ["pipe", "pipe", "inherit"] });
+let buf = "";
+child.stdout.on("data", (d) => {
+  buf += d.toString();
+  for (const line of buf.split("\n").slice(0, -1)) {
+    const msg = JSON.parse(line);
+    if (msg.id === 1) {
+      child.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+      child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "crow_browser_status", arguments: {} } }) + "\n");
+    }
+    if (msg.id === 2) { console.log(msg.result.content[0].text); child.kill(); process.exit(0); }
+  }
+  buf = buf.slice(buf.lastIndexOf("\n") + 1);
+});
+child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "probe", version: "0" } } }) + "\n");
+```
+
+Run it against each instance's resolved block:
+
+```bash
+node /tmp/browser-probe.mjs /home/kh0pp/.crow/bundles/browser \
+  CROW_HOME=/home/kh0pp/.crow CROW_BROWSER_CDP_PORT=9222 CROW_BROWSER_CONTAINER_NAME=crow-browser
+
+node /tmp/browser-probe.mjs /home/kh0pp/.crow-r4/bundles/browser \
+  CROW_HOME=/home/kh0pp/.crow-r4 CROW_BROWSER_CDP_PORT=9223 CROW_BROWSER_CONTAINER_NAME=crow-browser-r4
+```
+
+Expected — the primary reports `"container": "crow-browser"`, `"cdp_url": "http://127.0.0.1:9222"`, `"state_root": "/home/kh0pp/.crow"`; r4 reports `crow-browser-r4`, `http://127.0.0.1:9223`, `/home/kh0pp/.crow-r4`. Both should show `"container_running": true`. **If r4's status reports `crow-browser` or `/home/kh0pp/.crow`, stop** — Task 2 or Task 6 did not land, and continuing would paper over it.
+
+- [ ] **Step 9: Confirm pi itself resolves the override**
+
+The probe proves the servers behave; this proves pi picks the right block. In `~/r4-tehcy`, start a pi session and have it call the browser gateway tool with `action="call"`, `tool="crow_browser_status"`. Confirm the returned JSON names `crow-browser-r4` and port 9223. Then do the same from `~/crow` and confirm `crow-browser` and 9222.
+
+This is the step that actually closes the reported defect — everything before it is machinery. Do not skip it because the probe passed; the probe supplies the env by hand, and the whole bug was that pi supplied it differently.
+
+---
+
+## Task 8: Operator window — recreate r4's container
+
+**Files:** possibly `bundles/browser/entrypoint.sh`, depending on what Step 2 finds.
+
+**Interfaces:**
+- Consumes: Tasks 3, 6 and 7 complete.
+- Produces: `crow-browser-r4` bind-mounted to `/home/kh0pp/.crow-r4/browser-downloads`, and a decision on r4's local entrypoint patches.
+
+**Requires Kevin.** Recreating the container discards Chrome's profile — there is no volume for it — so anything logged in inside r4's browser is lost. **The primary's container is not touched**: its mount is already correct and recreating it would drop logged-in job-board sessions for nothing.
+
+- [ ] **Step 1: Confirm the operator is ready and record the current state**
+
+```bash
+docker inspect crow-browser-r4 --format '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}'
+docker inspect crow-browser-r4 --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -E 'DISPLAY|CDP_PORT|NOVNC|RFB'
+ls /home/kh0pp/.crow-r4/browser-sessions/
+```
+
+Expected: mount shows `/home/kh0pp/.crow/browser-downloads` (the bug), env shows `DISPLAY_NUM=98`, `CDP_PORT=9223`. Saved sessions under `~/.crow-r4/browser-sessions/` live on the host and survive the recreate.
+
+- [ ] **Step 2: Settle the entrypoint patches empirically**
+
+r4's `~/.crow-r4/bundles/browser/entrypoint.sh` differs from the repo in exactly two ways: `DISP_NUM="${DISPLAY_NUM:-99}"` instead of a hardcoded `99`, and `x11vnc … -noshm`. Nobody recorded why. The obvious hypothesis — two containers on `network_mode: host` colliding on Xvfb's TCP port — is **disproven**: both run `Xvfb -nolisten tcp` and nothing listens in 6000-6099. Do not upstream a patch whose reason is unknown.
+
+Test it directly. With `CROW_BROWSER_DISPLAY` removed from r4's `.env`, recreate and observe:
+
+```bash
+cd /home/kh0pp/.crow-r4/bundles/browser
+cp .env .env.bak.$(date +%Y%m%d-%H%M%S)
+sed -i 's/^CROW_BROWSER_DISPLAY=98/CROW_BROWSER_DISPLAY=99/' .env
+docker compose up -d --force-recreate
+sleep 15
+docker logs crow-browser-r4 --tail 40
+curl -s http://127.0.0.1:9223/json/version | head -3
+```
+
+Two outcomes, both useful:
+- **Both containers healthy on `:99`** — the patch is incidental. Revert r4 to the repo's `entrypoint.sh`, delete `CROW_BROWSER_DISPLAY` from its `.env`, and upstream nothing for `DISPLAY_NUM`.
+- **r4's Xvfb or Chrome fails** — the patch is required. Capture the exact error, restore `CROW_BROWSER_DISPLAY=98`, and upstream `DISP_NUM="${DISPLAY_NUM:-99}"` to `bundles/browser/entrypoint.sh` in a follow-up PR **with the captured error quoted in the commit message** as the justification.
+
+Repeat the same reasoning for `-noshm`: remove it, recreate, and see whether VNC still renders at `http://localhost:6081/vnc.html`. Record what you observe either way.
+
+- [ ] **Step 3: Fix the bind mount**
+
+Task 7 Step 7 already put `CROW_HOME=/home/kh0pp/.crow-r4` in this `.env`, so the recreate above should already have corrected the mount. Verify:
+
+```bash
+docker inspect crow-browser-r4 --format '{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}'
+```
+
+Expected: `/home/kh0pp/.crow-r4/browser-downloads -> /downloads`. If it still reads `/home/kh0pp/.crow/browser-downloads`, the `.env` edit did not take — Compose reads `.env` from the directory containing the compose file, so confirm you edited `/home/kh0pp/.crow-r4/bundles/browser/.env` and not the repo's.
+
+- [ ] **Step 4: Prove the two browsers are actually separate**
+
+```bash
+curl -s http://127.0.0.1:9222/json/version | python3 -c "import json,sys; print('9222', json.load(sys.stdin)['webSocketDebuggerUrl'][:60])"
+curl -s http://127.0.0.1:9223/json/version | python3 -c "import json,sys; print('9223', json.load(sys.stdin)['webSocketDebuggerUrl'][:60])"
+docker inspect crow-browser --format '{{range .Mounts}}{{.Source}}{{end}}'
+docker inspect crow-browser-r4 --format '{{range .Mounts}}{{.Source}}{{end}}'
+```
+
+Expected: two different debugger endpoints, and two different mount sources — `/home/kh0pp/.crow/browser-downloads` and `/home/kh0pp/.crow-r4/browser-downloads`.
+
+- [ ] **Step 5: Confirm the primary was left alone**
+
+```bash
+docker ps --format '{{.Names}}\t{{.Status}}' | grep -i brows
+```
+
+Expected: `crow-browser` shows an uptime predating this window — it must **not** have been recreated. If its uptime resets, something targeted the wrong container; investigate before continuing, because that is precisely the defect this whole change exists to prevent.
+
+- [ ] **Step 6: Record the outcome**
+
+Write the entrypoint decision, its evidence, and the final mount state into the session handoff. If Step 2 concluded the patches are required, open the follow-up PR upstreaming them with the captured error as justification.
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 model → Tasks 7-8 (two owners, MPA none). §2 finding 1 → Task 7 Steps 5-6. Finding 2 → Task 1. Finding 3 → Tasks 3, 8. Finding 4 → Task 4. Finding 5 → Task 7 Step 2. Finding 6 → Task 8 Step 2. Addendum finding 8 → Task 2. §3.1 → Task 1. §3.2 → Task 3. §3.3 → Task 4. §3.4 → Task 8 Step 2. §4 steps 1-5 → Task 7 Steps 2, 5, 6, 7, 8-9. §5 testing → Tasks 1-4 plus Task 5 Steps 2-3, with the mutation check at Task 4 Step 5. §6 risk → Task 6 Steps 1 and 5 (soak logging), Task 5 Step 3 (`check-ports`). §7 out-of-scope items are correctly absent from every task.
+
+One thing the spec did not name and the plan adds: the `manifest.json` version bump (Task 5 Step 1). Without it `refreshVersionedBundle` returns early on equal versions and the entire repo change stays inert on the host. Discovered while writing Task 6.
+
+**Placeholder scan.** No TBD, TODO, "handle appropriately", or "similar to Task N". Every code step carries the actual code. Task 8 Step 2's branch is not a placeholder — it is a genuine empirical fork with both outcomes specified, which is the honest shape for a question whose answer nobody recorded.
+
+**Type consistency.** `stateRoot()` and `stateDir(name)` are defined in Task 1 and used in Tasks 1, 2 and 8. `containerName()` is defined in Task 2 and used only there. The `crow_browser_status` fields `container`, `cdp_url`, `state_root` are added in Task 2 and read in Task 7 Step 8 under exactly those names. `crowServerCatalog(crowHome, { binding })` matches the existing signature and the existing test file's `BINDING_B` helper. The `.env` key is `CROW_HOME` everywhere; the compose interpolation is `${CROW_HOME:?…}` in both the change and its test.

--- a/docs/superpowers/specs/2026-08-08-per-instance-browser-design.md
+++ b/docs/superpowers/specs/2026-08-08-per-instance-browser-design.md
@@ -1,0 +1,221 @@
+# Design — the per-instance browser
+
+Written 2026-08-08. Approved by Kevin in two sections during the brainstorm.
+
+The `crow-browser` MCP server is the last member of the defect family PR #279 fixed:
+a Crow server that a bot or an operator shell resolves to an instance other than its
+own. PR #279 deliberately left it, because `rebindBlock` reads its repo `cwd` as
+instance-neutral. Its port says otherwise.
+
+---
+
+## 1. The model
+
+**An instance either owns a browser or has none.** Owning means its own container, its
+own port triple, and its own state directories, declared in that instance's own
+`mcp-addons.json` under the name **`browser`**. Nothing about a browser is inherited
+from a user-global config.
+
+On this host that is two owners:
+
+| instance | container | CDP | noVNC | RFB |
+|---|---|---|---|---|
+| `~/.crow` (primary) | `crow-browser` | 9222 | 6080 | 5900 |
+| `~/.crow-r4` | `crow-browser-r4` | 9223 | 6081 | 5901 |
+
+MPA gets none. It is a same-identity peer of the primary and is slated for retirement
+(Item F amendment, `plans/2026-07-17-crow-state-and-direction-review.md` in Gitea
+`kh0pp/crow-engineering`), so building it a browser — or a sharing mechanism — would
+be work for an instance that is going away. Its two `crow-browser` selections are
+dropped instead; see §4.
+
+There is deliberately **no sharing mechanism**. An earlier draft carried a
+`CROW_BROWSER_STATE_DIR` so a non-owning instance could point at an owner's browser.
+Kevin's scoping decision — independent instances get their own, same-identity
+co-hosting is being retired — removes the only case it served. YAGNI.
+
+## 2. What is actually broken
+
+Verified live on 2026-08-08. Every database claim was made against a copy of the
+`.db` plus `-wal` and `-shm`, never against a running gateway's file.
+
+1. **`~/.pi/agent/mcp.json` carries `crow-browser`** with `cwd` of
+   `/home/kh0pp/crow/bundles/browser` and `CROW_BROWSER_CDP_URL=http://127.0.0.1:9222`.
+   `rebindBlock`'s anchor is `INSTANCE_BUNDLE_CWD = /\/\.crow[^/]*\/bundles\/([^/]+)\/?$/`
+   (`crow-server-catalog.mjs:90`), which the repo path does not match, and
+   `CROW_BROWSER_CDP_URL` is not one of the four
+   `INSTANCE_ENV_KEYS`. So the block reads as instance-neutral and falls through to the
+   canonical branch unchanged. `~/r4-tehcy/.mcp.json` defines no browser, so pi sessions
+   in the r4 tree inherit it and drive the primary's Chrome.
+
+2. **`bundles/browser/server/server.js` disagrees with itself about `CROW_HOME`.**
+   `browser-sessions` honors it (line 35); `browser-exports` (960) and
+   `browser-downloads` (1411) hardcode `join(homedir(), ".crow", …)`. Two tool
+   descriptions promise `~/.crow/browser-…` in prose, which is false on any instance
+   but the primary.
+
+3. **`crow-browser-r4`'s `/downloads` bind mount is the primary's directory** —
+   `docker inspect` reports `/home/kh0pp/.crow/browser-downloads`. This is **not** a
+   product defect: `runCompose` uses `execFile` with no `env` option
+   (`servers/gateway/routes/bundles.js:702-712, 743-746`), so it inherits the gateway's
+   environment, and `crow-r4-gateway.service` sets `CROW_HOME=/home/kh0pp/.crow-r4`.
+   Installing through the Extensions panel would have produced the right mount. The
+   container was created by hand from the bundle directory, where `CROW_HOME` was unset
+   and `${CROW_HOME:-${HOME}/.crow}` silently fell back to the primary.
+
+4. **The catalog never injects `CROW_HOME` into derived bundle blocks.** `rebindBlock`
+   rewrites instance env keys only when they are *already present*. r4's `browser` addon
+   carries none of the four, so the server's `CROW_HOME` comes from whatever ambient
+   environment pi happened to have. `browser-sessions` directories exist under all three
+   instance homes, and `~/.crow-r4/browser-sessions/brandfolder-tea.json` shows the
+   ambient value *was* correct at least once — which is the point: correctness here is a
+   property of the caller's shell, not of the block, and nothing makes it hold.
+
+5. **`router: true` silently disables per-tool selection.** With it set, pi registers a
+   single gateway tool `mcp__crow-browser` and no individual tools
+   (`pi-lab/extensions/mcp-client.ts:399`); direct registration would name them
+   `mcp__<server>__<tool>` (`:313`). `toolAllowlist()` emits
+   `mcp__crow-browser__crow_browser_launch`, and pi's `--tools` filter is exact Set
+   membership (`agent-session.js:1788`). So MPA's `job-searcher` and
+   `job-searcher-dayane` get **zero** browser tools — and would for as long as the flag
+   has been set, though I did not date when it was. They are not driving the wrong
+   Chrome; they are driving none.
+
+6. **Bundle drift in both directions.** r4's `entrypoint.sh` carries two local patches
+   the repo lacks (`DISP_NUM="${DISPLAY_NUM:-99}"`, `x11vnc -noshm`). The primary's
+   *installed* `entrypoint.sh` is stale against the repo — it hardcodes 6080/5900 and
+   ignores `NOVNC_PORT`/`RFB_PORT`. Bundle updates deliberately never copy
+   `docker-compose.yml`, `Dockerfile`, `entrypoint.sh` or `.env`
+   (`servers/gateway/routes/bundles.js:513-514`), so neither drift self-heals.
+
+**Consumers, for the record.** Only MPA's two `job-searcher` bots select `crow-browser`.
+No r4 bot and no primary bot does. `bot_jobs` is empty on MPA and the only saved browser
+session anywhere is r4's `brandfolder-tea.json` from 2026-07-23: in practice this is an
+interactive, human-supervised tool.
+
+### The router rule, settled
+
+`router: true` belongs in **operator project configs** — an interactive shell has no
+`--tools` allowlist, and 28 browser tools is real context cost. It belongs **absent from
+addon blocks** — for a bot the per-tool allowlist *is* the permission envelope, and
+collapsing 28 tools into one ungated gateway would grant navigate-anywhere,
+evaluate-JS and download behind a single name. The addon blocks were already right. The
+bug was bots resolving the canonical block at all.
+
+## 3. Repo changes
+
+**3.1 One state root.** Extract `bundles/browser/server/paths.js`:
+
+```js
+export const stateRoot = () => process.env.CROW_HOME || join(homedir(), ".crow");
+export const stateDir = (name) => join(stateRoot(), name);
+```
+
+`server.js` uses it for all three directories. A separate module rather than an export
+from `server.js` so the tests import twenty lines instead of dragging in puppeteer. Fix
+the two tool descriptions to describe the resolved directory instead of asserting
+`~/.crow`.
+
+**3.2 Make the mount fail loudly.** In `bundles/browser/docker-compose.yml`, replace
+`${CROW_HOME:-${HOME}/.crow}/browser-downloads` with `${CROW_HOME:?…}`. A hand-run
+`docker compose up` in a second instance's bundle directory then errors instead of
+quietly mounting the primary's downloads. This matches the style already in that file
+(`${CROW_BROWSER_VNC_PASSWORD:?…}`) and is the precise failure that produced finding 3.
+Add `CROW_HOME` to `.env.example` with a comment saying why.
+
+**3.3 Derived bundle blocks carry their instance.** In `crowServerCatalog`'s
+`mcp-addons.json` loop, set `CROW_HOME` on the resulting block. Deliberately **in that
+loop and not inside `rebindBlock`**, which is also used for third-party canonical blocks
+that have no business carrying an instance. Only `CROW_HOME`: injecting `CROW_DB_PATH`
+would trip `touchesCrowDb()` and apply the journal guard to bundles that never open
+`crow.db`.
+
+**3.4 Settle r4's entrypoint patches on evidence, then upstream what survives.** My
+first hypothesis — that two containers on `network_mode: host` collide on Xvfb's TCP
+port — is **disproven**: both run `Xvfb -nolisten tcp` and nothing listens in the
+6000–6099 range. So the reason for `:98` is not yet known and nothing gets upstreamed on
+faith. The plan determines it empirically (run r4's container at `:99`, observe) and
+upstreams only what is justified, with the reason recorded. If the patches turn out to be
+incidental, the honest outcome is to drop them from r4 rather than add them to the repo.
+
+## 4. Host changes, in order
+
+Nothing may reference a name that is about to disappear — the ordering trap from the
+previous session, where the rename had to precede the strip.
+
+1. **Drop the dead `crow-browser/*` selections** from MPA's `job-searcher` and
+   `job-searcher-dayane`. Per finding 5 these resolve to zero tools, so this removes a
+   lie rather than a capability.
+2. **Rename `crow-browser` → `browser`** in `~/.pi/agent/mcp.json`, bound explicitly to
+   the primary: `cwd` `~/.crow/bundles/browser`, `CROW_HOME=/home/kh0pp/.crow`,
+   `CROW_BROWSER_CDP_PORT=9222`, `router: true`. The *installed* bundle rather than the
+   repo, because the repo tree gets branch-switched under running services — Item H's
+   complaint.
+3. **Add `browser` to `~/r4-tehcy/.mcp.json`**: `cwd` `~/.crow-r4/bundles/browser`,
+   `CROW_HOME=/home/kh0pp/.crow-r4`, `CROW_BROWSER_CDP_PORT=9223`, `router: true`.
+   Nearest-file-wins makes this authoritative in the r4 tree.
+4. **Add `CROW_HOME` to both bundles' `.env`** so a hand-run compose interpolates rather
+   than tripping the new `:?` guard.
+5. **Verify by running, not reading.** `scripts/pi-bots/s0_mcp_probe.mjs` already exists:
+   confirm pi in `~/crow` resolves `browser` to 9222 and in `~/r4-tehcy` to 9223.
+
+**Accepted tension.** Step 2 puts an instance-bound Crow server back into the homedir
+config, which PR #279's rule reserves for third-party servers carrying credentials rather
+than identity. Approved deliberately: the alternative — a hand-added block in
+`~/crow/.mcp.json` — does not survive, because `scripts/generate-mcp-config.js:135`
+rewrites that file wholesale with no merge. Bots are unaffected either way: the catalog
+is consulted before canonical, and unselected canonical names are written
+`{"disabled": true}`. The exposure is limited to interactive shells, where a
+primary-by-default browser is the desired behavior.
+
+**Container handling.** Fixing `crow-browser-r4`'s mount requires **recreating** it, and
+there is no volume for Chrome's profile, so anything logged in inside r4's browser is
+lost — Kevin picks the moment. The primary's container is left strictly alone: its mount
+is already correct and recreating it would drop logged-in job-board sessions for no gain.
+
+**Deployment reality.** The `server.js` fix reaches instances through the Extensions
+*update* path, which copies `server/`, and needs no container restart because the MCP
+server is a fresh child on each pi spawn. The compose and entrypoint changes reach
+nothing automatically (`routes/bundles.js:513-514`) and must be applied deliberately.
+
+## 5. Testing
+
+- `stateDir()` returns `<CROW_HOME>/browser-{sessions,downloads,exports}`, and falls back
+  to `~/.crow` when `CROW_HOME` is unset.
+- The catalog gives an r4-derived `browser` block `CROW_HOME=~/.crow-r4` and CDP 9223,
+  and no value anywhere in that block containing the primary's `.crow/`. Extends the
+  existing `tests/pibot-crow-server-catalog.test.js`.
+- **Mutation check, not optional:** delete the §3.3 injection line and confirm the test
+  goes red. The previous session's central claim shipped with no executable protection
+  and its acceptance harness was bound to a scratch copy it could not have detected a
+  leak through. A test that passes without the mechanism it names is worse than no test.
+- The browser compose contains no `${CROW_HOME:-` default — the exact regression that
+  produced finding 3.
+- Full suite green, plus `node bundles/browser/server/index.js` starting cleanly.
+
+## 6. Risk
+
+`crow-server-catalog.mjs` lives under `scripts/pi-bots/`, inside the
+`pibot-gateways@r4` soak's blast radius through ~2026-08-12. The worktree leaves `~/crow`
+untouched until merge, but the post-merge `git pull` will change a file that unit's
+process has already loaded, and it takes effect only on restart. `bridge.mjs` is not
+touched, so its exports stay name-stable for `job_runner`; the §3.3 change is purely
+additive. The pull and the restart both get logged, and `r4-deploy.sh` does not restart
+that unit, so the restart is a separate deliberate step.
+
+`check-ports` does not bite here. It only scans `bundles/*/docker-compose.yml` for
+`host:container` port mappings, and the browser bundle uses `network_mode: host` with no
+`ports:` list. No new host ports are introduced either — 9223/6081/5901 already exist,
+and `docs/developers/port-allocation.md:66` already documents the +1 convention.
+
+## 7. Out of scope — flagged, not fixed
+
+- **`crow-core` in Kevin's Claude Code user config** points at
+  `http://localhost:3001/router/mcp`, the **primary** gateway (r4's is 3008, MPA's 3006).
+  User scope means every project, including `~/r4-tehcy`. Not the browser — the router
+  exposes core categories plus `media`, not browser tools — but it is the same defect
+  family through a second door.
+- **`servers/gateway/router.js:105`** hardcodes `~/.crow/bundles/media`.
+- **The primary's `crow-home` bot selects `crow-tasks`**, a name that exists in neither
+  the registry nor any `mcp-addons.json` since the previous session's MPA-only rename. A
+  one-row fix, left alone only because it is outside this change's story.

--- a/docs/superpowers/specs/2026-08-08-per-instance-browser-design.md
+++ b/docs/superpowers/specs/2026-08-08-per-instance-browser-design.md
@@ -104,7 +104,8 @@ bug was bots resolving the canonical block at all.
 
 ## 3. Repo changes
 
-**3.1 One state root.** Extract `bundles/browser/server/paths.js`:
+**3.1 One state root.** Extract `bundles/browser/server/instance.js` — one module whose
+single responsibility is answering "which instance is this server bound to":
 
 ```js
 export const stateRoot = () => process.env.CROW_HOME || join(homedir(), ".crow");
@@ -112,7 +113,7 @@ export const stateDir = (name) => join(stateRoot(), name);
 ```
 
 `server.js` uses it for all three directories. A separate module rather than an export
-from `server.js` so the tests import twenty lines instead of dragging in puppeteer. Fix
+from `server.js` so the tests import twenty lines instead of dragging in playwright. Fix
 the two tool descriptions to describe the resolved directory instead of asserting
 `~/.crow`.
 
@@ -219,3 +220,43 @@ and `docs/developers/port-allocation.md:66` already documents the +1 convention.
 - **The primary's `crow-home` bot selects `crow-tasks`**, a name that exists in neither
   the registry nor any `mcp-addons.json` since the previous session's MPA-only rename. A
   one-row fix, left alone only because it is outside this change's story.
+
+---
+
+## Addendum — 2026-08-09, found while writing the plan
+
+**Finding 8: the browser server ignores its own container name, and one of the calls is
+destructive.** `CROW_BROWSER_CONTAINER_NAME` is declared in `manifest.json:18` as a
+configurable env key, and r4's addon sets it to `crow-browser-r4` — but `server.js` never
+reads it. Four `docker` invocations hardcode the string `"crow-browser"`:
+
+| line | call | effect on a non-primary instance |
+|---|---|---|
+| 125 | `docker inspect … {{range .Config.Env}}` | reads the primary's VNC password |
+| 127 | `docker inspect … compose.project.config_files` | finds the primary's compose file |
+| 155 | `docker restart crow-browser` | **restarts the primary's container** |
+| 200 | `docker inspect -f {{.State.Running}}` | `crow_browser_status` reports the primary |
+
+Line 155 is the sharp one: r4's browser server, asked to restart its own browser, kills
+the primary's Chrome and every session logged into it. Line 39's `{ name: "crow-browser" }`
+is the MCP protocol server name, not a container, and stays as is.
+
+This is the same defect as the rest of §2 — a value that looks instance-neutral and
+silently resolves to the primary — so it is folded into scope as its own task rather than
+deferred. `containerName()` joins `stateRoot()`/`stateDir()` in the extracted module,
+which is therefore named `server/instance.js` rather than `server/paths.js`: its
+responsibility is instance identity, of which paths are one part.
+
+**Consequence for §4's verification step.** The spec proposed verifying with
+`scripts/pi-bots/s0_mcp_probe.mjs`. That was an over-claim on my part — the probe is an
+S0-era spike with `TARGETS` hardcoded to MPA's `tasks` and `bots-sql` bundles, not a
+general resolver. Better, and available once this task lands: `crow_browser_status` today
+reports neither the CDP endpoint nor the container it inspected, so the task adds
+`container`, `cdp_url` and `state_root` to its payload. Verification then becomes a single
+tool call per instance whose output names exactly what it bound to.
+
+**One interaction to expect.** §3.2's `${CROW_HOME:?…}` guard makes the proxy-recreate
+path at lines 136-139 (`docker compose … up -d --force-recreate`, which passes
+`{ ...process.env }`) fail when `CROW_HOME` is unset. That is the correct behavior, not a
+regression: the catalog injection (§3.3) and the operator blocks (§4) both guarantee it is
+set on every path that should be recreating a container.

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -324,7 +324,7 @@
     {
       "id": "browser",
       "name": "Browser Automation",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Stealth browser automation — navigate, fill forms, take screenshots, extract content via Chrome DevTools Protocol with VNC viewing",
       "type": "bundle",
       "author": "Crow",

--- a/scripts/pi-bots/crow-server-catalog.mjs
+++ b/scripts/pi-bots/crow-server-catalog.mjs
@@ -210,8 +210,19 @@ export function crowServerCatalog(crowHome = process.env.CROW_HOME || join(homed
       continue;
     }
     const r = rebindBlock(id, { ...addon, cwd }, binding, crowHome);
-    if (r.disabled) unconfigured[id] = r.reason;
-    else servers[id] = r.block;
+    if (r.disabled) {
+      unconfigured[id] = r.reason;
+    } else {
+      // A bundle server runs UNDER this instance, so it must be told which one.
+      // rebindBlock only rewrites instance keys a block already carries, and most
+      // addon blocks carry none — which left CROW_HOME to whatever ambient
+      // environment the caller happened to have (the browser bundle wrote its
+      // sessions wherever that pointed). CROW_HOME only: injecting CROW_DB_PATH
+      // would trip touchesCrowDb() and apply the journal guard to bundles that
+      // never open crow.db.
+      r.block.env = { ...(r.block.env || {}), CROW_HOME: crowHome };
+      servers[id] = r.block;
+    }
   }
   return { servers, unconfigured, coreNames };
 }

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -72,7 +72,29 @@ test("no docker call in server.js hardcodes a container name", () => {
 
 test("crow_browser_status reports what the server bound to", () => {
   const src = readFileSync(SERVER_JS, "utf8");
-  for (const field of ["container:", "cdp_url:", "state_root:"]) {
-    assert.ok(src.includes(field), `crow_browser_status must report ${field} so a deploy can be verified by running it`);
+
+  // Scope to the crow_browser_status handler only — checking the whole file lets
+  // unrelated matches (e.g. a Zod field named `container` on a different tool, or
+  // a pre-existing `cdp_url` in the reconnect response) pass the assertion even
+  // when this handler's own payload never mentions the field.
+  const statusStart = src.indexOf('"crow_browser_status"');
+  assert.ok(statusStart !== -1, "could not find the crow_browser_status tool registration");
+  const nextToolStart = src.indexOf("server.tool(", statusStart);
+  const handlerSlice = nextToolStart === -1 ? src.slice(statusStart) : src.slice(statusStart, nextToolStart);
+  assert.ok(handlerSlice.length > 0, "crow_browser_status handler slice must be non-empty");
+
+  // Narrow further to the JSON.stringify(...) payload object itself, so the tool's
+  // own description text ("Check browser container...") can't satisfy the check.
+  const payloadStart = handlerSlice.indexOf("JSON.stringify(");
+  assert.ok(payloadStart !== -1, "could not find the JSON.stringify(...) status payload inside the handler");
+  const payloadEnd = handlerSlice.indexOf("}, null, 2)", payloadStart);
+  assert.ok(payloadEnd !== -1, "could not find the end of the status payload object");
+  const payloadSlice = handlerSlice.slice(payloadStart, payloadEnd);
+  assert.ok(payloadSlice.length > 0, "crow_browser_status payload slice must be non-empty");
+
+  for (const field of ["container", "cdp_url", "state_root"]) {
+    // Word-boundary match: "container" must not be satisfied by "container_running".
+    const re = new RegExp(`\\b${field}\\b`);
+    assert.ok(re.test(payloadSlice), `crow_browser_status payload must report ${field} so a deploy can be verified by running it`);
   }
 });

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -98,3 +98,12 @@ test("crow_browser_status reports what the server bound to", () => {
     assert.ok(re.test(payloadSlice), `crow_browser_status payload must report ${field} so a deploy can be verified by running it`);
   }
 });
+
+test("the downloads mount requires CROW_HOME instead of defaulting to the primary", () => {
+  const compose = readFileSync(new URL("../bundles/browser/docker-compose.yml", import.meta.url), "utf8");
+  assert.ok(
+    !compose.includes("${CROW_HOME:-"),
+    "a CROW_HOME default lets a hand-run compose mount the primary's downloads into a second instance's container",
+  );
+  assert.match(compose, /\$\{CROW_HOME:\?/, "the mount must fail loudly when CROW_HOME is unset");
+});

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { stateRoot, stateDir } from "../bundles/browser/server/instance.js";
+
+const SERVER_JS = new URL("../bundles/browser/server/server.js", import.meta.url);
+
+/** Run `fn` with CROW_HOME forced to `value` (or unset when value is null). */
+function withCrowHome(value, fn) {
+  const prev = process.env.CROW_HOME;
+  if (value === null) delete process.env.CROW_HOME;
+  else process.env.CROW_HOME = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.CROW_HOME;
+    else process.env.CROW_HOME = prev;
+  }
+}
+
+test("every state directory derives from CROW_HOME", () => {
+  withCrowHome("/tmp/scratch-crow-r4", () => {
+    assert.equal(stateRoot(), "/tmp/scratch-crow-r4");
+    assert.equal(stateDir("browser-sessions"), "/tmp/scratch-crow-r4/browser-sessions");
+    assert.equal(stateDir("browser-downloads"), "/tmp/scratch-crow-r4/browser-downloads");
+    assert.equal(stateDir("browser-exports"), "/tmp/scratch-crow-r4/browser-exports");
+  });
+});
+
+test("state directories fall back to ~/.crow when CROW_HOME is unset", () => {
+  withCrowHome(null, () => {
+    assert.equal(stateRoot(), join(homedir(), ".crow"));
+    assert.equal(stateDir("browser-downloads"), join(homedir(), ".crow", "browser-downloads"));
+  });
+});
+
+test("server.js never hardcodes the primary's home", () => {
+  const src = readFileSync(SERVER_JS, "utf8");
+  assert.ok(
+    !/join\(\s*homedir\(\)\s*,\s*"\.crow"/.test(src),
+    "server.js must resolve state through stateDir(), not join(homedir(), \".crow\", ...)",
+  );
+});

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -43,3 +43,36 @@ test("server.js never hardcodes the primary's home", () => {
     "server.js must resolve state through stateDir(), not join(homedir(), \".crow\", ...)",
   );
 });
+
+test("containerName honors CROW_BROWSER_CONTAINER_NAME and defaults to crow-browser", async () => {
+  const { containerName } = await import("../bundles/browser/server/instance.js");
+  const prev = process.env.CROW_BROWSER_CONTAINER_NAME;
+  try {
+    process.env.CROW_BROWSER_CONTAINER_NAME = "crow-browser-r4";
+    assert.equal(containerName(), "crow-browser-r4");
+    delete process.env.CROW_BROWSER_CONTAINER_NAME;
+    assert.equal(containerName(), "crow-browser");
+  } finally {
+    if (prev === undefined) delete process.env.CROW_BROWSER_CONTAINER_NAME;
+    else process.env.CROW_BROWSER_CONTAINER_NAME = prev;
+  }
+});
+
+test("no docker call in server.js hardcodes a container name", () => {
+  const src = readFileSync(SERVER_JS, "utf8");
+  const dockerLines = src.split("\n").filter((l) => l.includes('execFileSync("docker"'));
+  assert.ok(dockerLines.length >= 4, `expected the docker calls to still exist, found ${dockerLines.length}`);
+  for (const line of dockerLines) {
+    assert.ok(
+      !line.includes('"crow-browser"'),
+      `docker call targets the primary's container by name: ${line.trim()}`,
+    );
+  }
+});
+
+test("crow_browser_status reports what the server bound to", () => {
+  const src = readFileSync(SERVER_JS, "utf8");
+  for (const field of ["container:", "cdp_url:", "state_root:"]) {
+    assert.ok(src.includes(field), `crow_browser_status must report ${field} so a deploy can be verified by running it`);
+  }
+});

--- a/tests/pibot-crow-server-catalog.test.js
+++ b/tests/pibot-crow-server-catalog.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 import {
   INSTANCE_ENV_KEYS,
@@ -21,6 +21,22 @@ function instanceB() {
   writeFileSync(join(home, "mcp-addons.json"), JSON.stringify({
     tasks: { command: "node", args: ["server/index.js"], env: { CROW_TASKS_DB_PATH: "/wrong/tasks.db" } },
     ghost: { command: "node", args: ["server/index.js"] },
+  }));
+  return { dir, home };
+}
+
+/** An instance home with a browser bundle whose addon names no instance env at all. */
+function instanceBrowser() {
+  const dir = mkdtempSync(join(tmpdir(), "instBrowser-"));
+  const home = join(dir, ".crow-r4");
+  mkdirSync(join(home, "bundles", "browser"), { recursive: true });
+  mkdirSync(join(home, "data"), { recursive: true });
+  writeFileSync(join(home, "mcp-addons.json"), JSON.stringify({
+    browser: {
+      command: "node",
+      args: ["server/index.js"],
+      env: { CROW_BROWSER_CDP_PORT: "9223", CROW_BROWSER_CONTAINER_NAME: "crow-browser-r4" },
+    },
   }));
   return { dir, home };
 }
@@ -196,4 +212,29 @@ test("instanceBinding honors the crowHome argument when CROW_DB_PATH and CROW_DA
     if (savedDb === undefined) delete process.env.CROW_DB_PATH; else process.env.CROW_DB_PATH = savedDb;
     if (savedData === undefined) delete process.env.CROW_DATA_DIR; else process.env.CROW_DATA_DIR = savedData;
   }
+});
+
+test("catalog stamps CROW_HOME on every bundle server it derives", () => {
+  const { home } = instanceB();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  assert.equal(servers.tasks.env.CROW_HOME, home,
+    "a bundle server must be TOLD its instance, not inherit it from the caller's shell");
+});
+
+test("a derived browser block names its own instance and never the primary", () => {
+  const { home } = instanceBrowser();
+  const { servers } = crowServerCatalog(home, { binding: BINDING_B(home) });
+  const block = servers.browser;
+  assert.ok(block, "the browser addon should be in the catalog");
+  assert.equal(block.env.CROW_HOME, home);
+  assert.equal(block.env.CROW_BROWSER_CDP_PORT, "9223", "the addon's own port must survive the stamp");
+  assert.equal(block.env.CROW_BROWSER_CONTAINER_NAME, "crow-browser-r4");
+  assert.equal(block.cwd, join(home, "bundles", "browser"));
+
+  const primary = join(homedir(), ".crow");
+  for (const [k, v] of Object.entries(block.env)) {
+    assert.ok(v !== primary && !String(v).startsWith(primary + "/"),
+      `browser block env ${k} points at the primary instance: ${v}`);
+  }
+  assert.ok(!block.cwd.startsWith(primary + "/"), `browser block cwd points at the primary: ${block.cwd}`);
 });


### PR DESCRIPTION
Each independent Crow instance must own its browser — its own container, port triple and state directories — so no instance's browser server can read, write, or restart another instance's Chrome. This is the last member of the defect family PR #279 fixed; it was deliberately left out then because `rebindBlock` reads the bundle's repo `cwd` as instance-neutral.

Spec: `docs/superpowers/specs/2026-08-08-per-instance-browser-design.md` (read the Addendum). Plan: `docs/superpowers/plans/2026-08-09-per-instance-browser.md`.

## What was actually wrong

Verified live before designing. All database claims were made against copies of `.db` + `-wal` + `-shm`, never a running gateway's file.

1. **`~/.pi/agent/mcp.json` carries `crow-browser`** pinned to `http://127.0.0.1:9222`, with `cwd` under the repo. The repo path doesn't match `INSTANCE_BUNDLE_CWD`, and `CROW_BROWSER_CDP_URL` isn't in `INSTANCE_ENV_KEYS`, so it reads as neutral and falls through unchanged. Sessions in the second instance's tree inherit it and drive the primary's Chrome.
2. **`server.js` disagreed with itself about `CROW_HOME`** — `browser-sessions` honored it; `browser-exports` and `browser-downloads` hardcoded `~/.crow`. Two tool descriptions promised a path they no longer controlled.
3. **`crow-browser-r4`'s `/downloads` is bind-mounted to the primary's directory.** Not a product defect: `runCompose` inherits the gateway's env and the r4 unit sets `CROW_HOME`, so the Extensions path was always right. The container was created by hand, where `${CROW_HOME:-${HOME}/.crow}` silently fell back.
4. **The catalog never injected `CROW_HOME` into derived bundle blocks** — `rebindBlock` only rewrites instance keys a block already carries, and most addon blocks carry none, so the value came from the caller's ambient shell.
5. **`router: true` silently disables per-tool selection.** pi registers only `mcp__crow-browser`, while tool allowlists name `mcp__crow-browser__<tool>` and `--tools` is exact-match — so the two bots selecting browser tools have been getting none.
6. **`CROW_BROWSER_CONTAINER_NAME` is declared in the manifest, set by the second instance, and never read.** Four `docker` calls hardcoded `"crow-browser"`, including `docker restart` — so the second instance's browser server, asked to restart its own browser, restarted the primary's container and every session logged into it.

## What this PR changes

- **`bundles/browser/server/instance.js`** (new) — one module answering "which instance am I bound to": `stateRoot()`, `stateDir(name)`, `containerName()`. No I/O, no side effects.
- **`bundles/browser/server/server.js`** — all three state directories and all four `docker` calls route through it. `crow_browser_status` now reports `container`, `cdp_url` and `state_root`, which turns deployment verification into one tool call instead of a config read. The MCP protocol server name is untouched.
- **`bundles/browser/docker-compose.yml`** — the downloads mount requires `CROW_HOME` (`${CROW_HOME:?…}`) instead of defaulting to `~/.crow`, so a hand-run compose fails loudly rather than borrowing. Documented in `.env.example`.
- **`scripts/pi-bots/crow-server-catalog.mjs`** — bundle blocks derived from `mcp-addons.json` are stamped with this instance's `CROW_HOME`. In the addon loop, not in `rebindBlock`, which also serves third-party blocks that carry no instance. Only `CROW_HOME`: injecting `CROW_DB_PATH` would apply the WAL journal guard to bundles that never open `crow.db`.
- **`manifest.json` 1.0.0 → 1.1.0** plus the regenerated `registry/add-ons.json`. `refreshVersionedBundle` returns early on equal versions, so without the bump none of the above reaches an installed bundle.

## Verification

Full suite **3103/3103**, `check-port-allocation` and `build-registry --check` both clean.

Every behavioral claim is mutation-tested rather than asserted. Two tests were caught being vacuous during review and rewritten: the status-payload check was matching unrelated fields elsewhere in the file, and the catalog stamp was confirmed to flip both its tests red when the stamping line is commented out. That discipline is deliberate — the previous session in this defect family shipped a claim with no executable protection and an acceptance harness that couldn't reach the mechanism it named.

`check-ports` is unaffected: it scans for `host:container` port mappings and this bundle uses `network_mode: host` with no `ports:` list. No new host ports are introduced — 9223/6081/5901 already exist and the +1 convention is already documented.

## Not in this PR

The host sequence follows separately and needs the operator: renaming the homedir entry, adding the second instance's override, dropping the two dead bot selections, and recreating that instance's container (which discards its Chrome profile). The primary's container is deliberately left alone — its mount is already correct and recreating it would drop logged-in sessions for nothing.

Also found and deliberately left alone: `crow-core` in the operator's Claude Code user config points every project at the primary gateway; `servers/gateway/router.js:105` hardcodes `~/.crow/bundles/media`; and one bot still selects `crow-tasks`, a server name that no longer exists anywhere.