### PR TITLE
ramble 0.9.2: fog like weather, seed like seed, and a bird that only speaks up when it has something to say

### DIFF
--- a/bundles/ramble/manifest.json
+++ b/bundles/ramble/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ramble",
   "name": "Ramble",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "mcp-server",
   "author": "Crow",
   "category": "social",

--- a/bundles/ramble/package.json
+++ b/bundles/ramble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crow-ramble",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Ramble MCP server — proximity marks, caws, privacy grid, egg and bird companion, gifts and swaps",
   "type": "module",
   "main": "server/index.js",

--- a/bundles/ramble/panel/ramble.js
+++ b/bundles/ramble/panel/ramble.js
@@ -127,7 +127,7 @@ export default {
             </div>
 
             <div class="rb-perch">
-              <div class="rb-say" id="rb-perch-say">Getting your bearings&hellip;</div>
+              <div class="rb-say" id="rb-perch-say" hidden></div>
               <button class="rb-btn rb-btn-ghost rb-perch-go" id="rb-perch-open" type="button">Your egg</button>
             </div>
           </div>

--- a/bundles/ramble/panel/static/ramble.css
+++ b/bundles/ramble/panel/static/ramble.css
@@ -860,21 +860,44 @@
 /* Unlocked ground is punched out of the mask: a clear map is what walking
    buys you. The frontier is a hole too, then dimmed on top, so it reads as
    previewed rather than owned. */
-#ramble .rb-fog { fill: var(--rb-surface-2); fill-opacity: 0.93; }
+/* Weather, not a spreadsheet: the filter wobbles the geohash-grid boundary and
+   takes the corners off. See ensureFogFilter() for the filter itself. */
+#ramble .rb-fog { fill: var(--rb-surface-2); fill-opacity: 0.93; filter: url(#rb-fog-clouds); }
 #ramble .rb-frontier-cell { fill: var(--rb-line); fill-opacity: 0.3; }
-/* Seed waiting in ground you have already cleared. Same accent as the
-   counter it feeds, so the pip and the number read as one thing. */
-#ramble .rb-seed-pip { fill: var(--rb-accent-2); }
+/* Seed waiting in ground you have already cleared. The pip is a divIcon
+   wrapping the engine's seed art; the -dot rule is the engine-less fallback. */
+#ramble .rb-seed-pip { display: grid; place-items: center; }
+#ramble .rb-seed-pip > svg { width: 18px; height: 18px; filter: drop-shadow(1px 2px 0 var(--rb-shadow-col)); }
+#ramble .rb-seed-dot { fill: var(--rb-accent-2); }
 #ramble .rb-beacon { stroke: var(--rb-line); fill: var(--rb-accent-2); opacity: 0.7; }
 #ramble .rb-beacon-nest { fill: var(--rb-accent); }
 
+/* ------------------------------------------------------------ the bird's voice */
+/* A Leaflet tooltip, restyled as a speech bubble. Leaflet supplies the tail
+   via .leaflet-tooltip-top:before, so this only has to colour it. */
+#ramble .rb-voice.leaflet-tooltip {
+  background: var(--rb-surface); color: var(--rb-text);
+  border: var(--rb-line-w) solid var(--rb-line); border-radius: 14px;
+  padding: 8px 12px; box-shadow: 2px 3px 0 var(--rb-shadow-col);
+  font: 800 13px/1.35 var(--rb-font-display); white-space: normal; max-width: 15rem;
+}
+#ramble .rb-voice.leaflet-tooltip-top:before { border-top-color: var(--rb-line); }
+
 /* ------------------------------------------------------- the unlock moment */
 @keyframes rb-unlock {
-  0% { fill-opacity: 0; }
-  35% { fill-opacity: 0.75; }
-  100% { fill-opacity: 0; }
+  0%   { fill-opacity: 0.93; transform: scale(1); }
+  100% { fill-opacity: 0; transform: scale(1.6); }
 }
-#ramble .rb-unlock-flash { fill: var(--rb-accent-2); animation: rb-unlock .9s ease-out; }
+/* The fog BURNING OFF the square you just earned, rather than a blue rectangle
+   blinking on it: it starts as fog and drifts outward as it thins. */
+#ramble .rb-unlock-flash {
+  fill: var(--rb-surface-2);
+  /* Invisible by default so prefers-reduced-motion (which kills the animation)
+     leaves NOTHING behind, rather than a solid fog square sitting on the cell. */
+  fill-opacity: 0;
+  transform-box: fill-box; transform-origin: center;
+  animation: rb-unlock 1.1s ease-out forwards;
+}
 #ramble .rb-seed {
   position: relative;   /* anchors the +N pop */
   display: inline-flex; align-items: center; gap: 5px;

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -136,6 +136,9 @@
   var lastPostedFix = null;
   var lastWalkFix = null;
   var walkStopTimer = null;
