### PR TITLE
fix(tests): eliminate the two host-global suite flakes — port-range collisions and prod-sweeper fixture reaping

### DIFF
--- a/scripts/run-suite.mjs
+++ b/scripts/run-suite.mjs
@@ -107,6 +107,15 @@ env.CROW_DISABLE_PERCH = "1";
 // under test would arm real restart/exit paths inside test processes.
 delete env.INVOCATION_ID;
 delete env.CROW_SUPERVISED;
+// Cross-run port isolation (2026-08-13 flake hunt): models-state /
+// models-registration tests bind-probe the model-port allocator range with
+// REAL sockets. Concurrent suite runs (worktrees, subagent implementers)
+// colliding on the fixed 18100 base was a reproduced flake — give each run
+// its own hundred-port window well away from the production range. Rare
+// same-window collisions between two concurrent runs remain possible
+// (~0.25% per pair) and resolve the old way; this removes the guaranteed
+// collision, not the concept of a shared host.
+env.CROW_MODELS_PORT_RANGE_START = String(20000 + Math.floor(Math.random() * 395) * 100);
 
 // Passthrough flags go BEFORE the positional file list; node --test treats
 // anything after the first positional as a test path.

--- a/servers/gateway/models/state.js
+++ b/servers/gateway/models/state.js
@@ -38,8 +38,19 @@ import net from "node:net";
 
 import { resolveDataDir } from "../../db.js";
 
