### PR TITLE
feat: box-reservation scheduling for the gpu-orchestrator (reservations win, 8h default hold)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -307,6 +307,7 @@ export default defineConfig({
           { text: 'Songbook', link: '/architecture/songbook' },
           { text: "Crow's Nest", link: '/architecture/dashboard' },
           { text: 'Gateway', link: '/architecture/gateway' },
+          { text: 'Box Reservation', link: '/architecture/box-reservation' },
           { text: 'Crow OS', link: '/architecture/crow-os' },
           { text: 'Portable Identity', link: '/architecture/portable-identity' },
           { text: 'Context Management', link: '/architecture/context-management' },

--- a/docs/architecture/box-reservation.md
+++ b/docs/architecture/box-reservation.md
@@ -1,0 +1,61 @@
+# Box Reservation
+
+A **box reservation** tells the gateway's GPU orchestrator that this machine is spoken for. While one exists, no local model that the reservation did not allow gets started: on-demand escalations degrade to the resident fast model, dashboard and panel starts are refused with a clear reason, and the residency timers wait. It exists so unattended benchmark windows and on-demand bot model starts stop colliding.
+
+## The record
+
+One JSON file on tmpfs, at `$CROW_BOX_RESERVATION_PATH` or `/run/user/<uid>/crow-box-reservation.json` by default:
+
+```json
+{
+  "owner": "dsv4-window-20260904-2005",
+  "reason": "bench window (cap 3600s)",
+  "started_at": "2026-09-04T20:05:11Z",
+  "expires_at": "2026-09-04T21:15:11Z",
+  "allow": []
+}
+```
+
+- `expires_at` is mandatory. A crashed writer can never wedge the box: the reservation simply lapses.
+- `allow` lists providers the holder permits to start anyway. The embed provider (`crow-embed`) is always allowed, so search and memory keep working during a window.
+- A file that cannot be parsed, or that has no expiry, counts as **reserved** (fail closed). The dashboard gets a notification saying so.
+- tmpfs means a reboot clears every reservation, which is the right default: a reboot ends every window.
+
+## Who writes it
+
+- **Unattended windows** (pi-lab `dsv4-window.sh`) write it when they open and remove it at teardown. The window's deadman also removes it when it restores production after a crash. The expiry is the window's wall-clock cap plus ten minutes of slack.
+- **Manual holds** use the CLI:
+
+```bash
+node ~/crow/scripts/ops/box-reserve.mjs hold --owner kevin --reason "serving dsv4 tonight" [--minutes 480] [--allow p1,p2] [--force]
+node ~/crow/scripts/ops/box-reserve.mjs status
+node ~/crow/scripts/ops/box-reserve.mjs release
+```
+
+The default hold is eight hours. A longer hold needs `--force`, so a forgotten manual hold auto-releases before a work morning.
+
+## What the gateway does while reserved
+
+| Actor | Behavior |
+|---|---|
+| `/llm/v1/chat/completions` escalation (companion, glasses, voice bots) | If the fast model is resident, the request is served by it with a system note that the larger model is unavailable. Otherwise `503` with `error.code = "box_reserved"` and a `Retry-After`. Never a 240-second stall, never a start. |
+| `POST /llm/acquire` (bots warming a model) | `409 box_reserved`. The bridge already treats a failed warm as "proceed without warming". |
+| Dashboard chat | An error event naming the owner and the expiry instead of a generic "model did not load". |
+| Models panel start | `409 BOX_RESERVED` with owner and expiry. |
+| Boot residency, deferred-resident retries, idle-revert timer | Skipped while reserved, logged once per reservation, resumed on the next residency tick after expiry. |
+| A provider that is **already running** | Untouched. Reservations only gate starts. |
+
+Every refused start is logged with the requester tag (`ip ua=… client=…`), and the first refusal per reservation raises a high-priority notification so a stale reservation is visible from the phone.
+
+## Precedence
+
+Reservations win. Bots degrade rather than wait. This was decided on 2026-09-04 after two benchmark windows in one evening were aborted by anonymous escalations to the 35B model: the window's ownership guard stopped the container, the client retried, and the second strike aborted the run. The design gives the guard a way to win instead of a way to fight longer.
+
+## Files
+
+- `servers/gateway/box-reservation.js` — reader, writer, `ReservedError`, defaults.
+- `servers/gateway/box-reservation-notify.js` — once-per-reservation notices.
+- `servers/gateway/gpu-orchestrator.js` — the gate before every start.
+- `servers/gateway/routes/llm-router.js` — degrade or `503`.
+- `scripts/ops/box-reserve.mjs` — the CLI.
+- pi-lab `scripts/dsv4-window.sh` — the window-side writer.

--- a/scripts/ops/box-reserve.mjs
+++ b/scripts/ops/box-reserve.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * box-reserve — hold / release / inspect the box reservation the
+ * gpu-orchestrator honors before starting any local model.
+ *
+ *   box-reserve hold --owner <name> --reason <text> [--minutes N=480] [--allow p1,p2] [--force]
+ *   box-reserve release
+ *   box-reserve status
+ *
+ * Writes/reads $CROW_BOX_RESERVATION_PATH (default
+ * /run/user/<uid>/crow-box-reservation.json). A hold longer than 8 h needs
+ * --force (Kevin decision 2, 2026-09-04). While the file exists, escalations
+ * degrade to the fast resident model and non-allowed model starts are
+ * refused with `box_reserved` — see docs/architecture/box-reservation.md.
+ *
+ * Exit codes: 0 ok · 1 refused (e.g. over the 8 h max) · 2 usage.
+ */
+
+import {
+  readReservation, writeReservation, clearReservation, reservationPath,
+} from "../../servers/gateway/box-reservation.js";
+
+const USAGE = [
+  "usage:",
+  "  box-reserve hold --owner <name> --reason <text> [--minutes N=480] [--allow p1,p2] [--force]",
+  "  box-reserve release",
+  "  box-reserve status",
+  "",
+  `file: ${reservationPath()}  (override with CROW_BOX_RESERVATION_PATH)`,
+].join("\n");
+
+function usage(code = 2) {
+  console.error(USAGE);
+  process.exit(code);
+}
+
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--force") { out.force = true; continue; }
+    if (a === "--help" || a === "-h") { out.help = true; continue; }
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1];
+      if (val === undefined || val.startsWith("--")) usage();
+      out[key] = val; i++;
+      continue;
+    }
+    out._.push(a);
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const cmd = args._[0];
+if (args.help || !cmd) usage();
+
+if (cmd === "status") {
+  const r = readReservation();
+  console.log(r ? JSON.stringify(r, null, 2) : "none");
+  process.exit(0);
+}
+
+if (cmd === "release") {
+  const removed = clearReservation();
+  console.log(removed ? `released ${reservationPath()}` : "none (nothing to release)");
+  process.exit(0);
+}
+
+if (cmd === "hold") {
+  if (!args.owner) usage();
+  const minutes = args.minutes === undefined ? 480 : Number(args.minutes);
+  const allow = args.allow ? String(args.allow).split(",").map((s) => s.trim()).filter(Boolean) : [];
+  try {
+    const rec = writeReservation({ owner: args.owner, reason: args.reason || "", minutes, allow, force: !!args.force });
+    console.log(`held by ${rec.owner} until ${rec.expires_at} (${reservationPath()})`);
+    process.exit(0);
+  } catch (e) {
+    console.error(`refused: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+usage();

--- a/servers/gateway/box-reservation-notify.js
+++ b/servers/gateway/box-reservation-notify.js
@@ -1,0 +1,97 @@
+/**
+ * Box-reservation visibility (scope §3.5): the operator hears ONCE per
+ * reservation that the box is reserved, and ONCE per reservation that the
+ * reservation refused a model start — so a stuck or surprising reservation is
+ * visible from the phone without flooding the notification list.
+ *
+ * `reservationNotices` is a pure state machine (no I/O) the orchestrator
+ * calls on every residency tick and on every refusal; `sendReservationNotice`
+ * is the thin sender that must never throw back into the orchestrator (a
+ * notification failure is never a reason to change model residency).
+ */
+
+import { createDbClient } from "../db.js";
+
+/** @returns {{ seen: Map<string, {refused: boolean}> }} */
+export function createNoticeState() {
+  return { seen: new Map() };
+}
+
+/**
+ * @param {{seen: Map}} state
+ * @param {{reservation: object|null, refused?: {provider: string, requester: string}}} input
+ * @returns {Array<{kind: "start"|"refused", reservation: object, refused?: object}>}
+ */
+export function reservationNotices(state, { reservation, refused } = {}) {
+  if (!reservation) return [];
+  const key = reservation.key || "unknown";
+  const out = [];
+  let entry = state.seen.get(key);
+  if (!entry) {
+    // Bounded: only the live reservation is remembered. A new key means the
+    // previous reservation ended; its notices can never fire again anyway.
+    state.seen.clear();
+    entry = { refused: false };
+    state.seen.set(key, entry);
+    out.push({ kind: "start", reservation });
+  }
+  if (refused && !entry.refused) {
+    entry.refused = true;
+    out.push({ kind: "refused", reservation, refused: { provider: String(refused.provider || "?"), requester: String(refused.requester || "-") } });
+  }
+  return out;
+}
+
+function shape(notice) {
+  const r = notice.reservation || {};
+  const until = r.expires_at || "?";
+  if (notice.kind === "refused") {
+    const who = notice.refused || {};
+    return {
+      type: "system",
+      priority: "high",
+      title: `Box reservation refused a model start: ${who.provider || "?"}`,
+      body: `Reserved by ${r.owner || "unknown"} until ${until}. Asked by ${who.requester || "-"}. Escalations degrade to the resident fast model until the reservation ends; run \`box-reserve release\` if it is stale.`,
+      action_url: "/dashboard/models",
+      metadata: { kind: "box_reservation_refused", owner: r.owner || null, expires_at: r.expires_at || null, provider: who.provider || null },
+    };
+  }
+  return {
+    type: "system",
+    priority: "normal",
+    title: r.corrupt
+      ? "Box reservation file is unreadable — treating the box as reserved"
+      : `Box reserved by ${r.owner || "unknown"} until ${until}`,
+    body: r.corrupt
+      ? "The reservation file could not be parsed; no local model will start until it is fixed or removed (box-reserve release)."
+      : `${r.reason || "(no reason given)"} — non-allowed local model starts are refused until then.`,
+    action_url: "/dashboard/models",
+    metadata: { kind: "box_reservation_start", owner: r.owner || null, expires_at: r.expires_at || null, corrupt: !!r.corrupt },
+  };
+}
+
+async function defaultNotify(opts) {
+  let db;
+  try {
+    const { createNotification } = await import("../shared/notifications.js");
+    db = createDbClient();
+    await createNotification(db, opts);
+  } finally {
+    if (db) { try { db.close(); } catch { /* already closed */ } }
+  }
+}
+
+/**
+ * @param {{kind: string, reservation: object, refused?: object}} notice
+ * @param {{notify?: (opts: object) => Promise<void>, log?: (msg: string) => void}} [deps]
+ * @returns {Promise<boolean>} true when the notification was handed off, false on any failure (logged, never thrown).
+ */
+export async function sendReservationNotice(notice, { notify = defaultNotify, log = (m) => console.warn(m) } = {}) {
+  try {
+    await notify(shape(notice));
+    return true;
+  } catch (e) {
+    log(`[gpu-orchestrator] reservation notice failed (non-fatal): ${(e && e.message) || e}`);
+    return false;
+  }
+}

