### PR TITLE
fix(browser): the dashboard panel acts on its own instance, not the primary

### DIFF
--- a/bundles/browser/manifest.json
+++ b/bundles/browser/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "browser",
   "name": "Browser Automation",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Stealth browser automation — navigate, fill forms, take screenshots, extract content via Chrome DevTools Protocol with VNC viewing",
   "type": "bundle",
   "author": "Crow",

--- a/bundles/browser/panel/browser.js
+++ b/bundles/browser/panel/browser.js
@@ -22,11 +22,26 @@ export default {
       pathToFileURL(join(appRoot, "servers/gateway/dashboard/shared/components.js")).href
     );
 
+    // The panel is deployed to <CROW_HOME>/panels/, not the bundle directory, so a
+    // relative import of instance.js can't be correct in both the repo and the
+    // deployed layout — resolve it by absolute path from CROW_HOME instead.
+    //
+    // Fail soft like the docker/curl calls below: if the bundle isn't installed
+    // (instance.js missing), leave everything at its "unknown/empty" default —
+    // never silently fall back to primary-flavoured constants, which is the
+    // defect this resolves.
+    let stateDir = null, containerName = null, cdpPort = null;
+    try {
+      const crowHome = process.env.CROW_HOME || join(homedir(), ".crow");
+      const instanceUrl = pathToFileURL(join(crowHome, "bundles", "browser", "server", "instance.js")).href;
+      ({ stateDir, containerName, cdpPort } = await import(instanceUrl));
+    } catch {}
+
     // --- Container status ---
     let containerRunning = false;
     let startedAt = null;
     try {
-      const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}|{{.State.StartedAt}}", "crow-browser"], { encoding: "utf-8", timeout: 5000 }).trim();
+      const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}|{{.State.StartedAt}}", containerName()], { encoding: "utf-8", timeout: 5000 }).trim();
       const parts = out.split("|");
       containerRunning = parts[0] === "true";
       startedAt = parts[1];
