### PR TITLE
fix(bundles): every gateway-driven compose run names its instance

### DIFF
--- a/servers/gateway/routes/bundles.js
+++ b/servers/gateway/routes/bundles.js
@@ -739,10 +739,24 @@ async function getComposeCmd() {
   throw new Error("No docker compose command found. Install docker-compose-plugin or docker-compose.");
 }
 
+/**
+ * The environment every gateway-driven `docker compose` run gets.
+ *
+ * `run()` passes no `env`, so compose would otherwise inherit the gateway's
+ * environment verbatim — and `crow-gateway.service` does not set CROW_HOME, while
+ * `crow-r4-gateway.service` does. The browser bundle's mount requires it
+ * (`${CROW_HOME:?…}`), so an unset value fails the run outright. Resolving it here
+ * means every compose run names its instance explicitly rather than depending on
+ * whichever unit happened to export it.
+ */
+export function composeEnv(base = process.env) {
+  return { ...base, CROW_HOME };
+}
+
 /** Run a docker compose command with the detected compose variant */
 async function runCompose(composeArgs, opts = {}) {
   const compose = await getComposeCmd();
-  return run(compose.cmd, [...compose.prefix, ...composeArgs], opts);
+  return run(compose.cmd, [...compose.prefix, ...composeArgs], { ...opts, env: composeEnv(opts.env) });
 }
 
 /** Read JSON file with fallback */

--- a/tests/bundles-compose-env.test.js
+++ b/tests/bundles-compose-env.test.js
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { composeEnv } from "../servers/gateway/routes/bundles.js";
+import { CROW_HOME } from "../servers/gateway/bundles-config.js";
+
+test("compose always receives a CROW_HOME, even when the gateway's env has none", () => {
+  const env = composeEnv({ PATH: "/usr/bin" });
+  assert.equal(env.CROW_HOME, CROW_HOME);
+  assert.ok(env.CROW_HOME && env.CROW_HOME.length > 0);
+});
+
+test("compose env preserves the caller's other variables", () => {
+  const env = composeEnv({ PATH: "/usr/bin", SOME_TOKEN: "abc" });
+  assert.equal(env.PATH, "/usr/bin");
+  assert.equal(env.SOME_TOKEN, "abc");
+});
+
+test("an explicit CROW_HOME from the caller does not win over the resolved one", () => {
+  const env = composeEnv({ CROW_HOME: "/wrong/instance" });
+  assert.equal(env.CROW_HOME, CROW_HOME,
+    "the resolved instance home must be authoritative — a stale inherited value is exactly the bug");
+});


### PR DESCRIPTION
Fixes a latent regression from #281, found by that branch's own final review.

## The problem

#281 made the browser bundle's downloads mount require `CROW_HOME`:

```yaml
- ${CROW_HOME:?CROW_HOME is required so each instance writes downloads to its own directory}/browser-downloads:/downloads
```

That guard is right — it stops a hand-run `docker compose up` from silently mounting the primary instance's directory into a secondary instance's container, which is exactly how one deployed container ended up cross-mounted.

But `runCompose` calls `run()`, which calls `execFile` with no `env` option, so compose inherits the gateway's environment. And the gateway units disagree:

- `crow-r4-gateway.service` sets `Environment=CROW_HOME=/home/kh0pp/.crow-r4`
- `crow-gateway.service` sets only `PATH` and `PIBOT_MAX_PI` — **no `CROW_HOME`**

Nothing in `servers/` assigns `process.env.CROW_HOME`; every consumer reads it with a `|| join(homedir(), ".crow")` fallback. So on a stock single-instance Crow, a gateway-driven `docker compose up -d` for the browser bundle would fail with `required variable CROW_HOME is missing a value`, reaching both the Extensions install flow and the Start action. #281's reasoning generalised from the r4 unit, which happens to set it, to all instances — which was wrong.

This is latent rather than live: `refreshVersionedBundle` never copies `docker-compose.yml` into installed bundles, so deployed copies still carry the old `:-` default. It would bite the next fresh install.

## The fix

Resolve `CROW_HOME` once and stamp it on every gateway-driven compose run, rather than depending on whichever systemd unit happened to export it:

```js
export function composeEnv(base = process.env) {
  return { ...base, CROW_HOME };
}
```

This is strictly better than the old fallback: every compose invocation now states which instance it is for. Same principle #281 applied to derived bot blocks — a component that runs under an instance should be *told* which one, not left to infer it from ambient state.

`runCompose` merges it as `{ ...opts, env: composeEnv(opts.env) }`, so a caller-supplied env would still be stamped rather than dropped. All 7 current call sites pass only `cwd`.

## Verification

Full suite **3106/3106**. The three new tests cover the properties that matter: stamped when the base lacks it, other variables preserved, and the resolved value authoritative over a stale inherited one.

Mutation-checked: deleting `CROW_HOME` from the returned object turns tests 1 and 3 red with value-level diffs. Test 2 stays green by design — it asserts only pass-through of unrelated variables, a property orthogonal to the stamp.

Blast radius checked rather than assumed: `bundles/browser/docker-compose.yml` is the only bundle compose file in the repo that references `CROW_HOME`, so stamping it on every invocation is a no-op for the other 74.