### PR TITLE
fix(board): emitted client script parses again — escape \n in the template-literal source

### DIFF
--- a/servers/gateway/dashboard/panels/bot-board/client.js
+++ b/servers/gateway/dashboard/panels/bot-board/client.js
@@ -725,7 +725,7 @@ export function clientJs(botId, trackerType, projectId, trackerSlug, contextFiel
       });
     }
     function cfgStatusList(){
-      return $('bb-cfg-statuses').value.split('\n').map(function(x){return x.trim();}).filter(Boolean);
+      return $('bb-cfg-statuses').value.split('\\n').map(function(x){return x.trim();}).filter(Boolean);
     }
     function cfgFieldRow(f){
       f=f||{};
@@ -749,7 +749,7 @@ export function clientJs(botId, trackerType, projectId, trackerSlug, contextFiel
       api('GET','/board-def?project_id='+encodeURIComponent(pid)).then(function(r){
         if(!r.ok||!r.j){ msg($('bb-cfg-msg'),(r.j&&r.j.error)||'load failed','err'); return; }
         $('bb-cfg-name').value=r.j.display_name||'';
-        $('bb-cfg-statuses').value=(r.j.status_values||[]).join('\n');
+        $('bb-cfg-statuses').value=(r.j.status_values||[]).join('\\n');
         cfgTerminalBoxes(r.j.status_values||[], r.j.terminal_values||[]);
         var fw=$('bb-cfg-fields'); clearEl(fw);
         (r.j.fields||[]).forEach(function(f){ fw.appendChild(cfgFieldRow(f)); });

--- a/tests/board-panel-config.test.js
+++ b/tests/board-panel-config.test.js
@@ -178,3 +178,19 @@ test("no-JS move validates against the def", async () => {
     t2.close();
   } finally { db.close(); }
 });
+
+test("emitted client script parses as JavaScript in both board modes", async () => {
+  // The client script is emitted from a template literal, where a single-escaped
+  // sequence like '\n' becomes a REAL newline inside a quoted string in the
+  // browser — one SyntaxError kills the whole script: no bb-js class (the no-JS
+  // move buttons stay visible), no card-click drawer, no filters. Caught live on
+  // r4 2026-08-11 (Configure-drawer split('\n')). Parse what we actually serve.
+  const { clientJs } = await import("../servers/gateway/dashboard/panels/bot-board/client.js");
+  for (const [label, js] of [
+    ["kanban", clientJs("scout", "kanban", 7, null, null, "en")],
+    ["tracker", clientJs("scout", "custom", null, "pir", [{ key: "phase", label: "Phase" }], "es")],
+  ]) {
+    const body = js.replace(/^<script>/, "").replace(/<\/script>$/, "");
+    assert.doesNotThrow(() => new Function(body), `${label} client script must parse`);
+  }
+});


### PR DESCRIPTION
## Live regression from PR #286 (Track 0 Phase A), found during the soak review

The Configure-drawer client code used `'\n'` inside the template literal that emits the bot-board panel's inline `<script>` (`client.js:728` and `:752`). Template-literal escape processing happens at **emit time**, so the browser received a single-quoted string containing a raw newline — a SyntaxError that killed the entire board script:

- clicking a card no longer opened the detail drawer (no delegated click handler),
- the no-JS fallback move buttons (pending/done/cancelled) stayed visible on every card face (`body.bb-js` never set),
- search/chips/list-view/collapse were all inert.

Reported by the operator from daily use on r4; reproduced by fetching the served page and running the extracted inline script through `node --check`.

## Fix

Both sites double-escape (`'\\n'`), matching the file's existing convention (`'loading\\u2026'`). Two characters of production change.

## Test

New regression test in `tests/board-panel-config.test.js` parses the emitted script (`new Function`) in both board modes (kanban EN, tracker ES) — any future emit-time escape or backtick slip in this panel fails the suite instead of the browser. Watched fail on the bug (each site independently, by mutation), watched pass on the fix.

Suite: **3136 / 0** (floor 3135 + the new test).