### PR TITLE
feat: attribute every model start to its requester (log-only)

### DIFF
--- a/scripts/pi-bots/warm.mjs
+++ b/scripts/pi-bots/warm.mjs
@@ -30,7 +30,9 @@ export async function warmModel(provider, log = () => {}) {
   try {
     const r = await fetch(`${WARM_BASE}/llm/acquire`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      // Model-start attribution: the gateway logs this tag beside every
+      // start it makes on our behalf (see servers/gateway/requester-tag.js).
+      headers: { "content-type": "application/json", "x-crow-client": "pibot-warm" },
       body: JSON.stringify({ provider }),
       signal: AbortSignal.timeout(WARM_TIMEOUT_MS),
     });

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -493,11 +493,11 @@ export function resolveWarmableProviderName(cfg, name, ownAddrs = getOwnAddresse
  * (returns null — no-op). Backs POST /llm/acquire for the pi-bots background-job /
  * bridge warm path; the gateway chat path already warms inline.
  */
-export async function warmProviderByName(name) {
+export async function warmProviderByName(name, opts = {}) {
   if (!name) return null;
   const target = resolveWarmableProviderName(loadProviders(), name);
   if (!target) return null;
-  return maybeAcquireLocalProvider(target);
+  return maybeAcquireLocalProvider(target, opts);
 }
 
 // Test/introspection helpers — exported for smoke scripts.
@@ -700,7 +700,7 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
     }
   } catch { /* catalog unreadable → no extra args, model starts as before */ }
 
-  console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port}, readinessTimeoutMs=${readinessTimeoutMs})`);
+  console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port}, readinessTimeoutMs=${readinessTimeoutMs}) requested-by=${opts.requester || "-"}`);
   const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal: wrappedOnTerminal, extraArgs });
   _nativeHandles.set(providerName, handle);
 
@@ -983,7 +983,7 @@ export async function acquireProvider(providerName, opts = {}) {
     }
 
     // Start target.
