### PR TITLE
fix(android): grant WebView geolocation + let the Ramble map suspend pull-to-refresh

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,8 +14,8 @@ android {
         //   - Meta Wearables DAT SDK (mwdat-*) targets API 34+
         minSdk 34
         targetSdk 34
-        versionCode 17
-        versionName "1.5.0"
+        versionCode 18
+        versionName "1.5.1"
     }
 
     // VERSION_NAME is exposed via BuildConfig so the WebView UA + appVersion()

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />

--- a/android/app/src/main/java/press/maestro/crow/CrowWebChromeClient.java
+++ b/android/app/src/main/java/press/maestro/crow/CrowWebChromeClient.java
@@ -3,6 +3,7 @@ package press.maestro.crow;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
+import android.webkit.GeolocationPermissions;
 import android.webkit.JsResult;
 import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
@@ -63,6 +64,21 @@ public class CrowWebChromeClient extends WebChromeClient {
                 } else {
                     activity.requestAudioPermissionForWebView(request);
                 }
+            }
+        });
+    }
+
+    @Override
+    public void onGeolocationPermissionsShowPrompt(final String origin,
+                                                    final GeolocationPermissions.Callback callback) {
+        // No `retain` (third arg false): if the permission is later revoked in
+        // system settings, the WebView re-prompts instead of replaying a stale grant.
+        activity.runOnUiThread(() -> {
+            if (activity.hasLocationPermission()) {
+                callback.invoke(origin, true, false);
+            } else {
+                activity.requestLocationPermission(() ->
+                        callback.invoke(origin, activity.hasLocationPermission(), false));
             }
         });
     }

--- a/android/app/src/main/java/press/maestro/crow/MainActivity.java
+++ b/android/app/src/main/java/press/maestro/crow/MainActivity.java
@@ -99,6 +99,17 @@ public class MainActivity extends AppCompatActivity {
                 pendingNeedCamera = false;
             });
 
+    private Runnable pendingLocationCallback;
+
+    private final ActivityResultLauncher<String[]> locationPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestMultiplePermissions(), grantResults -> {
+                Runnable callback = pendingLocationCallback;
+                pendingLocationCallback = null;
+                if (callback != null) {
+                    runOnUiThread(callback);
+                }
+            });
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -247,6 +258,7 @@ public class MainActivity extends AppCompatActivity {
         settings.setDomStorageEnabled(true);
         settings.setDatabaseEnabled(true);
         settings.setAllowFileAccess(true);
+        settings.setGeolocationEnabled(true);
         settings.setMediaPlaybackRequiresUserGesture(false);
         settings.setUserAgentString(settings.getUserAgentString() + " CrowAndroid/" + BuildConfig.VERSION_NAME);
 
@@ -277,6 +289,16 @@ public class MainActivity extends AppCompatActivity {
                 Intent intent = new Intent(MainActivity.this, PairingActivity.class);
                 startActivity(intent);
             });
+        }
+
+        /**
+         * Let a panel suspend pull-to-refresh while it handles its own vertical
+         * drag gestures (e.g. the Ramble map). Called from the panel's own
+         * touchstart/touchend handlers, not from the scroll-probe above.
+         */
+        @JavascriptInterface
+        public void setPullToRefresh(boolean enabled) {
+            runOnUiThread(() -> swipeRefresh.setEnabled(enabled));
         }
     }
 
