### PR TITLE
fix(browser): give each co-hosted instance its own X display, and fail loudly when it can't

### DIFF
--- a/bundles/browser/.env.example
+++ b/bundles/browser/.env.example
@@ -2,6 +2,12 @@ CROW_BROWSER_VNC_PASSWORD=changeme
 CROW_BROWSER_CDP_PORT=9222
 CROW_BROWSER_VNC_PORT=6080
 
+# The X display number for this instance's virtual screen. Co-hosted instances
+# MUST differ: abstract X sockets are shared across containers under
+# network_mode:host, so two instances on the same number collide and the second
+# silently ends up on the first one's display. Primary 99, second instance 98.
+CROW_BROWSER_DISPLAY=99
+
 # Required. The Crow instance this browser belongs to — decides where downloads,
 # exports and saved sessions land. The gateway sets it automatically when you
 # install through the Extensions panel; set it here if you run docker compose by

--- a/bundles/browser/docker-compose.yml
+++ b/bundles/browser/docker-compose.yml
@@ -10,7 +10,12 @@ services:
     container_name: ${CROW_BROWSER_CONTAINER_NAME:-crow-browser}
     network_mode: host
     environment:
-      - DISPLAY=:99
+      # Abstract X sockets (@/tmp/.X11-unix/XNN) are scoped to the NETWORK
+      # namespace, which network_mode:host shares — so a second instance left on
+      # :99 collides with the first, its Xvfb dies with "Cannot establish any
+      # listening sockets", and x11vnc silently attaches to the FIRST instance's
+      # display. Give each co-hosted instance its own number. Proven 2026-08-09.
+      - DISPLAY_NUM=${CROW_BROWSER_DISPLAY:-99}
       - VNC_PASSWORD=${CROW_BROWSER_VNC_PASSWORD:?VNC password is required}
       - CDP_PORT=${CROW_BROWSER_CDP_PORT:-9222}
       - NOVNC_PORT=${CROW_BROWSER_VNC_PORT:-6080}

--- a/bundles/browser/entrypoint.sh
+++ b/bundles/browser/entrypoint.sh
@@ -47,6 +47,16 @@ for i in $(seq 1 30); do
   sleep 0.5
 done
 [ "$ready" = 1 ] || die "Xvfb did not become ready on :${DISP_NUM} within 15s"
+
+# A display answering is NOT proof it is OURS. Abstract X sockets
+# (@/tmp/.X11-unix/XNN) are scoped to the network namespace, which
+# network_mode:host shares, so a co-hosted instance already on this number
+# answers xdpyinfo while our own Xvfb loses the bind and dies — and x11vnc
+# would then attach to THEIR display. Confirm our process actually survived.
+sleep 0.5
+if ! kill -0 "$XVFB_PID" 2>/dev/null; then
+  die "Xvfb on :${DISP_NUM} died — another container is already using that display. Set CROW_BROWSER_DISPLAY to a number no other Crow instance uses."
+fi
 log "Xvfb ready (pid ${XVFB_PID})."
 
 # --- x11vnc ---

--- a/bundles/browser/entrypoint.sh
+++ b/bundles/browser/entrypoint.sh
@@ -6,7 +6,7 @@
 # recycles the container.
 set -uo pipefail
 
-DISP_NUM=99
+DISP_NUM="${DISPLAY_NUM:-99}"
 DISPLAY=":${DISP_NUM}"
 export DISPLAY
 CDP_PORT="${CDP_PORT:-9222}"

--- a/bundles/browser/manifest.json
+++ b/bundles/browser/manifest.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "CROW_BROWSER_DISPLAY",
-      "description": "X display number — co-hosted instances must each use a different number, since network_mode: host shares abstract X sockets and the second instance would silently land on the first's display",
+      "description": "X display number — must differ per co-hosted instance (network_mode: host shares X sockets)",
       "default": "99"
     }
   ],

--- a/bundles/browser/manifest.json
+++ b/bundles/browser/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "browser",
   "name": "Browser Automation",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Stealth browser automation — navigate, fill forms, take screenshots, extract content via Chrome DevTools Protocol with VNC viewing",
   "type": "bundle",
   "author": "Crow",
