### PR TITLE
fix(gateway): a proxied bundle's webUI port comes from its own instance

### DIFF
--- a/servers/gateway/routes/extension-proxy.js
+++ b/servers/gateway/routes/extension-proxy.js
@@ -38,6 +38,50 @@ function getManifest(bundleId) {
   }
 }
 
+/**
+ * Parse a bundle's own `.env` file (installer-written, per-instance).
+ * Skips blank lines and `#` comments; splits on the first `=`; trims both
+ * sides. Returns `{}` on any read failure — a bundle with no `.env` is
+ * normal, not an error.
+ */
+function readBundleEnv(bundleId) {
+  const path = join(BUNDLES_DIR, bundleId, ".env");
+  const values = {};
+  try {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      values[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+  } catch {
+    // No .env for this bundle — defaults apply.
+  }
+  return values;
+}
+
+/**
+ * The backend port for a bundle's webUI, resolved for THIS instance.
+ *
+ * manifest.webUI.port is a shared constant, so a co-hosted second instance whose
+ * gateway does not export the portEnv override silently proxied to the FIRST
+ * instance's backend — for the browser bundle that meant a secondary dashboard's
+ * VNC iframe driving the primary's Chrome. The instance's own bundle .env is where
+ * that override actually lives (the installer writes it), so read it as the layer
+ * between the process environment and the manifest default.
+ */
+export function resolveWebUIPort(manifest, bundleId) {
+  const key = manifest?.webUI?.portEnv;
+  const fallback = manifest?.webUI?.port;
+  if (!key) return fallback;
+  const fromProcess = Number(process.env[key]);
+  if (fromProcess) return fromProcess;
+  const fromBundle = Number(readBundleEnv(bundleId)[key]);
+  if (fromBundle) return fromBundle;
+  return fallback;
+}
+
 function getProxiedExtensions() {
   if (!existsSync(INSTALLED_PATH)) return [];
   try {
@@ -46,16 +90,10 @@ function getProxiedExtensions() {
     for (const entry of installed) {
       const manifest = getManifest(entry.id);
       if (manifest?.webUI?.port) {
-        // webUI.portEnv names an env var that overrides the manifest port —
-        // lets a per-instance unit remap the backend (e.g. a second browser
-        // container on 6081) without editing the shared manifest.
-        const envPort = manifest.webUI.portEnv
-          ? Number(process.env[manifest.webUI.portEnv]) || null
-          : null;
         proxied.push({
           id: entry.id,
           name: manifest.name || entry.id,
-          port: envPort || manifest.webUI.port,
+          port: resolveWebUIPort(manifest, entry.id),
           path: manifest.webUI.path || "/",
           label: manifest.webUI.label || manifest.name || entry.id,
           proxyMode: manifest.webUI.proxyMode || "subpath",

--- a/tests/extension-proxy-instance-port.test.js
+++ b/tests/extension-proxy-instance-port.test.js
@@ -1,0 +1,87 @@
+/**
+ * Follow-up C — a proxied bundle's webUI port must come from its own instance.
+ *
+ * manifest.webUI.port is a shared constant, so a co-hosted second instance
+ * whose gateway doesn't export the portEnv override silently proxied to the
+ * FIRST instance's backend — for the browser bundle, a secondary dashboard's
+ * VNC iframe drove the primary's Chrome. resolveWebUIPort() layers the
+ * instance's own bundle .env (installer-written, per-instance) between
+ * process.env and the manifest default, the same precedence
+ * bundles/browser/server/instance.js established in #283.
+ *
+ * extension-proxy.js resolves CROW_HOME (and BUNDLES_DIR from it) at module
+ * load, so CROW_HOME is pointed at a scratch dir BEFORE the import —
+ * extension-proxy-auth-token.test.js idiom.
+ */
+import { test, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const CROW_HOME = mkdtempSync(join(tmpdir(), "crow-proxy-port-"));
+process.env.CROW_HOME = CROW_HOME;
+
+after(() => { try { rmSync(CROW_HOME, { recursive: true, force: true }); } catch {} });
+
+const { resolveWebUIPort } = await import("../servers/gateway/routes/extension-proxy.js");
+
+const PORT_ENV = "CROW_BROWSER_VNC_PORT_TEST";
+
+beforeEach(() => {
+  delete process.env[PORT_ENV];
+});
+
+function bundleDir(id) {
+  return join(CROW_HOME, "bundles", id);
+}
+
+function writeBundleEnv(id, contents) {
+  const dir = bundleDir(id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".env"), contents);
+}
+
+test("process.env[portEnv] wins when set", () => {
+  const id = "browser-a";
+  mkdirSync(bundleDir(id), { recursive: true });
+  writeBundleEnv(id, `${PORT_ENV}=6081\n`);
+  process.env[PORT_ENV] = "7000";
+  try {
+    const manifest = { webUI: { port: 6080, portEnv: PORT_ENV } };
+    assert.equal(resolveWebUIPort(manifest, id), 7000);
+  } finally {
+    delete process.env[PORT_ENV];
+  }
+});
+
+test("the bundle .env value is used when process.env has none (the bug this fixes)", () => {
+  const id = "browser-b";
+  writeBundleEnv(id, `${PORT_ENV}=6081\n`);
+  const manifest = { webUI: { port: 6080, portEnv: PORT_ENV } };
+  assert.equal(resolveWebUIPort(manifest, id), 6081,
+    "a secondary instance's own bundle .env must win over the shared manifest default");
+});
+
+test("manifest.webUI.port is the fallback when neither process.env nor the bundle .env has a value", () => {
+  const id = "browser-c";
+  mkdirSync(bundleDir(id), { recursive: true });
+  // No .env file at all for this bundle.
+  const manifest = { webUI: { port: 6080, portEnv: PORT_ENV } };
+  assert.equal(resolveWebUIPort(manifest, id), 6080);
+});
+
+test("a manifest with no portEnv returns manifest.webUI.port unchanged", () => {
+  const id = "minio";
+  writeBundleEnv(id, `${PORT_ENV}=6081\n`); // present but irrelevant — no portEnv key names it
+  const manifest = { webUI: { port: 9001 } };
+  assert.equal(resolveWebUIPort(manifest, id), 9001);
+});
+
+test("a bundle with no .env file does not throw", () => {
+  const id = "no-env-bundle";
+  // Deliberately do not create bundleDir(id) at all.
+  const manifest = { webUI: { port: 5555, portEnv: PORT_ENV } };
+  assert.doesNotThrow(() => resolveWebUIPort(manifest, id));
+  assert.equal(resolveWebUIPort(manifest, id), 5555);
+});


### PR DESCRIPTION
The last member of the defect family closed by #281 and #283, and the worst-shaped of them.

`extension-proxy.js` resolved a bundle's webUI backend as `process.env[portEnv] || manifest.webUI.port`. The manifest port is a shared constant (`6080` for the browser bundle), so a co-hosted second instance whose gateway didn't export the override proxied to the **first** instance's backend. For the browser bundle that means a secondary dashboard's VNC iframe drives the primary's Chrome — live and interactive, which is worse than the cross-instance `docker restart` fixed in #283.

## Why the old shape was wrong

The previous code comment presented a per-instance systemd drop-in as the intended mechanism, and one exists on this host (`crow-r4-gateway.service.d/browser-ports.conf` sets `CROW_BROWSER_VNC_PORT=6081`). That's instance configuration papering over a product default — the shape the "fix the product, not the instance" directive exists to prevent. It also fails *silently toward the primary* whenever the drop-in is absent, which is every other instance and every other host.

## The fix

Layer the instance's own bundle `.env` between the process environment and the manifest default:

**`process.env[portEnv]` → `<BUNDLES_DIR>/<id>/.env[portEnv]` → `manifest.webUI.port`**

`BUNDLES_DIR` is already instance-scoped, so this needs no new notion of instance identity. A bundle's `.env` is exactly the per-instance configuration the installer writes — and it is already where `CROW_BROWSER_VNC_PORT=6081` lives for the secondary instance today, which is what makes the drop-in redundant rather than load-bearing.

This is the same precedence #283 established in the browser bundle, and it's generic: any of the 94 bundles declaring `webUI.portEnv` gets per-instance resolution for free.

## Scope

`extension-proxy.js` carries the proxy's CSRF and bearer-token-injection logic and serves every proxied bundle, so the diff is deliberately confined to port resolution: two new helpers plus one call-site swap. `readAuthToken`, `authorizeExtensionUpgrade`, the CSRF block and WebSocket upgrade handling are untouched, confirmed byte-identical in review.

## Verification

Full suite **3115/3115**. Five behavioural tests covering both override layers, the fallback, the no-`portEnv` case, and a bundle with no `.env`.

Mutation-checked: removing the `.env` layer turns the `.env` test red with `6080 !== 6081` — the exact cross-instance value the bug produced — while the other four stay green. The reviewer independently re-ran the test file to confirm.

## Known, not fixed

`Number()` coercion means a set-but-non-numeric `portEnv` value (`""`, `"0"`, a typo) falls through to the manifest default with no operator-visible signal. Pre-existing shape, carried forward deliberately rather than changed under a security-sensitive file; worth a logging pass later. There are now three hand-rolled `.env` parsers in the tree (here, `bundles/browser/server/instance.js`, `bundles-config.js`) — a genuine dedup opportunity for a future cleanup.