+  var momentTimer = null;
+  var spokeMarks = null;
+  var spokeNests = 0;
   var lastMarks = [];
 
   if (mapEl && typeof L !== "undefined") {
@@ -244,18 +247,13 @@
      * state; a divIcon is a focusable div with neither. Restore both. */
     var el = hereDot.getElement();
     if (el) {
-      el.setAttribute("role", "button");
-      el.setAttribute("aria-label", perchTarget === "pet" ? "Open your bird" : "Open your egg");
-      /* keyboard:true only gives Leaflet's tabIndex + role; its one keypress
-       * handler is popup-only (_onKeyPress -> _openPopup) and hereDot binds no
-       * popup. A role="button" div gets no synthesized click from Enter/Space,
-       * so wire it by hand. Property assignment, not addEventListener: this runs
-       * on every re-skin and must not stack duplicate handlers. */
-      el.onkeydown = function (ev) {
-        if (ev.key !== "Enter" && ev.key !== " ") return;
-        ev.preventDefault();
-        showView(perchTarget);
-      };
+      /* NOT role="button" any more: tapping no longer navigates, it asks. The
+       * tooltip Leaflet opens on focus carries the answer, and Leaflet sets
+       * aria-describedby to point at it, so a screen reader hears the status
+       * on focus without us inventing anything. */
+      el.setAttribute("role", "img");
+      el.setAttribute("aria-label", perchTarget === "pet" ? "You, and your bird" : "You, and your egg");
+      el.onkeydown = null;
     }
   }
 
@@ -298,7 +296,10 @@
          * role and aria-label to keep that. */
         title: "You",
       }).addTo(hereLayer);
-      hereDot.on("click", function () { showView(perchTarget); });
+      /* No showView here any more. Tapping the bird asks it what is around
+       * (Leaflet opens the tooltip on click and on focus); the labelled strip
+       * button is the door, and it works with no fix and no pointer. */
+      bindPerchVoice();
       paintHereArt();
     } else {
       hereRing.setLatLng(ll);
@@ -426,8 +427,7 @@
    * the flash would be invisible. A rectangle in the fog pane is on top of the
    * tiles and is the thing the user actually wants to see light up. */
   function celebrateUnlock(box) {
-    var say = $("rb-perch-say");
-    if (say) say.textContent = "New ground.";
+    sayMoment("New ground.");
     /* Its OWN layer, not zoneLayer: drawZones opens with clearLayers(), and
      * the refreshZones below resolves in tens of milliseconds, so a flash
      * parked in zoneLayer would be wiped long before its 900 ms animation
@@ -440,7 +440,7 @@
       var flash = L.rectangle(bounds, {
         pane: "rb-fog", className: "rb-unlock-flash", stroke: false, interactive: false,
       }).addTo(hereLayer);
-      setTimeout(function () { if (hereLayer) hereLayer.removeLayer(flash); }, 900);
+      setTimeout(function () { if (hereLayer) hereLayer.removeLayer(flash); }, 1200);
     }
     refreshZones();
     refreshMarks();
@@ -640,7 +640,7 @@
   }
 
   function drawMarks(marks) {
-    /* drawNearby renders a list row per mark and paintPerchSay counts
+    /* drawNearby renders a list row per mark and statusLine counts
      * lastMarks: a beacon has no content_text, mark_id or created_at, so both
      * must work from the full marks only, never the raw response. */
     var full = marks.filter(function (m) { return !m.beacon; });
@@ -672,7 +672,7 @@
       }
     });
     drawNearby(full);