-    console.log(`[gpu-orchestrator] starting ${providerName} (bundleId=${p.bundleId})`);
+    console.log(`[gpu-orchestrator] starting ${providerName} (bundleId=${p.bundleId}) requested-by=${opts.requester || "-"}`);
     await bundleUpFn(p.bundleId);
     const ready = await waitForReadyFn(p.baseUrl);
     if (ready) {
@@ -1026,7 +1026,7 @@ async function checkIdleRevert() {
       if (idleFor < IDLE_REVERT_MS) continue;
       console.log(`[gpu-orchestrator] ${m.name} idle ${Math.round(idleFor / 1000)}s — reverting to ${group.default}`);
       try {
-        await acquireProvider(group.default);
+        await acquireProvider(group.default, { requester: "idle-revert" });
       } catch (err) {
         console.warn(`[gpu-orchestrator] auto-revert to ${group.default} failed: ${err.message}`);
       }
@@ -1111,8 +1111,9 @@ async function ensureNativeResident(name, p, cfg, opts = {}) {
 export async function ensureResident(name, cfg = loadProviders(), opts = {}) {
   try {
     const p = (cfg.providers || {})[name];
+    const requester = opts.requester || "residency";
     if (p && isNativeRuntime(p)) {
-      return await ensureNativeResident(name, p, cfg, opts);
+      return await ensureNativeResident(name, p, cfg, { ...opts, requester });
     }
     if (!p?.bundleId) {
       console.warn(`[gpu-orchestrator] ${name} has no bundleId — skipping`);
@@ -1122,7 +1123,7 @@ export async function ensureResident(name, cfg = loadProviders(), opts = {}) {
       console.log(`[gpu-orchestrator] ${name} already resident`);
       return false;
     }
-    console.log(`[gpu-orchestrator] starting ${name} (bundleId=${p.bundleId})`);
+    console.log(`[gpu-orchestrator] starting ${name} (bundleId=${p.bundleId}) requested-by=${requester}`);
     await bundleUp(p.bundleId);
     const ready = await waitForReady(p.baseUrl);
     if (!ready) {
@@ -1153,7 +1154,7 @@ export async function retryDeferredResidents({
     if (!isLocallyOrchestratable(p, ownAddrs)) continue; // still not ours — stays parked
     _deferredResidents.delete(name);
     console.log(`[gpu-orchestrator] deferred alwaysResident ${name} is now locally hosted — ensuring (its interface came up after boot)`);
-    if (await ensure(name, cfg)) embedRecovered = true;
+    if (await ensure(name, cfg, { requester: "residency-retry" })) embedRecovered = true;
     ensured.push(name);
   }
   if (embedRecovered) triggerEmbedBackfill();
@@ -1461,7 +1462,7 @@ export async function initOrchestrator() {
     }
     let embedRecovered = false;
     for (const name of residents) {
-      if (await ensureResident(name, cfg)) embedRecovered = true;
+      if (await ensureResident(name, cfg, { requester: "residency" })) embedRecovered = true;
     }
     startIdleRevertTimer();
     if (embedRecovered) {

--- a/servers/gateway/requester-tag.js
+++ b/servers/gateway/requester-tag.js
@@ -1,0 +1,12 @@
+/** Who asked for a model? /llm/v1 is unauthenticated by design (companion is
+ * loopback), so attribution is whatever the request carries: peer ip, a
+ * bounded user-agent, and the optional X-Crow-Client tag first-party clients set.
+ * Pure and never throws — `req` may be `{}`, null, or headerless. The result is
+ * a log token only (model-start attribution); it gates nothing. */
+export function requesterTag(req) {
+  const h = (req && req.headers) || {};
+  const ip = String((req && req.ip) || "").replace(/^::ffff:/, "") || "-";
+  const ua = String(h["user-agent"] || "").replace(/\s+/g, " ").trim().slice(0, 40) || "-";
+  const client = String(h["x-crow-client"] || "").replace(/[^A-Za-z0-9._/-]+/g, "_").slice(0, 40) || "-";
+  return `${ip} ua=${ua} client=${client}`;
+}

--- a/servers/gateway/routes/chat.js
+++ b/servers/gateway/routes/chat.js
@@ -700,7 +700,7 @@ export default function chatRouter(dashboardAuth) {
         const { maybeAcquireLocalProvider, isNativeRuntimeProvider } = await import("../gpu-orchestrator.js");
         const isNative = isNativeRuntimeProvider(effectiveProvider);
         sendEvent("provider_warming", nativeWarmingEvent(effectiveProvider, isNative, lang));
-        const warmed = await maybeAcquireLocalProvider(effectiveProvider);
+        const warmed = await maybeAcquireLocalProvider(effectiveProvider, { requester: "dashboard-chat" });
         if (warmed === false) {
           sendEvent("error", providerNotReadyError(effectiveProvider, isNative, lang));
           closeStream();

--- a/servers/gateway/routes/llm-router.js
+++ b/servers/gateway/routes/llm-router.js
@@ -34,6 +34,7 @@ import { Readable } from "node:stream";
 import { createDbClient } from "../../db.js";
 import { resolveProviderConfig } from "../ai/resolve-profile.js";
 import { maybeAcquireLocalProvider, warmProviderByName } from "../gpu-orchestrator.js";
+import { requesterTag } from "../requester-tag.js";
 import { connectTimeout, isTimeoutError, LLM_CONNECT_TIMEOUT_MS } from "../../shared/http-timeout.js";
 import { extractUsageFromOpenAIResponse, recordUsageEvent } from "../../shared/metering.js";
 import { resolveTenantId } from "../../shared/tenancy.js";
@@ -216,7 +217,8 @@ async function handleChat(req, res) {
   // companion sees a warm-up simply as this await taking longer, same as
   // before this task.
   const [providerId] = splitKey(key);
-  await maybeAcquireLocalProvider(providerId);
+  const requester = requesterTag(req);
+  await maybeAcquireLocalProvider(providerId, { requester });
 
   let up;
   try {
@@ -228,7 +230,7 @@ async function handleChat(req, res) {
   body.model = up.model;
   const url = `${up.baseUrl}/chat/completions`;
   const t0 = Date.now();
-  console.log(`[llm-router] route=${escalate ? `escalate(${escReason})` : "fast"} -> ${key} (${up.model}) stream=${!!body.stream}`);
+  console.log(`[llm-router] route=${escalate ? `escalate(${escReason})` : "fast"} -> ${key} (${up.model}) stream=${!!body.stream} requester=${requester}`);
 
   let upstream;
   try {
@@ -333,7 +335,7 @@ export default function llmRouterRouter() {
     const provider = req.body && (req.body.provider || req.body.providerId);
     if (!provider) return res.status(400).json({ ok: false, error: "provider required" });
     try {
-      const warmed = await warmProviderByName(provider);
+      const warmed = await warmProviderByName(provider, { requester: requesterTag(req) });
       res.json({ ok: warmed !== false, warmed, provider });
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -585,7 +585,7 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
       // captures it (opt-in seam on maybeAcquireLocalProvider, see its
       // doc) so it can ride along in the response body as `cause`.
       let startError = null;
-      const result = await maybeAcquireLocalProviderFn(modelId, { onError: (err) => { startError = err; } });
+      const result = await maybeAcquireLocalProviderFn(modelId, { requester: "models-panel", onError: (err) => { startError = err; } });
       if (result === true) return res.json({ running: true });
       if (result === false) {
         const cause = startError ? { code: startError.code || "UNKNOWN", message: startError.message } : null;

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -944,3 +944,56 @@ test("Finding c: persisting the marker against an unwritable dir never throws an
   const result = await acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn }));
   assert.equal(result, true, "an unwritable/fake persistence dir never blocks a successful start");
 });
+
+// --- model-start attribution (log-only): every native start line names its
+// requester via `opts.requester`, threaded through the existing opts bag ---
+
+/** Capture `console.log` lines for the duration of `fn`. */
+async function captureLogs(fn) {
+  const logs = [];
+  const orig = console.log;
+  console.log = (m) => logs.push(String(m));
+  try { await fn(); } finally { console.log = orig; }
+  return logs;
+}
+
+/** identityProbe stub: "down" on the fast-path check, "resident" after. */
+function downThenResident() {
+  let calls = 0;
+  return async () => (++calls === 1 ? "down" : "resident");
+}
+
+test("attribution: acquireProvider native start log carries requested-by=<opts.requester>", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18120, "qwen3-4b") } };
+  const logs = await captureLogs(async () => {
+    const result = await acquireProvider("native-target", {
+      ...startCapableOpts({ cfg, identityProbeFn: downThenResident() }),
+      requester: "10.0.0.5 ua=curl/8 client=companion",
+    });
+    assert.equal(result, true);
+  });
+  const line = logs.find((l) => l.includes("starting native native-target"));
+  assert.ok(line, `expected a 'starting native' line, got:\n${logs.join("\n")}`);
+  assert.ok(line.endsWith(" requested-by=10.0.0.5 ua=curl/8 client=companion"), line);
+});
+
+test("attribution: a native start with no requester logs requested-by=-", async () => {
+  const cfg = { providers: { "native-target": nativeProv(18121, "qwen3-4b") } };
+  const logs = await captureLogs(async () => {
+    await acquireProvider("native-target", startCapableOpts({ cfg, identityProbeFn: downThenResident() }));
+  });
+  const line = logs.find((l) => l.includes("starting native native-target"));
+  assert.ok(line, `expected a 'starting native' line, got:\n${logs.join("\n")}`);
+  assert.ok(line.endsWith(" requested-by=-"), line);
+});
+
+test("attribution: ensureResident's native start is attributed to residency", async () => {
+  const p = nativeProv(18122, "qwen3-4b", { gpuPolicy: { alwaysResident: true, runtime: "native" } });
+  const cfg = { providers: { "native-target": p } };
+  const logs = await captureLogs(async () => {
+    await ensureResident("native-target", cfg, startCapableOpts({ cfg, identityProbeFn: downThenResident() }));
+  });
+  const line = logs.find((l) => l.includes("starting native native-target"));
+  assert.ok(line, `expected a 'starting native' line, got:\n${logs.join("\n")}`);
+  assert.ok(line.endsWith(" requested-by=residency"), line);
+});

--- a/tests/requester-tag.test.js
+++ b/tests/requester-tag.test.js
@@ -1,0 +1,34 @@
+/**
+ * requesterTag — who asked for a model? (model-start attribution, log-only).
+ *
+ * /llm/v1 is unauthenticated by design (the companion is loopback), so the
+ * only attribution available is what the request carries: peer ip, a
+ * bounded user-agent, and the optional X-Crow-Client tag first-party
+ * clients set. The tag is pure, never throws, and tolerates `{}`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { requesterTag } from "../servers/gateway/requester-tag.js";
+
+test("requesterTag: ip + ua + client, bounded, dash for missing", () => {
+  assert.equal(requesterTag({}), "- ua=- client=-");
+  assert.equal(
+    requesterTag({ ip: "::ffff:10.0.0.5", headers: { "user-agent": "x".repeat(60), "x-crow-client": "companion" } }),
+    "10.0.0.5 ua=" + "x".repeat(40) + " client=companion"
+  );
+  assert.equal(requesterTag({ ip: "127.0.0.1", headers: { "x-crow-client": "a b\nc" } }), "127.0.0.1 ua=- client=a_b_c");
+});
+
+test("requesterTag: never throws on a null/undefined request or headers", () => {
+  assert.equal(requesterTag(undefined), "- ua=- client=-");
+  assert.equal(requesterTag(null), "- ua=- client=-");
+  assert.equal(requesterTag({ ip: "10.0.0.9", headers: null }), "10.0.0.9 ua=- client=-");
+});
+
+test("requesterTag: user-agent whitespace is collapsed and the client tag is bounded to 40 chars", () => {
+  const tag = requesterTag({
+    ip: "10.0.0.7",
+    headers: { "user-agent": "  Mozilla/5.0\n(X11;\tLinux)  ", "x-crow-client": "pibot-warm/" + "b".repeat(80) },
+  });
+  assert.equal(tag, "10.0.0.7 ua=Mozilla/5.0 (X11; Linux) client=pibot-warm/" + "b".repeat(29));
+});


### PR DESCRIPTION
PR 1 of the box-reservation work (scope: `docs/superpowers/specs/2026-09-04-box-reservation-scheduling-scope.md` §3.4; plan: `docs/superpowers/plans/2026-09-04-acceptance-gaps-and-box-reservation.md` PR B).

**Why:** on 2026-08-29 two unattended benchmark windows were aborted by anonymous escalations to the 35B model. `/llm/v1` is unauthenticated by design (the companion arrives as loopback), so today nothing in the logs says who asked for a model start. This PR makes the next occurrence name its requester.

**What (log-only, zero behavior change):**
- new `servers/gateway/requester-tag.js` — `requesterTag(req)` = `<ip> ua=<first 40 chars> client=<X-Crow-Client or ->`, pure, never throws.
- `/llm/v1` route log gains ` requester=<tag>`; `/llm/acquire` and the router pass `{ requester }` through `maybeAcquireLocalProvider` / `warmProviderByName(name, opts)`.
- gpu-orchestrator start lines (docker, native, residency) gain ` requested-by=<requester|->`; residency paths tag themselves `residency` / `residency-retry` / `idle-revert`.
- dashboard chat tags `dashboard-chat`, models panel `models-panel`, pi-bots `warm.mjs` sends `X-Crow-Client: pibot-warm`.

**Tests:** `tests/requester-tag.test.js` (new) + 3 log-line assertions on the real native start path in `tests/gpu-orchestrator-native.test.js`. Full suite 3621/0 under node 22; port + registry checks OK.