### PR TITLE
ramble 0.8.1: the pet page lists what actually feeds the bird

### DIFF
--- a/bundles/ramble/manifest.json
+++ b/bundles/ramble/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ramble",
   "name": "Ramble",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "mcp-server",
   "author": "Crow",
   "category": "social",

--- a/bundles/ramble/package.json
+++ b/bundles/ramble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crow-ramble",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Ramble MCP server — proximity marks, caws, privacy grid, egg and bird companion, gifts and swaps",
   "type": "module",
   "main": "server/index.js",

--- a/bundles/ramble/panel/ramble.js
+++ b/bundles/ramble/panel/ramble.js
@@ -264,6 +264,37 @@ export default {
           </section>
 
           <section class="rb-card">
+            <p class="rb-eyebrow">What your bird runs on</p>
+            <div class="rb-steps">
+              <div class="rb-step">
+                <span class="rb-step-n">+20</span>
+                <div class="rb-step-txt"><strong>Meet another crow</strong><span class="rb-muted rb-fine">run into someone else out rambling</span></div>
+              </div>
+              <div class="rb-step">
+                <span class="rb-step-n">+15</span>
+                <div class="rb-step-txt"><strong>Somewhere new</strong><span class="rb-muted rb-fine">an area you haven&rsquo;t been this week</span></div>
+              </div>
+              <div class="rb-step">
+                <span class="rb-step-n">+10</span>
+                <div class="rb-step-txt"><strong>Unlock a mark</strong><span class="rb-muted rb-fine">open something someone left behind</span></div>
+              </div>
+              <div class="rb-step">
+                <span class="rb-step-n">+8</span>
+                <div class="rb-step-txt"><strong>A chore below</strong><span class="rb-muted rb-fine">feed, preen or play, once a day each</span></div>
+              </div>
+              <div class="rb-step">
+                <span class="rb-step-n">+5</span>
+                <div class="rb-step-txt"><strong>Check in</strong><span class="rb-muted rb-fine">a daily tap on the egg screen</span></div>
+              </div>
+              <div class="rb-step">
+                <span class="rb-step-n">&minus;10</span>
+                <div class="rb-step-txt"><strong>A quiet stretch</strong><span class="rb-muted rb-fine">nothing at all for a while and it droops</span></div>
+              </div>
+            </div>
+            <p class="rb-muted rb-fine">Getting out is worth more than tapping.</p>
+          </section>
+
+          <section class="rb-card">
             <p class="rb-eyebrow">Today</p>
             <div class="rb-chores">
               <button class="rb-chore" data-kind="feed" type="button">${icon("feed")}Feed</button>

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4887,7 +4887,7 @@
     {
       "id": "ramble",
       "name": "Ramble",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "type": "mcp-server",
       "author": "Crow",
       "category": "social",

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -165,6 +165,14 @@ test("panel handler renders the world-first shell, its three views and every ass
   assert.match(sent, /id="rb-world-name"[^>]*maxlength="24"/);
   assert.ok(sent.includes("Contacts see the name they saved for you, or your Crow name."));
 
+  // The pet page must name what actually feeds the bird, not just the three
+  // chore buttons: walking is worth more than tapping and the page hid that.
+  assert.ok(sent.includes("What your bird runs on"), "the energy-sources card is on the pet page");
+  for (const src of ["Meet another crow", "Somewhere new", "Unlock a mark", "A chore below", "Check in", "A quiet stretch"]) {
+    assert.ok(sent.includes(src), `pet page names the energy source: ${src}`);
+  }
+  assert.ok(sent.includes("Getting out is worth more than tapping."), "the page says walking beats tapping");
+
   // The legacy ids are GONE — anything still selecting them is broken.
   assert.doesNotMatch(sent, /id="ramble-map"/);
   assert.doesNotMatch(sent, /id="ramble-pet"/);


### PR DESCRIPTION
The pet page showed three chore buttons under a heading that said "Today", and a weekly row of bare counters that never mentioned the bird. Nothing on the page said that walking is what actually feeds it, so the game read as three taps.

It isn't. Walking is worth more than tapping, and the page now says so.

| What you do | Energy |
|---|---|
| Meet another crow | +20 |
| Visit somewhere new | +15 |
| Unlock a mark | +10 |
| A daily chore | +8 |
| Check in | +5 |
| A quiet stretch | −10 |

Two of these were invisible before: that meeting someone and going somewhere new are the two largest rewards, and that the bird droops from inactivity at all.

Pure presentation. No mechanics change, no new numbers, no cadence change — the system already worked, the page just hid it. Reuses the existing step-row pattern from the egg checklist, so there is no new CSS.

Bundle 0.8.0 → 0.8.1 so the installed copy refreshes.

## Verification

| Gate | Result |
|---|---|
| Full suite | 4249 passing, 0 failing |
| `check-port-allocation.js` | OK — 45 ports, no collisions |
| `build-registry -- --check` | OK — in sync |

Test-driven: the assertions on the served page failed before the card existed and pass after. They pin each energy source by name, so removing one from the page fails the test.

## Context

First piece of the Ramble follow-up queue, taken as a bounded change ahead of the daily-loop design work. The chore cadence and the egg economy are being designed together separately, since spacing the taps only creates a reason to reopen the app, not a reason to go outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpkA6EtBWm2rnr7miS8yAV