### PR TITLE
fix: Track 3 acceptance gaps F1–F4 (brief text, board auto-mount, empty steer, cycle feedback)

### DIFF
--- a/scripts/pi-bots/bot-world.mjs
+++ b/scripts/pi-bots/bot-world.mjs
@@ -52,17 +52,21 @@ function loadBridge() { return import("./bridge.mjs"); }
  * Phase A — identity. The exact sequence handleInbound ran inline before C-11.
  *
  * @param {{botId: string, threadId: string, gatewayType?: string,
- *          log?: (m: string) => void, jobId?: string|null}} opts
+ *          log?: (m: string) => void, jobId?: string|null, cardBound?: boolean}} opts
  *   `jobId` (Track 1 Task 7 — the missing link in the job_id chain):
  *   job_runner.runCardExecute passes job.job_id through here so it reaches
  *   writeBotMcp's board-entry headers (X-Crow-Job-Id) — without it the
  *   result-service job-rail lock exemption (D-T1.5) can never match a
  *   job-dispatched turn's own bot_jobs row.
+ *   `cardBound` (Track 3 acceptance F2): a perch session spawned against a
+ *   card. Like a job turn, it must be able to call board_report_result (the
+ *   dispatch brief ends the run with that call), so the board MCP entry is
+ *   ensured regardless of the def's own crow_mcp selection.
  * @returns {Promise<{def, bot, crowHome, projectId, projectSpace, projectMembers,
  *          sessionDir, tasksDbPath, remoteEnabled, peerGatewayUrls, session,
  *          narrowedTools, gatewayType}>}
  */