-    paintPerchSay();
+    notePerch();
   }
 
   /* A frontier beacon: something is there, but not what. The server already
@@ -793,14 +793,15 @@
     var bird = pet && pet.bird;
     var valid = !!(Bird && bird && Bird.isValidBird({ species: bird.species, seed: bird.seed }));
     perchTarget = valid ? "pet" : "egg";
-    paintPerchSay();
+    notePerch();
     paintHereArt();
     paintPerchGo();
   }
 
-  function paintPerchSay() {
-    var say = $("rb-perch-say");
-    if (!say) return;
+  /* What the bird would say if asked. Ambient status, no longer shown
+   * unprompted — the map was carrying this line permanently and it did not
+   * earn the space. */
+  function statusLine() {
     var line;
     if (perchTarget === "egg") {
       line = "Your egg is " + Math.round(eggPercent) + "% warm.";
@@ -813,7 +814,56 @@
      * only ever runs from fetch/stream callbacks, after the whole script has
      * been evaluated, so the var is initialised by then. The guard is belt. */
     if ((lastNests || []).length > 0) line += " There's a nest nearby.";
-    say.textContent = line;
+    return line;
+  }
+
+  /* The bird's voice is a Leaflet tooltip on the marker, not a box in the
+   * strip. That buys three things the box could not: a real tail that points
+   * at the bird, a position that tracks it, and — because Leaflet binds both
+   * click and focus/blur for a non-permanent tooltip — tap-to-ask and
+   * keyboard-to-ask for free. */
+  function bindPerchVoice() {
+    if (!hereDot || hereDot.getTooltip()) return;
+    hereDot.bindTooltip("", { direction: "top", offset: [0, -16], className: "rb-voice", opacity: 1 });
+    refreshPerchVoice();
+  }
+
+  /* Update the ambient line WITHOUT interrupting a moment that is on screen. */
+  function refreshPerchVoice() {
+    if (!hereDot || !hereDot.getTooltip() || momentTimer) return;
+    hereDot.setTooltipContent(statusLine());
+  }
+
+  /* A moment: say it out loud, hold it, then fall back to ambient and go
+   * quiet again. This is the only thing that opens the bubble on its own. */
+  function sayMoment(text) {
+    if (!text || !hereDot || !hereDot.getTooltip()) return;
+    hereDot.setTooltipContent(text);
+    hereDot.openTooltip();
+    if (momentTimer) clearTimeout(momentTimer);
+    momentTimer = setTimeout(function () {
+      momentTimer = null;
+      if (!hereDot || !hereDot.getTooltip()) return;
+      hereDot.closeTooltip();
+      refreshPerchVoice();
+    }, 4200);
+  }
+
+  /* Decide whether anything that just changed is worth speaking. Only
+   * ARRIVALS speak — a count going down, or staying put, is not news. */
+  function notePerch() {
+    var marks = lastMarks.length;
+    var nests = (lastNests || []).length;
+    var firstLook = spokeMarks === null;
+    if (!firstLook && nests > spokeNests && spokeNests === 0) {
+      sayMoment("There's a nest nearby.");
+    } else if (!firstLook && marks > spokeMarks) {
+      sayMoment(marks === 1 ? "One thing waiting nearby." : (marks + " things waiting nearby."));
+    } else {
+      refreshPerchVoice();
+    }
+    spokeMarks = marks;
+    spokeNests = nests;
   }
 
   /* -------------------------------------------------------------- compose */
@@ -1084,7 +1134,7 @@
     paintStep("rb-step-checkin", !!list.checked_in_today, list.checked_in_today ? "✓" : "·",
       list.checked_in_today ? "checked in today" : "a tap a day keeps it warm");
 
-    paintPerchSay();
+    notePerch();
   }
 
   function refreshEgg() {
@@ -1170,7 +1220,7 @@
     /* The successor egg, and the only route back to the egg view (and its
      * daily check-in) once the perch belongs to a hatched bird. */
     var nextPct = (pet.egg && typeof pet.egg.percent === "number") ? pet.egg.percent : eggPercent;
-    /* paintPerchSay renders the world view's warmth line from this, and the
+    /* statusLine renders the world view's warmth line from this, and the
      * ring that used to show live progress is gone, so this is now the only
      * thing keeping that line honest between egg-view visits. */
     if (pet.egg && typeof pet.egg.percent === "number") eggPercent = pet.egg.percent;
@@ -1368,8 +1418,54 @@
    * frontier cell as a hole. Leaflet fills even-odd, so the holes are clear
    * and everything else is fogged. Frontier cells get a dim square on top so
    * they read as previewed rather than owned. */
+  /* Cloudy edges. Leaflet draws the mask as an SVG path, so a filter reference
+   * on it works — but the filter itself has to exist somewhere in the document.
+   * Built with createElementNS: no markup sink, no backticks. Injected once.
+   *
+   * The old mask had hard geohash-grid edges, which read as a spreadsheet
+   * rather than as weather. Turbulence wobbles the boundary and the blur takes
+   * the corners off. Keep the scale modest — displacement is per-pixel work on a
+   * full-viewport path, and this runs on a phone. */
+  function ensureFogFilter() {
+    if (document.getElementById("rb-fog-clouds")) return;
+    var NS = "http://www.w3.org/2000/svg";
+    var host = document.createElementNS(NS, "svg");
+    host.setAttribute("width", "0");
+    host.setAttribute("height", "0");
+    host.setAttribute("aria-hidden", "true");
+    host.setAttribute("class", "rb-defs");
+    var filter = document.createElementNS(NS, "filter");
+    filter.setAttribute("id", "rb-fog-clouds");
+    filter.setAttribute("x", "-20%");
+    filter.setAttribute("y", "-20%");
+    filter.setAttribute("width", "140%");
+    filter.setAttribute("height", "140%");
+    var turb = document.createElementNS(NS, "feTurbulence");
+    turb.setAttribute("type", "fractalNoise");
+    turb.setAttribute("baseFrequency", "0.014");
+    turb.setAttribute("numOctaves", "3");
+    turb.setAttribute("seed", "11");
+    turb.setAttribute("result", "rb-noise");
+    var disp = document.createElementNS(NS, "feDisplacementMap");
+    disp.setAttribute("in", "SourceGraphic");
+    disp.setAttribute("in2", "rb-noise");
+    disp.setAttribute("scale", "18");
+    disp.setAttribute("xChannelSelector", "R");
+    disp.setAttribute("yChannelSelector", "G");
+    disp.setAttribute("result", "rb-wobbled");
+    var blur = document.createElementNS(NS, "feGaussianBlur");
+    blur.setAttribute("in", "rb-wobbled");
+    blur.setAttribute("stdDeviation", "4");
+    filter.appendChild(turb);
+    filter.appendChild(disp);
+    filter.appendChild(blur);
+    host.appendChild(filter);
+    document.body.appendChild(host);
+  }
+
   function drawZones(out) {
     if (!out || !zoneLayer || !map) return;
+    ensureFogFilter();
     zoneLayer.clearLayers();
     var b = map.getBounds().pad(0.5);
     var outer = [
@@ -1388,17 +1484,39 @@
     }
   }
 
-  /* A pip in every unlocked cell whose seed has regrown: the map says where
-   * walking pays, instead of the counter silently ticking up. Not interactive
-   * — you collect by walking there, not by tapping. */
+  /* A grain of seed in every unlocked cell whose seed has regrown: the map says
+   * where walking pays, instead of the counter silently ticking up. Not
+   * interactive — you collect by walking there, not by tapping.
+   *
+   * A real seed, not a dot: the first version used a plain circleMarker in the
+   * UI accent, which read as map chrome rather than as something to go and get.
+   * Each pip needs its OWN element — appending an Element MOVES it, so one
+   * shared node would leave a single seed hopping between cells. */
+  function seedIcon() {
+    if (!Bird || typeof Bird.mountSeed !== "function") return null;
+    var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    try { Bird.mountSeed(svg); } catch (e) { return null; }
+    var opts = { className: "rb-seed-pip", iconSize: [18, 18], iconAnchor: [9, 9] };
+    opts.html = svg;   /* an Element: Leaflet appends, so this is no markup sink */
+    return L.divIcon(opts);
+  }
+
   function paintSeedPips(cells) {
     for (var i = 0; i < cells.length; i++) {
       var c = cells[i];
       if (!cellUsable(c)) continue;
-      L.circleMarker([(c.south + c.north) / 2, (c.west + c.east) / 2], {
-        pane: "rb-fog", className: "rb-seed-pip", radius: 4, weight: 0,
-        fillOpacity: 0.9, interactive: false
-      }).addTo(zoneLayer);
+      var ll = [(c.south + c.north) / 2, (c.west + c.east) / 2];
+      var icon = seedIcon();
+      if (icon) {
+        L.marker(ll, { pane: "rb-fog", icon: icon, interactive: false, keyboard: false }).addTo(zoneLayer);
+      } else {
+        /* The engine did not load. A dot is worse than a seed but far better
+         * than nothing, since it still says "walking here pays". */
+        L.circleMarker(ll, {
+          pane: "rb-fog", className: "rb-seed-dot", radius: 4, weight: 0,
+          fillOpacity: 0.9, interactive: false
+        }).addTo(zoneLayer);
+      }
     }
   }
 
@@ -1448,7 +1566,7 @@
       marker.addTo(nestLayer);
       nestMarkers[nest.cell] = marker;
     });
