### PR TITLE
gateway: exempt the Ramble map, static and API paths from the general rate limiter

### DIFF
--- a/servers/gateway/index.js
+++ b/servers/gateway/index.js
@@ -58,6 +58,7 @@ import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middlew
 import { getOAuthProtectedResourceMetadataUrl } from "@modelcontextprotocol/sdk/server/auth/router.js";
 import express from "express";
 import rateLimit, { ipKeyGenerator } from "express-rate-limit";
+import { generalLimiterSkip } from "./middleware/rate-limit.js";
 import cors from "cors";
 import { crowdsecMiddleware } from "./middleware/crowdsec.js";
 import { rejectFunneledMiddleware } from "./funnel.js";
@@ -404,8 +405,9 @@ if (!noAuth) {
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: "Too many requests, please try again later" },
-    skip: (req) => req.path.startsWith("/dashboard") || req.path.startsWith("/api/meta-glasses/") || req.path.startsWith("/llm")
-      || rateLimitSkipPrefixes.some((p) => req.path.startsWith(p)),
+    // The exempt list (dashboard, glasses, llm, the Ramble map + API) lives
+    // in middleware/rate-limit.js so a test can pin it.
+    skip: (req) => generalLimiterSkip(req, rateLimitSkipPrefixes),
   }));
 }
 

--- a/servers/gateway/middleware/rate-limit.js
+++ b/servers/gateway/middleware/rate-limit.js
@@ -116,3 +116,24 @@ export function fixedWindowLimit({
   middleware._buckets = buckets; // test introspection only
   return middleware;
 }
+
+/**
+ * Paths the GENERAL per-IP limiter in servers/gateway/index.js never counts.
+ * Everything here already sits behind its own gate (the dashboard session,
+ * the glasses device binding, the in-process LLM router), so the limiter
+ * adds no protection there — only the failure mode where a legitimate
+ * session burns the bucket. `/ramble/` (proxied map tiles: ~50 per view, and
+ * the panel's static assets) and `/api/ramble/` (the panel's data calls) were
+ * added 2026-09-07 after one phone walk 429'd the egg check-in and then the
+ * page's own scripts on reload.
+ */
+export const GENERAL_LIMITER_SKIP_PREFIXES = Object.freeze([
+  "/dashboard", "/api/meta-glasses/", "/llm", "/ramble/", "/api/ramble/",
+]);
+
+/** express-rate-limit `skip` predicate for the general limiter; `extraPrefixes` = GATEWAY_RATE_LIMIT_SKIP_PREFIXES. */
+export function generalLimiterSkip(req, extraPrefixes = []) {
+  const path = String(req?.path ?? "");
+  return GENERAL_LIMITER_SKIP_PREFIXES.some((p) => path.startsWith(p))
+    || extraPrefixes.some((p) => path.startsWith(p));
+}

--- a/tests/rate-limit-middleware.test.js
+++ b/tests/rate-limit-middleware.test.js
@@ -104,3 +104,20 @@ test("pickTier: blog-embed tier selection and keys", () => {
   const mw = tieredRateLimit({ windowMs: 60_000, tiers, message: { error: "Too many requests" } });
   assert.equal(typeof mw, "function");
 });
+
+import { generalLimiterSkip, GENERAL_LIMITER_SKIP_PREFIXES } from "../servers/gateway/middleware/rate-limit.js";
+
+// The general per-IP limiter (servers/gateway/index.js, 200 req / 15 min) must
+// not count traffic that already sits behind the dashboard session: the Ramble
+// map pulls ~50 proxied tiles per view and 429'd a phone's check-in, then its
+// own scripts, on the first real walk (2026-09-07).
+test("generalLimiterSkip: dashboard, glasses, llm AND every Ramble surface are exempt; other API paths are not", () => {
+  const skip = (path, extra = []) => generalLimiterSkip({ path }, extra);
+  for (const p of ["/dashboard", "/dashboard/ramble", "/api/meta-glasses/x", "/llm/v1/chat",
+    "/ramble/tiles/15/7000/13000.png", "/ramble/static/ramble-ar.js", "/api/ramble/egg/checkin", "/api/ramble/around"]) {
+    assert.equal(skip(p), true, p);
+  }
+  for (const p of ["/api/chat", "/api/ramblex", "/rambler", "/mcp", "/"]) assert.equal(skip(p), false, p);
+  assert.equal(skip("/api/other", ["/api/other"]), true, "an operator prefix is honoured");
+  assert.ok(GENERAL_LIMITER_SKIP_PREFIXES.includes("/ramble/") && GENERAL_LIMITER_SKIP_PREFIXES.includes("/api/ramble/"));
+});


### PR DESCRIPTION
Hotfix for the first phone walk (2026-09-07): the general per-IP limiter (200 requests / 15 min) counted `/ramble/tiles/…` (about 50 proxied tiles per map view), `/ramble/static/…` and `/api/ramble/…`. A normal session exhausted the bucket, the egg check-in answered 429 "Too many requests", and re-opening the panel 429'd its own scripts and stylesheet for the rest of the window.

- The exempt list moves into `servers/gateway/middleware/rate-limit.js` as `GENERAL_LIMITER_SKIP_PREFIXES` (`/dashboard`, `/api/meta-glasses/`, `/llm`, and now `/ramble/`, `/api/ramble/`) with a `generalLimiterSkip(req, extraPrefixes)` predicate; `index.js` uses it (the `GATEWAY_RATE_LIMIT_SKIP_PREFIXES` env knob still works). Every exempt path already sits behind its own gate (dashboard session, device binding, in-process router).
- `tests/rate-limit-middleware.test.js` pins the list: the Ramble surfaces skip, `/api/chat`, `/api/ramblex`, `/rambler`, `/mcp`, `/` do not, an operator prefix is honoured.
- Verified: `tests/rate-limit-middleware.test.js` + `tests/auth-network.test.js` 27/27; the gateway boots from a scratch data dir with the change.

Deploy: core change — restart all three gateways after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpkA6EtBWm2rnr7miS8yAV