--- a/servers/gateway/box-reservation.js
+++ b/servers/gateway/box-reservation.js
@@ -1,0 +1,147 @@
+/**
+ * Box reservation — the shared "this machine is spoken for" signal between
+ * unattended GPU windows and the gateway's gpu-orchestrator.
+ *
+ * Spec: docs/superpowers/specs/2026-09-04-box-reservation-scheduling-scope.md
+ * (§3.1 record, §3.2 orchestrator behavior, §6 decisions: reservations win,
+ * 8 h default max hold, crow-embed exempt via DEFAULT_ALLOW).
+ *
+ * The record is a small JSON file on tmpfs (vanishes on reboot, which is the
+ * right default — a reboot ends every window):
+ *
+ *   { owner, reason, started_at, expires_at, allow: [providerName…] }
+ *
+ * Writers: pi-lab's dsv4-window.sh at window open (removed at teardown) and
+ * scripts/ops/box-reserve.mjs for manual holds. Reader: gpu-orchestrator.js,
+ * before ANY model start. `expires_at` is mandatory so a crashed writer can
+ * never wedge bots forever; a file we cannot parse, or one with no expiry,
+ * counts as RESERVED (fail closed — someone may be mid-write, and an
+ * unbounded hold is exactly what the expiry rule forbids).
+ *
+ * Path: $CROW_BOX_RESERVATION_PATH (the test seam, and what pi-lab honors
+ * too) else /run/user/<uid>/crow-box-reservation.json.
+ */
+
+import { readFileSync, statSync, writeFileSync, renameSync, unlinkSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** Kevin decision 2 (2026-09-04): a hold longer than this needs `force`. */
+export const DEFAULT_MAX_HOLD_MS = 8 * 60 * 60 * 1000;
+/** Kevin decision 3: providers that may start even while reserved. The embed
+ *  model is small, never evicted, and search/memory depend on it. */
+export const DEFAULT_ALLOW = Object.freeze(["crow-embed"]);
+const DEFAULT_MINUTES = 480;
+const CACHE_MS = 2_000;
+
+export function reservationPath() {
+  if (process.env.CROW_BOX_RESERVATION_PATH) return process.env.CROW_BOX_RESERVATION_PATH;
+  const uid = typeof process.getuid === "function" ? process.getuid() : 1000;
+  return `/run/user/${uid}/crow-box-reservation.json`;
+}
+
+const CORRUPT = Object.freeze({
+  owner: "unknown", reason: "unreadable reservation file", started_at: null, expires_at: null,
+  allow: Object.freeze([]), corrupt: true, key: "corrupt",
+});
+
+// One-entry cache keyed by (path, mtimeMs): the router's hot path reads this
+// per request. Corrupt reads are never cached so a fixed file is seen at once.
+let _cache = null; // { path, mtimeMs, at, value }
+
+function unionAllow(list) {
+  const out = new Set(DEFAULT_ALLOW);
+  for (const n of Array.isArray(list) ? list : []) if (typeof n === "string" && n) out.add(n);
+  return [...out];
+}
+
+/**
+ * @returns {null | {owner:string, reason:string, started_at:string|null, expires_at:string|null,
+ *                   allow:string[], corrupt:boolean, key:string}}
+ *   null when there is no file or the record has expired.
+ */
+export function readReservation({ now = Date.now(), path = reservationPath() } = {}) {
+  let st;
+  try { st = statSync(path); } catch { _cache = null; return null; }
+  if (_cache && _cache.path === path && _cache.mtimeMs === st.mtimeMs && now - _cache.at < CACHE_MS && now - _cache.at >= 0) {
+    return expireCheck(_cache.value, now);
+  }
+  let raw;
+  try { raw = JSON.parse(readFileSync(path, "utf8")); } catch { _cache = null; return CORRUPT; }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) { _cache = null; return CORRUPT; }
+  const expiresMs = Date.parse(raw.expires_at);
+  if (!Number.isFinite(expiresMs)) { _cache = null; return CORRUPT; }
+  const owner = String(raw.owner || "unknown");
+  const started = typeof raw.started_at === "string" ? raw.started_at : null;
+  const value = Object.freeze({
+    owner,
+    reason: String(raw.reason || ""),
+    started_at: started,
+    expires_at: new Date(expiresMs).toISOString(),
+    allow: Object.freeze(unionAllow(raw.allow)),
+    corrupt: false,
+    key: `${owner}@${started || new Date(expiresMs).toISOString()}`,
+  });
+  _cache = { path, mtimeMs: st.mtimeMs, at: now, value };
+  return expireCheck(value, now);
+}
+
+function expireCheck(value, now) {
+  return Date.parse(value.expires_at) > now ? value : null;
+}
+
+/** True when nothing is reserved, or `providerName` is on the allow list. */
+export function isStartAllowed(reservation, providerName) {
+  if (!reservation) return true;
+  if (reservation.corrupt) return false;
+  return !!providerName && (reservation.allow || []).includes(providerName);
+}
+
+export class ReservedError extends Error {
+  constructor(reservation, providerName) {
+    const owner = (reservation && reservation.owner) || "unknown";
+    const until = (reservation && reservation.expires_at) || "?";
+    super(`box reserved by ${owner} until ${until} — refusing to start ${providerName || "a model"}`);
+    this.name = "ReservedError";
+    this.code = "box_reserved";
+    this.http = 503;
+    this.owner = owner;
+    this.expires_at = reservation && reservation.expires_at ? reservation.expires_at : null;
+    this.provider = providerName || null;
+  }
+}
+
+/**
+ * Write a reservation atomically (temp file + rename in the same directory).
+ * @returns the record written.
+ * @throws RangeError when the hold exceeds DEFAULT_MAX_HOLD_MS and !force.
+ */
+export function writeReservation({ owner, reason = "", minutes = DEFAULT_MINUTES, allow = [], force = false, now = Date.now(), path = reservationPath() } = {}) {
+  const who = String(owner || "").trim();
+  if (!who) throw new Error("writeReservation: owner is required");
+  const mins = Number(minutes);
+  if (!Number.isFinite(mins) || mins <= 0) throw new RangeError("writeReservation: minutes must be a positive number");
+  const holdMs = Math.round(mins * 60_000);
+  if (holdMs > DEFAULT_MAX_HOLD_MS && !force) {
+    throw new RangeError(`hold of ${mins} min exceeds the 8h default max; pass force to exceed it`);
+  }
+  const rec = {
+    owner: who,
+    reason: String(reason || ""),
+    started_at: new Date(now).toISOString(),
+    expires_at: new Date(now + holdMs).toISOString(),
+    allow: [...new Set((Array.isArray(allow) ? allow : []).filter((n) => typeof n === "string" && n))],
+  };
+  const dir = dirname(path);
+  try { mkdirSync(dir, { recursive: true }); } catch { /* exists or unwritable — the write below reports it */ }
+  const tmp = join(dir, `.crow-box-reservation.${process.pid}.${Date.now()}.tmp`);
+  writeFileSync(tmp, JSON.stringify(rec, null, 2) + "\n", { mode: 0o644 });
+  renameSync(tmp, path);
+  _cache = null;
+  return rec;
+}
+
+/** @returns true when a file was removed, false when there was none. */
+export function clearReservation({ path = reservationPath() } = {}) {
+  _cache = null;
+  try { unlinkSync(path); return true; } catch (e) { if (e && e.code === "ENOENT") return false; throw e; }
+}

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -362,6 +362,7 @@ export const translations = {
 
   // ─── Chat — native model runtime (Item G, Task 10) ───
   "chat.native_model_loading": { en: "Loading local model \"{provider}\" — this can take a few minutes for larger models.", es: "Cargando el modelo local \"{provider}\" — esto puede tardar varios minutos en modelos más grandes." },
+  "chat.box_reserved": { en: "The box is reserved by {owner} until {until}; local models can't start right now. Try a smaller resident model or wait.", es: "El equipo está reservado por {owner} hasta {until}; los modelos locales no pueden iniciarse ahora. Prueba un modelo residente más pequeño o espera." },
   "chat.native_model_load_failed": { en: "The local model \"{provider}\" didn't load in time. Check the gateway logs for details.", es: "El modelo local \"{provider}\" no cargó a tiempo. Consulta los registros del gateway para más detalles." },
 
   // ─── Peer invite share (Messages Phase 2 PR1) ───

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -82,6 +82,8 @@ import { loadState, saveState, reconcileOnBoot } from "./models/state.js";
 import { acquireHostLock } from "./models/native-lock.js";
 import { identityProbe, startModel, stopModel, ensureRuntime, nativeReadinessTimeoutMs } from "./models/runtime.js";
 import { getCachedProbe, reprobe } from "./models/probe.js";
+import { readReservation, isStartAllowed, ReservedError } from "./box-reservation.js";
+import { createNoticeState, reservationNotices, sendReservationNotice } from "./box-reservation-notify.js";
 import { enqueueDownload } from "./models/manager.js";
 import { listProvidersAll } from "../shared/providers-db.js";
 
@@ -428,6 +430,70 @@ export async function isProviderReady(providerName) {
  * caller ever saw — the actual cause previously reached nothing but
  * this function's own `console.warn` below.
  */
+
+// ---- box reservation gate (docs/architecture/box-reservation.md) --------------
+//
+// While /run/user/<uid>/crow-box-reservation.json exists, NO path below may
+// START a provider the reservation did not allow: on-demand acquire (docker
+// and native), boot/retry residency, and the idle-revert timer all pass
+// through startBlockedBy(). A provider that is already running is never
+// touched — reservations gate starts, not residency. The reader is a seam so
+// tests never touch the real tmpfs file.
+let _reservationReader = null;
+export function _setReservationReaderForTest(fn) { _reservationReader = fn; }
+let _noticeState = createNoticeState();
+let _noticeSender = sendReservationNotice;
+export function _setReservationNoticeSenderForTest(fn) { _noticeSender = fn ? (n) => fn(n) : sendReservationNotice; }
+const _deferNoticed = new Set();
+export function _resetReservationNoticesForTest() { _noticeState = createNoticeState(); _deferNoticed.clear(); }
+
+function currentReservation() {
+  try { return (_reservationReader || readReservation)(); }
+  catch (err) {
+    // A reader that throws is a corrupt-file case in disguise: fail closed.
+    console.warn(`[gpu-orchestrator] reservation read failed (treating as reserved): ${err.message}`);
+    return { owner: "unknown", reason: "unreadable reservation file", started_at: null, expires_at: null, allow: [], corrupt: true, key: "corrupt" };
+  }
+}
+
+/** The reservation blocking `providerName` from starting right now, else null. */
+function startBlockedBy(providerName) {
+  const r = currentReservation();
+  if (!r || isStartAllowed(r, providerName)) return null;
+  return r;
+}
+
+function emitReservationNotices(input) {
+  for (const n of reservationNotices(_noticeState, input)) {
+    Promise.resolve().then(() => _noticeSender(n)).catch(() => { /* sender never throws; belt and braces */ });
+  }
+}
+
+/** Refuse a start: log with the requester, notify once per reservation, return the error to throw. */
+function refuseStart(reservation, providerName, opts = {}) {
+  const requester = opts.requester || "-";
+  console.log(`[gpu-orchestrator] refusing to start ${providerName}: box reserved by ${reservation.owner} until ${reservation.expires_at || "?"} (requested-by=${requester})`);
+  emitReservationNotices({ reservation, refused: { provider: providerName, requester } });
+  return new ReservedError(reservation, providerName);
+}
+
+/** Residency paths never throw — they announce once per reservation and skip. */
+function noteDeferred(reservation, what) {
+  emitReservationNotices({ reservation });
+  const k = reservation.key + ":" + what;
+  if (_deferNoticed.has(k)) return;
+  _deferNoticed.add(k);
+  console.log(`[gpu-orchestrator] residency deferred: box reserved by ${reservation.owner} until ${reservation.expires_at || "?"} (${what})`);
+}
+
+/** Called from the residency tick so a NEW reservation is announced even
+ *  before anything tries to start (scope §3.5). Returns the reservation. */
+export function noticeReservation() {
+  const r = currentReservation();
+  if (r) emitReservationNotices({ reservation: r });
+  return r;
+}
+
 export async function maybeAcquireLocalProvider(providerName, opts = {}) {
   if (!providerName) return null;
   const cfg = opts.cfg || loadProviders();
@@ -439,6 +505,9 @@ export async function maybeAcquireLocalProvider(providerName, opts = {}) {
   try {
     return await acquireProvider(providerName, opts);
   } catch (err) {
+    // A reservation is a decision, not a failure: callers degrade on it
+    // (llm-router, chat, models panel) and must be able to tell it apart.
+    if (err instanceof ReservedError) throw err;
     console.warn(`[gpu-orchestrator] maybeAcquireLocalProvider(${providerName}) failed: ${err.message}`);
     if (typeof opts.onError === "function") {
       try { opts.onError(err); } catch { /* caller's observer must never break this function */ }
@@ -823,6 +892,11 @@ async function acquireOrStartNative(providerName, p, cfg, opts = {}) {
     // "down" — fall through to sibling swap + lock + start.
   }
 
+  {
+    const blocked = startBlockedBy(providerName);
+    if (blocked) throw refuseStart(blocked, providerName, opts);
+  }
+
   const siblings = getMutexSiblings(providerName, cfg);
   for (const sibName of siblings) {
     const sib = getProvider(sibName, cfg);
@@ -945,6 +1019,12 @@ export async function acquireProvider(providerName, opts = {}) {
       return true;
     }
 
+    // Box reservation: a start (and the sibling eviction that precedes it)
+    // needs the box; a caller not on the allow list is refused here, BEFORE
+    // any sibling is stopped.
+    const blocked = startBlockedBy(providerName);
+    if (blocked) throw refuseStart(blocked, providerName, opts);
+
     // Stop mutex siblings first. A sibling can be native (Task 9 review
     // round 1, finding 3: same-PROCESS symmetric eviction — a native
     // sibling with a live handle in _nativeHandles is stopped via that
@@ -1024,6 +1104,8 @@ async function checkIdleRevert() {
       }
       const idleFor = Date.now() - last;
       if (idleFor < IDLE_REVERT_MS) continue;
+      const blocked = startBlockedBy(group.default);
+      if (blocked) { noteDeferred(blocked, "idle-revert:" + group.default); continue; }
       console.log(`[gpu-orchestrator] ${m.name} idle ${Math.round(idleFor / 1000)}s — reverting to ${group.default}`);
       try {
         await acquireProvider(group.default, { requester: "idle-revert" });
@@ -1094,7 +1176,15 @@ async function ensureNativeResident(name, p, cfg, opts = {}) {
   // that started a model without taking/holding its mutexGroup's host
   // lock would leave that lock free for a DIFFERENT gateway process to
   // walk right past while this model is genuinely resident.
-  const result = await acquireOrStartNative(name, p, cfg, opts);
+  let result;
+  try {
+    result = await acquireOrStartNative(name, p, cfg, opts);
+  } catch (err) {
+    // Residency never throws on a reservation: a resident native provider
+    // returns before the gate; a cold one is deferred (logged once).
+    if (err instanceof ReservedError) { noteDeferred(currentReservation() || err, name); return false; }
+    throw err;
+  }
   if (!result.freshStart) {
     console.log(`[gpu-orchestrator] ${name} already resident`);
     return false;
@@ -1119,13 +1209,16 @@ export async function ensureResident(name, cfg = loadProviders(), opts = {}) {
       console.warn(`[gpu-orchestrator] ${name} has no bundleId — skipping`);
       return false;
     }
-    if (await probeReady(p.baseUrl)) {
+    const { probeReadyFn = probeReady, bundleUpFn = bundleUp, waitForReadyFn = waitForReady } = opts;
+    if (await probeReadyFn(p.baseUrl)) {
       console.log(`[gpu-orchestrator] ${name} already resident`);
       return false;
     }
+    const blocked = startBlockedBy(name);
+    if (blocked) { noteDeferred(blocked, name); return false; }
     console.log(`[gpu-orchestrator] starting ${name} (bundleId=${p.bundleId}) requested-by=${requester}`);
-    await bundleUp(p.bundleId);
-    const ready = await waitForReady(p.baseUrl);
+    await bundleUpFn(p.bundleId);
+    const ready = await waitForReadyFn(p.baseUrl);
     if (!ready) {
       console.warn(`[gpu-orchestrator] ${name} did NOT warm up in time`);
       return false;
@@ -1152,6 +1245,8 @@ export async function retryDeferredResidents({
     const p = (cfg.providers || {})[name];
     if (!p) { _deferredResidents.delete(name); continue; }
     if (!isLocallyOrchestratable(p, ownAddrs)) continue; // still not ours — stays parked
+    const blocked = startBlockedBy(name);
+    if (blocked) { noteDeferred(blocked, "residency-retry:" + name); continue; } // reserved — stays parked
     _deferredResidents.delete(name);
     console.log(`[gpu-orchestrator] deferred alwaysResident ${name} is now locally hosted — ensuring (its interface came up after boot)`);
     if (await ensure(name, cfg, { requester: "residency-retry" })) embedRecovered = true;
@@ -1177,6 +1272,9 @@ export async function retryDeferredResidents({
  */
 export async function pollResidency(opts = {}) {
   const probed = [];
+  // Scope §3.5: announce a new box reservation on the tick, even before any
+  // start is attempted, so the operator sees it from the phone.
+  try { noticeReservation(); } catch { /* never let visibility break residency */ }
   try {
     const cfg = opts.cfg !== undefined ? opts.cfg : loadProviders();
     const ownAddrs = opts.ownAddrs !== undefined ? opts.ownAddrs : getOwnAddresses();

--- a/servers/gateway/routes/chat.js
+++ b/servers/gateway/routes/chat.js
@@ -68,6 +68,18 @@ export function nativeWarmingEvent(providerName, isNative, lang) {
  * file, so it must NEVER see that hint — it gets the new, real-i18n
  * `chat.native_model_load_failed` copy and a distinct `code` instead.
  */
+/** Box reservation (docs/architecture/box-reservation.md): the start was
+ *  refused on purpose — say who holds the box and until when, never the
+ *  generic "didn't load in time". */
+export function boxReservedError(err, lang) {
+  return {
+    message: fill(t("chat.box_reserved", lang), { owner: (err && err.owner) || "unknown", until: (err && err.expires_at) || "?" }),
+    code: "box_reserved",
+    owner: (err && err.owner) || null,
+    expires_at: (err && err.expires_at) || null,
+  };
+}
+
 export function providerNotReadyError(providerName, isNative, lang) {
   if (isNative) {
     return {
@@ -707,6 +719,11 @@ export default function chatRouter(dashboardAuth) {
           return;
         }
       } catch (err) {
+        if (err && err.code === "box_reserved") {
+          sendEvent("error", boxReservedError(err, lang));
+          closeStream();
+          return;
+        }
         console.warn(`[chat] gpu-orchestrator acquire(${effectiveProvider}) failed: ${err.message}`);
         // fall through — adapter will surface the real connection error.
       }

--- a/servers/gateway/routes/llm-router.js
+++ b/servers/gateway/routes/llm-router.js
@@ -35,6 +35,7 @@ import { createDbClient } from "../../db.js";
 import { resolveProviderConfig } from "../ai/resolve-profile.js";
 import { maybeAcquireLocalProvider, warmProviderByName } from "../gpu-orchestrator.js";
 import { requesterTag } from "../requester-tag.js";
+import { ReservedError } from "../box-reservation.js";
 import { connectTimeout, isTimeoutError, LLM_CONNECT_TIMEOUT_MS } from "../../shared/http-timeout.js";
 import { extractUsageFromOpenAIResponse, recordUsageEvent } from "../../shared/metering.js";
 import { resolveTenantId } from "../../shared/tenancy.js";
@@ -183,7 +184,17 @@ function stripEscalate(body) {
   }
 }
 
-async function handleChat(req, res) {
+/** Is the fast model answering right now? A 2 s GET on its models list —
+ *  same shape as the orchestrator's readiness probe, kept local so the
+ *  router's degrade decision has no orchestrator dependency. */
+async function defaultProbeReady(baseUrl) {
+  try {
+    const r = await fetch(`${baseUrl}/models`, { signal: AbortSignal.timeout(2_000) });
+    return r.ok;
+  } catch { return false; }
+}
+
+async function handleChat(req, res, deps) {
   const body = req.body && typeof req.body === "object" ? req.body : null;
   if (!body) return res.status(400).json({ error: { message: "invalid JSON body" } });
 
@@ -192,7 +203,8 @@ async function handleChat(req, res) {
   const toolEsc = !manualEsc && wantsToolEscalation(body);
   const escalate = manualEsc || toolEsc;
   const escReason = manualEsc ? "manual" : toolEsc ? "tool-intent" : null;
-  const key = escalate ? ESC_KEY : FAST_KEY;
+  let key = escalate ? ESC_KEY : FAST_KEY;
+  let routeLabel = escalate ? `escalate(${escReason})` : "fast";
 
   // Voice quality: the fast model (Qwen3.5-4B) emits its chain-of-thought as
   // PLAIN text ("Thinking Process: ...") that the avatar would speak aloud, so
@@ -216,13 +228,38 @@ async function handleChat(req, res) {
   // frames, so there is no event channel to put a "warming" notice on. The
   // companion sees a warm-up simply as this await taking longer, same as
   // before this task.
-  const [providerId] = splitKey(key);
+  let [providerId] = splitKey(key);
   const requester = requesterTag(req);
-  await maybeAcquireLocalProvider(providerId, { requester });
+  try {
+    await deps.acquireFn(providerId, { requester });
+  } catch (err) {
+    if (!(err instanceof ReservedError)) throw err;
+    // Box reserved (docs/architecture/box-reservation.md): DEGRADE, never
+    // stall and never retry — a retry is exactly what turned one refused
+    // start into a second ownership strike on 2026-08-29. An escalation
+    // falls back to the resident fast model with a note; anything else (or
+    // a cold fast model) gets a fast 503 the client can show or wait on.
+    const fast = escalate ? await deps.resolveKeyFn(FAST_KEY).catch(() => null) : null;
+    if (fast && await deps.probeReadyFn(fast.baseUrl)) {
+      key = FAST_KEY;
+      [providerId] = splitKey(key);
+      routeLabel = "degraded(box_reserved)";
+      body.messages = [
+        ...(Array.isArray(body.messages) ? body.messages : []),
+        { role: "system", content: `Note: the box is reserved (by ${err.owner} until ${err.expires_at || "?"}); the larger model is unavailable, answer with what you have.` },
+      ];
+    } else {
+      const secs = Math.round((Date.parse(err.expires_at || 0) - Date.now()) / 1000);
+      const retryAfter = Math.max(60, Number.isFinite(secs) ? secs : 60);
+      console.log(`[llm-router] route=refused(box_reserved) -> ${key} requester=${requester} owner=${err.owner}`);
+      res.setHeader("Retry-After", String(retryAfter));
+      return res.status(503).json({ error: { code: "box_reserved", message: err.message, owner: err.owner, expires_at: err.expires_at, retry_after: retryAfter } });
+    }
+  }
 
   let up;
   try {
-    up = await resolveKey(key);
+    up = await deps.resolveKeyFn(key);
   } catch (e) {
     return res.status(502).json({ error: { message: `model routing failed for ${key}: ${e.message}` } });
   }
@@ -230,7 +267,7 @@ async function handleChat(req, res) {
   body.model = up.model;
   const url = `${up.baseUrl}/chat/completions`;
   const t0 = Date.now();
-  console.log(`[llm-router] route=${escalate ? `escalate(${escReason})` : "fast"} -> ${key} (${up.model}) stream=${!!body.stream} requester=${requester}`);
+  console.log(`[llm-router] route=${routeLabel} -> ${key} (${up.model}) stream=${!!body.stream} requester=${requester}`);
 
   let upstream;
   try {
@@ -317,14 +354,23 @@ async function handleModels(res) {
  *
  * @returns {import('express').Router}
  */
-export default function llmRouterRouter() {
+export default function llmRouterRouter(opts = {}) {
+  // Seams (tests): acquireFn/resolveKeyFn/probeReadyFn/warmFn default to the
+  // real orchestrator + providers table.
+  const deps = {
+    acquireFn: maybeAcquireLocalProvider,
+    resolveKeyFn: resolveKey,
+    probeReadyFn: defaultProbeReady,
+    warmFn: warmProviderByName,
+    ...opts,
+  };
   const router = express.Router();
   // Route-scoped 10mb JSON limit: the global parser is 1mb and a multi-turn
   // companion/glasses transcript (with tool history + base64 image parts) can
   // exceed that and 413.
   router.use("/llm", express.json({ limit: "10mb" }));
   router.get("/llm/v1/models", (req, res) => handleModels(res));
-  router.post("/llm/v1/chat/completions", (req, res) => handleChat(req, res));
+  router.post("/llm/v1/chat/completions", (req, res) => handleChat(req, res, deps));
   // POST /llm/acquire { provider } — warm a local model bundle and wait until it's
   // ready. The gateway chat path warms inline before a turn; this gives the same
   // capability to the pi-bots host (background jobs + bridge) which runs in a
@@ -335,9 +381,12 @@ export default function llmRouterRouter() {
     const provider = req.body && (req.body.provider || req.body.providerId);
     if (!provider) return res.status(400).json({ ok: false, error: "provider required" });
     try {
-      const warmed = await warmProviderByName(provider, { requester: requesterTag(req) });
+      const warmed = await deps.warmFn(provider, { requester: requesterTag(req) });
       res.json({ ok: warmed !== false, warmed, provider });
     } catch (err) {
+      if (err instanceof ReservedError) {
+        return res.status(409).json({ ok: false, error: "box_reserved", owner: err.owner, expires_at: err.expires_at, message: err.message });
+      }
       res.status(500).json({ ok: false, error: err.message });
     }
   });

--- a/servers/gateway/routes/models.js
+++ b/servers/gateway/routes/models.js
@@ -585,7 +585,17 @@ export default function modelsRouter(dashboardAuth, opts = {}) {
       // captures it (opt-in seam on maybeAcquireLocalProvider, see its
       // doc) so it can ride along in the response body as `cause`.
       let startError = null;
-      const result = await maybeAcquireLocalProviderFn(modelId, { requester: "models-panel", onError: (err) => { startError = err; } });
+      let result;
+      try {
+        result = await maybeAcquireLocalProviderFn(modelId, { requester: "models-panel", onError: (err) => { startError = err; } });
+      } catch (err) {
+        // Box reservation: maybeAcquireLocalProvider rethrows ReservedError so
+        // callers can tell a refusal from a failure (docs/architecture/box-reservation.md).
+        if (err && err.code === "box_reserved") {
+          return res.status(409).json({ error: err.message, code: "BOX_RESERVED", owner: err.owner || null, expires_at: err.expires_at || null });
+        }
+        throw err;
+      }
       if (result === true) return res.json({ running: true });
       if (result === false) {
         const cause = startError ? { code: startError.code || "UNKNOWN", message: startError.message } : null;

--- a/tests/box-reservation-notify.test.js
+++ b/tests/box-reservation-notify.test.js
@@ -1,0 +1,73 @@
+// tests/box-reservation-notify.test.js
+//
+// Visibility rule (scope §3.5): once per reservation the operator hears that
+// the box is reserved, and once per reservation that a model start was
+// refused. The decision is a pure state machine so it needs no DB; the sender
+// is a thin wrapper that must never throw into the orchestrator.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createNoticeState, reservationNotices, sendReservationNotice,
+} from "../servers/gateway/box-reservation-notify.js";
+
+const R1 = { owner: "win", reason: "bench", started_at: "2026-09-04T20:00:00.000Z", expires_at: "2026-09-04T23:00:00.000Z", allow: ["crow-embed"], corrupt: false, key: "win@2026-09-04T20:00:00.000Z" };
+const R2 = { ...R1, owner: "kevin", started_at: "2026-09-04T23:30:00.000Z", key: "kevin@2026-09-04T23:30:00.000Z" };
+
+test("first sight of a reservation emits 'start' once; later sights emit nothing", () => {
+  const st = createNoticeState();
+  assert.deepEqual(reservationNotices(st, { reservation: R1 }), [{ kind: "start", reservation: R1 }]);
+  assert.deepEqual(reservationNotices(st, { reservation: R1 }), []);
+  assert.deepEqual(reservationNotices(st, { reservation: R1 }), []);
+});
+
+test("no reservation emits nothing and does not disturb state", () => {
+  const st = createNoticeState();
+  assert.deepEqual(reservationNotices(st, { reservation: null }), []);
+  assert.deepEqual(reservationNotices(st, { reservation: R1 }), [{ kind: "start", reservation: R1 }]);
+});
+
+test("a refusal emits 'refused' once per reservation (and 'start' first if unseen)", () => {
+  const st = createNoticeState();
+  const first = reservationNotices(st, { reservation: R1, refused: { provider: "crow-chat", requester: "10.0.0.5 ua=x client=companion" } });
+  assert.deepEqual(first.map((n) => n.kind), ["start", "refused"]);
+  assert.equal(first[1].refused.provider, "crow-chat");
+  assert.deepEqual(reservationNotices(st, { reservation: R1, refused: { provider: "crow-chat", requester: "-" } }), []);
+  assert.deepEqual(reservationNotices(st, { reservation: R1, refused: { provider: "crow-voice", requester: "-" } }), [], "once per reservation, not per provider");
+});
+
+test("a new reservation key resets both notices; old keys are forgotten (bounded state)", () => {
+  const st = createNoticeState();
+  reservationNotices(st, { reservation: R1, refused: { provider: "crow-chat", requester: "-" } });
+  const n = reservationNotices(st, { reservation: R2, refused: { provider: "crow-chat", requester: "-" } });
+  assert.deepEqual(n.map((x) => x.kind), ["start", "refused"]);
+  assert.equal(st.seen.size, 1, "only the live key is retained");
+});
+
+test("corrupt reservation: 'start' notice names the unreadable file, refused still once", () => {
+  const st = createNoticeState();
+  const corrupt = { owner: "unknown", reason: "unreadable reservation file", started_at: null, expires_at: null, allow: [], corrupt: true, key: "corrupt" };
+  const n = reservationNotices(st, { reservation: corrupt, refused: { provider: "crow-chat", requester: "-" } });
+  assert.deepEqual(n.map((x) => x.kind), ["start", "refused"]);
+  assert.deepEqual(reservationNotices(st, { reservation: corrupt, refused: { provider: "crow-chat", requester: "-" } }), []);
+});
+
+test("sendReservationNotice: shapes the notification and swallows sender failures", async () => {
+  const calls = [];
+  const ok = await sendReservationNotice({ kind: "start", reservation: R1 }, { notify: async (opts) => { calls.push(opts); } });
+  assert.equal(ok, true);
+  assert.equal(calls[0].type, "system");
+  assert.equal(calls[0].priority, "normal");
+  assert.match(calls[0].title, /Box reserved by win until 2026-09-04T23:00:00\.000Z/);
+  assert.match(calls[0].body, /bench/);
+  assert.equal(calls[0].action_url, "/dashboard/models");
+
+  const r = await sendReservationNotice({ kind: "refused", reservation: R1, refused: { provider: "crow-chat", requester: "10.0.0.5 ua=x client=companion" } }, { notify: async (opts) => { calls.push(opts); } });
+  assert.equal(r, true);
+  assert.equal(calls[1].priority, "high");
+  assert.match(calls[1].title, /refused a model start: crow-chat/);
+  assert.match(calls[1].body, /companion/);
+
+  const bad = await sendReservationNotice({ kind: "start", reservation: R1 }, { notify: async () => { throw new Error("db down"); } });
+  assert.equal(bad, false, "never throws into the orchestrator");
+});

--- a/tests/box-reservation.test.js
+++ b/tests/box-reservation.test.js
@@ -1,0 +1,120 @@
+// tests/box-reservation.test.js
+//
+// The box-reservation file is the shared signal between unattended GPU
+// windows (pi-lab dsv4-window.sh writes it) and the gateway's
+// gpu-orchestrator (reads it before ANY model start). Spec:
+// docs/superpowers/specs/2026-09-04-box-reservation-scheduling-scope.md §3.1.
+//
+// Contract pinned here: missing/expired -> null; corrupt -> reserved (fail
+// closed); DEFAULT_ALLOW always unioned in; 8h default max hold unless force.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readReservation, isStartAllowed, writeReservation, clearReservation,
+  ReservedError, DEFAULT_ALLOW, DEFAULT_MAX_HOLD_MS, reservationPath,
+} from "../servers/gateway/box-reservation.js";
+
+const dir = mkdtempSync(join(tmpdir(), "box-res-"));
+const path = join(dir, "r.json");
+const T0 = Date.parse("2026-09-04T20:00:00Z");
+const iso = (ms) => new Date(ms).toISOString();
+
+test("no file -> null; expired -> null; live -> record with default allow + stable key", () => {
+  assert.equal(readReservation({ path, now: T0 }), null);
+  writeFileSync(path, JSON.stringify({
+    owner: "win", reason: "bench", started_at: iso(T0), expires_at: iso(T0 + 1000), allow: [],
+  }));
+  assert.equal(readReservation({ path, now: T0 + 2000 }), null, "expired reads as absent");
+  const r = readReservation({ path, now: T0 + 500 });
+  assert.equal(r.owner, "win");
+  assert.equal(r.reason, "bench");
+  assert.equal(r.corrupt, false);
+  assert.deepEqual(r.allow, DEFAULT_ALLOW);
+  assert.equal(r.key, "win@" + iso(T0));
+});
+
+test("file allow is unioned with DEFAULT_ALLOW (deduped)", () => {
+  writeFileSync(path, JSON.stringify({
+    owner: "k", reason: "serve", started_at: iso(T0), expires_at: iso(T0 + 60_000), allow: ["my-heavy", DEFAULT_ALLOW[0]],
+  }));
+  const r = readReservation({ path, now: T0 });
+  assert.deepEqual([...r.allow].sort(), [...new Set([...DEFAULT_ALLOW, "my-heavy"])].sort());
+});
+
+test("corrupt file -> reserved (fail closed) and flagged; missing expires_at -> corrupt too", () => {
+  writeFileSync(path, "{not json");
+  const r = readReservation({ path, now: T0 });
+  assert.equal(r.corrupt, true);
+  assert.equal(r.owner, "unknown");
+  assert.equal(r.key, "corrupt");
+  assert.equal(isStartAllowed(r, "crow-chat"), false);
+  writeFileSync(path, JSON.stringify({ owner: "x", reason: "y" }));
+  assert.equal(readReservation({ path, now: T0 }).corrupt, true, "no expiry = unbounded hold = refuse");
+});
+
+test("readReservation caches by mtime for a moment but never caches a corrupt read", () => {
+  writeFileSync(path, "{bad");
+  assert.equal(readReservation({ path, now: T0 }).corrupt, true);
+  writeFileSync(path, JSON.stringify({ owner: "ok", reason: "r", started_at: iso(T0), expires_at: iso(T0 + 60_000) }));
+  assert.equal(readReservation({ path, now: T0 }).owner, "ok", "a fixed file is seen immediately");
+});
+
+test("isStartAllowed: null reservation allows; allow list membership decides", () => {
+  assert.equal(isStartAllowed(null, "crow-chat"), true);
+  assert.equal(isStartAllowed(undefined, "crow-chat"), true);
+  const r = { allow: ["crow-embed", "my-heavy"], corrupt: false };
+  assert.equal(isStartAllowed(r, "my-heavy"), true);
+  assert.equal(isStartAllowed(r, "crow-embed"), true);
+  assert.equal(isStartAllowed(r, "crow-chat"), false);
+  assert.equal(isStartAllowed(r, ""), false);
+});
+
+test("writeReservation enforces the 8h default max unless force; atomic write; clearReservation removes", () => {
+  assert.equal(DEFAULT_MAX_HOLD_MS, 8 * 60 * 60 * 1000);
+  assert.throws(() => writeReservation({ owner: "k", reason: "serve", minutes: 9 * 60, path, now: T0 }), RangeError);
+  assert.equal(existsSync(path) && readFileSync(path, "utf8").includes('"k"'), false, "refused hold writes nothing");
+  const rec = writeReservation({ owner: "k", reason: "serve", minutes: 9 * 60, force: true, allow: ["h"], path, now: T0 });
+  assert.equal(rec.expires_at, iso(T0 + 9 * 3600 * 1000));
+  assert.equal(rec.started_at, iso(T0));
+  assert.deepEqual(rec.allow, ["h"]);
+  const back = JSON.parse(readFileSync(path, "utf8"));
+  assert.equal(back.owner, "k");
+  assert.equal(readReservation({ path, now: T0 + 60_000 }).owner, "k");
+  assert.equal(clearReservation({ path }), true);
+  assert.equal(existsSync(path), false);
+  assert.equal(clearReservation({ path }), false);
+});
+
+test("writeReservation defaults minutes to 480 and rejects empty owner", () => {
+  const rec = writeReservation({ owner: "k", reason: "r", path, now: T0 });
+  assert.equal(rec.expires_at, iso(T0 + 480 * 60_000));
+  assert.throws(() => writeReservation({ owner: "", reason: "r", path, now: T0 }), /owner/);
+  clearReservation({ path });
+});
+
+test("ReservedError carries code/http/owner/expires_at/provider and a readable message", () => {
+  const e = new ReservedError({ owner: "win", expires_at: "2026-09-04T21:00:00.000Z" }, "crow-chat");
+  assert.equal(e.code, "box_reserved");
+  assert.equal(e.http, 503);
+  assert.equal(e.owner, "win");
+  assert.equal(e.provider, "crow-chat");
+  assert.equal(e.expires_at, "2026-09-04T21:00:00.000Z");
+  assert.match(e.message, /reserved by win until 2026-09-04T21:00:00\.000Z/);
+  assert.ok(e instanceof Error);
+});
+
+test("reservationPath honors CROW_BOX_RESERVATION_PATH and defaults under /run/user/<uid>", () => {
+  const prev = process.env.CROW_BOX_RESERVATION_PATH;
+  try {
+    process.env.CROW_BOX_RESERVATION_PATH = "/tmp/x/r.json";
+    assert.equal(reservationPath(), "/tmp/x/r.json");
+    delete process.env.CROW_BOX_RESERVATION_PATH;
+    assert.match(reservationPath(), /^\/run\/user\/\d+\/crow-box-reservation\.json$/);
+  } finally {
+    if (prev === undefined) delete process.env.CROW_BOX_RESERVATION_PATH; else process.env.CROW_BOX_RESERVATION_PATH = prev;
+  }
+});

--- a/tests/box-reserve-cli.test.js
+++ b/tests/box-reserve-cli.test.js
@@ -1,0 +1,85 @@
+// tests/box-reserve-cli.test.js
+//
+// scripts/ops/box-reserve.mjs — the manual "I'm using the box tonight" knob.
+// Exercised as a real child process against a temp CROW_BOX_RESERVATION_PATH
+// (the same env seam the gateway and pi-lab honor).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CLI = join(REPO, "scripts", "ops", "box-reserve.mjs");
+const dir = mkdtempSync(join(tmpdir(), "box-reserve-cli-"));
+const path = join(dir, "reservation.json");
+
+function run(...args) {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    env: { ...process.env, CROW_BOX_RESERVATION_PATH: path },
+    encoding: "utf8",
+  });
+  return { code: r.status, out: (r.stdout || "").trim(), err: (r.stderr || "").trim() };
+}
+
+test("no args / --help -> usage on stderr, exit 2", () => {
+  const r = run();
+  assert.equal(r.code, 2);
+  assert.match(r.err, /box-reserve hold --owner/);
+  assert.equal(run("--help").code, 2);
+});
+
+test("status with no reservation prints 'none', exit 0", () => {
+  const r = run("status");
+  assert.equal(r.code, 0);
+  assert.equal(r.out, "none");
+});
+
+test("hold writes the file (default 480 min), status prints it as JSON", () => {
+  const before = Date.now();
+  const r = run("hold", "--owner", "kevin", "--reason", "serving dsv4 tonight", "--allow", "crow-embed,my-heavy");
+  assert.equal(r.code, 0, r.err);
+  assert.ok(existsSync(path));
+  const rec = JSON.parse(readFileSync(path, "utf8"));
+  assert.equal(rec.owner, "kevin");
+  assert.equal(rec.reason, "serving dsv4 tonight");
+  assert.deepEqual(rec.allow, ["crow-embed", "my-heavy"]);
+  const held = Date.parse(rec.expires_at) - Date.parse(rec.started_at);
+  assert.equal(held, 480 * 60_000);
+  assert.ok(Date.parse(rec.started_at) >= before - 1000);
+  const s = run("status");
+  assert.equal(s.code, 0);
+  assert.equal(JSON.parse(s.out).owner, "kevin");
+});
+
+test("hold beyond 8h without --force fails (exit 1) and leaves the existing file untouched", () => {
+  const prev = readFileSync(path, "utf8");
+  const r = run("hold", "--owner", "kevin", "--reason", "long", "--minutes", "600");
+  assert.equal(r.code, 1);
+  assert.match(r.err, /8h/);
+  assert.equal(readFileSync(path, "utf8"), prev);
+});
+
+test("hold beyond 8h WITH --force succeeds", () => {
+  const r = run("hold", "--owner", "kevin", "--reason", "long", "--minutes", "600", "--force");
+  assert.equal(r.code, 0, r.err);
+  const rec = JSON.parse(readFileSync(path, "utf8"));
+  assert.equal(Date.parse(rec.expires_at) - Date.parse(rec.started_at), 600 * 60_000);
+});
+
+test("hold without --owner is a usage error (exit 2)", () => {
+  const r = run("hold", "--reason", "x");
+  assert.equal(r.code, 2);
+});
+
+test("release removes the file; a second release reports none and still exits 0", () => {
+  assert.equal(run("release").code, 0);
+  assert.equal(existsSync(path), false);
+  const again = run("release");
+  assert.equal(again.code, 0);
+  assert.match(again.out, /none/);
+  assert.equal(run("status").out, "none");
+});

--- a/tests/chat-native-copy.test.js
+++ b/tests/chat-native-copy.test.js
@@ -21,7 +21,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { nativeWarmingEvent, providerNotReadyError } from "../servers/gateway/routes/chat.js";
+import { nativeWarmingEvent, providerNotReadyError, boxReservedError } from "../servers/gateway/routes/chat.js";
 import { t, fill } from "../servers/gateway/dashboard/shared/i18n.js";
 
 // --- Docker/cloud path: unchanged from pre-Task-10 behavior ----------------
@@ -87,4 +87,21 @@ test("providerNotReadyError: an unsupported lang falls back to English (t()'s ow
   const fr = providerNotReadyError("qwen3-4b", true, "fr");
   const en = providerNotReadyError("qwen3-4b", true, "en");
   assert.equal(fr.message, en.message);
+});
+
+test("boxReservedError: names the owner + expiry in both langs, code box_reserved (never the generic not-ready copy)", () => {
+  const err = { code: "box_reserved", owner: "win", expires_at: "2026-09-04T23:00:00.000Z" };
+  const en = boxReservedError(err, "en");
+  const es = boxReservedError(err, "es");
+  assert.equal(en.code, "box_reserved");
+  assert.equal(en.owner, "win");
+  assert.equal(en.expires_at, "2026-09-04T23:00:00.000Z");
+  assert.equal(en.message, fill(t("chat.box_reserved", "en"), { owner: "win", until: "2026-09-04T23:00:00.000Z" }));
+  assert.equal(es.message, fill(t("chat.box_reserved", "es"), { owner: "win", until: "2026-09-04T23:00:00.000Z" }));
+  assert.notEqual(en.message, es.message);
+  assert.match(en.message, /win/);
+  assert.match(en.message, /2026-09-04T23:00:00\.000Z/);
+  assert.notEqual(en.message, providerNotReadyError("x", true, "en").message);
+  const bare = boxReservedError({}, "en");
+  assert.match(bare.message, /unknown/);
 });

--- a/tests/gpu-orchestrator-reservation.test.js
+++ b/tests/gpu-orchestrator-reservation.test.js
@@ -1,0 +1,131 @@
+// tests/gpu-orchestrator-reservation.test.js
+//
+// The reservation gate (scope §3.2): while the box is reserved, the
+// orchestrator refuses to START any provider the reservation did not allow —
+// on every path that can start one (on-demand acquire, boot/retry residency,
+// idle-revert) — and never touches a provider that is already running.
+// Loopback baseUrls are "local everywhere" (see gpu-orchestrator-host-gate),
+// so these providers are orchestratable without pinning ownAddrs.
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as orch from "../servers/gateway/gpu-orchestrator.js";
+import { ReservedError } from "../servers/gateway/box-reservation.js";
+
+const RES = Object.freeze({
+  owner: "win", reason: "bench", started_at: "2026-09-04T20:00:00.000Z", expires_at: "2026-09-04T23:00:00.000Z",
+  allow: ["crow-embed"], corrupt: false, key: "win@2026-09-04T20:00:00.000Z",
+});
+const cfg = {
+  providers: {
+    "crow-chat":  { bundleId: "llamacpp-vulkan-qwen36-35b-a3b", baseUrl: "http://127.0.0.1:8003/v1", host: "local" },
+    "crow-embed": { bundleId: "llamacpp-vulkan-qwen3-embed",   baseUrl: "http://127.0.0.1:8005/v1", host: "local" },
+  },
+};
+const notReady = async () => false;
+const mustNotStart = async () => { throw new Error("must not start"); };
+
+let logs, origLog;
+beforeEach(() => {
+  orch._setReservationReaderForTest(null);
+  orch._resetReservationNoticesForTest();
+  logs = []; origLog = console.log; console.log = (m) => logs.push(String(m));
+});
+afterEach(() => { console.log = origLog; orch._setReservationReaderForTest(null); });
+
+test("reserved + provider not ready + not allowed -> ReservedError; bundleUp never called", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  let started = 0;
+  await assert.rejects(
+    () => orch.acquireProvider("crow-chat", { cfg, probeReadyFn: notReady, bundleUpFn: async () => { started++; }, waitForReadyFn: async () => true, bundleStopFn: async () => {} }),
+    (e) => e instanceof ReservedError && e.code === "box_reserved" && e.owner === "win" && e.provider === "crow-chat" && e.expires_at === RES.expires_at
+  );
+  assert.equal(started, 0);
+  assert.ok(logs.some((l) => /refusing to start crow-chat.*box reserved by win/.test(l)), logs.join("\n"));
+});
+
+test("reserved + provider already ready -> true, nothing started, nothing logged as refused", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  const r = await orch.acquireProvider("crow-chat", { cfg, probeReadyFn: async () => true, bundleUpFn: mustNotStart });
+  assert.equal(r, true);
+  assert.ok(!logs.some((l) => /refusing/.test(l)));
+});
+
+test("reserved + allowed provider (default allow) -> starts normally", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  let started = 0;
+  const r = await orch.acquireProvider("crow-embed", { cfg, probeReadyFn: notReady, bundleUpFn: async () => { started++; }, waitForReadyFn: async () => true, bundleStopFn: async () => {} });
+  assert.equal(r, true);
+  assert.equal(started, 1);
+});
+
+test("no reservation -> unchanged: starts", async () => {
+  let started = 0;
+  const r = await orch.acquireProvider("crow-chat", { cfg, probeReadyFn: notReady, bundleUpFn: async () => { started++; }, waitForReadyFn: async () => true, bundleStopFn: async () => {} });
+  assert.equal(r, true);
+  assert.equal(started, 1);
+});
+
+test("corrupt reservation file -> reserved (fail closed) for every provider incl. the default allow", async () => {
+  orch._setReservationReaderForTest(() => ({ owner: "unknown", reason: "unreadable reservation file", started_at: null, expires_at: null, allow: [], corrupt: true, key: "corrupt" }));
+  await assert.rejects(
+    () => orch.acquireProvider("crow-embed", { cfg, probeReadyFn: notReady, bundleUpFn: mustNotStart }),
+    (e) => e instanceof ReservedError && e.owner === "unknown"
+  );
+});
+
+test("maybeAcquireLocalProvider RETHROWS ReservedError (callers must see it) but still swallows other failures", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  await assert.rejects(
+    () => orch.maybeAcquireLocalProvider("crow-chat", { cfg, probeReadyFn: notReady, bundleUpFn: mustNotStart }),
+    (e) => e instanceof ReservedError
+  );
+  orch._setReservationReaderForTest(null);
+  const seen = [];
+  const r = await orch.maybeAcquireLocalProvider("crow-chat", { cfg, probeReadyFn: notReady, bundleUpFn: async () => { throw new Error("compose exploded"); }, onError: (e) => seen.push(e.message) });
+  assert.equal(r, false);
+  assert.deepEqual(seen, ["compose exploded"]);
+});
+
+test("ensureResident defers while reserved (once-per-reservation log), never starts; resumes when the reservation is gone", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  const opts = { probeReadyFn: notReady, bundleUpFn: mustNotStart, waitForReadyFn: async () => true };
+  assert.equal(await orch.ensureResident("crow-chat", cfg, opts), false);
+  assert.equal(await orch.ensureResident("crow-chat", cfg, opts), false);
+  assert.equal(logs.filter((l) => /residency deferred: box reserved by win until 2026-09-04T23:00:00\.000Z/.test(l)).length, 1, logs.join("\n"));
+  orch._setReservationReaderForTest(null);
+  let started = 0;
+  assert.equal(await orch.ensureResident("crow-chat", cfg, { probeReadyFn: notReady, bundleUpFn: async () => { started++; }, waitForReadyFn: async () => true }), false, "not embed-capable -> false, but it DID start");
+  assert.equal(started, 1);
+});
+
+test("ensureResident while reserved still reports an allowed provider normally", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  let started = 0;
+  await orch.ensureResident("crow-embed", cfg, { probeReadyFn: notReady, bundleUpFn: async () => { started++; }, waitForReadyFn: async () => true });
+  assert.equal(started, 1);
+});
+
+test("retryDeferredResidents keeps a blocked name parked (not dropped) while reserved", async () => {
+  orch._setReservationReaderForTest(() => RES);
+  orch._setDeferredResidentsForTest(["crow-chat"]);
+  const ensured = [];
+  const ensure = async (name) => { ensured.push(name); return false; };
+  assert.deepEqual(await orch.retryDeferredResidents({ cfg, ownAddrs: new Set(["127.0.0.1"]), ensure }), []);
+  assert.deepEqual(ensured, []);
+  orch._setReservationReaderForTest(null);
+  assert.deepEqual(await orch.retryDeferredResidents({ cfg, ownAddrs: new Set(["127.0.0.1"]), ensure }), ["crow-chat"]);
+  assert.deepEqual(ensured, ["crow-chat"]);
+  orch._setDeferredResidentsForTest([]);
+});
+
+test("refusal notices: the first refused start per reservation is handed to the notifier once", async () => {
+  const notices = [];
+  orch._setReservationNoticeSenderForTest(async (n) => { notices.push(n.kind + ":" + (n.refused ? n.refused.provider : "")); });
+  orch._setReservationReaderForTest(() => RES);
+  const opts = { cfg, probeReadyFn: notReady, bundleUpFn: mustNotStart, requester: "10.0.0.5 ua=x client=companion" };
+  await assert.rejects(() => orch.acquireProvider("crow-chat", opts));
+  await assert.rejects(() => orch.acquireProvider("crow-chat", opts));
+  await new Promise((r) => setTimeout(r, 5)); // fire-and-forget sender
+  assert.deepEqual(notices, ["start:", "refused:crow-chat"]);
+});

--- a/tests/llm-router-reserved.test.js
+++ b/tests/llm-router-reserved.test.js
@@ -1,0 +1,124 @@
+// tests/llm-router-reserved.test.js
+//
+// Scope §3.3: while the box is reserved, /llm/v1 DEGRADES instead of
+// stalling — an escalation whose acquire is refused is served by the resident
+// fast model (with a system note), or answered 503 box_reserved with a
+// Retry-After when even the fast model is not resident. Nothing retries, and
+// no request waits 240 s for a model that will never start. /llm/acquire
+// answers 409 box_reserved.
+//
+// The router's seams (acquireFn, resolveKeyFn, probeReadyFn, warmFn) keep
+// this hermetic: no gpu-orchestrator, no providers table, a stub upstream.
+
+process.env.COMPANION_FAST_MODEL = "crow-voice/qwen3.5-4b";
+process.env.COMPANION_ESCALATION_MODEL = "crow-chat/qwen3.6-35b-a3b";
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import express from "express";
+import llmRouterRouter from "../servers/gateway/routes/llm-router.js";
+import { ReservedError } from "../servers/gateway/box-reservation.js";
+
+const RES = { owner: "win", reason: "bench", started_at: "2026-09-04T20:00:00.000Z", expires_at: new Date(Date.now() + 30 * 60_000).toISOString(), allow: ["crow-embed"], corrupt: false, key: "k" };
+
+let upstream, upstreamUrl, seen, app, appUrl, srv;
+let fastReady = true;
+let acquireCalls = [];
+
+before(async () => {
+  upstream = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => { raw += c; });
+    req.on("end", () => {
+      seen.push(JSON.parse(raw));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ choices: [{ message: { role: "assistant", content: "ok" } }] }));
+    });
+  });
+  await new Promise((r) => upstream.listen(0, "127.0.0.1", r));
+  upstreamUrl = `http://127.0.0.1:${upstream.address().port}/v1`;
+
+  const router = llmRouterRouter({
+    acquireFn: async (providerId, opts) => {
+      acquireCalls.push({ providerId, opts });
+      if (providerId === "crow-chat") throw new ReservedError(RES, providerId);
+      if (providerId === "crow-voice" && !fastReady) throw new ReservedError(RES, providerId);
+      return true;
+    },
+    resolveKeyFn: async (key) => ({ baseUrl: upstreamUrl, model: key.split("/")[1], apiKey: null }),
+    probeReadyFn: async () => fastReady,
+    warmFn: async (provider) => { throw new ReservedError(RES, provider); },
+  });
+  app = express();
+  app.use(router);
+  srv = http.createServer(app);
+  await new Promise((r) => srv.listen(0, "127.0.0.1", r));
+  appUrl = `http://127.0.0.1:${srv.address().port}`;
+});
+
+after(() => { if (srv) srv.close(); if (upstream) upstream.close(); });
+
+function reset() { seen = []; acquireCalls = []; }
+
+async function chat(text) {
+  let r;
+  try { r = await fetch(`${appUrl}/llm/v1/chat/completions`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-crow-client": "test" },
+    body: JSON.stringify({ model: "crow", messages: [{ role: "user", content: text }], stream: false }),
+  }); } catch (e) { throw new Error("fetch to " + appUrl + " failed: " + (e.cause && (e.cause.code + " " + e.cause.message))); }
+  return { status: r.status, headers: r.headers, body: await r.json() };
+}
+
+test("escalation refused by a reservation + fast model resident -> served by the fast model with a system note", async () => {
+  reset(); fastReady = true;
+  const r = await chat("!escalate plan the migration");
+  assert.equal(r.status, 200, JSON.stringify(r.body));
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].model, "qwen3.5-4b", "re-routed to FAST_KEY's model");
+  const last = seen[0].messages[seen[0].messages.length - 1];
+  assert.equal(last.role, "system");
+  assert.match(last.content, /reserved \(by win until /);
+  assert.match(seen[0].messages[0].content, /^plan the migration/, "the !escalate token is still stripped");
+  assert.deepEqual(acquireCalls.map((c) => c.providerId), ["crow-chat"], "no second acquire, no retry");
+});
+
+test("escalation refused + fast model NOT resident -> 503 box_reserved with Retry-After, nothing forwarded", async () => {
+  reset(); fastReady = false;
+  const r = await chat("!escalate hi");
+  assert.equal(r.status, 503);
+  assert.equal(r.body.error.code, "box_reserved");
+  assert.equal(r.body.error.owner, "win");
+  assert.equal(r.body.error.expires_at, RES.expires_at);
+  assert.ok(r.body.error.retry_after >= 60);
+  assert.equal(r.headers.get("retry-after"), String(r.body.error.retry_after));
+  assert.equal(seen.length, 0);
+});
+
+test("fast request refused (fast model cold and not allowed) -> 503 box_reserved", async () => {
+  reset(); fastReady = false;
+  const r = await chat("hi");
+  assert.equal(r.status, 503);
+  assert.equal(r.body.error.code, "box_reserved");
+  assert.equal(seen.length, 0);
+});
+
+test("fast request with acquire OK -> unchanged forwarding, no system note", async () => {
+  reset(); fastReady = true;
+  const r = await chat("hi");
+  assert.equal(r.status, 200);
+  assert.equal(seen[0].model, "qwen3.5-4b");
+  assert.ok(!seen[0].messages.some((m) => m.role === "system" && /reserved/.test(m.content)));
+});
+
+test("POST /llm/acquire refused by a reservation -> 409 box_reserved", async () => {
+  const r = await fetch(`${appUrl}/llm/acquire`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ provider: "crow-chat" }),
+  });
+  assert.equal(r.status, 409);
+  const body = await r.json();
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "box_reserved");
+  assert.equal(body.owner, "win");
+});

--- a/tests/models-panel.test.js
+++ b/tests/models-panel.test.js
@@ -1250,3 +1250,25 @@ test("GET /api/models/probe + POST /api/models/reprobe", async () => {
     });
   } finally { await h.cleanup(); }
 });
+
+test("POST /api/models/:id/start: a box reservation (ReservedError) maps to 409 BOX_RESERVED with owner + expiry", async () => {
+  const h = freshLibsql();
+  try {
+    const token = await seedSession(h.db);
+    const { registerModel } = await import("../servers/gateway/models/manager.js");
+    await registerModel({ modelId: "panel-test-model", quant: "Q4_K_M", catalog: makeCatalog(), db: h.db, dir: h.dir });
+    const { ReservedError } = await import("../servers/gateway/box-reservation.js");
+    await withServer({
+      dir: h.dir, loadCatalogFn: makeCatalog, getCachedProbeFn: () => FIXED_PROBE,
+      maybeAcquireLocalProviderFn: async (id) => { throw new ReservedError({ owner: "win", expires_at: "2026-09-04T23:00:00.000Z" }, id); },
+    }, async (base) => {
+      const r = await fetch(base + "/api/models/panel-test-model/start", { method: "POST", headers: authHeaders(token) });
+      assert.equal(r.status, 409);
+      const body = await r.json();
+      assert.equal(body.code, "BOX_RESERVED");
+      assert.equal(body.owner, "win");
+      assert.equal(body.expires_at, "2026-09-04T23:00:00.000Z");
+      assert.match(body.error, /reserved by win/);
+    });
+  } finally { await h.cleanup(); }
+});


### PR DESCRIPTION
PR 2 of the box-reservation work. Scope: `docs/superpowers/specs/2026-09-04-box-reservation-scheduling-scope.md`; plan: `docs/superpowers/plans/2026-09-04-acceptance-gaps-and-box-reservation.md` PR C. Builds on #299 (requester attribution). The pi-lab window side (writes/clears the file) is already on pi-lab `main` (`9502dc6`).

**Decisions applied (accepted by the operator 2026-09-04):** reservations outrank bots — bots degrade to the resident fast model rather than wait; default max hold 8 h, `--force` to exceed; `crow-embed` is always allowed.

**What ships**
- `servers/gateway/box-reservation.js` — reads `$CROW_BOX_RESERVATION_PATH` (default `/run/user/<uid>/crow-box-reservation.json`): missing/expired → none; corrupt or no expiry → **reserved** (fail closed); `allow` unioned with the default; `writeReservation`/`clearReservation` (atomic); typed `ReservedError` (`code: box_reserved`, `http: 503`).
- `gpu-orchestrator.js` — one gate (`startBlockedBy`) in front of **every** start path: on-demand acquire (docker + native, checked before any sibling eviction), boot/retry residency, and the idle-revert timer. A provider that is already running is never touched. `maybeAcquireLocalProvider` rethrows `ReservedError` (only that class) so callers can tell a refusal from a failure. Residency paths never throw; they log once per reservation. The residency tick announces a new reservation.
- `routes/llm-router.js` — an escalation refused by a reservation is served by the resident fast model with a system note (`route=degraded(box_reserved)`); if even the fast model is cold → `503 {error.code:"box_reserved", owner, expires_at, retry_after}` + `Retry-After`. Nothing retries. `/llm/acquire` → `409 box_reserved`. Router gains injectable seams (`acquireFn`, `resolveKeyFn`, `probeReadyFn`, `warmFn`).
- Dashboard chat → an error event naming owner + expiry (new i18n key `chat.box_reserved`, en+es); models panel → `409 BOX_RESERVED`.
- `box-reservation-notify.js` — once per reservation: "Box reserved by X until T" (normal) and "refused a model start: <provider> (asked by <requester>)" (high); sender never throws into the orchestrator.
- `scripts/ops/box-reserve.mjs hold|release|status` — manual holds.
- `docs/architecture/box-reservation.md` (+ sidebar).

**Tests (+45):** `box-reservation`, `box-reservation-notify`, `box-reserve-cli` (real child process), `gpu-orchestrator-reservation` (bundleUp never called while reserved; allowed provider starts; corrupt → refused; rethrow contract; residency defers once; deferred residents stay parked; refusal notice once), `llm-router-reserved` (degrade / 503 / unchanged / 409 against a stub upstream), chat + models-panel cases, i18n parity. Full suite **3673/0** under node 22; port, registry, docs build OK.

**Deploy note:** both gateways on the primary box run from the `~/crow` tree and need a restart to pick this up; no schema change, no new ports.