### PR TITLE
ramble 0.9.3: chores first on the pet page, and the reference panel folds away

### DIFF
--- a/bundles/ramble/manifest.json
+++ b/bundles/ramble/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ramble",
   "name": "Ramble",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "mcp-server",
   "author": "Crow",
   "category": "social",

--- a/bundles/ramble/package.json
+++ b/bundles/ramble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crow-ramble",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Ramble MCP server — proximity marks, caws, privacy grid, egg and bird companion, gifts and swaps",
   "type": "module",
   "main": "server/index.js",

--- a/bundles/ramble/panel/ramble.js
+++ b/bundles/ramble/panel/ramble.js
@@ -255,7 +255,18 @@ export default {
           </section>
 
           <section class="rb-card">
-            <p class="rb-eyebrow">What your bird runs on</p>
+            <p class="rb-eyebrow">Today</p>
+            <div class="rb-chores">
+              <button class="rb-chore" data-kind="feed" type="button">${icon("feed")}Feed</button>
+              <button class="rb-chore" data-kind="preen" type="button">${icon("preen")}Preen</button>
+              <button class="rb-chore" data-kind="play" type="button">${icon("play")}Play</button>
+            </div>
+            <p class="rb-muted rb-fine">Three taps a day. Miss a few and it gets droopy, never worse than that.</p>
+            <p class="rb-muted rb-fine" id="rb-pet-status"></p>
+          </section>
+
+          <details class="rb-card rb-fold" id="rb-runs-on" open>
+            <summary class="rb-eyebrow rb-fold-sum">What your bird runs on</summary>
             <div class="rb-steps">
               <div class="rb-step">
                 <span class="rb-step-n">+20</span>
@@ -271,7 +282,7 @@ export default {
               </div>
               <div class="rb-step">
                 <span class="rb-step-n">+8</span>
-                <div class="rb-step-txt"><strong>A chore below</strong><span class="rb-muted rb-fine">feed, preen or play, once a day each</span></div>
+                <div class="rb-step-txt"><strong>A daily chore</strong><span class="rb-muted rb-fine">feed, preen or play, once a day each</span></div>
               </div>
               <div class="rb-step">
                 <span class="rb-step-n">+5</span>
@@ -283,18 +294,7 @@ export default {
               </div>
             </div>
             <p class="rb-muted rb-fine">Getting out is worth more than tapping.</p>
-          </section>
-
-          <section class="rb-card">
-            <p class="rb-eyebrow">Today</p>
-            <div class="rb-chores">
-              <button class="rb-chore" data-kind="feed" type="button">${icon("feed")}Feed</button>
-              <button class="rb-chore" data-kind="preen" type="button">${icon("preen")}Preen</button>
-              <button class="rb-chore" data-kind="play" type="button">${icon("play")}Play</button>
-            </div>
-            <p class="rb-muted rb-fine">Three taps a day. Miss a few and it gets droopy, never worse than that.</p>
-            <p class="rb-muted rb-fine" id="rb-pet-status"></p>
-          </section>
+          </details>
 
           <section class="rb-card">
             <p class="rb-eyebrow">This week</p>

--- a/bundles/ramble/panel/static/ramble.css
+++ b/bundles/ramble/panel/static/ramble.css
@@ -129,6 +129,20 @@
 #ramble .rb-center { text-align: center; }
 #ramble .rb-label { width: 66px; font-weight: 800; color: var(--rb-muted); flex: 0 0 auto; }
 
+/* The reference panel folds away. <details> is native, so the toggle, the
+   keyboard handling and the screen-reader semantics all come for free — and if
+   the remember-my-choice script never runs, it simply stays open. */
+#ramble .rb-fold > summary { cursor: pointer; list-style: none; display: flex; align-items: center; gap: 8px; }
+#ramble .rb-fold > summary::-webkit-details-marker { display: none; }
+/* Our own marker, so it matches the display font rather than the OS triangle. */
+#ramble .rb-fold > summary::after {
+  content: "+"; margin-left: auto;
+  font: 800 15px/1 var(--rb-font-display); color: var(--rb-muted);
+}
+#ramble .rb-fold[open] > summary::after { content: "\2212"; }
+#ramble .rb-fold[open] > summary { margin-bottom: 10px; }
+#ramble .rb-fold > summary:focus-visible { outline: 2px solid var(--rb-accent-2); outline-offset: 3px; border-radius: 6px; }
+
 #ramble .rb-eyebrow {
   margin: 0 0 6px;
   font: 800 11px/1 var(--rb-font-display);

--- a/bundles/ramble/panel/static/ramble.js
+++ b/bundles/ramble/panel/static/ramble.js
@@ -1176,6 +1176,18 @@
   var outsideBtn = $("rb-go-outside");
   if (outsideBtn) outsideBtn.addEventListener("click", function () { showView("world"); });
 
+  /* Remember whether the reference panel is folded. Ships open, because a new
+   * player needs it; once you know the numbers it is just height above the
+   * chores. Storage can throw outright (private mode, blocked site data), and a
+   * remembered preference is never worth breaking the panel for. */
+  var runsOn = $("rb-runs-on");
+  if (runsOn) {
+    try { if (window.localStorage.getItem("rb.runsOn") === "0") runsOn.open = false; } catch (e) { /* stays open */ }
+    runsOn.addEventListener("toggle", function () {
+      try { window.localStorage.setItem("rb.runsOn", runsOn.open ? "1" : "0"); } catch (e) { /* forget it, then */ }
+    });
+  }
+
   var perchOpenBtn = $("rb-perch-open");
   if (perchOpenBtn) perchOpenBtn.addEventListener("click", function () { showView(perchTarget); });
 

--- a/registry/add-ons.json
+++ b/registry/add-ons.json
@@ -4887,7 +4887,7 @@
     {
       "id": "ramble",
       "name": "Ramble",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "type": "mcp-server",
       "author": "Crow",
       "category": "social",

--- a/tests/ramble-panel.test.js
+++ b/tests/ramble-panel.test.js
@@ -226,7 +226,8 @@ test("panel handler renders the world-first shell, its three views and every ass
   // The pet page must name what actually feeds the bird, not just the three
   // chore buttons: walking is worth more than tapping and the page hid that.
   assert.ok(sent.includes("What your bird runs on"), "the energy-sources card is on the pet page");
-  for (const src of ["Meet another crow", "Somewhere new", "Unlock a mark", "A chore below", "Check in", "A quiet stretch"]) {
+  // "A daily chore", not "A chore below": the chores moved ABOVE this panel.
+  for (const src of ["Meet another crow", "Somewhere new", "Unlock a mark", "A daily chore", "Check in", "A quiet stretch"]) {
     assert.ok(sent.includes(src), `pet page names the energy source: ${src}`);
   }
   assert.ok(sent.includes("Getting out is worth more than tapping."), "the page says walking beats tapping");
@@ -271,6 +272,20 @@ test("panel handler renders the world-first shell, its three views and every ass
   // corner button was retired, but the world view still needs a door that
   // does not depend on a GPS fix.
   assert.ok(sent.includes('id="rb-perch-open"'), "the world view keeps a door that does not need a GPS fix");
+
+  // The pet page puts the thing you ACT on above the thing you read once.
+  // Asserting the ORDER, not just presence: both cards existed before and the
+  // complaint was that the reference panel pushed the chores below the fold.
+  const chores = sent.indexOf('class="rb-chores"');
+  const runsOn = sent.indexOf('id="rb-runs-on"');
+  assert.ok(chores > -1 && runsOn > -1, "both the chores and the reference panel are on the pet page");
+  assert.ok(chores < runsOn, "the chore buttons come BEFORE what your bird runs on");
+  assert.ok(sent.includes('<details class="rb-card rb-fold" id="rb-runs-on" open>'),
+    "the reference panel folds, and ships open for a player who has not read it yet");
+  assert.ok(sent.includes('<summary class="rb-eyebrow rb-fold-sum">'), "with a real summary, so it toggles without script");
+  // The list used to point DOWN at the chores. They are above it now.
+  assert.ok(!sent.includes("A chore below"), "the copy must not still point below at chores that moved above it");
+  assert.ok(sent.includes("A daily chore"), "it names the chore without a direction");
   assert.ok(sent.includes('id="rb-perch-say"'), "the status strip stays");
 
   assert.ok(sent.includes('id="rb-seed-count"'), "the map bar carries the seed counter");
@@ -867,6 +882,10 @@ test("GET /ramble/static/ramble.js serves the client script as JavaScript", asyn
   // The world view's GPS-independent door (FIX 1): the map marker is the
   // pretty way in, but it needs a real position fix to exist at all.
   assert.ok(body.includes("function paintPerchGo()"));
+  assert.ok(body.includes('window.localStorage.getItem("rb.runsOn")'), "the fold remembers whether you closed it");
+  assert.ok(body.includes('runsOn.addEventListener("toggle"'), "and records the change");
+  assert.match(body, /getItem\("rb\.runsOn"\)[\s\S]{0,80}catch/,
+    "storage can throw outright in private mode — a remembered preference must never break the panel");
   assert.ok(body.includes('perchOpenBtn.addEventListener("click"'), "the door is wired independently of the map marker");
 
   assert.ok(body.includes("eggPercent = pet.egg.percent"), "the world view's warmth line follows the pet refresh");
@@ -920,6 +939,9 @@ test("GET /ramble/static/ramble.css serves the panel stylesheet", async () => {
   assert.ok(body.includes("#ramble .rb-here-pet.is-walking"));
   assert.ok(body.includes("#ramble .rb-here-pet.rb-here-plain::before {"), "the engine-less fallback dot has a rule");
 
+  assert.ok(body.includes("#ramble .rb-fold > summary {"), "the fold has its own summary rule");
+  assert.ok(body.includes("summary::-webkit-details-marker"), "and hides the OS triangle for a marker in the display font");
+  assert.ok(body.includes("#ramble .rb-fold > summary:focus-visible"), "and stays keyboard-visible");
   assert.ok(body.includes("#ramble .rb-seed-pip {"), "seed pips have a rule");
   assert.ok(body.includes("#ramble .rb-seed-dot {"), "and the engine-less fallback dot has its own");
   assert.ok(body.includes("filter: url(#rb-fog-clouds)"), "the mask actually references the cloud filter");


### PR DESCRIPTION
The pet page led with a six-row explainer and pushed the three buttons you actually tap below the fold. Reordered so the thing you act on comes before the thing you read once, and the explainer now folds away.

## Changes

- **Chores move above "What your bird runs on."** The energy meter, then Today's three buttons, then the reference panel.
- **The reference panel is a `<details>`.** Native, so the toggle, the keyboard handling and the screen-reader semantics all come free — and if the remember-my-choice script never runs, it just stays open rather than becoming unopenable. The OS triangle is hidden in favour of a `+`/`−` marker in the display font, and the summary keeps a visible focus ring.
- **It ships open and remembers if you close it.** A new player needs the numbers; once you know them it is only height above the chores. Stored in `localStorage`, and both the read and the write are wrapped — storage *throws* in private mode, and a remembered preference is never worth breaking the panel for.
- **Copy fix: "A chore below" → "A daily chore."** That row pointed down at the chores, which are now above it.

## Verification

Full suite **4299/4299**. `check-ports` OK, `build-registry --check` in sync. Backticks 0 and markup sinks 2 in the panel client. Ramble 0.9.2 → 0.9.3.

The new test asserts the **order**, not just presence — both cards existed before, and the whole complaint was about which came first:

```js
assert.ok(chores < runsOn, "the chore buttons come BEFORE what your bird runs on");
```

It also pins that the panel ships `open`, that the storage access is inside a `catch`, and that the stale "A chore below" copy cannot come back. One pre-existing assertion listed that old string in a loop over the energy sources; it now lists the new wording, with a comment saying why it changed.