@@ -15,7 +15,7 @@
   "server": {
     "command": "node",
     "args": ["server/index.js"],
-    "envKeys": ["CROW_BROWSER_VNC_PASSWORD", "CROW_BROWSER_CDP_PORT", "CROW_BROWSER_VNC_PORT", "CROW_BROWSER_RFB_PORT", "CROW_BROWSER_CONTAINER_NAME"]
+    "envKeys": ["CROW_BROWSER_VNC_PASSWORD", "CROW_BROWSER_CDP_PORT", "CROW_BROWSER_VNC_PORT", "CROW_BROWSER_RFB_PORT", "CROW_BROWSER_CONTAINER_NAME", "CROW_BROWSER_DISPLAY"]
   },
   "panel": "panel/browser.js",
   "panelRoutes": "panel/routes.js",
@@ -51,6 +51,11 @@
       "name": "CROW_BROWSER_CONTAINER_NAME",
       "description": "Docker container name — override so a second Crow instance on the same host can run its own browser container",
       "default": "crow-browser"
+    },
+    {
+      "name": "CROW_BROWSER_DISPLAY",
+      "description": "X display number — co-hosted instances must each use a different number, since network_mode: host shares abstract X sockets and the second instance would silently land on the first's display",
+      "default": "99"
     }
   ],
   "ports": [6080, 9222, 5900],

--- a/docs/developers/port-allocation.md
+++ b/docs/developers/port-allocation.md
@@ -63,7 +63,7 @@ These predate this registry and need follow-up resolution outside the MVP scope:
 | 5335 | 127.0.0.1 | adguard-home (DNS, TCP+UDP) | MVP PR 3 |
 | 5336 | — | pi-hole (DNS) | reserved (Phase 2 DNS) |
 | 5337 | — | technitium (DNS) | reserved (Phase 2 DNS) |
-| 6080 | 127.0.0.1 | browser (noVNC, existing) — overridable via `CROW_BROWSER_VNC_PORT`; RFB 5900 via `CROW_BROWSER_RFB_PORT`, CDP 9222 via `CROW_BROWSER_CDP_PORT`. Secondary instances on one host pick +1 offsets (6081/5901/9223) | existing |
+| 6080 | 127.0.0.1 | browser (noVNC, existing) — overridable via `CROW_BROWSER_VNC_PORT`; RFB 5900 via `CROW_BROWSER_RFB_PORT`, CDP 9222 via `CROW_BROWSER_CDP_PORT`. Secondary instances on one host pick +1 offsets (6081/5901/9223), and MUST also set a distinct X display number via `CROW_BROWSER_DISPLAY` (default 99, secondary 98) — under `network_mode: host` two instances on the same display collide | existing |
 | 6875 | 127.0.0.1 | bookstack (existing) | existing |
 | 8000 | 127.0.0.1 | paperless (existing) | existing |
 | 8002 | tailscale IP | ~~ed-jobs-scraper backend~~ — freed 2026-07-26 (stack migrated to grackle :8002) | external, freed |

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -324,7 +324,7 @@
     {
       "id": "browser",
       "name": "Browser Automation",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "description": "Stealth browser automation — navigate, fill forms, take screenshots, extract content via Chrome DevTools Protocol with VNC viewing",
       "type": "bundle",
       "author": "Crow",
@@ -352,7 +352,8 @@
           "CROW_BROWSER_CDP_PORT",
           "CROW_BROWSER_VNC_PORT",
           "CROW_BROWSER_RFB_PORT",
-          "CROW_BROWSER_CONTAINER_NAME"
+          "CROW_BROWSER_CONTAINER_NAME",
+          "CROW_BROWSER_DISPLAY"
         ]
       },
       "panel": "panel/browser.js",
@@ -394,6 +395,11 @@
           "name": "CROW_BROWSER_CONTAINER_NAME",
           "description": "Docker container name — override so a second Crow instance on the same host can run its own browser container",
           "default": "crow-browser"
+        },
+        {
+          "name": "CROW_BROWSER_DISPLAY",
+          "description": "X display number — co-hosted instances must each use a different number, since network_mode: host shares abstract X sockets and the second instance would silently land on the first's display",
+          "default": "99"
         }
       ],
       "ports": [

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -398,7 +398,7 @@
         },
         {
           "name": "CROW_BROWSER_DISPLAY",
-          "description": "X display number — co-hosted instances must each use a different number, since network_mode: host shares abstract X sockets and the second instance would silently land on the first's display",
+          "description": "X display number — must differ per co-hosted instance (network_mode: host shares X sockets)",
           "default": "99"
         }
       ],

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -231,3 +231,30 @@ test("stateRoot ignores a CROW_HOME written inside the bundle .env — it must c
     });
   });
 });
