### PR TITLE
ramble 0.7.0: World name + "your mark" labels (Plan A)

### DIFF
--- a/bundles/ramble/manifest.json
+++ b/bundles/ramble/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ramble",
   "name": "Ramble",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "mcp-server",
   "author": "Crow",
   "category": "social",

--- a/bundles/ramble/package.json
+++ b/bundles/ramble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crow-ramble",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Ramble MCP server — proximity marks, caws, privacy grid, egg and bird companion, gifts and swaps",
   "type": "module",
   "main": "server/index.js",

--- a/bundles/ramble/panel/ramble.js
+++ b/bundles/ramble/panel/ramble.js
@@ -360,6 +360,11 @@ export default {
                 <option value="real">real</option>
               </select>
             </div>
+            <div class="rb-row">
+              <label class="rb-label" for="rb-world-name">World name</label>
+              <input id="rb-world-name" type="text" maxlength="24" autocomplete="nickname" placeholder="how strangers see you">
+            </div>
+            <p class="rb-muted rb-fine">Strangers see your world name on your marks when Name is pseudonym or real, next to a short key so two people with one name stay apart. Contacts always see your Crow name.</p>
             <p class="rb-muted rb-fine" id="rb-grid-status"></p>
           </div>
         </div>

--- a/bundles/ramble/panel/ramble.js
+++ b/bundles/ramble/panel/ramble.js
@@ -364,7 +364,7 @@ export default {
               <label class="rb-label" for="rb-world-name">World name</label>
               <input id="rb-world-name" type="text" maxlength="24" autocomplete="nickname" placeholder="how strangers see you">
             </div>
-            <p class="rb-muted rb-fine">Strangers see your world name on your marks when Name is pseudonym or real, next to a short key so two people with one name stay apart. Contacts always see your Crow name.</p>
+            <p class="rb-muted rb-fine">Strangers see your world name on your marks when Name is pseudonym or real, next to a short key so two people with one name stay apart. Contacts see the name they saved for you.</p>
             <p class="rb-muted rb-fine" id="rb-grid-status"></p>
           </div>
         </div>

--- a/bundles/ramble/panel/routes.js
+++ b/bundles/ramble/panel/routes.js
@@ -625,6 +625,7 @@ export default function rambleRouter(dashboardAuth, options = {}) {
     if (b.identityLevel != null && !IDENTITY_LEVELS.includes(b.identityLevel)) {
       bad(`identityLevel must be one of: ${IDENTITY_LEVELS.join(", ")}`);
     }
+    if (b.worldName != null && (typeof b.worldName !== "string" || b.worldName.length > 128)) bad("worldName must be a string of at most 128 characters");
     if (b.cells != null) {
       if (typeof b.cells !== "object" || Array.isArray(b.cells)) bad("cells must be an object");
       for (const [audience, channels] of Object.entries(b.cells)) {
@@ -646,6 +647,7 @@ export default function rambleRouter(dashboardAuth, options = {}) {
       }
     }
     if (b.identityLevel != null) await mods.gridMod.setIdentityLevel(db, b.identityLevel, { emit });
+    if (b.worldName != null) await mods.gridMod.setWorldName(db, b.worldName, { emit });
 
     res.json(await mods.gridMod.getGrid(db));
   }));

--- a/bundles/ramble/panel/routes.js
+++ b/bundles/ramble/panel/routes.js
@@ -277,7 +277,7 @@ export default function rambleRouter(dashboardAuth, options = {}) {
    * mark by a contact is named (phase 3); a stranger's stays anonymous.
    */
   async function annotateMarks(marks) {
-    const byPubkey = await contactsByPubkey();
+    const byPubkey = await mods.deliveryMod.contactsByPubkey(db);
     return marks.map(withApproxAnchor).map((m) => {
       const c = m.origin === "remote" ? byPubkey.get(String(m.author)) : null;
       return c ? { ...m, contact_name: c.name } : m;
@@ -344,22 +344,6 @@ export default function rambleRouter(dashboardAuth, options = {}) {
   async function contactOrNull(crowId) {
     try { return await mods.deliveryMod.resolveContact(db, crowId); }
     catch (err) { console.warn("[ramble routes] contact lookup failed:", err?.message ?? err); return null; }
-  }
-
-  /** x-only pubkey -> { crow_id, name } for every unblocked full contact — bots included on purpose, naming a bot's mark is harmless (round-2 Q2). Tolerant: empty map without the core tables. */
-  async function contactsByPubkey() {
-    const map = new Map();
-    try {
-      // ORDER BY id + first-wins: two contact rows can share a key (a bot
-      // hosted beside its owner); the older row names the mark, deterministically.
-      const { rows } = await db.execute({ sql: "SELECT crow_id, display_name, secp256k1_pubkey FROM contacts WHERE is_blocked = 0 AND request_status IS NULL ORDER BY id", args: [] });
-      for (const r of rows) {
-        const pk = String(r.secp256k1_pubkey || "");
-        const key = pk.length === 66 ? pk.slice(2) : pk;
-        if (key && !map.has(key)) map.set(key, { crow_id: r.crow_id, name: r.display_name || r.crow_id });
-      }
-    } catch { /* no core tables: nobody is a contact */ }
-    return map;
   }
 
   async function contactNames() {

--- a/bundles/ramble/panel/static/ramble.css
+++ b/bundles/ramble/panel/static/ramble.css
@@ -248,7 +248,8 @@
   color: var(--rb-text);
   background: var(--rb-surface);
 }
-#ramble select {
+#ramble select,
+#ramble .rb-sheet input[type="text"] {
   min-height: var(--rb-tap);
   padding: 0 12px;
   border: var(--rb-line-w) solid var(--rb-line);
@@ -257,6 +258,7 @@
   color: var(--rb-text);
   font: 700 15px var(--rb-font-body);
 }
+#ramble .rb-sheet input[type="text"] { flex: 1; min-width: 0; }
 #ramble svg.rb-i { width: 20px; height: 20px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; flex: 0 0 auto; }
 
 /* -------------------------------------------------------------------- map */

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -269,10 +269,16 @@
 
   /* ---------------------------------------------------------------- marks */
 
+  /* The one label rule (spec 2026-09-08 §3.1), mirrored from server/labels.js:
+   * yours, then a contact's saved name, then a stranger's world name with a
+   * key tail (unverified, so the tail keeps two Kevins apart), then the key. */
   function markLabel(mark) {
-    if (mark.contact_name) return (mark.kind === "caw" ? "caw by " : "mark by ") + mark.contact_name;
-    var who = (mark.author || "anon").slice(0, 8);
-    return (mark.kind === "caw" ? "caw by " : "mark by ") + who;
+    var noun = mark.kind === "caw" ? "caw" : "mark";
+    if (mark.origin === "local" || mark.origin === "sync") return "your " + noun;
+    if (mark.contact_name) return noun + " by " + mark.contact_name;
+    var who = mark.author || "anon";
+    if (mark.author_name) return noun + " by " + mark.author_name + " · " + who.slice(0, 4);
+    return noun + " by " + who.slice(0, 8);
   }
 
   /** A stranger's bird on your map: the way to trade with them is to become contacts first. */
@@ -1474,7 +1480,12 @@
 
   function arTitle(mark) {
     if (isLocked(mark)) return "A locked mark";
-    if (mark.kind === "caw") return "A caw" + (mark.contact_name ? " from " + mark.contact_name : "");
+    if (mark.kind === "caw") {
+      if (mark.origin === "local" || mark.origin === "sync") return "Your caw";
+      if (mark.contact_name) return "A caw from " + mark.contact_name;
+      if (mark.author_name) return "A caw from " + mark.author_name + " · " + (mark.author || "anon").slice(0, 4);
+      return "A caw";
+    }
     var t = String(mark.content_text || "(no text)").trim();
     return t.length > 40 ? t.slice(0, 39) + "…" : t;
   }

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -742,6 +742,7 @@
     if (masterEl) masterEl.checked = !!grid.master;
     if (identityEl && grid.identityLevel) identityEl.value = grid.identityLevel;
     if (worldNameEl && worldNameEl !== document.activeElement) worldNameEl.value = grid.worldName || "";
+    if (worldNameEl) worldNameEl.placeholder = grid.identityLevel === "rotating" ? "not sent while Name is rotating" : "how strangers see you";
     cellEls.forEach(function (el) {
       var row = grid.cells && grid.cells[el.getAttribute("data-audience")];
       el.checked = !!(row && row[el.getAttribute("data-channel")]);

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -717,6 +717,7 @@
   var sheetEl = $("rb-grid-sheet");
   var masterEl = $("rb-master");
   var identityEl = $("rb-identity");
+  var worldNameEl = $("rb-world-name");
   var cellEls = Array.prototype.slice.call(document.querySelectorAll(".rb-grid-cell"));
 
   function openSheet(open) {
@@ -740,6 +741,7 @@
     if (!grid) return;
     if (masterEl) masterEl.checked = !!grid.master;
     if (identityEl && grid.identityLevel) identityEl.value = grid.identityLevel;
+    if (worldNameEl && worldNameEl !== document.activeElement) worldNameEl.value = grid.worldName || "";
     cellEls.forEach(function (el) {
       var row = grid.cells && grid.cells[el.getAttribute("data-audience")];
       el.checked = !!(row && row[el.getAttribute("data-channel")]);
@@ -757,6 +759,7 @@
 
   if (masterEl) masterEl.addEventListener("change", function () { postGrid({ master: masterEl.checked }); });
   if (identityEl) identityEl.addEventListener("change", function () { postGrid({ identityLevel: identityEl.value }); });
+  if (worldNameEl) worldNameEl.addEventListener("change", function () { worldNameEl.blur(); postGrid({ worldName: worldNameEl.value }); });
   cellEls.forEach(function (el) {
     el.addEventListener("change", function () {
       var cells = {};

--- a/bundles/ramble/server/delivery.js
+++ b/bundles/ramble/server/delivery.js
@@ -210,6 +210,26 @@ export async function listAudiences(db) {
 }
 
 /**
+ * x-only pubkey -> { crow_id, name } for every unblocked full contact, bots
+ * included on purpose (naming a bot's mark is harmless). ORDER BY id +
+ * first-wins so two rows sharing a key name the older one deterministically.
+ * Tolerant: an empty map when the core table is unreadable (the stdio MCP
+ * process on a fresh db).
+ */
+export async function contactsByPubkey(db) {
+  const map = new Map();
+  try {
+    const { rows } = await db.execute({ sql: "SELECT crow_id, display_name, secp256k1_pubkey FROM contacts WHERE is_blocked = 0 AND request_status IS NULL ORDER BY id", args: [] });
+    for (const r of rows) {
+      const pk = String(r.secp256k1_pubkey || "");
+      const key = pk.length === 66 ? pk.slice(2) : pk;
+      if (key && !map.has(key)) map.set(key, { crow_id: r.crow_id, name: r.display_name || r.crow_id });
+    }
+  } catch { /* no core tables: nobody is a contact */ }
+  return map;
+}
+
+/**
  * Who a mark with this visibility goes to. `contacts` = every deliverable
  * contact; `group:<uid>` = the deliverable members of that PLAIN contact group
  * (rooms — room_uid NOT NULL — are not groups). Public/private marks never

--- a/bundles/ramble/server/grid.js
+++ b/bundles/ramble/server/grid.js
@@ -36,7 +36,8 @@ export function sanitizeWorldName(value) {
   let s = value
     .replace(/[\x00-\x1F\x7F\x80-\x9F]/g, "")
     .replace(/[\u202A-\u202E\u2066-\u2069]/g, "")
-    .replace(/·/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
+    .replace(/[\u00AD\u061C\u200B-\u200F\u2060-\u2064\uFEFF]/g, "") // zero-width: "f6<ZWSP>65c26b" must not slip past the hex rule
+    .replace(/\u00B7/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
   s = s.replace(/\s+/g, " ").trim();
   if (/^(crow|req):/i.test(s)) return null;
   const points = Array.from(s);

--- a/bundles/ramble/server/grid.js
+++ b/bundles/ramble/server/grid.js
@@ -35,7 +35,7 @@ export function sanitizeWorldName(value) {
   if (typeof value !== "string") return null;
   let s = value
     .replace(/[\x00-\x1F\x7F\x80-\x9F]/g, "")
-    .replace(/[‪-‮⁦-⁩]/g, "")
+    .replace(/[\u202A-\u202E\u2066-\u2069]/g, "")
     .replace(/·/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
   s = s.replace(/\s+/g, " ").trim();
   if (/^(crow|req):/i.test(s)) return null;

--- a/bundles/ramble/server/grid.js
+++ b/bundles/ramble/server/grid.js
@@ -21,6 +21,30 @@ export const AUDIENCES = ["public", "contacts", "groups"];
 export const CHANNELS = ["ble", "lan", "geo"];
 export const IDENTITY_LEVELS = ["rotating", "pseudonym", "real"];
 
+/** Spec 2026-09-08 §2.1: the name strangers see, capped short so a label stays one line. */
+export const WORLD_NAME_MAX = 24;
+
+/**
+ * The same seven steps as core's sanitizeDisplayName (kept in the bundle so
+ * the stdio MCP process needs no core import), then the two Ramble rules: a
+ * 24-code-point cap and no hex-only values (a name that looks like a key
+ * tail would defeat the "name · key4" disambiguation). Applied on save AND
+ * on every read from the wire.
+ */
+export function sanitizeWorldName(value) {
+  if (typeof value !== "string") return null;
+  let s = value
+    .replace(/[\x00-\x1F\x7F\x80-\x9F]/g, "")
+    .replace(/[‪-‮⁦-⁩]/g, "")
+    .replace(/·/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
+  s = s.replace(/\s+/g, " ").trim();
+  if (/^(crow|req):/i.test(s)) return null;
+  const points = Array.from(s);
+  if (points.length > WORLD_NAME_MAX) s = points.slice(0, WORLD_NAME_MAX).join("").trim();
+  if (/^[0-9a-f]{4,}$/i.test(s)) return null;
+  return s.length > 0 ? s : null;
+}
+
 async function safeEmit(emit, table, op, row) {
   if (!emit) return;
   try { await emit(table, op, row); }
@@ -64,6 +88,7 @@ export async function getGrid(db) {
 
   const master = (await readSetting(db, "master")) === "1";
   const identityLevel = (await readSetting(db, "public_identity_level")) ?? "rotating";
+  const worldName = sanitizeWorldName(await readSetting(db, "world.name"));
 
   let activeArea = [];
   const rawArea = await readSetting(db, "local.active_area");
@@ -76,7 +101,7 @@ export async function getGrid(db) {
     }
   }
 
-  return { master, cells, identityLevel, activeArea };
+  return { master, cells, identityLevel, worldName, activeArea };
 }
 
 export async function setCell(db, audience, channel, on, { emit } = {}) {
@@ -116,6 +141,13 @@ export async function setMaster(db, on, { emit } = {}) {
 export async function setIdentityLevel(db, level, { emit } = {}) {
   if (!IDENTITY_LEVELS.includes(level)) throw new Error(`unknown identity level: ${level}`);
   await writeSetting(db, "public_identity_level", level, { emit });
+}
+
+/** Store the sanitized world name ("" when rejected/empty, so a bad value never lingers). Returns what was stored, or null. */
+export async function setWorldName(db, name, { emit } = {}) {
+  const clean = sanitizeWorldName(name);
+  await writeSetting(db, "world.name", clean ?? "", { emit });
+  return clean;
 }
 
 /** True only when the master switch AND the specific (audience, channel) cell are both on. */

--- a/bundles/ramble/server/init-tables.js
+++ b/bundles/ramble/server/init-tables.js
@@ -51,6 +51,7 @@ export async function initRambleTables(db) {
 
   await ensureColumn(db, "ramble_marks", "bird_species", "TEXT");
   await ensureColumn(db, "ramble_marks", "bird_seed", "INTEGER");
+  await ensureColumn(db, "ramble_marks", "author_name", "TEXT");
 
   await initTable(db, "ramble_pet", `
     CREATE TABLE IF NOT EXISTS ramble_pet (

--- a/bundles/ramble/server/labels.js
+++ b/bundles/ramble/server/labels.js
@@ -1,0 +1,29 @@
+/**
+ * Ramble labels — the ONE rule for "who left this" (spec 2026-09-08 §3.1),
+ * used by the MCP world query here and mirrored by the panel client's
+ * markLabel (a plain script cannot import this). Order matters:
+ *   1. yours (origin local or sync — sync rows are your own other instances);
+ *   2. a contact's saved name (verified by the handshake key; no tail);
+ *   3. a stranger's chosen world name plus a key tail (unverified, so the
+ *      tail keeps two "Kevin"s apart and matches the key the map showed);
+ *   4. the short key alone.
+ */
+export function keyTail(author, n) {
+  return typeof author === "string" && author.length > 0 ? author.slice(0, n) : "anon";
+}
+
+export function labelFor(row, { contactName = null } = {}) {
+  const noun = row?.kind === "caw" ? "caw" : "mark";
+  if (row?.origin === "local" || row?.origin === "sync") return `your ${noun}`;
+  if (contactName) return `${noun} by ${contactName}`;
+  if (row?.author_name) return `${noun} by ${row.author_name} · ${keyTail(row.author, 4)}`;
+  return `${noun} by ${keyTail(row?.author, 8)}`;
+}
+
+/** The AR anchor title for a caw, same order. */
+export function cawTitleFor(row, { contactName = null } = {}) {
+  if (row?.origin === "local" || row?.origin === "sync") return "Your caw";
+  if (contactName) return `A caw from ${contactName}`;
+  if (row?.author_name) return `A caw from ${row.author_name} · ${keyTail(row.author, 4)}`;
+  return "A caw";
+}

--- a/bundles/ramble/server/marks.js
+++ b/bundles/ramble/server/marks.js
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import { encodeGeohash } from "./anchors.js";
 import { teaser, revealContent } from "./reveal.js";
 import { escapeLikePattern } from "./db.js";
+import { sanitizeWorldName } from "./grid.js";
 
 async function safeEmit(emit, table, op, row) {
   if (!emit) return;
@@ -216,12 +217,12 @@ export async function insertRemoteMark(db, row) {
     sql: `INSERT INTO ramble_marks (
             mark_id, author, author_level, kind, anchor_kind, geohash, lat, lon, accuracy_m, anchor_ref,
             visibility, reveal, content_text, content_kind, content_ref,
-            created_at, expires_at, nostr_event_id, publish_state, origin, bird_species, bird_seed
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'remote', 'remote', ?, ?)`,
+            created_at, expires_at, nostr_event_id, publish_state, origin, bird_species, bird_seed, author_name
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'remote', 'remote', ?, ?, ?)`,
     args: [
       mark_id, row.author, row.author_level ?? null, row.kind, anchor_kind, finalGeohash, lat, lon, accuracy_m, anchor_ref,
       row.visibility ?? "public", row.reveal ?? "open", row.content_text ?? null, row.content_kind ?? "none", row.content_ref ?? null,
-      created_at, expires_at, row.nostr_event_id ?? null, row.bird_species ?? null, row.bird_seed ?? null,
+      created_at, expires_at, row.nostr_event_id ?? null, row.bird_species ?? null, row.bird_seed ?? null, sanitizeWorldName(row.author_name),
     ],
   });
 

--- a/bundles/ramble/server/nostr-map.js
+++ b/bundles/ramble/server/nostr-map.js
@@ -20,6 +20,7 @@
  */
 
 import { createRequire } from "node:module";
+import { sanitizeWorldName } from "./grid.js";
 
 const require = createRequire(import.meta.url);
 const { isValidBird } = require("./bird-svg.cjs");
@@ -74,7 +75,7 @@ function geohashPrefixTags(geohash) {
  * Tag order: g (shortest first), d (marks only), k, rv, expiration (if
  * set), crow (if crowId given).
  */
-export function markToEvent(row, { precision = 5, crowId = null, bird = null } = {}) {
+export function markToEvent(row, { precision = 5, crowId = null, bird = null, name = null } = {}) {
   if (row.visibility !== "public") {
     throw new RambleNotPublic(`markToEvent: mark ${row.mark_id} is not public (visibility=${row.visibility})`);
   }
@@ -121,6 +122,12 @@ export function markToEvent(row, { precision = 5, crowId = null, bird = null } =
   // fails isValidBird (unknown species, non-uint32 seed) is silently
   // dropped rather than shipped malformed.
   if (isValidBird(bird)) content.bird = { species: bird.species, seed: bird.seed };
+
+  // The author's chosen world name (spec 2026-09-08 §2.2). The transport
+  // hands it over only for pseudonym/real rows — a rotating row never gets
+  // one — and it is sanitized again here so a bad setting cannot reach a relay.
+  const cleanName = sanitizeWorldName(name);
+  if (cleanName) content.name = cleanName;
 
   return { kind: isCaw ? CAW_KIND : MARK_KIND, created_at, tags, content: JSON.stringify(content) };
 }
@@ -178,5 +185,6 @@ export function eventToMark(event) {
     crow_id: crowTag ?? null,
     bird_species: validBird ? validBird.species : null,
     bird_seed: validBird ? validBird.seed : null,
+    author_name: sanitizeWorldName(content.name),
   };
 }

--- a/bundles/ramble/server/reveal.js
+++ b/bundles/ramble/server/reveal.js
@@ -6,7 +6,7 @@ export function anchorOf(row) {
 export function teaser(row) {
   if (row.reveal === "open") return { ...row };
   // For locked (or any non-open value): return only safe fields
-  const allowed = ["mark_id", "author", "author_level", "kind", "anchor_kind", "geohash", "reveal", "visibility", "created_at", "expires_at", "content_kind", "origin", "publish_state", "bird_species", "bird_seed"];
+  const allowed = ["mark_id", "author", "author_level", "kind", "anchor_kind", "geohash", "reveal", "visibility", "created_at", "expires_at", "content_kind", "origin", "publish_state", "bird_species", "bird_seed", "author_name"];
   const safe = {};
   for (const field of allowed) {
     if (field in row) safe[field] = row[field];

--- a/bundles/ramble/server/server.js
+++ b/bundles/ramble/server/server.js
@@ -29,7 +29,8 @@ import { petState, doChore } from "./pet.js";
 import { eggState, activeBird, isoWeek } from "./eggs.js";
 import { feedAll } from "./feed.js";
 import { flockState, listNests, claimNest } from "./flock.js";
-import { resolveContact, resolveAudience, enqueueMark, CROW_ID_RE, ID_RE } from "./delivery.js";
+import { resolveContact, resolveAudience, enqueueMark, contactsByPubkey, CROW_ID_RE, ID_RE } from "./delivery.js";
+import { labelFor } from "./labels.js";
 import { giftEgg, proposeSwap } from "./trades.js";
 
 const text = (t) => ({ content: [{ type: "text", text: t }] });
@@ -242,7 +243,7 @@ export function createRambleServer(db, options = {}) {
 
   register(
     "ramble_query_world",
-    "List nearby marks and caws within the geohash cell containing the given location.",
+    "List nearby marks and caws within the geohash cell containing the given location. Each row carries a label (\"your mark\", \"mark by <contact>\", \"mark by <world name> · <key4>\", or \"mark by <key8>\").",
     {
       lat: z.number().min(-90).max(90),
       lon: z.number().min(-180).max(180),
@@ -256,7 +257,12 @@ export function createRambleServer(db, options = {}) {
         const clampedEnvPrecision = Number.isInteger(envPrecision) && envPrecision >= 1 && envPrecision <= 12 ? envPrecision : 5;
         const p = precision ?? clampedEnvPrecision;
         const cell = encodeGeohash(lat, lon, p);
-        const marks = await listMarks(db, { visibility, geohashPrefix: cell });
+        const rows = await listMarks(db, { visibility, geohashPrefix: cell });
+        const byPubkey = await contactsByPubkey(db);
+        const marks = rows.map((m) => {
+          const c = m.origin === "remote" ? byPubkey.get(String(m.author)) : null;
+          return { ...m, label: labelFor(m, { contactName: c ? c.name : null }) };
+        });
         return text(JSON.stringify({ cell, marks }));
       } catch (err) {
         return errorText(err.message);

--- a/docs/es/guide/ramble.md
+++ b/docs/es/guide/ramble.md
@@ -29,6 +29,8 @@ El **nivel de identidad pública** decide qué clave firma lo que publicas:
 | `pseudonym` | Marcas y caws usan el seudónimo estable — identidad consistente, sin vínculo con tu id real de Crow. |
 | `real` | La clave propia de tu instancia y su `crow_id`. Todo lo que publiques es atribuible a este Crow. |
 
+**Nombre en el mundo.** En la hoja Visible puedes fijar un nombre en el mundo (hasta 24 caracteres) que los desconocidos ven en tus marcas y caws públicos en lugar de una clave — pero solo mientras tu nivel de Nombre sea `pseudonym` o `real`; en `rotating` no sale nada más que la clave corta. No está verificado, así que el nombre de un desconocido se muestra siempre con los cuatro primeros caracteres de su clave ("Kevin · f665"). Los contactos nunca lo ven: ven el nombre que guardaron para ti. Tus propias marcas dicen "your mark".
+
 ## Cómo funciona la publicación
 
 La autoría es local y síncrona; el cable no. Una marca nueva se guarda con `publish_state = 'pending'`, y el transporte del gateway la publica en el siguiente tick de drenaje (cada 15 s, o de inmediato si se creó dentro del mismo proceso).

--- a/docs/es/guide/ramble.md
+++ b/docs/es/guide/ramble.md
@@ -143,7 +143,7 @@ Toca **Mirar alrededor** en el mapa para abrir la vista AR: la cámara trasera l
 
 La posición viene de `watchPosition`; el rumbo de `deviceorientationabsolute` (Safari informa `webkitCompassHeading` en el evento normal, y iOS pide una vez acceso al movimiento desde el toque del botón). Sin posición, sin cámara o sin brújula se recurre a la **franja de radar** — un anillo de rumbos (norte arriba, o rumbo arriba cuando hay brújula) y una lista de distancias — así que la pantalla nunca queda en blanco; la primera apertura explica los límites (precisión de la brújula, el aviso de iOS, sin anclaje a superficies, la cámara se queda en el teléfono). La imagen de la cámara nunca sale del dispositivo: la vista se dibuja en el cliente sin captura, canvas ni subida, y el flujo se detiene al cerrar la vista o cambiar de pestaña (se reanuda al volver).
 
-El panel consulta `GET /api/ramble/around?lat=&lon=&radius_m=` (radio 50–1000 m, 500 por defecto): marcas tal como están guardadas (una marca bloqueada como su adelanto en el centro de la celda, la marca de un contacto con su nombre), cada una con `distance_m`, más los nidos de esta semana, los más cercanos primero. El panel lista lo mismo que el mapa (marcas públicas, de contactos y tus propias marcas "solo para mí"). Se actualiza tras moverte 50 m, una vez por minuto, al cerrar una etiqueta tocada y con cada evento en vivo. Es una lectura y no acredita nada. La vista necesita un contexto seguro: abre el Nest por su dirección HTTPS de Tailscale Serve, no por una URL `http://` con IP, o el navegador rechaza la cámara y la brújula y obtienes la franja de radar.
+El panel consulta `GET /api/ramble/around?lat=&lon=&radius_m=` (radio 50–1000 m, 500 por defecto): marcas tal como están guardadas (una marca bloqueada como su adelanto en el centro de la celda, la marca de un contacto con su nombre, el nombre en el mundo de un desconocido con la cola de su clave), cada una con `distance_m`, más los nidos de esta semana, los más cercanos primero. El panel lista lo mismo que el mapa (marcas públicas, de contactos y tus propias marcas "solo para mí"). Se actualiza tras moverte 50 m, una vez por minuto, al cerrar una etiqueta tocada y con cada evento en vivo. Es una lectura y no acredita nada. La vista necesita un contexto seguro: abre el Nest por su dirección HTTPS de Tailscale Serve, no por una URL `http://` con IP, o el navegador rechaza la cámara y la brújula y obtienes la franja de radar.
 
 ## Marcas solo para mí
 
@@ -196,7 +196,7 @@ Cada peso de la tabla anterior es también un override de `ramble_settings`, le�
 |---|---|
 | `ramble_leave_mark` | Dejar una marca en una ubicación. |
 | `ramble_caw` | Emitir un marcador de presencia público y efímero. |
-| `ramble_query_world` | Listar marcas y caws cercanos en la celda que contiene una ubicación. |
+| `ramble_query_world` | Listar marcas y caws cercanos en la celda que contiene una ubicación; cada fila lleva un `label` ("your mark", "mark by <contacto>", "mark by <nombre en el mundo> · <clave4>" o "mark by <clave8>"). |
 | `ramble_unlock` | Desbloquear una marca bloqueada probando proximidad a su ancla. |
 | `ramble_pet_state` | Ánimo, energía, contadores semanales, pájaro activo y progreso del huevo de la mascota compañera. |
 | `ramble_egg_state` | El progreso de calor del huevo incubando y la lista de comprobación hacia la eclosión. |

--- a/docs/guide/ramble.md
+++ b/docs/guide/ramble.md
@@ -29,6 +29,8 @@ The **public identity level** picks which key signs what you publish:
 | `pseudonym` | Both marks and caws use the stable world pseudonym — consistent identity, no link to your real Crow id. |
 | `real` | Your instance's own key and `crow_id`. Anything you publish is attributable to this Crow. |
 
+**World name.** In the Visible sheet you can set a world name (up to 24 characters) that strangers see on your public marks and caws instead of a bare key — but only while your Name level is `pseudonym` or `real`; at `rotating` nothing but the short key goes out. It is unverified, so a stranger's name is always shown with the first four characters of their key ("Kevin · f665"). Contacts never see it: they see the name they saved for you. Your own marks read "your mark".
+
 ## How publishing works
 
 Authoring is local and synchronous; the wire is not. A new mark is stored with `publish_state = 'pending'`, and the gateway's transport publishes it on the next drain tick (every 15 s, or immediately when authored in-process).

--- a/docs/guide/ramble.md
+++ b/docs/guide/ramble.md
@@ -143,7 +143,7 @@ Tap **Look around** on the map to open the AR view: the rear camera fills the sc
 
 Position comes from `watchPosition`; heading from `deviceorientationabsolute` (Safari reports `webkitCompassHeading` on the plain event, and iOS asks once for motion access from the button tap). No fix, no camera or no compass falls back to the **radar strip** — a bearing ring (north up, or heading up when there is a compass) and a distance list — so the screen is never blank; the first open explains the limits (compass accuracy, the iOS prompt, no surface placement, the camera stays on the phone). The camera picture never leaves the device: the view is client-side rendering with no capture, canvas or upload, and the stream stops when you close the view or switch away from the tab (it restarts when you come back).
 
-The panel fetches `GET /api/ramble/around?lat=&lon=&radius_m=` (radius 50–1000 m, default 500): marks as stored (a locked mark as its cell-centre teaser, a contact's mark named), each with `distance_m`, plus this week's nests, nearest first. The panel lists what the map lists (public, contacts and your own "Just me" marks). It refreshes after you move 50 m, once a minute, when you close a tapped label, and on every live event. It is a read and credits nothing. The view needs a secure context: open the Nest over its HTTPS Tailscale Serve address, not a raw-IP `http://` URL, or the browser refuses the camera and the compass and you get the radar strip.
+The panel fetches `GET /api/ramble/around?lat=&lon=&radius_m=` (radius 50–1000 m, default 500): marks as stored (a locked mark as its cell-centre teaser, a contact's mark named, a stranger's world name with its key tail), each with `distance_m`, plus this week's nests, nearest first. The panel lists what the map lists (public, contacts and your own "Just me" marks). It refreshes after you move 50 m, once a minute, when you close a tapped label, and on every live event. It is a read and credits nothing. The view needs a secure context: open the Nest over its HTTPS Tailscale Serve address, not a raw-IP `http://` URL, or the browser refuses the camera and the compass and you get the radar strip.
 
 ## Just me marks
 
@@ -196,7 +196,7 @@ Every weight from the table above is also a `ramble_settings` override, read liv
 |---|---|
 | `ramble_leave_mark` | Leave a mark at a location. |
 | `ramble_caw` | Broadcast a short-lived public presence marker. |
-| `ramble_query_world` | List nearby marks and caws in the cell containing a location. |
+| `ramble_query_world` | List nearby marks and caws in the cell containing a location; each row carries a `label` ("your mark", "mark by <contact>", "mark by <world name> · <key4>", or "mark by <key8>"). |
 | `ramble_unlock` | Unlock a locked mark by proving proximity to its anchor. |
 | `ramble_pet_state` | The companion pet's mood, energy, weekly counters, active bird, and egg progress. |
 | `ramble_egg_state` | The incubating egg's warmth progress and hatch checklist. |

--- a/docs/superpowers/plans/2026-09-08-ramble-world-name.md
+++ b/docs/superpowers/plans/2026-09-08-ramble-world-name.md
@@ -14,7 +14,7 @@
 
 - **DB access** through the bundle's `createDbClient()` / `appImport("servers/db.js")` only; async libsql-shaped client. Test files may use `@libsql/client` in-memory; bundle server files never import it.
 - **No `SCHEMA_GENERATION` bump; no new table.** The one new column is `ramble_marks.author_name TEXT` via `ensureColumn` in `bundles/ramble/server/init-tables.js`. `ramble_marks` is already replicated: the column joins `RAMBLE_MARK_WIRE_COLUMNS` in `servers/sharing/instance-sync.js` (and therefore `RAMBLE_MARK_UPDATE_COLUMNS`); the apply door is tested with the column. The setting `world.name` is a plain `ramble_settings` row (not `local.`-prefixed → replicates; `EXCLUDED_COLUMNS.ramble_settings` unchanged).
-- **World name rules (spec §2.1, exact):** `sanitizeWorldName(value)`: non-string → `null`; strip C0/DEL/C1 controls and bidi overrides/isolates; collapse whitespace, trim; reject `/^(crow|req):/i` → `null`; cap at `WORLD_NAME_MAX = 24` code points (truncate); reject a value that is only hex of 4+ chars `/^[0-9a-f]{4,}$/i` → `null`; empty → `null`. Applied on save AND on every read from the wire.
+- **World name rules (spec §2.1, exact):** `sanitizeWorldName(value)`: non-string → `null`; strip C0/DEL/C1 controls and bidi overrides/isolates; collapse whitespace, trim; reject `/^(crow|req):/i` → `null`; cap at `WORLD_NAME_MAX = 24` code points (truncate); reject a value that is only hex of 4+ chars `/^[0-9a-f]{4,}$/i` → `null`; empty → `null`. Applied on save AND on every read from the wire, and again at the store (`insertRemoteMark`) as defense in depth; instance sync carries the column trusted (same-owner instances; own rows never carry a name, so a synced `author_name` is never displayed).
 - **Wire (spec §2.2, exact):** `markToEvent(row, { precision, crowId, bird, name })` adds `content.name` only when `sanitizeWorldName(name)` is non-null; the TRANSPORT passes `name` only when `(row.author_level ?? level) ∈ { pseudonym, real }` (`level` = the instance's `public_identity_level`), so a `rotating` row never carries one (D1; note: at `rotating` only CAWS rotate their key — marks already use the stable world key — the decision stands: the level decides). `eventToMark` sets `author_name: sanitizeWorldName(content.name)`. Contacts/group marks (`markPayload` / `payloadToMark`) never carry or read a name.
 - **Labels (spec §3.1, exact, in this order):** own (`origin` ∈ `local`, `sync`) → `your mark` / `your caw`; contact (`contact_name`) → `mark by <contact name>`; stranger with `author_name` → `mark by <author_name> · <key4>`; else → `mark by <key8>`. `key4`/`key8` = the first 4/8 characters of `author`, `anon` when missing. AR caw title: `Your caw` / `A caw from <contact name>` / `A caw from <author_name> · <key4>` / `A caw`.
 - **Teasers:** `reveal.js`'s allowlist gains `author_name` (a locked stranger's mark still shows who left it, as `author` already does).
@@ -73,6 +73,7 @@ test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:
   assert.equal(sanitizeWorldName("f665c26b"), null, "a key look-alike");
   assert.equal(sanitizeWorldName("DEADBEEF1234"), null);
   assert.equal(sanitizeWorldName("Kev1"), "Kev1", "hex-ish but not all hex");
+  assert.equal(sanitizeWorldName("Kev · f665"), "Kev f665", "the label separator cannot be faked");
   assert.equal(sanitizeWorldName("abc"), "abc", "3 hex chars is a word, not a tail");
   assert.equal(sanitizeWorldName("x".repeat(40)), "x".repeat(24));
   assert.equal(sanitizeWorldName("🐦".repeat(30)), "🐦".repeat(24), "code points, not UTF-16 units");
@@ -120,7 +121,8 @@ export function sanitizeWorldName(value) {
   if (typeof value !== "string") return null;
   let s = value
     .replace(/[\x00-\x1F\x7F\x80-\x9F]/g, "")
-    .replace(/[‪-‮⁦-⁩]/g, "");
+    .replace(/[‪-‮⁦-⁩]/g, "")
+    .replace(/·/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
   s = s.replace(/\s+/g, " ").trim();
   if (/^(crow|req):/i.test(s)) return null;
   const points = Array.from(s);
@@ -173,7 +175,7 @@ test("world name: rides in content only when given and clean; eventToMark reads 
   assert.equal(JSON.parse(markToEvent(row, { name: "f665c26b" }).content).name, undefined, "a key look-alike is dropped");
   assert.equal(JSON.parse(markToEvent(row, { name: "crow:x" }).content).name, undefined);
   const ev = { id: "e".repeat(64), pubkey: "a".repeat(64), kind: MARK_KIND, created_at: 1, tags: [["g", "9v6m2"], ["d", "m1"]], content: JSON.stringify({ v: 1, text: "hi", name: "  Bad Name " }) };
-  assert.equal(eventToMark(ev).author_name, "BadName");
+  assert.equal(eventToMark(ev).author_name, "Bad Name", "collapsed, not squeezed");
   ev.content = JSON.stringify({ v: 1, text: "hi", name: "deadbeef" });
   assert.equal(eventToMark(ev).author_name, null);
   ev.content = JSON.stringify({ v: 1, text: "hi" });
@@ -192,17 +194,17 @@ test("insertRemoteMark stores author_name and a locked teaser keeps it", async (
   const result = await insertRemoteMark(db, {
     mark_id: "named-remote-1", author: "pk9", kind: "mark", anchor_kind: "geo", geohash: "9v6m2c",
     lat: 30.2672, lon: -97.7431, visibility: "public", reveal: "locked", content_text: "named",
-    created_at: Date.now(), nostr_event_id: "ev-named-1", author_name: "Kevin",
+    created_at: Date.now(), nostr_event_id: "ev-named-1", author_name: "  Kevin‮ ",
   });
   assert.equal(result.inserted, true);
-  assert.equal(result.row.author_name, "Kevin");
+  assert.equal(result.row.author_name, "Kevin", "sanitized at the store too");
   const listed = (await listMarks(db, { visibility: "public" })).find((r) => r.mark_id === "named-remote-1");
   assert.equal(listed.author_name, "Kevin", "the teaser allowlist carries the name");
   assert.equal(listed.content_text, undefined, "still a teaser");
 });
 ```
 
-`tests/ramble-sync.test.js` — append (`b` is the file's peer db; `applyRemoteOp` is imported):
+`tests/ramble-sync.test.js` — append (`b` is the file's peer db; `applyRemoteOp` is imported). Only the apply door is tested: own rows never carry a name, so an outbox-door assertion would be vacuous (Review ruling R1-3).
 
 ```js
 test("author_name rides the apply door (wire column) and is updatable by LWW", async () => {
@@ -244,7 +246,19 @@ test("world name rides only pseudonym/real rows: a rotating row never carries it
 (`makeHarness`, `seedPublicMark(db, text, extra)` — `extra` spreads over `author_level` — `setMaster`, `setCell`, `h.published`, `h.transport.drainOnce()` are the file's existing fixtures; the harness's default gate is the real `makePublishGate`, hence the master + public/geo cell.)
 ```
 
-- [ ] **Step 2: Run** the four files → the new tests FAIL.
+`tests/ramble-delivery.test.js` — append (reuse the `row` and `PK` fixtures of its `markPayload`/`payloadToMark` bird test; import nothing new):
+
+```js
+test("contacts marks never carry a world name in either direction", () => {
+  const payload = markPayload({ ...row, author_name: "Kevin" });
+  assert.equal(payload.author_name, undefined);
+  assert.equal(payload.name, undefined);
+  const back = payloadToMark({ ...payload, author_name: "Kevin", name: "Kevin" }, { author: PK, eventId: "evt-n" });
+  assert.equal(back.author_name, undefined, "a contact is named from the contacts table, never from the payload");
+});
+```
+
+- [ ] **Step 2: Run** the five files → the new tests FAIL.
 
 - [ ] **Step 3: Implement**
 
@@ -260,13 +274,21 @@ test("world name rides only pseudonym/real rows: a rotating row never carries it
 
 In `eventToMark`'s returned object add `author_name: sanitizeWorldName(content.name),` after `bird_seed`.
 
-`bundles/ramble/server/marks.js` `insertRemoteMark`: add `author_name` as the last INSERT column with `row.author_name ?? null` as the last arg (the VALUES list gains one `?`). Nothing for `createMark` (own rows carry no name; their label is "your mark").
+`bundles/ramble/server/marks.js`: `import { sanitizeWorldName } from "./grid.js";` (grid.js imports nothing from marks.js — no cycle). `insertRemoteMark`: add `author_name` as the last INSERT column with `sanitizeWorldName(row.author_name)` as the last arg (the VALUES list gains one `?`); if the function builds `result.row` from its own args rather than a re-read, use the same sanitized value there. Nothing for `createMark` (own rows carry no name; their label is "your mark").
 
 `bundles/ramble/server/reveal.js`: add `"author_name"` to `allowed` after `"bird_seed"`.
 
 `servers/sharing/instance-sync.js`: append `"author_name",` to `RAMBLE_MARK_WIRE_COLUMNS` with the comment `// 2026-09-08: the world name a stranger's mark was left under.`
 
-`servers/gateway/boot/ramble-transport.js`: the grid load destructures `{ makePublishGate }` — make it `{ makePublishGate, sanitizeWorldName }`. In `drainMarks`, after `const bird = await activeBird(db);` add `const worldName = sanitizeWorldName(await getSetting("world.name"));` and inside the row loop change the `markToEvent(...)` call to:
+`servers/gateway/boot/ramble-transport.js`: core consumes NO new bundle export (an installed copy older than 0.7.0 must keep draining — the phase-3 guarded-load lesson). In `drainMarks`, after `const bird = await activeBird(db);` add:
+
+```js
+    // Raw on purpose: markToEvent sanitizes (an installed bundle older than
+    // 0.7.0 ignores the option, so a stale copy keeps draining unchanged).
+    const worldName = await getSetting("world.name");
+```
+
+and inside the row loop change the `markToEvent(...)` call to:
 
 ```js
         const rowLevel = row.author_level ?? level;
@@ -274,8 +296,8 @@ In `eventToMark`'s returned object add `author_name: sanitizeWorldName(content.n
         const template = markToEvent(row, { precision: prec, crowId: persona.crowId, bird, name });
 ```
 
-- [ ] **Step 4: Run** `node scripts/run-suite.mjs tests/ramble-nostr-map.test.js tests/ramble-marks.test.js tests/ramble-sync.test.js tests/ramble-transport.test.js` → PASS.
-- [ ] **Step 5: Commit** — `git commit bundles/ramble/server/nostr-map.js bundles/ramble/server/marks.js bundles/ramble/server/reveal.js servers/sharing/instance-sync.js servers/gateway/boot/ramble-transport.js tests/ramble-nostr-map.test.js tests/ramble-marks.test.js tests/ramble-sync.test.js tests/ramble-transport.test.js -m "ramble wire: the world name rides pseudonym/real rows as content.name; author_name stored, teased and synced"`
+- [ ] **Step 4: Run** `node scripts/run-suite.mjs tests/ramble-nostr-map.test.js tests/ramble-marks.test.js tests/ramble-sync.test.js tests/ramble-transport.test.js tests/ramble-delivery.test.js` → PASS.
+- [ ] **Step 5: Commit** — `git commit bundles/ramble/server/nostr-map.js bundles/ramble/server/marks.js bundles/ramble/server/reveal.js servers/sharing/instance-sync.js servers/gateway/boot/ramble-transport.js tests/ramble-nostr-map.test.js tests/ramble-marks.test.js tests/ramble-sync.test.js tests/ramble-transport.test.js tests/ramble-delivery.test.js -m "ramble wire: the world name rides pseudonym/real rows as content.name; author_name stored, teased and synced"`
 
 ---
 
@@ -465,6 +487,11 @@ test("POST /api/ramble/grid stores a sanitized worldName, clears a rejected one,
   assert.equal((await (await req("/api/ramble/grid")).json()).worldName, "Kevin");
   res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "f665c26b" } });
   assert.equal((await res.json()).worldName, null, "a key look-alike clears the name");
+  await req("/api/ramble/grid", { method: "POST", body: { worldName: "Kevin" } });
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "" } });
+  assert.equal((await res.json()).worldName, null, "an empty string clears");
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: null, master: true } });
+  assert.equal(res.status, 200, "null means not-sent, not clear");
   res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "x".repeat(129) } });
   assert.equal(res.status, 400);
   res = await req("/api/ramble/grid", { method: "POST", body: { worldName: 7 } });
@@ -506,7 +533,7 @@ Docs — `docs/guide/ramble.md`, in `## Privacy` append a paragraph:
 
 Bump: `sed -i 's/"version": "0.6.0"/"version": "0.7.0"/' bundles/ramble/manifest.json bundles/ramble/package.json && npm run build-registry`.
 
-- [ ] **Step 4: Run** `tests/ramble-panel.test.js` → PASS (parity included). Then the FULL suite in the foreground (`node scripts/run-suite.mjs 2>&1 | tail -12`, expect pass = total, fail 0: 4186 + 8 new = 4194 — tables +0 (an assertion), grid +2, nostr-map +1, marks +1, sync +1, transport +1, labels +2, tools +1, panel +1 = 4196; report the actual), `node scripts/check-port-allocation.js`, `npm run build-registry -- --check`.
+- [ ] **Step 4: Run** `tests/ramble-panel.test.js` → PASS (parity included). Then the FULL suite in the foreground (`node scripts/run-suite.mjs 2>&1 | tail -12`, expect pass = total, fail 0: 4186 + 11 new = 4197 — grid +2, nostr-map +1, marks +1, sync +1, transport +1, delivery +1, labels +2, tools +1, panel +1; report the actual), `node scripts/check-port-allocation.js`, `npm run build-registry -- --check`.
 - [ ] **Step 5: Commit** — `git commit bundles/ramble/panel/ramble.js bundles/ramble/panel/routes.js bundles/ramble/panel/static/ramble.js bundles/ramble/panel/static/ramble.css docs/guide/ramble.md docs/es/guide/ramble.md bundles/ramble/manifest.json bundles/ramble/package.json registry/add-ons.json tests/ramble-panel.test.js -m "ramble 0.7.0: the World name field; docs en/es; registry"`
 - [ ] **Step 6 (controller):** push, PR, check-runs, merge, CROW-SCHEDULE.md, three-gateway restart (grackle: `refreshed ramble 0.6.0 -> 0.7.0`), Kevin sets a world name and leaves a pseudonym-level mark from grackle; a second instance (crow's transport receives the public event) stores `author_name` — verify with a read-only SELECT on crow's live db.
 
@@ -516,4 +543,15 @@ Bump: `sed -i 's/"version": "0.6.0"/"version": "0.7.0"/' bundles/ramble/manifest
 - Type consistency: `markToEvent`'s `name` option ↔ the transport call; `author_name` on rows ↔ `labelFor`/`markLabel`/`RAMBLE_MARK_WIRE_COLUMNS`/`insertRemoteMark`/teaser; `getGrid().worldName` ↔ the route response ↔ `paintGrid`; `contactsByPubkey` in delivery.js ↔ routes.js and server.js.
 
 ## Review
-Recorded below after each gate (round 1, round 2, scoped check), before execution.
+
+### Round 1 — 2026-09-08, opus, code-traced (implemented the plan verbatim in a scratch mirror; full suite 4196/0 after C1)
+**Verdict: REVISE.** Folded:
+- **C1** nostr-map test expected `"BadName"` for `"  Bad Name "`; the sanitizer collapses whitespace → `"Bad Name"`. Fixed.
+- **C2** the drain destructured a NEW export (`sanitizeWorldName`) from the INSTALLED bundle's grid.js unguarded; booted against the real 0.6.0 copy the whole drain (marks, tombstones, trade expiry, contacts delivery) died with `sanitizeWorldName is not a function`. **Ruling R1-1:** core consumes no new bundle export at all — the transport passes the raw setting and `markToEvent` sanitizes; a stale copy ignores the unknown option. No guard, no stale-bundle test needed for this class (nothing new is imported).
+- **S1** unsanitized ingress at `insertRemoteMark` → sanitize there too (defense in depth; the marks test now feeds a dirty name). **Ruling R1-2:** the instance-sync apply door stays a trusted same-owner path (no bundle import from core); a synced `author_name` lands on a row labelled "your mark" and is never displayed.
+- **S2** both sync doors: **Ruling R1-3:** apply door only; own rows never carry a name, an outbox assertion would be vacuous.
+- **S3** contacts marks: explicit `markPayload`/`payloadToMark` test added (delivery test).
+- **S4** `·` in a name could fake a key tail (`Kevin · f665 · <real4>`): **Ruling R1-4:** the sanitizer replaces U+00B7 with a space (a third Ramble rule beyond the spec's two; recorded here as a spec amendment).
+- **S5** `maxlength="24"` counts UTF-16 units, the sanitizer code points: **Ruling R1-5:** keep 24 — an emoji-heavy name is merely shorter in the field; the server cap is the contract.
+- **S6** suite arithmetic corrected (4186 → 4197 with the delivery test).
+- **Q1** `worldName: null` = not sent; `""` clears (route test pins both). **Q2** the wire column is forward-looking per spec §6 (harmless today). **Q3** D1 stands (marks use the stable key already; the level decides). **Q4** yes, r4 is one of the three gateways.

--- a/docs/superpowers/plans/2026-09-08-ramble-world-name.md
+++ b/docs/superpowers/plans/2026-09-08-ramble-world-name.md
@@ -67,7 +67,7 @@ Append to `tests/ramble-grid.test.js` (its import from `../bundles/ramble/server
 ```js
 test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:/req: rejected, hex-only rejected, capped at 24 code points, empty is null", () => {
   assert.equal(sanitizeWorldName("Kevin"), "Kevin");
-  assert.equal(sanitizeWorldName("  Kevin‮   H  "), "Kevin H");
+  assert.equal(sanitizeWorldName("  Kevin\u202E   H\u0000 "), "Kevin H");
   assert.equal(sanitizeWorldName("crow:kevin"), null);
   assert.equal(sanitizeWorldName("REQ:x"), null);
   assert.equal(sanitizeWorldName("f665c26b"), null, "a key look-alike");
@@ -76,6 +76,7 @@ test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:
   assert.equal(sanitizeWorldName("Kev · f665"), "Kev f665", "the label separator cannot be faked");
   assert.equal(sanitizeWorldName("abc"), "abc", "3 hex chars is a word, not a tail");
   assert.equal(sanitizeWorldName("x".repeat(40)), "x".repeat(24));
+  assert.equal(sanitizeWorldName("x".repeat(23) + " yz"), "x".repeat(23), "a cut that lands on a space is re-trimmed");
   assert.equal(sanitizeWorldName("🐦".repeat(30)), "🐦".repeat(24), "code points, not UTF-16 units");
   assert.equal(sanitizeWorldName(""), null);
   assert.equal(sanitizeWorldName("   "), null);
@@ -121,12 +122,12 @@ export function sanitizeWorldName(value) {
   if (typeof value !== "string") return null;
   let s = value
     .replace(/[\x00-\x1F\x7F\x80-\x9F]/g, "")
-    .replace(/[‪-‮⁦-⁩]/g, "")
-    .replace(/·/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
+    .replace(/[\u202A-\u202E\u2066-\u2069]/g, "")
+    .replace(/\u00B7/g, " "); // the label's own separator: "Kev · f665" could fake a key tail
   s = s.replace(/\s+/g, " ").trim();
   if (/^(crow|req):/i.test(s)) return null;
   const points = Array.from(s);
-  if (points.length > WORLD_NAME_MAX) s = points.slice(0, WORLD_NAME_MAX).join("");
+  if (points.length > WORLD_NAME_MAX) s = points.slice(0, WORLD_NAME_MAX).join("").trim();
   if (/^[0-9a-f]{4,}$/i.test(s)) return null;
   return s.length > 0 ? s : null;
 }
@@ -169,7 +170,7 @@ export async function setWorldName(db, name, { emit } = {}) {
 ```js
 test("world name: rides in content only when given and clean; eventToMark reads it through the sanitizer", () => {
   const row = { ...openMarkRow, author_level: "pseudonym" };
-  const withName = JSON.parse(markToEvent(row, { name: "  Kevin‮ " }).content);
+  const withName = JSON.parse(markToEvent(row, { name: "  Kevin\u202E " }).content);
   assert.equal(withName.name, "Kevin");
   assert.equal(JSON.parse(markToEvent(row, {}).content).name, undefined, "no name given, none sent");
   assert.equal(JSON.parse(markToEvent(row, { name: "f665c26b" }).content).name, undefined, "a key look-alike is dropped");
@@ -194,7 +195,7 @@ test("insertRemoteMark stores author_name and a locked teaser keeps it", async (
   const result = await insertRemoteMark(db, {
     mark_id: "named-remote-1", author: "pk9", kind: "mark", anchor_kind: "geo", geohash: "9v6m2c",
     lat: 30.2672, lon: -97.7431, visibility: "public", reveal: "locked", content_text: "named",
-    created_at: Date.now(), nostr_event_id: "ev-named-1", author_name: "  Kevin‮ ",
+    created_at: Date.now(), nostr_event_id: "ev-named-1", author_name: "  Kevin\u202E ",
   });
   assert.equal(result.inserted, true);
   assert.equal(result.row.author_name, "Kevin", "sanitized at the store too");
@@ -218,7 +219,7 @@ test("author_name rides the apply door (wire column) and is updatable by LWW", a
 });
 ```
 
-`tests/ramble-transport.test.js` — append (uses `makeHarness`, `seedPublicMark`, `setMaster`, `setCell`; add `import { eventToMark } from "../bundles/ramble/server/nostr-map.js";` if not imported — `MARK_KIND, CAW_KIND` are):
+`tests/ramble-transport.test.js` — append; FIRST change the existing import `import { MARK_KIND, CAW_KIND } from "../bundles/ramble/server/nostr-map.js";` to `import { MARK_KIND, CAW_KIND, eventToMark } from "../bundles/ramble/server/nostr-map.js";` (one import line, not a second one):
 
 ```js
 test("world name rides only pseudonym/real rows: a rotating row never carries it; eventToMark round-trips it", async () => {
@@ -246,10 +247,16 @@ test("world name rides only pseudonym/real rows: a rotating row never carries it
 (`makeHarness`, `seedPublicMark(db, text, extra)` — `extra` spreads over `author_level` — `setMaster`, `setCell`, `h.published`, `h.transport.drainOnce()` are the file's existing fixtures; the harness's default gate is the real `makePublishGate`, hence the master + public/geo cell.)
 ```
 
-`tests/ramble-delivery.test.js` — append (reuse the `row` and `PK` fixtures of its `markPayload`/`payloadToMark` bird test; import nothing new):
+`tests/ramble-delivery.test.js` — append (`PK`, `db`, `createMark`, `markPayload`, `payloadToMark` are file-scope in that test; the other tests' `row` variables are test-local, so build your own):
 
 ```js
-test("contacts marks never carry a world name in either direction", () => {
+test("contacts marks never carry a world name in either direction", async () => {
+  const row = await createMark(db, {
+    author: "c".repeat(64), author_level: "pseudonym", kind: "mark",
+    anchor: { anchor_kind: "geo", lat: 30.46, lon: -98.08, accuracy_m: 12 },
+    visibility: "contacts", reveal: "open",
+    content: { content_text: "for my people", content_kind: "none" },
+  });
   const payload = markPayload({ ...row, author_name: "Kevin" });
   assert.equal(payload.author_name, undefined);
   assert.equal(payload.name, undefined);
@@ -426,7 +433,7 @@ export async function contactsByPubkey(db) {
 
 `bundles/ramble/panel/routes.js`: delete the router-local zero-arg `contactsByPubkey()` function (body identical to the one above) and replace its one use in `annotateMarks` with `const byPubkey = await mods.deliveryMod.contactsByPubkey(db);`.
 
-`bundles/ramble/server/server.js`: import `{ labelFor } from "./labels.js"` and `contactsByPubkey` from `./delivery.js` (extend the existing delivery import). In `ramble_query_world` replace `const marks = await listMarks(db, { visibility, geohashPrefix: cell });` with:
+`bundles/ramble/server/server.js`: import `{ labelFor } from "./labels.js"` and `contactsByPubkey` from `./delivery.js` (extend the existing delivery import). Extend the tool description `"List nearby marks and caws within the geohash cell containing the given location."` with ` Each row carries a label ("your mark", "mark by <contact>", "mark by <world name> · <key4>", or "mark by <key8>").`. In `ramble_query_world` replace `const marks = await listMarks(db, { visibility, geohashPrefix: cell });` with:
 
 ```js
         const rows = await listMarks(db, { visibility, geohashPrefix: cell });
@@ -481,7 +488,7 @@ In the panel shell test add `assert.match(sent, /id="rb-world-name"[^>]*maxlengt
 
 ```js
 test("POST /api/ramble/grid stores a sanitized worldName, clears a rejected one, and bounds the input", async () => {
-  let res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "  Kevin‮  " } });
+  let res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "  Kevin\u202E  " } });
   assert.equal(res.status, 200);
   assert.equal((await res.json()).worldName, "Kevin");
   assert.equal((await (await req("/api/ramble/grid")).json()).worldName, "Kevin");
@@ -515,7 +522,7 @@ test("POST /api/ramble/grid stores a sanitized worldName, clears a rejected one,
 
 `bundles/ramble/panel/routes.js` `POST /api/ramble/grid`: in the validation block add `if (b.worldName != null && (typeof b.worldName !== "string" || b.worldName.length > 128)) bad("worldName must be a string of at most 128 characters");` and after the identity-level write add `if (b.worldName != null) await mods.gridMod.setWorldName(db, b.worldName, { emit });` (the response is `getGrid`, which now carries `worldName`).
 
-`bundles/ramble/panel/static/ramble.js`: beside `var identityEl = $("rb-identity");` add `var worldNameEl = $("rb-world-name");`; in `paintGrid` add `if (worldNameEl && worldNameEl !== document.activeElement) worldNameEl.value = grid.worldName || "";`; beside the identity `change` listener add `if (worldNameEl) worldNameEl.addEventListener("change", function () { postGrid({ worldName: worldNameEl.value }); });`.
+`bundles/ramble/panel/static/ramble.js`: beside `var identityEl = $("rb-identity");` add `var worldNameEl = $("rb-world-name");`; in `paintGrid` add `if (worldNameEl && worldNameEl !== document.activeElement) worldNameEl.value = grid.worldName || "";`; beside the identity `change` listener add `if (worldNameEl) worldNameEl.addEventListener("change", function () { worldNameEl.blur(); postGrid({ worldName: worldNameEl.value }); });` (the blur closes the phone keyboard and lets the saved, sanitized value repaint the field — `paintGrid` skips a focused field so an SSE repaint never clobbers typing).
 
 `bundles/ramble/panel/static/ramble.css`: the existing `#ramble select { … }` rule becomes `#ramble select,\n#ramble .rb-sheet input[type="text"] { … }` (same declarations), plus one new rule `#ramble .rb-sheet input[type="text"] { flex: 1; min-width: 0; }`.
 
@@ -535,7 +542,7 @@ Bump: `sed -i 's/"version": "0.6.0"/"version": "0.7.0"/' bundles/ramble/manifest
 
 - [ ] **Step 4: Run** `tests/ramble-panel.test.js` → PASS (parity included). Then the FULL suite in the foreground (`node scripts/run-suite.mjs 2>&1 | tail -12`, expect pass = total, fail 0: 4186 + 11 new = 4197 — grid +2, nostr-map +1, marks +1, sync +1, transport +1, delivery +1, labels +2, tools +1, panel +1; report the actual), `node scripts/check-port-allocation.js`, `npm run build-registry -- --check`.
 - [ ] **Step 5: Commit** — `git commit bundles/ramble/panel/ramble.js bundles/ramble/panel/routes.js bundles/ramble/panel/static/ramble.js bundles/ramble/panel/static/ramble.css docs/guide/ramble.md docs/es/guide/ramble.md bundles/ramble/manifest.json bundles/ramble/package.json registry/add-ons.json tests/ramble-panel.test.js -m "ramble 0.7.0: the World name field; docs en/es; registry"`
-- [ ] **Step 6 (controller):** push, PR, check-runs, merge, CROW-SCHEDULE.md, three-gateway restart (grackle: `refreshed ramble 0.6.0 -> 0.7.0`), Kevin sets a world name and leaves a pseudonym-level mark from grackle; a second instance (crow's transport receives the public event) stores `author_name` — verify with a read-only SELECT on crow's live db.
+- [ ] **Step 6 (controller):** push, PR, check-runs, merge, CROW-SCHEDULE.md, three-gateway restart. Cross-version note: a new core beside an UNREFRESHED 0.6.0 bundle copy has no `author_name` column, so a synced row carrying one fails to apply until the copy refreshes — on grackle confirm the journal's `refreshed ramble 0.6.0 -> 0.7.0` line comes before `[ramble] transport started`, then `PRAGMA table_info(ramble_marks)` on grackle's live db shows `author_name` (read-only); crow primary and r4 load the server from the repo tree and add the column on boot. Kevin sets a world name and leaves a pseudonym-level mark from grackle; a second instance (crow's transport receives the public event) stores `author_name` — verify with a read-only SELECT on crow's live db.
 
 ## Self-review notes
 - D1: the level decides (transport, per row from `author_level ?? level`); `rotating` never carries a name (transport test). D2: key4 tail on named strangers (labels test, client pin). D3: own marks (labels test, tools assertion, client pin).
@@ -555,3 +562,15 @@ Bump: `sed -i 's/"version": "0.6.0"/"version": "0.7.0"/' bundles/ramble/manifest
 - **S5** `maxlength="24"` counts UTF-16 units, the sanitizer code points: **Ruling R1-5:** keep 24 — an emoji-heavy name is merely shorter in the field; the server cap is the contract.
 - **S6** suite arithmetic corrected (4186 → 4197 with the delivery test).
 - **Q1** `worldName: null` = not sent; `""` clears (route test pins both). **Q2** the wire column is forward-looking per spec §6 (harmless today). **Q3** D1 stands (marks use the stable key already; the level decides). **Q4** yes, r4 is one of the three gateways.
+
+### Round 2 — 2026-09-08, opus, code-traced (fresh mirror; full suite 4197/0; stale-0.6.0-bundle probe PASSED: published 1, no `name`)
+**Verdict: APPROVE with two test-fixture edits.** Folded:
+- **C1** the delivery test reused a `row` that is test-local in that file → the new test builds its own row with `createMark`.
+- **C2** `eventToMark` was not imported in the transport test → the existing import line is extended (stated definitely).
+- **S1** the Nearby list appends `· <ago>` after the label: **Ruling R2-1:** keep — the sanitizer strips U+00B7 from names, so the tail always sits immediately after the name and the trailing ` · 3 min ago` is ours; no faking is possible.
+- **S2** Enter kept the field focused so the sanitized value never repainted → the change handler blurs first.
+- **S3** no save on Turbo-navigate-away before blur: **Ruling R2-2:** accepted; `change` fires on blur, matching the Name select's behaviour.
+- **S4** cross-version skew (new core + unrefreshed copy lacks the column) → restart-order + PRAGMA verification note in Step 6; same class as `bird_species`, covered by the manifest bump.
+- **S5** truncation re-trimmed; bidi characters in the plan's source are `\u` escapes now.
+- **S6** the tool description mentions `label`. **S7** the moved `contactsByPubkey` keeps its ORDER BY provenance comment (already in the plan's code).
+- Verified by the reviewer: `origin = "sync"` rows are provably the owner's own (no emit path replicates remote/contact marks); `markLabel`/`arTitle` are the only "by" builders; all client sinks are `textContent`; `labels.js` ships with the bundle (manifest lists no server files individually).

--- a/docs/superpowers/plans/2026-09-08-ramble-world-name.md
+++ b/docs/superpowers/plans/2026-09-08-ramble-world-name.md
@@ -175,7 +175,7 @@ test("world name: rides in content only when given and clean; eventToMark reads 
   assert.equal(JSON.parse(markToEvent(row, {}).content).name, undefined, "no name given, none sent");
   assert.equal(JSON.parse(markToEvent(row, { name: "f665c26b" }).content).name, undefined, "a key look-alike is dropped");
   assert.equal(JSON.parse(markToEvent(row, { name: "crow:x" }).content).name, undefined);
-  const ev = { id: "e".repeat(64), pubkey: "a".repeat(64), kind: MARK_KIND, created_at: 1, tags: [["g", "9v6m2"], ["d", "m1"]], content: JSON.stringify({ v: 1, text: "hi", name: "  Bad Name " }) };
+  const ev = { id: "e".repeat(64), pubkey: "a".repeat(64), kind: MARK_KIND, created_at: 1, tags: [["g", "9v6m2"], ["d", "m1"]], content: JSON.stringify({ v: 1, text: "hi", name: "  Bad\u0000 Name " }) };
   assert.equal(eventToMark(ev).author_name, "Bad Name", "collapsed, not squeezed");
   ev.content = JSON.stringify({ v: 1, text: "hi", name: "deadbeef" });
   assert.equal(eventToMark(ev).author_name, null);

--- a/docs/superpowers/plans/2026-09-08-ramble-world-name.md
+++ b/docs/superpowers/plans/2026-09-08-ramble-world-name.md
@@ -574,3 +574,6 @@ Bump: `sed -i 's/"version": "0.6.0"/"version": "0.7.0"/' bundles/ramble/manifest
 - **S5** truncation re-trimmed; bidi characters in the plan's source are `\u` escapes now.
 - **S6** the tool description mentions `label`. **S7** the moved `contactsByPubkey` keeps its ORDER BY provenance comment (already in the plan's code).
 - Verified by the reviewer: `origin = "sync"` rows are provably the owner's own (no emit path replicates remote/contact marks); `markLabel`/`arTitle` are the only "by" builders; all client sinks are `textContent`; `labels.js` ships with the bundle (manifest lists no server files individually).
+
+### Scoped check — 2026-09-08, sonnet, fresh mirror, plan implemented verbatim
+**Verdict: PASS.** grid 18, tables 8, nostr-map 25, marks 13, sync 27, transport 33, delivery 7, labels 2, tools 17, panel 54 — all 0 fail; full suite 4197/4197/0; check-ports OK; `build-registry --check` in sync; backticks 0; sinks 2 (unchanged). All six round-2 folds re-verified. No deviations from the plan text were needed. Awaiting Kevin's approval to execute.

--- a/docs/superpowers/plans/2026-09-08-ramble-world-name.md
+++ b/docs/superpowers/plans/2026-09-08-ramble-world-name.md
@@ -1,0 +1,519 @@
+# Ramble World Name + "Your mark" (Plan A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A Ramble "World name" a user chooses for strangers, carried on public marks and caws only at the pseudonym or real Name level, shown as "name · key4"; contacts keep their saved name; the user's own marks read "your mark" / "your caw" on the map, in the Nearby list, in AR and in the MCP world query.
+
+**Architecture:** One new replicated Ramble setting (`world.name`, sanitized by a pure `sanitizeWorldName` in `grid.js`), one new column (`ramble_marks.author_name`, guarded `ensureColumn`, added to the instance-sync wire columns), one new wire field (`content.name` on kinds 30397/20397, written by `markToEvent` only when the transport hands it a name for that row — the transport decides per row from the row's own `author_level`; read by `eventToMark` through the same sanitizer), one label rule implemented twice deliberately — a pure server `labelFor` (new `labels.js`, used by the MCP world query) and the client's `markLabel` (plain script) — plus a shared `contactsByPubkey` reader moved into `delivery.js` so the panel routes and the MCP server name contacts the same way. The Visible sheet gets the field. No new table, no new route, no new tool.
+
+**Tech Stack:** Node 22 ESM, libsql client, `nostr-tools` events, Express router, plain-script panel client (no backticks), Node test runner via `scripts/run-suite.mjs`.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-ramble-names-and-profile-design.md` §0 D1–D3, §1, §2, §3, §6 (Plan A rows), §7, §8 (Plan A). Phase-5 rulings still bind (`docs/superpowers/plans/2026-09-07-ramble-phase5-first-walk.md` Global Constraints + Review).
+
+## Global Constraints
+
+- **DB access** through the bundle's `createDbClient()` / `appImport("servers/db.js")` only; async libsql-shaped client. Test files may use `@libsql/client` in-memory; bundle server files never import it.
+- **No `SCHEMA_GENERATION` bump; no new table.** The one new column is `ramble_marks.author_name TEXT` via `ensureColumn` in `bundles/ramble/server/init-tables.js`. `ramble_marks` is already replicated: the column joins `RAMBLE_MARK_WIRE_COLUMNS` in `servers/sharing/instance-sync.js` (and therefore `RAMBLE_MARK_UPDATE_COLUMNS`); the apply door is tested with the column. The setting `world.name` is a plain `ramble_settings` row (not `local.`-prefixed → replicates; `EXCLUDED_COLUMNS.ramble_settings` unchanged).
+- **World name rules (spec §2.1, exact):** `sanitizeWorldName(value)`: non-string → `null`; strip C0/DEL/C1 controls and bidi overrides/isolates; collapse whitespace, trim; reject `/^(crow|req):/i` → `null`; cap at `WORLD_NAME_MAX = 24` code points (truncate); reject a value that is only hex of 4+ chars `/^[0-9a-f]{4,}$/i` → `null`; empty → `null`. Applied on save AND on every read from the wire.
+- **Wire (spec §2.2, exact):** `markToEvent(row, { precision, crowId, bird, name })` adds `content.name` only when `sanitizeWorldName(name)` is non-null; the TRANSPORT passes `name` only when `(row.author_level ?? level) ∈ { pseudonym, real }` (`level` = the instance's `public_identity_level`), so a `rotating` row never carries one (D1; note: at `rotating` only CAWS rotate their key — marks already use the stable world key — the decision stands: the level decides). `eventToMark` sets `author_name: sanitizeWorldName(content.name)`. Contacts/group marks (`markPayload` / `payloadToMark`) never carry or read a name.
+- **Labels (spec §3.1, exact, in this order):** own (`origin` ∈ `local`, `sync`) → `your mark` / `your caw`; contact (`contact_name`) → `mark by <contact name>`; stranger with `author_name` → `mark by <author_name> · <key4>`; else → `mark by <key8>`. `key4`/`key8` = the first 4/8 characters of `author`, `anon` when missing. AR caw title: `Your caw` / `A caw from <contact name>` / `A caw from <author_name> · <key4>` / `A caw`.
+- **Teasers:** `reveal.js`'s allowlist gains `author_name` (a locked stranger's mark still shows who left it, as `author` already does).
+- **Panel rules:** `router.use("/api/ramble", dashboardAuth)` path-scoped; `static/ramble.js` ZERO backticks, `textContent` only, EXACTLY two engine markup sinks (unchanged), no emoji; every input bounded (`worldName` ≤ 128 chars on the wire into the route, then sanitized to ≤ 24). Direction C tokens only.
+- **Tests:** `export PATH=/home/kh0pp/.nvm/versions/node/v22.23.1/bin:$PATH`; `node scripts/run-suite.mjs tests/<file>.test.js` foreground only; never bare `node --test`; never boot a gateway from the worktree without a scratch `CROW_DATA_DIR`. Docs en/es heading parity: no new headings (paragraph edits only).
+- **Commits:** subject-only, positional paths, `git add` new files first, no attribution trailers. Worktree `/home/kh0pp/crow-wt-names` (branch `feat/ramble-world-name`, `node_modules` symlinked from `~/crow`); never `git checkout` in `~/crow`. PR + green `suite`/`static-checks`/`audit` on the head sha (public check-runs API via python; GitHub MCP tools for PR/merge). Read `/home/kh0pp/CROW-SCHEDULE.md` before the deploy; restart all three gateways back-to-back after merge; grackle's journal must show `[bundles] refreshed ramble 0.6.0 -> 0.7.0`, `[ramble] transport started`, `[panel] ramble routes mounted`, `addon ramble: connected, 15 tools discovered`.
+- **Bundle version bump:** `bundles/ramble/manifest.json` AND `package.json` `0.6.0` → `0.7.0`; `npm run build-registry`.
+- **Base:** `main` @0cd42ce2 (PR #322 merge).
+
+---
+
+## File structure
+
+**Create**
+- `bundles/ramble/server/labels.js` — `keyTail(author, n)`, `labelFor(row, { contactName })`, `cawTitleFor(row, { contactName })`.
+- `tests/ramble-labels.test.js`.
+
+**Modify**
+- `bundles/ramble/server/grid.js` — `WORLD_NAME_MAX`, `sanitizeWorldName`, `setWorldName`, `getGrid` returns `worldName`.
+- `bundles/ramble/server/init-tables.js` — `ensureColumn(db, "ramble_marks", "author_name", "TEXT")`.
+- `bundles/ramble/server/nostr-map.js` — `markToEvent` `name` option; `eventToMark` `author_name`.
+- `bundles/ramble/server/marks.js` — `insertRemoteMark` writes `author_name`.
+- `bundles/ramble/server/reveal.js` — teaser allowlist.
+- `bundles/ramble/server/delivery.js` — exported `contactsByPubkey(db)` (moved from routes.js).
+- `bundles/ramble/server/server.js` — `ramble_query_world` rows gain `label`.
+- `servers/sharing/instance-sync.js` — `RAMBLE_MARK_WIRE_COLUMNS` + `author_name`.
+- `servers/gateway/boot/ramble-transport.js` — the drain passes `name` per row.
+- `bundles/ramble/panel/routes.js` — `POST /api/ramble/grid` accepts `worldName`; `contactsByPubkey` imported from delivery.js.
+- `bundles/ramble/panel/ramble.js` — the World name field in the Visible sheet.
+- `bundles/ramble/panel/static/ramble.js` — `markLabel`, `arTitle`, the field wiring.
+- `bundles/ramble/panel/static/ramble.css` — the text input in the sheet.
+- `docs/guide/ramble.md`, `docs/es/guide/ramble.md`, `bundles/ramble/manifest.json`, `bundles/ramble/package.json`, `registry/add-ons.json`.
+- Tests: `ramble-grid`, `ramble-nostr-map`, `ramble-marks`, `ramble-sync`, `ramble-transport`, `ramble-tools`, `ramble-panel`.
+
+---
+
+## Task 1: `sanitizeWorldName` + the `world.name` setting + the column
+
+**Files:**
+- Modify: `bundles/ramble/server/grid.js`, `bundles/ramble/server/init-tables.js`
+- Test: `tests/ramble-grid.test.js` (append), `tests/ramble-tables.test.js` (append one assertion)
+
+**Interfaces:**
+- Produces: `WORLD_NAME_MAX = 24`; `sanitizeWorldName(value) → string | null`; `setWorldName(db, name, { emit }) → string | null` (writes `world.name` = the clean value or `""`); `getGrid(db)` gains `worldName: string | null`.
+
+- [ ] **Step 1: Failing tests**
+
+Append to `tests/ramble-grid.test.js` (its import from `../bundles/ramble/server/grid.js` gains `sanitizeWorldName, WORLD_NAME_MAX, setWorldName`; the file's shared `db` is reset by its `beforeEach`, so the second test starts from empty settings):
+
+```js
+test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:/req: rejected, hex-only rejected, capped at 24 code points, empty is null", () => {
+  assert.equal(sanitizeWorldName("Kevin"), "Kevin");
+  assert.equal(sanitizeWorldName("  Kevin‮   H  "), "Kevin H");
+  assert.equal(sanitizeWorldName("crow:kevin"), null);
+  assert.equal(sanitizeWorldName("REQ:x"), null);
+  assert.equal(sanitizeWorldName("f665c26b"), null, "a key look-alike");
+  assert.equal(sanitizeWorldName("DEADBEEF1234"), null);
+  assert.equal(sanitizeWorldName("Kev1"), "Kev1", "hex-ish but not all hex");
+  assert.equal(sanitizeWorldName("abc"), "abc", "3 hex chars is a word, not a tail");
+  assert.equal(sanitizeWorldName("x".repeat(40)), "x".repeat(24));
+  assert.equal(sanitizeWorldName("🐦".repeat(30)), "🐦".repeat(24), "code points, not UTF-16 units");
+  assert.equal(sanitizeWorldName(""), null);
+  assert.equal(sanitizeWorldName("   "), null);
+  assert.equal(sanitizeWorldName(123), null);
+  assert.equal(sanitizeWorldName(null), null);
+  assert.equal(WORLD_NAME_MAX, 24);
+});
+
+test("world name: set/read through the grid; unset reads null; the setting replicates (not local.)", async () => {
+  assert.equal((await getGrid(db)).worldName, null);
+  const calls = [];
+  assert.equal(await setWorldName(db, "  Kevin  ", { emit: async (t, op, row) => calls.push([t, op, row.key, row.value]) }), "Kevin");
+  assert.equal((await getGrid(db)).worldName, "Kevin");
+  assert.deepEqual(calls, [["ramble_settings", "update", "world.name", "Kevin"]]);
+  assert.equal(await setWorldName(db, "crow:nope"), null);
+  assert.equal((await getGrid(db)).worldName, null, "a rejected name clears the setting");
+  assert.equal(await setWorldName(db, "f665c26b"), null);
+});
+```
+
+If the file's existing "default grid" test compares the whole `getGrid` result with `deepEqual`, add `worldName: null` to its expected object.
+
+In `tests/ramble-tables.test.js`, the loop `for (const c of ["bird_species", "bird_seed"]) assert.ok(marks.includes(c), …)` gains `"author_name"` in its list.
+
+- [ ] **Step 2: Run** `node scripts/run-suite.mjs tests/ramble-grid.test.js tests/ramble-tables.test.js` → FAIL (missing exports / column).
+
+- [ ] **Step 3: Implement**
+
+`bundles/ramble/server/grid.js`, after `export const IDENTITY_LEVELS = […];`:
+
+```js
+/** Spec 2026-09-08 §2.1: the name strangers see, capped short so a label stays one line. */
+export const WORLD_NAME_MAX = 24;
+
+/**
+ * The same seven steps as core's sanitizeDisplayName (kept in the bundle so
+ * the stdio MCP process needs no core import), then the two Ramble rules: a
+ * 24-code-point cap and no hex-only values (a name that looks like a key
+ * tail would defeat the "name · key4" disambiguation). Applied on save AND
+ * on every read from the wire.
+ */
+export function sanitizeWorldName(value) {
+  if (typeof value !== "string") return null;
+  let s = value
+    .replace(/[\x00-\x1F\x7F\x80-\x9F]/g, "")
+    .replace(/[‪-‮⁦-⁩]/g, "");
+  s = s.replace(/\s+/g, " ").trim();
+  if (/^(crow|req):/i.test(s)) return null;
+  const points = Array.from(s);
+  if (points.length > WORLD_NAME_MAX) s = points.slice(0, WORLD_NAME_MAX).join("");
+  if (/^[0-9a-f]{4,}$/i.test(s)) return null;
+  return s.length > 0 ? s : null;
+}
+```
+
+In `getGrid`, after the `identityLevel` line: `const worldName = sanitizeWorldName(await readSetting(db, "world.name"));` and return `{ master, cells, identityLevel, worldName, activeArea }`.
+
+After `setIdentityLevel` add:
+
+```js
+/** Store the sanitized world name ("" when rejected/empty, so a bad value never lingers). Returns what was stored, or null. */
+export async function setWorldName(db, name, { emit } = {}) {
+  const clean = sanitizeWorldName(name);
+  await writeSetting(db, "world.name", clean ?? "", { emit });
+  return clean;
+}
+```
+
+`bundles/ramble/server/init-tables.js`: beside the two `bird_*` `ensureColumn` lines add `await ensureColumn(db, "ramble_marks", "author_name", "TEXT");`.
+
+- [ ] **Step 4: Run** the two files → PASS.
+- [ ] **Step 5: Commit** — `git commit bundles/ramble/server/grid.js bundles/ramble/server/init-tables.js tests/ramble-grid.test.js tests/ramble-tables.test.js -m "ramble grid: the world name setting and its sanitizer; author_name column"`
+
+---
+
+## Task 2: The wire — `content.name`, `author_name` on stored rows, sync, the drain
+
+**Files:**
+- Modify: `bundles/ramble/server/nostr-map.js`, `bundles/ramble/server/marks.js`, `bundles/ramble/server/reveal.js`, `servers/sharing/instance-sync.js`, `servers/gateway/boot/ramble-transport.js`
+- Test: `tests/ramble-nostr-map.test.js`, `tests/ramble-marks.test.js`, `tests/ramble-sync.test.js`, `tests/ramble-transport.test.js` (append)
+
+**Interfaces:**
+- Consumes: `sanitizeWorldName` (Task 1).
+- Produces: `markToEvent(row, { precision, crowId, bird, name })`; `eventToMark(event).author_name`; `insertRemoteMark` stores `author_name`; teasers keep it; sync carries it; the transport passes `name` per row.
+
+- [ ] **Step 1: Failing tests**
+
+`tests/ramble-nostr-map.test.js` — append (the file has a `baseRow`/fixture helper; reuse the one its bird tests use):
+
+```js
+test("world name: rides in content only when given and clean; eventToMark reads it through the sanitizer", () => {
+  const row = { ...openMarkRow, author_level: "pseudonym" };
+  const withName = JSON.parse(markToEvent(row, { name: "  Kevin‮ " }).content);
+  assert.equal(withName.name, "Kevin");
+  assert.equal(JSON.parse(markToEvent(row, {}).content).name, undefined, "no name given, none sent");
+  assert.equal(JSON.parse(markToEvent(row, { name: "f665c26b" }).content).name, undefined, "a key look-alike is dropped");
+  assert.equal(JSON.parse(markToEvent(row, { name: "crow:x" }).content).name, undefined);
+  const ev = { id: "e".repeat(64), pubkey: "a".repeat(64), kind: MARK_KIND, created_at: 1, tags: [["g", "9v6m2"], ["d", "m1"]], content: JSON.stringify({ v: 1, text: "hi", name: "  Bad Name " }) };
+  assert.equal(eventToMark(ev).author_name, "BadName");
+  ev.content = JSON.stringify({ v: 1, text: "hi", name: "deadbeef" });
+  assert.equal(eventToMark(ev).author_name, null);
+  ev.content = JSON.stringify({ v: 1, text: "hi" });
+  assert.equal(eventToMark(ev).author_name, null);
+  ev.content = JSON.stringify({ v: 1, text: "hi", name: 42 });
+  assert.equal(eventToMark(ev).author_name, null);
+});
+```
+
+(`baseRow()` = `({ ...openMarkRow })`, the file's public open mark fixture; `MARK_KIND` is already imported.)
+
+`tests/ramble-marks.test.js` — append:
+
+```js
+test("insertRemoteMark stores author_name and a locked teaser keeps it", async () => {
+  const result = await insertRemoteMark(db, {
+    mark_id: "named-remote-1", author: "pk9", kind: "mark", anchor_kind: "geo", geohash: "9v6m2c",
+    lat: 30.2672, lon: -97.7431, visibility: "public", reveal: "locked", content_text: "named",
+    created_at: Date.now(), nostr_event_id: "ev-named-1", author_name: "Kevin",
+  });
+  assert.equal(result.inserted, true);
+  assert.equal(result.row.author_name, "Kevin");
+  const listed = (await listMarks(db, { visibility: "public" })).find((r) => r.mark_id === "named-remote-1");
+  assert.equal(listed.author_name, "Kevin", "the teaser allowlist carries the name");
+  assert.equal(listed.content_text, undefined, "still a teaser");
+});
+```
+
+`tests/ramble-sync.test.js` — append (`b` is the file's peer db; `applyRemoteOp` is imported):
+
+```js
+test("author_name rides the apply door (wire column) and is updatable by LWW", async () => {
+  const row = { mark_id: "named-9", author: "c".repeat(64), author_level: "pseudonym", kind: "mark", anchor_kind: "geo", geohash: "9v6m21h", lat: 30.46, lon: -98.08, visibility: "public", reveal: "open", content_text: "n", content_kind: "none", created_at: 1, expires_at: null, nostr_event_id: "ev-n9", author_name: "Kevin" };
+  await applyRemoteOp(b, "ramble_marks", "insert", row, 11);
+  let got = (await b.execute({ sql: "SELECT author_name, origin FROM ramble_marks WHERE mark_id = 'named-9'", args: [] })).rows[0];
+  assert.deepEqual([got.author_name, got.origin], ["Kevin", "sync"]);
+  await applyRemoteOp(b, "ramble_marks", "update", { ...row, author_name: "Kev" }, 12);
+  got = (await b.execute({ sql: "SELECT author_name FROM ramble_marks WHERE mark_id = 'named-9'", args: [] })).rows[0];
+  assert.equal(got.author_name, "Kev");
+});
+```
+
+`tests/ramble-transport.test.js` — append (uses `makeHarness`, `seedPublicMark`, `setMaster`, `setCell`; add `import { eventToMark } from "../bundles/ramble/server/nostr-map.js";` if not imported — `MARK_KIND, CAW_KIND` are):
+
+```js
+test("world name rides only pseudonym/real rows: a rotating row never carries it; eventToMark round-trips it", async () => {
+  const h = await makeHarness();
+  await setMaster(h.db, true);
+  await setCell(h.db, "public", "geo", true);
+  await h.db.execute({ sql: "INSERT INTO ramble_settings (key, value) VALUES ('world.name', ?)", args: ["Kevin"] });
+  const rot = await seedPublicMark(h.db, "rotating row", { author_level: "rotating" });
+  const pseud = await seedPublicMark(h.db, "pseudonym row", { author_level: "pseudonym" });
+  const real = await seedPublicMark(h.db, "real row", { author_level: "real" });
+  await h.transport.drainOnce();
+  const byText = (t) => h.published.find((e) => JSON.parse(e.content).text === t);
+  assert.equal(JSON.parse(byText("rotating row").content).name, undefined);
+  assert.equal(JSON.parse(byText("pseudonym row").content).name, "Kevin");
+  assert.equal(JSON.parse(byText("real row").content).name, "Kevin");
+  assert.equal(eventToMark(byText("pseudonym row")).author_name, "Kevin");
+  // A row with no level of its own follows the instance level (createMark stores author_level ?? null).
+  await h.db.execute({ sql: "INSERT INTO ramble_settings (key, value) VALUES ('public_identity_level', 'pseudonym') ON CONFLICT(key) DO UPDATE SET value = excluded.value", args: [] });
+  const bare = await seedPublicMark(h.db, "bare row", { author_level: null });
+  await h.transport.drainOnce();
+  assert.equal(JSON.parse(byText("bare row").content).name, "Kevin");
+  void rot; void pseud; void real; void bare;
+});
+
+(`makeHarness`, `seedPublicMark(db, text, extra)` — `extra` spreads over `author_level` — `setMaster`, `setCell`, `h.published`, `h.transport.drainOnce()` are the file's existing fixtures; the harness's default gate is the real `makePublishGate`, hence the master + public/geo cell.)
+```
+
+- [ ] **Step 2: Run** the four files → the new tests FAIL.
+
+- [ ] **Step 3: Implement**
+
+`bundles/ramble/server/nostr-map.js`: import `sanitizeWorldName` from `./grid.js`. `markToEvent(row, { precision = 5, crowId = null, bird = null, name = null } = {})`; after the bird line add:
+
+```js
+  // The author's chosen world name (spec 2026-09-08 §2.2). The transport
+  // hands it over only for pseudonym/real rows — a rotating row never gets
+  // one — and it is sanitized again here so a bad setting cannot reach a relay.
+  const cleanName = sanitizeWorldName(name);
+  if (cleanName) content.name = cleanName;
+```
+
+In `eventToMark`'s returned object add `author_name: sanitizeWorldName(content.name),` after `bird_seed`.
+
+`bundles/ramble/server/marks.js` `insertRemoteMark`: add `author_name` as the last INSERT column with `row.author_name ?? null` as the last arg (the VALUES list gains one `?`). Nothing for `createMark` (own rows carry no name; their label is "your mark").
+
+`bundles/ramble/server/reveal.js`: add `"author_name"` to `allowed` after `"bird_seed"`.
+
+`servers/sharing/instance-sync.js`: append `"author_name",` to `RAMBLE_MARK_WIRE_COLUMNS` with the comment `// 2026-09-08: the world name a stranger's mark was left under.`
+
+`servers/gateway/boot/ramble-transport.js`: the grid load destructures `{ makePublishGate }` — make it `{ makePublishGate, sanitizeWorldName }`. In `drainMarks`, after `const bird = await activeBird(db);` add `const worldName = sanitizeWorldName(await getSetting("world.name"));` and inside the row loop change the `markToEvent(...)` call to:
+
+```js
+        const rowLevel = row.author_level ?? level;
+        const name = rowLevel === "pseudonym" || rowLevel === "real" ? worldName : null;
+        const template = markToEvent(row, { precision: prec, crowId: persona.crowId, bird, name });
+```
+
+- [ ] **Step 4: Run** `node scripts/run-suite.mjs tests/ramble-nostr-map.test.js tests/ramble-marks.test.js tests/ramble-sync.test.js tests/ramble-transport.test.js` → PASS.
+- [ ] **Step 5: Commit** — `git commit bundles/ramble/server/nostr-map.js bundles/ramble/server/marks.js bundles/ramble/server/reveal.js servers/sharing/instance-sync.js servers/gateway/boot/ramble-transport.js tests/ramble-nostr-map.test.js tests/ramble-marks.test.js tests/ramble-sync.test.js tests/ramble-transport.test.js -m "ramble wire: the world name rides pseudonym/real rows as content.name; author_name stored, teased and synced"`
+
+---
+
+## Task 3: Labels — `labels.js` + the MCP world query + the client
+
+**Files:**
+- Create: `bundles/ramble/server/labels.js`, `tests/ramble-labels.test.js`
+- Modify: `bundles/ramble/server/delivery.js` (exported `contactsByPubkey`), `bundles/ramble/panel/routes.js` (use it), `bundles/ramble/server/server.js` (`label` on world-query rows), `bundles/ramble/panel/static/ramble.js` (`markLabel`, `arTitle`)
+- Test: `tests/ramble-tools.test.js`, `tests/ramble-panel.test.js` (append)
+
+**Interfaces:**
+- Produces: `keyTail(author, n)`, `labelFor(row, { contactName }) → string`, `cawTitleFor(row, { contactName }) → string`; `contactsByPubkey(db) → Map<xOnlyPubkey, { crow_id, name }>` (delivery.js); `ramble_query_world` rows gain `label`.
+
+- [ ] **Step 1: Failing tests**
+
+Create `tests/ramble-labels.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { keyTail, labelFor, cawTitleFor } from "../bundles/ramble/server/labels.js";
+
+const A = "f665c26b" + "0".repeat(56);
+test("labelFor: own > contact > named stranger with key4 > key8; caws use their noun", () => {
+  assert.equal(labelFor({ kind: "mark", origin: "local", author: A }), "your mark");
+  assert.equal(labelFor({ kind: "caw", origin: "sync", author: A, author_name: "Kevin" }), "your caw");
+  assert.equal(labelFor({ kind: "mark", origin: "remote", author: A, author_name: "Kevin" }, { contactName: "Pal" }), "mark by Pal");
+  assert.equal(labelFor({ kind: "caw", origin: "remote", author: A, author_name: "Kevin" }), "caw by Kevin · f665");
+  assert.equal(labelFor({ kind: "mark", origin: "remote", author: A }), "mark by f665c26b");
+  assert.equal(labelFor({ kind: "mark", origin: "remote" }), "mark by anon");
+  assert.equal(keyTail(A, 4), "f665");
+  assert.equal(keyTail(null, 8), "anon");
+});
+test("cawTitleFor mirrors the rule for the AR title", () => {
+  assert.equal(cawTitleFor({ kind: "caw", origin: "local", author: A }), "Your caw");
+  assert.equal(cawTitleFor({ kind: "caw", origin: "remote", author: A }, { contactName: "Pal" }), "A caw from Pal");
+  assert.equal(cawTitleFor({ kind: "caw", origin: "remote", author: A, author_name: "Kevin" }), "A caw from Kevin · f665");
+  assert.equal(cawTitleFor({ kind: "caw", origin: "remote", author: A }), "A caw");
+});
+```
+
+`tests/ramble-tools.test.js` — in the first test ("leave_mark then query_world …") after `assert.match(m.author, …)` add `assert.equal(m.label, "your mark");`. Append:
+
+```js
+test("ramble_query_world labels a named stranger's mark 'mark by <name> · key4'", async () => {
+  const { insertRemoteMark } = await import("../bundles/ramble/server/marks.js");
+  await insertRemoteMark(db, { mark_id: "named-tool", author: "f665c26b" + "1".repeat(56), kind: "mark", anchor_kind: "geo", geohash: encodeGeohash(30.2672, -97.7431, 7), lat: 30.2672, lon: -97.7431, visibility: "public", reveal: "open", content_text: "named", created_at: Date.now(), nostr_event_id: "ev-named-tool", author_name: "Kevin" });
+  const q = await h.ramble_query_world({ lat: 30.2672, lon: -97.7431, visibility: "public" });
+  const m = JSON.parse(q.content[0].text).marks.find((x) => x.mark_id === "named-tool");
+  assert.equal(m.label, "mark by Kevin · f665");
+});
+```
+
+(`db`, `h`, `encodeGeohash` are the file's existing fixtures/imports.)
+
+`tests/ramble-panel.test.js` — in the `GET /ramble/static/ramble.js` test add:
+
+```js
+  // World name labels (spec 2026-09-08 §3.1): own marks say so; a named stranger gets a key tail.
+  assert.ok(body.includes('return "your " + noun;'), "own marks read your mark / your caw");
+  assert.ok(body.includes('" · " + who.slice(0, 4)'), "a named stranger carries a key4 tail");
+  assert.ok(body.includes('"Your caw"') && body.includes('"A caw from "'));
+```
+
+- [ ] **Step 2: Run** `node scripts/run-suite.mjs tests/ramble-labels.test.js tests/ramble-tools.test.js tests/ramble-panel.test.js` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `bundles/ramble/server/labels.js`:
+
+```js
+/**
+ * Ramble labels — the ONE rule for "who left this" (spec 2026-09-08 §3.1),
+ * used by the MCP world query here and mirrored by the panel client's
+ * markLabel (a plain script cannot import this). Order matters:
+ *   1. yours (origin local or sync — sync rows are your own other instances);
+ *   2. a contact's saved name (verified by the handshake key; no tail);
+ *   3. a stranger's chosen world name plus a key tail (unverified, so the
+ *      tail keeps two "Kevin"s apart and matches the key the map showed);
+ *   4. the short key alone.
+ */
+export function keyTail(author, n) {
+  return typeof author === "string" && author.length > 0 ? author.slice(0, n) : "anon";
+}
+
+export function labelFor(row, { contactName = null } = {}) {
+  const noun = row?.kind === "caw" ? "caw" : "mark";
+  if (row?.origin === "local" || row?.origin === "sync") return `your ${noun}`;
+  if (contactName) return `${noun} by ${contactName}`;
+  if (row?.author_name) return `${noun} by ${row.author_name} · ${keyTail(row.author, 4)}`;
+  return `${noun} by ${keyTail(row?.author, 8)}`;
+}
+
+/** The AR anchor title for a caw, same order. */
+export function cawTitleFor(row, { contactName = null } = {}) {
+  if (row?.origin === "local" || row?.origin === "sync") return "Your caw";
+  if (contactName) return `A caw from ${contactName}`;
+  if (row?.author_name) return `A caw from ${row.author_name} · ${keyTail(row.author, 4)}`;
+  return "A caw";
+}
+```
+
+`bundles/ramble/server/delivery.js` — add (after `listAudiences`):
+
+```js
+/**
+ * x-only pubkey -> { crow_id, name } for every unblocked full contact, bots
+ * included on purpose (naming a bot's mark is harmless). ORDER BY id +
+ * first-wins so two rows sharing a key name the older one deterministically.
+ * Tolerant: an empty map when the core table is unreadable (the stdio MCP
+ * process on a fresh db).
+ */
+export async function contactsByPubkey(db) {
+  const map = new Map();
+  try {
+    const { rows } = await db.execute({ sql: "SELECT crow_id, display_name, secp256k1_pubkey FROM contacts WHERE is_blocked = 0 AND request_status IS NULL ORDER BY id", args: [] });
+    for (const r of rows) {
+      const pk = String(r.secp256k1_pubkey || "");
+      const key = pk.length === 66 ? pk.slice(2) : pk;
+      if (key && !map.has(key)) map.set(key, { crow_id: r.crow_id, name: r.display_name || r.crow_id });
+    }
+  } catch { /* no core tables: nobody is a contact */ }
+  return map;
+}
+```
+
+`bundles/ramble/panel/routes.js`: delete the router-local zero-arg `contactsByPubkey()` function (body identical to the one above) and replace its one use in `annotateMarks` with `const byPubkey = await mods.deliveryMod.contactsByPubkey(db);`.
+
+`bundles/ramble/server/server.js`: import `{ labelFor } from "./labels.js"` and `contactsByPubkey` from `./delivery.js` (extend the existing delivery import). In `ramble_query_world` replace `const marks = await listMarks(db, { visibility, geohashPrefix: cell });` with:
+
+```js
+        const rows = await listMarks(db, { visibility, geohashPrefix: cell });
+        const byPubkey = await contactsByPubkey(db);
+        const marks = rows.map((m) => {
+          const c = m.origin === "remote" ? byPubkey.get(String(m.author)) : null;
+          return { ...m, label: labelFor(m, { contactName: c ? c.name : null }) };
+        });
+```
+
+`bundles/ramble/panel/static/ramble.js` — replace `markLabel`:
+
+```js
+  /* The one label rule (spec 2026-09-08 §3.1), mirrored from server/labels.js:
+   * yours, then a contact's saved name, then a stranger's world name with a
+   * key tail (unverified, so the tail keeps two Kevins apart), then the key. */
+  function markLabel(mark) {
+    var noun = mark.kind === "caw" ? "caw" : "mark";
+    if (mark.origin === "local" || mark.origin === "sync") return "your " + noun;
+    if (mark.contact_name) return noun + " by " + mark.contact_name;
+    var who = mark.author || "anon";
+    if (mark.author_name) return noun + " by " + mark.author_name + " · " + who.slice(0, 4);
+    return noun + " by " + who.slice(0, 8);
+  }
+```
+
+and in `arTitle` replace the caw line with:
+
+```js
+    if (mark.kind === "caw") {
+      if (mark.origin === "local" || mark.origin === "sync") return "Your caw";
+      if (mark.contact_name) return "A caw from " + mark.contact_name;
+      if (mark.author_name) return "A caw from " + mark.author_name + " · " + (mark.author || "anon").slice(0, 4);
+      return "A caw";
+    }
+```
+
+- [ ] **Step 4: Run** the three files (plus `tests/ramble-marks.test.js` is unaffected) → PASS; sinks still 2, backticks 0 in `static/ramble.js`.
+- [ ] **Step 5: Commit** — `git add bundles/ramble/server/labels.js tests/ramble-labels.test.js && git commit bundles/ramble/server/labels.js tests/ramble-labels.test.js bundles/ramble/server/delivery.js bundles/ramble/panel/routes.js bundles/ramble/server/server.js bundles/ramble/panel/static/ramble.js tests/ramble-tools.test.js tests/ramble-panel.test.js -m "ramble labels: your mark, contact name, world name with a key tail, then the key — server and client"`
+
+---
+
+## Task 4: The Visible sheet field, the route, docs en/es, 0.7.0, registry, suite
+
+**Files:**
+- Modify: `bundles/ramble/panel/ramble.js`, `bundles/ramble/panel/routes.js`, `bundles/ramble/panel/static/ramble.js`, `bundles/ramble/panel/static/ramble.css`, `docs/guide/ramble.md`, `docs/es/guide/ramble.md`, `bundles/ramble/manifest.json`, `bundles/ramble/package.json`, `registry/add-ons.json`
+- Test: `tests/ramble-panel.test.js`
+
+- [ ] **Step 1: Failing tests**
+
+In the panel shell test add `assert.match(sent, /id="rb-world-name"[^>]*maxlength="24"/);`. In the `GET /ramble/static/ramble.js` test add `assert.ok(body.includes('postGrid({ worldName: worldNameEl.value })'));`. Append after the grid tests:
+
+```js
+test("POST /api/ramble/grid stores a sanitized worldName, clears a rejected one, and bounds the input", async () => {
+  let res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "  Kevin‮  " } });
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).worldName, "Kevin");
+  assert.equal((await (await req("/api/ramble/grid")).json()).worldName, "Kevin");
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "f665c26b" } });
+  assert.equal((await res.json()).worldName, null, "a key look-alike clears the name");
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "x".repeat(129) } });
+  assert.equal(res.status, 400);
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: 7 } });
+  assert.equal(res.status, 400);
+});
+```
+
+- [ ] **Step 2: Run** `tests/ramble-panel.test.js` → the new assertions FAIL.
+
+- [ ] **Step 3: Implement**
+
+`bundles/ramble/panel/ramble.js`, after the Name `</div>` (the `rb-identity` row) and before `<p class="rb-muted rb-fine" id="rb-grid-status"></p>`:
+
+```html
+            <div class="rb-row">
+              <label class="rb-label" for="rb-world-name">World name</label>
+              <input id="rb-world-name" type="text" maxlength="24" autocomplete="nickname" placeholder="how strangers see you">
+            </div>
+            <p class="rb-muted rb-fine">Strangers see your world name on your marks when Name is pseudonym or real, next to a short key so two people with one name stay apart. Contacts always see your Crow name.</p>
+```
+
+`bundles/ramble/panel/routes.js` `POST /api/ramble/grid`: in the validation block add `if (b.worldName != null && (typeof b.worldName !== "string" || b.worldName.length > 128)) bad("worldName must be a string of at most 128 characters");` and after the identity-level write add `if (b.worldName != null) await mods.gridMod.setWorldName(db, b.worldName, { emit });` (the response is `getGrid`, which now carries `worldName`).
+
+`bundles/ramble/panel/static/ramble.js`: beside `var identityEl = $("rb-identity");` add `var worldNameEl = $("rb-world-name");`; in `paintGrid` add `if (worldNameEl && worldNameEl !== document.activeElement) worldNameEl.value = grid.worldName || "";`; beside the identity `change` listener add `if (worldNameEl) worldNameEl.addEventListener("change", function () { postGrid({ worldName: worldNameEl.value }); });`.
+
+`bundles/ramble/panel/static/ramble.css`: the existing `#ramble select { … }` rule becomes `#ramble select,\n#ramble .rb-sheet input[type="text"] { … }` (same declarations), plus one new rule `#ramble .rb-sheet input[type="text"] { flex: 1; min-width: 0; }`.
+
+Docs — `docs/guide/ramble.md`, in `## Privacy` append a paragraph:
+
+```
+**World name.** In the Visible sheet you can set a world name (up to 24 characters) that strangers see on your public marks and caws instead of a bare key — but only while your Name level is `pseudonym` or `real`; at `rotating` nothing but the short key goes out. It is unverified, so a stranger's name is always shown with the first four characters of their key ("Kevin · f665"). Contacts never see it: they see the name they saved for you. Your own marks read "your mark".
+```
+
+`docs/es/guide/ramble.md`, in `## Privacidad` append:
+
+```
+**Nombre en el mundo.** En la hoja Visible puedes fijar un nombre en el mundo (hasta 24 caracteres) que los desconocidos ven en tus marcas y caws públicos en lugar de una clave — pero solo mientras tu nivel de Nombre sea `pseudonym` o `real`; en `rotating` no sale nada más que la clave corta. No está verificado, así que el nombre de un desconocido se muestra siempre con los cuatro primeros caracteres de su clave ("Kevin · f665"). Los contactos nunca lo ven: ven el nombre que guardaron para ti. Tus propias marcas dicen "your mark".
+```
+
+Bump: `sed -i 's/"version": "0.6.0"/"version": "0.7.0"/' bundles/ramble/manifest.json bundles/ramble/package.json && npm run build-registry`.
+
+- [ ] **Step 4: Run** `tests/ramble-panel.test.js` → PASS (parity included). Then the FULL suite in the foreground (`node scripts/run-suite.mjs 2>&1 | tail -12`, expect pass = total, fail 0: 4186 + 8 new = 4194 — tables +0 (an assertion), grid +2, nostr-map +1, marks +1, sync +1, transport +1, labels +2, tools +1, panel +1 = 4196; report the actual), `node scripts/check-port-allocation.js`, `npm run build-registry -- --check`.
+- [ ] **Step 5: Commit** — `git commit bundles/ramble/panel/ramble.js bundles/ramble/panel/routes.js bundles/ramble/panel/static/ramble.js bundles/ramble/panel/static/ramble.css docs/guide/ramble.md docs/es/guide/ramble.md bundles/ramble/manifest.json bundles/ramble/package.json registry/add-ons.json tests/ramble-panel.test.js -m "ramble 0.7.0: the World name field; docs en/es; registry"`
+- [ ] **Step 6 (controller):** push, PR, check-runs, merge, CROW-SCHEDULE.md, three-gateway restart (grackle: `refreshed ramble 0.6.0 -> 0.7.0`), Kevin sets a world name and leaves a pseudonym-level mark from grackle; a second instance (crow's transport receives the public event) stores `author_name` — verify with a read-only SELECT on crow's live db.
+
+## Self-review notes
+- D1: the level decides (transport, per row from `author_level ?? level`); `rotating` never carries a name (transport test). D2: key4 tail on named strangers (labels test, client pin). D3: own marks (labels test, tools assertion, client pin).
+- §2.1 rules: grid test covers each rule incl. code points and hex-only. §2.2: nostr-map + transport + sync door. Teaser allowlist: marks test. Contacts marks never carry a name: `markPayload`/`payloadToMark` untouched (asserted implicitly — `payloadToMark` ignores unknown keys).
+- Type consistency: `markToEvent`'s `name` option ↔ the transport call; `author_name` on rows ↔ `labelFor`/`markLabel`/`RAMBLE_MARK_WIRE_COLUMNS`/`insertRemoteMark`/teaser; `getGrid().worldName` ↔ the route response ↔ `paintGrid`; `contactsByPubkey` in delivery.js ↔ routes.js and server.js.
+
+## Review
+Recorded below after each gate (round 1, round 2, scoped check), before execution.

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4887,7 +4887,7 @@
     {
       "id": "ramble",
       "name": "Ramble",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "type": "mcp-server",
       "author": "Crow",
       "category": "social",

--- a/servers/gateway/boot/ramble-transport.js
+++ b/servers/gateway/boot/ramble-transport.js
@@ -229,6 +229,9 @@ export async function startRambleTransport({
     // mid-tick, and every row published this tick should ride the same
     // bird rather than each doing its own db round trip.
     const bird = await activeBird(db);
+    // Raw on purpose: markToEvent sanitizes (an installed bundle older than
+    // 0.7.0 ignores the option, so a stale copy keeps draining unchanged).
+    const worldName = await getSetting("world.name");
 
     for (const row of rows) {
       try {
@@ -241,7 +244,9 @@ export async function startRambleTransport({
           sessionId,
           _derive,
         });
-        const template = markToEvent(row, { precision: prec, crowId: persona.crowId, bird });
+        const rowLevel = row.author_level ?? level;
+        const name = rowLevel === "pseudonym" || rowLevel === "real" ? worldName : null;
+        const template = markToEvent(row, { precision: prec, crowId: persona.crowId, bird, name });
         const event = finalizeEvent(template, persona.secp256k1Priv);
         // eslint-disable-next-line no-await-in-loop
         const accepted = await nostrManager.publishRendezvousEvent(event);

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -415,6 +415,7 @@ const RAMBLE_MARK_WIRE_COLUMNS = [
   // that stored it — without these on the wire a replicated mark would render
   // birdless on the user's other instances.
   "bird_species", "bird_seed",
+  "author_name", // 2026-09-08: the world name a stranger's mark was left under.
 ];
 
 /**

--- a/tests/ramble-delivery.test.js
+++ b/tests/ramble-delivery.test.js
@@ -175,3 +175,17 @@ test("enqueueMark fans a contacts mark out to every full contact and refuses an 
   assert.deepEqual(await enqueueMark(db, lonely), { ok: true, recipients: 0 });
   assert.equal((await db.execute({ sql: "SELECT publish_state FROM ramble_marks WHERE mark_id = ?", args: [lonely.mark_id] })).rows[0].publish_state, "published");
 });
+
+test("contacts marks never carry a world name in either direction", async () => {
+  const row = await createMark(db, {
+    author: "c".repeat(64), author_level: "pseudonym", kind: "mark",
+    anchor: { anchor_kind: "geo", lat: 30.46, lon: -98.08, accuracy_m: 12 },
+    visibility: "contacts", reveal: "open",
+    content: { content_text: "for my people", content_kind: "none" },
+  });
+  const payload = markPayload({ ...row, author_name: "Kevin" });
+  assert.equal(payload.author_name, undefined);
+  assert.equal(payload.name, undefined);
+  const back = payloadToMark({ ...payload, author_name: "Kevin", name: "Kevin" }, { author: PK, eventId: "evt-n" });
+  assert.equal(back.author_name, undefined, "a contact is named from the contacts table, never from the payload");
+});

--- a/tests/ramble-grid.test.js
+++ b/tests/ramble-grid.test.js
@@ -16,6 +16,7 @@ import { createMark, insertRemoteMark } from "../bundles/ramble/server/marks.js"
 import {
   AUDIENCES, CHANNELS, IDENTITY_LEVELS,
   getGrid, setCell, setMaster, setIdentityLevel, emitAllowed, audienceOf, makePublishGate,
+  sanitizeWorldName, WORLD_NAME_MAX, setWorldName,
 } from "../bundles/ramble/server/grid.js";
 
 let db;
@@ -208,4 +209,35 @@ test("makePublishGate: false under the default grid, true once enabled", async (
 
   const contactsRow = { visibility: "contacts" };
   assert.equal(await gate(contactsRow), false, "contacts row is never gated true by the geo cell alone");
+});
+
+test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:/req: rejected, hex-only rejected, capped at 24 code points, empty is null", () => {
+  assert.equal(sanitizeWorldName("Kevin"), "Kevin");
+  assert.equal(sanitizeWorldName("  Kevin‮   H  "), "Kevin H");
+  assert.equal(sanitizeWorldName("crow:kevin"), null);
+  assert.equal(sanitizeWorldName("REQ:x"), null);
+  assert.equal(sanitizeWorldName("f665c26b"), null, "a key look-alike");
+  assert.equal(sanitizeWorldName("DEADBEEF1234"), null);
+  assert.equal(sanitizeWorldName("Kev1"), "Kev1", "hex-ish but not all hex");
+  assert.equal(sanitizeWorldName("Kev · f665"), "Kev f665", "the label separator cannot be faked");
+  assert.equal(sanitizeWorldName("abc"), "abc", "3 hex chars is a word, not a tail");
+  assert.equal(sanitizeWorldName("x".repeat(40)), "x".repeat(24));
+  assert.equal(sanitizeWorldName("x".repeat(23) + " yz"), "x".repeat(23), "a cut that lands on a space is re-trimmed");
+  assert.equal(sanitizeWorldName("🐦".repeat(30)), "🐦".repeat(24), "code points, not UTF-16 units");
+  assert.equal(sanitizeWorldName(""), null);
+  assert.equal(sanitizeWorldName("   "), null);
+  assert.equal(sanitizeWorldName(123), null);
+  assert.equal(sanitizeWorldName(null), null);
+  assert.equal(WORLD_NAME_MAX, 24);
+});
+
+test("world name: set/read through the grid; unset reads null; the setting replicates (not local.)", async () => {
+  assert.equal((await getGrid(db)).worldName, null);
+  const calls = [];
+  assert.equal(await setWorldName(db, "  Kevin  ", { emit: async (t, op, row) => calls.push([t, op, row.key, row.value]) }), "Kevin");
+  assert.equal((await getGrid(db)).worldName, "Kevin");
+  assert.deepEqual(calls, [["ramble_settings", "update", "world.name", "Kevin"]]);
+  assert.equal(await setWorldName(db, "crow:nope"), null);
+  assert.equal((await getGrid(db)).worldName, null, "a rejected name clears the setting");
+  assert.equal(await setWorldName(db, "f665c26b"), null);
 });

--- a/tests/ramble-grid.test.js
+++ b/tests/ramble-grid.test.js
@@ -220,6 +220,9 @@ test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:
   assert.equal(sanitizeWorldName("DEADBEEF1234"), null);
   assert.equal(sanitizeWorldName("Kev1"), "Kev1", "hex-ish but not all hex");
   assert.equal(sanitizeWorldName("Kev · f665"), "Kev f665", "the label separator cannot be faked");
+  assert.equal(sanitizeWorldName("f6\u200B65c26b"), null, "a zero-width space cannot hide a key look-alike");
+  assert.equal(sanitizeWorldName("cro\u200Dw:kevin"), null, "a zero-width joiner cannot hide the crow: prefix");
+  assert.equal(sanitizeWorldName("Ke\uFEFFvin"), "Kevin", "a BOM is stripped");
   assert.equal(sanitizeWorldName("abc"), "abc", "3 hex chars is a word, not a tail");
   assert.equal(sanitizeWorldName("x".repeat(40)), "x".repeat(24));
   assert.equal(sanitizeWorldName("x".repeat(23) + " yz"), "x".repeat(23), "a cut that lands on a space is re-trimmed");

--- a/tests/ramble-grid.test.js
+++ b/tests/ramble-grid.test.js
@@ -213,7 +213,7 @@ test("makePublishGate: false under the default grid, true once enabled", async (
 
 test("sanitizeWorldName: controls and bidi stripped, whitespace collapsed, crow:/req: rejected, hex-only rejected, capped at 24 code points, empty is null", () => {
   assert.equal(sanitizeWorldName("Kevin"), "Kevin");
-  assert.equal(sanitizeWorldName("  Kevin‮   H  "), "Kevin H");
+  assert.equal(sanitizeWorldName("  Kevin\u202E   H\u0000 "), "Kevin H");
   assert.equal(sanitizeWorldName("crow:kevin"), null);
   assert.equal(sanitizeWorldName("REQ:x"), null);
   assert.equal(sanitizeWorldName("f665c26b"), null, "a key look-alike");

--- a/tests/ramble-labels.test.js
+++ b/tests/ramble-labels.test.js
@@ -1,0 +1,21 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { keyTail, labelFor, cawTitleFor } from "../bundles/ramble/server/labels.js";
+
+const A = "f665c26b" + "0".repeat(56);
+test("labelFor: own > contact > named stranger with key4 > key8; caws use their noun", () => {
+  assert.equal(labelFor({ kind: "mark", origin: "local", author: A }), "your mark");
+  assert.equal(labelFor({ kind: "caw", origin: "sync", author: A, author_name: "Kevin" }), "your caw");
+  assert.equal(labelFor({ kind: "mark", origin: "remote", author: A, author_name: "Kevin" }, { contactName: "Pal" }), "mark by Pal");
+  assert.equal(labelFor({ kind: "caw", origin: "remote", author: A, author_name: "Kevin" }), "caw by Kevin · f665");
+  assert.equal(labelFor({ kind: "mark", origin: "remote", author: A }), "mark by f665c26b");
+  assert.equal(labelFor({ kind: "mark", origin: "remote" }), "mark by anon");
+  assert.equal(keyTail(A, 4), "f665");
+  assert.equal(keyTail(null, 8), "anon");
+});
+test("cawTitleFor mirrors the rule for the AR title", () => {
+  assert.equal(cawTitleFor({ kind: "caw", origin: "local", author: A }), "Your caw");
+  assert.equal(cawTitleFor({ kind: "caw", origin: "remote", author: A }, { contactName: "Pal" }), "A caw from Pal");
+  assert.equal(cawTitleFor({ kind: "caw", origin: "remote", author: A, author_name: "Kevin" }), "A caw from Kevin · f665");
+  assert.equal(cawTitleFor({ kind: "caw", origin: "remote", author: A }), "A caw");
+});

--- a/tests/ramble-marks.test.js
+++ b/tests/ramble-marks.test.js
@@ -175,3 +175,16 @@ test("a private mark synced in from the user's OWN other instance (origin='sync'
   assert.ok(noFilterList.find((r) => r.mark_id === "sync-private-1"), "synced-from-own-instance private mark must appear in the owner's overview");
   assert.ok(!noFilterList.find((r) => r.mark_id === "wire-private-1"), "a private mark tagged origin=remote must never appear in the owner's overview");
 });
+
+test("insertRemoteMark stores author_name and a locked teaser keeps it", async () => {
+  const result = await insertRemoteMark(db, {
+    mark_id: "named-remote-1", author: "pk9", kind: "mark", anchor_kind: "geo", geohash: "9v6m2c",
+    lat: 30.2672, lon: -97.7431, visibility: "public", reveal: "locked", content_text: "named",
+    created_at: Date.now(), nostr_event_id: "ev-named-1", author_name: "  Kevin\u202E ",
+  });
+  assert.equal(result.inserted, true);
+  assert.equal(result.row.author_name, "Kevin", "sanitized at the store too");
+  const listed = (await listMarks(db, { visibility: "public" })).find((r) => r.mark_id === "named-remote-1");
+  assert.equal(listed.author_name, "Kevin", "the teaser allowlist carries the name");
+  assert.equal(listed.content_text, undefined, "still a teaser");
+});

--- a/tests/ramble-nostr-map.test.js
+++ b/tests/ramble-nostr-map.test.js
@@ -375,3 +375,20 @@ test("caws also carry a valid bird, but never coordinates", () => {
   assert.equal("lat" in content, false);
   assert.equal("lon" in content, false);
 });
+
+test("world name: rides in content only when given and clean; eventToMark reads it through the sanitizer", () => {
+  const row = { ...openMarkRow, author_level: "pseudonym" };
+  const withName = JSON.parse(markToEvent(row, { name: "  Kevin\u202E " }).content);
+  assert.equal(withName.name, "Kevin");
+  assert.equal(JSON.parse(markToEvent(row, {}).content).name, undefined, "no name given, none sent");
+  assert.equal(JSON.parse(markToEvent(row, { name: "f665c26b" }).content).name, undefined, "a key look-alike is dropped");
+  assert.equal(JSON.parse(markToEvent(row, { name: "crow:x" }).content).name, undefined);
+  const ev = { id: "e".repeat(64), pubkey: "a".repeat(64), kind: MARK_KIND, created_at: 1, tags: [["g", "9v6m2"], ["d", "m1"]], content: JSON.stringify({ v: 1, text: "hi", name: "  Bad\u0000 Name " }) };
+  assert.equal(eventToMark(ev).author_name, "Bad Name", "collapsed, not squeezed");
+  ev.content = JSON.stringify({ v: 1, text: "hi", name: "deadbeef" });
+  assert.equal(eventToMark(ev).author_name, null);
+  ev.content = JSON.stringify({ v: 1, text: "hi" });
+  assert.equal(eventToMark(ev).author_name, null);
+  ev.content = JSON.stringify({ v: 1, text: "hi", name: 42 });
+  assert.equal(eventToMark(ev).author_name, null);
+});

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -559,6 +559,11 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
   // attribute name on BOTH sides so a rename cannot silently split them.
   assert.ok(body.includes('"data-visibility"'), "client must read the data-visibility attribute");
 
+  // World name labels (spec 2026-09-08 §3.1): own marks say so; a named stranger gets a key tail.
+  assert.ok(body.includes('return "your " + noun;'), "own marks read your mark / your caw");
+  assert.ok(body.includes('" · " + who.slice(0, 4)'), "a named stranger carries a key4 tail");
+  assert.ok(body.includes('"Your caw"') && body.includes('"A caw from "'));
+
   // Phase 2 wiring: nests for the viewport, the claim, the flock, the swap,
   // the activation, and the third named SSE frame.
   assert.ok(body.includes('"/api/ramble/nests?bbox="'), "client must fetch nests by bbox");

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -159,6 +159,9 @@ test("panel handler renders the world-first shell, its three views and every ass
   // Grid checkbox names are the wire contract with POST /api/ramble/grid.
   assert.match(sent, /name="grid-public-geo"/);
 
+  // The Visible sheet's World name field: bounded to 24 characters client-side.
+  assert.match(sent, /id="rb-world-name"[^>]*maxlength="24"/);
+
   // The legacy ids are GONE — anything still selecting them is broken.
   assert.doesNotMatch(sent, /id="ramble-map"/);
   assert.doesNotMatch(sent, /id="ramble-pet"/);
@@ -315,6 +318,24 @@ test("POST /api/ramble/grid rejects an unknown audience or channel", async () =>
   assert.equal(bad.status, 400);
   const badChannel = await req("/api/ramble/grid", { method: "POST", body: { cells: { public: { carrier_pigeon: true } } } });
   assert.equal(badChannel.status, 400);
+});
+
+test("POST /api/ramble/grid stores a sanitized worldName, clears a rejected one, and bounds the input", async () => {
+  let res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "  Kevin\u202E  " } });
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).worldName, "Kevin");
+  assert.equal((await (await req("/api/ramble/grid")).json()).worldName, "Kevin");
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "f665c26b" } });
+  assert.equal((await res.json()).worldName, null, "a key look-alike clears the name");
+  await req("/api/ramble/grid", { method: "POST", body: { worldName: "Kevin" } });
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "" } });
+  assert.equal((await res.json()).worldName, null, "an empty string clears");
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: null, master: true } });
+  assert.equal(res.status, 200, "null means not-sent, not clear");
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: "x".repeat(129) } });
+  assert.equal(res.status, 400);
+  res = await req("/api/ramble/grid", { method: "POST", body: { worldName: 7 } });
+  assert.equal(res.status, 400);
 });
 
 // ------------------------------------------------------------------- the pet
@@ -543,6 +564,7 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
   // is the client half of the fix/android-geolocation-map-swipe change).
   assert.match(body, /Crow\.setPullToRefresh\(false\)/);
   assert.match(body, /Crow\.setPullToRefresh\(true\)/);
+  assert.ok(body.includes('postGrid({ worldName: worldNameEl.value })'));
 
   // House rule for panel client scripts: NO template literals. The panel
   // tooling treats a backtick as its own delimiter, so one here silently

--- a/tests/ramble-sync.test.js
+++ b/tests/ramble-sync.test.js
@@ -526,3 +526,13 @@ test("phase 3 apply door: trade insert, LWW by envelope lamport, update, delete 
   assert.equal((await b.execute("SELECT 1 FROM ramble_trades WHERE trade_id='t-in'")).rows.length, 0);
   await assert.doesNotReject(applyRemoteOp(b, "ramble_trades", "update", { counterpart: "x" }, 10), "a keyless row is ignored, never thrown on");
 });
+
+test("author_name rides the apply door (wire column) and is updatable by LWW", async () => {
+  const row = { mark_id: "named-9", author: "c".repeat(64), author_level: "pseudonym", kind: "mark", anchor_kind: "geo", geohash: "9v6m21h", lat: 30.46, lon: -98.08, visibility: "public", reveal: "open", content_text: "n", content_kind: "none", created_at: 1, expires_at: null, nostr_event_id: "ev-n9", author_name: "Kevin" };
+  await applyRemoteOp(b, "ramble_marks", "insert", row, 11);
+  let got = (await b.execute({ sql: "SELECT author_name, origin FROM ramble_marks WHERE mark_id = 'named-9'", args: [] })).rows[0];
+  assert.deepEqual([got.author_name, got.origin], ["Kevin", "sync"]);
+  await applyRemoteOp(b, "ramble_marks", "update", { ...row, author_name: "Kev" }, 12);
+  got = (await b.execute({ sql: "SELECT author_name FROM ramble_marks WHERE mark_id = 'named-9'", args: [] })).rows[0];
+  assert.equal(got.author_name, "Kev");
+});

--- a/tests/ramble-tables.test.js
+++ b/tests/ramble-tables.test.js
@@ -44,7 +44,7 @@ test("flock tables + columns exist (phase 1)", async () => {
   const pet = await cols("ramble_pet");
   for (const c of ["active_egg_id", "chores_json", "lamport_ts", "week_start"]) assert.ok(pet.includes(c), `ramble_pet.${c}`);
   const marks = await cols("ramble_marks");
-  for (const c of ["bird_species", "bird_seed"]) assert.ok(marks.includes(c), `ramble_marks.${c}`);
+  for (const c of ["bird_species", "bird_seed", "author_name"]) assert.ok(marks.includes(c), `ramble_marks.${c}`);
   const eggs = await cols("ramble_eggs");
   for (const c of ["egg_id", "status", "warmth", "species", "seed", "found_cell", "found_week", "from_crow_id", "created_at", "hatched_at", "lamport_ts"]) assert.ok(eggs.includes(c), `ramble_eggs.${c}`);
 });

--- a/tests/ramble-tools.test.js
+++ b/tests/ramble-tools.test.js
@@ -28,6 +28,7 @@ test("leave_mark then query_world returns it, attributed to the x-only world pse
   const m = payload.marks.find((m) => m.content_text === "hello");
   assert.ok(m);
   assert.match(m.author, /^[0-9a-f]{64}$/);
+  assert.equal(m.label, "your mark");
 });
 
 test("ramble_leave_mark with visibility:private succeeds and ramble_query_world({visibility:private}) returns it", async () => {
@@ -267,4 +268,12 @@ test("phase 3 tools: gift and propose_swap validate the contact and the egg, que
   assert.equal((await db.execute("SELECT count(*) AS n FROM ramble_marks WHERE visibility='group:nope'")).rows[0].n, 0);
   r = await h.ramble_leave_mark({ lat: 30.2, lon: -97.7, text: "public", visibility: "public" });
   assert.equal(JSON.parse(r.content[0].text).recipients, undefined, "public marks do not report recipients");
+});
+
+test("ramble_query_world labels a named stranger's mark 'mark by <name> · key4'", async () => {
+  const { insertRemoteMark } = await import("../bundles/ramble/server/marks.js");
+  await insertRemoteMark(db, { mark_id: "named-tool", author: "f665c26b" + "1".repeat(56), kind: "mark", anchor_kind: "geo", geohash: encodeGeohash(30.2672, -97.7431, 7), lat: 30.2672, lon: -97.7431, visibility: "public", reveal: "open", content_text: "named", created_at: Date.now(), nostr_event_id: "ev-named-tool", author_name: "Kevin" });
+  const q = await h.ramble_query_world({ lat: 30.2672, lon: -97.7431, visibility: "public" });
+  const m = JSON.parse(q.content[0].text).marks.find((x) => x.mark_id === "named-tool");
+  assert.equal(m.label, "mark by Kevin · f665");
 });

--- a/tests/ramble-transport.test.js
+++ b/tests/ramble-transport.test.js
@@ -23,7 +23,7 @@ import { tmpdir } from "node:os";
 import { createClient } from "@libsql/client";
 import { generateSecretKey, getPublicKey, finalizeEvent } from "nostr-tools/pure";
 import { createMark, getMark } from "../bundles/ramble/server/marks.js";
-import { MARK_KIND, CAW_KIND } from "../bundles/ramble/server/nostr-map.js";
+import { MARK_KIND, CAW_KIND, eventToMark } from "../bundles/ramble/server/nostr-map.js";
 import { setMaster, setCell } from "../bundles/ramble/server/grid.js";
 import { isoWeek } from "../bundles/ramble/server/eggs.js";
 import { startRambleTransport } from "../servers/gateway/boot/ramble-transport.js";
@@ -893,4 +893,26 @@ test("phase 4: two of a user's instances over one bus and identity both apply on
   assert.equal(B.sent.length, 1, "B never replies to a completion");
 
   A1.transport.stop(); A2.transport.stop(); B.transport.stop();
+});
+
+test("world name rides only pseudonym/real rows: a rotating row never carries it; eventToMark round-trips it", async () => {
+  const h = await makeHarness();
+  await setMaster(h.db, true);
+  await setCell(h.db, "public", "geo", true);
+  await h.db.execute({ sql: "INSERT INTO ramble_settings (key, value) VALUES ('world.name', ?)", args: ["Kevin"] });
+  const rot = await seedPublicMark(h.db, "rotating row", { author_level: "rotating" });
+  const pseud = await seedPublicMark(h.db, "pseudonym row", { author_level: "pseudonym" });
+  const real = await seedPublicMark(h.db, "real row", { author_level: "real" });
+  await h.transport.drainOnce();
+  const byText = (t) => h.published.find((e) => JSON.parse(e.content).text === t);
+  assert.equal(JSON.parse(byText("rotating row").content).name, undefined);
+  assert.equal(JSON.parse(byText("pseudonym row").content).name, "Kevin");
+  assert.equal(JSON.parse(byText("real row").content).name, "Kevin");
+  assert.equal(eventToMark(byText("pseudonym row")).author_name, "Kevin");
+  // A row with no level of its own follows the instance level (createMark stores author_level ?? null).
+  await h.db.execute({ sql: "INSERT INTO ramble_settings (key, value) VALUES ('public_identity_level', 'pseudonym') ON CONFLICT(key) DO UPDATE SET value = excluded.value", args: [] });
+  const bare = await seedPublicMark(h.db, "bare row", { author_level: null });
+  await h.transport.drainOnce();
+  assert.equal(JSON.parse(byText("bare row").content).name, "Kevin");
+  void rot; void pseud; void real; void bare;
 });


### PR DESCRIPTION
## Ramble 0.7.0 — World name + "your mark" labels (Plan A)

Spec: `docs/superpowers/specs/2026-09-08-ramble-names-and-profile-design.md` (§0 D1–D3, §1–§3, §6, §7, §8). Plan with three review gates + rulings: `docs/superpowers/plans/2026-09-08-ramble-world-name.md`.

### What changes
- **World name** (`ramble_settings` `world.name`, ≤ 24 code points, `sanitizeWorldName` in `bundles/ramble/server/grid.js`): strips controls, bidi and zero-width characters, rejects `crow:`/`req:` prefixes and hex-only look-alikes, replaces the label's own `·` separator. Set from the Visible sheet (new field under Name; `POST /api/ramble/grid { worldName }`).
- **Wire**: `content.name` on public marks/caws (kinds 30397/20397) only when the ROW's `author_level` is `pseudonym` or `real` — a `rotating` row never carries one (D1). `markToEvent` sanitizes on send, `eventToMark` on receipt, `insertRemoteMark` again at the store. New column `ramble_marks.author_name` (guarded `ensureColumn`, no schema-generation bump), on the teaser allowlist and the instance-sync wire columns. Contacts/group marks never carry a name.
- **Core consumes no new bundle export**: the transport passes the raw setting and the bundle's `markToEvent` sanitizes, so an installed copy older than 0.7.0 keeps draining unchanged (verified against the real 0.6.0 copy in review).
- **Labels** (one rule, `bundles/ramble/server/labels.js`, mirrored by the plain-script client): own → `your mark` / `your caw`; contact → `mark by <saved name>`; named stranger → `mark by <world name> · <key4>`; else `mark by <key8>`. AR caw titles follow the same order. `ramble_query_world` rows gain `label`; `contactsByPubkey(db)` moved to `delivery.js` and shared by the panel routes and the MCP server.
- Docs en/es (Privacy paragraph, /around line, MCP table). Manifest + package 0.6.0 → 0.7.0; registry rebuilt.

### Tests
Full suite 4197 / 4197 / 0 (+11: grid, nostr-map, marks, sync apply door, transport level gating, delivery no-name, labels ×2, tools label, panel field/route). Static client rules pinned: 0 backticks, 2 markup sinks, `textContent` only.

### Deploy notes
- All three gateways restart back-to-back; grackle's journal must show `refreshed ramble 0.6.0 -> 0.7.0` before `[ramble] transport started`, then `author_name` in `PRAGMA table_info(ramble_marks)` (a sub-second boot window exists where a synced row can hit an unrefreshed receiver — same class as `bird_species`).
- Phone smoke (grackle, HTTPS): set a World name at Name = pseudonym, leave a public mark, see "your mark" on the map/Nearby/AR; the field's placeholder reads "not sent while Name is rotating" at the default level.

### Deferred (noted in review, ruled accept)
- Lookalike dots (U+2022/U+22C5/U+30FB) survive the sanitizer; harmless — the real ` · key4` tail is appended unconditionally and contact labels carry no tail.
- The sheet's "Contacts see the name they saved for you" becomes "your Crow name" once Plan B ships the profile handshake.
- Zero-width joiner is stripped with the other default-ignorables, so a multi-person emoji sequence in a name renders as separate glyphs.