-export async function buildBotWorld({ botId, threadId, gatewayType = "perch", log = () => {}, jobId = null }) {
+export async function buildBotWorld({ botId, threadId, gatewayType = "perch", log = () => {}, jobId = null, cardBound = false }) {
   const B = await loadBridge();
   const bot = B.loadBot(botId);
   const def = bot.def;
@@ -116,7 +120,12 @@ export async function buildBotWorld({ botId, threadId, gatewayType = "perch", lo
     if (remoteEnabled) peerGatewayUrls = B.readPeerGatewayUrls(_conn);
   } finally { _conn.close(); }
   try {
-    const w = writeBotMcp(def, { sessionDir, crowHome, remoteEnabled, peerGatewayUrls, botId, jobId });
+    // acceptance F2: a card-bound session (or a job turn) must be able to
+    // call board_report_result — ensure the board entry is minted.
+    const w = writeBotMcp(def, {
+      sessionDir, crowHome, remoteEnabled, peerGatewayUrls, botId, jobId,
+      ensureServers: (jobId || cardBound) ? ["board"] : [],
+    });
     if (w.warnings.length) log("mcp.json warnings: " + w.warnings.join("; "));
     if (w.remoteWarnings && w.remoteWarnings.length) {
       for (const warn of w.remoteWarnings) log("remote-tool: " + warn);

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -35,7 +35,7 @@ import { dirname } from "node:path";
 import { countLivePi, LIFECYCLE_DEFAULTS } from "./pi_lifecycle.mjs";
 import { isMultiAgentCapable } from "./pi_extensions_allowlist.mjs";
 import { resolveModel, escalateRequested, stripEscalateToken } from "./model_resolver.mjs";
-import { getTrackerContext, kanbanText, cardStatus, resolveTrackerType, boardVocab } from "./tracker.mjs";
+import { getTrackerContext, kanbanText, cardStatus, resolveTrackerType, boardVocab, cardText } from "./tracker.mjs";
 import { cardBriefBlock } from "./card-brief.mjs";
 import { resolveNodeBin, requirePiCli } from "./pi_resolver.mjs";
 import { gatewayHint as resolveGatewayHint } from "./gateways/index.mjs";
@@ -763,7 +763,7 @@ export async function handleInbound(opts) {
     // "...not a status write.") is now a shared pure builder — see
     // card-brief.mjs — so the interactive dispatch rail can compose the same
     // brief. projectHeader/gatewayHint and the channel tail stay caller-side.
-    promptText = projectHeader + "\n\n" + cardBriefBlock({ cardId, tasksDbPath, userLine: cleanMsg, planForCard, cardStatus, boardVocab }) +
+    promptText = projectHeader + "\n\n" + cardBriefBlock({ cardId, tasksDbPath, userLine: cleanMsg, planForCard, cardStatus, boardVocab, cardText }) +
       " Then reply with a short summary for the gateway thread. One card only.";
   } else {
     // No card reference — let the bot DECIDE based on its system prompt

--- a/scripts/pi-bots/card-brief.mjs
+++ b/scripts/pi-bots/card-brief.mjs
@@ -1,19 +1,23 @@
 // scripts/pi-bots/card-brief.mjs
 //
 // Track 3 Task 2 — pure builder for the "Work the following card" prompt
-// block, extracted verbatim out of bridge.mjs (the `cardId != null` branch)
-// so a later dispatch rail (interactive, not just the mail/discord bridge)
-// can compose the identical brief. Deliberately has NO imports from
-// bridge.mjs or tracker.mjs — every DB-touching lookup is injected by the
-// caller as a function, so this module stays a pure string assembler with
-// no cycle risk and no DB of its own.
+// block, extracted out of bridge.mjs (the `cardId != null` branch) so the
+// interactive dispatch rail (not just the mail/discord bridge) composes the
+// identical brief. Deliberately has NO imports from bridge.mjs or
+// tracker.mjs — every DB-touching lookup is injected by the caller as a
+// function, so this module stays a pure string assembler with no cycle risk
+// and no DB of its own.
 //
-// BYTE-IDENTITY with the historical bridge.mjs text is the binding
-// requirement (see tests/card-brief.test.js's golden). The block starts at
-// "Work the following card." and ends at "...not a status write." — the
+// Both callers (bridge.mjs and perch-interactive.js) call this one builder,
+// so the two rails' briefs are identical by construction. The block starts
+// at "Work the following card." and ends at "...not a status write." — the
 // caller (bridge.mjs) still owns projectHeader/gatewayHint before this text
 // and the channel-specific tail (" Then reply with a short summary for the
 // gateway thread. One card only.") after it.
+//
+// Track 3 acceptance F1: the brief carries the card's own title and
+// description (the `cardText` seam) — a card with no plan record used to
+// dispatch a bot with nothing but a number and "(no plan)".
 
 /**
  * @param {object} args
@@ -23,15 +27,21 @@
  * @param {(cardId: number|string) => string|null} args.planForCard
  * @param {(cardId: number|string, tasksDbPath: string) => string} args.cardStatus
  * @param {(cardId: number|string, tasksDbPath: string) => { statuses: string[], terminals: string[] }} args.boardVocab
+ * @param {(cardId: number|string, tasksDbPath: string) => { title: string, description: string|null }} [args.cardText]
+ *   optional (legacy callers omit it) — absent behaves as `{ title: "", description: null }`
  * @returns {string}
  */
-export function cardBriefBlock({ cardId, tasksDbPath, userLine, planForCard, cardStatus, boardVocab }) {
+export function cardBriefBlock({ cardId, tasksDbPath, userLine, planForCard, cardStatus, boardVocab, cardText }) {
   const vocab = boardVocab(cardId, tasksDbPath);
   const planBody = planForCard(cardId);
-  return "Work the following card.\n\nCARD #" + cardId +
-    " (current board status: " + cardStatus(cardId, tasksDbPath) + "; this board's statuses: " + vocab.statuses.join(", ") + ").\nPLAN:\n---\n" +
+  const text = typeof cardText === "function" ? (cardText(cardId, tasksDbPath) || {}) : {};
+  const title = text.title ? " — " + String(text.title).replace(/\s+/g, " ").trim() : "";
+  const desc = text.description ? String(text.description).trim() : "(none)";
+  return "Work the following card.\n\nCARD #" + cardId + title +
+    " (current board status: " + cardStatus(cardId, tasksDbPath) + "; this board's statuses: " + vocab.statuses.join(", ") + ").\n" +
+    "DESCRIPTION:\n---\n" + desc + "\n---\nPLAN:\n---\n" +
     (planBody || "(no plan)") + "\n---\n\nUser said: \"" + userLine + "\"\n\n" +
-    "Do the work the plan describes. You may use board_move_item to update this card's status " +
+    "Do the work the plan describes; if there is no plan, do what the card's title and description ask. You may use board_move_item to update this card's status " +
     "as you go (only ever use this board's statuses). When you are done, call board_report_result " +
     "with item_id=" + cardId + ", an outcome of success/failure/partial, and a summary_md describing " +
     "what you did — that call is what ends the run, not a status write.";

--- a/scripts/pi-bots/mcp_writer.mjs
+++ b/scripts/pi-bots/mcp_writer.mjs
@@ -155,7 +155,14 @@ export function extraServersFromExtensions(def, crowHome = resolveCrowHome(), op
  *   `servers` lists ACTIVE names only; disabled names are in `disabled`.
  */
 export function buildBotMcp(def, canonical, opts = {}) {
-  const want = serversForBot(def);
+  // opts.ensureServers (Track 3 acceptance F2): names unioned into the
+  // selection BEFORE catalog resolution, so a card-bound session gets the
+  // board entry (it must be able to call board_report_result — that call is
+  // what ends the run) even when the def never selected board/*. An ensured
+  // name absent from the catalog rides the same unconfigured/soft-warning
+  // path as a selected-but-absent server.
+  const ensure = (opts.ensureServers || []).filter((n) => typeof n === "string" && n);
+  const want = [...new Set([...serversForBot(def), ...ensure])];
   const catalog = opts.catalog || {};
   const unconfigured = opts.unconfigured || {};
   const binding = opts.binding;
@@ -278,6 +285,7 @@ export function writeBotMcp(def, opts = {}) {
   });
   const built = buildBotMcp(def, canonical, {
     extraServers, catalog, unconfigured, binding, crowHome,
+    ensureServers: opts.ensureServers,
   });
   // F4a L2b: merge cross-instance forward-proxy blocks when the caller has
   // confirmed feature_flags.remote_invocation is on (the DB read is done by the

--- a/scripts/pi-bots/tracker.mjs
+++ b/scripts/pi-bots/tracker.mjs
@@ -58,6 +58,16 @@ export function cardStatus(cardId, tasksDbPath) {
   return r ? r.status : null;
 }
 
+/** Track 3 acceptance F1: the card's own words for the dispatch brief. */
+export function cardText(cardId, tasksDbPath) {
+  const path = tasksDbPath || TASKS_DB;
+  const t = db(path);
+  try {
+    const r = t.prepare("SELECT title, description FROM tasks_items WHERE id=?").get(cardId);
+    return { title: r && r.title ? String(r.title) : "", description: r && r.description ? String(r.description) : null };
+  } finally { t.close(); }
+}
+
 // Track 0: statuses and terminal-ness are per-board (board_defs). The bridge
 // must not hardcode 'done' — a custom board's terminal is whatever its def
 // says. Every failure mode (no card, no project, no board_defs table, corrupt

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -1629,10 +1629,14 @@ export function createInteractiveEngine({
     const s = await resolveSession(sessionId);
     if (!s) throw engineError("no_such_session");
     if (s.state === "stopped") throw engineError("session_stopped");
+    // Acceptance F3: a blank steer is a client bug (the drawer's composer
+    // sent nothing), never a silent no-op — refused BEFORE the no_turn/
+    // pi_gone checks so it is reported even when no turn is running.
+    const message = String(text == null ? "" : text);
+    if (!message.trim()) throw engineError("empty_message");
     if (!s.turn) throw engineError("no_turn");
     const alive = !!(s.pi && s.pi._exitCode == null);
     if (!alive) throw engineError("pi_gone");
-    const message = String(text == null ? "" : text);
     s.pi.send({ type: "steer", message });
     emit(s, { type: "log", text: "steered: " + message.slice(0, 200) });
     return { ok: true };

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -313,6 +313,8 @@ export function createInteractiveEngine({
       projectContextBlock: br.projectContextBlock,
       cardStatus: tracker.cardStatus,
       boardVocab: tracker.boardVocab,
+      // Acceptance F1: the card's title/description ride in the brief.
+      cardText: tracker.cardText,
       // Metering wants a better-sqlite3 connection opened busy_timeout-ONLY
       // (metering.mjs's header: createDbClient would WAL-flip the prod crow.db
       // out from under the bridge). Use the bridge's own db()/CROW_DB, exactly
@@ -1594,6 +1596,7 @@ export function createInteractiveEngine({
         planForCard: S.planForCard,
         cardStatus: S.cardStatus,
         boardVocab: S.boardVocab,
+        cardText: S.cardText,
       }) + "\n\nDeliverables you produce as files go in: " + s.outputsDir;
       s.dispatchBrief = null;
     }

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -139,7 +139,7 @@
  * (spec §9).
  */
 import { randomUUID } from "node:crypto";
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -506,6 +506,22 @@ export function createInteractiveEngine({
       log(s.sessionId + ": " + text);
       emit(s, { type: "log", text });
     };
+  }
+
+  /**
+   * Acceptance F4: ": N MCP server(s) minted" for the "world rebuilt" log
+   * line, read off the per-bot .mcp.json writeBotMcp just wrote into the
+   * world's sessionDir. Never throws — an absent file (a test world, a
+   * skipped write) yields "" and the line stays "world rebuilt".
+   */
+  function mintedSummary(world) {
+    try {
+      const j = JSON.parse(readFileSync(join(world.sessionDir, ".mcp.json"), "utf8"));
+      const names = Object.keys((j && j.mcpServers) || {}).filter((n) => !(j.mcpServers[n] && j.mcpServers[n].disabled));
+      return ": " + names.length + " MCP server(s) minted";
+    } catch {
+      return "";
+    }
   }
 
   // ---- timers --------------------------------------------------------------
@@ -1007,6 +1023,11 @@ export function createInteractiveEngine({
       botId: s.botId, threadId: s.threadId, gatewayType: "perch", log: slog,
       cardBound: s.cardId != null,
     });
+    // Acceptance F4: narrate the rebuild for the drawer (spawn, wake and
+    // cycle all come through here). The world itself does not expose what
+    // writeBotMcp minted, so count the active entries off the .mcp.json it
+    // just wrote — best-effort, a missing/unreadable file just drops the count.
+    slog("world rebuilt" + mintedSummary(world));
     const prep = await S.prepareSpawn(world, { escalate: false, log: slog });
     s.projectId = world.projectId == null ? null : Number(world.projectId);
     // Track 3 Task 6: refreshed on EVERY startChild (spawn and wake alike),
@@ -1037,6 +1058,7 @@ export function createInteractiveEngine({
     }
     s.resolved = prep.resolved;
     await S.warmModel(prep.resolved.provider, slog);
+    slog("model warm: " + (s.currentModel || (prep.resolved && prep.resolved.key) || "?"));
 
     // Track 3 Task 6: per-session outputs/uploads dirs — every spawn/wake,
     // not just card-bound ones (a free-chat session gets a workspace too).
@@ -1680,6 +1702,10 @@ export function createInteractiveEngine({
     if (s.state === "stopped") throw engineError("session_stopped");
     if (s.turn || s.pendingUi || s.cycling) throw engineError("cycle_busy");
     s.cycling = true;                                  // ← the re-entrancy claim
+    // Acceptance F4: the drawer renders `log` events, and a cycle is several
+    // seconds of world rebuild + model warm + spawn during which the operator
+    // previously saw nothing at all. Narrate the moments they wait on.
+    emit(s, { type: "log", text: "cycling: stopping the child and rebuilding its world (spawn-bound settings apply now)" });
     try {
       await hibernate(s);                              // no-op if already hibernating
       // ---- one synchronous block: reservation, no await between check+flip
@@ -1707,6 +1733,7 @@ export function createInteractiveEngine({
       }
       emit(s, stateEvent(s));
       armIdle(s);
+      emit(s, { type: "log", text: "ready — the first turn re-reads its full transcript, which can take a minute on long sessions" });
       return { state: s.state };
     } finally {
       s.cycling = false;

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -1000,8 +1000,12 @@ export function createInteractiveEngine({
   async function startChild(S, s) {
     const slog = sessionLog(s);
     // Track 3 Task 6: serialized per-bot — see buildWorldSerialized's comment.
+    // acceptance F2: a card-bound session must be able to call
+    // board_report_result — cardBound makes the world builder mint the
+    // board MCP entry whatever the def's own tool selection says.
     const world = await buildWorldSerialized(S, {
       botId: s.botId, threadId: s.threadId, gatewayType: "perch", log: slog,
+      cardBound: s.cardId != null,
     });
     const prep = await S.prepareSpawn(world, { escalate: false, log: slog });
     s.projectId = world.projectId == null ? null : Number(world.projectId);

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -127,6 +127,8 @@ const ERROR_MAP = {
   no_such_request: [409, "no_such_request"],
   no_turn: [409, "no_turn"],
   bad_request: [400, "bad_request"],
+  // Acceptance F3: a blank steer is a client bug, not a silent 200.
+  empty_message: [400, "empty_message"],
   // Track 3 Task 9 additions.
   card_occupied: [409, "card_occupied"],
   no_session_dir: [409, "no_session_dir"],

--- a/tests/bridge-board-rail.test.js
+++ b/tests/bridge-board-rail.test.js
@@ -407,4 +407,35 @@ describe("handleInbound board rail (execute prompt + board_report_result detecti
     const mcpNoJob = JSON.parse(readFileSync(join(worldNoJob.sessionDir, ".mcp.json"), "utf8"));
     assert.ok(!("X-Crow-Job-Id" in mcpNoJob.mcpServers.board.headers));
   });
+
+  test("buildBotWorld(cardBound:true) mints the board entry for a def that never selected board/*; default does not (acceptance F2)", async () => {
+    // Track 3 acceptance F2: the dispatch brief ends the run with
+    // board_report_result, so a card-bound perch session whose def never
+    // selected board/* used to spawn with NO board entry and could only
+    // time out. railbot selects board itself (above), so this needs a bot
+    // that does not — same scratch HOME/canonical/board-token as the jobId
+    // test, same REAL buildBotWorld.
+    const c = new Database(CROW_DB);
+    c.prepare("INSERT OR REPLACE INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,?)").run(
+      "plainbot", "Plain Bot",
+      JSON.stringify({
+        system_prompt: "You are a bot with no board tools.",
+        models: { default: "stub/m1" },
+        tools: { pi_builtin: ["read"], crow_mcp: [] },
+        permission_policy: { bash: "deny", write_paths: [], multi_agent: false },
+        session_dir: join(ROOT, "bots", "plainbot"),
+      }), 1,
+    );
+    c.close();
+    const { buildBotWorld } = await import("../scripts/pi-bots/bot-world.mjs");
+    const a = await buildBotWorld({ botId: "plainbot", threadId: "cardbound-a", gatewayType: "perch", cardBound: true, log: () => {} });
+    const mcpA = JSON.parse(readFileSync(join(a.sessionDir, ".mcp.json"), "utf8"));
+    assert.ok(mcpA.mcpServers.board && !mcpA.mcpServers.board.disabled, "card-bound: board entry minted and active");
+    assert.equal(mcpA.mcpServers.board.headers["X-Crow-Actor-Id"], "plainbot");
+    assert.ok(!("X-Crow-Job-Id" in mcpA.mcpServers.board.headers), "card-bound without a job: no job header");
+
+    const b = await buildBotWorld({ botId: "plainbot", threadId: "cardbound-b", gatewayType: "perch", log: () => {} });
+    const mcpB = JSON.parse(readFileSync(join(b.sessionDir, ".mcp.json"), "utf8"));
+    assert.ok(!mcpB.mcpServers.board || mcpB.mcpServers.board.disabled, "default (free chat): closed-world selection unchanged");
+  });
 });

--- a/tests/card-brief.test.js
+++ b/tests/card-brief.test.js
@@ -1,24 +1,25 @@
 // tests/card-brief.test.js
 //
-// Track 3 Task 2 — extract the "Work the following card" prompt block out
-// of bridge.mjs into a pure, DB-free helper (card-brief.mjs) so the
-// interactive dispatch rail (a later task) can compose the same brief.
-// BYTE-IDENTITY of the bridge's composed prompt is the binding requirement:
-// this golden is copied verbatim from the current bridge.mjs:688-695
-// concatenation (fixed inputs substituted for cardId/status/statuses/plan),
-// and stops at "...not a status write." — the trailing channel tail
-// (" Then reply with a short summary for the gateway thread. One card
-// only.") is caller-side and stays in bridge.mjs.
+// Track 3 Task 2 — the "Work the following card" prompt block lives in a
+// pure, DB-free helper (card-brief.mjs) so the mail/discord bridge and the
+// interactive dispatch rail compose the same brief by construction (both
+// call this one builder — byte-identity between the two callers is
+// guaranteed without a golden per caller). Track 3 acceptance F1: the brief
+// carries the card's own title and description, so a card with no plan
+// record still tells the bot what to do. The trailing channel tail (" Then
+// reply with a short summary for the gateway thread. One card only.") is
+// caller-side and stays in bridge.mjs.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { cardBriefBlock } from "../scripts/pi-bots/card-brief.mjs";
 
-test("card brief is byte-identical to the bridge's historical block", () => {
+test("card brief carries the card's title and description above the plan", () => {
   const expected =
-    "Work the following card.\n\nCARD #42 (current board status: todo; this board's statuses: todo, doing, done).\nPLAN:\n---\n" +
+    "Work the following card.\n\nCARD #42 — Fix the login redirect (current board status: todo; this board's statuses: todo, doing, done).\n" +
+    "DESCRIPTION:\n---\nUsers land on /dashboard/login twice.\n---\nPLAN:\n---\n" +
     "PLAN BODY\n---\n\nUser said: \"do card 42\"\n\n" +
-    "Do the work the plan describes. You may use board_move_item to update this card's status " +
+    "Do the work the plan describes; if there is no plan, do what the card's title and description ask. You may use board_move_item to update this card's status " +
     "as you go (only ever use this board's statuses). When you are done, call board_report_result " +
     "with item_id=42, an outcome of success/failure/partial, and a summary_md describing " +
     "what you did — that call is what ends the run, not a status write.";
@@ -27,8 +28,28 @@ test("card brief is byte-identical to the bridge's historical block", () => {
     planForCard: () => "PLAN BODY",
     cardStatus: () => "todo",
     boardVocab: () => ({ statuses: ["todo", "doing", "done"], terminals: ["done"] }),
+    cardText: () => ({ title: "Fix the login redirect", description: "Users land on /dashboard/login twice." }),
   });
   assert.equal(got, expected);
+});
+
+test("no plan + no description: both blocks say so, title still present", () => {
+  const got = cardBriefBlock({
+    cardId: 7, tasksDbPath: "/x", userLine: "Work this card.",
+    planForCard: () => null, cardStatus: () => "pending",
+    boardVocab: () => ({ statuses: ["pending", "done"], terminals: ["done"] }),
+    cardText: () => ({ title: "Say hello", description: null }),
+  });
+  assert.match(got, /^Work the following card\.\n\nCARD #7 — Say hello \(current board status: pending; this board's statuses: pending, done\)\.\nDESCRIPTION:\n---\n\(none\)\n---\nPLAN:\n---\n\(no plan\)\n---\n/);
+});
+
+test("cardText omitted (legacy caller): no title dash, description (none)", () => {
+  const got = cardBriefBlock({
+    cardId: 9, tasksDbPath: "/x", userLine: "x",
+    planForCard: () => "P", cardStatus: () => "todo",
+    boardVocab: () => ({ statuses: ["todo"], terminals: [] }),
+  });
+  assert.match(got, /^Work the following card\.\n\nCARD #9 \(current board status: todo; this board's statuses: todo\)\.\nDESCRIPTION:\n---\n\(none\)\n---\n/);
 });
 
 test("falls back to '(no plan)' when planForCard returns nothing", () => {

--- a/tests/mcp-writer-ensure-servers.test.js
+++ b/tests/mcp-writer-ensure-servers.test.js
@@ -1,0 +1,45 @@
+// tests/mcp-writer-ensure-servers.test.js
+//
+// Track 3 acceptance F2: a card-bound session must be able to call
+// board_report_result even when the bot's def never selected board/* —
+// the dispatch brief ends the run with that call, so a session with no
+// board entry can only ever time out. `ensureServers` is the mcp_writer
+// seam: names unioned into the selection BEFORE catalog resolution, so the
+// entry rides the exact same catalog/unconfigured plumbing (and the same
+// soft warning when the token is missing) as a selected server.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildBotMcp } from "../scripts/pi-bots/mcp_writer.mjs";
+
+const canonical = { mcpServers: { tasks: { command: "node", args: ["x"] } } };
+const catalog = {
+  tasks: { command: "node", args: ["server/index.js"], env: {} },
+  board: { url: "http://127.0.0.1:3001/board/mcp", headers: { Authorization: "Bearer t" } },
+};
+
+test("ensureServers adds the board entry even when the def never selected board/*", () => {
+  const def = { tools: { crow_mcp: ["tasks/tasks_list"] } };
+  const r = buildBotMcp(def, canonical, { catalog, unconfigured: {}, ensureServers: ["board"] });
+  assert.deepEqual(r.json.mcpServers.board, catalog.board);
+  assert.ok(r.servers.includes("board"));
+});
+
+test("without ensureServers the board entry is NOT minted (unchanged closed-world behavior)", () => {
+  const def = { tools: { crow_mcp: ["tasks/tasks_list"] } };
+  const r = buildBotMcp(def, canonical, { catalog, unconfigured: {} });
+  assert.equal(r.json.mcpServers.board, undefined);
+});
+
+test("ensureServers with an unconfigured board (no token) disables it with the catalog's reason, never throws", () => {
+  const def = { tools: { crow_mcp: [] } };
+  const r = buildBotMcp(def, canonical, { catalog: { tasks: catalog.tasks }, unconfigured: { board: "board token not found" }, ensureServers: ["board"] });
+  assert.deepEqual(r.json.mcpServers.board, { disabled: true });
+  assert.ok(r.warnings.some((w) => /board token not found/.test(w)));
+});
+
+test("ensureServers dedupes against the def's own selection and ignores non-string junk", () => {
+  const def = { tools: { crow_mcp: ["board/board_report_result"] } };
+  const r = buildBotMcp(def, canonical, { catalog, unconfigured: {}, ensureServers: ["board", "", null, 7] });
+  assert.equal(r.servers.filter((n) => n === "board").length, 1);
+});

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -329,6 +329,52 @@ test("steer: empty message is reported as empty_message even when no turn is run
 });
 
 // ---------------------------------------------------------------------------
+// 0b. cycle/wake progress is visible in the drawer (acceptance F4)
+// ---------------------------------------------------------------------------
+
+test("cycle emits progress log lines: cycling, world rebuilt, model warm, context re-read warning", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  // The fake world writes no .mcp.json; seed one where the real writeBotMcp
+  // would put it so the "world rebuilt" line can report the ACTIVE count
+  // (disabled entries are canonical leftovers, not minted servers).
+  writeFileSync(join(dir, "bots", "botty", ".mcp.json"), JSON.stringify({
+    mcpServers: { tasks: { command: "node" }, board: { url: "http://127.0.0.1:1/board/mcp" }, other: { disabled: true } },
+  }));
+  const logs = [];
+  const unsub = await engine.subscribe(s.sessionId, (ev) => { if (ev.type === "log") logs.push(ev.text); });
+  await engine.cycle(s.sessionId);
+  unsub();
+  assert.ok(logs.some((t) => /^cycling: stopping the child/.test(t)), logs.join("|"));
+  assert.ok(logs.some((t) => t === "world rebuilt: 2 MCP server(s) minted"), logs.join("|"));
+  assert.ok(logs.some((t) => /^model warm: crow-local\/qwen3\.6-35b-a3b/.test(t)), logs.join("|"));
+  assert.ok(logs.some((t) => /re-reads its full transcript/.test(t)), logs.join("|"));
+  // Order matters to an operator watching the drawer: the warning that the
+  // first turn will be slow is the LAST line, after the child is up.
+  const idx = (re) => logs.findIndex((t) => re.test(t));
+  assert.ok(idx(/^cycling:/) < idx(/^world rebuilt/), "cycling precedes world rebuilt");
+  assert.ok(idx(/^world rebuilt/) < idx(/^model warm:/), "world rebuilt precedes model warm");
+  assert.ok(idx(/^model warm:/) < idx(/re-reads its full transcript/), "model warm precedes the ready line");
+});
+
+test("wake (hibernate -> message) emits the world rebuilt + model warm lines too", async () => {
+  const { engine, clock, state } = makeEngine();
+  const s = await spawned(engine);
+  clock.advance(600_001); // idle timer -> hibernate
+  await tick();
+  assert.equal((await engine.get(s.sessionId)).state, "hibernating");
+  const logs = [];
+  const unsub = await engine.subscribe(s.sessionId, (ev) => { if (ev.type === "log") logs.push(ev.text); });
+  await engine.message(s.sessionId, "wake up");
+  unsub();
+  assert.ok(logs.some((t) => /^world rebuilt/.test(t)), logs.join("|"));
+  assert.ok(logs.some((t) => /^model warm:/.test(t)), logs.join("|"));
+  const pi = state.instances[state.instances.length - 1];
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+});
+
+// ---------------------------------------------------------------------------
 // 1. model_select event tracking
 // ---------------------------------------------------------------------------
 

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -301,6 +301,34 @@ after(() => {
 });
 
 // ---------------------------------------------------------------------------
+// 0. steer: an empty message is a client bug, refused loudly (acceptance F3)
+// ---------------------------------------------------------------------------
+
+test("steer: empty / whitespace message is refused with empty_message and nothing is sent to pi", async () => {
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  await engine.message(s.sessionId, "go"); // turn in flight (promptTurn pending)
+  const pi = state.instances[0];
+  const before = pi.sent.length;
+  await assert.rejects(() => engine.steer(s.sessionId, "   "), (e) => e.code === "empty_message");
+  await assert.rejects(() => engine.steer(s.sessionId, ""), (e) => e.code === "empty_message");
+  await assert.rejects(() => engine.steer(s.sessionId, null), (e) => e.code === "empty_message");
+  assert.equal(pi.sent.length, before, "no steer frame reached pi");
+  const r = await engine.steer(s.sessionId, "  go left ");
+  assert.deepEqual(r, { ok: true });
+  assert.equal(pi.sent.length, before + 1, "a real steer still goes through unchanged");
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+});
+
+test("steer: empty message is reported as empty_message even when no turn is running (client bug beats no_turn)", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  await assert.rejects(() => engine.steer(s.sessionId, " "), (e) => e.code === "empty_message");
+  await assert.rejects(() => engine.steer(s.sessionId, "x"), (e) => e.code === "no_turn");
+});
+
+// ---------------------------------------------------------------------------
 // 1. model_select event tracking
 // ---------------------------------------------------------------------------
 

--- a/tests/perch-interactive-dispatch.test.js
+++ b/tests/perch-interactive-dispatch.test.js
@@ -248,6 +248,7 @@ function makeBridge(opts = {}) {
     projectContextBlock,
     cardStatus: () => state.cardStatusVal,
     boardVocab: () => state.vocab,
+    cardText: () => ({ title: "T", description: null }),
   };
   return seam;
 }
@@ -432,6 +433,7 @@ test("dispatch: spawn stores the brief; the FIRST message() composes header+brie
     planForCard: () => "PLAN BODY",
     cardStatus: () => "in_progress",
     boardVocab: () => ({ statuses: ["todo", "in_progress", "done"], terminals: ["done"] }),
+    cardText: () => ({ title: "T", description: null }),
   });
   const expected = expectedHeader + "\n\n" + expectedBody + "\n\nDeliverables you produce as files go in: " + snap.outputsDir;
   assert.equal(pi.turns[0].message, expected, "the composed prompt is byte-identical to a directly-built cardBriefBlock golden");

--- a/tests/perch-interactive-dispatch.test.js
+++ b/tests/perch-interactive-dispatch.test.js
@@ -483,6 +483,15 @@ test("startChild passes extraWritePaths=[outputsDir] and both outputs/uploads di
 // 6. free-chat cwd refusal (bot-world.mjs)
 // ---------------------------------------------------------------------------
 
+test("spawn passes cardBound to buildBotWorld: true for a card-bound spawn, false for free chat (acceptance F2)", async () => {
+  const { engine, state } = makeEngine();
+  await spawned(engine, { botId: "cardbot", cardId: 77 });
+  await spawned(engine, { botId: "freebot" });
+  const byBot = Object.fromEntries(state.worlds.map((w) => [w.botId, w]));
+  assert.equal(byBot.cardbot.cardBound, true, "card-bound spawn asks the world builder for the board entry");
+  assert.equal(byBot.freebot.cardBound, false, "free chat keeps the def's closed-world selection");
+});
+
 test("buildBotWorld with no def.session_dir and no project workspace throws code no_session_dir", async () => {
   const { buildBotWorld } = await import("../scripts/pi-bots/bot-world.mjs");
   const botId = "nowhereBot";

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -208,6 +208,9 @@ beforeEach(() => {
     },
     async steer(sid, text) {
       engineCalls.steer.push({ sid, text });
+      // Mirrors the real engine's contract (acceptance F3): a blank steer is
+      // a client bug, refused before anything else is checked.
+      if (!String(text == null ? "" : text).trim()) throw engineErr("empty_message");
       return { ok: true };
     },
     async checkCardFree(cardId, opts) {
@@ -430,6 +433,19 @@ test("the interactive steer message is capped at 32k before it reaches the engin
   const { status } = await postJson("/interactive/sess-1/steer", { message: big });
   assert.equal(status, 200);
   assert.equal(engineCalls.steer[0].text.length, 32_000);
+});
+
+test("POST /interactive/:sid/steer with no message is a 400 empty_message, never a silent 200 (acceptance F3)", async () => {
+  let r = await postJson("/interactive/sess-1/steer", {});
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, "empty_message");
+  r = await postJson("/interactive/sess-1/steer", { message: "   " });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, "empty_message");
+  r = await postJson("/interactive/sess-1/steer", { message: "go left" });
+  assert.equal(r.status, 200);
+  assert.deepEqual(r.body, { ok: true });
+  assert.equal(engineCalls.steer[engineCalls.steer.length - 1].text, "go left");
 });
 
 test("POST /interactive/:sid/steer maps no_turn (409), pi_gone (409), and session_stopped→410 stopped", async () => {


### PR DESCRIPTION
Closes the four product gaps surfaced by the r4 live acceptance (see the "Live acceptance on r4" comment on #298). Plan: `docs/superpowers/plans/2026-09-04-acceptance-gaps-and-box-reservation.md` PR A.

- **F1 — plan-less dispatch gave the bird nothing to work on.** `card-brief.mjs` now renders `CARD #N — <title>` plus a `DESCRIPTION:` block (via a new `cardText(cardId, tasksDbPath)` helper in `tracker.mjs`), and the closing instruction reads "if there is no plan, do what the card's title and description ask". Both callers (bridge job rail and the perch dispatch) feed it, so the two briefs stay identical by construction.
- **F2 — dispatch onto a bot without board verbs could never `board_report_result`.** `buildBotMcp`/`writeBotMcp` gain `ensureServers`; `buildBotWorld` takes `cardBound` and ensures the `board` entry whenever `jobId || cardBound`; the perch engine passes `cardBound` for card-bound sessions. Closed-world selection is otherwise unchanged (a bot that never selected `board/*` and is not card-bound still does not get it).
- **F3 — empty steer was a silent `{ok:true}`.** The engine throws `empty_message`; the route maps it to 400.
- **F4 — cycle/wake showed nothing in the drawer.** The engine emits `log` lines the drawer already renders: "cycling: …", "world rebuilt: N MCP server(s) minted", "model warm: <key>", and "ready — the first turn re-reads its full transcript…".

A latent bug fixed on the way: `readFileSync` was not imported in `perch-interactive.js`, so the minted-count helper would have silently degraded in production; the test now pins the exact count.

**Tests:** 13 new (card-brief golden + no-plan/no-description cases, `mcp-writer-ensure-servers`, `bridge-board-rail` cardBound positive/negative, dispatch passes `cardBound`, empty steer at engine and route, cycle/wake log-line order). Full suite 3628/0 under node 22; port + registry checks OK.