@@ -34,14 +49,14 @@ export default {
 
     let cdpConnected = false;
     try {
-      execFileSync("curl", ["-s", "-m", "2", "http://127.0.0.1:9222/json/version"], { encoding: "utf-8", timeout: 5000 });
+      execFileSync("curl", ["-s", "-m", "2", `http://127.0.0.1:${cdpPort()}/json/version`], { encoding: "utf-8", timeout: 5000 });
       cdpConnected = true;
     } catch {}
 
     // --- Saved sessions ---
     let sessions = [];
-    const sessDir = join(homedir(), ".crow", "browser-sessions");
     try {
+      const sessDir = stateDir("browser-sessions");
       if (existsSync(sessDir)) {
         sessions = readdirSync(sessDir)
           .filter(f => f.endsWith(".json"))
@@ -56,8 +71,8 @@ export default {
 
     // --- Installed skills/recipes ---
     let skills = [];
-    const skillsDir = join(homedir(), ".crow", "skills");
     try {
+      const skillsDir = stateDir("skills");
       if (existsSync(skillsDir)) {
         skills = readdirSync(skillsDir)
           .filter(f => f.startsWith("crow-browser") || f.includes("ffff") || f.includes("scrape"))

--- a/bundles/browser/panel/routes.js
+++ b/bundles/browser/panel/routes.js
@@ -9,6 +9,21 @@ import { Router } from "express";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+// The panel is deployed to <CROW_HOME>/panels/, not the bundle directory, so a
+// relative import of instance.js can't be correct in both the repo and the
+// deployed layout — resolve it by absolute path from CROW_HOME instead.
+//
+// This is done per-handler rather than once in the factory: panel-registry.js
+// calls browserRouter(authMiddleware) synchronously and mounts its return value
+// immediately (servers/gateway/index.js), never awaiting it — an async factory
+// would hand Express a Promise instead of a Router and silently break mounting.
+async function loadInstance() {
+  const crowHome = process.env.CROW_HOME || join(homedir(), ".crow");
+  const instanceUrl = pathToFileURL(join(crowHome, "bundles", "browser", "server", "instance.js")).href;
+  return import(instanceUrl);
+}
 
 export default function browserRouter(authMiddleware) {
   const router = Router();
@@ -16,24 +31,28 @@ export default function browserRouter(authMiddleware) {
   // POST /api/browser/control — start/stop/restart container
   router.post("/api/browser/control", authMiddleware, async (req, res) => {
     const { action } = req.body || {};
-    const composePath = join(homedir(), ".crow", "bundles", "browser", "docker-compose.yml");
+    if (!["start", "stop", "restart"].includes(action)) {
+      return res.status(400).json({ error: `Unknown action: ${action}` });
+    }
 
     try {
+      const { stateRoot, containerName } = await loadInstance();
+      const composePath = join(stateRoot(), "bundles", "browser", "docker-compose.yml");
+      const container = containerName();
+
       switch (action) {
         case "start":
           execFileSync("docker", ["compose", "-f", composePath, "up", "-d"], { timeout: 30000 });
           break;
         case "stop":
-          execFileSync("docker", ["stop", "crow-browser"], { timeout: 15000 });
+          execFileSync("docker", ["stop", container], { timeout: 15000 });
           break;
         case "restart":
-          execFileSync("docker", ["restart", "crow-browser"], { timeout: 30000 });
+          execFileSync("docker", ["restart", container], { timeout: 30000 });
           break;
-        default:
-          return res.status(400).json({ error: `Unknown action: ${action}` });
       }
     } catch (err) {
-      // Don't fail hard — container might not exist yet
+      // Don't fail hard — container might not exist yet (or the bundle isn't installed)
     }
 
     if (req.headers.accept?.includes("text/html")) {
@@ -45,16 +64,22 @@ export default function browserRouter(authMiddleware) {
   // GET /api/browser/status — container and CDP health check
   router.get("/api/browser/status", authMiddleware, async (req, res) => {
     let containerRunning = false;
-    try {
-      const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", "crow-browser"], { encoding: "utf-8", timeout: 5000 }).trim();
-      containerRunning = out === "true";
-    } catch {}
-
     let cdpConnected = false;
     try {
-      execFileSync("curl", ["-s", "-m", "2", "http://127.0.0.1:9222/json/version"], { encoding: "utf-8", timeout: 5000 });
-      cdpConnected = true;
-    } catch {}
+      const { containerName, cdpPort } = await loadInstance();
+
+      try {
+        const out = execFileSync("docker", ["inspect", "-f", "{{.State.Running}}", containerName()], { encoding: "utf-8", timeout: 5000 }).trim();
+        containerRunning = out === "true";
+      } catch {}
+
+      try {
+        execFileSync("curl", ["-s", "-m", "2", `http://127.0.0.1:${cdpPort()}/json/version`], { encoding: "utf-8", timeout: 5000 });
+        cdpConnected = true;
+      } catch {}
+    } catch {
+      // instance.js not resolvable (bundle not installed) — report both as down
+    }
 
     res.json({ containerRunning, cdpConnected });
   });

--- a/bundles/browser/server/instance.js
+++ b/bundles/browser/server/instance.js
@@ -8,6 +8,7 @@
  */
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { readFileSync } from "node:fs";
 
 /** This instance's home. Falls back to the primary, which is correct only for the primary. */
 export function stateRoot() {
@@ -20,6 +21,39 @@ export function stateDir(name) {
 }
 
 /**
+ * The instance's bundle .env, parsed lazily and cached per resolved path.
+ *
+ * The MCP server gets CROW_BROWSER_* from its MCP config block, but the dashboard
+ * panel runs inside the gateway process, which carries none of them — they live in
+ * <CROW_HOME>/bundles/browser/.env. Layering that file under process.env keeps the
+ * server's behaviour identical while making the panel resolve its own instance.
+ */
+let envCache = null;
+function bundleEnv() {
+  const path = join(stateRoot(), "bundles", "browser", ".env");
+  if (envCache && envCache.path === path) return envCache.values;
+  const values = {};
+  try {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      values[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+  } catch {
+    // No .env (fresh checkout, bundle not installed) — defaults apply.
+  }
+  envCache = { path, values };
+  return values;
+}
+
+/** process.env wins, then this instance's bundle .env, then the default. */
+function setting(key, fallback) {
+  return process.env[key] || bundleEnv()[key] || fallback;
+}
+
+/**
  * The docker container this instance's browser runs in.
  *
  * manifest.json declares CROW_BROWSER_CONTAINER_NAME and r4's addon sets it, but
@@ -28,5 +62,15 @@ export function stateDir(name) {
  * killed the primary's Chrome and every session logged into it.
  */
 export function containerName() {
-  return process.env.CROW_BROWSER_CONTAINER_NAME || "crow-browser";
+  return setting("CROW_BROWSER_CONTAINER_NAME", "crow-browser");
+}
+
+/** This instance's Chrome DevTools Protocol port. */
+export function cdpPort() {
+  return setting("CROW_BROWSER_CDP_PORT", "9222");
+}
+
+/** This instance's noVNC port. */
+export function vncPort() {
+  return setting("CROW_BROWSER_VNC_PORT", "6080");
 }

--- a/bundles/browser/server/server.js
+++ b/bundles/browser/server/server.js
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSy
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
-import { stateDir, stateRoot, containerName } from "./instance.js";
+import { stateDir, stateRoot, containerName, cdpPort, vncPort } from "./instance.js";
 
 /**
  * Create and configure the crow-browser MCP server.
@@ -30,9 +30,9 @@ import { stateDir, stateRoot, containerName } from "./instance.js";
  */
 export function createBrowserServer(options = {}) {
   const cdpUrl = options.cdpUrl || process.env.CROW_BROWSER_CDP_URL ||
-    `http://127.0.0.1:${process.env.CROW_BROWSER_CDP_PORT || "9222"}`;
+    `http://127.0.0.1:${cdpPort()}`;
   const sessionDir = options.sessionDir || stateDir("browser-sessions");
-  const vncPort = process.env.CROW_BROWSER_VNC_PORT || "6080";
+  const resolvedVncPort = vncPort();
   const container = containerName();
 
   const server = new McpServer(
@@ -170,7 +170,7 @@ export function createBrowserServer(options = {}) {
             type: "text",
             text: JSON.stringify({
               status: "connected",
-              vnc_url: `http://localhost:${vncPort}/vnc.html`,
+              vnc_url: `http://localhost:${resolvedVncPort}/vnc.html`,
               cdp_url: cdpUrl,
               user_agent: profile.ua,
               page_url: page.url(),
@@ -217,7 +217,7 @@ export function createBrowserServer(options = {}) {
             cdp_connected: cdpConnected,
             state_root: stateRoot(),
             current_url: currentUrl,
-            vnc_url: containerRunning ? `http://localhost:${vncPort}/vnc.html` : null,
+            vnc_url: containerRunning ? `http://localhost:${resolvedVncPort}/vnc.html` : null,
           }, null, 2),
         }],
       };
@@ -470,7 +470,7 @@ export function createBrowserServer(options = {}) {
           text: JSON.stringify({
             status: "waiting_for_user",
             message,
-            vnc_url: `http://localhost:${vncPort}/vnc.html`,
+            vnc_url: `http://localhost:${resolvedVncPort}/vnc.html`,
             instruction: "Complete the required action in the VNC viewer, then call crow_browser_wait_for_user with resume=true to continue.",
           }, null, 2),
         }],

--- a/docs/superpowers/plans/2026-08-09-per-instance-browser.md
+++ b/docs/superpowers/plans/2026-08-09-per-instance-browser.md
@@ -904,7 +904,12 @@ for i in .crow .crow-r4 .crow-mpa; do
 const D = require(\"/home/kh0pp/crow/node_modules/better-sqlite3\");
 const db = new D(\"/home/kh0pp/$i/data/crow.db\", { readonly: true });
 for (const r of db.prepare(\"select bot_id, definition from pi_bot_defs\").all()) {
-  if (/crow-browser/.test(r.definition)) console.log(\"$i\", r.bot_id, \"STILL SELECTS crow-browser\");
+  // Check the SELECTIONS, not the raw definition JSON — several bots mention
+  // crow-browser tool names in their system_prompt prose, which is stale text
+  // but not a resolvable server reference and not what this step is about.
+  const d = JSON.parse(r.definition);
+  const servers = new Set(((d.tools && d.tools.crow_mcp) || []).map((s) => s.split(\"/\")[0]));
+  if (servers.has(\"crow-browser\")) console.log(\"$i\", r.bot_id, \"STILL SELECTS crow-browser\");
 }
 console.log(\"$i checked\");
 "

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -324,7 +324,7 @@
     {
       "id": "browser",
       "name": "Browser Automation",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "description": "Stealth browser automation — navigate, fill forms, take screenshots, extract content via Chrome DevTools Protocol with VNC viewing",
       "type": "bundle",
       "author": "Crow",

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -1,11 +1,23 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { readFileSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { stateRoot, stateDir } from "../bundles/browser/server/instance.js";
+import { stateRoot, stateDir, containerName, cdpPort, vncPort } from "../bundles/browser/server/instance.js";
 
 const SERVER_JS = new URL("../bundles/browser/server/server.js", import.meta.url);
+
+/** Every executable file in the bundle — server and panel both run code. */
+function bundleSources() {
+  const out = [];
+  for (const sub of ["server", "panel"]) {
+    const dir = new URL(`../bundles/browser/${sub}/`, import.meta.url);
+    for (const f of readdirSync(dir)) {
+      if (f.endsWith(".js")) out.push({ path: `${sub}/${f}`, src: readFileSync(new URL(f, dir), "utf8") });
+    }
+  }
+  return out;
+}
 
 /** Run `fn` with CROW_HOME forced to `value` (or unset when value is null). */
 function withCrowHome(value, fn) {
@@ -17,6 +29,43 @@ function withCrowHome(value, fn) {
   } finally {
     if (prev === undefined) delete process.env.CROW_HOME;
     else process.env.CROW_HOME = prev;
+  }
+}
+
+/** Run `fn` with each key of `overrides` set (or deleted when its value is null), restoring after. */
+function withEnv(overrides, fn) {
+  const prev = {};
+  for (const key of Object.keys(overrides)) prev[key] = process.env[key];
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try {
+    fn();
+  } finally {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+/**
+ * Build a fresh temp instance home with an optional bundles/browser/.env
+ * (one "KEY=value" string per line), run `fn(dir)`, then clean up.
+ *
+ * A fresh mkdtemp dir per call means bundleEnv()'s path-keyed cache in
+ * instance.js naturally invalidates between tests — no need to reset it.
+ */
+function withInstanceHome(envLines, fn) {
+  const dir = mkdtempSync(join(tmpdir(), "crow-browser-instance-"));
+  const bundleDir = join(dir, "bundles", "browser");
+  mkdirSync(bundleDir, { recursive: true });
+  if (envLines) writeFileSync(join(bundleDir, ".env"), envLines.join("\n") + "\n");
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 }
 
@@ -36,12 +85,24 @@ test("state directories fall back to ~/.crow when CROW_HOME is unset", () => {
   });
 });
 
-test("server.js never hardcodes the primary's home", () => {
-  const src = readFileSync(SERVER_JS, "utf8");
-  assert.ok(
-    !/join\(\s*homedir\(\)\s*,\s*"\.crow"/.test(src),
-    "server.js must resolve state through stateDir(), not join(homedir(), \".crow\", ...)",
-  );
+test("no file in the bundle hardcodes the primary's home", () => {
+  // `process.env.CROW_HOME || join(homedir(), ".crow")` is the one legitimate
+  // shape: instance.js's own stateRoot() fallback, and the unavoidable
+  // bootstrap each panel file needs to locate instance.js before it can
+  // delegate to stateDir() (see panel/browser.js and panel/routes.js). Any
+  // OTHER join(homedir(), ".crow", ...) — without that CROW_HOME fallback —
+  // is the defect: a path resolved straight to the primary's home.
+  const HARDCODE = /join\(\s*homedir\(\)\s*,\s*"\.crow"/;
+  const BOOTSTRAP = /process\.env\.CROW_HOME\s*\|\|\s*join\(\s*homedir\(\)\s*,\s*"\.crow"/;
+  for (const { path, src } of bundleSources()) {
+    for (const line of src.split("\n")) {
+      if (!HARDCODE.test(line)) continue;
+      assert.ok(
+        BOOTSTRAP.test(line),
+        `${path} must resolve state through stateDir()/the CROW_HOME fallback, not a bare join(homedir(), ".crow", ...): ${line.trim()}`,
+      );
+    }
+  }
 });
 
 test("containerName honors CROW_BROWSER_CONTAINER_NAME and defaults to crow-browser", async () => {
@@ -58,16 +119,16 @@ test("containerName honors CROW_BROWSER_CONTAINER_NAME and defaults to crow-brow
   }
 });
 
-test("no docker call in server.js hardcodes a container name", () => {
-  const src = readFileSync(SERVER_JS, "utf8");
-  const dockerLines = src.split("\n").filter((l) => l.includes('execFileSync("docker"'));
-  assert.ok(dockerLines.length >= 4, `expected the docker calls to still exist, found ${dockerLines.length}`);
-  for (const line of dockerLines) {
-    assert.ok(
-      !line.includes('"crow-browser"'),
-      `docker call targets the primary's container by name: ${line.trim()}`,
-    );
+test("no docker call in the bundle hardcodes a container name", () => {
+  let dockerLineCount = 0;
+  for (const { path, src } of bundleSources()) {
+    for (const line of src.split("\n")) {
+      if (!line.includes('execFileSync("docker"')) continue;
+      dockerLineCount++;
+      assert.ok(!line.includes('"crow-browser"'), `${path} targets the primary's container by name: ${line.trim()}`);
+    }
   }
+  assert.ok(dockerLineCount >= 9, `expected the bundle's docker calls to still exist, found ${dockerLineCount}`);
 });
 
 test("crow_browser_status reports what the server bound to", () => {
@@ -106,4 +167,67 @@ test("the downloads mount requires CROW_HOME instead of defaulting to the primar
     "a CROW_HOME default lets a hand-run compose mount the primary's downloads into a second instance's container",
   );
   assert.match(compose, /\$\{CROW_HOME:\?/, "the mount must fail loudly when CROW_HOME is unset");
+});
+
+test("containerName, cdpPort, vncPort read the instance's bundle .env when process.env has no override", () => {
+  withInstanceHome([
+    "CROW_BROWSER_CONTAINER_NAME=crow-browser-r4",
+    "CROW_BROWSER_CDP_PORT=9322",
+    "CROW_BROWSER_VNC_PORT=6180",
+  ], (dir) => {
+    withEnv({
+      CROW_HOME: dir,
+      CROW_BROWSER_CONTAINER_NAME: null,
+      CROW_BROWSER_CDP_PORT: null,
+      CROW_BROWSER_VNC_PORT: null,
+    }, () => {
+      assert.equal(containerName(), "crow-browser-r4");
+      assert.equal(cdpPort(), "9322");
+      assert.equal(vncPort(), "6180");
+    });
+  });
+});
+
+test("process.env wins over the instance's bundle .env when both are set", () => {
+  withInstanceHome([
+    "CROW_BROWSER_CONTAINER_NAME=crow-browser-r4",
+    "CROW_BROWSER_CDP_PORT=9322",
+    "CROW_BROWSER_VNC_PORT=6180",
+  ], (dir) => {
+    withEnv({
+      CROW_HOME: dir,
+      CROW_BROWSER_CONTAINER_NAME: "crow-browser-override",
+      CROW_BROWSER_CDP_PORT: "9999",
+      CROW_BROWSER_VNC_PORT: "6999",
+    }, () => {
+      assert.equal(containerName(), "crow-browser-override");
+      assert.equal(cdpPort(), "9999");
+      assert.equal(vncPort(), "6999");
+    });
+  });
+});
+
+test("containerName, cdpPort, vncPort fall back to their defaults when neither process.env nor the bundle .env has a value", () => {
+  withInstanceHome(null, (dir) => {
+    withEnv({
+      CROW_HOME: dir,
+      CROW_BROWSER_CONTAINER_NAME: null,
+      CROW_BROWSER_CDP_PORT: null,
+      CROW_BROWSER_VNC_PORT: null,
+    }, () => {
+      assert.equal(containerName(), "crow-browser");
+      assert.equal(cdpPort(), "9222");
+      assert.equal(vncPort(), "6080");
+    });
+  });
+});
+
+test("stateRoot ignores a CROW_HOME written inside the bundle .env — it must come from process.env only", () => {
+  withInstanceHome([
+    "CROW_HOME=/tmp/should-never-be-used",
+  ], (dir) => {
+    withEnv({ CROW_HOME: dir }, () => {
+      assert.equal(stateRoot(), dir);
+    });
+  });
 });


### PR DESCRIPTION
#281 made the browser bundle's **MCP server** instance-correct and missed the bundle's other executable surface. This closes it.

`bundles/browser/panel/` is loaded per instance (`panel-registry.js` honors `CROW_HOME`) and hardcoded the primary in nine places:

| file:line | effect on a secondary instance |
|---|---|
| `routes.js:19` | Start ran the **primary's** compose file (a raw `homedir()`) |
| `routes.js:27` | `docker stop crow-browser` — stopped the primary's container |
| `routes.js:30` | `docker restart crow-browser` — **restarted the primary's Chrome, killing every logged-in session** |
| `routes.js:49,55` · `browser.js:29,37` | status and CDP health reported the primary |
| `browser.js:43` | listed the primary's saved sessions |
| `browser.js:59` | listed the primary's skills |

The panel is the surface humans actually use, so this was the sharper half of the defect.

## Two non-obvious constraints

**The panel isn't loaded from the bundle directory.** Served artifacts are copied to `<CROW_HOME>/panels/`, so a relative import of `instance.js` can't be correct in both the repo and the deployed layout. It resolves by absolute path from `CROW_HOME` instead — verified loadable in the deployed layout, not just in tests.

**The gateway carries no `CROW_BROWSER_CONTAINER_NAME` or `CROW_BROWSER_CDP_PORT`** — those live in the instance's bundle `.env`. So `instance.js` now layers `process.env` → `<CROW_HOME>/bundles/browser/.env` → default, via new `cdpPort()` and `vncPort()` accessors alongside `containerName()`. Without that layer, routing the panel through `instance.js` would have looked right and resolved the primary anyway.

`CROW_HOME` itself deliberately resolves from `process.env` only, never from the bundle `.env` — that file lives *inside* the instance being identified. Both live instances currently have a `CROW_HOME=` line in theirs, so this is a live footgun, not a hypothetical.

`options.cdpUrl` and `CROW_BROWSER_CDP_URL` precedence is preserved byte-for-byte; the primary's MCP block uses the URL form.

## Verification

Full suite **3110/3110**. The two source scans are widened from `server.js` to every `.js` in `server/` and `panel/` — that widening alone would have caught this defect for free, which is why it's the durable part of the change.

Both scans mutation-tested. The reviewer independently re-ran the widened scan against seven mutation variants: a bare `join(homedir(), ".crow", …)`, a hoisted two-line variant, a re-hardcoded container argument, and a `spawnSync` swap all go red.

Version bumped 1.1.0 → 1.2.0 with the regenerated registry, so it reaches installed bundles.

## Deviations from the brief, both corrections to it

The brief offered an async panel-route factory as an option. That would have been actively harmful: `servers/gateway/index.js:643` calls the factory synchronously and dereferences `.stack`, so returning a Promise makes `app.use(Promise)` throw inside a `try` whose `catch` abandons **every** panel's routes. Per-handler dynamic import used instead.

The brief's literal scan regex would have been permanently red — it matches `instance.js`'s own legitimate `process.env.CROW_HOME || join(homedir(), ".crow")` fallback. The shipped version flags that shape only when the line lacks the `CROW_HOME ||` guard.

## Known remaining gap

`servers/gateway/routes/extension-proxy.js:52-53` resolves a bundle's webUI port as `process.env[portEnv] || manifest.webUI.port`, so a secondary instance's VNC iframe proxies to `127.0.0.1:6080` — the primary's noVNC, interactively — unless its gateway sets `CROW_BROWSER_VNC_PORT`. On this host that is currently masked by a per-instance systemd drop-in, which is the "fix the instance, not the product" shape we don't want. Out of scope here because that file is shared by all 94 bundles and carries its own security-annotated proxy logic; it gets its own change. The `.env` layering added here generalizes to it directly.