### PR TITLE
bot-board: make card/item ids searchable

### DIFF
--- a/servers/gateway/dashboard/panels/bot-board/html.js
+++ b/servers/gateway/dashboard/panels/bot-board/html.js
@@ -83,7 +83,8 @@ export function cardFaceHtml(card, locked, lang, def = DEFAULT_BOARD_DEF) {
   try { data = JSON.parse(card.data_json || "{}"); } catch { data = {}; }
   const fieldMeta = declaredFieldMeta(def, card, data);
   // Search text mirrors the tracker face: everything a human would scan for.
-  const searchParts = [card.title || "", card.status || "", card.owner || "", card.tags || "", card.due_date || ""];
+  // The id leads so a typed "#284" (or a bare "284") finds one card among hundreds.
+  const searchParts = [`#${card.id}`, card.title || "", card.status || "", card.owner || "", card.tags || "", card.due_date || ""];
   for (const f of def.fields || []) {
     const v = f.storage === "column" ? card[f.key] : data[f.key];
     if (v != null && v !== "") searchParts.push(String(v));
@@ -120,7 +121,7 @@ export function trackerCardFaceHtml(item, contextFields, statusValues, locked, l
   // Extract metadata from data_json for context fields (skip "label" and "status")
   let data = {};
   try { data = JSON.parse(item.data_json || "{}"); } catch { data = {}; }
-  const searchParts = [item.label || "", item.status || "", item.tags || ""];
+  const searchParts = [`#${item.id}`, item.label || "", item.status || "", item.tags || ""];
   for (const v of Object.values(data)) {
     if (v != null && v !== "") searchParts.push(typeof v === "object" ? JSON.stringify(v) : String(v));
   }
@@ -604,7 +605,7 @@ export async function renderCustomTracker(req, res, { db, layout, selBot, bots, 
 
   const filterBarHtml =
     `<div class="bb-filter-bar">` +
-    `<input type="text" id="bb-search" class="bb-search" placeholder="Search items…">` +
+    `<input type="text" id="bb-search" class="bb-search" placeholder="Search items (label, tag, #id)…">` +
     `<div class="bb-chips">` +
     statusValues.map((sv) => `<button type="button" class="bb-chip" data-status-filter="${escapeHtml(sv)}">${escapeHtml(sv)}</button>`).join("") +
     `<button type="button" class="bb-chip bb-chip-action" data-filter="action-needed">${t("botboard.filterActionNeeded", lang)}</button>` +

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1380,7 +1380,7 @@ export const translations = {
   "botboard.cfgAddField": { en: "+ Add field", es: "+ A\u00f1adir campo" },
   "botboard.cfgSave": { en: "Save board settings", es: "Guardar ajustes del tablero" },
   "botboard.cfgSaved": { en: "Saved \u2014 reloading\u2026", es: "Guardado \u2014 recargando\u2026" },
-  "botboard.searchCards": { en: "Search cards\u2026", es: "Buscar tarjetas\u2026" },
+  "botboard.searchCards": { en: "Search cards (title, tag, #id)\u2026", es: "Buscar tarjetas (t\u00edtulo, etiqueta, #id)\u2026" },
   "botboard.viewColumns": { en: "Columns", es: "Columnas" },
   "botboard.viewList": { en: "List", es: "Lista" },
 


### PR DESCRIPTION
The Bot Board search box matched title, status, owner, tags, due date and declared fields, but not the card number, so finding one card by id on a board with a few hundred cards meant scrolling. This puts `#<id>` first in the search text for kanban cards and custom-tracker items, and names `#id` in the placeholder (en/es).

Typing `#284` now narrows the board to that card (`284` alone also matches). No behavior change elsewhere; the hash-persisted filters, drawer deep links, and list view all reuse the same `data-search-text`.