### PR TITLE
Make verifyTotp total so a malformed 2FA POST cannot kill the gateway

### DIFF
--- a/servers/gateway/dashboard/totp.js
+++ b/servers/gateway/dashboard/totp.js
@@ -53,18 +53,35 @@ export async function generateQrDataUri(uri) {
 
 /**
  * Verify a TOTP code against a secret.
+ *
+ * Total on both arguments by design. Every caller passes at least one of them
+ * straight out of a request body (`/dashboard/login/2fa` the code,
+ * `/dashboard/login/2fa/setup` and the settings enable_2fa action both), so an
+ * absent field is an ordinary malformed request. otpauth reads `.length` off
+ * the token and `.replace` off the secret, so `undefined` used to raise a
+ * TypeError inside an async route handler — an unhandled rejection, and
+ * therefore fatal to the whole gateway process. A bad input answers false.
+ *
  * @param {string} token - 6-digit code from authenticator
  * @param {string} secret - Base32-encoded secret
  * @returns {boolean}
  */
 export function verifyTotp(token, secret) {
+  if (typeof token !== "string" || token.trim() === "") return false;
+  if (typeof secret !== "string" || secret.trim() === "") return false;
+  let parsedSecret;
+  try {
+    parsedSecret = OTPAuth.Secret.fromBase32(secret);
+  } catch {
+    return false; // not base32 at all
+  }
   const totp = new OTPAuth.TOTP({
     issuer: "Crow",
     label: "Crow's Nest",
     algorithm: "SHA1",
     digits: 6,
     period: 30,
-    secret: OTPAuth.Secret.fromBase32(secret),
+    secret: parsedSecret,
   });
   // window: 1 allows previous + next 30-second period (clock skew tolerance)
   const delta = totp.validate({ token, window: 1 });

--- a/tests/dashboard-2fa-login.test.js
+++ b/tests/dashboard-2fa-login.test.js
@@ -168,3 +168,53 @@ test("the i18n keys index.js asks for actually exist", async () => {
     assert.notEqual(t(k, "en"), k, `i18n key "${k}" is missing from shared/i18n.js`);
   }
 });
+
+// --- Defect 3: verifyTotp threw on a missing code ----------------------------
+//
+// A POST to /dashboard/login/2fa (or /2fa/setup, or the settings enable_2fa
+// action) with the `totp_code` field simply absent reached
+// verifyTotp(undefined, secret). otpauth reads `.length` off the token, so an
+// absent field raised `TypeError: Cannot read properties of undefined` inside
+// an async route handler — an unhandled rejection, which is fatal, so a
+// malformed request took the gateway down. Same class as defect 2: a bad
+// request must render an error, never end the process.
+
+const TEST_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"; // RFC 6238 SHA1 seed
+
+test("verifyTotp answers false for a missing code instead of throwing", async () => {
+  const { verifyTotp } = await import("../servers/gateway/dashboard/totp.js");
+  for (const absent of [undefined, null]) {
+    assert.equal(verifyTotp(absent, TEST_SECRET), false);
+  }
+});
+
+test("verifyTotp answers false for a code that is not a usable string", async () => {
+  const { verifyTotp } = await import("../servers/gateway/dashboard/totp.js");
+  for (const junk of ["", "   ", "abc", 123456, {}, [], true]) {
+    assert.equal(verifyTotp(junk, TEST_SECRET), false);
+  }
+});
+
+test("verifyTotp answers false for a missing or unusable secret", async () => {
+  const { verifyTotp } = await import("../servers/gateway/dashboard/totp.js");
+  // /dashboard/login/2fa/setup and the settings enable_2fa action both pass a
+  // secret straight from the request body, so this argument is attacker-shaped
+  // too — and Secret.fromBase32(undefined) throws the same way.
+  for (const bad of [undefined, null, "", "not base32!"]) {
+    assert.equal(verifyTotp("123456", bad), false);
+  }
+});
+
+test("verifyTotp still accepts the real code for the current period", async () => {
+  const { verifyTotp } = await import("../servers/gateway/dashboard/totp.js");
+  const OTPAuth = await import("otpauth");
+  const totp = new OTPAuth.TOTP({
+    issuer: "Crow",
+    label: "Crow's Nest",
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(TEST_SECRET),
+  });
+  assert.equal(verifyTotp(totp.generate(), TEST_SECRET), true);
+});


### PR DESCRIPTION
## The defect

A POST to `/dashboard/login/2fa` with the `totp_code` field simply absent reaches `verifyTotp(undefined, secret)`. otpauth reads `.length` off the token, so it raises `TypeError: Cannot read properties of undefined (reading 'length')` inside an async route handler. That is an unhandled rejection, which is fatal, so **one malformed request takes the whole gateway process down**.

Same class as the `t()`-not-imported defect in #343: a bad request must render an error, never end the process. This one was found the same evening, on the same instance, and offered rather than fixed then.

Reproduced directly against the pinned otpauth:

```
undefined -> THROWS TypeError: Cannot read properties of undefined (reading 'length')
null      -> THROWS TypeError: Cannot read properties of null (reading 'length')
123456    -> null      (already answered false)
""        -> null
"abc"     -> null
{}        -> null
```

## The secret argument is attacker-shaped too

Three call sites, and the code is not the only field that comes out of a request body:

- `dashboard/index.js:240` — `/dashboard/login/2fa`, the code
- `dashboard/index.js:350` — `/dashboard/login/2fa/setup`, the code
- `dashboard/settings/sections/two-factor.js:124` — `enable_2fa`, code **and** `secret`

`Secret.fromBase32(undefined)` throws `Cannot read properties of undefined (reading 'replace')`, and a string that is not base32 throws on parse.

## The fix

`verifyTotp` is now total on both arguments. A non-string or blank token, a non-string or blank secret, and a secret that will not parse as base32 each answer `false`. Guarding in the one function covers all three call sites.

**Nothing else changes.** A number, an object or a junk string already answered `false` through otpauth's own `null` return, so the observable behaviour for every previously-working input is identical. A real code for the current period still verifies.

## Tests

Four cases appended to `tests/dashboard-2fa-login.test.js`, the file #343 added:

- a missing code (`undefined`, `null`) answers false instead of throwing
- a code that is not a usable string answers false
- a missing or unparseable secret answers false
- the real code for the current period still verifies (RFC 6238 SHA1 seed)

The first and third fail on `main` with a `TypeError`. All ten in the file pass with the fix, as do `csrf-middleware` (14) and `i18n-global-parity` (7).