@@ -328,6 +350,28 @@ public class MainActivity extends AppCompatActivity {
     public boolean hasCameraPermission() {
         return ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
                 == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /** Check if app has FINE or COARSE location permission (called by CrowWebChromeClient) */
+    public boolean hasLocationPermission() {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Request FINE + COARSE location permission, invoking {@code onResult} on the UI
+     * thread once the user has answered (the result is not passed back directly —
+     * the caller re-checks {@link #hasLocationPermission()} itself, e.g. from
+     * {@code CrowWebChromeClient#onGeolocationPermissionsShowPrompt}).
+     */
+    public void requestLocationPermission(Runnable onResult) {
+        pendingLocationCallback = onResult;
+        locationPermissionLauncher.launch(new String[]{
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+        });
     }
 
     /** Request RECORD_AUDIO and grant WebView permission on callback */

--- a/bundles/ramble/panel/ramble.js
+++ b/bundles/ramble/panel/ramble.js
@@ -65,7 +65,7 @@ export default {
         .rb-card { background:var(--crow-bg-surface); border:1px solid var(--crow-border);
           border-radius:8px; padding:0.9rem 1rem; margin-bottom:1rem; }
         #ramble-map { height:420px; width:100%; border-radius:8px; border:1px solid var(--crow-border);
-          background:var(--crow-bg); }
+          background:var(--crow-bg); touch-action: none; overscroll-behavior: contain; }
         .rb-compose { display:flex; flex-direction:column; gap:0.5rem; }
         .rb-compose textarea { width:100%; min-height:4.5rem; padding:0.45rem 0.6rem; border-radius:6px;
           border:1px solid var(--crow-border); background:var(--crow-bg); color:var(--crow-text);

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -62,6 +62,28 @@
   }).addTo(map);
   markerLayer = L.layerGroup().addTo(map);
 
+  /* The Android shell wraps the WebView in a SwipeRefreshLayout for
+   * pull-to-refresh; a northward drag on the map (which never itself
+   * scrolls) would otherwise be read as "pull to refresh the page".
+   * Suspend it for the duration of any touch on the map so Leaflet's own
+   * pan/zoom gestures win. window.Crow is only injected inside the Android
+   * app, and this must never let a native-bridge hiccup break the map. */
+  mapEl.addEventListener("touchstart", function () {
+    try {
+      if (window.Crow && typeof Crow.setPullToRefresh === "function") Crow.setPullToRefresh(false);
+    } catch (e) { /* not fatal to the map */ }
+  });
+  mapEl.addEventListener("touchend", function () {
+    try {
+      if (window.Crow && typeof Crow.setPullToRefresh === "function") Crow.setPullToRefresh(true);
+    } catch (e) { /* not fatal to the map */ }
+  });
+  mapEl.addEventListener("touchcancel", function () {
+    try {
+      if (window.Crow && typeof Crow.setPullToRefresh === "function") Crow.setPullToRefresh(true);
+    } catch (e) { /* not fatal to the map */ }
+  });
+
   function here() {
     return new Promise(function (resolve, reject) {
       if (!navigator.geolocation) { reject(new Error("this browser has no geolocation")); return; }

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -109,6 +109,10 @@ test("panel handler renders the map mount and the client script tag", async () =
   assert.match(sent, /id="ramble-pet"/);
   assert.match(sent, /id="ramble-marks"/);
   assert.match(sent, /name="grid-public-geo"/);
+  // Android WebView pull-to-refresh guard (fix/android-geolocation-map-swipe):
+  // the map must opt out of the browser/WebView's own touch gestures so a
+  // northward drag pans Leaflet instead of triggering SwipeRefreshLayout.
+  assert.match(sent, /touch-action:\s*none/);
 });
 
 // -------------------------------------------------------------- auth scoping
@@ -247,6 +251,11 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
   assert.match(res.headers.get("content-type") || "", /javascript/);
   const body = await res.text();
   assert.ok(body.length > 100, "client script looks empty");
+  // Android pull-to-refresh guard: the client must call the native bridge
+  // to suspend/restore SwipeRefreshLayout around a touch on the map (this
+  // is the client half of the fix/android-geolocation-map-swipe change).
+  assert.match(body, /Crow\.setPullToRefresh\(false\)/);
+  assert.match(body, /Crow\.setPullToRefresh\(true\)/);
 });
 
 test("GET /ramble/static/leaflet/leaflet.js serves the vendored copy", async () => {


### PR DESCRIPTION
## Two Android-shell bugs found on first use of Ramble on the Pixel

1. **"User denied Geolocation"** inside the Crow Android app. The WebView shell had no location permissions and `CrowWebChromeClient` never implemented `onGeolocationPermissionsShowPrompt`, so every `navigator.geolocation` call was auto-denied. Fix: `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION` in the manifest, `setGeolocationEnabled(true)`, a runtime permission launcher on `MainActivity`, and the prompt callback granting for the page origin (no `retain`, so a later revoke re-prompts). `versionCode 18`, `versionName 1.5.1`.
2. **Dragging the map north pulled-to-refresh the page.** `SwipeRefreshLayout` only gated on page scroll position; a map at the top never scrolls. Fix: a `Crow.setPullToRefresh(boolean)` bridge method; the Ramble client suspends refresh for the duration of any touch on the map (`touchstart` → false, `touchend`/`touchcancel` → true, try/caught, no-op outside the app), plus `touch-action: none; overscroll-behavior: contain` on the map container.

Tests: `tests/ramble-panel.test.js` gains string-level guards for the bridge calls and the CSS (24/24). `./gradlew assembleDebug` builds clean (only pre-existing warnings).

Not yet installed on the device: the phone runs the release build from the `android-v1.5.0` GitHub release, signed with the release keystore whose passwords are operator-held. A release APK (`android-v1.5.1`) follows once those are available.