+
+test("docker-compose.yml passes DISPLAY_NUM from CROW_BROWSER_DISPLAY, not a bare DISPLAY=:99", () => {
+  const compose = readFileSync(new URL("../bundles/browser/docker-compose.yml", import.meta.url), "utf8");
+  assert.ok(
+    !/DISPLAY=:99/.test(compose),
+    "a hardcoded DISPLAY=:99 makes a second instance's Xvfb collide with the first's abstract X socket " +
+      "(network_mode: host shares the network namespace) and silently attach to the first instance's display",
+  );
+  assert.match(
+    compose,
+    /DISPLAY_NUM=\$\{CROW_BROWSER_DISPLAY:-99\}/,
+    "docker-compose.yml must pass DISPLAY_NUM through from CROW_BROWSER_DISPLAY so a second instance can pick its own X display number",
+  );
+});
+
+test("entrypoint.sh derives DISP_NUM from DISPLAY_NUM instead of hardcoding it", () => {
+  const entrypoint = readFileSync(new URL("../bundles/browser/entrypoint.sh", import.meta.url), "utf8");
+  assert.ok(
+    !/^DISP_NUM=99$/m.test(entrypoint),
+    "a hardcoded DISP_NUM=99 ignores DISPLAY_NUM from the compose file, so every instance still starts Xvfb on :99",
+  );
+  assert.match(
+    entrypoint,
+    /^DISP_NUM="\$\{DISPLAY_NUM:-99\}"$/m,
+    "entrypoint.sh must read DISP_NUM from ${DISPLAY_NUM:-99} so docker-compose.yml's CROW_BROWSER_DISPLAY pass-through takes effect",
+  );
+});

--- a/tests/browser-bundle-instance.test.js
+++ b/tests/browser-bundle-instance.test.js
@@ -258,3 +258,27 @@ test("entrypoint.sh derives DISP_NUM from DISPLAY_NUM instead of hardcoding it",
     "entrypoint.sh must read DISP_NUM from ${DISPLAY_NUM:-99} so docker-compose.yml's CROW_BROWSER_DISPLAY pass-through takes effect",
   );
 });
+
+test("entrypoint.sh re-checks the Xvfb process after the readiness loop, not only inside it", () => {
+  // A display answering xdpyinfo is not proof it's OURS: under network_mode:host,
+  // a co-hosted instance already on this display number answers on the first
+  // xdpyinfo poll while our own Xvfb is still losing the abstract-socket bind and
+  // dying, so the loop's own kill -0 guard never gets a second iteration to catch
+  // it. Scope strictly to the code AFTER the `ready` assertion (and before x11vnc
+  // starts) so a match inside the polling loop above can't satisfy this.
+  const entrypoint = readFileSync(new URL("../bundles/browser/entrypoint.sh", import.meta.url), "utf8");
+  const readyAssertion = 'die "Xvfb did not become ready on :${DISP_NUM} within 15s"';
+  const readyAssertionIdx = entrypoint.indexOf(readyAssertion);
+  assert.ok(readyAssertionIdx !== -1, "could not find the Xvfb readiness assertion to scope past");
+  const afterReady = entrypoint.slice(readyAssertionIdx + readyAssertion.length);
+  const x11vncStart = afterReady.indexOf("Starting x11vnc");
+  assert.ok(x11vncStart !== -1, "could not find the x11vnc startup section to scope before");
+  const postReadySlice = afterReady.slice(0, x11vncStart);
+  assert.match(
+    postReadySlice,
+    /kill -0 "\$XVFB_PID"/,
+    "entrypoint.sh must re-check kill -0 \"$XVFB_PID\" after the readiness loop — a co-hosted instance on the same " +
+      "display can make xdpyinfo succeed for OUR loop before our own Xvfb has finished dying, so the loop's guard " +
+      "alone isn't enough; declaring ready without re-checking lets x11vnc attach to the other instance's display",
+  );
+});


