### PR TITLE
Reader bundle: document import + Read view (milestone 1)

### DIFF
--- a/bundles/reader/README.md
+++ b/bundles/reader/README.md
@@ -1,0 +1,95 @@
+# Reader
+
+An e-reader bundle for Crow: import PDFs, web pages, and files; read
+them in a clean paragraph view; keep the original as an archival copy.
+
+This is **milestone 1**: import + Read view + server-authoritative
+progress. TTS (gateway registry, timing-aware playback), quote-anchored
+annotations with crow memory promotion, a pdf.js Original view, and
+Drive/Doc export are on the roadmap and land in later milestones — the
+schema for annotations/chunks/embeddings already exists so those
+milestones don't need a migration.
+
+## What it does today
+
+- **Import** — upload a PDF/HTML/TXT/MD file, import a web page by URL
+  (Readability-extracted, raw HTML archived), or hand it a local path
+  or URL from an MCP client (`crow_reader_ingest`). Every import stores
+  the original/archived copy alongside the extracted text.
+- **Extraction** — PDFs go through a vendored PyMuPDF extractor
+  (`scripts/extract.py`, run via `uv`): block-level text, `[TABLE]`
+  markdown for tabular content, and a cleanup chain (de-hyphenation,
+  paragraph reflow, long-paragraph sentence splitting) shared with the
+  capstone-tracker bundle's e-reader pipeline. Web pages go through
+  `@mozilla/readability` + `linkedom`. Extraction runs as a subprocess
+  with a timeout and structured JSON errors — a failed or partial
+  extraction still creates a document row (`extraction_status`:
+  `ok` / `partial` / `failed`) rather than losing the import.
+- **Read view** — `/reader-app/:id`, a plain paragraph view with
+  section navigation and `[TABLE]` blocks rendered as HTML tables.
+  Scroll position saves as reading progress (forward-only: a document
+  never rewinds itself) and resumes on reload.
+- **Library** — `/dashboard/reader` panel: an import card and a table
+  of documents with source, extraction status, progress, and tags.
+  FTS5 search over document text backs `crow_reader_list`.
+- **MCP tools** — `crow_reader_ingest` (import from a local path or
+  URL; local paths are checked against an allowlist), `crow_reader_list`
+  (FTS-searchable library listing), `crow_reader_get` (one document
+  with its sections).
+
+## Requirements
+
+- **[uv](https://docs.astral.sh/uv/)** on `PATH` (or point
+  `READER_UV_BIN` at it) — runs the PDF extractor as a self-contained
+  script; its `pymupdf` dependency is declared inline and resolved by
+  `uv` on first run, no separate `pip install` needed.
+- **System Tesseract + tessdata** for the `--ocr` extraction path
+  (scanned/image-only PDFs). PyMuPDF's `get_textpage_ocr` shells out to
+  Tesseract at runtime and raises if it isn't installed — OCR import
+  will fail with a structured error until `tesseract` and language
+  data are present on the host. Regular text-layer PDFs need neither.
+
+## Configuration
+
+Config is layered: `$CROW_HOME/env/reader.env` → the file named by
+`READER_SECRETS_FILE` → `process.env` (highest wins), same `KEY=VALUE`
+format as the other bundles (`#` comments, optional `export `, quoted
+values all accepted).
+
+| Key | Purpose |
+|---|---|
+| `READER_SECRETS_FILE` | Optional second env file |
+| `READER_EMBED_URL` / `READER_EMBED_MODEL` | OpenAI-style embeddings endpoint for semantic search; unset disables it, FTS still works |
+| `GOOGLE_TOKEN_FILE` | Google OAuth2 `authorized_user` JSON; unset hides Drive import and Doc export (later milestone) |
+| `READER_EXPORT_DRIVE_FOLDER_ID` | Drive folder id for Google Doc exports (later milestone) |
+| `READER_UV_BIN` | Path to the `uv` binary (default: `uv` on `PATH`) |
+| `READER_EXTRACT_TIMEOUT_MS` | Extraction subprocess timeout in ms (default `180000`) |
+| `READER_MAX_UPLOAD_MB` | Upload size cap in MB; also caps URL-import downloads (default `50`) |
+| `READER_AUDIO_CACHE_MB` | TTS audio cache cap in MB, used from milestone 2 (default `2048`) |
+| `READER_ALLOW_PRIVATE_URLS` | Set to `1` to let URL import fetch private/loopback addresses (default: blocked — SSRF guard) |
+| `READER_INGEST_ROOTS` | Colon-separated directory allowlist for `crow_reader_ingest` local paths (default: the user home directory) |
+
+URL import blocks private/loopback/link-local addresses by default
+(including addresses reached only after a redirect — every hop is
+re-checked, up to 5 hops) and caps response size at
+`READER_MAX_UPLOAD_MB`. `READER_ALLOW_PRIVATE_URLS=1` is for
+single-user or trusted-network instances that want to archive pages
+served on the LAN; it does not relax the size cap or the scheme check
+(`http`/`https` only).
+
+## Storage
+
+Tables in `crow.db`: `reader_documents` (+ FTS5), `reader_sections`,
+`reader_progress`, `reader_annotations` (+ FTS5, unused until the
+annotations milestone), `reader_chunks` / `reader_chunk_embeddings`
+(unused until semantic search is wired up). Original files and
+archived HTML land in `$CROW_DATA_DIR/reader/originals/` and
+`$CROW_DATA_DIR/reader/archives/`.
+
+## Panel
+
+`/dashboard/reader` — the library: an import card (file upload or
+URL) and a table of imported documents linking into the Read view.
+Import and Read-view HTTP endpoints (`/api/reader/*`, `/reader-app/:id`)
+live in the companion routes file per the gateway's panel-mount
+contract; the panel itself only renders inside the dashboard.

--- a/bundles/reader/README.md
+++ b/bundles/reader/README.md
@@ -31,7 +31,7 @@ milestones don't need a migration.
   never rewinds itself) and resumes on reload.
 - **Library** — `/dashboard/reader` panel: an import card and a table
   of documents with source, extraction status, progress, and tags.
