### PR TITLE
fix(board): action_needed + next_followup_date persist on card updates

### DIFF
--- a/servers/gateway/board/card-service.js
+++ b/servers/gateway/board/card-service.js
@@ -173,7 +173,11 @@ export async function createCard(tdb, fields, actor) {
 // set — project-assignment is its own explicit operation, not something that
 // follows from another field, so it belongs in the generic key/value loop
 // with no special-case logic.
-const CARD_UPDATE_FIELDS = ["title", "description", "due_date", "phase", "owner", "tags", "priority", "autonomy", "assigned_bot", "project_id"];
+// "action_needed" and "next_followup_date" joined this list 2026-08-20: the
+// board_update_item tool schema has always advertised both for cards, but only
+// updateItem's ITEM_PLAIN_FIELDS wrote them — on a card they were silently
+// dropped (and an update passing only those fields returned changed:false).
+const CARD_UPDATE_FIELDS = ["title", "description", "due_date", "phase", "owner", "tags", "priority", "autonomy", "assigned_bot", "project_id", "action_needed", "next_followup_date"];
 
 // `allowArchived` (Finding 1 fix wave): bulk-assign's `?include_archived=1`
 // escape hatch (Task 5, D-T1.6) is a deliberate operator override that lets

--- a/tests/board-mcp.test.js
+++ b/tests/board-mcp.test.js
@@ -326,6 +326,19 @@ test("board_update_item: plain fields, and parent_id re-parents + re-inherits pr
   assert.equal(got.item.title, "changed");
   assert.equal(got.item.owner, "kevin");
 
+  // action_needed / next_followup_date persist on CARDS too (regression:
+  // they were in the tool schema but missing from CARD_UPDATE_FIELDS, so a
+  // card update carrying only these fields silently dropped them and
+  // returned changed:false).
+  const flagged = payload(await client.callTool({
+    name: "board_update_item",
+    arguments: { id: created.id, action_needed: "review the doc", next_followup_date: "2026-08-25" },
+  }));
+  assert.equal(flagged.changed, true, "action_needed-only card update reports changed");
+  const gotFlagged = payload(await client.callTool({ name: "board_get_item", arguments: { id: created.id } }));
+  assert.equal(gotFlagged.item.action_needed, "review the doc");
+  assert.equal(gotFlagged.item.next_followup_date, "2026-08-25");
+
   // parent_id round trip: re-parenting onto a card in a different project
   // re-inherits that project (D-T1.1 "parent_id supported" — same semantics
   // as create, per card-service.updateCard).


### PR DESCRIPTION
board_update_item's schema advertises `action_needed` and `next_followup_date` for both id spaces, but only updateItem's ITEM_PLAIN_FIELDS wrote them. On a card the two fields were silently dropped: an update carrying only them returned `changed:false`, and one carrying them alongside other fields returned `changed:true` while persisting everything except them. Bit the operator three times (first logged 2026-08-18).

Fix: add both to CARD_UPDATE_FIELDS (plain string columns, same normalize path as the rest of the loop). The wire test now proves an action_needed-only card update reports changed and reads both fields back.

Known gap left as-is: updateCard also ignores the schema's `data` merge (item-only today); this change stays scoped to the reported fields.

Tests: `node --test tests/board-mcp.test.js` = 14 pass / 0 fail (node v22; better-sqlite3 ABI needs it).