### PR TITLE
feat: model catalog v2 — curated for the models this lab runs; shards, companions, embedding/rerank tasks

### DIFF
--- a/registry/model-catalog.json
+++ b/registry/model-catalog.json
@@ -37,9 +37,17 @@
       "min_runtime_version": "b10068",
       "default_quant": "UD-Q4_K_XL",
       "first_run_default": true,
-      "chat_template_kwargs": { "enable_thinking": false },
-      "tags": ["small", "chat", "vision", "cpu-capable", "voice"],
-      "notes": "The fast route. This is the voice/companion model on this box (crow-voice): every Meta Glasses and AI Companion turn hits it first and only escalates to the 35B on a leading !escalate. It is also the fresh-install default — the UD-Q4_K_XL quant runs on CPU alone in under 8 GB of RAM. chat_template_kwargs suppresses Qwen's <think> block: on a 4B the reasoning preamble is noisy filler that ruins a first chat and adds latency to a voice turn. Natively vision-language; the mmproj companion is downloaded beside it and passed to llama-server as --mmproj so image turns work out of the box.",
+      "chat_template_kwargs": {
+        "enable_thinking": false
+      },
+      "tags": [
+        "small",
+        "chat",
+        "vision",
+        "cpu-capable",
+        "voice"
+      ],
+      "notes": "The fast route. This is the voice/companion model on this box (crow-voice): every Meta Glasses and AI Companion turn hits it first and only escalates to the 35B on a leading !escalate. It is also the fresh-install default \u2014 the UD-Q4_K_XL quant runs on CPU alone in under 8 GB of RAM. chat_template_kwargs suppresses Qwen's <think> block: on a 4B the reasoning preamble is noisy filler that ruins a first chat and adds latency to a voice turn. Natively vision-language; the mmproj companion is downloaded beside it and passed to llama-server as --mmproj so image turns work out of the box.",
       "companions": [
         {
           "kind": "mmproj",
@@ -78,8 +86,13 @@
       "context_len": 32768,
       "min_runtime_version": "b10068",
       "default_quant": "Q4_0",
-      "tags": ["small", "chat", "vision", "cpu-capable"],
-      "notes": "Google's Gemma 4 E2B (effective 2B parameters) instruction-tuned, unsloth GGUF. The second small-class option: a different lineage from the Qwen default for comparing small-model behavior, CPU-capable, vision-capable through its mmproj companion. Gemma license, not Apache — the card shows it honestly. Not gated on Hugging Face (unlike the older official Gemma 3 QAT repo this catalog used to carry).",
+      "tags": [
+        "small",
+        "chat",
+        "vision",
+        "cpu-capable"
+      ],
+      "notes": "Google's Gemma 4 E2B (effective 2B parameters) instruction-tuned, unsloth GGUF. The second small-class option: a different lineage from the Qwen default for comparing small-model behavior, CPU-capable, vision-capable through its mmproj companion. Gemma license, not Apache \u2014 the card shows it honestly. Not gated on Hugging Face (unlike the older official Gemma 3 QAT repo this catalog used to carry).",
       "companions": [
         {
           "kind": "mmproj",
@@ -110,8 +123,12 @@
       "context_len": 8192,
       "min_runtime_version": "b10068",
       "default_quant": "Q8_0",
-      "tags": ["small", "embedding", "cpu-capable"],
-      "notes": "The fleet embedding model. Every Crow memory in this lab is embedded with it — grackle serves it under vLLM today (grackle-embed) — and this entry lets a fresh install or a CPU-only box serve the same vector space with llama-server --embedding, so memories stay comparable across instances without a re-embed. Switching to a different embedding model means re-embedding everything (see the AI providers guide). Official Qwen GGUF; min_ram_mb is computed at its 8k context.",
+      "tags": [
+        "small",
+        "embedding",
+        "cpu-capable"
+      ],
+      "notes": "The fleet embedding model. Every Crow memory in this lab is embedded with it \u2014 grackle serves it under vLLM today (grackle-embed) \u2014 and this entry lets a fresh install or a CPU-only box serve the same vector space with llama-server --embedding, so memories stay comparable across instances without a re-embed. Switching to a different embedding model means re-embedding everything (see the AI providers guide). Official Qwen GGUF; min_ram_mb is computed at its 8k context.",
       "quants": [
         {
           "file": "Qwen3-Embedding-0.6B-Q8_0.gguf",
@@ -134,8 +151,12 @@
       "context_len": 8192,
       "min_runtime_version": "b10068",
       "default_quant": "Q8_0",
-      "tags": ["small", "rerank", "cpu-capable"],
-      "notes": "The fleet reranker, paired with the embedding model above for two-stage retrieval (embed, take the top k, rerank). Runs on grackle under vLLM today; this entry serves it with llama-server --reranking. GGUF by mradermacher — Qwen publishes no official GGUF for the reranker, and the file is named with a dot before the quant (Qwen3-Reranker-0.6B.Q8_0.gguf) in that repo's convention.",
+      "tags": [
+        "small",
+        "rerank",
+        "cpu-capable"
+      ],
+      "notes": "The fleet reranker, paired with the embedding model above for two-stage retrieval (embed, take the top k, rerank). Runs on grackle under vLLM today; this entry serves it with llama-server --reranking. GGUF by mradermacher \u2014 Qwen publishes no official GGUF for the reranker, and the file is named with a dot before the quant (Qwen3-Reranker-0.6B.Q8_0.gguf) in that repo's convention.",
       "quants": [
         {
           "file": "Qwen3-Reranker-0.6B.Q8_0.gguf",
@@ -158,8 +179,13 @@
       "context_len": 32768,
       "min_runtime_version": "b10068",
       "default_quant": "Q4_K_M",
-      "tags": ["small", "vision", "chat", "cpu-capable"],
-      "notes": "The fleet vision specialist (grackle-vision under vLLM today). A dedicated vision-language model for turns where the image is the point — the 35B's mmproj covers casual vision, this is what the companion and the glasses escalate to for real image work. Small enough for CPU; the mmproj companion downloads beside it. Registered as task vision, so it does not join the chat mutex group and can sit next to a resident chat model.",
+      "tags": [
+        "small",
+        "vision",
+        "chat",
+        "cpu-capable"
+      ],
+      "notes": "The fleet vision specialist (grackle-vision under vLLM today). A dedicated vision-language model for turns where the image is the point \u2014 the 35B's mmproj covers casual vision, this is the tier the dashboard smart-router sends image turns to (vision \u2192 grackle-vision today). Small enough for CPU; the mmproj companion downloads beside it. Registered as task vision, so it does not join the chat mutex group and can sit next to a resident chat model.",
       "companions": [
         {
           "kind": "mmproj",
@@ -198,8 +224,14 @@
       "context_len": 262144,
       "min_runtime_version": "b10068",
       "default_quant": "UD-Q5_K_XL",
-      "tags": ["mid", "chat", "vision", "agentic", "default-workhorse"],
-      "notes": "The resident workhorse. crow-chat on this box: a 35B mixture-of-experts with 3B active parameters, which is why it runs at interactive speed on the Strix Halo's unified memory and why it stays loaded — every bot, every Bot Builder turn, the dashboard chat, and the companion's !escalate target all land here. Agentic tool-calling is its strength; multimodal via the mmproj companion. UD-Q5_K_XL is the daily quant, UD-Q4_K_XL for a tighter box. 256k context is the model's; min_ram_mb is computed at a 32k fit context — budget more RAM for long agentic sessions.",
+      "tags": [
+        "mid",
+        "chat",
+        "vision",
+        "agentic",
+        "default-workhorse"
+      ],
+      "notes": "The resident workhorse. crow-chat on this box: a 35B mixture-of-experts with 3B active parameters, which is why it runs at interactive speed on the Strix Halo's unified memory and why it stays loaded \u2014 every bot, every Bot Builder turn, the dashboard chat, and the companion's !escalate target all land here. Agentic tool-calling is its strength; multimodal via the mmproj companion. UD-Q5_K_XL is the daily quant, UD-Q4_K_XL for a tighter box. 256k context is the model's; min_ram_mb is computed at a 32k fit context \u2014 budget more RAM for long agentic sessions.",
       "companions": [
         {
           "kind": "mmproj",
@@ -238,8 +270,15 @@
       "context_len": 262144,
       "min_runtime_version": "b10068",
       "default_quant": "UD-Q6_K_XL",
-      "tags": ["mid", "chat", "vision", "coding", "copilot", "long-context"],
-      "notes": "The dense copilot and critic. Where the 35B is the fast agentic hand, the 27B is the second opinion: code review, plan critique, and long-context batch work (a 512k-YaRN variant exposed as a bot model is a separate queued item). It shares the chat mutex group with the 35B, so starting it evicts the workhorse — deliberate: on this box it is a batch model, not a resident. UD-Q6_K_XL is the quality quant; UD-Q4_K_XL when RAM is tight. Vision via the mmproj companion; min_ram_mb is computed at a 32k fit context.",
+      "tags": [
+        "mid",
+        "chat",
+        "vision",
+        "coding",
+        "copilot",
+        "long-context"
+      ],
+      "notes": "The dense copilot and critic. Where the 35B is the fast agentic hand, the 27B is the second opinion: code review, plan critique, and long-context batch work (a 512k-YaRN variant exposed as a bot model is a separate queued item). It shares the chat mutex group with the 35B, so starting it evicts the workhorse \u2014 deliberate: on this box it is a batch model, not a resident. UD-Q6_K_XL is the quality quant; UD-Q4_K_XL when RAM is tight. Vision via the mmproj companion; min_ram_mb is computed at a 32k fit context.",
       "companions": [
         {
           "kind": "mmproj",
@@ -278,8 +317,13 @@
       "context_len": 262144,
       "min_runtime_version": "b10068",
       "default_quant": "UD-Q4_K_XL",
-      "tags": ["large", "chat", "bench", "mtp"],
-      "notes": "Benchmark-window heavy. A four-part UD-Q4_K_XL (about 111 GB total) that needs the whole box: start it only inside a registered CROW-SCHEDULE window — the orchestrator's reservation gate refuses on-demand starts while a window is active for anything else. Ships a multi-token-prediction (MTP) head as a companion: the catalog downloads it beside the model for the operator's own llama-server launchers but passes no MTP flag, because MTP loading is build-specific in llama.cpp. Needs a llama.cpp build with the Qwen3.8-Flash-Next architecture; the operator runs it from his own builds today, and the stock runtime release may not load it.",
+      "tags": [
+        "large",
+        "chat",
+        "bench",
+        "mtp"
+      ],
+      "notes": "Benchmark-window heavy. A four-part UD-Q4_K_XL (about 111 GB total) that needs the whole box: start it only inside a registered CROW-SCHEDULE window \u2014 the orchestrator's reservation gate refuses on-demand starts while a window is active for anything else. Ships a multi-token-prediction (MTP) head as a companion: the catalog downloads it beside the model for the operator's own llama-server launchers but passes no MTP flag, because MTP loading is build-specific in llama.cpp. Needs a llama.cpp build with the Qwen3.8-Flash-Next architecture; the operator runs it from his own builds today, and the stock runtime release may not load it.",
       "companions": [
         {
           "kind": "mtp",
@@ -327,8 +371,14 @@
       "context_len": 131072,
       "min_runtime_version": "b10068",
       "default_quant": "UD-IQ2_XXS",
-      "tags": ["large", "chat", "vision", "bench", "two-box"],
-      "notes": "Benchmark-window heavy, replacing the GLM-5.2 bench entry. Z.ai's GLM-5.3-Flash in unsloth dynamic quants of four to six parts: UD-IQ2_XXS (about 102 GB) fits this box alone, UD-IQ4_XS (about 157 GB) and UD-Q4_K_XL (about 200 GB) are the two-box split. Vision via the mmproj companion. Requires a llama.cpp build with glm5_next support — the operator runs it from his own builds today; the catalog's stock runtime release will not load it. Reservation-gated like the other heavies: register a CROW-SCHEDULE window before starting.",
+      "tags": [
+        "large",
+        "chat",
+        "vision",
+        "bench",
+        "two-box"
+      ],
+      "notes": "Benchmark-window heavy, replacing the GLM-5.2 bench entry. Z.ai's GLM-5.3-Flash in unsloth dynamic quants of four to six parts: UD-IQ2_XXS (about 102 GB) fits this box alone, UD-IQ4_XS (about 157 GB) and UD-Q4_K_XL (about 200 GB) are the two-box split. Vision via the mmproj companion. Requires a llama.cpp build with glm5_next support \u2014 the operator runs it from his own builds today; the catalog's stock runtime release will not load it. Reservation-gated like the other heavies: register a CROW-SCHEDULE window before starting.",
       "companions": [
         {
           "kind": "mmproj",
@@ -441,8 +491,12 @@
       "context_len": 131072,
       "min_runtime_version": "b10068",
       "default_quant": "UD-IQ3_XXS",
-      "tags": ["large", "chat", "bench"],
-      "notes": "Benchmark-window heavy. DeepSeek-V4-Flash (0731) in unsloth dynamic quants of three to four parts (about 97 to 104 GB). Text-only. Requires a llama.cpp build with deepseek4 support — the operator runs it from his own builds today; the catalog's stock runtime release will not load it. Reservation-gated like the other heavies: register a CROW-SCHEDULE window before starting, and expect the whole box for the duration.",
+      "tags": [
+        "large",
+        "chat",
+        "bench"
+      ],
+      "notes": "Benchmark-window heavy. DeepSeek-V4-Flash (0731) in unsloth dynamic quants of three to four parts (about 97 to 104 GB). Text-only. Requires a llama.cpp build with deepseek4 support \u2014 the operator runs it from his own builds today; the catalog's stock runtime release will not load it. Reservation-gated like the other heavies: register a CROW-SCHEDULE window before starting, and expect the whole box for the duration.",
       "quants": [
         {
           "file": "UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00001-of-00004.gguf",

--- a/registry/model-catalog.json
+++ b/registry/model-catalog.json
@@ -26,172 +26,468 @@
   },
   "models": [
     {
-      "id": "qwen3-4b",
-      "family": "qwen3",
+      "id": "qwen3.5-4b",
+      "family": "qwen3.5",
       "lab": "Qwen",
-      "hf_repo": "Qwen/Qwen3-4B-GGUF",
+      "hf_repo": "unsloth/Qwen3.5-4B-GGUF",
       "license": "apache-2.0",
       "gated": false,
       "task": "chat",
-      "context_len": 8192,
+      "context_len": 32768,
       "min_runtime_version": "b10068",
-      "default_quant": "Q4_K_M",
+      "default_quant": "UD-Q4_K_XL",
       "first_run_default": true,
       "chat_template_kwargs": { "enable_thinking": false },
-      "tags": ["chat", "small", "cpu-capable"],
-      "notes": "Small class default. Runs on CPU alone (min_vram_mb: 0) on an 8 GB RAM machine; this is the first model Crow offers on a fresh install. chat_template_kwargs suppresses Qwen3's <think> reasoning block: on a small model the thinking preamble is noisy filler that ruins the first-chat experience, and the llm-router's fast voice route already defaults to the same enable_thinking:false.",
+      "tags": ["small", "chat", "vision", "cpu-capable", "voice"],
+      "notes": "The fast route. This is the voice/companion model on this box (crow-voice): every Meta Glasses and AI Companion turn hits it first and only escalates to the 35B on a leading !escalate. It is also the fresh-install default — the UD-Q4_K_XL quant runs on CPU alone in under 8 GB of RAM. chat_template_kwargs suppresses Qwen's <think> block: on a 4B the reasoning preamble is noisy filler that ruins a first chat and adds latency to a voice turn. Natively vision-language; the mmproj companion is downloaded beside it and passed to llama-server as --mmproj so image turns work out of the box.",
+      "companions": [
+        {
+          "kind": "mmproj",
+          "file": "mmproj-F16.gguf",
+          "size_mb": 672.42,
+          "sha256": "cd88edcf8d031894960bb0c9c5b9b7e1fea6ebee02b9f7ce925a00d12891f864"
+        }
+      ],
       "quants": [
         {
-          "file": "Qwen3-4B-Q4_K_M.gguf",
-          "quant": "Q4_K_M",
-          "size_mb": 2497.28,
-          "min_ram_mb": 6030,
+          "file": "Qwen3.5-4B-UD-Q4_K_XL.gguf",
+          "quant": "UD-Q4_K_XL",
+          "size_mb": 2912.11,
+          "min_ram_mb": 7720,
           "min_vram_mb": 0,
-          "sha256": "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5"
-        }
-      ]
-    },
-    {
-      "id": "phi-4-mini-instruct",
-      "family": "phi4",
-      "lab": "Microsoft",
-      "hf_repo": "unsloth/Phi-4-mini-instruct-GGUF",
-      "license": "mit",
-      "gated": false,
-      "task": "chat",
-      "context_len": 8192,
-      "min_runtime_version": "b10068",
-      "default_quant": "Q4_K_M",
-      "tags": ["chat", "small", "cpu-capable"],
-      "notes": "GGUF requantized by unsloth from Microsoft's Phi-4-mini-instruct (3.8B). CPU-capable second small-class option alongside the Qwen default.",
-      "quants": [
+          "sha256": "b252c5610a42ca82d20fe2a12813e9d069eed89292907e26c783eeb0bc961bc7"
+        },
         {
-          "file": "Phi-4-mini-instruct-Q4_K_M.gguf",
-          "quant": "Q4_K_M",
-          "size_mb": 2491.87,
-          "min_ram_mb": 6226,
+          "file": "Qwen3.5-4B-Q8_0.gguf",
+          "quant": "Q8_0",
+          "size_mb": 4482.4,
+          "min_ram_mb": 9290,
           "min_vram_mb": 0,
-          "sha256": "88c00229914083cd112853aab84ed51b87bdf6b9ce42f532d8c85c7c63b1730a"
+          "sha256": "10cc391b403021dd11c614679d2fd92f611c3681d29e29651b717316965d61e1"
         }
       ]
     },
     {
-      "id": "llama-3.1-8b-instruct",
-      "family": "llama3.1",
-      "lab": "Meta",
-      "hf_repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
-      "license": "llama3.1",
+      "id": "gemma-4-e2b-it",
+      "family": "gemma4",
+      "lab": "Google",
+      "hf_repo": "unsloth/gemma-4-E2B-it-GGUF",
+      "license": "gemma",
       "gated": false,
       "task": "chat",
-      "context_len": 8192,
+      "context_len": 32768,
       "min_runtime_version": "b10068",
-      "default_quant": "Q4_K_M",
-      "tags": ["chat", "mid"],
-      "notes": "Community GGUF requantization by bartowski (275k+ downloads) — Meta does not publish official GGUF files for Llama 3.1. min_vram_mb is an engineering estimate (quant size rounded up + ~1 GiB headroom for KV/activations at this entry's context_len), not a vendor-published figure.",
+      "default_quant": "Q4_0",
+      "tags": ["small", "chat", "vision", "cpu-capable"],
+      "notes": "Google's Gemma 4 E2B (effective 2B parameters) instruction-tuned, unsloth GGUF. The second small-class option: a different lineage from the Qwen default for comparing small-model behavior, CPU-capable, vision-capable through its mmproj companion. Gemma license, not Apache — the card shows it honestly. Not gated on Hugging Face (unlike the older official Gemma 3 QAT repo this catalog used to carry).",
+      "companions": [
+        {
+          "kind": "mmproj",
+          "file": "mmproj-F16.gguf",
+          "size_mb": 985.65,
+          "sha256": "140be8d7849741f88c50757d529b84373ee8e27052cc2236855b537f4a8215fa"
+        }
+      ],
       "quants": [
         {
-          "file": "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-          "quant": "Q4_K_M",
-          "size_mb": 4920.74,
-          "min_ram_mb": 9728,
-          "min_vram_mb": 6144,
-          "sha256": "7b064f5842bf9532c91456deda288a1b672397a54fa729aa665952863033557c"
+          "file": "gemma-4-E2B-it-Q4_0.gguf",
+          "quant": "Q4_0",
+          "size_mb": 3041.38,
+          "min_ram_mb": 4728,
+          "min_vram_mb": 0,
+          "sha256": "31d3a3c630d4e71a7416498c42660dd3805066948acaec76a47e1ffac7010132"
         }
       ]
     },
     {
-      "id": "ministral-8b-instruct",
-      "family": "ministral",
-      "lab": "Mistral AI",
-      "hf_repo": "bartowski/Ministral-8B-Instruct-2410-GGUF",
-      "license": "mrl",
-      "gated": false,
-      "task": "chat",
-      "context_len": 8192,
-      "min_runtime_version": "b10068",
-      "default_quant": "Q4_K_M",
-      "tags": ["chat", "mid"],
-      "notes": "Mistral Research License (MRL) — non-commercial use only, not permissive; documented here so the catalog card shows it honestly. min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology).",
-      "quants": [
-        {
-          "file": "Ministral-8B-Instruct-2410-Q4_K_M.gguf",
-          "quant": "Q4_K_M",
-          "size_mb": 4911.5,
-          "min_ram_mb": 10256,
-          "min_vram_mb": 6144,
-          "sha256": "bbe8d91c196491b1802b20aba121d2ef38945a8e6c6c6a8710bfd2ef393fe73f"
-        }
-      ]
-    },
-    {
-      "id": "qwen3-14b",
+      "id": "qwen3-embedding-0.6b",
       "family": "qwen3",
       "lab": "Qwen",
-      "hf_repo": "Qwen/Qwen3-14B-GGUF",
+      "hf_repo": "Qwen/Qwen3-Embedding-0.6B-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "embedding",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q8_0",
+      "tags": ["small", "embedding", "cpu-capable"],
+      "notes": "The fleet embedding model. Every Crow memory in this lab is embedded with it — grackle serves it under vLLM today (grackle-embed) — and this entry lets a fresh install or a CPU-only box serve the same vector space with llama-server --embedding, so memories stay comparable across instances without a re-embed. Switching to a different embedding model means re-embedding everything (see the AI providers guide). Official Qwen GGUF; min_ram_mb is computed at its 8k context.",
+      "quants": [
+        {
+          "file": "Qwen3-Embedding-0.6B-Q8_0.gguf",
+          "quant": "Q8_0",
+          "size_mb": 639.15,
+          "min_ram_mb": 2091,
+          "min_vram_mb": 0,
+          "sha256": "06507c7b42688469c4e7298b0a1e16deff06caf291cf0a5b278c308249c3e439"
+        }
+      ]
+    },
+    {
+      "id": "qwen3-reranker-0.6b",
+      "family": "qwen3",
+      "lab": "Qwen",
+      "hf_repo": "mradermacher/Qwen3-Reranker-0.6B-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "rerank",
+      "context_len": 8192,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q8_0",
+      "tags": ["small", "rerank", "cpu-capable"],
+      "notes": "The fleet reranker, paired with the embedding model above for two-stage retrieval (embed, take the top k, rerank). Runs on grackle under vLLM today; this entry serves it with llama-server --reranking. GGUF by mradermacher — Qwen publishes no official GGUF for the reranker, and the file is named with a dot before the quant (Qwen3-Reranker-0.6B.Q8_0.gguf) in that repo's convention.",
+      "quants": [
+        {
+          "file": "Qwen3-Reranker-0.6B.Q8_0.gguf",
+          "quant": "Q8_0",
+          "size_mb": 639.15,
+          "min_ram_mb": 2091,
+          "min_vram_mb": 0,
+          "sha256": "c525a7449243f690a7062e6377d6cf5adbb289354bd4316312367cd20e187ab7"
+        }
+      ]
+    },
+    {
+      "id": "qwen3-vl-4b-instruct",
+      "family": "qwen3-vl",
+      "lab": "Qwen",
+      "hf_repo": "unsloth/Qwen3-VL-4B-Instruct-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "vision",
+      "context_len": 32768,
+      "min_runtime_version": "b10068",
+      "default_quant": "Q4_K_M",
+      "tags": ["small", "vision", "chat", "cpu-capable"],
+      "notes": "The fleet vision specialist (grackle-vision under vLLM today). A dedicated vision-language model for turns where the image is the point — the 35B's mmproj covers casual vision, this is what the companion and the glasses escalate to for real image work. Small enough for CPU; the mmproj companion downloads beside it. Registered as task vision, so it does not join the chat mutex group and can sit next to a resident chat model.",
+      "companions": [
+        {
+          "kind": "mmproj",
+          "file": "mmproj-F16.gguf",
+          "size_mb": 836.18,
+          "sha256": "1b9f4e92f0fbda14d7d7b58baed86039b8a980fe503d9d6a9393f25c0028f1fc"
+        }
+      ],
+      "quants": [
+        {
+          "file": "Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+          "quant": "Q4_K_M",
+          "size_mb": 2497.28,
+          "min_ram_mb": 7842,
+          "min_vram_mb": 0,
+          "sha256": "d4dcd426bfba75752a312b266b80fec8136fbaca13c62d93b7ac41fa67f0492b"
+        },
+        {
+          "file": "Qwen3-VL-4B-Instruct-Q8_0.gguf",
+          "quant": "Q8_0",
+          "size_mb": 4280.41,
+          "min_ram_mb": 9625,
+          "min_vram_mb": 0,
+          "sha256": "e30b41d2f2cc48149dfbba1b3fb2c023c7e6bf2def75833d4d43820df75efeb3"
+        }
+      ]
+    },
+    {
+      "id": "qwen3.6-35b-a3b",
+      "family": "qwen3.6",
+      "lab": "Qwen",
+      "hf_repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
       "license": "apache-2.0",
       "gated": false,
       "task": "chat",
-      "context_len": 8192,
+      "context_len": 262144,
       "min_runtime_version": "b10068",
-      "default_quant": "Q4_K_M",
-      "tags": ["chat", "mid"],
-      "notes": "Official Qwen GGUF. min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology).",
+      "default_quant": "UD-Q5_K_XL",
+      "tags": ["mid", "chat", "vision", "agentic", "default-workhorse"],
+      "notes": "The resident workhorse. crow-chat on this box: a 35B mixture-of-experts with 3B active parameters, which is why it runs at interactive speed on the Strix Halo's unified memory and why it stays loaded — every bot, every Bot Builder turn, the dashboard chat, and the companion's !escalate target all land here. Agentic tool-calling is its strength; multimodal via the mmproj companion. UD-Q5_K_XL is the daily quant, UD-Q4_K_XL for a tighter box. 256k context is the model's; min_ram_mb is computed at a 32k fit context — budget more RAM for long agentic sessions.",
+      "companions": [
+        {
+          "kind": "mmproj",
+          "file": "mmproj-F16.gguf",
+          "size_mb": 899.28,
+          "sha256": "8971ee4f331ff0a4c609374f32984b3d4e6dc086c0aa35f1d637fad1829e887f"
+        }
+      ],
       "quants": [
         {
-          "file": "Qwen3-14B-Q4_K_M.gguf",
-          "quant": "Q4_K_M",
-          "size_mb": 9001.75,
-          "min_ram_mb": 16225,
-          "min_vram_mb": 10240,
-          "sha256": "500a8806e85ee9c83f3ae08420295592451379b4f8cf2d0f41c15dffeb6b81f0"
+          "file": "Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf",
+          "quant": "UD-Q5_K_XL",
+          "size_mb": 26592.51,
+          "min_ram_mb": 29789,
+          "min_vram_mb": 0,
+          "sha256": "25233af7642e3a91bd52cc4aeefdbd4a117479088e06cf1aea5b6bedb443c506"
+        },
+        {
+          "file": "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+          "quant": "UD-Q4_K_XL",
+          "size_mb": 22360.46,
+          "min_ram_mb": 25557,
+          "min_vram_mb": 0,
+          "sha256": "707a55a8a4397ecde44de0c499d3e68c1ad1d240d1da65826b4949d1043f4450"
         }
       ]
     },
     {
-      "id": "deepseek-r1-distill-qwen-32b",
-      "family": "deepseek-r1-distill",
-      "lab": "DeepSeek",
-      "hf_repo": "bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+      "id": "qwen3.8-27b",
+      "family": "qwen3.8",
+      "lab": "Qwen",
+      "hf_repo": "unsloth/Qwen3.8-27B-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "chat",
+      "context_len": 262144,
+      "min_runtime_version": "b10068",
+      "default_quant": "UD-Q6_K_XL",
+      "tags": ["mid", "chat", "vision", "coding", "copilot", "long-context"],
+      "notes": "The dense copilot and critic. Where the 35B is the fast agentic hand, the 27B is the second opinion: code review, plan critique, and long-context batch work (a 512k-YaRN variant exposed as a bot model is a separate queued item). It shares the chat mutex group with the 35B, so starting it evicts the workhorse — deliberate: on this box it is a batch model, not a resident. UD-Q6_K_XL is the quality quant; UD-Q4_K_XL when RAM is tight. Vision via the mmproj companion; min_ram_mb is computed at a 32k fit context.",
+      "companions": [
+        {
+          "kind": "mmproj",
+          "file": "mmproj-F16.gguf",
+          "size_mb": 927.61,
+          "sha256": "cbb841a9ee0636b2ec172f5bb8df2ea8dfeb01e90fe7c6126581d662a0b4e43e"
+        }
+      ],
+      "quants": [
+        {
+          "file": "Qwen3.8-27B-UD-Q6_K_XL.gguf",
+          "quant": "UD-Q6_K_XL",
+          "size_mb": 25299.06,
+          "min_ram_mb": 34401,
+          "min_vram_mb": 0,
+          "sha256": "701d8fa9ed214ab21bfc130cd2a7df19ca89bbef7713e2dfb19f3c63696aa917"
+        },
+        {
+          "file": "Qwen3.8-27B-UD-Q4_K_XL.gguf",
+          "quant": "UD-Q4_K_XL",
+          "size_mb": 17559.18,
+          "min_ram_mb": 26662,
+          "min_vram_mb": 0,
+          "sha256": "3f227079003add2511437e5b1e94812e363385225bf6a9b47b0054a72bc8b01e"
+        }
+      ]
+    },
+    {
+      "id": "qwen3.8-flash-next",
+      "family": "qwen3.8",
+      "lab": "Qwen",
+      "hf_repo": "unsloth/Qwen3.8-Flash-Next-GGUF",
+      "license": "apache-2.0",
+      "gated": false,
+      "task": "chat",
+      "context_len": 262144,
+      "min_runtime_version": "b10068",
+      "default_quant": "UD-Q4_K_XL",
+      "tags": ["large", "chat", "bench", "mtp"],
+      "notes": "Benchmark-window heavy. A four-part UD-Q4_K_XL (about 111 GB total) that needs the whole box: start it only inside a registered CROW-SCHEDULE window — the orchestrator's reservation gate refuses on-demand starts while a window is active for anything else. Ships a multi-token-prediction (MTP) head as a companion: the catalog downloads it beside the model for the operator's own llama-server launchers but passes no MTP flag, because MTP loading is build-specific in llama.cpp. Needs a llama.cpp build with the Qwen3.8-Flash-Next architecture; the operator runs it from his own builds today, and the stock runtime release may not load it.",
+      "companions": [
+        {
+          "kind": "mtp",
+          "file": "MTP/mtp-Qwen3.8-Flash-Next-Q8_0.gguf",
+          "size_mb": 4137.43,
+          "sha256": "cd87e5d1a4dadaeed63e35929f3b2f28d13e081b4cd32e00f2835095ec09351e"
+        }
+      ],
+      "quants": [
+        {
+          "file": "UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00001-of-00004.gguf",
+          "quant": "UD-Q4_K_XL",
+          "size_mb": 111334.65,
+          "min_ram_mb": 115068,
+          "min_vram_mb": 0,
+          "sha256": "4448186216b3af4cc558bbce2c3213f01608f8f8b2e5267a9767971dd3ec8082",
+          "shards": [
+            {
+              "file": "UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00002-of-00004.gguf",
+              "size_mb": 49859.58,
+              "sha256": "3f342f1c1580473f1ee94ddd5b28206e8c07a70fa1a366f59d1d6c922919a6c9"
+            },
+            {
+              "file": "UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00003-of-00004.gguf",
+              "size_mb": 49376.14,
+              "sha256": "56758f40269cad5cd9b0d3d6fbae0f40f6d5be6de49e4ab392dbe83157d9cbd3"
+            },
+            {
+              "file": "UD-Q4_K_XL/Qwen3.8-Flash-Next-UD-Q4_K_XL-00004-of-00004.gguf",
+              "size_mb": 12087.98,
+              "sha256": "753bda48b98ba4f1636134a90a967de1b2d3908a236c026e464777342e53510a"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "glm-5.3-flash",
+      "family": "glm5",
+      "lab": "Z.ai",
+      "hf_repo": "unsloth/GLM-5.3-Flash-GGUF",
       "license": "mit",
       "gated": false,
       "task": "chat",
-      "context_len": 8192,
+      "context_len": 131072,
       "min_runtime_version": "b10068",
-      "default_quant": "Q4_K_M",
-      "tags": ["chat", "large", "reasoning"],
-      "notes": "DeepSeek-R1 reasoning distilled onto a Qwen2.5-32B base, released by DeepSeek under MIT; GGUF requantized by bartowski. Large class — needs a real GPU or a lot of RAM to be usable; min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology).",
+      "default_quant": "UD-IQ2_XXS",
+      "tags": ["large", "chat", "vision", "bench", "two-box"],
+      "notes": "Benchmark-window heavy, replacing the GLM-5.2 bench entry. Z.ai's GLM-5.3-Flash in unsloth dynamic quants of four to six parts: UD-IQ2_XXS (about 102 GB) fits this box alone, UD-IQ4_XS (about 157 GB) and UD-Q4_K_XL (about 200 GB) are the two-box split. Vision via the mmproj companion. Requires a llama.cpp build with glm5_next support — the operator runs it from his own builds today; the catalog's stock runtime release will not load it. Reservation-gated like the other heavies: register a CROW-SCHEDULE window before starting.",
+      "companions": [
+        {
+          "kind": "mmproj",
+          "file": "mmproj-F16.gguf",
+          "size_mb": 1128.05,
+          "sha256": "96ccc182997646ad4405385a1987b1ac1e6adccd2669de43c3ea39692699ed27"
+        }
+      ],
       "quants": [
         {
-          "file": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-          "quant": "Q4_K_M",
-          "size_mb": 19851.34,
-          "min_ram_mb": 31101,
-          "min_vram_mb": 21504,
-          "sha256": "bed9b0f551f5b95bf9da5888a48f0f87c37ad6b72519c4cbd775f54ac0b9fc62"
+          "file": "UD-IQ2_XXS/GLM-5.3-Flash-UD-IQ2_XXS-00001-of-00004.gguf",
+          "quant": "UD-IQ2_XXS",
+          "size_mb": 101844.96,
+          "min_ram_mb": 102934,
+          "min_vram_mb": 0,
+          "sha256": "d9605eec5aa2c14fc9ccff1ba3341a1e9a1476b08714d41cd43d0e10a4db3f7a",
+          "shards": [
+            {
+              "file": "UD-IQ2_XXS/GLM-5.3-Flash-UD-IQ2_XXS-00002-of-00004.gguf",
+              "size_mb": 49896.3,
+              "sha256": "d51a3d9ca05022d53e71753df75ee64ed5fd4e47655650ae023e9717b3ec158d"
+            },
+            {
+              "file": "UD-IQ2_XXS/GLM-5.3-Flash-UD-IQ2_XXS-00003-of-00004.gguf",
+              "size_mb": 49248.51,
+              "sha256": "89180f13784dc1128586b98adf1ca876279881a20bc4f01747703ce352563372"
+            },
+            {
+              "file": "UD-IQ2_XXS/GLM-5.3-Flash-UD-IQ2_XXS-00004-of-00004.gguf",
+              "size_mb": 2690.72,
+              "sha256": "9e0ef47daa1fdffce3cf2ac1594ce4634d176ad018be6e692729757f38d5fbf6"
+            }
+          ]
+        },
+        {
+          "file": "UD-IQ4_XS/GLM-5.3-Flash-UD-IQ4_XS-00001-of-00005.gguf",
+          "quant": "UD-IQ4_XS",
+          "size_mb": 156822.11,
+          "min_ram_mb": 157911,
+          "min_vram_mb": 0,
+          "sha256": "eec97673e9acb38f8682250e778f88991e731771bab8d3c0b787985949aacefa",
+          "shards": [
+            {
+              "file": "UD-IQ4_XS/GLM-5.3-Flash-UD-IQ4_XS-00002-of-00005.gguf",
+              "size_mb": 49989.33,
+              "sha256": "7d64cf0395672c4322012841abec502ea7e20518299bb5e3069003f06f9e6de9"
+            },
+            {
+              "file": "UD-IQ4_XS/GLM-5.3-Flash-UD-IQ4_XS-00003-of-00005.gguf",
+              "size_mb": 49607.03,
+              "sha256": "7c2c63c9c30f8060428fdf2ac935dbf2ee9ad8f771d62b6ae47a7f7f2c1520e7"
+            },
+            {
+              "file": "UD-IQ4_XS/GLM-5.3-Flash-UD-IQ4_XS-00004-of-00005.gguf",
+              "size_mb": 49486.53,
+              "sha256": "06c90f191871317c92dd9d25a353b687aed44c50f3ac6c713e9fe410bc2d26dd"
+            },
+            {
+              "file": "UD-IQ4_XS/GLM-5.3-Flash-UD-IQ4_XS-00005-of-00005.gguf",
+              "size_mb": 7729.79,
+              "sha256": "66ebf9ec85e04d3f44af674ae4f694acbc89cc53db75e42f2f4d3646bf321c0d"
+            }
+          ]
+        },
+        {
+          "file": "UD-Q4_K_XL/GLM-5.3-Flash-UD-Q4_K_XL-00001-of-00006.gguf",
+          "quant": "UD-Q4_K_XL",
+          "size_mb": 199707.33,
+          "min_ram_mb": 200797,
+          "min_vram_mb": 0,
+          "sha256": "00dceaf3ed08781b1e44513a44ebb19e96248d01ba2a80b17f675a2b6fa9a1ee",
+          "shards": [
+            {
+              "file": "UD-Q4_K_XL/GLM-5.3-Flash-UD-Q4_K_XL-00002-of-00006.gguf",
+              "size_mb": 49198.04,
+              "sha256": "d3ecb6ff3957a99878f9a0352676a0913748a431a9a4a1b1ffa5ade9b8947a74"
+            },
+            {
+              "file": "UD-Q4_K_XL/GLM-5.3-Flash-UD-Q4_K_XL-00003-of-00006.gguf",
+              "size_mb": 49988.63,
+              "sha256": "328073c004e7c5395b208247feed26089db247b94dd8fa4ab0f2569d86c1d770"
+            },
+            {
+              "file": "UD-Q4_K_XL/GLM-5.3-Flash-UD-Q4_K_XL-00004-of-00006.gguf",
+              "size_mb": 48700.7,
+              "sha256": "6803ab7effa6da4a0b02c9c7865952fdd6c5b2e10e53903348da369e90bd13f9"
+            },
+            {
+              "file": "UD-Q4_K_XL/GLM-5.3-Flash-UD-Q4_K_XL-00005-of-00006.gguf",
+              "size_mb": 49026.03,
+              "sha256": "852f3df9dacde3d196796f9fe738468e80c8701555ff0a8c30bc010fb8974dd8"
+            },
+            {
+              "file": "UD-Q4_K_XL/GLM-5.3-Flash-UD-Q4_K_XL-00006-of-00006.gguf",
+              "size_mb": 2784.5,
+              "sha256": "c6ba510fafc1e12cc0addbc361a329c0c592ab96980098e7e25e107d8faa983e"
+            }
+          ]
         }
       ]
     },
     {
-      "id": "gemma-3-27b-it",
-      "family": "gemma3",
-      "lab": "Google",
-      "hf_repo": "google/gemma-3-27b-it-qat-q4_0-gguf",
-      "license": "gemma",
-      "gated": true,
+      "id": "deepseek-v4-flash",
+      "family": "deepseek4",
+      "lab": "DeepSeek",
+      "hf_repo": "unsloth/DeepSeek-V4-Flash-0731-GGUF",
+      "license": "mit",
+      "gated": false,
       "task": "chat",
-      "context_len": 8192,
+      "context_len": 131072,
       "min_runtime_version": "b10068",
-      "default_quant": "Q4_0",
-      "tags": ["chat", "large", "gated"],
-      "notes": "Official Google QAT (quantization-aware training) GGUF, gated on Hugging Face (gated: \"manual\" — requires an HF account that has clicked accept on the Gemma license before download works, even with a valid token). Exercises the catalog's three-state gated-download flow. This repo's blobs=true metadata endpoint happened to still expose a real sha256 for the quant file despite the gate (only the actual file download at /resolve/ enforces it) — verified independently against the HF tree API's file-size field, which matches exactly. Large class — needs a real GPU or a lot of RAM to be usable; min_vram_mb is an engineering estimate (see llama-3.1-8b-instruct entry for the methodology). The repo also ships a multimodal mmproj file that is NOT included here — this entry is text-chat only.",
+      "default_quant": "UD-IQ3_XXS",
+      "tags": ["large", "chat", "bench"],
+      "notes": "Benchmark-window heavy. DeepSeek-V4-Flash (0731) in unsloth dynamic quants of three to four parts (about 97 to 104 GB). Text-only. Requires a llama.cpp build with deepseek4 support — the operator runs it from his own builds today; the catalog's stock runtime release will not load it. Reservation-gated like the other heavies: register a CROW-SCHEDULE window before starting, and expect the whole box for the duration.",
       "quants": [
         {
-          "file": "gemma-3-27b-it-q4_0.gguf",
-          "quant": "Q4_0",
-          "size_mb": 17229.63,
-          "min_ram_mb": 28664,
-          "min_vram_mb": 18432,
-          "sha256": "7b131f721b95bd06ef4066e18ed2febed15ad6620f61c6eaf37832837ca109fe"
+          "file": "UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00001-of-00004.gguf",
+          "quant": "UD-IQ3_XXS",
+          "size_mb": 104207.85,
+          "min_ram_mb": 106344,
+          "min_vram_mb": 0,
+          "sha256": "dec1cee704800267d9d836d5a61aefc33705be939bbb3058fa9006d98191576d",
+          "shards": [
+            {
+              "file": "UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00002-of-00004.gguf",
+              "size_mb": 49910.53,
+              "sha256": "3064d3c4c1d6363e9f9ad88e90a3e2c5fb2d6f7ae16ca72135c3ce6a5c984da5"
+            },
+            {
+              "file": "UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00003-of-00004.gguf",
+              "size_mb": 49257.86,
+              "sha256": "2e9b2732eca7da8324f731653624a4f5c9846258926fd9f468cc703afb51a019"
+            },
+            {
+              "file": "UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00004-of-00004.gguf",
+              "size_mb": 5034.2,
+              "sha256": "4ca79d8e5107dd1b9bb57b176a7c09948837425dee49f0f1dfd6547a3769fea7"
+            }
+          ]
+        },
+        {
+          "file": "UD-Q2_K_XL/DeepSeek-V4-Flash-0731-UD-Q2_K_XL-00001-of-00003.gguf",
+          "quant": "UD-Q2_K_XL",
+          "size_mb": 96832.51,
+          "min_ram_mb": 98968,
+          "min_vram_mb": 0,
+          "sha256": "de65c5bb660817b95cc281bf54935f9d1bcc3b22535f2eae63b35a14c7c5724b",
+          "shards": [
+            {
+              "file": "UD-Q2_K_XL/DeepSeek-V4-Flash-0731-UD-Q2_K_XL-00002-of-00003.gguf",
+              "size_mb": 49437.01,
+              "sha256": "c8728a298862cd8736782e2e4056e5e3e03c415ba552a38173264494e41ef327"
+            },
+            {
+              "file": "UD-Q2_K_XL/DeepSeek-V4-Flash-0731-UD-Q2_K_XL-00003-of-00003.gguf",
+              "size_mb": 47390.24,
+              "sha256": "a4bae0788c025c1b2388754592c98fefa1372981748ac9875039bf6a30e6eeb4"
+            }
+          ]
         }
       ]
     }

--- a/scripts/validate-model-catalog.js
+++ b/scripts/validate-model-catalog.js
@@ -28,6 +28,23 @@
  *     strings, and null are rejected) — it is threaded verbatim into
  *     llama-server's --jinja request body and into the openai adapter's
  *     chat_template_kwargs pass-through (C1 Task 1).
+ *
+ * Schema v2 (model catalog curation, 2026-09):
+ *   - task is an enum: chat | embedding | rerank | vision. The native start
+ *     path maps embedding/rerank to llama-server's --embedding/--reranking.
+ *   - a quant may carry `shards`: parts 2..n of a multi-part GGUF
+ *     (`-00002-of-0000N` siblings; llama-server discovers them from the
+ *     primary part). Each shard has file, positive size_mb and sha256
+ *     (sha256 optional only when the model is gated). The quant's size_mb
+ *     is the TOTAL of every part, so it must be >= sum(shards) + 1 (the
+ *     primary part is never zero-sized) and min_ram_mb is checked against
+ *     that total.
+ *   - a model may carry `companions`: sidecar GGUFs downloaded beside the
+ *     quant — kind mmproj (vision projector, passed as --mmproj) or mtp
+ *     (multi-token-prediction head, kept beside the model; no flag). Same
+ *     file/size_mb/sha256 rules as shards.
+ *   - every file basename within a model (quant files, shards, companions)
+ *     must be unique: the downloader stores blobs in ONE flat directory.
  */
 
 import { readFileSync } from "node:fs";
@@ -45,6 +62,46 @@ const KNOWN_RUNTIME_ASSET_KEYS = new Set([
 ]);
 
 const SHA256_RE = /^[0-9a-f]{64}$/i;
+
+const TASKS = ["chat", "embedding", "rerank", "vision"];
+const COMPANION_KINDS = ["mmproj", "mtp"];
+
+/** Basename of a catalog file path (catalog paths use "/" — HF repo paths). */
+function fileBasename(file) {
+  const str = String(file ?? "");
+  const idx = str.lastIndexOf("/");
+  return idx >= 0 ? str.slice(idx + 1) : str;
+}
+
+/**
+ * Shared checks for a shard or companion entry: file present, positive
+ * size_mb, sha256 present (unless gated) and well-formed. Pushes errors
+ * prefixed with `label`; returns the entry's basename (or null when it has
+ * no usable file) so the caller can run the per-model uniqueness check.
+ */
+function checkSidecarFile(entry, label, gated, errors) {
+  if (!entry || typeof entry !== "object") {
+    errors.push(`${label}: entry must be an object`);
+    return null;
+  }
+  let base = null;
+  if (typeof entry.file !== "string" || fileBasename(entry.file).length === 0) {
+    errors.push(`${label}: file must be a non-empty string`);
+  } else {
+    base = fileBasename(entry.file);
+  }
+  if (typeof entry.size_mb !== "number" || !(entry.size_mb > 0)) {
+    errors.push(`${label}: size_mb must be a positive number`);
+  }
+  if (entry.sha256 == null) {
+    if (!gated) {
+      errors.push(`${label}: missing sha256 (only allowed when the model is gated:true)`);
+    }
+  } else if (!SHA256_RE.test(entry.sha256)) {
+    errors.push(`${label}: sha256 is not a valid 64-char hex string`);
+  }
+  return base;
+}
 
 /** Parse a llama.cpp release tag "b<number>" into its numeric build. Returns NaN on malformed input. */
 function parseBuildNumber(tag) {
@@ -120,6 +177,24 @@ export function validateCatalog(catalog) {
       firstRunDefaults.push(model);
     }
 
+    if (!TASKS.includes(model.task)) {
+      errors.push(`${label}: task must be one of ${TASKS.join(", ")}, got ${JSON.stringify(model.task)}`);
+    }
+
+    // Every file basename this model owns (quant files, shards, companions)
+    // — the downloader writes them all to one flat blob dir, so a
+    // collision would silently overwrite a sibling.
+    const seenBasenames = new Map(); // basename -> label of the first owner
+    const claimBasename = (base, owner) => {
+      if (base == null) return;
+      const prior = seenBasenames.get(base);
+      if (prior) {
+        errors.push(`${owner}: file basename "${base}" duplicates ${prior} in the same model`);
+      } else {
+        seenBasenames.set(base, owner);
+      }
+    };
+
     if (model.chat_template_kwargs !== undefined) {
       const isPlainObject = model.chat_template_kwargs !== null
         && typeof model.chat_template_kwargs === "object"
@@ -145,6 +220,30 @@ export function validateCatalog(catalog) {
       errors.push(`${label}: must have at least one quant`);
     }
 
+    // Claim every quant's primary basename first so a shard/companion that
+    // collides with ANY quant file is reported against the sidecar, not
+    // the quant.
+    quants.forEach((quant, qidx) => {
+      if (quant && typeof quant === "object" && typeof quant.file === "string" && fileBasename(quant.file)) {
+        claimBasename(fileBasename(quant.file), `${label} quant[${qidx}] file`);
+      }
+    });
+
+    if (model.companions !== undefined) {
+      if (!Array.isArray(model.companions)) {
+        errors.push(`${label}: companions must be an array when present`);
+      } else {
+        model.companions.forEach((companion, cidx) => {
+          const clabel = `${label} companion[${cidx}]`;
+          const base = checkSidecarFile(companion, clabel, model.gated === true, errors);
+          if (companion && typeof companion === "object" && !COMPANION_KINDS.includes(companion.kind)) {
+            errors.push(`${clabel}: kind must be one of ${COMPANION_KINDS.join(", ")}, got ${JSON.stringify(companion.kind)}`);
+          }
+          claimBasename(base, clabel);
+        });
+      }
+    }
+
     quants.forEach((quant, qidx) => {
       const qlabel = `${label} quant[${qidx}]${quant && quant.quant ? ` (${quant.quant})` : ""}`;
 
@@ -167,6 +266,25 @@ export function validateCatalog(catalog) {
 
       if (typeof quant.size_mb !== "number" || !(quant.size_mb > 0)) {
         errors.push(`${qlabel}: size_mb must be a positive number`);
+      }
+
+      if (quant.shards !== undefined) {
+        if (!Array.isArray(quant.shards)) {
+          errors.push(`${qlabel}: shards must be an array when present`);
+        } else {
+          let shardTotal = 0;
+          quant.shards.forEach((shard, sidx) => {
+            const slabel = `${qlabel} shard[${sidx}]`;
+            const base = checkSidecarFile(shard, slabel, gated, errors);
+            if (shard && typeof shard.size_mb === "number" && shard.size_mb > 0) shardTotal += shard.size_mb;
+            claimBasename(base, slabel);
+          });
+          if (quant.shards.length > 0 && typeof quant.size_mb === "number" && quant.size_mb < shardTotal + 1) {
+            errors.push(
+              `${qlabel}: size_mb (${quant.size_mb}) must be at least the shards' total (${shardTotal}) + 1 — size_mb is the TOTAL of all parts and the primary part is never zero-sized`
+            );
+          }
+        }
       }
       if (typeof quant.min_ram_mb !== "number") {
         errors.push(`${qlabel}: min_ram_mb must be a number`);

--- a/servers/gateway/gpu-orchestrator.js
+++ b/servers/gateway/gpu-orchestrator.js
@@ -762,12 +762,32 @@ async function startNativeAndAwaitReady(providerName, p, opts = {}) {
   // only honored under llama-server's jinja engine; scoped per-model — the
   // other catalog models are not template-verified under --jinja.
   let extraArgs = [];
+  let catalogEntry = null;
   try {
-    const entry = (loadCatalogFn()?.models || []).find((m) => m.id === providerName);
-    if (entry && entry.chat_template_kwargs && typeof entry.chat_template_kwargs === "object") {
-      extraArgs = ["--jinja"];
+    catalogEntry = (loadCatalogFn()?.models || []).find((m) => m.id === providerName) || null;
+  } catch { /* catalog unreadable → no catalog-driven args, model starts as before */ }
+  if (catalogEntry && catalogEntry.chat_template_kwargs && typeof catalogEntry.chat_template_kwargs === "object") {
+    extraArgs = ["--jinja"];
+  }
+
+  // Schema v2 companion + task flags (model catalog curation, 2026-09):
+  //   - an `mmproj` companion on the registry row (written by manager.js's
+  //     registerModel, stored under the same flat blob dir as the model)
+  //     is the vision projector -> `--mmproj <path>`;
+  //   - an `mtp` companion adds NO flag: llama.cpp's multi-token-prediction
+  //     loading is build-specific, so the file is kept beside the model for
+  //     the operator's own launchers rather than guessed at here;
+  //   - shards need no flag either: llama-server discovers the
+  //     `-0000N-of-0000M` siblings from the primary part it is given;
+  //   - catalog task embedding -> `--embedding`, rerank -> `--reranking`
+  //     (chat and vision get no task flag).
+  for (const c of Array.isArray(regEntry.companions) ? regEntry.companions : []) {
+    if (c && c.kind === "mmproj" && typeof c.file === "string" && c.file) {
+      extraArgs.push("--mmproj", join(dir, "models", "blobs", c.file));
     }
-  } catch { /* catalog unreadable → no extra args, model starts as before */ }
+  }
+  if (catalogEntry?.task === "embedding") extraArgs.push("--embedding");
+  else if (catalogEntry?.task === "rerank") extraArgs.push("--reranking");
 
   console.log(`[gpu-orchestrator] starting native ${providerName} (alias=${alias}, port=${port}, readinessTimeoutMs=${readinessTimeoutMs}) requested-by=${opts.requester || "-"}`);
   const handle = startModelFn({ binPath, ggufPath, alias, port, spawn: spawnFn, onTerminal: wrappedOnTerminal, extraArgs });

--- a/servers/gateway/models/manager.js
+++ b/servers/gateway/models/manager.js
@@ -34,13 +34,17 @@
  *     to re-feed the bytes already on disk into a fresh hash before
  *     appending the rest). Knows nothing about `state.js` or catalogs.
  *
- *   - `downloadModel()` — the orchestrator. Resolves a catalog entry to a
- *     URL + a sanitized on-disk destination, consults the journal (from
- *     `state.js`) to decide whether this is a fresh download or a resume,
- *     and journals progress (throttled) back through `loadState`/
+ *   - `downloadModel()` — the orchestrator. Resolves a catalog entry to the
+ *     ordered list of files it needs (`planFiles`: the quant's primary
+ *     part, then its `shards`, then the model's `companions` — schema v2,
+ *     multi-part GGUFs + mmproj/mtp sidecars), each with its own URL,
+ *     sanitized on-disk destination and sha256; consults the journal (from
+ *     `state.js`) to decide, PER FILE, whether it is finished, resumable or
+ *     fresh; and journals progress (throttled) back through `loadState`/
  *     `saveState` so a killed process can pick up where it left off. This
  *     is the layer real callers (the model panel, Task 7's provider
- *     registration) use.
+ *     registration) use. A legacy single-file entry plans exactly one
+ *     file and behaves exactly as before.
  *
  * `enqueueDownload()` is a module-level serial queue over `downloadModel`:
  * concurrency defaults to 1 and is honored up to a max of 2 via
@@ -95,12 +99,16 @@ export class HostNotAllowedError extends Error {
  * this is thrown — a mismatched blob is never left on disk to be
  * mistaken for a good one. */
 export class ChecksumError extends Error {
-  constructor(expectedSha, actualSha) {
-    super(`Checksum mismatch: expected ${expectedSha}, got ${actualSha}`);
+  constructor(expectedSha, actualSha, file) {
+    super(`Checksum mismatch: expected ${expectedSha}, got ${actualSha}${file ? ` for ${basename(String(file))}` : ""}`);
     this.name = "ChecksumError";
     this.code = "CHECKSUM_MISMATCH";
     this.expectedSha = expectedSha;
     this.actualSha = actualSha;
+    /** Destination path of the file that failed verification (multi-part
+     * downloads: names WHICH part, since the verified earlier parts are
+     * kept on disk). */
+    this.file = file || null;
   }
 }
 
@@ -594,7 +602,7 @@ export async function fetchModelBlob({
   const sha256 = hash.digest("hex");
   if (expectedSha && sha256.toLowerCase() !== String(expectedSha).toLowerCase()) {
     try { unlinkSync(dest); } catch { /* best effort */ }
-    throw new ChecksumError(expectedSha, sha256);
+    throw new ChecksumError(expectedSha, sha256, dest);
   }
   return { path: dest, sha256, bytesDone };
 }
@@ -607,10 +615,107 @@ function modelsBlobDir(dir) {
   return join(dir, "models", "blobs");
 }
 
+/** On-disk basename for a companion file. Namespaced by the model id
+ * because every vision repo ships its projector under the SAME name
+ * (`mmproj-F16.gguf`) and the blob dir is flat — two vision models
+ * installed side by side must never overwrite each other's projector. */
+export function companionFilename(modelId, file) {
+  return sanitizeFilename(`${modelId}--${sanitizeFilename(file)}`);
+}
+
 /**
- * Download a model's quant file, journaling progress to `state.js` so a
- * killed/restarted process can resume. See module doc for the full
- * contract; `dir` is the injected CROW_HOME/data dir (never guessed).
+ * The ordered list of files a catalog quant needs on disk (schema v2):
+ * the quant's primary part, then each `shards[i]` (parts 2..n of a
+ * multi-part GGUF, in catalog order), then each of the model's
+ * `companions` (mmproj / mtp sidecars). Pure: no I/O.
+ *
+ * Each entry: `{ url, dest, expectedSha, sizeMb, role, kind? }` —
+ * `role` is "primary" | "shard" | "companion", `kind` is the companion
+ * kind ("mmproj" | "mtp") and absent otherwise. `dest` is the sanitized
+ * basename, joined under `blobDir` when one is given. `sizeMb` for the
+ * primary is the quant's TOTAL `size_mb` minus its shards (the catalog
+ * records the total on the quant), so the entries' sizes sum to the whole
+ * download — used to seed cumulative progress before every part has been
+ * HEAD-ed. `baseUrl` is the test-only override `downloadModel` accepts.
+ */
+export function planFiles(model, quantEntry, { baseUrl, blobDir } = {}) {
+  const url = (file) => (baseUrl ? buildDownloadUrl(model.hf_repo, file, baseUrl) : buildDownloadUrl(model.hf_repo, file));
+  const place = (name) => (blobDir ? join(blobDir, name) : name);
+  const num = (n) => (typeof n === "number" && Number.isFinite(n) ? n : null);
+
+  const shards = Array.isArray(quantEntry.shards) ? quantEntry.shards : [];
+  const companions = Array.isArray(model.companions) ? model.companions : [];
+
+  const shardTotal = shards.reduce((acc, sh) => acc + (num(sh.size_mb) || 0), 0);
+  const total = num(quantEntry.size_mb);
+  const primarySize = total == null ? null : Math.max(0, total - shardTotal);
+
+  const plan = [{
+    url: url(quantEntry.file),
+    dest: place(sanitizeFilename(quantEntry.file)),
+    expectedSha: quantEntry.sha256 || null,
+    sizeMb: primarySize,
+    role: "primary",
+  }];
+  for (const sh of shards) {
+    plan.push({
+      url: url(sh.file),
+      dest: place(sanitizeFilename(sh.file)),
+      expectedSha: sh.sha256 || null,
+      sizeMb: num(sh.size_mb),
+      role: "shard",
+    });
+  }
+  for (const c of companions) {
+    plan.push({
+      url: url(c.file),
+      dest: place(companionFilename(model.id, c.file)),
+      expectedSha: c.sha256 || null,
+      sizeMb: num(c.size_mb),
+      role: "companion",
+      kind: c.kind,
+    });
+  }
+  return plan;
+}
+
+/** Normalize a journal entry to its per-file list. Entries written before
+ * the multi-file journal (`{url,dest,bytesDone,expectedSha,startedAt}`,
+ * no `files`) are read as a one-file list — never a crash. */
+function journalFiles(entry) {
+  if (!entry || typeof entry !== "object") return [];
+  if (Array.isArray(entry.files)) return entry.files.filter((f) => f && typeof f === "object");
+  if (entry.url && entry.dest) {
+    return [{ url: entry.url, dest: entry.dest, bytesDone: entry.bytesDone || 0, expectedSha: entry.expectedSha ?? null, done: false }];
+  }
+  return [];
+}
+
+/**
+ * Download every file a model's quant needs (see `planFiles`), journaling
+ * progress to `state.js` so a killed/restarted process can resume. See
+ * module doc for the full contract; `dir` is the injected CROW_HOME/data
+ * dir (never guessed).
+ *
+ * Journal entry shape (`state.journal[modelId]`):
+ *   `{ url, dest, bytesDone, expectedSha, startedAt,
+ *      files: [ { url, dest, bytesDone, expectedSha, done }, ... ] }`
+ * `files` is one record per planned file, in download order; a file with
+ * `done:true` was fully downloaded AND sha-verified and is skipped on
+ * resume. The top-level `url`/`dest`/`bytesDone`/`expectedSha` mirror the
+ * file currently in flight so every pre-existing single-file reader
+ * (`state.js`'s `resumableDownloads`, the panel's progress view) keeps
+ * working unchanged. An old-shape entry with no `files` is read as a
+ * one-file list (`journalFiles`).
+ *
+ * `onProgress({ bytesDone, totalBytes, file, fileIndex, fileCount })` —
+ * `bytesDone`/`totalBytes` are CUMULATIVE across all files (finished files
+ * count in full; not-yet-started files contribute their catalog size);
+ * `file` is the in-flight file's basename.
+ *
+ * Returns `{ path, sha256, files: [ { path, sha256 }, ... ] }` — `path`/
+ * `sha256` are the primary part's (the pre-v2 return shape), `files` lists
+ * every part in plan order.
  *
  * `baseUrl`, `lookup`, and `insecureHttpHosts` exist purely for tests —
  * production never sets them (real huggingface.co, real DNS, https
@@ -636,21 +741,38 @@ export async function downloadModel({
   const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
   const blobDir = modelsBlobDir(dir);
   mkdirSync(blobDir, { recursive: true });
-  const dest = join(blobDir, sanitizeFilename(quantEntry.file));
-  assertNotSymlink(dest);
-
-  const url = baseUrl ? buildDownloadUrl(model.hf_repo, quantEntry.file, baseUrl) : buildDownloadUrl(model.hf_repo, quantEntry.file);
-  const expectedSha = quantEntry.sha256 || null;
+  const plan = planFiles(model, quantEntry, { baseUrl, blobDir });
+  for (const f of plan) assertNotSymlink(f.dest);
 
   const initialState = loadState(dir);
-  const existingEntry = initialState.journal[modelId];
-  const resumeFrom = existingEntry && existingEntry.url === url && existingEntry.dest === dest ? existingEntry.bytesDone || 0 : 0;
-  const startedAt = (existingEntry && existingEntry.url === url && existingEntry.dest === dest && existingEntry.startedAt) || new Date().toISOString();
+  const prior = journalFiles(initialState.journal[modelId]);
+  let matchedPrior = false;
+  const files = plan.map((f) => {
+    const p = prior.find((e) => e.url === f.url && e.dest === f.dest);
+    if (p) matchedPrior = true;
+    return {
+      url: f.url,
+      dest: f.dest,
+      expectedSha: f.expectedSha,
+      sizeMb: f.sizeMb,
+      bytesDone: p ? (p.bytesDone || 0) : 0,
+      done: !!(p && p.done === true),
+      sha256: p && p.done === true ? (p.expectedSha ?? null) : null,
+    };
+  });
+  const startedAt = (matchedPrior && initialState.journal[modelId]?.startedAt) || new Date().toISOString();
 
-  // Seed/refresh the journal entry immediately, before any network I/O, so
-  // even an interruption in the first instant leaves a resumable record.
-  initialState.journal[modelId] = { url, dest, bytesDone: resumeFrom, expectedSha, startedAt };
-  saveState(dir, initialState);
+  const journalEntry = (idx) => {
+    const cur = files[idx] || files[files.length - 1];
+    return {
+      url: cur.url,
+      dest: cur.dest,
+      bytesDone: cur.bytesDone,
+      expectedSha: cur.expectedSha,
+      startedAt,
+      files: files.map(({ url, dest, bytesDone, expectedSha, done }) => ({ url, dest, bytesDone, expectedSha, done })),
+    };
+  };
 
   // Persisting reloads state fresh each time (rather than reusing one
   // in-memory object across the whole download) to minimize — though not
@@ -658,58 +780,105 @@ export async function downloadModel({
   // when CROW_MODEL_DL_CONCURRENCY=2. state.json has no real locking; this
   // is a known, accepted v1 limitation (matches state.js's own
   // documented tradeoffs), not something this task solves.
-  const persistJournal = (bytesDone) => {
+  const persistJournal = (idx) => {
     const s = loadState(dir);
-    s.journal[modelId] = { url, dest, bytesDone, expectedSha, startedAt };
+    s.journal[modelId] = journalEntry(idx);
     saveState(dir, s);
   };
-
-  let lastSave = Date.now();
-  const wrappedOnProgress = ({ bytesDone, totalBytes }) => {
-    if (typeof onProgress === "function") onProgress({ bytesDone, totalBytes });
-    const now = Date.now();
-    if (now - lastSave >= journalIntervalMs) {
-      lastSave = now;
-      persistJournal(bytesDone);
-    }
-  };
-
-  try {
-    const result = await fetchModelBlob({
-      url,
-      dest,
-      resumeFrom,
-      expectedSha,
-      lookup,
-      maxRedirects,
-      createWriteStream,
-      insecureHttpHosts,
-      timeoutMs,
-      extraHeaders,
-      onProgress: wrappedOnProgress,
-    });
+  const clearJournal = () => {
     const s = loadState(dir);
     delete s.journal[modelId];
     saveState(dir, s);
-    return { path: result.path, sha256: result.sha256 };
-  } catch (err) {
-    if (err instanceof ChecksumError) {
-      // fetchModelBlob already deleted the bad file — the journal entry
-      // for it is equally stale, drop it rather than offering a "resume"
-      // that would just re-download from scratch anyway.
-      const s = loadState(dir);
-      delete s.journal[modelId];
-      saveState(dir, s);
+  };
+
+  // Seed/refresh the journal entry immediately, before any network I/O, so
+  // even an interruption in the first instant leaves a resumable record.
+  persistJournal(files.findIndex((f) => !f.done));
+
+  const estimateBytes = (f) => (f.sizeMb == null ? 0 : Math.round(f.sizeMb * 1_000_000));
+
+  for (let idx = 0; idx < files.length; idx++) {
+    const f = files[idx];
+    if (f.done) continue;
+
+    let liveTotal = null;
+    let lastSave = Date.now();
+    const cumulative = () => {
+      let bytesDone = 0;
+      let totalBytes = 0;
+      files.forEach((g, i) => {
+        if (i === idx) {
+          bytesDone += g.bytesDone;
+          totalBytes += liveTotal != null ? liveTotal : estimateBytes(g);
+        } else if (g.done) {
+          bytesDone += g.bytesDone;
+          totalBytes += g.bytesDone;
+        } else {
+          totalBytes += estimateBytes(g);
+        }
+      });
+      return { bytesDone, totalBytes };
+    };
+    const wrappedOnProgress = ({ bytesDone, totalBytes }) => {
+      f.bytesDone = bytesDone;
+      if (totalBytes != null) liveTotal = totalBytes;
+      if (typeof onProgress === "function") {
+        onProgress({ ...cumulative(), file: basename(f.dest), fileIndex: idx, fileCount: files.length });
+      }
+      const now = Date.now();
+      if (now - lastSave >= journalIntervalMs) {
+        lastSave = now;
+        persistJournal(idx);
+      }
+    };
+
+    try {
+      const result = await fetchModelBlob({
+        url: f.url,
+        dest: f.dest,
+        resumeFrom: f.bytesDone,
+        expectedSha: f.expectedSha,
+        lookup,
+        maxRedirects,
+        createWriteStream,
+        insecureHttpHosts,
+        timeoutMs,
+        extraHeaders,
+        onProgress: wrappedOnProgress,
+      });
+      f.bytesDone = result.bytesDone;
+      f.done = true;
+      f.sha256 = result.sha256;
+      if (idx < files.length - 1) persistJournal(idx + 1);
+    } catch (err) {
+      if (err instanceof ChecksumError) {
+        // fetchModelBlob already deleted the bad file — its record is
+        // equally stale. Earlier parts that verified are KEPT on disk and
+        // stay `done` in the journal so a retry only re-fetches this one;
+        // when nothing was verified yet, drop the entry rather than
+        // offering a "resume" that would re-download from scratch anyway.
+        f.bytesDone = 0;
+        f.done = false;
+        if (files.some((g) => g.done)) persistJournal(idx);
+        else clearJournal();
+        throw err;
+      }
+      // Any other failure (host refused, interrupted connection, disk full,
+      // ...): flush the latest known bytesDone unconditionally, bypassing
+      // the throttle, so a subsequent call always resumes from an accurate
+      // point rather than losing up to journalIntervalMs of progress.
+      if (typeof err.bytesDone === "number") f.bytesDone = err.bytesDone;
+      persistJournal(idx);
       throw err;
     }
-    // Any other failure (host refused, interrupted connection, disk full,
-    // ...): flush the latest known bytesDone unconditionally, bypassing
-    // the throttle, so a subsequent call always resumes from an accurate
-    // point rather than losing up to journalIntervalMs of progress.
-    const bytesDone = typeof err.bytesDone === "number" ? err.bytesDone : resumeFrom;
-    persistJournal(bytesDone);
-    throw err;
   }
+
+  clearJournal();
+  return {
+    path: files[0].dest,
+    sha256: files[0].sha256,
+    files: files.map((f) => ({ path: f.dest, sha256: f.sha256 })),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -926,21 +1095,27 @@ export async function downloadHfFile({
 }
 
 /**
- * Remove a downloaded model's blob (and its journal entry, if any) from
- * `dir`. Task 7 extends this to also unregister the corresponding
- * provider row; this task's version only ever touches the filesystem +
- * `state.js`.
+ * Remove a downloaded model's blob — every part and companion file
+ * `planFiles` names — (and its journal entry, if any) from `dir`. Task 7
+ * extends this to also unregister the corresponding provider row; this
+ * task's version only ever touches the filesystem + `state.js`.
+ * `deleted` is true when at least one file was actually removed; `path`
+ * is the primary part's.
  */
 export function deleteModel({ modelId, quant, dir, catalog }) {
-  const { quantEntry } = resolveEntry(catalog, modelId, quant);
-  const dest = join(modelsBlobDir(dir), sanitizeFilename(quantEntry.file));
+  const { model, quantEntry } = resolveEntry(catalog, modelId, quant);
+  const plan = planFiles(model, quantEntry, { blobDir: modelsBlobDir(dir) });
+  const dest = plan[0].dest;
 
+  // Every part and companion, not just the primary (schema v2).
   let deleted = false;
-  try {
-    unlinkSync(dest);
-    deleted = true;
-  } catch (err) {
-    if (err && err.code !== "ENOENT") throw err;
+  for (const f of plan) {
+    try {
+      unlinkSync(f.dest);
+      deleted = true;
+    } catch (err) {
+      if (err && err.code !== "ENOENT") throw err;
+    }
   }
 
   const state = loadState(dir);
@@ -1205,12 +1380,20 @@ export async function registerModel({
   }
 
   const port = await allocatePortFn(state, modelId, { crowHome: dir, pid: process.pid });
+  // Schema v2: the row records every on-disk file the install owns —
+  // `shardFiles` (parts 2..n of a multi-part GGUF; llama-server finds them
+  // beside the primary) and `companions` (mmproj → `--mmproj` on native
+  // start; mtp kept beside the model) — so `unregisterModel` can remove
+  // them all. Both are empty arrays for a plain single-file quant.
+  const plannedFiles = planFiles(model, quantEntry);
   state.registry[modelId] = {
     file: sanitizeFilename(quantEntry.file),
     quant: quantEntry.quant,
     catalogId: model.id,
     registeredAt: new Date().toISOString(),
     sizeMb: Number.isFinite(quantEntry.size_mb) ? quantEntry.size_mb : null,
+    shardFiles: plannedFiles.filter((f) => f.role === "shard").map((f) => f.dest),
+    companions: plannedFiles.filter((f) => f.role === "companion").map((f) => ({ kind: f.kind, file: f.dest })),
     ...registryExtra,
   };
   saveState(dir, state);
@@ -1270,7 +1453,8 @@ export async function registerModel({
  * Tear down a registered native model: stop its process (if a live runtime
  * handle is given — no process supervisor exists yet as of Task 7, this is
  * a forward-looking seam for the task that adds one), free its port
- * reservation, delete its blob, soft-delete its provider row, and
+ * reservation, delete its blob (every part and companion the registry row
+ * names), soft-delete its provider row, and
  * invalidate the providers cache. Order is binding (asserted via injected
  * spies in tests) — each step only starts once the previous one has
  * settled.
@@ -1302,9 +1486,18 @@ export async function unregisterModel({
   delete state.registry[modelId];
   saveState(dir, state);
 
+  // Primary part, then shards, then companions (schema v2) — a legacy row
+  // with neither field unlinks exactly its one file, as before.
+  const ownedFiles = regEntry?.file
+    ? [
+      regEntry.file,
+      ...(Array.isArray(regEntry.shardFiles) ? regEntry.shardFiles : []),
+      ...(Array.isArray(regEntry.companions) ? regEntry.companions.map((c) => c && c.file) : []),
+    ].filter((name) => typeof name === "string" && name.length > 0)
+    : [];
   let deleted = false;
-  if (regEntry?.file) {
-    const dest = join(modelsBlobDir(dir), regEntry.file);
+  for (const name of ownedFiles) {
+    const dest = join(modelsBlobDir(dir), name);
     try {
       unlinkFn(dest);
       deleted = true;

--- a/tests/chat-template-kwargs.test.js
+++ b/tests/chat-template-kwargs.test.js
@@ -21,7 +21,7 @@ import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDbClient } from "../servers/db.js";
@@ -173,24 +173,31 @@ test("resolveProviderConfig returns undefined chatTemplateKwargs for a row witho
   assert.equal(cfg.chatTemplateKwargs, undefined);
 });
 
+/** The live catalog's entry that carries chat_template_kwargs (the
+ * first_run_default small model) — read dynamically so the test follows
+ * the curated catalog instead of pinning an id. */
+const LIVE_CATALOG = JSON.parse(readFileSync(join(import.meta.dirname, "..", "registry", "model-catalog.json"), "utf8"));
+const KWARGS_MODEL = LIVE_CATALOG.models.find((m) => m.chat_template_kwargs && typeof m.chat_template_kwargs === "object");
+
 test("resolveProviderConfig heals a pre-Task-1 native row (no chatTemplateKwargs) from the catalog", async () => {
   // Pre-Task-1 registration shape: models[] entry has no chatTemplateKwargs
   // field at all, but gpu_policy.runtime is "native" and the provider id IS
-  // the catalog model id (qwen3-4b) — exactly crow prod's shape before this
-  // change shipped.
+  // the catalog model id — exactly crow prod's shape before this change
+  // shipped.
+  assert.ok(KWARGS_MODEL, "the live catalog carries a model with chat_template_kwargs");
   await upsertProvider(db, {
-    id: "qwen3-4b",
+    id: KWARGS_MODEL.id,
     baseUrl: "http://127.0.0.1:9412/v1",
     host: "local",
     bundleId: null,
     description: "test",
-    models: [{ id: "qwen3-4b" }],
+    models: [{ id: KWARGS_MODEL.id }],
     disabled: false,
     providerType: null,
     gpuPolicy: { runtime: "native", mutexGroup: "local-llm" },
   });
-  const cfg = await resolveProviderConfig(db, "qwen3-4b", "qwen3-4b");
-  assert.deepEqual(cfg.chatTemplateKwargs, { enable_thinking: false });
+  const cfg = await resolveProviderConfig(db, KWARGS_MODEL.id, KWARGS_MODEL.id);
+  assert.deepEqual(cfg.chatTemplateKwargs, KWARGS_MODEL.chat_template_kwargs);
 });
 
 test("healing fallback does NOT apply to non-native gpu_policy rows (docker runtime at a catalog-colliding id)", async () => {

--- a/tests/gpu-orchestrator-native.test.js
+++ b/tests/gpu-orchestrator-native.test.js
@@ -997,3 +997,105 @@ test("attribution: ensureResident's native start is attributed to residency", as
   assert.ok(line, `expected a 'starting native' line, got:\n${logs.join("\n")}`);
   assert.ok(line.endsWith(" requested-by=residency"), line);
 });
+
+// --- Schema v2: companion + task flags on native start ---------------------
+//
+// `regEntry.companions` (written by manager.js's registerModel) and the
+// catalog entry's `task` drive extra llama-server args: an mmproj
+// companion -> `--mmproj <blob path>`, task embedding -> `--embedding`,
+// task rerank -> `--reranking`. Shards need no flag (llama-server finds
+// the -0000N-of-0000M siblings from the primary part) and mtp companions
+// add none either.
+
+function v2StartOpts({ registryEntry, catalogEntry, startCalls }) {
+  const cfg = { providers: { "native-target": nativeProv(18160, "native-target") } };
+  let probeCalls = 0;
+  const identityProbeFn = async () => {
+    probeCalls += 1;
+    return probeCalls === 1 ? "down" : "resident";
+  };
+  return {
+    ...startCapableOpts({ cfg, identityProbeFn, startCalls }),
+    loadStateFn: () => ({ registry: { "native-target": registryEntry } }),
+    loadCatalogFn: () => ({ runtime: { release: "b1", assets: {} }, models: catalogEntry ? [catalogEntry] : [] }),
+  };
+}
+
+test("v2 native start: an mmproj companion on the registry row adds --mmproj with the companion's blob path", async () => {
+  const startCalls = [];
+  const ok = await acquireProvider("native-target", v2StartOpts({
+    registryEntry: { file: "model.gguf", shardFiles: [], companions: [{ kind: "mmproj", file: "native-target--mmproj-F16.gguf" }] },
+    catalogEntry: { id: "native-target", task: "chat" },
+    startCalls,
+  }));
+  assert.equal(ok, true);
+  assert.equal(startCalls.length, 1);
+  assert.equal(startCalls[0].ggufPath, join("/fake/crow-home", "models", "blobs", "model.gguf"));
+  assert.deepEqual(startCalls[0].extraArgs, ["--mmproj", join("/fake/crow-home", "models", "blobs", "native-target--mmproj-F16.gguf")]);
+});
+
+test("v2 native start: an mtp companion adds NO flag; shards add no flag", async () => {
+  const startCalls = [];
+  const ok = await acquireProvider("native-target", v2StartOpts({
+    registryEntry: {
+      file: "big-00001-of-00003.gguf",
+      shardFiles: ["big-00002-of-00003.gguf", "big-00003-of-00003.gguf"],
+      companions: [{ kind: "mtp", file: "native-target--mtp-big-Q8_0.gguf" }],
+    },
+    catalogEntry: { id: "native-target", task: "chat" },
+    startCalls,
+  }));
+  assert.equal(ok, true);
+  assert.equal(startCalls[0].ggufPath, join("/fake/crow-home", "models", "blobs", "big-00001-of-00003.gguf"));
+  assert.deepEqual(startCalls[0].extraArgs, []);
+});
+
+test("v2 native start: task embedding adds --embedding; task rerank adds --reranking", async () => {
+  for (const [task, flag] of [["embedding", "--embedding"], ["rerank", "--reranking"]]) {
+    _setNativeHandleForTest("native-target", null);
+    _resetProviderHealth();
+    const startCalls = [];
+    const ok = await acquireProvider("native-target", v2StartOpts({
+      registryEntry: { file: "model.gguf", shardFiles: [], companions: [] },
+      catalogEntry: { id: "native-target", task },
+      startCalls,
+    }));
+    assert.equal(ok, true, task);
+    assert.deepEqual(startCalls[0].extraArgs, [flag], task);
+  }
+});
+
+test("v2 native start: --jinja (chat_template_kwargs) and --mmproj compose, jinja first", async () => {
+  const startCalls = [];
+  await acquireProvider("native-target", v2StartOpts({
+    registryEntry: { file: "model.gguf", companions: [{ kind: "mmproj", file: "native-target--mmproj-F16.gguf" }] },
+    catalogEntry: { id: "native-target", task: "vision", chat_template_kwargs: { enable_thinking: false } },
+    startCalls,
+  }));
+  assert.deepEqual(startCalls[0].extraArgs, ["--jinja", "--mmproj", join("/fake/crow-home", "models", "blobs", "native-target--mmproj-F16.gguf")]);
+});
+
+test("v2 native start: a chat model with no companions and no kwargs gets exactly today's args (empty extraArgs); a legacy row with no companions field is fine", async () => {
+  const startCalls = [];
+  const ok = await acquireProvider("native-target", v2StartOpts({
+    registryEntry: { file: "model.gguf" },
+    catalogEntry: { id: "native-target", task: "chat" },
+    startCalls,
+  }));
+  assert.equal(ok, true);
+  assert.deepEqual(startCalls[0].extraArgs, []);
+  assert.equal(startCalls[0].ggufPath, join("/fake/crow-home", "models", "blobs", "model.gguf"));
+  assert.equal(startCalls[0].alias, "native-target");
+  assert.equal(startCalls[0].port, 18160);
+});
+
+test("v2 native start: a model absent from the catalog (Browse-HF install) still starts, with only its companion flags", async () => {
+  const startCalls = [];
+  const ok = await acquireProvider("native-target", v2StartOpts({
+    registryEntry: { file: "model.gguf", companions: [{ kind: "mmproj", file: "native-target--mmproj-F16.gguf" }] },
+    catalogEntry: null,
+    startCalls,
+  }));
+  assert.equal(ok, true);
+  assert.deepEqual(startCalls[0].extraArgs, ["--mmproj", join("/fake/crow-home", "models", "blobs", "native-target--mmproj-F16.gguf")]);
+});

--- a/tests/model-catalog-validate.test.js
+++ b/tests/model-catalog-validate.test.js
@@ -186,3 +186,253 @@ test("chat_template_kwargs as null fails", () => {
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));
 });
+
+// --- Schema v2: task enum, multi-part shards, companion files ---------------
+//
+// These cases build their own minimal catalog (not the shipped seed) so they
+// stay valid no matter which models the curated catalog carries.
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const SHA_C = "c".repeat(64);
+const SHA_D = "d".repeat(64);
+
+function makeV2Catalog() {
+  return {
+    version: 1,
+    runtime: {
+      name: "llama.cpp",
+      release: "b10068",
+      assets: {
+        "linux-x64-cpu": { file: "llama-b10068-bin-ubuntu-x64.tar.gz", sha256: SHA_A, min_glibc: "2.34" },
+      },
+    },
+    models: [
+      {
+        id: "fixture-small",
+        family: "fixture",
+        lab: "Fixture Lab",
+        hf_repo: "fixture/small-GGUF",
+        license: "apache-2.0",
+        gated: false,
+        task: "chat",
+        context_len: 8192,
+        min_runtime_version: "b10068",
+        default_quant: "Q4_K_M",
+        first_run_default: true,
+        tags: ["chat", "small", "cpu-capable"],
+        notes: "fixture",
+        quants: [
+          { file: "small-Q4_K_M.gguf", quant: "Q4_K_M", size_mb: 100, min_ram_mb: 400, min_vram_mb: 0, sha256: SHA_A },
+        ],
+      },
+      {
+        id: "fixture-sharded",
+        family: "fixture",
+        lab: "Fixture Lab",
+        hf_repo: "fixture/sharded-GGUF",
+        license: "apache-2.0",
+        gated: false,
+        task: "chat",
+        context_len: 8192,
+        min_runtime_version: "b10068",
+        default_quant: "Q4_K_M",
+        tags: ["chat", "large"],
+        notes: "fixture",
+        quants: [
+          {
+            file: "Q4_K_M/sharded-Q4_K_M-00001-of-00003.gguf",
+            quant: "Q4_K_M",
+            size_mb: 300,
+            min_ram_mb: 400,
+            min_vram_mb: 0,
+            sha256: SHA_A,
+            shards: [
+              { file: "Q4_K_M/sharded-Q4_K_M-00002-of-00003.gguf", size_mb: 100, sha256: SHA_B },
+              { file: "Q4_K_M/sharded-Q4_K_M-00003-of-00003.gguf", size_mb: 100, sha256: SHA_C },
+            ],
+          },
+        ],
+        companions: [
+          { kind: "mmproj", file: "mmproj-F16.gguf", size_mb: 10, sha256: SHA_D },
+        ],
+      },
+    ],
+  };
+}
+
+function v2Model(catalog, id) {
+  return catalog.models.find((m) => m.id === id);
+}
+
+test("v2 fixture (shards + mmproj companion + chat task) validates cleanly", () => {
+  const result = validateCatalog(makeV2Catalog());
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+});
+
+test("task: embedding, rerank and vision are accepted", () => {
+  for (const task of ["embedding", "rerank", "vision"]) {
+    const catalog = makeV2Catalog();
+    v2Model(catalog, "fixture-sharded").task = task;
+    const result = validateCatalog(catalog);
+    assert.deepEqual(result.errors, [], `task ${task} should validate`);
+  }
+});
+
+test("task outside the enum fails with an error naming task", () => {
+  const catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").task = "banana";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /fixture-sharded/.test(e) && /\btask\b/.test(e) && /banana/.test(e)), JSON.stringify(result.errors));
+});
+
+test("task missing entirely fails with an error naming task", () => {
+  const catalog = makeV2Catalog();
+  delete v2Model(catalog, "fixture-sharded").task;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /fixture-sharded/.test(e) && /\btask\b/.test(e)), JSON.stringify(result.errors));
+});
+
+test("shard missing sha256 on an ungated model fails, naming the shard", () => {
+  const catalog = makeV2Catalog();
+  delete v2Model(catalog, "fixture-sharded").quants[0].shards[1].sha256;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shard\[1\]/.test(e) && /sha256/i.test(e)), JSON.stringify(result.errors));
+});
+
+test("shard missing sha256 is tolerated when the model is gated:true", () => {
+  const catalog = makeV2Catalog();
+  const model = v2Model(catalog, "fixture-sharded");
+  model.gated = true;
+  delete model.quants[0].shards[1].sha256;
+  delete model.companions[0].sha256;
+  const result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+});
+
+test("shard with a malformed sha256 fails", () => {
+  const catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").quants[0].shards[0].sha256 = "nope";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shard\[0\]/.test(e) && /sha256/i.test(e)), JSON.stringify(result.errors));
+});
+
+test("shard missing file or with a non-positive size_mb fails", () => {
+  let catalog = makeV2Catalog();
+  delete v2Model(catalog, "fixture-sharded").quants[0].shards[0].file;
+  let result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shard\[0\]/.test(e) && /\bfile\b/.test(e)), JSON.stringify(result.errors));
+
+  catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").quants[0].shards[0].size_mb = 0;
+  result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shard\[0\]/.test(e) && /size_mb/.test(e)), JSON.stringify(result.errors));
+});
+
+test("shard whose basename equals the quant's primary file fails", () => {
+  const catalog = makeV2Catalog();
+  const quant = v2Model(catalog, "fixture-sharded").quants[0];
+  quant.shards[0].file = "other-dir/sharded-Q4_K_M-00001-of-00003.gguf";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shard\[0\]/.test(e) && /sharded-Q4_K_M-00001-of-00003\.gguf/.test(e)), JSON.stringify(result.errors));
+});
+
+test("two shards sharing a basename fail", () => {
+  const catalog = makeV2Catalog();
+  const quant = v2Model(catalog, "fixture-sharded").quants[0];
+  quant.shards[1].file = quant.shards[0].file;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shard\[1\]/.test(e) && /sharded-Q4_K_M-00002-of-00003\.gguf/.test(e)), JSON.stringify(result.errors));
+});
+
+test("companion whose basename equals a quant file fails", () => {
+  const catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").companions[0].file = "sharded-Q4_K_M-00001-of-00003.gguf";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /companion\[0\]/.test(e) && /sharded-Q4_K_M-00001-of-00003\.gguf/.test(e)), JSON.stringify(result.errors));
+});
+
+test("quant size_mb below the shards' total + 1 fails", () => {
+  const catalog = makeV2Catalog();
+  const quant = v2Model(catalog, "fixture-sharded").quants[0];
+  quant.size_mb = 200.5; // shards sum to 200; primary must add at least 1 MB
+  quant.min_ram_mb = 400;
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /fixture-sharded/.test(e) && /size_mb/.test(e) && /shard/i.test(e)), JSON.stringify(result.errors));
+});
+
+test("min_ram_mb is checked against the quant's TOTAL size_mb (all parts)", () => {
+  const catalog = makeV2Catalog();
+  const quant = v2Model(catalog, "fixture-sharded").quants[0];
+  quant.min_ram_mb = 250; // less than the 300 MB total, more than the 100 MB primary part
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /min_ram_mb/.test(e)), JSON.stringify(result.errors));
+});
+
+test("shards that is not an array fails", () => {
+  const catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").quants[0].shards = { file: "x.gguf" };
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /shards/.test(e)), JSON.stringify(result.errors));
+});
+
+test("companion kinds mmproj and mtp are accepted", () => {
+  const catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").companions.push({ kind: "mtp", file: "mtp-sharded-Q8_0.gguf", size_mb: 5, sha256: SHA_B });
+  const result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+});
+
+test("companion kind outside the enum fails", () => {
+  const catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").companions[0].kind = "draft";
+  const result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /companion\[0\]/.test(e) && /kind/.test(e) && /draft/.test(e)), JSON.stringify(result.errors));
+});
+
+test("companion missing size_mb, file, or sha256 (ungated) fails", () => {
+  let catalog = makeV2Catalog();
+  delete v2Model(catalog, "fixture-sharded").companions[0].size_mb;
+  let result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /companion\[0\]/.test(e) && /size_mb/.test(e)), JSON.stringify(result.errors));
+
+  catalog = makeV2Catalog();
+  delete v2Model(catalog, "fixture-sharded").companions[0].file;
+  result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /companion\[0\]/.test(e) && /\bfile\b/.test(e)), JSON.stringify(result.errors));
+
+  catalog = makeV2Catalog();
+  delete v2Model(catalog, "fixture-sharded").companions[0].sha256;
+  result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /companion\[0\]/.test(e) && /sha256/i.test(e)), JSON.stringify(result.errors));
+});
+
+test("companions that is not an array fails; an empty array is fine", () => {
+  let catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").companions = "mmproj-F16.gguf";
+  let result = validateCatalog(catalog);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /companions/.test(e)), JSON.stringify(result.errors));
+
+  catalog = makeV2Catalog();
+  v2Model(catalog, "fixture-sharded").companions = [];
+  result = validateCatalog(catalog);
+  assert.deepEqual(result.errors, []);
+});

--- a/tests/model-catalog-validate.test.js
+++ b/tests/model-catalog-validate.test.js
@@ -18,8 +18,15 @@ function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-function firstModel(catalog, id) {
-  return catalog.models.find((m) => m.id === id);
+/** The seed's first_run_default entry (read dynamically, never pinned). */
+function defaultModel(catalog) {
+  return catalog.models.find((m) => m.first_run_default === true);
+}
+
+/** Some ungated, non-default seed entry — the curated catalog carries no
+ * gated model, so every "gated" case below builds its own fixture. */
+function otherModel(catalog) {
+  return catalog.models.find((m) => m.first_run_default !== true && m.gated !== true);
 }
 
 test("valid seed catalog passes", () => {
@@ -31,8 +38,8 @@ test("valid seed catalog passes", () => {
 
 test("duplicate model id fails", () => {
   const catalog = loadSeed();
-  const dup = clone(firstModel(catalog, "phi-4-mini-instruct"));
-  dup.id = "qwen3-4b"; // collide with the existing first_run_default entry
+  const dup = clone(otherModel(catalog));
+  dup.id = defaultModel(catalog).id; // collide with the existing first_run_default entry
   catalog.models.push(dup);
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
@@ -41,7 +48,7 @@ test("duplicate model id fails", () => {
 
 test("missing quant sha256 fails on an ungated entry", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "phi-4-mini-instruct");
+  const model = otherModel(catalog);
   assert.equal(model.gated, false);
   model.quants[0].sha256 = null;
   const result = validateCatalog(catalog);
@@ -51,7 +58,7 @@ test("missing quant sha256 fails on an ungated entry", () => {
 
 test("min_ram_mb below quant size_mb fails (RAM-math floor)", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "phi-4-mini-instruct");
+  const model = otherModel(catalog);
   model.quants[0].min_ram_mb = Math.floor(model.quants[0].size_mb) - 1;
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
@@ -60,9 +67,9 @@ test("min_ram_mb below quant size_mb fails (RAM-math floor)", () => {
 
 test("min_runtime_version greater than runtime.release fails", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "phi-4-mini-instruct");
-  // runtime.release is "b10068" in the seed.
-  model.min_runtime_version = "b10069";
+  const model = otherModel(catalog);
+  // one build past whatever runtime.release the seed carries.
+  model.min_runtime_version = `b${Number(catalog.runtime.release.slice(1)) + 1}`;
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /min_runtime_version/i.test(e)));
@@ -78,7 +85,7 @@ test("zero first_run_default entries fails", () => {
 
 test("two first_run_default entries fails", () => {
   const catalog = loadSeed();
-  firstModel(catalog, "phi-4-mini-instruct").first_run_default = true;
+  otherModel(catalog).first_run_default = true;
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /first_run_default/i.test(e)));
@@ -86,9 +93,10 @@ test("two first_run_default entries fails", () => {
 
 test("first_run_default entry that is gated:true fails", () => {
   const catalog = loadSeed();
-  const current = firstModel(catalog, "qwen3-4b");
+  const current = defaultModel(catalog);
   delete current.first_run_default;
-  const gated = firstModel(catalog, "gemma-3-27b-it");
+  const gated = otherModel(catalog);
+  gated.gated = true;
   gated.first_run_default = true;
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
@@ -97,8 +105,8 @@ test("first_run_default entry that is gated:true fails", () => {
 
 test("first_run_default entry with no min_vram_mb:0 quant fails", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "qwen3-4b");
-  model.quants[0].min_vram_mb = 4096;
+  const model = defaultModel(catalog);
+  for (const q of model.quants) q.min_vram_mb = 4096;
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /first_run_default/i.test(e) && /min_vram_mb/i.test(e)));
@@ -124,8 +132,8 @@ test("missing min_glibc on a linux asset fails", () => {
 
 test("null quant sha256 is valid when the model entry is gated:true", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "gemma-3-27b-it");
-  assert.equal(model.gated, true);
+  const model = otherModel(catalog);
+  model.gated = true;
   model.quants[0].sha256 = null;
   const result = validateCatalog(catalog);
   assert.deepEqual(result.errors, []);
@@ -134,7 +142,7 @@ test("null quant sha256 is valid when the model entry is gated:true", () => {
 
 test("null quant sha256 is rejected when the model entry is gated:false", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "qwen3-14b");
+  const model = otherModel(catalog);
   assert.equal(model.gated, false);
   model.quants[0].sha256 = null;
   const result = validateCatalog(catalog);
@@ -144,9 +152,9 @@ test("null quant sha256 is rejected when the model entry is gated:false", () => 
 
 // --- chat_template_kwargs (C1 Task 1) ---
 
-test("seed qwen3-4b (first_run_default) carries chat_template_kwargs enable_thinking:false", () => {
+test("seed first_run_default entry carries chat_template_kwargs enable_thinking:false", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "qwen3-4b");
+  const model = defaultModel(catalog);
   assert.equal(model.first_run_default, true);
   assert.deepEqual(model.chat_template_kwargs, { enable_thinking: false });
   const result = validateCatalog(catalog);
@@ -156,7 +164,7 @@ test("seed qwen3-4b (first_run_default) carries chat_template_kwargs enable_thin
 
 test("a model with no chat_template_kwargs still validates cleanly", () => {
   const catalog = loadSeed();
-  const model = firstModel(catalog, "phi-4-mini-instruct");
+  const model = otherModel(catalog);
   assert.equal(model.chat_template_kwargs, undefined);
   const result = validateCatalog(catalog);
   assert.deepEqual(result.errors, []);
@@ -165,7 +173,7 @@ test("a model with no chat_template_kwargs still validates cleanly", () => {
 
 test("chat_template_kwargs as an array fails", () => {
   const catalog = loadSeed();
-  firstModel(catalog, "qwen3-4b").chat_template_kwargs = ["enable_thinking"];
+  defaultModel(catalog).chat_template_kwargs = ["enable_thinking"];
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));
@@ -173,7 +181,7 @@ test("chat_template_kwargs as an array fails", () => {
 
 test("chat_template_kwargs as a string fails", () => {
   const catalog = loadSeed();
-  firstModel(catalog, "qwen3-4b").chat_template_kwargs = "enable_thinking:false";
+  defaultModel(catalog).chat_template_kwargs = "enable_thinking:false";
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));
@@ -181,7 +189,7 @@ test("chat_template_kwargs as a string fails", () => {
 
 test("chat_template_kwargs as null fails", () => {
   const catalog = loadSeed();
-  firstModel(catalog, "qwen3-4b").chat_template_kwargs = null;
+  defaultModel(catalog).chat_template_kwargs = null;
   const result = validateCatalog(catalog);
   assert.equal(result.ok, false);
   assert.ok(result.errors.some((e) => /chat_template_kwargs/i.test(e)));

--- a/tests/models-manager.test.js
+++ b/tests/models-manager.test.js
@@ -65,8 +65,10 @@ import {
   fetchHfPathInfo,
   downloadHfFile,
   fetchModelBlob,
+  planFiles,
+  companionFilename,
 } from "../servers/gateway/models/manager.js";
-import { loadState } from "../servers/gateway/models/state.js";
+import { loadState, saveState } from "../servers/gateway/models/state.js";
 
 // Every fixture server in this file is plain http (no TLS) — this is the
 // explicit test-only escape from the manager's https-only enforcement.
@@ -1384,4 +1386,365 @@ test("downloadHfFile: rejects an invalid repo id / filename shape before any net
     () => downloadHfFile({ hfRepo: "org/repo", file: "../../x.gguf", dir: scratchDir("hf-bad-file") }),
     UnsafeDestinationError,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Schema v2: multi-part GGUFs (shards) + companion files (mmproj / mtp)
+// ---------------------------------------------------------------------------
+
+/** Distinct per-part content: the fill byte depends on `seed`, so no two
+ * parts share a prefix (a resumed/overwritten part can never accidentally
+ * hash to a sibling's sha256). */
+function makeSeededBlob(size, seed) {
+  const buf = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) buf[i] = (i * 7 + seed) % 256;
+  return buf;
+}
+const sha = (buf) => createHash("sha256").update(buf).digest("hex");
+const mb = (buf) => buf.length / 1_000_000;
+
+const MULTI_REPO = "test/multi";
+const MULTI_PRIMARY = "Q4/multi-Q4-00001-of-00003.gguf";
+const MULTI_SHARD2 = "Q4/multi-Q4-00002-of-00003.gguf";
+const MULTI_SHARD3 = "Q4/multi-Q4-00003-of-00003.gguf";
+const MULTI_MMPROJ = "mmproj-F16.gguf";
+const MULTI_PARTS = {
+  [MULTI_PRIMARY]: makeSeededBlob(120_000, 1),
+  [MULTI_SHARD2]: makeSeededBlob(90_000, 2),
+  [MULTI_SHARD3]: makeSeededBlob(60_000, 3),
+  [MULTI_MMPROJ]: makeSeededBlob(30_000, 4),
+};
+const MULTI_TOTAL_BYTES = Object.values(MULTI_PARTS).reduce((n, b) => n + b.length, 0);
+
+function makeMultiCatalog({ shard2Sha = sha(MULTI_PARTS[MULTI_SHARD2]) } = {}) {
+  const total = mb(MULTI_PARTS[MULTI_PRIMARY]) + mb(MULTI_PARTS[MULTI_SHARD2]) + mb(MULTI_PARTS[MULTI_SHARD3]);
+  return {
+    version: 1,
+    models: [
+      {
+        id: "multi-model",
+        hf_repo: MULTI_REPO,
+        task: "chat",
+        default_quant: "Q4",
+        quants: [{
+          file: MULTI_PRIMARY,
+          quant: "Q4",
+          size_mb: total,
+          min_ram_mb: total,
+          min_vram_mb: 0,
+          sha256: sha(MULTI_PARTS[MULTI_PRIMARY]),
+          shards: [
+            { file: MULTI_SHARD2, size_mb: mb(MULTI_PARTS[MULTI_SHARD2]), sha256: shard2Sha },
+            { file: MULTI_SHARD3, size_mb: mb(MULTI_PARTS[MULTI_SHARD3]), sha256: sha(MULTI_PARTS[MULTI_SHARD3]) },
+          ],
+        }],
+        companions: [
+          { kind: "mmproj", file: MULTI_MMPROJ, size_mb: mb(MULTI_PARTS[MULTI_MMPROJ]), sha256: sha(MULTI_PARTS[MULTI_MMPROJ]) },
+        ],
+      },
+    ],
+  };
+}
+
+/** Serves each part by the path after `/resolve/main/`, range-aware, and
+ * counts requests per part. `killOnce` names parts whose FIRST request is
+ * severed at half — the second request is served normally. `serve`
+ * overrides the bytes served for a part (wrong-content fixtures). */
+function multiPartHandler({ killOnce = [], serve = {} } = {}) {
+  const requests = {};
+  const killed = new Set();
+  const handler = (req, res) => {
+    const m = /\/resolve\/main\/(.+)$/.exec(req.url);
+    const part = m ? decodeURIComponent(m[1]) : null;
+    const blob = part && (serve[part] || MULTI_PARTS[part]);
+    if (!blob) {
+      res.writeHead(404);
+      res.end("no such part");
+      return;
+    }
+    requests[part] = (requests[part] || 0) + 1;
+    if (killOnce.includes(part) && !killed.has(part)) {
+      killed.add(part);
+      killAtHalfHandler(blob)(req, res);
+      return;
+    }
+    rangeAwareHandler(blob)(req, res);
+  };
+  return { handler, requests };
+}
+
+const blobPath = (dir, name) => join(dir, "models", "blobs", name);
+
+test("planFiles: primary, then shards in order, then companions — flat basenames, per-file sha, companions namespaced by model id", () => {
+  const catalog = makeMultiCatalog();
+  const { model, quantEntry } = resolveEntry(catalog, "multi-model");
+  const plan = planFiles(model, quantEntry, { baseUrl: "http://huggingface.co:1" });
+  assert.deepEqual(plan.map((f) => f.role), ["primary", "shard", "shard", "companion"]);
+  assert.deepEqual(plan.map((f) => f.dest), [
+    "multi-Q4-00001-of-00003.gguf",
+    "multi-Q4-00002-of-00003.gguf",
+    "multi-Q4-00003-of-00003.gguf",
+    companionFilename("multi-model", MULTI_MMPROJ),
+  ]);
+  assert.deepEqual(plan.map((f) => f.url), [
+    `http://huggingface.co:1/${MULTI_REPO}/resolve/main/${MULTI_PRIMARY}`,
+    `http://huggingface.co:1/${MULTI_REPO}/resolve/main/${MULTI_SHARD2}`,
+    `http://huggingface.co:1/${MULTI_REPO}/resolve/main/${MULTI_SHARD3}`,
+    `http://huggingface.co:1/${MULTI_REPO}/resolve/main/${MULTI_MMPROJ}`,
+  ]);
+  assert.deepEqual(plan.map((f) => f.expectedSha), [
+    sha(MULTI_PARTS[MULTI_PRIMARY]), sha(MULTI_PARTS[MULTI_SHARD2]), sha(MULTI_PARTS[MULTI_SHARD3]), sha(MULTI_PARTS[MULTI_MMPROJ]),
+  ]);
+  assert.equal(plan[3].kind, "mmproj");
+  assert.equal(plan[0].kind, undefined);
+  // sizeMb: the primary's share is the quant total minus its shards.
+  assert.ok(Math.abs(plan[0].sizeMb - mb(MULTI_PARTS[MULTI_PRIMARY])) < 1e-6, `primary sizeMb ${plan[0].sizeMb}`);
+  assert.equal(plan[1].sizeMb, mb(MULTI_PARTS[MULTI_SHARD2]));
+  assert.equal(plan[3].sizeMb, mb(MULTI_PARTS[MULTI_MMPROJ]));
+  // blobDir joins the destinations; the default (real huggingface.co) URL shape is unchanged.
+  const withDir = planFiles(model, quantEntry, { blobDir: "/x/blobs" });
+  assert.equal(withDir[0].dest, "/x/blobs/multi-Q4-00001-of-00003.gguf");
+  assert.equal(withDir[0].url, `https://huggingface.co/${MULTI_REPO}/resolve/main/${MULTI_PRIMARY}`);
+});
+
+test("planFiles: a legacy single-file quant with no shards/companions plans exactly one primary file", () => {
+  const { model, quantEntry } = resolveEntry(makeCatalog(), "test-model");
+  const plan = planFiles(model, quantEntry);
+  assert.equal(plan.length, 1);
+  assert.equal(plan[0].role, "primary");
+  assert.equal(plan[0].dest, "blob.gguf");
+  assert.equal(plan[0].expectedSha, BLOB_SHA256);
+});
+
+test("companionFilename: namespaced by model id so two vision models' mmproj-F16.gguf never collide in the flat blob dir", () => {
+  assert.equal(companionFilename("qwen3.5-4b", "mmproj-F16.gguf"), "qwen3.5-4b--mmproj-F16.gguf");
+  assert.equal(companionFilename("qwen3.8-flash-next", "MTP/mtp-Qwen3.8-Flash-Next-Q8_0.gguf"), "qwen3.8-flash-next--mtp-Qwen3.8-Flash-Next-Q8_0.gguf");
+  assert.notEqual(companionFilename("a", "mmproj-F16.gguf"), companionFilename("b", "mmproj-F16.gguf"));
+});
+
+test("downloadModel (multi-part): fetches primary + every shard + every companion into the blob dir, each sha-verified; returns every file", async () => {
+  const { handler, requests } = multiPartHandler();
+  const { srv, port } = await startServer(handler);
+  try {
+    const dir = scratchDir("multi-full");
+    try {
+      const progress = [];
+      const result = await downloadModel({
+        modelId: "multi-model",
+        dir,
+        catalog: makeMultiCatalog(),
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
+        onProgress: (p) => progress.push(p),
+      });
+      const expectedNames = [
+        "multi-Q4-00001-of-00003.gguf",
+        "multi-Q4-00002-of-00003.gguf",
+        "multi-Q4-00003-of-00003.gguf",
+        companionFilename("multi-model", MULTI_MMPROJ),
+      ];
+      assert.equal(result.path, blobPath(dir, expectedNames[0]));
+      assert.equal(result.sha256, sha(MULTI_PARTS[MULTI_PRIMARY]));
+      assert.deepEqual(result.files.map((f) => f.path), expectedNames.map((n) => blobPath(dir, n)));
+      assert.deepEqual(result.files.map((f) => f.sha256), [
+        sha(MULTI_PARTS[MULTI_PRIMARY]), sha(MULTI_PARTS[MULTI_SHARD2]), sha(MULTI_PARTS[MULTI_SHARD3]), sha(MULTI_PARTS[MULTI_MMPROJ]),
+      ]);
+      assert.deepEqual(readFileSync(blobPath(dir, expectedNames[0])), MULTI_PARTS[MULTI_PRIMARY]);
+      assert.deepEqual(readFileSync(blobPath(dir, expectedNames[1])), MULTI_PARTS[MULTI_SHARD2]);
+      assert.deepEqual(readFileSync(blobPath(dir, expectedNames[2])), MULTI_PARTS[MULTI_SHARD3]);
+      assert.deepEqual(readFileSync(blobPath(dir, expectedNames[3])), MULTI_PARTS[MULTI_MMPROJ]);
+      assert.deepEqual(requests, { [MULTI_PRIMARY]: 1, [MULTI_SHARD2]: 1, [MULTI_SHARD3]: 1, [MULTI_MMPROJ]: 1 });
+      assert.equal(loadState(dir).journal["multi-model"], undefined, "journal cleared on success");
+
+      // (c) progress is cumulative across files.
+      assert.ok(progress.length > 0);
+      const last = progress.at(-1);
+      assert.equal(last.bytesDone, MULTI_TOTAL_BYTES);
+      assert.equal(last.totalBytes, MULTI_TOTAL_BYTES);
+      assert.equal(last.fileCount, 4);
+      assert.equal(last.fileIndex, 3);
+      assert.equal(last.file, expectedNames[3]);
+      for (let i = 1; i < progress.length; i++) {
+        assert.ok(progress[i].bytesDone >= progress[i - 1].bytesDone, "cumulative bytesDone never goes backwards");
+      }
+      assert.ok(progress.every((p) => p.totalBytes === MULTI_TOTAL_BYTES), "totalBytes is the sum of every part from the first event");
+      assert.ok(progress.some((p) => p.fileIndex === 0 && p.file === expectedNames[0]));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("downloadModel (multi-part): wrong bytes for shard 2 -> ChecksumError naming that file; the verified primary is kept, the bad shard deleted", async () => {
+  const wrong = makeSeededBlob(MULTI_PARTS[MULTI_SHARD2].length, 99);
+  const { handler, requests } = multiPartHandler({ serve: { [MULTI_SHARD2]: wrong } });
+  const { srv, port } = await startServer(handler);
+  try {
+    const dir = scratchDir("multi-badsha");
+    try {
+      await assert.rejects(
+        () => downloadModel({
+          modelId: "multi-model",
+          dir,
+          catalog: makeMultiCatalog(),
+          lookup: lookupToLocalhost,
+          baseUrl: `http://huggingface.co:${port}`,
+          insecureHttpHosts: INSECURE_HF,
+        }),
+        (err) => {
+          assert.ok(err instanceof ChecksumError, `expected ChecksumError, got ${err}`);
+          assert.equal(err.expectedSha, sha(MULTI_PARTS[MULTI_SHARD2]));
+          assert.equal(err.file, blobPath(dir, "multi-Q4-00002-of-00003.gguf"));
+          assert.match(err.message, /multi-Q4-00002-of-00003\.gguf/);
+          return true;
+        },
+      );
+      assert.ok(existsSync(blobPath(dir, "multi-Q4-00001-of-00003.gguf")), "verified primary part is kept");
+      assert.equal(existsSync(blobPath(dir, "multi-Q4-00002-of-00003.gguf")), false, "bad shard deleted");
+      assert.equal(requests[MULTI_SHARD3], undefined, "download stops at the bad part");
+
+      // The journal remembers the primary is done, so a retry skips it.
+      const entry = loadState(dir).journal["multi-model"];
+      assert.ok(entry && Array.isArray(entry.files), "journal keeps the multi-file record");
+      assert.equal(entry.files[0].done, true);
+      assert.equal(entry.files[1].done, false);
+      assert.equal(entry.files[1].bytesDone, 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
+});
+
+test("downloadModel (multi-part): resume after an interruption in file 2 skips the finished file 1 and fetches files 2-4", async () => {
+  const port = await getFreePort();
+  const dir = scratchDir("multi-resume");
+  try {
+    const catalog = makeMultiCatalog();
+    const phase1 = multiPartHandler({ killOnce: [MULTI_SHARD2] });
+    const srv1 = await startServerOnPort(port, phase1.handler);
+    await assert.rejects(() => downloadModel({
+      modelId: "multi-model",
+      dir,
+      catalog,
+      lookup: lookupToLocalhost,
+      baseUrl: `http://huggingface.co:${port}`,
+      insecureHttpHosts: INSECURE_HF,
+    }));
+    await stopServer(srv1.srv);
+    assert.deepEqual(phase1.requests, { [MULTI_PRIMARY]: 1, [MULTI_SHARD2]: 1 });
+
+    const journaled = loadState(dir).journal["multi-model"];
+    assert.ok(journaled && Array.isArray(journaled.files) && journaled.files.length === 4, "journal has one record per file");
+    assert.equal(journaled.files[0].done, true);
+    assert.equal(journaled.files[1].done, false);
+    assert.ok(journaled.files[1].bytesDone > 0 && journaled.files[1].bytesDone < MULTI_PARTS[MULTI_SHARD2].length);
+    // Top-level mirror of the in-flight file, so the existing single-file
+    // readers (resumableDownloads, the panel) keep seeing url/dest/bytesDone.
+    assert.equal(journaled.dest, blobPath(dir, "multi-Q4-00002-of-00003.gguf"));
+    assert.equal(journaled.bytesDone, journaled.files[1].bytesDone);
+    const resumeAt = journaled.files[1].bytesDone;
+
+    const phase2 = multiPartHandler();
+    const ranges = {};
+    const srv2 = await startServerOnPort(port, (req, res) => {
+      const m = /\/resolve\/main\/(.+)$/.exec(req.url);
+      ranges[m[1]] = req.headers.range || null;
+      phase2.handler(req, res);
+    });
+    try {
+      const progress = [];
+      const result = await downloadModel({
+        modelId: "multi-model",
+        dir,
+        catalog,
+        lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`,
+        insecureHttpHosts: INSECURE_HF,
+        onProgress: (p) => progress.push(p),
+      });
+      assert.deepEqual(phase2.requests, { [MULTI_SHARD2]: 1, [MULTI_SHARD3]: 1, [MULTI_MMPROJ]: 1 }, "file 1 is never re-requested");
+      assert.equal(ranges[MULTI_SHARD2], `bytes=${resumeAt}-`, "file 2 resumes from the journaled offset");
+      assert.equal(ranges[MULTI_SHARD3], null);
+      assert.equal(result.files.length, 4);
+      assert.equal(result.files[0].sha256, sha(MULTI_PARTS[MULTI_PRIMARY]), "a previously-verified file reports its sha");
+      assert.deepEqual(readFileSync(blobPath(dir, "multi-Q4-00002-of-00003.gguf")), MULTI_PARTS[MULTI_SHARD2]);
+      assert.deepEqual(readFileSync(blobPath(dir, companionFilename("multi-model", MULTI_MMPROJ))), MULTI_PARTS[MULTI_MMPROJ]);
+      assert.equal(loadState(dir).journal["multi-model"], undefined);
+      const last = progress.at(-1);
+      assert.equal(last.bytesDone, MULTI_TOTAL_BYTES, "cumulative progress counts the already-finished file 1");
+      assert.equal(last.totalBytes, MULTI_TOTAL_BYTES);
+    } finally {
+      await stopServer(srv2.srv);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("downloadModel: an old-shape journal entry ({url,dest,bytesDone}) from before the multi-file journal still resumes with a Range header", async () => {
+  const port = await getFreePort();
+  const dir = scratchDir("legacy-journal");
+  try {
+    const catalog = makeCatalog();
+    const phase1 = await startServerOnPort(port, killAtHalfHandler(BLOB));
+    await assert.rejects(() => downloadModel({
+      modelId: "test-model", dir, catalog, lookup: lookupToLocalhost,
+      baseUrl: `http://huggingface.co:${port}`, insecureHttpHosts: INSECURE_HF,
+    }));
+    await stopServer(phase1.srv);
+
+    // Rewrite the journal in the pre-v2 shape: no `files` array at all.
+    const state = loadState(dir);
+    const { url, dest, bytesDone, expectedSha, startedAt } = state.journal["test-model"];
+    assert.ok(bytesDone > 0 && bytesDone < BLOB.length);
+    state.journal["test-model"] = { url, dest, bytesDone, expectedSha, startedAt };
+    saveState(dir, state);
+
+    let seenRange;
+    const phase2 = await startServerOnPort(port, (req, res) => {
+      seenRange = req.headers.range || null;
+      rangeAwareHandler(BLOB)(req, res);
+    });
+    try {
+      const result = await downloadModel({
+        modelId: "test-model", dir, catalog, lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`, insecureHttpHosts: INSECURE_HF,
+      });
+      assert.equal(seenRange, `bytes=${bytesDone}-`);
+      assert.equal(result.sha256, BLOB_SHA256);
+      assert.deepEqual(result.files, [{ path: result.path, sha256: BLOB_SHA256 }]);
+    } finally {
+      await stopServer(phase2.srv);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("deleteModel (multi-part): removes every part and companion", async () => {
+  const { handler } = multiPartHandler();
+  const { srv, port } = await startServer(handler);
+  try {
+    const dir = scratchDir("multi-delete");
+    try {
+      const catalog = makeMultiCatalog();
+      const result = await downloadModel({
+        modelId: "multi-model", dir, catalog, lookup: lookupToLocalhost,
+        baseUrl: `http://huggingface.co:${port}`, insecureHttpHosts: INSECURE_HF,
+      });
+      for (const f of result.files) assert.ok(existsSync(f.path));
+      const del = deleteModel({ modelId: "multi-model", dir, catalog });
+      assert.equal(del.deleted, true);
+      for (const f of result.files) assert.equal(existsSync(f.path), false, `${f.path} removed`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  } finally {
+    await stopServer(srv);
+  }
 });

--- a/tests/models-panel-ui.test.js
+++ b/tests/models-panel-ui.test.js
@@ -345,8 +345,12 @@ test("panel route: authenticated request renders 200 with the curated tab, runti
       assert.match(html, /data-tab-panel="curated"/);
       assert.match(html, /data-tab-panel="browse-hf"/);
       // real registry/model-catalog.json content — the small, permissively
-      // licensed first_run_default entry must be present
-      assert.match(html, /data-model-id="qwen3-4b"/);
+      // licensed first_run_default entry must be present (read dynamically,
+      // never pinned to an id the curated catalog may retire)
+      const liveCatalog = JSON.parse(readFileSync(new URL("../registry/model-catalog.json", import.meta.url), "utf8"));
+      const firstRunDefault = liveCatalog.models.find((m) => m.first_run_default === true);
+      assert.ok(firstRunDefault, "catalog has a first_run_default model");
+      assert.ok(html.includes(`data-model-id="${firstRunDefault.id}"`), `card for ${firstRunDefault.id} rendered`);
       assert.match(html, /data-action="download"/);
       assert.match(html, /id="mcat-hf-search-input"/);
     });

--- a/tests/models-registration.test.js
+++ b/tests/models-registration.test.js
@@ -101,6 +101,37 @@ function makeCatalog() {
           { file: "embed-test-model-Q4_K_M.gguf", quant: "Q4_K_M", size_mb: 1, min_ram_mb: 1, min_vram_mb: 0, sha256: "def" },
         ],
       },
+      {
+        id: "multi-test-model",
+        family: "TestMultiFamily",
+        lab: "TestLab",
+        hf_repo: "test/multi-test-model-GGUF",
+        license: "apache-2.0",
+        gated: false,
+        task: "chat",
+        context_len: 8192,
+        min_runtime_version: "b10068",
+        default_quant: "Q4_K_M",
+        tags: ["chat", "vision"],
+        notes: "test fixture: multi-part quant + mmproj companion",
+        quants: [
+          {
+            file: "Q4_K_M/multi-test-model-Q4_K_M-00001-of-00003.gguf",
+            quant: "Q4_K_M",
+            size_mb: 3,
+            min_ram_mb: 3,
+            min_vram_mb: 0,
+            sha256: "a1",
+            shards: [
+              { file: "Q4_K_M/multi-test-model-Q4_K_M-00002-of-00003.gguf", size_mb: 1, sha256: "a2" },
+              { file: "Q4_K_M/multi-test-model-Q4_K_M-00003-of-00003.gguf", size_mb: 1, sha256: "a3" },
+            ],
+          },
+        ],
+        companions: [
+          { kind: "mmproj", file: "mmproj-F16.gguf", size_mb: 1, sha256: "a4" },
+        ],
+      },
     ],
   };
 }
@@ -631,5 +662,68 @@ test("providerBindings: no ai_profiles row / no pi_bot_defs rows at all -> both 
     const { profiles, bots } = await providerBindings(db, "chat-test-model");
     assert.deepEqual(profiles, []);
     assert.deepEqual(bots, []);
+  } finally { cleanup(); }
+});
+
+// ---------------------------------------------------------------------------
+// Schema v2: registry row carries companions + shardFiles; unregister removes all
+// ---------------------------------------------------------------------------
+
+const MULTI_ON_DISK = [
+  "multi-test-model-Q4_K_M-00001-of-00003.gguf",
+  "multi-test-model-Q4_K_M-00002-of-00003.gguf",
+  "multi-test-model-Q4_K_M-00003-of-00003.gguf",
+  "multi-test-model--mmproj-F16.gguf",
+];
+
+test("registerModel: a legacy single-file model records empty companions/shardFiles", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    await registerModel({ modelId: "chat-test-model", catalog: makeCatalog(), db, dir });
+    const entry = loadState(dir).registry["chat-test-model"];
+    assert.equal(entry.file, "chat-test-model-Q4_K_M.gguf");
+    assert.deepEqual(entry.companions, []);
+    assert.deepEqual(entry.shardFiles, []);
+  } finally { cleanup(); }
+});
+
+test("registerModel: a sharded model with an mmproj companion records shardFiles + companions (on-disk basenames) on the registry row", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    const result = await registerModel({ modelId: "multi-test-model", catalog: makeCatalog(), db, dir });
+    assert.equal(result.id, "multi-test-model");
+    const entry = loadState(dir).registry["multi-test-model"];
+    assert.equal(entry.file, MULTI_ON_DISK[0]);
+    assert.deepEqual(entry.shardFiles, [MULTI_ON_DISK[1], MULTI_ON_DISK[2]]);
+    assert.deepEqual(entry.companions, [{ kind: "mmproj", file: MULTI_ON_DISK[3] }]);
+    assert.equal(entry.sizeMb, 3, "sizeMb is the quant's TOTAL");
+  } finally { cleanup(); }
+});
+
+test("unregisterModel: removes the primary, every shard and every companion; a missing part is not an error", async () => {
+  const { db, dir, cleanup } = freshLibsql();
+  try {
+    await registerModel({ modelId: "multi-test-model", catalog: makeCatalog(), db, dir });
+    mkdirSync(join(dir, "models", "blobs"), { recursive: true });
+    for (const name of MULTI_ON_DISK) writeFileSync(blobPathFor(dir, name), "fake bytes");
+
+    const unlinked = [];
+    const outcome = await unregisterModel({
+      modelId: "multi-test-model",
+      db,
+      dir,
+      unlinkFn: (p) => { unlinked.push(p); return unlinkSync(p); },
+    });
+    assert.equal(outcome.deleted, true);
+    assert.deepEqual(unlinked, MULTI_ON_DISK.map((n) => blobPathFor(dir, n)));
+    for (const name of MULTI_ON_DISK) assert.ok(!existsSync(blobPathFor(dir, name)), `${name} removed`);
+    assert.equal(loadState(dir).registry["multi-test-model"], undefined);
+
+    // Second registration, only the companion left on disk: still fine.
+    await registerModel({ modelId: "multi-test-model", catalog: makeCatalog(), db, dir });
+    writeFileSync(blobPathFor(dir, MULTI_ON_DISK[3]), "fake bytes");
+    const again = await unregisterModel({ modelId: "multi-test-model", db, dir });
+    assert.equal(again.deleted, true);
+    assert.ok(!existsSync(blobPathFor(dir, MULTI_ON_DISK[3])));
   } finally { cleanup(); }
 });


### PR DESCRIPTION
PR 1 of the model-catalog curation (plan: `docs/superpowers/plans/2026-09-04-model-catalog-curation.md`). Operator decision 2026-09-04: replace the placeholder catalog with the models actually run in this lab.

**Curated data** (`registry/model-catalog.json`, `runtime` block untouched; sizes + sha256 are real Hugging Face LFS values, `min_ram_mb` computed with exact GQA/MLA KV sizes at a 32k fit context): Qwen3.5-4B (fresh-install default, voice route), Gemma 4 E2B, Qwen3-Embedding-0.6B, Qwen3-Reranker-0.6B (mradermacher GGUF), Qwen3-VL-4B-Instruct, Qwen3.6-35B-A3B (the resident workhorse), Qwen3.8-27B (copilot/critic), Qwen3.8-Flash-Next, GLM-5.3-Flash (replaces GLM-5.2; UD-IQ2_XXS single-box, UD-IQ4_XS / UD-Q4_K_XL two-box), DeepSeek-V4-Flash-0731. All seven previous entries dropped.

**Schema v2** (`scripts/validate-model-catalog.js`): `task` enum (chat|embedding|rerank|vision); `quants[].shards[]` for multi-part GGUFs (`size_mb` = total, per-part sha256); model `companions[]` (`mmproj` | `mtp`); basename uniqueness across a model's files. Existing error strings unchanged.

**Downloader** (`servers/gateway/models/manager.js`): `planFiles()` orders primary → shards → companions; per-file journal with `done` flags (resume skips verified parts; a checksum failure names the part and keeps the verified ones); cumulative progress; companions namespaced on disk as `<modelId>--<basename>` because six entries ship an identically named `mmproj-F16.gguf`; register/unregister/delete handle every part.

**Runtime** (`gpu-orchestrator.js`): `--mmproj <blob>` for an mmproj companion; `--embedding` / `--reranking` by task; MTP companions get no flag (build-specific; kept beside the model for the operator's launchers).

**Harness**: `scripts/run-suite.mjs` sets `CROW_BOX_RESERVATION_PATH` to a scratch path (a live benchmark window was making every native-start test fail with `ReservedError`; same fix as #303 — whichever merges second rebases it away).

**Tests**: +35 (validator fixtures, multi-part download/checksum/resume/legacy-journal/delete, registration, runtime flags); three live-catalog tests now read the catalog dynamically instead of pinning `qwen3-4b`. Full suite 3708/0 under node 22; port, registry, vendored-payload, catalog checks and docs build OK.

**Worth a look before merge**: the VL-4B is `task: vision`, so it registers outside the chat mutex group and is not offered where chat models are — intended, since it is the router's vision tier, but it is a product-level choice.