-    paintPerchSay();
+    notePerch();
   }
 
   /* Nests are computed server-side for the viewport; below MIN_NEST_ZOOM the
@@ -2140,7 +2258,11 @@
       paintHere(pos);
       setFollowing(true);
     }).catch(function () {
-      setText($("rb-perch-say"), "Pan the map to pick where you are listening.");
+      /* The ONLY thing the strip line still says. There is no marker without a
+       * fix, so the bird has no mouth to say it with — and this is a standing
+       * condition, not a moment, so it stays until a fix arrives. */
+      var say = $("rb-perch-say");
+      if (say) { setText(say, "Pan the map to pick where you are listening."); setHidden(say, false); }
     }).then(function () { publishArea(); refreshNests(); refreshZones(); });
     setInterval(refreshNests, 10 * 60e3);
     setInterval(refreshZones, 10 * 60e3);

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -138,7 +138,7 @@
   var walkStopTimer = null;
   var momentTimer = null;
   var spokeMarks = null;
-  var spokeNests = 0;
+  var spokeNests = null;
   var lastMarks = [];
 
   if (mapEl && typeof L !== "undefined") {
@@ -287,14 +287,13 @@
     if (!hereDot) {
       hereRing = L.circle(ll, { pane: "rb-here", radius: r, className: "rb-here-ring", stroke: false, fillOpacity: 0.12, interactive: false }).addTo(hereLayer);
       hereDot = L.marker(ll, {
+        /* NO title option. Leaflet copies it to the element as a native HTML title,
+         * which the browser renders as its own tooltip — and the marker now
+         * carries a real Leaflet tooltip on the same hover, so keeping it would
+         * stack a grey "You" box under the bird's speech bubble. The accessible
+         * name comes from the aria-label paintHereArt sets, which is
+         * state-aware in a way a fixed title never was. */
         pane: "rb-here", icon: hereIcon(hereArt()), keyboard: true,
-        /* The retired button carried an accessible name; a divIcon has none,
-         * and the marker shows an egg as often as a bird. */
-        /* title carries the accessible name; divIcon ignores alt, which
-         * Leaflet only applies when it builds an img icon. The retired button
-         * was a real button with a state-aware label, so paintHereArt sets
-         * role and aria-label to keep that. */
-        title: "You",
       }).addTo(hereLayer);
       /* No showView here any more. Tapping the bird asks it what is around
        * (Leaflet opens the tooltip on click and on focus); the labelled strip
@@ -672,7 +671,7 @@
       }
     });
     drawNearby(full);
-    notePerch();
+    noteMarks();
   }
 
   /* A frontier beacon: something is there, but not what. The server already
@@ -793,7 +792,7 @@
     var bird = pet && pet.bird;
     var valid = !!(Bird && bird && Bird.isValidBird({ species: bird.species, seed: bird.seed }));
     perchTarget = valid ? "pet" : "egg";
-    notePerch();
+    refreshPerchVoice();
     paintHereArt();
     paintPerchGo();
   }
@@ -849,21 +848,35 @@
     }, 4200);
   }
 
-  /* Decide whether anything that just changed is worth speaking. Only
-   * ARRIVALS speak — a count going down, or staying put, is not news. */
-  function notePerch() {
-    var marks = lastMarks.length;
-    var nests = (lastNests || []).length;
-    var firstLook = spokeMarks === null;
-    if (!firstLook && nests > spokeNests && spokeNests === 0) {
-      sayMoment("There's a nest nearby.");
-    } else if (!firstLook && marks > spokeMarks) {
-      sayMoment(marks === 1 ? "One thing waiting nearby." : (marks + " things waiting nearby."));
+  /* Only ARRIVALS speak — a count going down, or holding, is not news.
+   *
+   * ⚠ EACH SOURCE TRACKS ITS OWN FIRST LOOK. One shared flag looked simpler and
+   * was wrong: marks and nests arrive from two independent fetches, and the egg
+   * refresh (which needs no geolocation) normally resolves before either of
+   * them. Whichever ran first consumed the single flag while lastMarks and
+   * lastNests were still their empty initial values, so the real data landing
+   * afterwards read as an arrival and the bird announced pre-existing marks on
+   * every page load. Two sentinels, set only by their own source. */
+  function noteMarks() {
+    var n = lastMarks.length;
+    if (spokeMarks !== null && n > spokeMarks) {
+      sayMoment(n === 1 ? "One thing waiting nearby." : (n + " things waiting nearby."));
     } else {
       refreshPerchVoice();
     }
-    spokeMarks = marks;
-    spokeNests = nests;
+    spokeMarks = n;
+  }
+
+  function noteNests() {
+    var n = (lastNests || []).length;
+    /* Only the 0 -> something transition: a nest count merely changing is not
+     * a nest ARRIVING within earshot. */
+    if (spokeNests !== null && spokeNests === 0 && n > 0) {
+      sayMoment("There's a nest nearby.");
+    } else {
+      refreshPerchVoice();
+    }
+    spokeNests = n;
   }
 
   /* -------------------------------------------------------------- compose */
@@ -1134,7 +1147,7 @@
     paintStep("rb-step-checkin", !!list.checked_in_today, list.checked_in_today ? "✓" : "·",
       list.checked_in_today ? "checked in today" : "a tap a day keeps it warm");
 
-    notePerch();
+    refreshPerchVoice();
   }
 
   function refreshEgg() {
@@ -1566,7 +1579,7 @@
       marker.addTo(nestLayer);
       nestMarkers[nest.cell] = marker;
     });
-    notePerch();
+    noteNests();
   }
 
   /* Nests are computed server-side for the viewport; below MIN_NEST_ZOOM the

--- a/bundles/ramble/server/bird-svg.cjs
+++ b/bundles/ramble/server/bird-svg.cjs
@@ -96,6 +96,18 @@
     return drawEgg(seed) + eggFeet;
   }
   function mountWalkingEgg(el, seed) { el.setAttribute("viewBox", "0 0 120 168"); el.innerHTML = drawWalkingEgg(seed); }
+  /* A grain of birdseed. It has to read as FOOD at about 14 px, which a plain
+   * dot never did — so: an almond husk with a seam and a highlight, warm
+   * against a blue-grey map, which is also what makes it findable at a glance.
+   * Same palette family as the egg's feet, so it belongs to this world. */
+  function drawSeed() {
+    return '<g transform="rotate(-20 12 12)">'
+      + '<ellipse cx="12" cy="12" rx="5.4" ry="8" fill="#e8b256" stroke="#8a5a1e" stroke-width="1.7"/>'
+      + '<path d="M12 5 L12 19" stroke="#8a5a1e" stroke-width="1.1" opacity="0.5"/>'
+      + '<ellipse cx="9.7" cy="8.7" rx="1.4" ry="2.3" fill="#fff8e6" opacity="0.5"/>'
+      + '</g>';
+  }
+  function mountSeed(el) { el.setAttribute("viewBox", "0 0 24 24"); el.innerHTML = drawSeed(); }
   function isValidBird(x) { return !!x && typeof x === "object" && ROSTER.indexOf(x.species) >= 0 && isUint32(x.seed); }
-  return { ROSTER: ROSTER, SPECIES: SPECIES, PARTS: PARTS, rollGenome: rollGenome, drawBird: drawBird, drawEgg: drawEgg, drawWalkingEgg: drawWalkingEgg, mountBird: mountBird, mountWalkingEgg: mountWalkingEgg, isValidBird: isValidBird };
+  return { ROSTER: ROSTER, SPECIES: SPECIES, PARTS: PARTS, rollGenome: rollGenome, drawBird: drawBird, drawEgg: drawEgg, drawWalkingEgg: drawWalkingEgg, drawSeed: drawSeed, mountBird: mountBird, mountWalkingEgg: mountWalkingEgg, mountSeed: mountSeed, isValidBird: isValidBird };
 });

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4887,7 +4887,7 @@
     {
       "id": "ramble",
       "name": "Ramble",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "type": "mcp-server",
       "author": "Crow",
       "category": "social",

--- a/tests/ramble-bird-svg.test.js
+++ b/tests/ramble-bird-svg.test.js
@@ -60,3 +60,18 @@ test("no ESM syntax (must load as a classic browser script)", async () => {
   const src = readFileSync(new URL("../bundles/ramble/server/bird-svg.cjs", import.meta.url), "utf8");
   assert.ok(!/^\s*(import|export)\s/m.test(src));
 });
+
+test("drawSeed: a grain that reads as food, not as another UI dot", () => {
+  const svg = Bird.drawSeed();
+  assert.match(svg, /<ellipse/, "the husk");
+  assert.ok(svg.includes("#e8b256"), "warm against a blue-grey map, which is what makes it findable");
+  assert.ok(!svg.includes("var(--"), "the engine draws with literals — it has no stylesheet");
+  assert.ok(!/[`]/.test(svg), "no backtick can reach a panel script through the engine");
+
+  // mountSeed must set the viewBox itself, like every other mount* in here:
+  // callers hand it a bare <svg> and the art is meaningless without one.
+  const el = { attrs: {}, setAttribute(k, v) { this.attrs[k] = v; }, set innerHTML(v) { this.html = v; } };
+  Bird.mountSeed(el);
+  assert.equal(el.attrs.viewBox, "0 0 24 24");
+  assert.equal(el.html, svg);
+});

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -776,6 +776,27 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
 
   // Seed pips and the pickup moment.
   assert.ok(body.includes("function paintSeedPips("), "the map shows where seed is waiting");
+  // A seed, not a dot. The first version used a circleMarker in the UI accent,
+  // which read as map chrome rather than as something to walk to.
+  assert.ok(body.includes("function seedIcon()"), "pips carry the engine's seed art");
+  assert.ok(body.includes("Bird.mountSeed(svg)"), "drawn by the shared engine, like every other creature part");
+  assert.ok(body.includes('opts.html = svg;'), "an Element, so Leaflet appends and the sink count holds");
+  assert.ok(body.includes("rb-seed-dot"), "and a plain dot survives the engine failing to load");
+
+  // Fog has to look like weather, not like the geohash grid it is.
+  assert.ok(body.includes("function ensureFogFilter()"), "the mask gets cloudy edges");
+  assert.ok(body.includes('filter.setAttribute("id", "rb-fog-clouds")'), "via a filter the stylesheet can reference");
+  assert.ok(body.includes('createElementNS(NS, "feTurbulence")') && body.includes('createElementNS(NS, "feDisplacementMap")'),
+    "built with createElementNS — a filter is markup, and this file may not use a sink to make markup");
+  assert.ok(body.includes("ensureFogFilter();"), "and is actually installed before the mask draws");
+
+  // The bird's voice: moments only, plus tap/focus to ask.
+  assert.ok(body.includes("function statusLine()"), "ambient status still exists");
+  assert.ok(body.includes("function sayMoment("), "but only moments open the bubble on their own");
+  assert.ok(body.includes("function notePerch()"), "and something decides what counts as a moment");
+  assert.ok(body.includes('sayMoment("New ground.")'), "a first unlock is one");
+  assert.ok(body.includes("|| momentTimer) return;"),
+    "an ambient refresh must not overwrite a moment that is still on screen");
   assert.ok(body.includes("paintSeedPips(out.seed || [])"), "fed from the server's seed list");
   assert.ok(body.includes("function celebrateSeed("), "a pickup is its own moment, not a silent counter tick");
   assert.ok(body.includes("out.seed_picked"), "and it consumes the field the server was already sending");
@@ -799,7 +820,13 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
   assert.ok(body.includes("function hereIcon("));
   assert.ok(body.includes("function paintHereArt()"));
   assert.ok(body.includes("function hereArt()"));
-  assert.ok(body.includes('hereDot.on("click"'), "the marker itself opens the view — the retired button also matched showView(perchTarget)");
+  // CONTRACT CHANGED 2026-09-08: tapping the bird now ASKS it what is around
+  // rather than navigating. Leaflet opens a non-permanent tooltip on click AND
+  // on focus, so tap-to-ask and keyboard-to-ask both come from binding it. The
+  // labelled strip button is the door — see the rb-perch-open assertions.
+  assert.ok(!body.includes('hereDot.on("click"'), "tapping the bird must not navigate any more");
+  assert.ok(body.includes("function bindPerchVoice()"), "the bird has a voice bound to the marker");
+  assert.ok(body.includes('hereDot.bindTooltip("", { direction: "top"'), "a real bubble with a tail, tracking the bird");
   assert.ok(body.includes('createElementNS("http://www.w3.org/2000/svg", "svg")'), "the art is built without a markup sink");
   assert.ok(body.includes("showView(perchTarget)"), "tapping the marker still opens egg or pet");
   assert.ok(!body.includes('L.circleMarker(ll, { pane: "rb-here"'), "the plain blue dot is gone");
@@ -809,11 +836,14 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
     "the waddle has its OWN anchor — regressing it to lastPostedFix must fail here",
   );
   assert.ok(body.includes("if (moved > 10)"), "and its own 10 m threshold, not the 75 m area-post ratchet");
-  assert.ok(body.includes('setAttribute("role", "button")'), "the marker keeps the accessible role the retired button had");
+  assert.ok(body.includes('setAttribute("role", "img")'), "the marker is not a button any more — it does not navigate");
+  assert.ok(!body.includes('setAttribute("role", "button")'), "and must not claim to be one");
   assert.ok(body.includes('classList.add("is-walking")'), "the marker waddles while you move");
 
-  assert.ok(body.includes('if (ev.key !== "Enter" && ev.key !== " ") return;'), "Enter and Space activate the marker Leaflet only made focusable");
-  assert.ok(body.includes("el.onkeydown ="), "property assignment, so re-skinning cannot stack duplicate handlers");
+  // The hand-rolled Enter/Space bridge is gone with the navigation it drove.
+  // Keyboard users now get the status from Leaflet's own focus/blur tooltip
+  // handlers, and reach the view through the real <button> in the strip.
+  assert.ok(body.includes("el.onkeydown = null"), "the old keyboard bridge is explicitly cleared, not left dangling");
 
   // The world view's GPS-independent door (FIX 1): the map marker is the
   // pretty way in, but it needs a real position fix to exist at all.
@@ -872,6 +902,12 @@ test("GET /ramble/static/ramble.css serves the panel stylesheet", async () => {
   assert.ok(body.includes("#ramble .rb-here-pet.rb-here-plain::before {"), "the engine-less fallback dot has a rule");
 
   assert.ok(body.includes("#ramble .rb-seed-pip {"), "seed pips have a rule");
+  assert.ok(body.includes("#ramble .rb-seed-dot {"), "and the engine-less fallback dot has its own");
+  assert.ok(body.includes("filter: url(#rb-fog-clouds)"), "the mask actually references the cloud filter");
+  assert.ok(body.includes("#ramble .rb-voice.leaflet-tooltip {"), "the bird's bubble is styled");
+  assert.ok(body.includes("#ramble .rb-voice.leaflet-tooltip-top:before"), "including the tail that makes it a speech bubble");
+  assert.match(body, /rb-unlock-flash \{[^}]*fill-opacity: 0;/,
+    "the unlock square is invisible without its animation, so reduced-motion leaves no fog block behind");
   assert.ok(body.includes("#ramble .rb-seed-pop {"), "the pickup pop has a rule");
   assert.ok(body.includes("@keyframes rb-seed-rise"), "and an animation");
   assert.match(body, /prefers-reduced-motion[\s\S]*\.rb-seed-pop \{ animation: none/,

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -793,7 +793,26 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
   // The bird's voice: moments only, plus tap/focus to ask.
   assert.ok(body.includes("function statusLine()"), "ambient status still exists");
   assert.ok(body.includes("function sayMoment("), "but only moments open the bubble on their own");
-  assert.ok(body.includes("function notePerch()"), "and something decides what counts as a moment");
+  // ⚠ ONE SENTINEL PER SOURCE. Marks and nests arrive from two independent
+  // fetches, and the egg refresh (no geolocation needed) normally beats both.
+  // A single shared "first look" flag let whichever ran first consume it while
+  // the lists were still empty, so the real data landing afterwards read as an
+  // arrival and the bird announced pre-existing marks on every page load.
+  assert.ok(body.includes("function noteMarks()") && body.includes("function noteNests()"),
+    "marks and nests each judge their own arrivals");
+  assert.ok(!body.includes("function notePerch()"), "the shared-flag version must not come back");
+  assert.ok(body.includes("var spokeMarks = null;") && body.includes("var spokeNests = null;"),
+    "and each starts un-looked-at, so neither source's first draw can speak");
+  assert.ok(body.includes("spokeMarks !== null && n > spokeMarks"), "marks speak only on a real increase");
+  assert.ok(body.includes("spokeNests !== null && spokeNests === 0 && n > 0"), "nests speak only on the 0 -> something transition");
+  // The egg/pet refresh changes the ambient LINE, not the world — it must never
+  // be able to trip an arrival.
+  assert.ok(!/paintEgg[\s\S]{0,900}note(Marks|Nests)\(\)/.test(body),
+    "the egg refresh must not evaluate arrivals");
+
+  // A native title would render the browser's own grey tooltip underneath the
+  // bird's speech bubble on the same hover.
+  assert.ok(!body.includes('title: "You"'), "the marker carries no competing native title");
   assert.ok(body.includes('sayMoment("New ground.")'), "a first unlock is one");
   assert.ok(body.includes("|| momentTimer) return;"),
     "an ambient refresh must not overwrite a moment that is still on screen");


### PR DESCRIPTION
Three things from playing 0.9.1 on a phone: the fog looked like a spreadsheet, the seed pips looked like UI dots, and the map was getting crowded by a status line that never earned its place.

## Fog looks like fog

The mask is drawn on a geohash grid, so its edges were hard right angles — it read as a rendering artefact rather than as weather. `ensureFogFilter()` installs an SVG filter (`feTurbulence` → `feDisplacementMap` → `feGaussianBlur`) that wobbles the boundary and softens the corners, and `.rb-fog` references it.

Built with `createElementNS`, not a markup string: a filter is markup, and this file may not use a markup sink to make any. Sink count holds at 2.

**⚠ Needs a real device to judge.** Displacement is per-pixel work over a full-viewport path. The values are deliberately modest (`scale 18`, `stdDeviation 4`) and coalescing already keeps the hole-ring count low, but if it feels sluggish on the phone the honest fix is to drop the displacement and keep the blur — one attribute.

## The unlock dissipates instead of blinking

A newly-cleared square used to flash in accent blue, which said "something happened" but not *what*. It now starts as fog and drifts outward as it thins, so the fog visibly burns off the square you just earned. The rect is `fill-opacity: 0` by default, so `prefers-reduced-motion` — which kills the animation — leaves nothing behind rather than parking a solid fog block on the cell.

## Seed looks like seed

`drawSeed()` joins the shared bird engine: an almond husk with a seam and a highlight, warm amber against the blue-grey map. The old pip was a `circleMarker` in `--rb-accent-2`, the same blue as every other piece of chrome, so it read as map furniture rather than as something to go and get.

Each pip builds its **own** element — appending an `Element` *moves* it, so one shared node would leave a single seed hopping between cells. A plain dot (`rb-seed-dot`) still renders if the engine fails to load.

## The bird only speaks when it has something to say

The status line was permanently on screen, including "Quiet around here right now," which is the definition of clutter. It is now a Leaflet tooltip bound to the bird marker, restyled as a speech bubble — Leaflet supplies the tail via `.leaflet-tooltip-top:before` and keeps it tracking the marker.

- **Moments open it on their own** and it fades after ~4s: a first unlock ("New ground."), a nest coming into range, more things waiting than last time. Only *arrivals* speak — a count going down is not news.
- **Tap or focus the bird to ask.** Leaflet binds `click` and focus/blur for a non-permanent tooltip, so tap-to-ask and keyboard-to-ask both come free, and it sets `aria-describedby` so a screen reader hears the status on focus.

**⚠ Contract change, chosen deliberately by the operator:** tapping the bird no longer navigates. The labelled `Your egg` / `Your bird` button in the strip is now the only door — which is fine, since it is a real `<button>`, always present, and works with no GPS fix and no pointer. The marker drops `role="button"` (it no longer acts like one) for `role="img"`, and the hand-rolled Enter/Space bridge is explicitly cleared rather than left dangling. Three tests asserted the old behaviour and now assert the new, each with a comment saying why.

The strip's line survives for exactly one message: "Pan the map to pick where you are listening." There is no marker without a fix, so the bird has no mouth to say it with, and it is a standing condition rather than a moment.

## Verification

Full suite **4299/4299**. `check-ports` OK, `build-registry --check` in sync. Backticks 0 and markup sinks 2 in the panel client. Ramble 0.9.1 → 0.9.2.

New assertions pin the mechanisms rather than the names: that the filter is built with `createElementNS` (a sink would be the easy wrong way), that an ambient refresh cannot overwrite a moment still on screen, that the unlock square is invisible without its animation, and that the engine's seed art carries no CSS variable or backtick — the engine has no stylesheet, and a backtick reaching a panel script truncates it.