-  FTS5 search over document text backs `crow_reader_list`.
+  FTS5 search over titles, tags, and sources backs `crow_reader_list`.
 - **MCP tools** — `crow_reader_ingest` (import from a local path or
   URL; local paths are checked against an allowlist), `crow_reader_list`
   (FTS-searchable library listing), `crow_reader_get` (one document

--- a/bundles/reader/manifest.json
+++ b/bundles/reader/manifest.json
@@ -2,7 +2,7 @@
   "id": "reader",
   "name": "Reader",
   "version": "0.1.0",
-  "description": "E-reader for project material — import PDFs, web pages, and files; read in a clean paragraph view; originals kept as archival copy. TTS, annotations, and memory promotion arrive in later milestones.",
+  "description": "E-reader for project material — import PDFs, web pages, and files; read in a clean paragraph view; originals kept as archival copies. TTS, annotations, and memory promotion arrive in later milestones.",
   "type": "mcp-server",
   "author": "Crow",
   "category": "productivity",

--- a/bundles/reader/manifest.json
+++ b/bundles/reader/manifest.json
@@ -1,0 +1,45 @@
+{
+  "id": "reader",
+  "name": "Reader",
+  "version": "0.1.0",
+  "description": "E-reader for project material — import PDFs, web pages, and files; read in a clean paragraph view; originals kept as archival copy. TTS, annotations, and memory promotion arrive in later milestones.",
+  "type": "mcp-server",
+  "author": "Crow",
+  "category": "productivity",
+  "tags": ["reader", "ereader", "pdf", "import", "reading"],
+  "icon": "book-open",
+  "server": {
+    "command": "node",
+    "args": ["server/index.js"],
+    "envKeys": [
+      "READER_SECRETS_FILE",
+      "READER_EMBED_URL",
+      "READER_EMBED_MODEL",
+      "GOOGLE_TOKEN_FILE",
+      "READER_EXPORT_DRIVE_FOLDER_ID",
+      "READER_UV_BIN",
+      "READER_EXTRACT_TIMEOUT_MS",
+      "READER_MAX_UPLOAD_MB",
+      "READER_AUDIO_CACHE_MB",
+      "READER_ALLOW_PRIVATE_URLS",
+      "READER_INGEST_ROOTS"
+    ]
+  },
+  "panel": "panel/reader.js",
+  "panelRoutes": "panel/routes.js",
+  "requires": { "min_ram_mb": 128, "min_disk_mb": 200 },
+  "env_vars": [
+    { "name": "READER_SECRETS_FILE", "description": "Optional path to a KEY=VALUE secrets file loaded after $CROW_HOME/env/reader.env (process.env still wins)", "required": false },
+    { "name": "READER_EMBED_URL", "description": "OpenAI-style embeddings base URL for semantic search (POSTs to <url>/embeddings); unset disables semantic search, FTS still works", "required": false },
+    { "name": "READER_EMBED_MODEL", "description": "Embedding model name", "required": false },
+    { "name": "GOOGLE_TOKEN_FILE", "description": "Path to a Google OAuth2 authorized_user JSON; unset hides Drive import and Doc export", "required": false },
+    { "name": "READER_EXPORT_DRIVE_FOLDER_ID", "description": "Drive folder id for Google Doc exports", "required": false },
+    { "name": "READER_UV_BIN", "description": "Path to the uv binary for the Python extractor (default: uv on PATH)", "required": false },
+    { "name": "READER_EXTRACT_TIMEOUT_MS", "description": "Extraction subprocess timeout in ms (default 180000)", "required": false },
+    { "name": "READER_MAX_UPLOAD_MB", "description": "Upload size cap in MB, also caps URL-import downloads (default 50)", "required": false },
+    { "name": "READER_AUDIO_CACHE_MB", "description": "TTS audio cache cap in MB, used from milestone 2 (default 2048)", "required": false },
+    { "name": "READER_ALLOW_PRIVATE_URLS", "description": "Set to 1 to let URL import fetch private/loopback addresses (default: blocked, SSRF guard)", "required": false },
+    { "name": "READER_INGEST_ROOTS", "description": "Colon-separated directory allowlist for crow_reader_ingest local paths (default: the user home directory)", "required": false }
+  ],
+  "notes": "Milestone 1 ships import + Read view. TTS (gateway registry, timing-aware), quote-anchored annotations with crow memory promotion, pdf.js Original view, and Drive/Doc export land in later milestones per the design spec."
+}

--- a/bundles/reader/package-lock.json
+++ b/bundles/reader/package-lock.json
@@ -1,0 +1,1808 @@
+{
+  "name": "crow-bundle-reader",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crow-bundle-reader",
+      "version": "0.1.0",
+      "dependencies": {
+        "@libsql/client": "^0.14.0",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "@mozilla/readability": "^0.6.0",
+        "linkedom": "^0.18.12",
+        "zod": "^3.24.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@libsql/client": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.14.0.tgz",
+      "integrity": "sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.14.0",
+        "@libsql/hrana-client": "^0.7.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.4.4",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.4.7.tgz",
+      "integrity": "sha512-yOL742IfWUlUevnI5PdnIT4fryY3LYTdLm56bnY0wXBw7dhFcnjuA7jrH3oSVz2mjZTHujxoITgAE7V6Z+eAbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.4.7.tgz",
+      "integrity": "sha512-ezc7V75+eoyyH07BO9tIyJdqXXcRfZMbKcLCeF8+qWK5nP8wWuMcfOVywecsXGRbT99zc5eNra4NEx6z5PkSsA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.7.0.tgz",
+      "integrity": "sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-fetch": "^0.3.1",
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "js-base64": "^3.7.5",
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/@libsql/isomorphic-fetch": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.1.tgz",
+      "integrity": "sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.4.7.tgz",
+      "integrity": "sha512-WlX2VYB5diM4kFfNaYcyhw5y+UJAI3xcMkEUJZPtRDEIu85SsSFrQ+gvoKfcVh76B//ztSeEX2wl9yrjF7BBCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.4.7.tgz",
+      "integrity": "sha512-6kK9xAArVRlTCpWeqnNMCoXW1pe7WITI378n4NpvU5EJ0Ok3aNTIC2nRPRjhro90QcnmLL1jPcrVwO4WD1U0xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.4.7.tgz",
+      "integrity": "sha512-CMnNRCmlWQqqzlTw6NeaZXzLWI8bydaXDke63JTUCvu8R+fj/ENsLrVBtPDlxQ0wGsYdXGlrUCH8Qi9gJep0yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.4.7.tgz",
+      "integrity": "sha512-nI6tpS1t6WzGAt1Kx1n1HsvtBbZ+jHn0m7ogNNT6pQHZQj7AFFTIMeDQw/i/Nt5H38np1GVRNsFe99eSIMs9XA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.4.7.tgz",
+      "integrity": "sha512-7pJzOWzPm6oJUxml+PCDRzYQ4A1hTMHAciTAHfFK4fkbDZX33nWPVG7Y3vqdKtslcwAzwmrNDc6sXy2nwWnbiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/libsql": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.4.7.tgz",
+      "integrity": "sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.4.7",
+        "@libsql/darwin-x64": "0.4.7",
+        "@libsql/linux-arm64-gnu": "0.4.7",
+        "@libsql/linux-arm64-musl": "0.4.7",
+        "@libsql/linux-x64-gnu": "0.4.7",
+        "@libsql/linux-x64-musl": "0.4.7",
+        "@libsql/win32-x64-msvc": "0.4.7"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/bundles/reader/package.json
+++ b/bundles/reader/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "crow-bundle-reader",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": { "test": "node --test test/" },
+  "dependencies": {
+    "@libsql/client": "^0.14.0",
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0",
+    "linkedom": "^0.18.12",
+    "@mozilla/readability": "^0.6.0"
+  }
+}

--- a/bundles/reader/package.json
+++ b/bundles/reader/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "scripts": { "test": "node --test test/" },
+  "scripts": { "test": "node --test" },
   "dependencies": {
     "@libsql/client": "^0.14.0",
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/bundles/reader/panel/reader.js
+++ b/bundles/reader/panel/reader.js
@@ -1,0 +1,183 @@
+/**
+ * Crow's Nest Panel — Reader
+ *
+ * Library view: an import card (file upload / URL) and a table of
+ * imported documents linking into the Read view (/reader-app/:id, served
+ * by panel/routes.js). Import + Read-view HTTP surface live in that
+ * companion routes file per the STRICT_PANEL_MOUNT contract; this
+ * handler only renders inside the gateway's dashboard `layout()`.
+ *
+ * Bundle-compatible: dynamic imports resolved from $CROW_HOME/bundles/
+ * reader inside try/catch — the panel renders (degraded) even if the
+ * bundle modules can't load.
+ */
+
+export default {
+  id: "reader",
+  name: "Reader",
+  icon: "book-open",
+  route: "/dashboard/reader",
+  navOrder: 45,
+  category: "productivity",
+
+  async handler(req, res, { db, layout, appRoot }) {
+    const { pathToFileURL } = await import("node:url");
+    const { join } = await import("node:path");
+    const { homedir } = await import("node:os");
+
+    const bundleDir = join(process.env.CROW_HOME || join(homedir(), ".crow"), "bundles", "reader");
+    async function bundleImport(rel) {
+      try {
+        return await import(pathToFileURL(join(bundleDir, rel)).href);
+      } catch {
+        return null;
+      }
+    }
+
+    const renderMod = await bundleImport("server/render.js");
+    if (!renderMod) {
+      const content = `
+        <div class="pm-card">
+          <strong>Reader bundle unavailable</strong>
+          <p class="pm-muted">The reader bundle's server modules could not be loaded. Check the gateway logs and confirm ${escapeFallback(bundleDir)} is installed.</p>
+        </div>`;
+      res.send(layout({ title: "Reader", content }));
+      return;
+    }
+    const { escapeHtml } = renderMod;
+
+    // Ensure reader_* tables exist even if the MCP server hasn't started yet.
+    let queriesMod = null;
+    try {
+      const initMod = await bundleImport("server/init-tables.js");
+      if (initMod) await initMod.initReaderTables(db);
+      queriesMod = await bundleImport("server/queries.js");
+    } catch { /* degraded render below */ }
+
+    let rowsHtml = "";
+    if (!queriesMod) {
+      rowsHtml = `<tr><td colspan="6" class="pm-muted">queries module unavailable</td></tr>`;
+    } else {
+      try {
+        const docs = await queriesMod.listDocuments(db, {});
+        rowsHtml = docs.map((d) => {
+          const progress = d.progress_paragraph != null && d.total_paragraphs
+            ? `${escapeHtml(String(d.progress_paragraph))}/${escapeHtml(String(d.total_paragraphs))}`
+            : "&mdash;";
+          const statusClass = d.extraction_status === "ok" ? "" : " pm-urgent";
+          return `
+            <tr>
+              <td><a href="/reader-app/${Number(d.id)}" data-turbo="false">${escapeHtml(d.title || "Untitled")}</a></td>
+              <td><span class="er-badge">${escapeHtml(d.source_type || "")}</span></td>
+              <td class="${statusClass}"><span class="er-badge er-badge-${escapeHtml(d.extraction_status || "")}">${escapeHtml(d.extraction_status || "")}</span></td>
+              <td>${progress}</td>
+              <td class="pm-muted">${escapeHtml(d.tags || "")}</td>
+              <td class="pm-muted">${escapeHtml((d.updated_at || "").slice(0, 16))}</td>
+            </tr>`;
+        }).join("");
+      } catch (err) {
+        rowsHtml = `<tr><td colspan="6" class="pm-muted">documents unavailable: ${escapeHtml(err.message)}</td></tr>`;
+      }
+    }
+
+    const content = `
+      <style>
+        .er-import-card { background:var(--crow-bg-surface); border:1px solid var(--crow-border);
+          border-radius:8px; padding:1rem; margin-bottom:1.5rem; }
+        .er-import-forms { display:flex; flex-wrap:wrap; gap:1.5rem; }
+        .er-import-form { display:flex; flex-direction:column; gap:0.5rem; min-width:260px; flex:1; }
+        .er-import-form input[type="text"], .er-import-form input[type="url"], .er-import-form input[type="file"] {
+          padding:0.4rem 0.6rem; border:1px solid var(--crow-border); border-radius:6px;
+          background:var(--crow-bg); color:var(--crow-text); }
+        .er-badge { display:inline-block; padding:0.1rem 0.5rem; border-radius:0.5rem;
+          background:var(--crow-bg); border:1px solid var(--crow-border); font-size:0.75rem; }
+        .er-badge-ok { background:#15803d; color:#fff; border-color:transparent; }
+        .er-badge-partial { background:#b45309; color:#fff; border-color:transparent; }
+        .er-badge-failed { background:#b91c1c; color:#fff; border-color:transparent; }
+        .er-badge-pending { background:var(--crow-text-muted); color:#fff; border-color:transparent; }
+        .pm-table { width:100%; border-collapse:collapse; margin-bottom:1.5rem; }
+        .pm-table th { text-align:left; padding:0.5rem 0.75rem; border-bottom:1px solid var(--crow-border); }
+        .pm-table td { padding:0.5rem 0.75rem; border-bottom:1px solid var(--crow-border); }
+        .pm-muted { color:var(--crow-text-muted); font-size:0.85rem; }
+        .pm-card { background:var(--crow-bg-surface); border:1px solid var(--crow-border); border-radius:8px; padding:0.75rem 1rem; margin-bottom:0.5rem; }
+        .pm-btn { display:inline-block; padding:0.4rem 0.9rem; background:var(--crow-accent); color:#fff; border:none; border-radius:6px; cursor:pointer; font-size:0.85rem; text-decoration:none; }
+        h3 { margin:1.25rem 0 0.5rem; }
+      </style>
+
+      <div class="er-import-card">
+        <h3 style="margin-top:0">Import</h3>
+        <div class="er-import-forms">
+          <form class="er-import-form" id="er-file-form">
+            <label for="er-file-input">File (PDF, HTML, TXT, MD)</label>
+            <input type="file" id="er-file-input" name="file" required>
+            <input type="text" name="title" placeholder="Title (optional)">
+            <input type="text" name="tags" placeholder="Tags, comma-separated (optional)">
+            <button class="pm-btn" type="submit">Import file</button>
+          </form>
+          <form class="er-import-form" id="er-url-form">
+            <label for="er-url-input">Web page URL</label>
+            <input type="url" id="er-url-input" name="url" placeholder="https://…" required>
+            <input type="text" name="title" placeholder="Title (optional)">
+            <input type="text" name="tags" placeholder="Tags, comma-separated (optional)">
+            <button class="pm-btn" type="submit">Import URL</button>
+          </form>
+        </div>
+        <p id="er-import-status" class="pm-muted"></p>
+      </div>
+
+      <h3>Library</h3>
+      <table class="pm-table">
+        <thead><tr><th>Title</th><th>Source</th><th>Status</th><th>Progress</th><th>Tags</th><th>Updated</th></tr></thead>
+        <tbody>${rowsHtml || '<tr><td colspan="6" class="pm-muted" style="text-align:center;padding:2rem">No documents yet. Import a file or URL above.</td></tr>'}</tbody>
+      </table>
+
+      <script>
+        (function () {
+          const statusEl = document.getElementById('er-import-status');
+
+          async function submitImport(body, isMultipart) {
+            statusEl.textContent = 'Importing…';
+            try {
+              const res = await fetch('/api/reader/import', {
+                method: 'POST',
+                headers: isMultipart ? undefined : { 'Content-Type': 'application/json' },
+                body,
+              });
+              const data = await res.json();
+              if (!res.ok) {
+                statusEl.textContent = 'Failed: ' + (data.error || res.status);
+                return;
+              }
+              statusEl.textContent = 'Imported (status: ' + data.extraction_status + ')';
+              setTimeout(() => location.reload(), 800);
+            } catch (e) {
+              statusEl.textContent = 'Error: ' + e.message;
+            }
+          }
+
+          const fileForm = document.getElementById('er-file-form');
+          fileForm.addEventListener('submit', (ev) => {
+            ev.preventDefault();
+            submitImport(new FormData(fileForm), true);
+          });
+
+          const urlForm = document.getElementById('er-url-form');
+          urlForm.addEventListener('submit', (ev) => {
+            ev.preventDefault();
+            const fd = new FormData(urlForm);
+            submitImport(JSON.stringify({
+              url: fd.get('url'), title: fd.get('title') || null, tags: fd.get('tags') || null,
+            }), false);
+          });
+        })();
+      </script>`;
+
+    res.send(layout({ title: "Reader", content }));
+  },
+};
+
+function escapeFallback(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/bundles/reader/panel/routes.js
+++ b/bundles/reader/panel/routes.js
@@ -88,11 +88,15 @@ export default function readerRouter(dashboardAuth) {
     });
   }
   router.post("/api/reader/import", async (req, res, next) => {
-    if (!(await ensureLoaded(res))) return;
-    next();
-  }, uploadSingle, async (req, res) => {
-    const config = mods.configMod.loadConfig();
     try {
+      if (!(await ensureLoaded(res))) return;
+      next();
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  }, uploadSingle, async (req, res) => {
+    try {
+      const config = mods.configMod.loadConfig();
       let input;
       if (req.file) {
         input = {
@@ -116,27 +120,32 @@ export default function readerRouter(dashboardAuth) {
 
   // Read view page
   router.get("/reader-app/:id", async (req, res) => {
-    if (!(await ensureLoaded(res))) return;
     const id = Number(req.params.id);
-    const got = await mods.queriesMod.getDocument(db, id);
-    if (!got) return res.status(404).send("Not found");
-    const sectionNumber = Number(req.query.section || 1);
-    const secRow = await db.execute({
-      sql: `SELECT * FROM reader_sections WHERE document_id = ? AND section_number = ?`,
-      args: [id, sectionNumber],
-    });
-    if (secRow.rows.length === 0) return res.status(404).send("Section not found");
-    const progress = await db.execute({
-      sql: `SELECT paragraph FROM reader_progress WHERE document_id = ? AND section_number = ?`,
-      args: [id, sectionNumber],
-    });
-    res.send(mods.renderMod.readerPage({
-      document: got.document,
-      section: secRow.rows[0],
-      sections: got.sections,
-      paragraphs: JSON.parse(String(secRow.rows[0].paragraphs_json)),
-      progress: progress.rows[0] || null,
-    }));
+    if (!Number.isInteger(id) || id <= 0) return res.status(400).send("Bad id");
+    try {
+      if (!(await ensureLoaded(res))) return;
+      const got = await mods.queriesMod.getDocument(db, id);
+      if (!got) return res.status(404).send("Not found");
+      const sectionNumber = Number(req.query.section || 1);
+      const secRow = await db.execute({
+        sql: `SELECT * FROM reader_sections WHERE document_id = ? AND section_number = ?`,
+        args: [id, sectionNumber],
+      });
+      if (secRow.rows.length === 0) return res.status(404).send("Section not found");
+      const progress = await db.execute({
+        sql: `SELECT paragraph FROM reader_progress WHERE document_id = ? AND section_number = ?`,
+        args: [id, sectionNumber],
+      });
+      res.send(mods.renderMod.readerPage({
+        document: got.document,
+        section: secRow.rows[0],
+        sections: got.sections,
+        paragraphs: JSON.parse(String(secRow.rows[0].paragraphs_json)),
+        progress: progress.rows[0] || null,
+      }));
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
   });
 
   return router;

--- a/bundles/reader/panel/routes.js
+++ b/bundles/reader/panel/routes.js
@@ -28,19 +28,20 @@ export default function readerRouter(dashboardAuth) {
 
   async function ensureLoaded(res) {
     if (!mods) {
-      const [dbMod, importMod, queriesMod, renderMod, configMod, initMod] = await Promise.all([
+      const [dbMod, importMod, queriesMod, renderMod, configMod, initMod, progressMod] = await Promise.all([
         importBundleModule("server/db.js"),
         importBundleModule("server/import.js"),
         importBundleModule("server/queries.js"),
         importBundleModule("server/render.js"),
         importBundleModule("server/config.js"),
         importBundleModule("server/init-tables.js"),
+        importBundleModule("server/progress.js"),
       ]);
       if (!dbMod || !importMod || !queriesMod || !renderMod || !configMod) {
         res.status(500).json({ error: "reader bundle modules not available" });
         return false;
       }
-      mods = { dbMod, importMod, queriesMod, renderMod, configMod, initMod };
+      mods = { dbMod, importMod, queriesMod, renderMod, configMod, initMod, progressMod };
     }
     if (!db) {
       db = mods.dbMod.createDbClient();
@@ -113,6 +114,39 @@ export default function readerRouter(dashboardAuth) {
       }
       const result = await mods.importMod.ingestDocument(db, config, input);
       res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.post("/api/reader/progress", async (req, res) => {
+    try {
+      if (!(await ensureLoaded(res))) return;
+      const b = req.body || {};
+      const documentId = Number(b.document_id);
+      const paragraph = Number(b.paragraph);
+      if (!Number.isInteger(documentId) || documentId <= 0 ||
+          !Number.isInteger(paragraph) || paragraph < 0) {
+        return res.status(400).json({ error: "document_id and paragraph must be non-negative integers" });
+      }
+      res.json(await mods.progressMod.saveProgress(db, {
+        document_id: documentId,
+        section_number: Number(b.section_number) || 1,
+        paragraph,
+        total_paragraphs: Number.isInteger(Number(b.total_paragraphs)) ? Number(b.total_paragraphs) : null,
+        audio_time: typeof b.audio_time === "number" ? b.audio_time : null,
+      }));
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.get("/api/reader/progress/:documentId/:sectionNumber", async (req, res) => {
+    try {
+      if (!(await ensureLoaded(res))) return;
+      const row = await mods.progressMod.getProgress(db,
+        Number(req.params.documentId), Number(req.params.sectionNumber));
+      res.json(row || {});
     } catch (err) {
       res.status(500).json({ error: err.message });
     }

--- a/bundles/reader/panel/routes.js
+++ b/bundles/reader/panel/routes.js
@@ -1,0 +1,143 @@
+/**
+ * Reader — panel companion routes.
+ * COPIED to $CROW_HOME/panels/reader-routes.js at install; no relative
+ * imports. STRICT_PANEL_MOUNT: every middleware is path-scoped.
+ */
+import { Router } from "express";
+import express from "express";
+import multer from "multer";
+import { join, resolve, normalize } from "node:path";
+import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const BUNDLE_DIR = join(process.env.CROW_HOME || join(homedir(), ".crow"), "bundles", "reader");
+
+async function importBundleModule(rel) {
+  try { return await import(pathToFileURL(join(BUNDLE_DIR, rel)).href); }
+  catch (err) {
+    console.warn(`[reader routes] failed to import ${rel}: ${err.message}`);
+    return null;
+  }
+}
+
+export default function readerRouter(dashboardAuth) {
+  const router = Router();
+  let mods = null;
+  let db = null;
+
+  async function ensureLoaded(res) {
+    if (!mods) {
+      const [dbMod, importMod, queriesMod, renderMod, configMod, initMod] = await Promise.all([
+        importBundleModule("server/db.js"),
+        importBundleModule("server/import.js"),
+        importBundleModule("server/queries.js"),
+        importBundleModule("server/render.js"),
+        importBundleModule("server/config.js"),
+        importBundleModule("server/init-tables.js"),
+      ]);
+      if (!dbMod || !importMod || !queriesMod || !renderMod || !configMod) {
+        res.status(500).json({ error: "reader bundle modules not available" });
+        return false;
+      }
+      mods = { dbMod, importMod, queriesMod, renderMod, configMod, initMod };
+    }
+    if (!db) {
+      db = mods.dbMod.createDbClient();
+      if (mods.initMod) await mods.initMod.initReaderTables(db);
+    }
+    return true;
+  }
+
+  if (typeof dashboardAuth === "function") {
+    router.use("/reader-app", dashboardAuth);
+    router.use("/api/reader", dashboardAuth);
+    router.use("/reader/static", dashboardAuth);
+  }
+  router.use("/api/reader", express.json({ limit: "1mb" }));
+
+  // Static assets
+  router.get("/reader/static/:file", (req, res) => {
+    const staticDir = resolve(join(BUNDLE_DIR, "panel", "static"));
+    const target = resolve(normalize(join(staticDir, req.params.file)));
+    if (!target.startsWith(staticDir + "/")) return res.status(400).send("Bad path");
+    if (!existsSync(target)) return res.status(404).send("Not found");
+    res.sendFile(target);
+  });
+
+  // Import: multipart file OR JSON {url,...}.
+  // multer resolves from the gateway's node_modules (^2.x) via the
+  // panels/node_modules symlink; the instance is built lazily so
+  // limits.fileSize reflects READER_MAX_UPLOAD_MB at request time.
+  let uploadMw = null;
+  function uploadSingle(req, res, next) {
+    if (!uploadMw) {
+      const capMb = Number(
+        (mods?.configMod?.loadConfig() || {}).READER_MAX_UPLOAD_MB || 50);
+      uploadMw = multer({
+        storage: multer.memoryStorage(),
+        limits: { fileSize: capMb * 1024 * 1024 },
+      }).single("file");
+    }
+    uploadMw(req, res, (err) => {
+      if (err && err.code === "LIMIT_FILE_SIZE") {
+        return res.status(413).json({ error: "File exceeds the upload size cap" });
+      }
+      if (err) return res.status(400).json({ error: err.message });
+      next();
+    });
+  }
+  router.post("/api/reader/import", async (req, res, next) => {
+    if (!(await ensureLoaded(res))) return;
+    next();
+  }, uploadSingle, async (req, res) => {
+    const config = mods.configMod.loadConfig();
+    try {
+      let input;
+      if (req.file) {
+        input = {
+          sourceType: "upload", buffer: req.file.buffer,
+          filename: req.file.originalname,
+          title: req.body?.title || null, tags: req.body?.tags || null,
+          ocr: req.body?.ocr === "1",
+        };
+      } else if (req.body?.url) {
+        input = { sourceType: "url", url: req.body.url,
+                  title: req.body.title || null, tags: req.body.tags || null };
+      } else {
+        return res.status(400).json({ error: "Provide a file or a url" });
+      }
+      const result = await mods.importMod.ingestDocument(db, config, input);
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // Read view page
+  router.get("/reader-app/:id", async (req, res) => {
+    if (!(await ensureLoaded(res))) return;
+    const id = Number(req.params.id);
+    const got = await mods.queriesMod.getDocument(db, id);
+    if (!got) return res.status(404).send("Not found");
+    const sectionNumber = Number(req.query.section || 1);
+    const secRow = await db.execute({
+      sql: `SELECT * FROM reader_sections WHERE document_id = ? AND section_number = ?`,
+      args: [id, sectionNumber],
+    });
+    if (secRow.rows.length === 0) return res.status(404).send("Section not found");
+    const progress = await db.execute({
+      sql: `SELECT paragraph FROM reader_progress WHERE document_id = ? AND section_number = ?`,
+      args: [id, sectionNumber],
+    });
+    res.send(mods.renderMod.readerPage({
+      document: got.document,
+      section: secRow.rows[0],
+      sections: got.sections,
+      paragraphs: JSON.parse(String(secRow.rows[0].paragraphs_json)),
+      progress: progress.rows[0] || null,
+    }));
+  });
+
+  return router;
+}

--- a/bundles/reader/panel/routes.js
+++ b/bundles/reader/panel/routes.js
@@ -37,7 +37,7 @@ export default function readerRouter(dashboardAuth) {
         importBundleModule("server/init-tables.js"),
         importBundleModule("server/progress.js"),
       ]);
-      if (!dbMod || !importMod || !queriesMod || !renderMod || !configMod) {
+      if (!dbMod || !importMod || !queriesMod || !renderMod || !configMod || !progressMod) {
         res.status(500).json({ error: "reader bundle modules not available" });
         return false;
       }
@@ -133,7 +133,7 @@ export default function readerRouter(dashboardAuth) {
         document_id: documentId,
         section_number: Number(b.section_number) || 1,
         paragraph,
-        total_paragraphs: Number.isInteger(Number(b.total_paragraphs)) ? Number(b.total_paragraphs) : null,
+        total_paragraphs: b.total_paragraphs == null ? null : (Number.isInteger(Number(b.total_paragraphs)) ? Number(b.total_paragraphs) : null),
         audio_time: typeof b.audio_time === "number" ? b.audio_time : null,
       }));
     } catch (err) {
@@ -144,8 +144,13 @@ export default function readerRouter(dashboardAuth) {
   router.get("/api/reader/progress/:documentId/:sectionNumber", async (req, res) => {
     try {
       if (!(await ensureLoaded(res))) return;
-      const row = await mods.progressMod.getProgress(db,
-        Number(req.params.documentId), Number(req.params.sectionNumber));
+      const documentId = Number(req.params.documentId);
+      const sectionNumber = Number(req.params.sectionNumber);
+      if (!Number.isInteger(documentId) || documentId <= 0 ||
+          !Number.isInteger(sectionNumber) || sectionNumber <= 0) {
+        return res.status(400).json({ error: "documentId and sectionNumber must be positive integers" });
+      }
+      const row = await mods.progressMod.getProgress(db, documentId, sectionNumber);
       res.json(row || {});
     } catch (err) {
       res.status(500).json({ error: err.message });

--- a/bundles/reader/panel/static/reader.css
+++ b/bundles/reader/panel/static/reader.css
@@ -1,0 +1,27 @@
+:root { --er-bg: #ffffff; --er-fg: #1a1a1a; --er-muted: #666; --er-accent: #2563eb; }
+@media (prefers-color-scheme: dark) {
+  :root { --er-bg: #111418; --er-fg: #e6e6e6; --er-muted: #9aa4b2; }
+}
+body { margin: 0; background: var(--er-bg); color: var(--er-fg);
+  font: 1.05rem/1.7 Georgia, "Times New Roman", serif; }
+.er-header { position: sticky; top: 0; background: var(--er-bg);
+  border-bottom: 1px solid var(--er-muted); padding: .5rem 1rem;
+  display: flex; align-items: center; gap: 1rem;
+  font-family: system-ui, sans-serif; }
+.er-header h1 { font-size: 1rem; margin: 0; flex: 1;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.er-back { color: var(--er-accent); text-decoration: none; font-family: system-ui, sans-serif; }
+.er-reading-pane { max-width: 42rem; margin: 0 auto; padding: 1.5rem 1rem 6rem; }
+.er-para { margin: 0 0 1.1em; }
+.er-para.resume-target { background: color-mix(in srgb, var(--er-accent) 12%, transparent); }
+.er-table-wrap { overflow-x: auto; }
+.er-table-wrap table { border-collapse: collapse; font-family: system-ui, sans-serif;
+  font-size: .85em; }
+.er-table-wrap th, .er-table-wrap td { border: 1px solid var(--er-muted);
+  padding: .3em .6em; text-align: left; }
+.er-status { font-family: system-ui, sans-serif; font-size: .75rem;
+  padding: .1rem .5rem; border-radius: .5rem; background: #b45309; color: #fff; }
+.er-sections { display: flex; gap: .5rem; flex-wrap: wrap; padding: .5rem 1rem;
+  font-family: system-ui, sans-serif; }
+.er-sections a { color: var(--er-accent); text-decoration: none; }
+.er-sections a.active { font-weight: 700; text-decoration: none; }

--- a/bundles/reader/panel/static/reader.js
+++ b/bundles/reader/panel/static/reader.js
@@ -1,0 +1,44 @@
+/** Read view client — resume scroll + progress reporting (no TTS yet). */
+const dataEl = document.getElementById("reader-data");
+if (dataEl) {
+  const DATA = JSON.parse(dataEl.textContent);
+  const paras = document.querySelectorAll(".er-para");
+
+  // Resume: scroll to the saved paragraph.
+  if (DATA.resumeParagraph > 0 && paras[DATA.resumeParagraph]) {
+    paras[DATA.resumeParagraph].classList.add("resume-target");
+    paras[DATA.resumeParagraph].scrollIntoView({ block: "center" });
+  }
+
+  // Progress: furthest paragraph that has crossed mid-viewport, debounced POST.
+  let furthest = DATA.resumeParagraph || 0;
+  let timer = null;
+  const observer = new IntersectionObserver((entries) => {
+    for (const e of entries) {
+      if (!e.isIntersecting) continue;
+      const idx = Number(e.target.dataset.para);
+      if (idx > furthest) {
+        furthest = idx;
+        clearTimeout(timer);
+        timer = setTimeout(save, 2000);
+      }
+    }
+  }, { rootMargin: "-40% 0px -40% 0px" });
+  paras.forEach((p) => observer.observe(p));
+
+  function save() {
+    navigator.sendBeacon?.("/api/reader/progress", new Blob([JSON.stringify({
+      document_id: DATA.documentId,
+      section_number: DATA.sectionNumber,
+      paragraph: furthest,
+      total_paragraphs: DATA.totalParagraphs,
+    })], { type: "application/json" })) ||
+    fetch("/api/reader/progress", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ document_id: DATA.documentId,
+        section_number: DATA.sectionNumber, paragraph: furthest,
+        total_paragraphs: DATA.totalParagraphs }),
+    }).catch(() => {});
+  }
+  window.addEventListener("pagehide", save);
+}

--- a/bundles/reader/scripts/extract.py
+++ b/bundles/reader/scripts/extract.py
@@ -1,0 +1,720 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pymupdf>=1.24"]
+# ///
+"""Reader bundle PDF/text extractor.
+
+Extracts text from a PDF (block-level via PyMuPDF, tables emitted as
+[TABLE] markdown paragraphs), runs the cleanup chain, and prints JSON.
+The cleanup functions are copied verbatim from
+bundles/capstone-tracker/src/services/ereader_tts.py so both readers
+share one battle-tested pipeline.
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import re
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path")
+    ap.add_argument(
+        "--ocr",
+        action="store_true",
+        help="Tesseract OCR at 300 DPI instead of text extraction",
+    )
+    args = ap.parse_args()
+    try:
+        # PyMuPDF prints deprecation/advisory notices ("the `fitz` API is
+        # deprecated...", "Consider using the pymupdf_layout package...")
+        # to stdout, not stderr. The CLI contract is one JSON object on
+        # stdout, so swallow any incidental prints from the library during
+        # extraction and only ever emit the final JSON ourselves.
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            result = extract_file(args.path, use_ocr=args.ocr)
+        print(json.dumps(result))
+    except Exception as e:  # noqa: BLE001 — CLI boundary, structured error out
+        print(json.dumps({"ok": False, "error": f"{type(e).__name__}: {e}"}))
+        sys.exit(1)
+
+
+def split_into_paragraphs(text: str) -> list[str]:
+    """Split text into paragraphs on double newlines, filtering empties."""
+    parts = re.split(r"\n\s*\n", text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def reflow_pdf_text(text: str) -> str:
+    """Clean up PDF-extracted text: rejoin wrapped lines, detect paragraphs.
+
+    PDF extraction produces hard line breaks at column edges and hyphenated
+    word breaks. This function:
+    1. Removes [Page N] markers (keeps content)
+    2. Rejoins hyphenated line breaks (e.g. "selec-\\ntive" -> "selective")
+    3. Detects paragraph boundaries via heuristics
+    4. Outputs clean text with double-newline paragraph separators
+    """
+    # Collapse page markers into a single newline (not double) so reflow
+    # can join sentences that span page boundaries.
+    text = re.sub(r"\n*\[Page \d+\]\n*", "\n", text)
+
+    # Remove page numbers that appear alone on a line (e.g. "615", "616")
+    text = re.sub(r"\n\d{3}\n", "\n", text)
+
+    # Remove common running headers:
+    # "622 Educational Policy" or "West et al. / ... 617"
+    # General pattern: line that's just a page number + journal name,
+    # or author et al. + page number
+    text = re.sub(
+        r"\n\d{2,4}\s+[A-Z][a-z]+\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\s*\n", "\n", text
+    )
+    text = re.sub(r"\n[A-Z][a-z]+(?:\s+et\s+al\.)[^\n]*?\d{2,4}\s*\n", "\n", text)
+
+    # Rejoin hyphenated line breaks
+    text = re.sub(r"-\s*\n\s*", "", text)
+
+    lines = text.split("\n")
+    paragraphs = []
+    current = []
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            # Blank line = paragraph break
+            if current:
+                paragraphs.append(" ".join(current))
+                current = []
+            continue
+
+        # Detect paragraph boundaries within continuous text:
+        # Previous line ends with sentence-ending punctuation (possibly
+        # followed by footnote numbers, closing quotes/parens) and
+        # current line starts with a capital letter
+        if (
+            current
+            and len(current[-1]) > 1
+            and re.search(r'[.?!][\d"\')\]]*$', current[-1])
+            and stripped[0].isupper()
+        ):
+            # Check it's not a mid-sentence capital (common abbreviations)
+            last_word = current[-1].split()[-1] if current[-1].split() else ""
+            # Strip trailing footnote numbers for abbreviation check
+            check_word = re.sub(r"\d+$", "", last_word)
+            # Don't break after common abbreviations or single initials
+            if not re.match(r"^[A-Z]\.$", check_word) and check_word not in (
+                "Dr.",
+                "Mr.",
+                "Mrs.",
+                "Ms.",
+                "St.",
+                "Jr.",
+                "Sr.",
+                "vs.",
+                "Vol.",
+                "No.",
+                "pp.",
+                "ed.",
+                "eds.",
+                "al.",
+                "etc.",
+                "i.e.",
+                "e.g.",
+                "U.S.",
+            ):
+                paragraphs.append(" ".join(current))
+                current = []
+
+        current.append(stripped)
+
+    if current:
+        paragraphs.append(" ".join(current))
+
+    # Clean up extra spaces
+    paragraphs = [re.sub(r"\s{2,}", " ", p).strip() for p in paragraphs]
+    # Filter empty and very short paragraphs (page artifacts)
+    paragraphs = [p for p in paragraphs if len(p) > 5]
+
+    return "\n\n".join(paragraphs)
+
+
+def strip_chart_axis_data(text: str) -> str:
+    """Strip chart axis data (runs of consecutive numbers) from text.
+
+    PDF chart extraction produces axis tick marks and data-point values
+    as regular text — either appended to figure captions or merged into
+    body paragraphs. This strips runs of 6+ consecutive bare numbers
+    and any trailing axis-label fragments.
+    """
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        result.append(_strip_number_run(line))
+    return "\n".join(result)
+
+
+def _strip_number_run(line: str, min_run: int = 6) -> str:
+    """Remove the first run of min_run+ consecutive bare numbers from a line.
+
+    Preserves numbers that end a year range (e.g. "1997 to 2013").
+    """
+    words = line.split()
+    if len(words) < min_run:
+        return line
+
+    run_start = None
+    run_len = 0
+
+    for i, word in enumerate(words):
+        if re.match(r"^\d[\d,.%$]*$", word):
+            if run_len == 0:
+                run_start = i
+            run_len += 1
+        else:
+            if run_len >= min_run:
+                # Preserve end of year range ("to 2013")
+                keep_to = run_start
+                if run_start > 0 and words[run_start - 1].lower() in (
+                    "to",
+                    "through",
+                    "–",
+                    "-",
+                ):
+                    keep_to = run_start + 1
+                return " ".join(words[:keep_to]).rstrip()
+            run_start = None
+            run_len = 0
+
+    # Run extends to end of line
+    if run_len >= min_run:
+        keep_to = run_start
+        if run_start > 0 and words[run_start - 1].lower() in (
+            "to",
+            "through",
+            "–",
+            "-",
+        ):
+            keep_to = run_start + 1
+        return " ".join(words[:keep_to]).rstrip()
+
+    return line
+
+
+def strip_running_headers(text: str) -> str:
+    """Auto-detect and strip running headers from PDF-extracted text.
+
+    Academic PDFs have running headers (shortened title on odd pages,
+    author name on even pages). PDF extraction sometimes merges these
+    into content lines. This detects repeated short phrases at line
+    starts and removes them.
+    """
+    lines = text.split("\n")
+    non_empty = [l.strip() for l in lines if l.strip()]
+
+    if len(non_empty) < 10:
+        return text
+
+    # Count occurrences and line positions of each short phrase at line starts
+    prefix_counts = {}  # prefix -> {standalone: N, as_prefix: N}
+    prefix_lines = {}  # prefix -> [line_indices] (for spread check)
+    for idx, line in enumerate(non_empty):
+        words = line.split()
+        for n in range(1, min(13, len(words) + 1)):
+            prefix = " ".join(words[:n])
+            if prefix not in prefix_counts:
+                prefix_counts[prefix] = {"standalone": 0, "as_prefix": 0}
+                prefix_lines[prefix] = []
+            prefix_lines[prefix].append(idx)
+            if len(words) == n:
+                prefix_counts[prefix]["standalone"] += 1
+            else:
+                prefix_counts[prefix]["as_prefix"] += 1
+
+    # Find headers: repeated short phrases starting with a capital letter
+    headers = []
+    total_lines = len(non_empty)
+    for prefix, counts in prefix_counts.items():
+        words = prefix.split()
+        # Single-word headers must start uppercase
+        if len(words) == 1 and not words[0][0].isupper():
+            continue
+        # Single words must be 4+ chars (skip "The", "For", etc.)
+        if len(words) == 1 and len(prefix) < 4:
+            continue
+        # Multi-word: standalone + prefix path (original, conservative)
+        if len(words) >= 2 and counts["standalone"] >= 1 and counts["as_prefix"] >= 2:
+            if words[0][0].isupper():
+                headers.append(prefix)
+        # Multi-word: prefix-only path (catches lowercase headers like
+        # "journal of education finance" that never appear standalone)
+        elif len(words) >= 2 and counts["as_prefix"] >= 4:
+            positions = prefix_lines[prefix]
+            span = positions[-1] - positions[0]
+            if span >= total_lines * 0.4:
+                headers.append(prefix)
+        # Single-word: standalone 3+ times AND spread across the document
+        # (filters out charter school names clustered in table rows)
+        elif counts["standalone"] >= 3:
+            positions = prefix_lines[prefix]
+            span = positions[-1] - positions[0]
+            if span >= total_lines * 0.6:
+                headers.append(prefix)
+
+    if not headers:
+        return text
+
+    # Keep longest non-overlapping headers (remove sub-prefixes)
+    headers.sort(key=len, reverse=True)
+    final_headers = []
+    for h in headers:
+        if not any(fh.startswith(h) for fh in final_headers):
+            final_headers.append(h)
+
+    # Strip headers from lines
+    result = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            result.append(line)
+            continue
+        modified = False
+        for header in final_headers:
+            if stripped == header:
+                result.append("")
+                modified = True
+                break
+            elif stripped.startswith(header + " "):
+                remainder = stripped[len(header) :].strip()
+                # Strip leading page number (1-3 digits only — avoids
+                # stripping 4-digit years like 2019, 2023)
+                remainder = re.sub(r"^\d{1,3}\s+", "", remainder)
+                result.append(remainder)
+                modified = True
+                break
+        if not modified:
+            result.append(line)
+
+    return "\n".join(result)
+
+
+def strip_publisher_watermarks(text: str) -> str:
+    """Strip publisher download watermarks and page margin artifacts.
+
+    Academic PDFs from Wiley, Elsevier, etc. contain per-page artifacts
+    that pdftotext extracts alongside content:
+    - Download notices ("Downloaded from https://... Online Library on ...")
+    - Terms and Conditions URLs
+    - Bare DOI fragments ("10.1002/asi")
+    - Merged-word sidebar artifacts ("OFASSOCIATION")
+    - Journal citation fragments in headers/footers
+    - Submission/revision metadata ("Received...; revised...; accepted...")
+    - Publisher URLs and short DOI lines
+    - Merged year+page numbers ("20162015 1173")
+    - Color figure boilerplate notices
+    """
+    # ── Inline substitutions (strip boilerplate from within lines) ──
+    # JSTOR download notice + terms (often merged inline with content)
+    text = re.sub(
+        r"This content downloaded from \d[\d.]+\s+on\s+\w+,\s+\d+\s+\w+\s+\d{4}\s+[\d:]+\s+UTC\s*"
+        r"All use subject to https?://about\.jstor\.org/terms\s*",
+        "\n\n",
+        text,
+        flags=re.IGNORECASE,
+    )
+    # Standalone variants
+    text = re.sub(
+        r"All use subject to https?://about\.jstor\.org/terms\s*",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        r"This content downloaded from \d[\d.]+[^\n]*UTC\s*",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+
+    # Wiley color figure notice in captions
+    text = re.sub(
+        r"\s*\[Color figure can be viewed in the online issue,"
+        r"[^]]*\]\.?",
+        "",
+        text,
+    )
+
+    lines = text.split("\n")
+    result = []
+
+    # ── Compiled patterns for line removal ──
+    remove_patterns = [
+        # Publisher download watermark
+        re.compile(
+            r"Downloaded from https?://.*(?:Online Library|wiley\.com"
+            r"|elsevier\.com|springer\.com|sagepub\.com|tandfonline\.com)",
+            re.IGNORECASE,
+        ),
+        # Terms and Conditions notice
+        re.compile(
+            r"Terms and Conditions.*(?:wiley|elsevier|springer"
+            r"|Creative Commons)",
+            re.IGNORECASE,
+        ),
+    ]
+
+    # Bare DOI fragment (just "10.NNNN/xxx" with no prose around it)
+    bare_doi_re = re.compile(r"^10\.\d{4,}/\S*$")
+    # Short DOI line: "DOI: 10.NNNN/xxx" possibly with publisher URL
+    short_doi_re = re.compile(r"^DOI:\s*10\.\d{4,}")
+    # Merged-word sidebar artifacts (ALL CAPS, no spaces, 8+ chars)
+    merged_caps_re = re.compile(r"^[A-Z]{8,}$")
+    # Short ALL-CAPS lines (journal sidebar fragments)
+    caps_frag_re = re.compile(r"^[A-Z][A-Z\s,–—•]+$")
+    # Journal citation header/footer fragments
+    citation_frag_re = re.compile(r"\d+\(\d+\):\d+[–-]\d+")
+    # Bullet-char citation placeholders: "••(••):••–••, 2015"
+    bullet_re = re.compile(r"••")
+    # Merged year+page numbers: "20162015 1173"
+    year_page_re = re.compile(r"^\d{8}\s+\d{3,4}$")
+    # Journal submission metadata: "Received Month DD, YYYY; revised..."
+    received_re = re.compile(r"^Received\s+\w+\s+\d{1,2},\s*\d{4}")
+    # Short publisher URL fragments
+    pub_url_re = re.compile(
+        r"wileyonlinelibrary\.com|onlinelibrary\.wiley\.com"
+        r"|sciencedirect\.com|link\.springer\.com",
+        re.IGNORECASE,
+    )
+    # Publisher/society name fragments: "ASIS&T", "inLibrary", "Published"
+    # (short lines only — these appear as garbled sidebar text)
+    pub_frag_re = re.compile(
+        r"(?:ASIS&T|inLibrary|Publishedonline|Published\s*online"
+        r"|Wiley\s+Online)",
+        re.IGNORECASE,
+    )
+    # Bare "DOI:" or "DOI:DOI:" without a number
+    bare_doi_label_re = re.compile(r"^DOI:\s*(?:DOI:)?\s*$")
+    # Lowercase "doi: 10.NNNN/..." line
+    lowercase_doi_re = re.compile(r"^doi:\s*10\.\d{4,}", re.IGNORECASE)
+    # Copyright line: "© 2011 ..." or "Ⓒ 2011 ..."
+    copyright_re = re.compile(r"^[©Ⓒ]\s*\d{4}\s+")
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            result.append(line)
+            continue
+
+        # Regex-search patterns (any match → remove)
+        if any(p.search(stripped) for p in remove_patterns):
+            result.append("")
+            continue
+
+        # Bare DOI fragment
+        if bare_doi_re.match(stripped):
+            result.append("")
+            continue
+        # Short standalone DOI line (< 60 chars)
+        if len(stripped) < 60 and short_doi_re.match(stripped):
+            result.append("")
+            continue
+        # Bare "DOI:" label
+        if bare_doi_label_re.match(stripped):
+            result.append("")
+            continue
+        # Lowercase DOI line (short)
+        if len(stripped) < 60 and lowercase_doi_re.match(stripped):
+            result.append("")
+            continue
+        # Copyright line
+        if len(stripped) < 80 and copyright_re.match(stripped):
+            result.append("")
+            continue
+        # Merged ALL-CAPS word
+        if merged_caps_re.match(stripped) and len(stripped) >= 10:
+            result.append("")
+            continue
+        # Short ALL-CAPS fragments (3-30 chars)
+        if 3 <= len(stripped) < 30 and caps_frag_re.match(stripped):
+            result.append("")
+            continue
+        # Citation fragment in short line
+        if len(stripped) < 60 and citation_frag_re.search(stripped):
+            result.append("")
+            continue
+        # Bullet placeholders in short line
+        if len(stripped) < 40 and bullet_re.search(stripped):
+            result.append("")
+            continue
+        # Merged year+page numbers
+        if year_page_re.match(stripped):
+            result.append("")
+            continue
+        # Journal submission metadata
+        if received_re.match(stripped):
+            result.append("")
+            continue
+        # Short publisher URL fragments (< 60 chars)
+        if len(stripped) < 60 and pub_url_re.search(stripped):
+            result.append("")
+            continue
+        # Publisher/society name fragments (< 60 chars)
+        if len(stripped) < 60 and pub_frag_re.search(stripped):
+            result.append("")
+            continue
+        # Wiley ISSN/download ID lines
+        if re.match(r"^\d{7,},\s*\d{4},", stripped):
+            result.append("")
+            continue
+
+        result.append(line)
+
+    return "\n".join(result)
+
+
+def split_figure_captions(text: str) -> str:
+    """Separate figure captions from body text when merged on one line.
+
+    PDF extraction sometimes puts a figure caption and the following
+    body text on the same line. This splits them apart when the line
+    starts with "Figure N." and is long enough to contain body text.
+    """
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        stripped = line.strip()
+        # Only process long lines starting with "Figure N"
+        if len(stripped) > 150 and re.match(r"Figure\s+\d", stripped):
+            # Split after the last year in the caption, before body text
+            m = re.match(
+                r"(Figure\s+\d+\.?\s+.+\b\d{4})\s+([A-Z][a-z])",
+                stripped,
+            )
+            if m:
+                result.append(m.group(1))
+                result.append("")  # blank line forces paragraph break in reflow
+                result.append(m.group(2) + stripped[m.end() :])
+                continue
+        result.append(line)
+    return "\n".join(result)
+
+
+def presplit_long_lines(text: str, max_len: int = 300) -> str:
+    """Pre-split very long lines at sentence boundaries.
+
+    PDF extraction sometimes puts an entire page on one line (1000+ chars).
+    reflow_pdf_text() only detects paragraph breaks across lines, not
+    within them. This splits long lines at sentence endings so reflow
+    can find paragraph boundaries.
+    """
+    lines = text.split("\n")
+    result = []
+    for line in lines:
+        if len(line.strip()) > max_len:
+            parts = re.split(r"(?<=[.!?])\s+", line.strip())
+            result.extend(parts)
+        else:
+            result.append(line)
+    return "\n".join(result)
+
+
+def extract_table_blocks(text: str) -> tuple[str, dict[str, str]]:
+    """Extract [TABLE] blocks from text, replacing with placeholders.
+
+    Before reflow_pdf_text() runs, this pulls out table markdown so it
+    won't be destroyed by line-joining heuristics.
+
+    Returns:
+        (text_with_placeholders, {placeholder_key: table_markdown})
+    """
+    tables = {}
+    counter = 0
+    lines = text.split("\n")
+    result_lines = []
+    i = 0
+
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped == "[TABLE]" or "[TABLE]" in stripped:
+            # Handle [TABLE] embedded mid-line (e.g. "Debt Service [TABLE]")
+            if stripped != "[TABLE]" and "[TABLE]" in stripped:
+                before = stripped.split("[TABLE]")[0].strip()
+                if before:
+                    result_lines.append(before)
+
+            # Collect table lines (pipe-delimited rows) until blank or non-pipe
+            table_lines = []
+            i += 1
+            while i < len(lines):
+                line = lines[i].strip()
+                if not line:
+                    break
+                if line.startswith("|") or re.match(r"^[-|:\s]+$", line):
+                    table_lines.append(lines[i])
+                    i += 1
+                else:
+                    break
+            if table_lines:
+                placeholder = f"__TABLE_PLACEHOLDER_{counter}__"
+                tables[placeholder] = "\n".join(table_lines)
+                result_lines.append("")
+                result_lines.append(placeholder)
+                result_lines.append("")
+                counter += 1
+            else:
+                # [TABLE] with no table content — keep as-is
+                result_lines.append(lines[i - 1] if i > 0 else stripped)
+        else:
+            result_lines.append(lines[i])
+            i += 1
+
+    return "\n".join(result_lines), tables
+
+
+def restore_table_blocks(paragraphs: list[str], tables: dict[str, str]) -> list[str]:
+    """Replace table placeholders in paragraphs with [TABLE] blocks.
+
+    After reflow + split, find placeholder strings and restore original
+    table markdown as standalone paragraphs.
+    """
+    result = []
+    for para in paragraphs:
+        stripped = para.strip()
+        # Check if this paragraph IS a placeholder (most common case)
+        if stripped in tables:
+            result.append(f"[TABLE]\n{tables[stripped]}")
+            continue
+        # Check if placeholder is embedded in merged text
+        found = False
+        for placeholder, table_md in tables.items():
+            if placeholder in para:
+                # Split around placeholder, emit non-empty parts
+                parts = para.split(placeholder)
+                before = parts[0].strip()
+                after = parts[1].strip() if len(parts) > 1 else ""
+                if before:
+                    result.append(before)
+                result.append(f"[TABLE]\n{table_md}")
+                if after:
+                    result.append(after)
+                found = True
+                break
+        if not found:
+            result.append(para)
+    return result
+
+
+def split_long_paragraph(text: str, max_words: int = 500) -> list[str]:
+    """Split a long paragraph at sentence boundaries if it exceeds max_words."""
+    words = text.split()
+    if len(words) <= max_words:
+        return [text]
+
+    # Split on sentence boundaries
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    chunks = []
+    current = []
+    current_count = 0
+
+    for sentence in sentences:
+        word_count = len(sentence.split())
+        if current_count + word_count > max_words and current:
+            chunks.append(" ".join(current))
+            current = [sentence]
+            current_count = word_count
+        else:
+            current.append(sentence)
+            current_count += word_count
+
+    if current:
+        chunks.append(" ".join(current))
+
+    return chunks
+
+
+def extract_pdf_text(path: str, use_ocr: bool = False) -> tuple[str, dict]:
+    """Whole-document block-level extraction. Tables become [TABLE] blocks."""
+    import fitz  # PyMuPDF
+
+    doc = fitz.open(path)
+    pages_out = []
+    empty_pages = 0
+    for page in doc:
+        if use_ocr:
+            tp = page.get_textpage_ocr(dpi=300, full=True)
+            text = page.get_text(textpage=tp)
+            pages_out.append(text)
+            if not text.strip():
+                empty_pages += 1
+            continue
+
+        table_bboxes, table_paras = [], []
+        try:
+            finder = page.find_tables()
+            for t in finder.tables if finder else []:
+                md = t.to_markdown()
+                if md and md.count("|") >= 4:
+                    table_bboxes.append(fitz.Rect(t.bbox))
+                    table_paras.append((t.bbox[1], "[TABLE]\n" + md.strip()))
+        except Exception:
+            pass  # tables are best-effort; text blocks still extract
+
+        blocks = []
+        for b in page.get_text("blocks"):
+            x0, y0, x1, y1, text, _bno, btype = b[:7]
+            if btype != 0 or not text.strip():
+                continue
+            rect = fitz.Rect(x0, y0, x1, y1)
+            if any(rect.intersects(tb) for tb in table_bboxes):
+                continue  # covered by the table markdown
+            blocks.append((y0, text.strip()))
+
+        merged = sorted(blocks + table_paras, key=lambda p: p[0])
+        page_text = "\n\n".join(t for _y, t in merged)
+        if not page_text.strip():
+            empty_pages += 1
+        pages_out.append(page_text)
+
+    diagnostics = {"pages": len(doc), "empty_pages": empty_pages, "used_ocr": use_ocr}
+    doc.close()
+    return "\n\n".join(pages_out), diagnostics
+
+
+SECTION_MAX_PARAS = 400
+
+
+def extract_file(path: str, use_ocr: bool = False) -> dict:
+    if path.lower().endswith(".pdf"):
+        raw, diagnostics = extract_pdf_text(path, use_ocr=use_ocr)
+        text, table_blocks = extract_table_blocks(raw)
+        text = strip_running_headers(text)
+        text = strip_publisher_watermarks(text)
+        text = strip_chart_axis_data(text)
+        text = split_figure_captions(text)
+        text = presplit_long_lines(text)
+        text = reflow_pdf_text(text)
+        paras = []
+        for p in split_into_paragraphs(text):
+            paras.extend(split_long_paragraph(p))
+        if table_blocks:
+            paras = restore_table_blocks(paras, table_blocks)
+    else:  # txt / md: trust the text, split only
+        with open(path, encoding="utf-8", errors="replace") as f:
+            raw = f.read()
+        diagnostics = {"pages": 0, "empty_pages": 0, "used_ocr": False}
+        paras = []
+        for p in split_into_paragraphs(raw):
+            paras.extend(split_long_paragraph(p))
+
+    sections = [
+        {"title": None, "paragraphs": paras[i : i + SECTION_MAX_PARAS]}
+        for i in range(0, len(paras), SECTION_MAX_PARAS)
+    ] or [{"title": None, "paragraphs": []}]
+    return {"ok": True, "sections": sections, "diagnostics": diagnostics}
+
+
+if __name__ == "__main__":
+    main()

--- a/bundles/reader/server/app-root.js
+++ b/bundles/reader/server/app-root.js
@@ -1,0 +1,30 @@
+/**
+ * Resolve the Crow app repo root from an INSTALLED copy (a bundles dir under any ~/.crow home)
+ * or an in-repo run, so bundle code can import the shared better-sqlite3
+ * db client instead of carrying its own SQLite build.
+ *
+ * WHY THIS MATTERS (2026-08-04 corruption root cause): loading a second
+ * SQLite implementation (@libsql/client) into a process that already holds
+ * better-sqlite3 connections defeats SQLite's last-closer detection -- POSIX
+ * fcntl locks never conflict within one PID, so a libsql connection close
+ * "wins" its am-I-alone check and unlinks crow.db-wal/-shm out from under
+ * every other connection. Split WAL generations then corrupt the DB.
+ * Panel routes import bundle server modules INTO the gateway process, so a
+ * bundle that opens crow.db must always reach the gateway's own client.
+ *
+ * Resolution: CROW_APP_ROOT (exported by the gateway to its children) ->
+ * relative guess (in-repo runs) -> ~/crow (conventional lab checkout, covers
+ * externally spawned stdio MCP copies that get no CROW_APP_ROOT).
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+function looksLikeAppRoot(p) { return !!p && existsSync(join(p, "servers", "db.js")); }
+const guess = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const conventional = join(homedir(), "crow");
+export const APP_ROOT = looksLikeAppRoot(process.env.CROW_APP_ROOT) ? process.env.CROW_APP_ROOT
+  : looksLikeAppRoot(guess) ? guess
+  : looksLikeAppRoot(conventional) ? conventional
+  : (process.env.CROW_APP_ROOT || guess);
+export const appImport = (rel) => import(pathToFileURL(join(APP_ROOT, rel)).href);

--- a/bundles/reader/server/config.js
+++ b/bundles/reader/server/config.js
@@ -1,0 +1,89 @@
+/**
+ * Reader — configuration loader.
+ *
+ * Layered, lowest to highest precedence:
+ *   1. $CROW_HOME/env/reader.env         (KEY=VALUE lines)
+ *   2. $READER_SECRETS_FILE              (same format, if set)
+ *   3. process.env                       (always wins)
+ *
+ * File format: one KEY=VALUE per line. Blank lines and lines starting
+ * with '#' are ignored. A leading "export " is stripped, and values may
+ * be wrapped in single or double quotes (stripped).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export function crowHome() {
+  return process.env.CROW_HOME || join(homedir(), ".crow");
+}
+
+/** Parse a KEY=VALUE env file into a plain object. Missing file → {}. */
+export function parseEnvFile(path) {
+  const out = {};
+  try {
+    if (!path || !existsSync(path)) return out;
+    const text = readFileSync(path, "utf8");
+    for (const rawLine of text.split("\n")) {
+      let line = rawLine.trim();
+      if (!line || line.startsWith("#")) continue;
+      if (line.startsWith("export ")) line = line.slice("export ".length).trim();
+      const eq = line.indexOf("=");
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq).trim();
+      let value = line.slice(eq + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+        (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (key) out[key] = value;
+    }
+  } catch (err) {
+    console.warn(`[reader] Failed to read env file ${path}: ${err.message}`);
+  }
+  return out;
+}
+
+const KEYS = [
+  "READER_SECRETS_FILE",
+  "READER_EMBED_URL",
+  "READER_EMBED_MODEL",
+  "GOOGLE_TOKEN_FILE",
+  "READER_EXPORT_DRIVE_FOLDER_ID",
+  "READER_UV_BIN",
+  "READER_EXTRACT_TIMEOUT_MS",
+  "READER_MAX_UPLOAD_MB",
+  "READER_AUDIO_CACHE_MB",
+  "READER_ALLOW_PRIVATE_URLS",
+  "READER_INGEST_ROOTS",
+  "CROW_DATA_DIR",
+  "CROW_DB_PATH",
+];
+
+/**
+ * Build the effective config. Re-reads files on every call so long-lived
+ * processes see edits without restart (calls are infrequent — tool invocations).
+ */
+export function loadConfig() {
+  const base = parseEnvFile(join(crowHome(), "env", "reader.env"));
+  // Secrets file may be named by process.env or by the base env file.
+  const secretsPath = process.env.READER_SECRETS_FILE || base.READER_SECRETS_FILE || null;
+  const secrets = parseEnvFile(secretsPath);
+
+  const merged = { ...base, ...secrets };
+  for (const k of KEYS) {
+    if (process.env[k] !== undefined && process.env[k] !== "") merged[k] = process.env[k];
+  }
+
+  return {
+    ...merged,
+    // Defaults
+    READER_UV_BIN: merged.READER_UV_BIN || "uv",
+    READER_EXTRACT_TIMEOUT_MS: merged.READER_EXTRACT_TIMEOUT_MS || "180000",
+    READER_MAX_UPLOAD_MB: merged.READER_MAX_UPLOAD_MB || "50",
+    READER_AUDIO_CACHE_MB: merged.READER_AUDIO_CACHE_MB || "2048",
+  };
+}

--- a/bundles/reader/server/db.js
+++ b/bundles/reader/server/db.js
@@ -1,0 +1,142 @@
+/**
+ * Reader — database client factory (bundle edition).
+ *
+ * Resolution order for the crow DB path:
+ *   1. explicit dbPath argument
+ *   2. CROW_DB_PATH env
+ *   3. $CROW_DATA_DIR/crow.db
+ *   4. $CROW_HOME/data/crow.db (default ~/.crow/data/crow.db)
+ *
+ * FTS sanitizer copied from the knowledge-base bundle so MATCH queries
+ * are always literal-term safe.
+ */
+
+import { appImport } from "./app-root.js";
+import { existsSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Sanitize user input for use in SQLite FTS5 MATCH queries.
+ * Strips FTS5 operators and wraps individual terms in double quotes
+ * for safe literal matching. Returns null if no valid terms remain.
+ */
+export function sanitizeFtsQuery(input) {
+  if (!input || typeof input !== "string") return null;
+  const cleaned = input
+    .replace(/\b(AND|OR|NOT|NEAR)\b/gi, "")
+    .replace(/[*"(){}[\]^~:]/g, "")
+    .trim();
+  if (!cleaned) return null;
+  const terms = cleaned
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+    .map((w) => `"${w}"`)
+    .join(" ");
+  return terms || null;
+}
+
+/**
+ * Escape SQL LIKE wildcard characters in user input.
+ * Use with `LIKE ? ESCAPE '\'` in queries.
+ */
+export function escapeLikePattern(input) {
+  if (!input || typeof input !== "string") return input;
+  return input
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_");
+}
+
+/** Resolve the Crow data directory. */
+export function resolveDataDir() {
+  if (process.env.CROW_DATA_DIR) return resolve(process.env.CROW_DATA_DIR);
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  const crowData = join(process.env.CROW_HOME || join(home, ".crow"), "data");
+  if (existsSync(crowData)) return crowData;
+  // Bundle fallback: repo root's data/ (3 levels up from bundles/reader/server/)
+  const repoData = resolve(__dirname, "../../../data");
+  if (existsSync(repoData)) return repoData;
+  return crowData;
+}
+
+/** Resolve the crow.db path without opening it. */
+export function resolveDbPath(dbPath) {
+  return dbPath || process.env.CROW_DB_PATH || join(resolveDataDir(), "crow.db");
+}
+
+/**
+ * Shared better-sqlite3 client factory from the core repo (libsql-shaped
+ * surface: execute/batch/executeMultiple/close). Loaded once at module init.
+ *
+ * A single SQLite implementation per process is a CORRECTNESS requirement,
+ * not a preference: this module is imported into the gateway process by the
+ * panel routes, and a second SQLite build (@libsql) opening crow.db there
+ * defeats last-closer detection and unlinks the live WAL (see app-root.js
+ * header — 2026-08-04 corruption root cause).
+ *
+ * Fallback: only when the core client cannot load (standalone install with
+ * no repo checkout, or a node whose ABI can't load the repo's
+ * better-sqlite3 — e.g. an externally spawned stdio MCP copy on an older
+ * node). @libsql is imported LAZILY there so gateway-hosted code never even
+ * maps the second SQLite library. Cross-process libsql is lock-safe; only
+ * in-process mixing is not, and in-process always resolves the core client.
+ */
+let _coreCreateDbClient = null;
+try {
+  ({ createDbClient: _coreCreateDbClient } = await appImport("servers/db.js"));
+} catch (err) {
+  console.warn(
+    `[reader db] core db client unavailable (${err.message}) — ` +
+    "will fall back to @libsql/client (safe cross-process only)"
+  );
+}
+
+let _coreBroken = false;
+/** Core factory with call-time fallback: better-sqlite3 binds its native
+ *  module lazily at construction, so an ABI mismatch (e.g. a node 20
+ *  process importing a node 22 build) throws HERE, not at import. */
+function tryCoreClient(filePath) {
+  if (_coreBroken || !_coreCreateDbClient) return null;
+  try { return _coreCreateDbClient(filePath); }
+  catch (err) {
+    _coreBroken = true;
+    console.warn(`[reader db] core db client failed (${err.message.split("\n")[0]}) -- ` +
+      "falling back to @libsql/client (safe cross-process only)");
+    return null;
+  }
+}
+
+
+async function libsqlClient(filePath, label) {
+  const { createClient } = await import("@libsql/client");
+  const client = createClient({ url: `file:${filePath}` });
+  client.execute("PRAGMA busy_timeout = 10000").catch((err) =>
+    console.warn(`[reader db] ${label} busy_timeout:`, err.message)
+  );
+  return client;
+}
+
+/** Create a client for the main crow DB (core better-sqlite3 wrapper). */
+export function createDbClient(dbPath) {
+  const filePath = resolveDbPath(dbPath);
+  return tryCoreClient(filePath) || libsqlProxy(filePath, "crow.db");
+}
+
+/**
+ * Wrap the async libsql fallback in a lazily-resolving proxy so the factory
+ * keeps its synchronous signature. Every method awaits the underlying
+ * client's creation first.
+ */
+function libsqlProxy(filePath, label) {
+  const clientPromise = libsqlClient(filePath, label);
+  return {
+    async execute(arg) { return (await clientPromise).execute(arg); },
+    async batch(stmts) { return (await clientPromise).batch(stmts); },
+    async executeMultiple(sql) { return (await clientPromise).executeMultiple(sql); },
+    close() { clientPromise.then((c) => c.close()).catch(() => {}); },
+  };
+}

--- a/bundles/reader/server/extract.js
+++ b/bundles/reader/server/extract.js
@@ -21,7 +21,12 @@ export function runExtraction(filePath, config, { ocr = false, scriptPath = DEFA
     let stdout = "";
     let stderr = "";
     let timedOut = false;
-    const child = spawn(config.READER_UV_BIN || "uv", args, { detached: true });
+    let child;
+    try {
+      child = spawn(config.READER_UV_BIN || "uv", args, { detached: true });
+    } catch (err) {
+      return resolvePromise({ ok: false, error: `extractor spawn failed: ${err.message}` });
+    }
     const timer = setTimeout(() => {
       timedOut = true;
       try { process.kill(-child.pid, "SIGKILL"); } catch { /* group already gone */ }

--- a/bundles/reader/server/extract.js
+++ b/bundles/reader/server/extract.js
@@ -1,0 +1,53 @@
+/**
+ * Reader — extraction subprocess wrapper.
+ *
+ * Spawns the vendored PEP-723 extractor via uv in its OWN PROCESS GROUP
+ * so a timeout kills uv AND the python it spawned (execFile's killSignal
+ * only reaches uv, orphaning a runaway OCR job). Structured result,
+ * never throws: {ok, sections, diagnostics} or {ok:false, error}.
+ */
+import { spawn } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "..", "scripts", "extract.py");
+const MAX_OUTPUT = 64 * 1024 * 1024;
+
+export function runExtraction(filePath, config, { ocr = false, scriptPath = DEFAULT_SCRIPT } = {}) {
+  const timeoutMs = Number(config.READER_EXTRACT_TIMEOUT_MS || 180000);
+  const args = ["run", "--quiet", scriptPath, filePath];
+  if (ocr) args.push("--ocr");
+  return new Promise((resolvePromise) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const child = spawn(config.READER_UV_BIN || "uv", args, { detached: true });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try { process.kill(-child.pid, "SIGKILL"); } catch { /* group already gone */ }
+    }, timeoutMs);
+    // setEncoding routes chunks through StringDecoder so a multi-byte UTF-8
+    // sequence split across a pipe-chunk boundary decodes correctly; naive
+    // per-chunk toString() silently yields U+FFFD inside paragraph text.
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (d) => { if (stdout.length < MAX_OUTPUT) stdout += d; });
+    child.stderr.on("data", (d) => { if (stderr.length < 4096) stderr += d; });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolvePromise({ ok: false, error: `extractor spawn failed: ${err.message}` });
+    });
+    child.on("close", () => {
+      clearTimeout(timer);
+      if (timedOut) {
+        return resolvePromise({ ok: false, error: `extraction timeout after ${timeoutMs}ms` });
+      }
+      try {
+        const parsed = JSON.parse(stdout);
+        if (parsed && typeof parsed.ok === "boolean") return resolvePromise(parsed);
+      } catch { /* fall through to error mapping */ }
+      const detail = stderr.trim().slice(0, 500) || "no parseable output";
+      resolvePromise({ ok: false, error: `extractor failed: ${detail}` });
+    });
+  });
+}

--- a/bundles/reader/server/import.js
+++ b/bundles/reader/server/import.js
@@ -1,0 +1,234 @@
+/**
+ * Reader — import pipeline. All four source paths converge here:
+ * store original, extract, write sections, set status.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, extname } from "node:path";
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import { resolveDataDir } from "./db.js";
+import { runExtraction } from "./extract.js";
+
+const FETCH_TIMEOUT_MS = 20000;
+const USER_AGENT = "Mozilla/5.0 (compatible; Crow-Reader/1.0; +https://github.com/kh0pper/crow)";
+
+const MIME_BY_EXT = {
+  ".pdf": "application/pdf", ".html": "text/html", ".htm": "text/html",
+  ".txt": "text/plain", ".md": "text/markdown",
+};
+
+export function readerDataDir(config) {
+  const base = join(config.CROW_DATA_DIR || resolveDataDir(), "reader");
+  mkdirSync(join(base, "originals"), { recursive: true });
+  mkdirSync(join(base, "archives"), { recursive: true });
+  return base;
+}
+
+export function splitIntoParagraphsJs(text) {
+  return String(text || "").split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+}
+
+/** Sentence-boundary split of an over-long paragraph (mirrors the Python cap). */
+export function splitLongParagraphJs(text, maxWords = 500) {
+  const words = text.split(/\s+/);
+  if (words.length <= maxWords) return [text];
+  const sentences = text.match(/[^.!?]+[.!?]+["')\]]*\s*|[^.!?]+$/g) || [text];
+  const out = [];
+  let current = [];
+  let count = 0;
+  for (const s of sentences) {
+    const n = s.split(/\s+/).filter(Boolean).length;
+    if (count + n > maxWords && current.length) {
+      out.push(current.join("").trim());
+      current = [];
+      count = 0;
+    }
+    current.push(s);
+    count += n;
+  }
+  if (current.length) out.push(current.join("").trim());
+  return out;
+}
+
+function textToSections(raw) {
+  const paras = [];
+  for (const p of splitIntoParagraphsJs(raw)) paras.push(...splitLongParagraphJs(p));
+  return [{ title: null, paragraphs: paras }];
+}
+
+/**
+ * SSRF guard: block loopback/private/link-local hosts unless configured open.
+ * Accepted risk: DNS rebinding TOCTOU (this lookup and the fetch resolve
+ * independently); fine for a single-user authenticated dashboard.
+ * Exported for direct unit testing.
+ */
+export async function assertPublicHost(url, config) {
+  if (config.READER_ALLOW_PRIVATE_URLS === "1") return;
+  const { lookup } = await import("node:dns/promises");
+  const { isIP } = await import("node:net");
+  const host = new URL(url).hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+  const addrs = isIP(host) ? [{ address: host }] : await lookup(host, { all: true });
+  for (const { address } of addrs) {
+    if (
+      /^127\.|^10\.|^192\.168\.|^169\.254\.|^0\./.test(address) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(address) ||
+      address === "::1" || /^f[cd]/i.test(address) || /^fe80/i.test(address)
+    ) {
+      throw new Error(`URL resolves to a private address (${address}); set READER_ALLOW_PRIVATE_URLS=1 to permit`);
+    }
+  }
+}
+
+const MAX_REDIRECTS = 5;
+
+async function fetchUrl(url, config, fetchImpl) {
+  const capBytes = Number(config.READER_MAX_UPLOAD_MB || 50) * 1024 * 1024;
+  const doFetch = fetchImpl || fetch;
+
+  // Follow redirects MANUALLY so every hop passes the SSRF guard; a
+  // public URL that 302s to a private address must not slip through.
+  // Injected fetchImpl (tests) skips the DNS guard but keeps the loop.
+  let current = url;
+  let res = null;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const parsed = new URL(current);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(`unsupported URL scheme: ${parsed.protocol}`);
+    }
+    if (!fetchImpl) await assertPublicHost(current, config);
+    res = await doFetch(current, {
+      headers: { "User-Agent": USER_AGENT, Accept: "text/html, application/pdf, */*" },
+      redirect: "manual",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    const location = res.headers.get("location");
+    if (res.status >= 300 && res.status < 400 && location) {
+      current = new URL(location, current).href;
+      continue;
+    }
+    break;
+  }
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error(`too many redirects fetching ${url}`);
+  }
+  if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${url}`);
+  const declared = Number(res.headers.get("content-length") || 0);
+  if (declared > capBytes) throw new Error(`response exceeds ${capBytes} byte cap`);
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of res.body) {
+    total += chunk.length;
+    if (total > capBytes) throw new Error(`response exceeds ${capBytes} byte cap`);
+    chunks.push(chunk);
+  }
+  const contentType = (res.headers.get("content-type") || "").split(";")[0].trim();
+  return { contentType, buffer: Buffer.concat(chunks) };
+}
+
+/** Normalize a comma-separated tag string: trim, drop empties, lowercase. */
+export function normalizeTags(tags) {
+  if (!tags) return null;
+  const list = String(tags).split(",").map((t) => t.trim().toLowerCase()).filter(Boolean);
+  return list.length ? list.join(",") : null;
+}
+
+function readableFromHtml(html, url) {
+  const { document } = parseHTML(html);
+  const title = document.querySelector("title")?.textContent?.trim() || null;
+  const article = new Readability(document).parse();
+  const text = article?.textContent?.trim() || "";
+  return { title: article?.title || title, text };
+}
+
+async function writeSections(db, docId, sections) {
+  await db.execute({ sql: "DELETE FROM reader_sections WHERE document_id = ?", args: [docId] });
+  let n = 1;
+  for (const s of sections) {
+    await db.execute({
+      sql: `INSERT INTO reader_sections (document_id, section_number, title, paragraphs_json)
+            VALUES (?, ?, ?, ?)`,
+      args: [docId, n++, s.title, JSON.stringify(s.paragraphs)],
+    });
+  }
+}
+
+export async function ingestDocument(db, config, input, deps = {}) {
+  const extractImpl = deps.extractImpl || ((p, o) => runExtraction(p, config, o));
+  const base = readerDataDir(config);
+
+  // 1. Insert the row first so the file name carries the id.
+  const insert = await db.execute({
+    sql: `INSERT INTO reader_documents (title, source_type, source_ref, tags, extraction_status)
+          VALUES (?, ?, ?, ?, 'pending')`,
+    args: [input.title || input.filename || input.url || "Untitled",
+           input.sourceType, input.url || input.filename || null, normalizeTags(input.tags)],
+  });
+  const id = Number(insert.lastInsertRowid);
+
+  let sections = null;
+  let status = "failed";
+  let diagnostics = null;
+  let originalPath = null;
+  let archivedHtmlPath = null;
+  let mime = null;
+  let resolvedTitle = input.title || null;
+
+  try {
+    let buffer = input.buffer || null;
+    let ext = input.filename ? extname(input.filename).toLowerCase() : null;
+
+    if (input.sourceType === "url") {
+      const fetched = await fetchUrl(input.url, config, deps.fetchImpl);
+      buffer = fetched.buffer;
+      ext = fetched.contentType === "application/pdf" ? ".pdf" : ".html";
+    }
+    if (!buffer) throw new Error("no content to ingest");
+    if (!ext || !(ext in MIME_BY_EXT)) {
+      throw new Error(`unsupported file type: ${ext || "unknown"}`);
+    }
+    mime = MIME_BY_EXT[ext];
+
+    originalPath = join(base, "originals", `${id}${ext}`);
+    writeFileSync(originalPath, buffer);
+
+    if (ext === ".pdf") {
+      const result = await extractImpl(originalPath, { ocr: !!input.ocr });
+      if (result.ok) {
+        sections = result.sections;
+        diagnostics = result.diagnostics;
+        const empty = sections.every((s) => s.paragraphs.length === 0);
+        status = empty ? "partial" : "ok";
+      } else {
+        diagnostics = { error: result.error };
+        status = "failed";
+      }
+    } else if (ext === ".html" || ext === ".htm") {
+      const html = buffer.toString("utf8");
+      archivedHtmlPath = join(base, "archives", `${id}.html`);
+      writeFileSync(archivedHtmlPath, html);
+      const { title, text } = readableFromHtml(html, input.url);
+      if (!resolvedTitle && title) resolvedTitle = title;
+      sections = textToSections(text);
+      status = text ? "ok" : "partial";
+    } else { // .txt / .md
+      sections = textToSections(buffer.toString("utf8"));
+      status = "ok";
+    }
+
+    if (sections) await writeSections(db, id, sections);
+  } catch (err) {
+    diagnostics = { error: err.message };
+    status = "failed";
+  }
+
+  await db.execute({
+    sql: `UPDATE reader_documents SET title = COALESCE(?, title), original_path = ?,
+            original_mime = ?, archived_html_path = ?, extraction_status = ?,
+            extraction_diagnostics = ?, updated_at = datetime('now')
+          WHERE id = ?`,
+    args: [resolvedTitle, originalPath, mime, archivedHtmlPath, status,
+           diagnostics ? JSON.stringify(diagnostics) : null, id],
+  });
+
+  return { id, extraction_status: status };
+}

--- a/bundles/reader/server/import.js
+++ b/bundles/reader/server/import.js
@@ -66,6 +66,7 @@ function isPrivateAddress(address) {
   return (
     /^127\.|^10\.|^192\.168\.|^169\.254\.|^0\./.test(address) ||
     /^172\.(1[6-9]|2\d|3[01])\./.test(address) ||
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(address) ||
     address === "::1" || /^f[cd]/i.test(address) || /^fe80/i.test(address)
   );
 }

--- a/bundles/reader/server/import.js
+++ b/bundles/reader/server/import.js
@@ -62,6 +62,35 @@ function textToSections(raw) {
  * independently); fine for a single-user authenticated dashboard.
  * Exported for direct unit testing.
  */
+function isPrivateAddress(address) {
+  return (
+    /^127\.|^10\.|^192\.168\.|^169\.254\.|^0\./.test(address) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(address) ||
+    address === "::1" || /^f[cd]/i.test(address) || /^fe80/i.test(address)
+  );
+}
+
+/**
+ * Unwrap an IPv4-mapped IPv6 address (::ffff:a.b.c.d) to its embedded IPv4
+ * tail. Two textual forms have to be handled: DNS lookups typically report
+ * the dotted-decimal form (::ffff:127.0.0.1), but the WHATWG URL parser
+ * canonicalizes bracketed IPv6 literals to pure hex groups
+ * (::ffff:7f00:1) before assertPublicHost ever sees the hostname. Returns
+ * null when the address isn't an IPv4-mapped IPv6 address.
+ */
+function unwrapIPv4MappedIPv6(address) {
+  const lower = address.toLowerCase();
+  const dotted = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(lower);
+  if (dotted) return dotted[1];
+  const hex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(lower);
+  if (hex) {
+    const hi = parseInt(hex[1], 16);
+    const lo = parseInt(hex[2], 16);
+    return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff].join(".");
+  }
+  return null;
+}
+
 export async function assertPublicHost(url, config) {
   if (config.READER_ALLOW_PRIVATE_URLS === "1") return;
   const { lookup } = await import("node:dns/promises");
@@ -69,11 +98,10 @@ export async function assertPublicHost(url, config) {
   const host = new URL(url).hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
   const addrs = isIP(host) ? [{ address: host }] : await lookup(host, { all: true });
   for (const { address } of addrs) {
-    if (
-      /^127\.|^10\.|^192\.168\.|^169\.254\.|^0\./.test(address) ||
-      /^172\.(1[6-9]|2\d|3[01])\./.test(address) ||
-      address === "::1" || /^f[cd]/i.test(address) || /^fe80/i.test(address)
-    ) {
+    // IPv4-mapped IPv6 embeds a routable-looking IPv4 tail that the
+    // bare-address checks above never match; unwrap and re-check it.
+    const mapped = unwrapIPv4MappedIPv6(address);
+    if (isPrivateAddress(address) || (mapped && isPrivateAddress(mapped))) {
       throw new Error(`URL resolves to a private address (${address}); set READER_ALLOW_PRIVATE_URLS=1 to permit`);
     }
   }
@@ -102,7 +130,8 @@ async function fetchUrl(url, config, fetchImpl) {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     const location = res.headers.get("location");
-    if (res.status >= 300 && res.status < 400 && location) {
+    if (res.status >= 300 && res.status < 400) {
+      if (!location) throw new Error(`redirect without location fetching ${current}`);
       current = new URL(location, current).href;
       continue;
     }

--- a/bundles/reader/server/import.js
+++ b/bundles/reader/server/import.js
@@ -67,7 +67,10 @@ function isPrivateAddress(address) {
     /^127\.|^10\.|^192\.168\.|^169\.254\.|^0\./.test(address) ||
     /^172\.(1[6-9]|2\d|3[01])\./.test(address) ||
     /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(address) ||
-    address === "::1" || /^f[cd]/i.test(address) || /^fe80/i.test(address)
+    // "::" (unspecified) connects to localhost on Linux; URL parsing
+    // canonicalizes every all-zero IPv6 literal to this exact form.
+    address === "::1" || address === "::" ||
+    /^f[cd]/i.test(address) || /^fe80/i.test(address)
   );
 }
 

--- a/bundles/reader/server/index.js
+++ b/bundles/reader/server/index.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/** Reader MCP server — bundle entry point (stdio transport). */
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createReaderServer } from "./server.js";
+import { initReaderTables } from "./init-tables.js";
+import { createDbClient } from "./db.js";
+
+const db = createDbClient();
+await initReaderTables(db);
+
+const server = createReaderServer(db, {
+  instructions:
+    "Crow Reader — import documents (crow_reader_ingest), browse the library (crow_reader_list), inspect a document (crow_reader_get). Reading happens in the dashboard Reader panel.",
+});
+await server.connect(new StdioServerTransport());

--- a/bundles/reader/server/ingest-guard.js
+++ b/bundles/reader/server/ingest-guard.js
@@ -1,0 +1,41 @@
+/**
+ * Reader — local-path ingest allowlist guard.
+ *
+ * `crow_reader_ingest` only reads local files under READER_INGEST_ROOTS
+ * (default: the user home directory). resolve() alone does not dereference
+ * symlinks, so a symlink planted under an allowed root could point outside
+ * it and defeat a plain prefix check. realpathSync both the target and each
+ * configured root before comparing.
+ */
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Resolve `path` to its real (symlink-free) path and reject it unless that
+ * real path falls under one of the configured allowlist roots (also
+ * symlink-resolved). Returns the resolved real path on success.
+ * Throws Error on a missing file or a path outside the allowlist.
+ */
+export function assertPathAllowed(path, config = {}) {
+  const roots = (config.READER_INGEST_ROOTS || homedir())
+    .split(":")
+    .filter(Boolean)
+    .map((r) => realpathSync(resolve(r)));
+
+  const resolvedPath = resolve(path);
+  let target;
+  try {
+    target = realpathSync(resolvedPath);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      throw new Error(`File not found: ${resolvedPath}`);
+    }
+    throw err;
+  }
+
+  if (!roots.some((r) => target === r || target.startsWith(r + "/"))) {
+    throw new Error(`Path outside READER_INGEST_ROOTS allowlist: ${target}`);
+  }
+  return target;
+}

--- a/bundles/reader/server/init-tables.js
+++ b/bundles/reader/server/init-tables.js
@@ -1,0 +1,147 @@
+/**
+ * Reader — table initialization.
+ *
+ * Idempotent (CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS
+ * everywhere). Safe to re-run on every server start.
+ */
+
+async function initTable(db, label, sql) {
+  try {
+    await db.executeMultiple(sql);
+  } catch (err) {
+    console.error(`[reader init] ${label}:`, err.message);
+    throw err;
+  }
+}
+
+export async function initReaderTables(db) {
+  await initTable(db, "reader_documents", `
+    CREATE TABLE IF NOT EXISTS reader_documents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT,
+      source_type TEXT CHECK(source_type IN ('upload','url','drive','mcp')),
+      source_ref TEXT,
+      original_path TEXT,
+      original_mime TEXT,
+      archived_html_path TEXT,
+      extraction_status TEXT DEFAULT 'pending'
+        CHECK(extraction_status IN ('pending','ok','partial','failed')),
+      extraction_diagnostics TEXT,
+      language TEXT,
+      tags TEXT,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_reader_documents_updated
+      ON reader_documents(updated_at DESC);
+  `);
+
+  await initTable(db, "reader_sections", `
+    CREATE TABLE IF NOT EXISTS reader_sections (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      document_id INTEGER NOT NULL REFERENCES reader_documents(id) ON DELETE CASCADE,
+      section_number INTEGER NOT NULL,
+      title TEXT,
+      paragraphs_json TEXT NOT NULL,
+      UNIQUE(document_id, section_number)
+    );
+  `);
+
+  await initTable(db, "reader_annotations", `
+    CREATE TABLE IF NOT EXISTS reader_annotations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      document_id INTEGER NOT NULL REFERENCES reader_documents(id) ON DELETE CASCADE,
+      section_id INTEGER REFERENCES reader_sections(id) ON DELETE SET NULL,
+      kind TEXT CHECK(kind IN ('highlight','comment')),
+      quote TEXT NOT NULL,
+      prefix TEXT,
+      suffix TEXT,
+      para_hint INTEGER,
+      page_hint INTEGER,
+      color TEXT DEFAULT 'yellow',
+      comment_md TEXT,
+      author TEXT DEFAULT 'user' CHECK(author IN ('user','agent')),
+      memory_id INTEGER,
+      orphaned INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_reader_annotations_doc
+      ON reader_annotations(document_id);
+  `);
+
+  await initTable(db, "reader_progress", `
+    CREATE TABLE IF NOT EXISTS reader_progress (
+      document_id INTEGER NOT NULL,
+      section_number INTEGER NOT NULL DEFAULT 1,
+      paragraph INTEGER NOT NULL DEFAULT 0,
+      total_paragraphs INTEGER,
+      audio_time REAL,
+      updated_at TEXT DEFAULT (datetime('now')),
+      PRIMARY KEY (document_id, section_number)
+    );
+  `);
+
+  await initTable(db, "reader_chunks", `
+    CREATE TABLE IF NOT EXISTS reader_chunks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      document_id INTEGER NOT NULL REFERENCES reader_documents(id) ON DELETE CASCADE,
+      section_id INTEGER REFERENCES reader_sections(id) ON DELETE CASCADE,
+      chunk_index INTEGER NOT NULL,
+      text TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS reader_chunk_embeddings (
+      chunk_id INTEGER PRIMARY KEY REFERENCES reader_chunks(id) ON DELETE CASCADE,
+      model TEXT,
+      dim INTEGER,
+      vec BLOB,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+
+  await initTable(db, "reader_documents FTS", `
+    CREATE VIRTUAL TABLE IF NOT EXISTS reader_documents_fts USING fts5(
+      title, tags, source_ref,
+      content=reader_documents, content_rowid=id
+    );
+  `);
+  await initTable(db, "reader_documents FTS triggers", `
+    CREATE TRIGGER IF NOT EXISTS reader_documents_ai AFTER INSERT ON reader_documents BEGIN
+      INSERT INTO reader_documents_fts(rowid, title, tags, source_ref)
+      VALUES (new.id, new.title, new.tags, new.source_ref);
+    END;
+    CREATE TRIGGER IF NOT EXISTS reader_documents_ad AFTER DELETE ON reader_documents BEGIN
+      INSERT INTO reader_documents_fts(reader_documents_fts, rowid, title, tags, source_ref)
+      VALUES ('delete', old.id, old.title, old.tags, old.source_ref);
+    END;
+    CREATE TRIGGER IF NOT EXISTS reader_documents_au AFTER UPDATE ON reader_documents BEGIN
+      INSERT INTO reader_documents_fts(reader_documents_fts, rowid, title, tags, source_ref)
+      VALUES ('delete', old.id, old.title, old.tags, old.source_ref);
+      INSERT INTO reader_documents_fts(rowid, title, tags, source_ref)
+      VALUES (new.id, new.title, new.tags, new.source_ref);
+    END;
+  `);
+
+  await initTable(db, "reader_annotations FTS", `
+    CREATE VIRTUAL TABLE IF NOT EXISTS reader_annotations_fts USING fts5(
+      quote, comment_md,
+      content=reader_annotations, content_rowid=id
+    );
+  `);
+  await initTable(db, "reader_annotations FTS triggers", `
+    CREATE TRIGGER IF NOT EXISTS reader_annotations_ai AFTER INSERT ON reader_annotations BEGIN
+      INSERT INTO reader_annotations_fts(rowid, quote, comment_md)
+      VALUES (new.id, new.quote, new.comment_md);
+    END;
+    CREATE TRIGGER IF NOT EXISTS reader_annotations_ad AFTER DELETE ON reader_annotations BEGIN
+      INSERT INTO reader_annotations_fts(reader_annotations_fts, rowid, quote, comment_md)
+      VALUES ('delete', old.id, old.quote, old.comment_md);
+    END;
+    CREATE TRIGGER IF NOT EXISTS reader_annotations_au AFTER UPDATE ON reader_annotations BEGIN
+      INSERT INTO reader_annotations_fts(reader_annotations_fts, rowid, quote, comment_md)
+      VALUES ('delete', old.id, old.quote, old.comment_md);
+      INSERT INTO reader_annotations_fts(rowid, quote, comment_md)
+      VALUES (new.id, new.quote, new.comment_md);
+    END;
+  `);
+}

--- a/bundles/reader/server/progress.js
+++ b/bundles/reader/server/progress.js
@@ -1,6 +1,7 @@
 /** Reader — server-authoritative reading progress (forward-only). */
 export async function saveProgress(db, { document_id, section_number = 1, paragraph,
   total_paragraphs = null, audio_time = null }) {
+  if (!Number.isInteger(total_paragraphs) || total_paragraphs <= 0) total_paragraphs = null;
   await db.execute({
     sql: `INSERT INTO reader_progress (document_id, section_number, paragraph, total_paragraphs, audio_time)
           VALUES (?, ?, ?, ?, ?)

--- a/bundles/reader/server/progress.js
+++ b/bundles/reader/server/progress.js
@@ -1,0 +1,24 @@
+/** Reader — server-authoritative reading progress (forward-only). */
+export async function saveProgress(db, { document_id, section_number = 1, paragraph,
+  total_paragraphs = null, audio_time = null }) {
+  await db.execute({
+    sql: `INSERT INTO reader_progress (document_id, section_number, paragraph, total_paragraphs, audio_time)
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(document_id, section_number) DO UPDATE SET
+            paragraph = MAX(reader_progress.paragraph, excluded.paragraph),
+            total_paragraphs = COALESCE(excluded.total_paragraphs, reader_progress.total_paragraphs),
+            audio_time = excluded.audio_time,
+            updated_at = datetime('now')`,
+    args: [document_id, section_number, paragraph, total_paragraphs, audio_time],
+  });
+  const row = await getProgress(db, document_id, section_number);
+  return { paragraph: Number(row.paragraph) };
+}
+
+export async function getProgress(db, documentId, sectionNumber) {
+  const { rows } = await db.execute({
+    sql: `SELECT * FROM reader_progress WHERE document_id = ? AND section_number = ?`,
+    args: [documentId, sectionNumber],
+  });
+  return rows[0] || null;
+}

--- a/bundles/reader/server/queries.js
+++ b/bundles/reader/server/queries.js
@@ -1,0 +1,52 @@
+/** Reader — read-side queries shared by MCP tools and the panel. */
+import { sanitizeFtsQuery } from "./db.js";
+
+export async function listDocuments(db, { query = null, tag = null, limit = 50 } = {}) {
+  const args = [];
+  let where = "1=1";
+  if (query) {
+    const fts = sanitizeFtsQuery(query);
+    if (fts) {
+      where = `d.id IN (SELECT rowid FROM reader_documents_fts WHERE reader_documents_fts MATCH ?)`;
+      args.push(fts);
+    }
+  }
+  if (tag) {
+    where += " AND (',' || COALESCE(d.tags,'') || ',') LIKE ?";
+    args.push(`%,${tag},%`);
+  }
+  args.push(limit);
+  const { rows } = await db.execute({
+    sql: `SELECT d.id, d.title, d.source_type, d.source_ref, d.extraction_status,
+                 d.tags, d.updated_at,
+                 (SELECT COUNT(*) FROM reader_sections s WHERE s.document_id = d.id) AS section_count,
+                 p.paragraph AS progress_paragraph, p.total_paragraphs
+          FROM reader_documents d
+          LEFT JOIN reader_progress p ON p.document_id = d.id AND p.section_number = 1
+          WHERE ${where}
+          ORDER BY d.updated_at DESC, d.id DESC
+          LIMIT ?`,
+    args,
+  });
+  return rows;
+}
+
+export async function getDocument(db, id) {
+  const doc = await db.execute({
+    sql: "SELECT * FROM reader_documents WHERE id = ?", args: [id] });
+  if (doc.rows.length === 0) return null;
+  const secs = await db.execute({
+    sql: `SELECT id, section_number, title, paragraphs_json
+          FROM reader_sections WHERE document_id = ? ORDER BY section_number`,
+    args: [id],
+  });
+  return {
+    document: doc.rows[0],
+    sections: secs.rows.map((s) => ({
+      id: Number(s.id),
+      section_number: Number(s.section_number),
+      title: s.title,
+      paragraph_count: JSON.parse(String(s.paragraphs_json)).length,
+    })),
+  };
+}

--- a/bundles/reader/server/queries.js
+++ b/bundles/reader/server/queries.js
@@ -1,5 +1,5 @@
 /** Reader — read-side queries shared by MCP tools and the panel. */
-import { sanitizeFtsQuery } from "./db.js";
+import { sanitizeFtsQuery, escapeLikePattern } from "./db.js";
 
 export async function listDocuments(db, { query = null, tag = null, limit = 50 } = {}) {
   const args = [];
@@ -12,8 +12,8 @@ export async function listDocuments(db, { query = null, tag = null, limit = 50 }
     }
   }
   if (tag) {
-    where += " AND (',' || COALESCE(d.tags,'') || ',') LIKE ?";
-    args.push(`%,${tag},%`);
+    where += " AND (',' || COALESCE(d.tags,'') || ',') LIKE ? ESCAPE '\\'";
+    args.push(`%,${escapeLikePattern(tag)},%`);
   }
   args.push(limit);
   const { rows } = await db.execute({

--- a/bundles/reader/server/render.js
+++ b/bundles/reader/server/render.js
@@ -1,0 +1,72 @@
+/** Reader — pure HTML renderers for the Read view (no Express, testable). */
+
+export function escapeHtml(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function tableHtml(md) {
+  const lines = md.split("\n").filter((l) => l.trim().startsWith("|"));
+  const rows = lines
+    .filter((l) => !/^\|[\s\-:|]+\|$/.test(l.trim()))
+    .map((l) => l.split("|").slice(1, -1).map((c) => c.trim()));
+  if (!rows.length) return `<pre>${escapeHtml(md)}</pre>`;
+  const [head, ...body] = rows;
+  const th = head.map((c) => `<th>${escapeHtml(c)}</th>`).join("");
+  const trs = body.map((r) => `<tr>${r.map((c) => `<td>${escapeHtml(c)}</td>`).join("")}</tr>`).join("");
+  return `<div class="er-table-wrap"><table><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table></div>`;
+}
+
+export function renderParagraph(raw, index) {
+  if (raw.startsWith("[TABLE]\n")) {
+    return `<div class="er-para er-table" data-para="${index}">${tableHtml(raw.slice(8))}</div>`;
+  }
+  return `<div class="er-para" data-para="${index}">${escapeHtml(raw)}</div>`;
+}
+
+export function readerPage({ document, section, sections, paragraphs, progress }) {
+  const data = JSON.stringify({
+    documentId: Number(document.id),
+    sectionNumber: Number(section.section_number),
+    totalParagraphs: paragraphs.length,
+    resumeParagraph: progress ? Number(progress.paragraph) : 0,
+  }).replace(/</g, "\\u003c");
+
+  const sectionNav = sections.length > 1
+    ? `<nav class="er-sections">${sections.map((s) =>
+        `<a href="/reader-app/${Number(document.id)}?section=${s.section_number}"
+           class="${s.section_number === Number(section.section_number) ? "active" : ""}">
+           ${escapeHtml(s.title || `Part ${s.section_number}`)}</a>`).join("")}</nav>`
+    : "";
+
+  const body = paragraphs.map((p, i) => renderParagraph(p, i)).join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="turbo-visit-control" content="reload">
+<title>${escapeHtml(document.title || "Reader")}</title>
+<link rel="stylesheet" href="/reader/static/reader.css">
+</head>
+<body>
+<header class="er-header">
+  <a class="er-back" href="/dashboard/reader">&larr; Library</a>
+  <h1>${escapeHtml(document.title || "Untitled")}</h1>
+  ${document.extraction_status !== "ok"
+    ? `<span class="er-status er-status-${escapeHtml(document.extraction_status)}">${escapeHtml(document.extraction_status)}</span>`
+    : ""}
+</header>
+${sectionNav}
+<main id="er-reading-pane" class="er-reading-pane">
+<div id="er-content">
+${body}
+</div>
+</main>
+<script type="application/json" id="reader-data">${data}</script>
+<script src="/reader/static/reader.js" type="module"></script>
+</body>
+</html>`;
+}

--- a/bundles/reader/server/render.js
+++ b/bundles/reader/server/render.js
@@ -35,8 +35,8 @@ export function readerPage({ document, section, sections, paragraphs, progress }
 
   const sectionNav = sections.length > 1
     ? `<nav class="er-sections">${sections.map((s) =>
-        `<a href="/reader-app/${Number(document.id)}?section=${s.section_number}"
-           class="${s.section_number === Number(section.section_number) ? "active" : ""}">
+        `<a href="/reader-app/${Number(document.id)}?section=${Number(s.section_number)}"
+           class="${Number(s.section_number) === Number(section.section_number) ? "active" : ""}">
            ${escapeHtml(s.title || `Part ${s.section_number}`)}</a>`).join("")}</nav>`
     : "";
 

--- a/bundles/reader/server/server.js
+++ b/bundles/reader/server/server.js
@@ -11,6 +11,7 @@ import { basename } from "node:path";
 import { ingestDocument } from "./import.js";
 import { listDocuments, getDocument } from "./queries.js";
 import { loadConfig } from "./config.js";
+import { assertPathAllowed } from "./ingest-guard.js";
 
 const text = (t) => ({ content: [{ type: "text", text: t }] });
 const errorText = (t) => ({ content: [{ type: "text", text: t }], isError: true });
@@ -40,14 +41,14 @@ export function createReaderServer(db, options = {}) {
           input = { sourceType: "url", url, title, tags, ocr };
         } else {
           // Path allowlist: local reads only under configured roots
-          // (default: the user home directory).
-          const { resolve } = await import("node:path");
-          const { homedir } = await import("node:os");
-          const roots = (config.READER_INGEST_ROOTS || homedir())
-            .split(":").filter(Boolean).map((r) => resolve(r));
-          const target = resolve(path);
-          if (!roots.some((r) => target === r || target.startsWith(r + "/"))) {
-            return errorText(`Path outside READER_INGEST_ROOTS allowlist: ${target}`);
+          // (default: the user home directory). assertPathAllowed
+          // realpath-resolves both the target and each root so a symlink
+          // planted under an allowed root cannot point outside it.
+          let target;
+          try {
+            target = assertPathAllowed(path, config);
+          } catch (err) {
+            return errorText(err.message);
           }
           input = { sourceType: "mcp", buffer: readFileSync(target),
                     filename: basename(target), title, tags, ocr };

--- a/bundles/reader/server/server.js
+++ b/bundles/reader/server/server.js
@@ -1,0 +1,89 @@
+/**
+ * Reader MCP server. Milestone 1 tools:
+ *   crow_reader_ingest, crow_reader_list, crow_reader_get
+ * Later plans add: annotations, annotate, store_summary, search,
+ * read_section, export.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { ingestDocument } from "./import.js";
+import { listDocuments, getDocument } from "./queries.js";
+import { loadConfig } from "./config.js";
+
+const text = (t) => ({ content: [{ type: "text", text: t }] });
+const errorText = (t) => ({ content: [{ type: "text", text: t }], isError: true });
+
+export function createReaderServer(db, options = {}) {
+  const server = new McpServer(
+    { name: "crow-reader", version: "0.1.0" },
+    { capabilities: { tools: {} }, instructions: options.instructions },
+  );
+
+  server.tool(
+    "crow_reader_ingest",
+    "Import a document into the reader library from a local file path or a URL. Stores the original as the archival copy, extracts readable paragraphs, and returns the document id and extraction status.",
+    {
+      path: z.string().optional().describe("Absolute local file path (pdf, html, txt, md)"),
+      url: z.string().url().optional().describe("URL to fetch (web page or PDF)"),
+      title: z.string().optional(),
+      tags: z.string().optional().describe("Comma-separated tags"),
+      ocr: z.boolean().optional().describe("Force Tesseract OCR for scanned PDFs"),
+    },
+    async ({ path, url, title, tags, ocr }) => {
+      if (!path && !url) return errorText("Provide path or url");
+      try {
+        const config = loadConfig();
+        let input;
+        if (url) {
+          input = { sourceType: "url", url, title, tags, ocr };
+        } else {
+          // Path allowlist: local reads only under configured roots
+          // (default: the user home directory).
+          const { resolve } = await import("node:path");
+          const { homedir } = await import("node:os");
+          const roots = (config.READER_INGEST_ROOTS || homedir())
+            .split(":").filter(Boolean).map((r) => resolve(r));
+          const target = resolve(path);
+          if (!roots.some((r) => target === r || target.startsWith(r + "/"))) {
+            return errorText(`Path outside READER_INGEST_ROOTS allowlist: ${target}`);
+          }
+          input = { sourceType: "mcp", buffer: readFileSync(target),
+                    filename: basename(target), title, tags, ocr };
+        }
+        const result = await ingestDocument(db, config, input);
+        return text(JSON.stringify(result, null, 2));
+      } catch (err) {
+        return errorText(`Ingest failed: ${err.message}`);
+      }
+    },
+  );
+
+  server.tool(
+    "crow_reader_list",
+    "List reader library documents with extraction status and reading progress. Optional FTS query and tag filter.",
+    {
+      query: z.string().optional(),
+      tag: z.string().optional(),
+      limit: z.number().int().positive().max(200).optional(),
+    },
+    async ({ query, tag, limit }) => {
+      const rows = await listDocuments(db, { query, tag, limit: limit || 50 });
+      return text(JSON.stringify(rows, null, 2));
+    },
+  );
+
+  server.tool(
+    "crow_reader_get",
+    "Get one document's metadata, extraction diagnostics, and section list.",
+    { id: z.number().int().positive() },
+    async ({ id }) => {
+      const got = await getDocument(db, id);
+      if (!got) return errorText(`No document ${id}`);
+      return text(JSON.stringify(got, null, 2));
+    },
+  );
+
+  return server;
+}

--- a/bundles/reader/test/config.test.js
+++ b/bundles/reader/test/config.test.js
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdirSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+test("loadConfig layers env file under process.env and applies defaults", async () => {
+  const home = mkdtempSync(join(tmpdir(), "reader-home-"));
+  mkdirSync(join(home, "env"), { recursive: true });
+  writeFileSync(join(home, "env", "reader.env"),
+    'READER_EMBED_URL="http://example.test:1234"\nREADER_UV_BIN=/opt/uv\n');
+  process.env.CROW_HOME = home;
+  process.env.READER_UV_BIN = "/env/wins/uv";
+  const { loadConfig } = await import("../server/config.js");
+  const cfg = loadConfig();
+  assert.equal(cfg.READER_EMBED_URL, "http://example.test:1234");
+  assert.equal(cfg.READER_UV_BIN, "/env/wins/uv");           // process.env wins
+  assert.equal(cfg.READER_EXTRACT_TIMEOUT_MS, "180000");      // default applied
+  assert.equal(cfg.READER_MAX_UPLOAD_MB, "50");
+  delete process.env.READER_UV_BIN;
+});

--- a/bundles/reader/test/extract-py.test.js
+++ b/bundles/reader/test/extract-py.test.js
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const UV = process.env.READER_UV_BIN || "uv";
+
+function haveUv() {
+  try { execFileSync(UV, ["--version"], { stdio: "ignore" }); return true; }
+  catch { return false; }
+}
+
+test("extract.py produces reflowed paragraphs from a PDF", { skip: !haveUv() }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "reader-fix-"));
+  const pdf = join(dir, "fixture.pdf");
+  execFileSync(UV, ["run", "--quiet", join(here, "fixtures", "make_fixture.py"), pdf]);
+  const out = execFileSync(UV, ["run", "--quiet", join(here, "..", "scripts", "extract.py"), pdf],
+    { encoding: "utf8" });
+  const result = JSON.parse(out);
+  assert.equal(result.ok, true);
+  assert.equal(result.diagnostics.pages, 2);
+  const paras = result.sections.flatMap((s) => s.paragraphs);
+  const joined = paras.join("\n");
+  assert.ok(joined.includes("hyphenated line break"), "dehyphenation failed");
+  assert.ok(paras.some((p) => p.includes("Second page paragraph")));
+});
+
+test("extract.py reports structured error for a missing file", { skip: !haveUv() }, () => {
+  let failed = false;
+  try {
+    execFileSync(UV, ["run", "--quiet", join(here, "..", "scripts", "extract.py"),
+      "/nonexistent/x.pdf"], { encoding: "utf8" });
+  } catch (err) {
+    failed = true;
+    const parsed = JSON.parse(err.stdout);
+    assert.equal(parsed.ok, false);
+    assert.ok(parsed.error.length > 0);
+  }
+  assert.ok(failed, "expected non-zero exit");
+});

--- a/bundles/reader/test/extract-wrapper.test.js
+++ b/bundles/reader/test/extract-wrapper.test.js
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runExtraction } from "../server/extract.js";
+
+const UV = process.env.READER_UV_BIN || "uv";
+function haveUv() {
+  try { execFileSync(UV, ["--version"], { stdio: "ignore" }); return true; }
+  catch { return false; }
+}
+const skip = !haveUv();
+
+function fakeScript(dir, body) {
+  const p = join(dir, "fake.py");
+  writeFileSync(p, body);
+  return p;
+}
+
+const cfgWith = (over = {}) => ({
+  READER_UV_BIN: UV,
+  READER_EXTRACT_TIMEOUT_MS: "5000",
+  ...over,
+});
+
+test("returns parsed JSON from a successful run", { skip }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "reader-ext-"));
+  const script = fakeScript(dir,
+    'import json; print(json.dumps({"ok": True, "sections": [{"title": None, "paragraphs": ["hello"]}], "diagnostics": {"pages": 1, "empty_pages": 0, "used_ocr": False}}))');
+  const res = await runExtraction("/any/input.pdf", cfgWith(), { scriptPath: script });
+  assert.equal(res.ok, true);
+  assert.equal(res.sections[0].paragraphs[0], "hello");
+});
+
+test("maps a crash to ok:false with the error text", { skip }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "reader-ext-"));
+  const script = fakeScript(dir, 'import sys; sys.stderr.write("boom"); sys.exit(2)');
+  const res = await runExtraction("/any/input.pdf", cfgWith(), { scriptPath: script });
+  assert.equal(res.ok, false);
+  assert.match(res.error, /boom|exit/i);
+});
+
+test("kills the subprocess on timeout", { skip }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "reader-ext-"));
+  const script = fakeScript(dir, "import time; time.sleep(60)");
+  const res = await runExtraction("/any/input.pdf",
+    cfgWith({ READER_EXTRACT_TIMEOUT_MS: "500" }), { scriptPath: script });
+  assert.equal(res.ok, false);
+  assert.match(res.error, /timeout/i);
+});

--- a/bundles/reader/test/extract-wrapper.test.js
+++ b/bundles/reader/test/extract-wrapper.test.js
@@ -50,3 +50,9 @@ test("kills the subprocess on timeout", { skip }, async () => {
   assert.equal(res.ok, false);
   assert.match(res.error, /timeout/i);
 });
+
+test("resolves ok:false instead of rejecting when spawn args are invalid", async () => {
+  const res = await runExtraction("/any/input.pdf", cfgWith({ READER_UV_BIN: 123 }));
+  assert.equal(res.ok, false);
+  assert.match(res.error, /spawn failed/i);
+});

--- a/bundles/reader/test/fixtures/make_fixture.py
+++ b/bundles/reader/test/fixtures/make_fixture.py
@@ -1,0 +1,24 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pymupdf>=1.24"]
+# ///
+"""Build fixture.pdf: 2 pages of known text with a hyphenated line break."""
+
+import sys
+import fitz
+
+doc = fitz.open()
+p1 = doc.new_page()
+p1.insert_text((72, 100), "The Reader Fixture", fontsize=18)
+p1.insert_text(
+    (72, 140),
+    "Design thinking starts with empathy for the people you are\n"
+    "designing for. This paragraph continues across a hyphen-\n"
+    "ated line break to exercise reflow.",
+    fontsize=11,
+)
+p2 = doc.new_page()
+p2.insert_text(
+    (72, 100), "Second page paragraph. It stands alone and ends cleanly.", fontsize=11
+)
+doc.save(sys.argv[1])

--- a/bundles/reader/test/import.test.js
+++ b/bundles/reader/test/import.test.js
@@ -99,3 +99,69 @@ test("url html import archives the raw page and extracts readable text", async (
     .rows[0].paragraphs_json));
   assert.ok(paras.some((p) => p.includes("moment that matters")));
 });
+
+test("assertPublicHost rejects an IPv4-mapped IPv6 loopback literal", async () => {
+  const { assertPublicHost } = await import("../server/import.js");
+  await assert.rejects(assertPublicHost("http://[::ffff:127.0.0.1]/x", {}), /private address/);
+});
+
+test("ingestDocument rejects a non-http(s) URL scheme", async () => {
+  const fetchImpl = async () => { throw new Error("fetchImpl should not be called"); };
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "url", url: "ftp://example.test/a.pdf",
+  }, { fetchImpl });
+  assert.equal(extraction_status, "failed");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_diagnostics FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.match(JSON.parse(String(doc.extraction_diagnostics)).error, /scheme/);
+});
+
+test("ingestDocument fails with too-many-redirects past the redirect cap", async () => {
+  const fetchImpl = async () => new Response(null, {
+    status: 302, headers: { location: "https://example.test/next" } });
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "url", url: "https://example.test/start",
+  }, { fetchImpl });
+  assert.equal(extraction_status, "failed");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_diagnostics FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.match(JSON.parse(String(doc.extraction_diagnostics)).error, /too many redirects/);
+});
+
+test("ingestDocument fails with a distinct message for a redirect with no location", async () => {
+  const fetchImpl = async () => new Response(null, { status: 302, headers: {} });
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "url", url: "https://example.test/nowhere",
+  }, { fetchImpl });
+  assert.equal(extraction_status, "failed");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_diagnostics FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.match(JSON.parse(String(doc.extraction_diagnostics)).error, /redirect without location/);
+});
+
+test("ingestDocument fails when declared content-length exceeds the byte cap", async () => {
+  const capConfig = { ...config, READER_MAX_UPLOAD_MB: "1" };
+  const fetchImpl = async () => new Response(null, {
+    status: 200, headers: { "content-type": "text/html", "content-length": "2097153" } });
+  const { id, extraction_status } = await ingestDocument(db, capConfig, {
+    sourceType: "url", url: "https://example.test/big",
+  }, { fetchImpl });
+  assert.equal(extraction_status, "failed");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_diagnostics FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.match(JSON.parse(String(doc.extraction_diagnostics)).error, /byte cap/);
+});
+
+test("ingestDocument fails when a streamed body exceeds the byte cap despite no honest content-length", async () => {
+  const capConfig = { ...config, READER_MAX_UPLOAD_MB: "1" };
+  const oversized = Buffer.alloc(1_200_000, 65); // 1.2 MB, over the 1 MB cap
+  const fetchImpl = async () => new Response(new Blob([oversized]), {
+    status: 200, headers: { "content-type": "text/html" } });
+  const { id, extraction_status } = await ingestDocument(db, capConfig, {
+    sourceType: "url", url: "https://example.test/stream-big",
+  }, { fetchImpl });
+  assert.equal(extraction_status, "failed");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_diagnostics FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.match(JSON.parse(String(doc.extraction_diagnostics)).error, /byte cap/);
+});

--- a/bundles/reader/test/import.test.js
+++ b/bundles/reader/test/import.test.js
@@ -1,0 +1,101 @@
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { initReaderTables } from "../server/init-tables.js";
+import { ingestDocument, splitLongParagraphJs } from "../server/import.js";
+
+let db, config;
+before(async () => {
+  db = createClient({ url: "file::memory:" });
+  await initReaderTables(db);
+  config = { CROW_DATA_DIR: mkdtempSync(join(tmpdir(), "reader-data-")) };
+});
+
+test("splitLongParagraphJs splits at sentence boundaries under the cap", () => {
+  const sentence = "This sentence has exactly eight words in it. ";
+  const long = sentence.repeat(90); // 720 words
+  const parts = splitLongParagraphJs(long, 500);
+  assert.ok(parts.length >= 2);
+  for (const p of parts) {
+    assert.ok(p.split(/\s+/).length <= 500);
+    assert.match(p.trim(), /\.$/);
+  }
+});
+
+test("txt upload ingests without the Python extractor", async () => {
+  const buffer = Buffer.from("First paragraph.\n\nSecond paragraph.", "utf8");
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "upload", buffer, filename: "notes.txt", title: "My Notes", tags: "test",
+  });
+  assert.equal(extraction_status, "ok");
+  const doc = (await db.execute({
+    sql: "SELECT * FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.equal(doc.title, "My Notes");
+  assert.ok(existsSync(String(doc.original_path)), "original not stored");
+  const sec = (await db.execute({
+    sql: "SELECT paragraphs_json FROM reader_sections WHERE document_id = ?", args: [id] })).rows[0];
+  assert.deepEqual(JSON.parse(String(sec.paragraphs_json)),
+    ["First paragraph.", "Second paragraph."]);
+});
+
+test("pdf upload routes through the extractor and records diagnostics", async () => {
+  const extractImpl = async () => ({
+    ok: true,
+    sections: [{ title: null, paragraphs: ["From the extractor."] }],
+    diagnostics: { pages: 3, empty_pages: 0, used_ocr: false },
+  });
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "upload", buffer: Buffer.from("%PDF-1.4 fake"), filename: "guide.pdf",
+  }, { extractImpl });
+  assert.equal(extraction_status, "ok");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_diagnostics, original_mime FROM reader_documents WHERE id = ?",
+    args: [id] })).rows[0];
+  assert.equal(doc.original_mime, "application/pdf");
+  assert.equal(JSON.parse(String(doc.extraction_diagnostics)).pages, 3);
+});
+
+test("extractor failure leaves the document with status failed, row intact", async () => {
+  const extractImpl = async () => ({ ok: false, error: "kaboom" });
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "upload", buffer: Buffer.from("%PDF-1.4 fake"), filename: "bad.pdf",
+  }, { extractImpl });
+  assert.equal(extraction_status, "failed");
+  const doc = (await db.execute({
+    sql: "SELECT extraction_status FROM reader_documents WHERE id = ?", args: [id] })).rows[0];
+  assert.equal(doc.extraction_status, "failed");
+});
+
+test("assertPublicHost rejects loopback, honors the opt-out", async () => {
+  const { assertPublicHost } = await import("../server/import.js");
+  await assert.rejects(assertPublicHost("http://127.0.0.1/x", {}), /private address/);
+  await assert.rejects(assertPublicHost("http://[::1]/x", {}), /private address/);
+  await assertPublicHost("http://127.0.0.1/x", { READER_ALLOW_PRIVATE_URLS: "1" });
+});
+
+test("url html import archives the raw page and extracts readable text", async () => {
+  const html = `<html><head><title>Method Card</title></head><body>
+    <article><h1>Journey Mapping</h1>
+    <p>${"Map the steps a person takes through a service. ".repeat(12)}</p>
+    <p>${"Each step reveals a moment that matters to them. ".repeat(12)}</p>
+    </article></body></html>`;
+  const fetchImpl = async () => new Response(html, {
+    status: 200, headers: { "content-type": "text/html; charset=utf-8" } });
+  const { id, extraction_status } = await ingestDocument(db, config, {
+    sourceType: "url", url: "https://example.test/methods/journey",
+  }, { fetchImpl });
+  assert.equal(extraction_status, "ok");
+  const doc = (await db.execute({
+    sql: "SELECT title, archived_html_path, source_ref FROM reader_documents WHERE id = ?",
+    args: [id] })).rows[0];
+  assert.ok(existsSync(String(doc.archived_html_path)), "raw HTML not archived");
+  assert.ok(readFileSync(String(doc.archived_html_path), "utf8").includes("Journey Mapping"));
+  assert.equal(doc.source_ref, "https://example.test/methods/journey");
+  const paras = JSON.parse(String((await db.execute({
+    sql: "SELECT paragraphs_json FROM reader_sections WHERE document_id = ?", args: [id] }))
+    .rows[0].paragraphs_json));
+  assert.ok(paras.some((p) => p.includes("moment that matters")));
+});

--- a/bundles/reader/test/import.test.js
+++ b/bundles/reader/test/import.test.js
@@ -105,6 +105,13 @@ test("assertPublicHost rejects an IPv4-mapped IPv6 loopback literal", async () =
   await assert.rejects(assertPublicHost("http://[::ffff:127.0.0.1]/x", {}), /private address/);
 });
 
+test("assertPublicHost rejects CGNAT/Tailscale range 100.64/10", async () => {
+  const { assertPublicHost } = await import("../server/import.js");
+  await assert.rejects(assertPublicHost("http://100.121.254.89/x", {}), /private address/);
+  await assert.rejects(assertPublicHost("http://100.127.255.255/x", {}), /private address/);
+  await assertPublicHost("http://100.63.0.1/x", { READER_ALLOW_PRIVATE_URLS: "1" });
+});
+
 test("ingestDocument rejects a non-http(s) URL scheme", async () => {
   const fetchImpl = async () => { throw new Error("fetchImpl should not be called"); };
   const { id, extraction_status } = await ingestDocument(db, config, {

--- a/bundles/reader/test/import.test.js
+++ b/bundles/reader/test/import.test.js
@@ -73,6 +73,10 @@ test("assertPublicHost rejects loopback, honors the opt-out", async () => {
   const { assertPublicHost } = await import("../server/import.js");
   await assert.rejects(assertPublicHost("http://127.0.0.1/x", {}), /private address/);
   await assert.rejects(assertPublicHost("http://[::1]/x", {}), /private address/);
+  // IPv6 unspecified — connects to localhost; both literal spellings
+  // canonicalize to "::" in the URL parser.
+  await assert.rejects(assertPublicHost("http://[::]/x", {}), /private address/);
+  await assert.rejects(assertPublicHost("http://[0:0:0:0:0:0:0:0]/x", {}), /private address/);
   await assertPublicHost("http://127.0.0.1/x", { READER_ALLOW_PRIVATE_URLS: "1" });
 });
 
@@ -109,7 +113,9 @@ test("assertPublicHost rejects CGNAT/Tailscale range 100.64/10", async () => {
   const { assertPublicHost } = await import("../server/import.js");
   await assert.rejects(assertPublicHost("http://100.121.254.89/x", {}), /private address/);
   await assert.rejects(assertPublicHost("http://100.127.255.255/x", {}), /private address/);
-  await assertPublicHost("http://100.63.0.1/x", { READER_ALLOW_PRIVATE_URLS: "1" });
+  // Just below the CGNAT range: must pass WITHOUT the opt-out, or the
+  // boundary assertion is vacuous (the opt-out short-circuits the guard).
+  await assertPublicHost("http://100.63.0.1/x", {});
 });
 
 test("ingestDocument rejects a non-http(s) URL scheme", async () => {

--- a/bundles/reader/test/ingest-guard.test.js
+++ b/bundles/reader/test/ingest-guard.test.js
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { assertPathAllowed } from "../server/ingest-guard.js";
+
+test("assertPathAllowed passes a file directly under the allowed root", () => {
+  const root = mkdtempSync(join(tmpdir(), "reader-guard-root-"));
+  try {
+    const file = join(root, "doc.txt");
+    writeFileSync(file, "hello");
+    const resolved = assertPathAllowed(file, { READER_INGEST_ROOTS: root });
+    assert.equal(resolved, realpathSync(file));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("assertPathAllowed rejects a symlink under the root pointing outside it", () => {
+  const root = mkdtempSync(join(tmpdir(), "reader-guard-root-"));
+  const outside = mkdtempSync(join(tmpdir(), "reader-guard-outside-"));
+  try {
+    const secret = join(outside, "secret.txt");
+    writeFileSync(secret, "outside content");
+    const link = join(root, "link.txt");
+    symlinkSync(secret, link);
+    assert.throws(
+      () => assertPathAllowed(link, { READER_INGEST_ROOTS: root }),
+      /outside READER_INGEST_ROOTS allowlist/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("assertPathAllowed throws a not-found error for a missing file", () => {
+  const root = mkdtempSync(join(tmpdir(), "reader-guard-root-"));
+  try {
+    const missing = join(root, "nope.txt");
+    assert.throws(
+      () => assertPathAllowed(missing, { READER_INGEST_ROOTS: root }),
+      /File not found/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/bundles/reader/test/init-tables.test.js
+++ b/bundles/reader/test/init-tables.test.js
@@ -1,0 +1,51 @@
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { initReaderTables } from "../server/init-tables.js";
+
+let db;
+before(async () => {
+  db = createClient({ url: "file::memory:" });
+  await initReaderTables(db);
+  await initReaderTables(db); // idempotent
+});
+
+test("all reader tables exist", async () => {
+  const { rows } = await db.execute(
+    "SELECT name FROM sqlite_master WHERE type IN ('table','view') ORDER BY name");
+  const names = rows.map((r) => r.name);
+  for (const t of ["reader_documents", "reader_sections", "reader_annotations",
+    "reader_progress", "reader_chunks", "reader_chunk_embeddings",
+    "reader_documents_fts", "reader_annotations_fts"]) {
+    assert.ok(names.includes(t), `missing ${t}`);
+  }
+});
+
+test("documents FTS triggers sync on insert/update/delete", async () => {
+  await db.execute({
+    sql: "INSERT INTO reader_documents (title, source_type, tags) VALUES (?, 'upload', ?)",
+    args: ["Field Guide to Design", "design,hcd"],
+  });
+  let hits = await db.execute(
+    "SELECT rowid FROM reader_documents_fts WHERE reader_documents_fts MATCH '\"design\"'");
+  assert.equal(hits.rows.length, 1);
+  await db.execute("UPDATE reader_documents SET title = 'Renamed' WHERE id = 1");
+  hits = await db.execute(
+    "SELECT rowid FROM reader_documents_fts WHERE reader_documents_fts MATCH '\"renamed\"'");
+  assert.equal(hits.rows.length, 1);
+  await db.execute("DELETE FROM reader_documents WHERE id = 1");
+  hits = await db.execute(
+    "SELECT rowid FROM reader_documents_fts WHERE reader_documents_fts MATCH '\"renamed\"'");
+  assert.equal(hits.rows.length, 0);
+});
+
+test("progress upsert key is (document_id, section_number)", async () => {
+  await db.execute({
+    sql: `INSERT INTO reader_progress (document_id, section_number, paragraph)
+          VALUES (1, 1, 5)
+          ON CONFLICT(document_id, section_number) DO UPDATE SET paragraph = excluded.paragraph`,
+    args: [],
+  });
+  const { rows } = await db.execute("SELECT paragraph FROM reader_progress WHERE document_id = 1");
+  assert.equal(Number(rows[0].paragraph), 5);
+});

--- a/bundles/reader/test/progress.test.js
+++ b/bundles/reader/test/progress.test.js
@@ -1,0 +1,26 @@
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { initReaderTables } from "../server/init-tables.js";
+import { saveProgress, getProgress } from "../server/progress.js";
+
+let db;
+before(async () => {
+  db = createClient({ url: "file::memory:" });
+  await initReaderTables(db);
+});
+
+test("progress only moves forward", async () => {
+  await saveProgress(db, { document_id: 1, section_number: 1, paragraph: 10, total_paragraphs: 40 });
+  await saveProgress(db, { document_id: 1, section_number: 1, paragraph: 4 });
+  const row = await getProgress(db, 1, 1);
+  assert.equal(Number(row.paragraph), 10);
+  await saveProgress(db, { document_id: 1, section_number: 1, paragraph: 22 });
+  assert.equal(Number((await getProgress(db, 1, 1)).paragraph), 22);
+});
+
+test("sections track independently; missing returns null", async () => {
+  await saveProgress(db, { document_id: 1, section_number: 2, paragraph: 3 });
+  assert.equal(Number((await getProgress(db, 1, 2)).paragraph), 3);
+  assert.equal(await getProgress(db, 99, 1), null);
+});

--- a/bundles/reader/test/progress.test.js
+++ b/bundles/reader/test/progress.test.js
@@ -24,3 +24,12 @@ test("sections track independently; missing returns null", async () => {
   assert.equal(Number((await getProgress(db, 1, 2)).paragraph), 3);
   assert.equal(await getProgress(db, 99, 1), null);
 });
+
+test("total_paragraphs: 0 treated as null, preserves prior value", async () => {
+  await saveProgress(db, { document_id: 2, section_number: 1, paragraph: 1, total_paragraphs: 50 });
+  let row = await getProgress(db, 2, 1);
+  assert.equal(Number(row.total_paragraphs), 50);
+  await saveProgress(db, { document_id: 2, section_number: 1, paragraph: 2, total_paragraphs: 0 });
+  row = await getProgress(db, 2, 1);
+  assert.equal(Number(row.total_paragraphs), 50);
+});

--- a/bundles/reader/test/queries.test.js
+++ b/bundles/reader/test/queries.test.js
@@ -1,0 +1,45 @@
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { createClient } from "@libsql/client";
+import { initReaderTables } from "../server/init-tables.js";
+import { ingestDocument } from "../server/import.js";
+import { listDocuments, getDocument } from "../server/queries.js";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let db, config;
+before(async () => {
+  db = createClient({ url: "file::memory:" });
+  await initReaderTables(db);
+  config = { CROW_DATA_DIR: mkdtempSync(join(tmpdir(), "reader-q-")) };
+  await ingestDocument(db, config, {
+    sourceType: "upload", buffer: Buffer.from("Alpha paragraph.\n\nBeta paragraph."),
+    filename: "alpha.txt", title: "Alpha Doc", tags: "hcd",
+  });
+  await ingestDocument(db, config, {
+    sourceType: "upload", buffer: Buffer.from("Gamma."), filename: "gamma.md", title: "Gamma Doc",
+  });
+});
+
+test("listDocuments returns both, newest first, with section counts", async () => {
+  const rows = await listDocuments(db, {});
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].title, "Gamma Doc");
+  assert.equal(Number(rows[0].section_count), 1);
+});
+
+test("listDocuments filters by FTS query", async () => {
+  const rows = await listDocuments(db, { query: "alpha" });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].title, "Alpha Doc");
+});
+
+test("getDocument returns sections with paragraph counts, null for missing id", async () => {
+  const rows = await listDocuments(db, { query: "alpha" });
+  const got = await getDocument(db, Number(rows[0].id));
+  assert.equal(got.document.title, "Alpha Doc");
+  assert.equal(got.sections.length, 1);
+  assert.equal(got.sections[0].paragraph_count, 2);
+  assert.equal(await getDocument(db, 9999), null);
+});

--- a/bundles/reader/test/queries.test.js
+++ b/bundles/reader/test/queries.test.js
@@ -43,3 +43,22 @@ test("getDocument returns sections with paragraph counts, null for missing id", 
   assert.equal(got.sections[0].paragraph_count, 2);
   assert.equal(await getDocument(db, 9999), null);
 });
+
+test("listDocuments escapes LIKE wildcards in the tag filter", async () => {
+  const localDb = createClient({ url: "file::memory:" });
+  await initReaderTables(localDb);
+  const localConfig = { CROW_DATA_DIR: mkdtempSync(join(tmpdir(), "reader-q-tag-")) };
+  await ingestDocument(localDb, localConfig, {
+    sourceType: "upload", buffer: Buffer.from("Delta paragraph."),
+    filename: "delta.txt", title: "Delta Doc", tags: "a_b",
+  });
+
+  const exact = await listDocuments(localDb, { tag: "a_b" });
+  assert.equal(exact.length, 1);
+  assert.equal(exact[0].title, "Delta Doc");
+
+  // "___" would match "a_b" via unescaped SQL LIKE wildcards (three
+  // single-char wildcards); it must not match once "_" is escaped.
+  const wildcard = await listDocuments(localDb, { tag: "___" });
+  assert.equal(wildcard.length, 0);
+});

--- a/bundles/reader/test/render.test.js
+++ b/bundles/reader/test/render.test.js
@@ -20,13 +20,18 @@ test("readerPage embeds document data and forces a full Turbo reload", () => {
   const html = readerPage({
     document: { id: 7, title: "Guide <b>", extraction_status: "ok" },
     section: { section_number: 1, title: null },
-    sections: [{ section_number: 1, title: null, paragraph_count: 2 }],
+    sections: [
+      { section_number: 1, title: null, paragraph_count: 2 },
+      { section_number: 2, title: null, paragraph_count: 1 },
+    ],
     paragraphs: ["One.", "Two."],
     progress: { paragraph: 1 },
   });
   assert.ok(html.includes('name="turbo-visit-control" content="reload"'));
   assert.ok(html.includes("Guide &lt;b&gt;"));
   assert.ok(html.includes('id="reader-data"'));
+  // Section nav (2+ sections) renders a numeric, unbroken href.
+  assert.ok(html.includes("/reader-app/7?section=2"));
   const m = html.match(/<script type="application\/json" id="reader-data">(.*?)<\/script>/s);
   const data = JSON.parse(m[1]);
   assert.equal(data.documentId, 7);

--- a/bundles/reader/test/render.test.js
+++ b/bundles/reader/test/render.test.js
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { renderParagraph, readerPage } from "../server/render.js";
+
+test("plain paragraph renders escaped text in an er-para div", () => {
+  const html = renderParagraph("Design <thinking> & empathy", 3);
+  assert.ok(html.includes('data-para="3"'));
+  assert.ok(html.includes("Design &lt;thinking&gt; &amp; empathy"));
+});
+
+test("[TABLE] paragraph renders an HTML table", () => {
+  const md = "[TABLE]\n| A | B |\n|---|---|\n| 1 | 2 |";
+  const html = renderParagraph(md, 0);
+  assert.ok(html.includes("<table"));
+  assert.ok(html.includes("<td>1</td>"));
+  assert.ok(!html.includes("[TABLE]"));
+});
+
+test("readerPage embeds document data and forces a full Turbo reload", () => {
+  const html = readerPage({
+    document: { id: 7, title: "Guide <b>", extraction_status: "ok" },
+    section: { section_number: 1, title: null },
+    sections: [{ section_number: 1, title: null, paragraph_count: 2 }],
+    paragraphs: ["One.", "Two."],
+    progress: { paragraph: 1 },
+  });
+  assert.ok(html.includes('name="turbo-visit-control" content="reload"'));
+  assert.ok(html.includes("Guide &lt;b&gt;"));
+  assert.ok(html.includes('id="reader-data"'));
+  const m = html.match(/<script type="application\/json" id="reader-data">(.*?)<\/script>/s);
+  const data = JSON.parse(m[1]);
+  assert.equal(data.documentId, 7);
+  assert.equal(data.totalParagraphs, 2);
+  assert.equal(data.resumeParagraph, 1);
+});

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -5078,6 +5078,107 @@
       "official": true
     },
     {
+      "id": "reader",
+      "name": "Reader",
+      "version": "0.1.0",
+      "description": "E-reader for project material — import PDFs, web pages, and files; read in a clean paragraph view; originals kept as archival copies. TTS, annotations, and memory promotion arrive in later milestones.",
+      "type": "mcp-server",
+      "author": "Crow",
+      "category": "productivity",
+      "tags": [
+        "reader",
+        "ereader",
+        "pdf",
+        "import",
+        "reading"
+      ],
+      "icon": "book-open",
+      "server": {
+        "command": "node",
+        "args": [
+          "server/index.js"
+        ],
+        "envKeys": [
+          "READER_SECRETS_FILE",
+          "READER_EMBED_URL",
+          "READER_EMBED_MODEL",
+          "GOOGLE_TOKEN_FILE",
+          "READER_EXPORT_DRIVE_FOLDER_ID",
+          "READER_UV_BIN",
+          "READER_EXTRACT_TIMEOUT_MS",
+          "READER_MAX_UPLOAD_MB",
+          "READER_AUDIO_CACHE_MB",
+          "READER_ALLOW_PRIVATE_URLS",
+          "READER_INGEST_ROOTS"
+        ]
+      },
+      "panel": "panel/reader.js",
+      "panelRoutes": "panel/routes.js",
+      "requires": {
+        "min_ram_mb": 128,
+        "min_disk_mb": 200
+      },
+      "env_vars": [
+        {
+          "name": "READER_SECRETS_FILE",
+          "description": "Optional path to a KEY=VALUE secrets file loaded after $CROW_HOME/env/reader.env (process.env still wins)",
+          "required": false
+        },
+        {
+          "name": "READER_EMBED_URL",
+          "description": "OpenAI-style embeddings base URL for semantic search (POSTs to <url>/embeddings); unset disables semantic search, FTS still works",
+          "required": false
+        },
+        {
+          "name": "READER_EMBED_MODEL",
+          "description": "Embedding model name",
+          "required": false
+        },
+        {
+          "name": "GOOGLE_TOKEN_FILE",
+          "description": "Path to a Google OAuth2 authorized_user JSON; unset hides Drive import and Doc export",
+          "required": false
+        },
+        {
+          "name": "READER_EXPORT_DRIVE_FOLDER_ID",
+          "description": "Drive folder id for Google Doc exports",
+          "required": false
+        },
+        {
+          "name": "READER_UV_BIN",
+          "description": "Path to the uv binary for the Python extractor (default: uv on PATH)",
+          "required": false
+        },
+        {
+          "name": "READER_EXTRACT_TIMEOUT_MS",
+          "description": "Extraction subprocess timeout in ms (default 180000)",
+          "required": false
+        },
+        {
+          "name": "READER_MAX_UPLOAD_MB",
+          "description": "Upload size cap in MB, also caps URL-import downloads (default 50)",
+          "required": false
+        },
+        {
+          "name": "READER_AUDIO_CACHE_MB",
+          "description": "TTS audio cache cap in MB, used from milestone 2 (default 2048)",
+          "required": false
+        },
+        {
+          "name": "READER_ALLOW_PRIVATE_URLS",
+          "description": "Set to 1 to let URL import fetch private/loopback addresses (default: blocked, SSRF guard)",
+          "required": false
+        },
+        {
+          "name": "READER_INGEST_ROOTS",
+          "description": "Colon-separated directory allowlist for crow_reader_ingest local paths (default: the user home directory)",
+          "required": false
+        }
+      ],
+      "notes": "Milestone 1 ships import + Read view. TTS (gateway registry, timing-aware), quote-anchored annotations with crow memory promotion, pdf.js Original view, and Drive/Doc export land in later milestones per the design spec.",
+      "official": true
+    },
+    {
       "id": "romm",
       "name": "RoMM",
       "description": "Retro game library and emulator — browse, organize, and play retro games in the browser",


### PR DESCRIPTION
## Reader bundle — milestone 1

New `bundles/reader/` bundle: an e-reader for project material. Import documents, read them in a clean paragraph view in the dashboard, and keep the originals as archival copies. First of a staged series (TTS with word-timing, quote-anchored annotations with memory promotion, a pdf.js Original view, and Drive integration follow in later milestones).

### What's in milestone 1

- **Import**: file upload, URL fetch (raw HTML archived alongside extracted text), and a `crow_reader_ingest` MCP tool for local paths. Originals stored under `$CROW_DATA_DIR/reader/originals/`.
- **Extraction**: vendored PEP-723 Python script (`uv` + PyMuPDF) reusing capstone-tracker's cleanup heuristics verbatim (11 functions, AST-identical); block-level extraction with `[TABLE]` markdown blocks; optional Tesseract OCR for scanned PDFs; structured diagnostics; extraction failure never blocks the document row.
- **Read view**: server-rendered paragraph view with table rendering, section nav, and server-authoritative forward-only reading progress (cross-device resume).
- **MCP tools**: `crow_reader_ingest`, `crow_reader_list`, `crow_reader_get`.
- **Tables**: idempotent `reader_*` DDL in crow.db (annotation/chunk tables created now, filled by later milestones). No existing table is touched; the branch adds files only.

### Hardening (review-driven)

- SSRF guard on URL import: scheme allowlist, manual redirects with a per-hop guard (max 5), private/loopback/link-local + IPv4-mapped IPv6 (both textual forms) + CGNAT 100.64/10 blocked by default (`READER_ALLOW_PRIVATE_URLS=1` opt-out), byte caps on declared and streamed size.
- `crow_reader_ingest` path allowlist (`READER_INGEST_ROOTS`, default `$HOME`) with realpath on both sides (symlink-escape tested).
- FTS input sanitized; tag filter LIKE-escaped; all rendered HTML escaped; panel routes path-scoped (STRICT_PANEL_MOUNT) with validated params and try/catch on every async handler (Express 4).

### Testing

- 36 unit tests (node:test, in-memory libsql), including a real PyMuPDF fixture round-trip and the security branches (SSRF ranges, redirect cap, byte caps, symlink escape, LIKE wildcards).
- End-to-end smoke against a scratch-CROW_HOME gateway: install-shape (panels copy + node_modules symlink), library render, upload, URL archive, PDF ingest + Read view, progress row + resume, 400 paths.

### Ops note for anyone repeating the smoke

Set **both** `CROW_HOME` and `CROW_DATA_DIR` when standing up a scratch gateway on a host with a real `~/.crow` — the core gateway db resolver honors `CROW_DATA_DIR`, not `CROW_HOME`, and `--no-auth` does not bypass `/dashboard` session auth (expect first-run password setup).