### PR DESCRIPTION
Proven on a live host today, not reasoned from the code.

## What happened

The browser bundle hardcoded the X display as `:99` in both `docker-compose.yml` and `entrypoint.sh`. A second instance was deliberately recreated on `:99` to test whether a local `DISPLAY_NUM=98` patch on this host was actually necessary. Its Xvfb died at startup:

```
[crow-browser] Starting Xvfb on :99 (1920x1080x24)...
[crow-browser] Xvfb ready (pid 12).
_XSERVTransSocketUNIXCreateListener: ...SocketCreateListener() failed
_XSERVTransMakeAllCOTSServerListeners: server already running
Fatal server error:
(EE) Cannot establish any listening sockets - Make sure an X server isn't already running
```

x11vnc then attached to the **first** instance's display. The second instance's noVNC was serving the first instance's screen, and its Chrome was rendering into it.

**Cause:** an X server binds an *abstract* unix socket (`@/tmp/.X11-unix/XNN`) in addition to the filesystem one. Abstract sockets are scoped to the **network namespace**, which `network_mode: host` shares across containers — so per-container `/tmp` isolation does not help. Two instances on the same display number collide, and the loser silently joins the winner's display.

Restoring `:98` fixed it, verified with `Xvfb :98` and `:99` both alive in their own containers, sockets `X98`/`X99`, distinct CDP browsers, distinct downloads mounts.

## The second bug, which is the worse one

The entrypoint's readiness check was a **false mitigation**:

```sh
for i in $(seq 1 30); do
  if ! kill -0 "$XVFB_PID" 2>/dev/null; then die "Xvfb process died during startup"; fi
  if xdpyinfo -display ":${DISP_NUM}" >/dev/null 2>&1; then ready=1; break; fi
  sleep 0.5
done
```

In the collision case `xdpyinfo` succeeds on the **first iteration** — because the *other* container's X server answers — so `ready=1; break` fires before our own Xvfb finishes dying, and the `kill -0` guard never gets a second iteration. The log above shows the consequence: `Xvfb ready (pid 12)` was printed for a display the container did not own. It reported healthy while screen-sharing another instance's browser.

A display answering is not proof it is yours. The fix re-asserts our own process's liveness after the loop and before the success message, so the failure is a hard container exit with an actionable message instead of a silent cross-instance leak:

```
Xvfb on :99 died — another container is already using that display.
Set CROW_BROWSER_DISPLAY to a number no other Crow instance uses.
```

Same philosophy as `${CROW_HOME:?}` in #281: when an instance can't have its own thing, say so rather than quietly borrowing someone else's.

## Changes

- `docker-compose.yml` passes `DISPLAY_NUM=${CROW_BROWSER_DISPLAY:-99}` instead of hardcoding `DISPLAY=:99`, with the abstract-socket reason in a comment.
- `entrypoint.sh` honors `DISPLAY_NUM` (one line — every downstream reference already used `${DISP_NUM}`), plus the liveness re-check.
- `CROW_BROWSER_DISPLAY` documented in `.env.example` and declared in `manifest.json`'s `envKeys` **and** `env_vars`, so the install UI offers it alongside the four port/name overrides. It's the one whose absence causes a silent leak rather than a visible error, so omitting it from the UI would have been the worst of the five.
- `docs/developers/port-allocation.md`'s browser row gains the display number next to the existing `+1` port convention.
- Version 1.2.0 → 1.3.0 with regenerated registry, so it reaches installed bundles.

## Verification

Full suite **3118/3118**. New tests assert compose passes `DISPLAY_NUM` with no bare `DISPLAY=:99`, that the entrypoint derives `DISP_NUM` from it, and that the liveness re-check exists *after* the readiness loop rather than only inside it. All mutation-checked empirically.

Backward compatible: no `CROW_BROWSER_DISPLAY` set → compose default 99 → entrypoint default 99, identical to today.

## Known, not fixed

`x11vnc -noshm` remains a local patch on this host's second instance, not upstreamed — VNC rendering can't be verified headlessly here, and a patch whose necessity can't be demonstrated shouldn't ship. `Dockerfile:4`'s `ENV DISPLAY=:99` is now stale but harmless, since the entrypoint recomputes and re-exports `DISPLAY` before any consumer starts.