-export const PORT_RANGE_START = 18100;
-export const PORT_RANGE_END = 18199; // inclusive
+// The base is env-overridable as a SUITE-ISOLATION knob only (2026-08-13
+// flake hunt: concurrent `npm test` runs bind-probe this range with real
+// sockets, and two runs colliding on a hardwired base was a reproduced
+// cross-process flake). run-suite.mjs assigns each run its own window;
+// production never sets the var. Co-hosted live instances deliberately
+// SHARE the fixed default range — cross-instance overlap is resolved by
+// the bind probe, and that design is unchanged.
+const envRangeStart = Number.parseInt(process.env.CROW_MODELS_PORT_RANGE_START ?? "", 10);
+export const PORT_RANGE_START =
+  Number.isInteger(envRangeStart) && envRangeStart >= 1024 && envRangeStart <= 65435
+    ? envRangeStart
+    : 18100;
+export const PORT_RANGE_END = PORT_RANGE_START + 99; // inclusive
 
 /**
  * Thrown by allocatePort when every port in the range is reserved or

--- a/tests/kill-orphan-gateways.test.js
+++ b/tests/kill-orphan-gateways.test.js
@@ -53,6 +53,18 @@ const SCRIPT = join(__dir, "..", "scripts", "ops", "kill-orphan-gateways.sh");
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const escRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+/** Pre-run fixture gate: a native fixture that died at/just after spawn
+ * (observed once, 2026-08-13, cause never captured — the sweep then finds
+ * nothing and the test fails at a misleading assert) should fail HERE,
+ * carrying the fixture's captured stderr as the diagnosis. */
+function assertFixtureLive(pid, binPath, label) {
+  if (isAlive(pid)) return;
+  let err = "";
+  try { err = readFileSync(binPath + ".stderr", "utf8").trim(); } catch { /* no capture */ }
+  assert.fail(`${label}: fixture pid ${pid} died at/just after spawn` +
+    (err ? ` — its stderr:\n${err}` : " — its stderr capture is empty (died without output)"));
+}
+
 /** true while the pid exists and is not a zombie */
 function isAlive(pid) {
   try {
@@ -184,11 +196,19 @@ process.stdout.write(String(c.pid));
  * {@link spawnOrphaned}.
  */
 async function spawnOrphanedBinary(binPath, args = [], opts = {}) {
+  // Fixture stderr is captured beside the binary (2026-08-13 flake hunt):
+  // a fixture that dies within ~100ms of spawn leaves a zombie that fools
+  // a bare /proc-exists aliveness check while pgrep skips its empty
+  // cmdline — the sweep then "finds nothing" and the test fails at the
+  // wrong assert with no evidence. assertFixtureLive reads this file into
+  // its failure message so a died-at-spawn fixture self-diagnoses.
   const bootstrap = `
 const { spawn } = require("node:child_process");
+const { openSync } = require("node:fs");
+const errFd = openSync(${JSON.stringify(binPath + ".stderr")}, "a");
 const c = spawn(${JSON.stringify(binPath)}, ${JSON.stringify(args)}, {
   detached: true,
-  stdio: "ignore",
+  stdio: ["ignore", "ignore", errFd],
   cwd: ${JSON.stringify(opts.cwd || tmpdir())},
 });
 c.unref();
@@ -261,10 +281,69 @@ function makeFakeNativeRuntime() {
  * `runtime.js`'s `buildLlamaServerArgs` shape exactly (the flags Sweep 3's
  * `native_port_of` actually parses). `port` omitted entirely tests the
  * fail-closed "couldn't determine a port" path. */
-function spawnFakeNativeModel(binPath, { port, alias = "test-model" } = {}) {
+async function spawnFakeNativeModel(binPath, { port, alias = "test-model" } = {}) {
+  await awaitProdSweeperClearance();
   const args = ["-c", "import time; time.sleep(600)", "--model", "/fake/model.gguf", "--alias", alias];
   if (port != null) args.push("--port", String(port), "--host", "127.0.0.1");
   return spawnOrphanedBinary(binPath, args);
+}
+
+// ── prod-sweeper avoidance (2026-08-13 flake hunt) ──────────────────────
+// crow-orphan-sweep.timer runs THIS SAME SCRIPT every minute with its
+// DEFAULT native pattern (`runtimes/llamacpp`). A live sweep-3 fixture is
+// BY DESIGN indistinguishable from a real orphan — that identity is what
+// these tests prove — so a fixture whose alive window overlaps a tick gets
+// legitimately reaped (journal-proven: 2026-08-13 07:56:43, the prod
+// sweeper SIGTERMed the dry-run test's port-18141 fixture mid-assertion).
+// Gateway fixtures were renamed out of the default pattern for this exact
+// class of flake (the de-collision test above); native fixtures cannot be,
+// so the spawn steers around the next tick instead. Fail-open: on any
+// surprise (no systemctl, no timer, unparseable output) we proceed exactly
+// as before — the clearance is flake-avoidance, never correctness.
+function parseSystemdSpanMs(str) {
+  if (typeof str !== "string") return null;
+  const t = str.trim();
+  if (!t || /^(infinity|n\/a)$/i.test(t)) return null;
+  const UNIT = { d: 86400000, h: 3600000, min: 60000, s: 1000, ms: 1, us: 0.001 };
+  let ms = 0;
+  for (const tok of t.split(/\s+/)) {
+    const m = /^([\d.]+)(d|h|min|s|ms|us)$/.exec(tok);
+    if (!m) return null;
+    ms += Number(m[1]) * UNIT[m[2]];
+  }
+  return ms;
+}
+
+async function awaitProdSweeperClearance(windowMs = 15000, capMs = 180000) {
+  // Poll-until-runway, never a fixed post-tick margin: systemd timers
+  // default AccuracySec=1min, so the real fire lands anywhere up to a
+  // minute AFTER NextElapse — the first version of this helper waited
+  // "tick + 6s" and the timer fired straight through it (observed
+  // 2026-08-13 08:09:03 vs a computed ~08:08:57 tick). Clear runway means:
+  // the next fire is comfortably far away AND no sweep is running right
+  // now. NextElapse jumps ~1min forward at activation, so both conditions
+  // flip true only after the awaited tick has observably happened.
+  const deadline = Date.now() + capMs;
+  while (Date.now() < deadline) {
+    let shown;
+    try {
+      shown = spawnSync("systemctl", ["show", "crow-orphan-sweep.timer", "-p", "NextElapseUSecMonotonic", "--value"],
+        { encoding: "utf8", timeout: 5000 });
+    } catch { return; }
+    if (!shown || shown.status !== 0) return;
+    const nextMs = parseSystemdSpanMs(shown.stdout);
+    if (nextMs == null || nextMs === 0) return; // timer absent/inactive → nothing to avoid
+    let uptimeMs;
+    try { uptimeMs = Number(readFileSync("/proc/uptime", "utf8").split(" ")[0]) * 1000; } catch { return; }
+    if (!Number.isFinite(uptimeMs)) return;
+    const untilFire = nextMs - uptimeMs; // negative = fired-late window, keep waiting
+    const active = spawnSync("systemctl", ["is-active", "crow-orphan-sweep.service"],
+      { encoding: "utf8", timeout: 5000 });
+    const sweepRunning = (active.stdout || "").trim() === "active";
+    if (!sweepRunning && untilFire >= windowMs) return;
+    await sleep(2000);
+  }
+  // Cap hit — proceed rather than hang the suite; worst case is the old flake odds.
 }
 
 /** Write `T/models/state.json` with a single reservation — the same shape
@@ -558,7 +637,7 @@ test("sweep 3 reaps an orphaned native model runtime process (ppid==1, exe under
   // missing state file as "not reserved", not "protected".
   const pid = await spawnFakeNativeModel(binPath, { port: 18140 });
   spawned.push(pid);
-  assert.ok(isAlive(pid), "native runtime fixture must be alive pre-run");
+  assertFixtureLive(pid, binPath, "native runtime fixture must be alive pre-run");
 
   const { stdout } = await runScript({
     ORPHAN_MATCH_PATTERN: "/nonexistent-orphan-test-path/servers/gateway/index\\.js",
@@ -823,6 +902,7 @@ test("sweep 3 candidate identity check matches on cwd too, not only exe", async 
   // A realistic --port flag so the adoption cross-check (fix round 1) can
   // determine the candidate's port and proceed past its fail-closed guard;
   // no T/models/state.json exists at all, so it's correctly unreserved.
+  await awaitProdSweeperClearance(); // cwd is under runtimes/llamacpp — prod-sweepable like the exe fixtures
   const pid = await spawnOrphaned(script, {
     cwd: releaseDir,
     extraArgs: ["--model", "/fake/model.gguf", "--alias", "cwd-test-model", "--port", "18144", "--host", "127.0.0.1"],
@@ -839,4 +919,29 @@ test("sweep 3 candidate identity check matches on cwd too, not only exe", async 
   await waitFor(() => !isAlive(pid), 5000, "cwd-matched native runtime fixture to die");
   assert.ok(!isAlive(pid), `cwd-matched native runtime fixture ${pid} must be gone`);
   assertProdAlive(prod, "after the cwd-match reap run");
+});
+
+// ---------------------------------------------------------------------------
+// prod-sweeper avoidance plumbing (2026-08-13 flake hunt) — the span parser
+// that awaitProdSweeperClearance feeds /proc/uptime math with. Journal-proven
+// flake: 2026-08-13 07:56:43, crow-orphan-sweep.service (the host's
+// once-a-minute DEFAULT-pattern run of this same script) SIGTERMed the
+// dry-run test's port-18141 fixture mid-assertion — a live sweep-3 fixture
+// is BY DESIGN indistinguishable from a real orphan, so unlike the gateway
+// fixtures (renamed out of the default pattern after the 2026-07-18 flake,
+// see the de-collision test above) native fixtures must steer AROUND the
+// tick instead.
+// ---------------------------------------------------------------------------
+
+test("parseSystemdSpanMs parses systemctl's human-readable monotonic spans", () => {
+  assert.equal(parseSystemdSpanMs("39s"), 39000);
+  assert.equal(parseSystemdSpanMs("1min 2.5s"), 62500);
+  assert.equal(parseSystemdSpanMs("500ms"), 500);
+  const composite = parseSystemdSpanMs("4d 22h 3min 39.930388s");
+  assert.ok(Math.abs(composite - (4 * 86400000 + 22 * 3600000 + 3 * 60000 + 39930.388)) < 0.01,
+    `composite span parsed wrong: ${composite}`);
+  assert.equal(parseSystemdSpanMs(""), null);
+  assert.equal(parseSystemdSpanMs("infinity"), null);
+  assert.equal(parseSystemdSpanMs("n/a"), null);
+  assert.equal(parseSystemdSpanMs("garbage tokens"), null, "unparseable → null → clearance is skipped, never guessed");
 });

--- a/tests/models-state.test.js
+++ b/tests/models-state.test.js
@@ -120,13 +120,21 @@ test("releasePort on a modelId with no reservation is a no-op", () => {
 test("allocatePort throws a typed PortRangeExhaustedError once the range is full", async () => {
   const state = { reservations: {}, journal: {}, registry: {} };
   const rangeSize = PORT_RANGE_END - PORT_RANGE_START + 1;
+  // Stubbed probe, same TOCTOU reasoning as the exact-port tests above: the
+  // loop needs exactly rangeSize successful allocations, and a REAL probe
+  // colliding with a concurrent test file's transient bind (observed under
+  // 3× concurrent suites, 2026-08-13: one skipped port → exhaustion one
+  // allocation early) fails the count. Real bind-test behavior is covered
+  // by the "bind-tests and skips" test; THIS test is about map exhaustion
+  // and the typed error.
+  const stub = { canBind: async () => true };
   for (let i = 0; i < rangeSize; i++) {
     // eslint-disable-next-line no-await-in-loop
-    await allocatePort(state, `model-${i}`);
+    await allocatePort(state, `model-${i}`, stub);
   }
   assert.equal(Object.keys(state.reservations).length, rangeSize);
   await assert.rejects(
-    () => allocatePort(state, "model-overflow"),
+    () => allocatePort(state, "model-overflow", stub),
     (err) => {
       assert.ok(err instanceof PortRangeExhaustedError);
       assert.equal(err.code, "PORT_RANGE_EXHAUSTED");
@@ -333,4 +341,28 @@ test("registryEntryRuntimeState: not live + wasLive:false/absent -> plain stoppe
 test("registryEntryRuntimeState: a truthy-but-not-strictly-true wasLive (e.g. a stray string) does not accidentally match", () => {
   assert.equal(registryEntryRuntimeState({ wasLive: "true" }, false), "stopped");
   assert.equal(registryEntryRuntimeState({ wasLive: 1 }, false), "stopped");
+});
+
+// ---------------------------------------------------------------------------
+// CROW_MODELS_PORT_RANGE_START — suite-isolation knob (2026-08-13 flake hunt:
+// concurrent `npm test` runs bind-probe the allocator range with REAL
+// sockets; two runs colliding on the hardwired 18100 base was a reproduced
+// cross-process flake — EADDRINUSE in "allocatePort bind-tests and skips a
+// port actually held on the host"). run-suite.mjs gives each run its own
+// window; production never sets the var and keeps 18100.
+// ---------------------------------------------------------------------------
+
+test("CROW_MODELS_PORT_RANGE_START relocates the allocator range; invalid values keep the default", async () => {
+  const { execFileSync } = await import("node:child_process");
+  const root = join(import.meta.dirname, "..");
+  const probe = (envVal) => execFileSync(process.execPath, ["--input-type=module", "-e",
+    `import { PORT_RANGE_START, PORT_RANGE_END } from "${join(root, "servers/gateway/models/state.js")}";
+     console.log(PORT_RANGE_START, PORT_RANGE_END);`,
+  ], {
+    env: { ...process.env, ...(envVal == null ? {} : { CROW_MODELS_PORT_RANGE_START: envVal }) },
+    encoding: "utf8",
+  }).trim();
+  assert.equal(probe("23400"), "23400 23499", "a valid base relocates the whole 100-port window");
+  assert.equal(probe("abc"), "18100 18199", "garbage keeps the production default");
+  assert.equal(probe("80"), "18100 18199", "sub-1024 bases are refused (privileged ports)");
 });

--- a/tests/port-inventory.test.js
+++ b/tests/port-inventory.test.js
@@ -148,17 +148,18 @@ test("dual-stack wildcard (0.0.0.0 + [::]) on same port -> NOT a conflict", () =
 });
 
 // ---------------------------------------------------------------------------
-// Native model port attribution (18100-18199) — Item G, Task 14
+// Native model port attribution (the PORT_RANGE_START..END window;
+// 18100-18199 in production, per-run relocated under npm test) — Item G, Task 14
 // ---------------------------------------------------------------------------
 
 import { loadNativeModelPortMap, GENERIC_LOCAL_MODEL_LABEL } from "../servers/gateway/port-inventory.js";
 
 test("a listening port in the native-model range with a matching reservation attributes to that model id, not foreign", () => {
   const rows = attributeAndDetect(
-    [], [{ port: 18100, boundAddr: "127.0.0.1" }], core,
-    new Map([[18100, "qwen3-4b-instruct"]]),
+    [], [{ port: PORT_RANGE_START, boundAddr: "127.0.0.1" }], core,
+    new Map([[PORT_RANGE_START, "qwen3-4b-instruct"]]),
   );
-  const r = rows.find((x) => x.port === 18100);
+  const r = rows.find((x) => x.port === PORT_RANGE_START);
   assert.equal(r.kind, "local-model");
   assert.equal(r.bundleName, "qwen3-4b-instruct");
   assert.equal(r.bundleId, "qwen3-4b-instruct");
@@ -167,16 +168,16 @@ test("a listening port in the native-model range with a matching reservation att
 });
 
 test("a listening port in the native-model range with NO matching reservation falls back to the generic label, not foreign", () => {
-  const rows = attributeAndDetect([], [{ port: 18150, boundAddr: "127.0.0.1" }], core, new Map());
-  const r = rows.find((x) => x.port === 18150);
+  const rows = attributeAndDetect([], [{ port: PORT_RANGE_START + 50, boundAddr: "127.0.0.1" }], core, new Map());
+  const r = rows.find((x) => x.port === PORT_RANGE_START + 50);
   assert.equal(r.kind, "local-model");
   assert.equal(r.bundleName, GENERIC_LOCAL_MODEL_LABEL);
   assert.equal(r.bundleId, null);
 });
 
 test("nativeModelPorts defaults to an empty map when the 4th arg is omitted (backward compatible call sites)", () => {
-  const rows = attributeAndDetect([], [{ port: 18100, boundAddr: "127.0.0.1" }], core);
-  const r = rows.find((x) => x.port === 18100);
+  const rows = attributeAndDetect([], [{ port: PORT_RANGE_START, boundAddr: "127.0.0.1" }], core);
+  const r = rows.find((x) => x.port === PORT_RANGE_START);
   assert.equal(r.kind, "local-model");
   assert.equal(r.bundleName, GENERIC_LOCAL_MODEL_LABEL);
 });
@@ -205,12 +206,12 @@ test("a bundle-declared endpoint on a port inside the native range still wins (c
   // endpoint branch is checked first in attributeAndDetect regardless — this
   // pins that ordering so a future change can't silently invert it.
   const rows = attributeAndDetect(
-    [ep("some-bundle", 18100, "loopback")],
-    [{ port: 18100, boundAddr: "127.0.0.1" }],
+    [ep("some-bundle", PORT_RANGE_START, "loopback")],
+    [{ port: PORT_RANGE_START, boundAddr: "127.0.0.1" }],
     core,
-    new Map([[18100, "some-model"]]),
+    new Map([[PORT_RANGE_START, "some-model"]]),
   );
-  const r = rows.find((x) => x.port === 18100);
+  const r = rows.find((x) => x.port === PORT_RANGE_START);
   assert.equal(r.kind, "hardcoded"); // ep() fixtures use source:"compose" with no portEnvVar
   assert.equal(r.bundleId, "some-bundle");
 });


### PR DESCRIPTION
## The hunt

Four historical "models-runtime flake" sightings (one per suite-heavy session since 2026-07-23, never reproducing on rerun). Six idle full-suite runs: clean. Three rounds of **3× concurrent** full suites: 3 failures in 9 runs — reproduced. Root causes are two distinct **cross-process escapes from the scratch env** (the historical "models-runtime" attribution was a near-miss label; the failures live in `models-state` and `kill-orphan-gateways`):

### 1. Port-range collision (`models-state.test.js`)
The model-port allocator's range (18100–18199) is a hardwired const, and its tests bind-probe it with **real sockets**. Two concurrent suite runs collide on 18100 (`EADDRINUSE` captured). Fix: `CROW_MODELS_PORT_RANGE_START` env knob (validated ≥1024, production default byte-identical; co-hosted instances still share the fixed range by design) + `run-suite.mjs` assigns each run a random hundred-port window. The range-exhaustion test now stubs its probe (its exact-count loop was the same TOCTOU the file's exact-port tests already stub against — observed failing once under load). `port-inventory` literal-18100 asserts became range-relative.

### 2. Prod sweeper reaping live fixtures (`kill-orphan-gateways.test.js`)
`crow-orphan-sweep.timer` runs the sweep script every minute with the DEFAULT native pattern (`runtimes/llamacpp`), and a live sweep-3 native fixture is **by design** indistinguishable from a real orphan. Journal-proven: the prod unit SIGTERMed the dry-run test's port-18141 fixture mid-assertion. The 2026-07-18 gateway-fixture flake was fixed by renaming out of the default pattern; native fixtures *cannot* be (the path IS their identity), so spawns now **steer around the timer's next tick** — poll-until-runway, because a first-cut fixed post-tick margin was defeated by systemd's `AccuracySec=1min` late fires (also observed live: fired 6s past the computed tick, straight through the margin). Fail-open on hosts without the timer/systemctl (CI unaffected).

Plus: native fixtures now capture stderr beside the binary, and the pre-run aliveness gate reports it — a once-observed (1-in-22) die-at-spawn mode self-diagnoses if it recurs instead of failing at a misleading assert.

## Validation

- Full suite: **3176 / 0** (floor 3174 + knob test + span-parser test, both mutation-checked — the parser mutation is caught by the scoped test; note it *also* stalls the clearance helper to its 180s cap if left in, which is why the suite-level mutation run times out rather than failing fast).
- 18 concurrent-load suite runs (2 × 3 rounds × 3 parallel) + 14 instrumented targeted runs: **zero occurrences of either fixed mode**.
- During validation a **separate** rare mode surfaced once (`models-manager.test.js` resume test: Range header null under load — possibly a real resume-logic bug under slow I/O). Evidence preserved at `~/crow-flake-evidence-models-manager-resume-20260813.out`; filed for its own hunt, deliberately not a rider here.