### PR TITLE
Bot drawer: label the controls, fix the plan-mode cascade, say which models are running

### DIFF
--- a/servers/gateway/dashboard/panels/bot-board/css.js
+++ b/servers/gateway/dashboard/panels/bot-board/css.js
@@ -41,6 +41,10 @@ export function botBoardStyles() {
   .bb-roost-state{font-size:.68rem;color:var(--crow-text-muted)}
   .bb-roost-primary{font-size:.7rem;padding:.2rem .5rem;background:${PERCH_TOKENS.light.teal};border:none;border-radius:var(--crow-radius-control);color:${PERCH_TOKENS.light.card};cursor:pointer}
   .bb-roost-primary.bb-roost-link{background:none;color:${PERCH_TOKENS.light.teal};text-decoration:underline;padding:0}
+  /* Talk sits beside the primary and must not compete with it: same size and
+     shape, outlined instead of filled. */
+  .bb-roost-secondary{font-size:.7rem;padding:.2rem .5rem;background:none;border:1px solid ${PERCH_TOKENS.light.teal};border-radius:var(--crow-radius-control);color:${PERCH_TOKENS.light.teal};cursor:pointer}
+  .bb-roost-secondary:hover{background:${PERCH_TOKENS.light.teal};color:${PERCH_TOKENS.light.card}}
   .bb-roost-more{background:none;border:none;color:var(--crow-text-muted);cursor:pointer;font-size:.85rem;padding:.1rem .3rem;line-height:1}
   .bb-roost-more:hover{color:var(--crow-text-primary)}
   .bb-roost-menu{display:none;position:absolute;top:100%;right:0;margin-top:.2rem;background:var(--crow-bg-surface);border:1px solid var(--crow-border);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,.2);padding:.3rem;z-index:20;min-width:130px}
@@ -52,6 +56,8 @@ export function botBoardStyles() {
     .bb-roost-track{border-bottom-color:${PERCH_TOKENS.dark.wire}}
     .bb-roost-primary{background:${PERCH_TOKENS.dark.teal};color:${PERCH_TOKENS.dark.card}}
     .bb-roost-primary.bb-roost-link{color:${PERCH_TOKENS.dark.teal}}
+    .bb-roost-secondary{border-color:${PERCH_TOKENS.dark.teal};color:${PERCH_TOKENS.dark.teal}}
+    .bb-roost-secondary:hover{background:${PERCH_TOKENS.dark.teal};color:${PERCH_TOKENS.dark.card}}
   }`;
   return `<style>
   ${birdCss}

--- a/servers/gateway/dashboard/panels/bot-board/drawer.js
+++ b/servers/gateway/dashboard/panels/bot-board/drawer.js
@@ -50,10 +50,25 @@ export function birdDrawerCss() {
   .bb-bd-ask-answered{font-size:.82rem;color:var(--crow-text-muted);font-style:italic;margin:.5rem 0}
   .bb-bd-picker-row{display:flex;justify-content:space-between;align-items:center;gap:.5rem;padding:.4rem 0;border-bottom:1px solid var(--crow-border);font-size:.85rem}
   .bb-card-focus{outline:2px solid ${PERCH_TOKENS.light.teal};outline-offset:2px}
-  .bb-bd-controls-row{display:flex;flex-wrap:wrap;gap:.4rem;align-items:center;margin:.6rem 0}
-  .bb-bd-controls-row select{width:auto;flex:1 1 auto;min-width:110px;padding:.3rem .4rem;font-size:.8rem}
-  .bb-bd-plan-label{display:flex;align-items:center;gap:.3rem;font-size:.8rem;color:var(--crow-text-secondary);text-transform:none;letter-spacing:normal;margin:0;flex:0 0 auto}
-  .bb-bd-plan-label input{width:auto}
+  /* Every rule that has to beat css.js's \`.bb-drawer label\` / \`.bb-drawer
+     select\` (specificity 0,1,1) is written .bb-drawer-qualified. A bare
+     .bb-bd-plan-label is 0,1,0 and LOSES, which is why the plan checkbox used
+     to render as a block with uppercase letter-spaced text instead of the flex
+     row it asks for -- at every width, not just narrow ones. */
+  .bb-bd-controls-row{display:flex;flex-wrap:wrap;gap:.5rem;align-items:flex-end;margin:.6rem 0}
+  /* Each control names itself. Unlabelled dropdowns read fine in a wide row
+     where the grouping carries the meaning, and read as three loose menus once
+     the row wraps on a phone. A span, not a label: .bb-drawer label is block +
+     uppercase, and these sit inside the field. */
+  .bb-bd-field{display:flex;flex-direction:column;gap:.15rem;flex:1 1 150px;min-width:0}
+  .bb-bd-field-model{flex:1 1 100%}
+  .bb-bd-field-label{font-size:.68rem;color:var(--crow-text-muted);text-transform:uppercase;letter-spacing:.05em}
+  .bb-drawer .bb-bd-controls-row select{width:100%;min-width:0;padding:.3rem .4rem;font-size:.8rem}
+  .bb-drawer .bb-bd-plan-label{display:flex;align-items:center;gap:.35rem;font-size:.8rem;color:var(--crow-text-secondary);text-transform:none;letter-spacing:normal;margin:0;flex:0 0 auto;align-self:flex-end;padding-bottom:.3rem}
+  .bb-drawer .bb-bd-plan-label input{width:auto;min-width:0;margin:0;flex:0 0 auto}
+  /* A model whose endpoint nothing is serving stays listed and stays readable,
+     but must not look like the plain working choice next to it. */
+  .bb-bd-model-off{color:var(--crow-text-muted)}
   .bb-bd-controls-toggle-wrap{display:flex;gap:.4rem;flex-wrap:wrap;margin:.3rem 0}
   .bb-bd-controls-pane{margin:.4rem 0;padding:.5rem;background:var(--crow-bg-elevated);border:1px solid var(--crow-border);border-radius:8px}
   .bb-bd-tools{display:flex;flex-direction:column;gap:.25rem;margin:.4rem 0}
@@ -102,6 +117,8 @@ export function birdDrawerJs(lang) {
     hibernating:'${tJs("botboard.roostStateHibernating", lang)}',
     stopped:'${tJs("botboard.bdStateStopped", lang)}'
   };
+  var BD_ON_DEMAND='${tJs("botboard.bdModelOnDemand", lang)}';
+  var BD_UNAVAILABLE='${tJs("botboard.bdModelUnavailable", lang)}';
 
   function bdBlank(){
     return {sid:null,botId:null,botName:null,threadId:null,cardId:null,
@@ -158,7 +175,18 @@ export function birdDrawerJs(lang) {
         models.forEach(function(m){
           var o=document.createElement('option');
           o.value=m.provider+'/'+m.id;
-          o.textContent=m.label||(m.provider+'/'+m.id);
+          // The payload has carried a human name all along ("Qwen3.6 35B A3B
+          // (Crow, Q5_K_XL MTP+vision, 256K)"); this read m.label, which no
+          // provider row sets, so every entry fell back to provider/id.
+          var text=m.name||m.label||(m.provider+'/'+m.id);
+          // Availability, from GET options. "up" says nothing — a working
+          // choice should read as the plain default.
+          if(m.availability==='on_demand'){ text+=' \u2014 '+BD_ON_DEMAND; }
+          else if(m.availability==='unavailable'){
+            text+=' \u2014 '+BD_UNAVAILABLE;
+            o.className='bb-bd-model-off';
+          }
+          o.textContent=text;
           bdModelSel.appendChild(o);
         });
       } else { bdModelSel.disabled=true; }

--- a/servers/gateway/dashboard/panels/bot-board/html.js
+++ b/servers/gateway/dashboard/panels/bot-board/html.js
@@ -291,14 +291,23 @@ export function birdDrawerMarkup(lang) {
     <div id="bb-bd-card-link-wrap" class="bb-msg" style="display:none"><a id="bb-bd-card-link" href="#"></a></div>
     <div id="bb-bd-hibernating" class="bb-msg warn" style="display:none">${t("botboard.bdHibernating", lang)}</div>
     <div class="bb-bd-controls-row">
-      <select id="bb-bd-model" disabled aria-label="${escapeHtml(t("botboard.bdEnvelopeModelPrefix", lang))}"></select>
-      <select id="bb-bd-thinking" disabled></select>
-      <select id="bb-bd-permission">
-        <option value="guarded">${t("botboard.bdPermGuarded", lang)}</option>
-        <option value="ask">${t("botboard.bdPermAsk", lang)}</option>
-        <option value="bypass">${t("botboard.bdPermBypass", lang)}</option>
-      </select>
-      <label class="bb-bd-plan-label"><input type="checkbox" id="bb-bd-plan-toggle"> ${t("botboard.bdPlanModeLabel", lang)}</label>
+      <span class="bb-bd-field bb-bd-field-model">
+        <span class="bb-bd-field-label" id="bb-bd-model-label">${t("botboard.bdModelSelectLabel", lang)}</span>
+        <select id="bb-bd-model" disabled aria-labelledby="bb-bd-model-label"></select>
+      </span>
+      <span class="bb-bd-field">
+        <span class="bb-bd-field-label" id="bb-bd-thinking-label">${t("botboard.bdThinkingSelectLabel", lang)}</span>
+        <select id="bb-bd-thinking" disabled aria-labelledby="bb-bd-thinking-label"></select>
+      </span>
+      <span class="bb-bd-field">
+        <span class="bb-bd-field-label" id="bb-bd-permission-label">${t("botboard.bdPermissionSelectLabel", lang)}</span>
+        <select id="bb-bd-permission" aria-labelledby="bb-bd-permission-label">
+          <option value="guarded">${t("botboard.bdPermGuarded", lang)}</option>
+          <option value="ask">${t("botboard.bdPermAsk", lang)}</option>
+          <option value="bypass">${t("botboard.bdPermBypass", lang)}</option>
+        </select>
+      </span>
+      <label class="bb-bd-plan-label"><input type="checkbox" id="bb-bd-plan-toggle"> <span>${t("botboard.bdPlanModeLabel", lang)}</span></label>
     </div>
     <div id="bb-bd-bindsatwake" class="bb-msg warn" style="display:none">
       <span id="bb-bd-bindsatwake-text">${t("botboard.bdBindsAtWake", lang)}</span>

--- a/servers/gateway/dashboard/panels/bot-board/html.js
+++ b/servers/gateway/dashboard/panels/bot-board/html.js
@@ -187,11 +187,20 @@ async function computeRoostBirds(bots, engine) {
   });
 }
 
-// One `.bb-roost-bird[data-bot]` — glyph, name, state text, and the ONE
-// primary action for this state (spec: idle→Send out, working/hibernating→
-// Open, waiting→Answer, observing→a plain link to Bot Builder). The overflow
-// menu (Talk/Sessions/Recall/Setup) is the SAME on every bird; Recall is
-// omitted when there is no live session to stop (idle/observing).
+// One `.bb-roost-bird[data-bot]` — glyph, name, state text, the primary action
+// for this state (spec: idle→Send out, working/hibernating→Open, waiting→
+// Answer, observing→a plain link to Bot Builder), and Talk.
+//
+// Talk is visible rather than an overflow item because it is the ONLY way to
+// start a session that is not tied to a card — it POSTs /bots/<id>/interactive,
+// whose cardId defaults to null. Buried in the ⋯ menu it left "Send out", the
+// card dispatch, as the only visible action on an idle bird, and the card-less
+// path read as though it did not exist. It is omitted on `observing`, where
+// perch is not attached and that POST would 403.
+//
+// The overflow menu (Sessions/Recall/Setup) is otherwise the SAME on every
+// bird; Recall is omitted when there is no live session to stop
+// (idle/observing).
 function roostBirdHtml(bird, lang) {
   const state = bird.state;
   const idAttr = escapeHtml(String(bird.id));
@@ -214,6 +223,12 @@ function roostBirdHtml(bird, lang) {
     primaryHtml = `<button type="button" class="bb-roost-primary" data-roost-action="open" data-bot="${idAttr}"${sidDataAttr}>${t("botboard.roostActionOpen", lang)}</button>`;
   }
 
+  // `observing` is the one state with no perch gateway record, so it is the one
+  // state where a session cannot be started at all.
+  const talkHtml = state === "observing"
+    ? ""
+    : `<button type="button" class="bb-roost-secondary" data-roost-action="talk" data-bot="${idAttr}">${t("botboard.roostActionTalk", lang)}</button>`;
+
   const recallHtml = bird.sessionId != null
     ? `<button type="button" data-roost-action="recall" data-bot="${idAttr}"${sidDataAttr}>${t("botboard.roostActionRecall", lang)}</button>`
     : "";
@@ -223,9 +238,9 @@ function roostBirdHtml(bird, lang) {
     `<span class="bb-roost-name">${escapeHtml(String(bird.name))}</span>` +
     `<span class="bb-roost-state">${escapeHtml(stateText)}</span>` +
     primaryHtml +
+    talkHtml +
     `<button type="button" class="bb-roost-more" data-roost-menu-toggle aria-haspopup="true" aria-expanded="false" aria-label="${escapeHtml(t("botboard.roostMoreAria", lang))}">⋯</button>` +
     `<div class="bb-roost-menu" aria-hidden="true">` +
-    `<button type="button" data-roost-action="talk" data-bot="${idAttr}">${t("botboard.roostActionTalk", lang)}</button>` +
     `<button type="button" data-roost-action="sessions" data-bot="${idAttr}"${sidDataAttr}>${t("botboard.roostActionSessions", lang)}</button>` +
     recallHtml +
     `<a href="/dashboard/bot-builder?bot=${encodeURIComponent(String(bird.id))}&tab=tracker">${t("botboard.roostActionSetup", lang)}</a>` +

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1441,6 +1441,16 @@ export const translations = {
   "botboard.bdPermAsk": { en: "Ask", es: "Preguntar" },
   "botboard.bdPermBypass": { en: "Bypass", es: "Omitir" },
   "botboard.bdPlanModeLabel": { en: "Plan mode", es: "Modo de plan" },
+  // The controls row is three unlabelled selects on a wide screen, where the
+  // grouping carries the meaning. Stacked on a phone it reads as three loose
+  // dropdowns, so each one names itself.
+  "botboard.bdModelSelectLabel": { en: "Model", es: "Modelo" },
+  "botboard.bdThinkingSelectLabel": { en: "Thinking", es: "Razonamiento" },
+  "botboard.bdPermissionSelectLabel": { en: "Permissions", es: "Permisos" },
+  // Model availability (see servers/gateway/model-availability.js). "up" needs
+  // no suffix — a working choice should read as the plain default.
+  "botboard.bdModelOnDemand": { en: "starts on demand", es: "se inicia bajo demanda" },
+  "botboard.bdModelUnavailable": { en: "not running", es: "no está en ejecución" },
   // T3-10 honesty: a permission/model change only binds at the NEXT wake —
   // the affordance below is the only place that promise is ever displayed.
   "botboard.bdBindsAtWake": { en: "Applies at the next wake.", es: "Se aplicará en el próximo despertar." },

--- a/servers/gateway/model-availability.js
+++ b/servers/gateway/model-availability.js
@@ -1,0 +1,92 @@
+/**
+ * model-availability — can a bot actually USE this model right now?
+ *
+ * The interactive drawer's model picker lists every model the instance's
+ * provider rows declare. That list says nothing about whether anything is
+ * listening, so a row pointing at a port that only comes up inside a
+ * hand-run window (`crow-dsv4` → 127.0.0.1:8020 is the live example) sits in
+ * the dropdown looking exactly like a working choice, and every turn that
+ * picks it fails on connection refused.
+ *
+ * Three states, because "reachable" alone would be a lie about on-demand
+ * providers — the gateway genuinely will start those when a turn asks:
+ *
+ *   "up"          the provider answers a probe right now
+ *   "on_demand"   silent, but this gateway can warm it (a bundle it owns,
+ *                 directly or through the alias→sibling resolution
+ *                 resolveWarmableProviderName does)
+ *   "unavailable" silent, and nothing here will start it — a windowed
+ *                 endpoint, or a bundle that belongs to a peer instance
+ *
+ * gpu-orchestrator is imported DYNAMICALLY, and only when the caller does not
+ * inject its own seams. That keeps the orchestrator's child_process/db chain
+ * out of the dashboard render path and out of the unit test, the same
+ * discipline provider-health.js's header spells out for the same reason.
+ */
+
+/** @typedef {"up"|"on_demand"|"unavailable"} Availability */
+
+async function defaultDeps() {
+  const [orch, providers] = await Promise.all([
+    import("./gpu-orchestrator.js"),
+    import("../shared/providers.js"),
+  ]);
+  // resolveWarmableProviderName takes the provider config explicitly (no
+  // default), and gpu-orchestrator's own loadProviders is a private one-line
+  // wrapper around this same cached loader.
+  const cfg = providers.loadProviders();
+  return {
+    isProviderReady: orch.isProviderReady,
+    resolveWarmable: (name) => orch.resolveWarmableProviderName(cfg, name),
+  };
+}
+
+/**
+ * Annotate each model with `availability`. Additive: every field on the input
+ * entry is preserved.
+ *
+ * Probes once per PROVIDER, not once per model — several models routinely share
+ * one provider, and on an instance with a dozen rows the difference is a dozen
+ * probes instead of one per dropdown entry.
+ *
+ * Never throws and never drops a model. A probe that fails for any reason
+ * (network, a provider name the orchestrator does not know) resolves to
+ * "unavailable", which is the honest answer: we could not confirm it works.
+ *
+ * @param {Array<object>|null|undefined} models
+ * @param {{isProviderReady?: (name:string)=>Promise<boolean>,
+ *          resolveWarmable?: (name:string)=>string|null}} [deps]
+ * @returns {Promise<Array<object & {availability: Availability}>>}
+ */
+export async function annotateAvailability(models, deps) {
+  const list = Array.isArray(models) ? models : [];
+  if (list.length === 0) return [];
+
+  const { isProviderReady, resolveWarmable } = deps || (await defaultDeps());
+
+  const providers = [...new Set(list.map((m) => m && m.provider).filter(Boolean))];
+  const state = new Map();
+  await Promise.all(
+    providers.map(async (name) => {
+      let ready = false;
+      try {
+        ready = !!(await isProviderReady(name));
+      } catch {
+        ready = false;
+      }
+      if (ready) return void state.set(name, "up");
+      let warmable = null;
+      try {
+        warmable = resolveWarmable(name);
+      } catch {
+        warmable = null;
+      }
+      state.set(name, warmable ? "on_demand" : "unavailable");
+    })
+  );
+
+  return list.map((m) => ({
+    ...m,
+    availability: state.get(m && m.provider) || "unavailable",
+  }));
+}

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -48,6 +48,7 @@ import { perchAttached } from "../shared/perch-attached.js";
 import { getInteractiveEngine } from "../perch-interactive.js";
 import { tasksDbPath } from "../../../scripts/pi-bots/instance-paths.mjs";
 import { updateCard } from "../board/card-service.js";
+import { annotateAvailability } from "../model-availability.js";
 
 /** Mount prefix. Every route below is registered under it, after the auth gate. */
 const P = "/dashboard/perch-api";
@@ -244,7 +245,7 @@ async function loadBotRow(db, botId) {
  *   directly — what every fake-engine test below injects, so a turn is never
  *   driven and no pi is ever spawned.
  */
-export default function perchInteractiveApiRouter(dashboardAuth, { engine = getInteractiveEngine } = {}) {
+export default function perchInteractiveApiRouter(dashboardAuth, { engine = getInteractiveEngine, annotate = annotateAvailability } = {}) {
   const router = Router();
 
   // FIRST statement: auth-gate the whole prefix (perch.js / bot-board-api idiom).
@@ -558,11 +559,20 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
   });
 
   // ---- GET /interactive/:sid/options — live model / thinking-level menus ----
+  // Each model carries an `availability` (up | on_demand | unavailable) so the
+  // picker can say which choices actually work. Without it a provider row
+  // pointing at a windowed endpoint (`crow-dsv4` → 127.0.0.1:8020) is
+  // indistinguishable from a serving one, and picking it fails every turn on
+  // connection refused. `models: null` is the hibernating contract and is
+  // passed through untouched — the drawer disables the picker on it.
   router.get(P + "/interactive/:sid/options", async (req, res) => {
     try {
       const eng = resolveEngine();
       const result = await eng.options(String(req.params.sid));
-      res.json(result);
+      const models = Array.isArray(result && result.models)
+        ? await annotate(result.models)
+        : (result && result.models) || null;
+      res.json({ ...result, models });
     } catch (err) {
       mapEngineError(res, err);
     }

--- a/tests/bird-drawer-controls.test.js
+++ b/tests/bird-drawer-controls.test.js
@@ -788,3 +788,77 @@ test("the drawer SSR shell carries the controls row, envelope toggle, attach-to-
     assert.ok(html.includes('id="' + id + '"'), "missing mount point: " + id);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Controls row: labels, CSS specificity, and model availability
+// ---------------------------------------------------------------------------
+//
+// Three defects lived in this row at once, all visible in one phone screenshot
+// of the R4 instance:
+//
+//   1. `.bb-bd-plan-label` (specificity 0,1,0) was written to override
+//      css.js's `.bb-drawer label` (0,1,1) and LOST, so the plan-mode checkbox
+//      rendered as a block with uppercase letter-spaced text instead of the
+//      flex row it asks for. Wrong at every width, not just narrow.
+//   2. The thinking and permission selects carried no label at all. Fine in a
+//      wide row where the grouping carries the meaning; unreadable once the
+//      row wraps.
+//   3. The option text read `m.label`, which no provider row sets, so every
+//      model showed as `provider/id` while the human `name` sat unused in the
+//      same payload.
+
+test("the plan-mode label outranks .bb-drawer label instead of losing to it", async () => {
+  const { birdDrawerCss } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const css = birdDrawerCss();
+  assert.ok(css.includes(".bb-drawer .bb-bd-plan-label{"),
+    "the plan label must be .bb-drawer-qualified (0,2,1) to beat .bb-drawer label (0,1,1)");
+  assert.ok(!/(^|[^ ])\.bb-bd-plan-label\{/.test(css),
+    "no bare .bb-bd-plan-label rule may remain — it is the one that silently lost");
+  assert.ok(css.includes(".bb-drawer .bb-bd-plan-label input{"),
+    "the checkbox width override needs the same qualification");
+});
+
+test("each select in the controls row names itself", async () => {
+  const { birdDrawerMarkup } = await import("../servers/gateway/dashboard/panels/bot-board/html.js");
+  const html = birdDrawerMarkup("en");
+  for (const id of ["bb-bd-model", "bb-bd-thinking", "bb-bd-permission"]) {
+    assert.ok(html.includes(`id="${id}-label"`), `${id} needs a visible label element`);
+    assert.ok(new RegExp(`id="${id}"[^>]*aria-labelledby="${id}-label"`).test(html),
+      `${id} must point at its label`);
+  }
+});
+
+test("the field labels are spans, not labels — .bb-drawer label is block + uppercase", async () => {
+  const { birdDrawerMarkup } = await import("../servers/gateway/dashboard/panels/bot-board/html.js");
+  const html = birdDrawerMarkup("en");
+  assert.ok(html.includes('<span class="bb-bd-field-label" id="bb-bd-model-label">'));
+  assert.ok(!/<label[^>]*id="bb-bd-(model|thinking|permission)-label"/.test(html));
+});
+
+test("model options render the human name, not provider/id", async () => {
+  const { birdDrawerJs } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const js = birdDrawerJs("en");
+  assert.ok(js.includes("m.name||m.label||(m.provider+'/'+m.id)"),
+    "name first, then the old label, then the provider/id fallback");
+});
+
+test("model options say when a model is on demand or not running, and say nothing when it is up", async () => {
+  const { birdDrawerJs } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const js = birdDrawerJs("en");
+  assert.ok(js.includes("m.availability==='on_demand'"));
+  assert.ok(js.includes("m.availability==='unavailable'"));
+  assert.ok(js.includes("starts on demand") && js.includes("not running"));
+  // "up" must not be decorated — a working choice reads as the plain default.
+  assert.ok(!js.includes("m.availability==='up'"));
+});
+
+test("an unavailable model is greyed but still listed and still selectable", async () => {
+  const { birdDrawerJs } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const { birdDrawerCss } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const js = birdDrawerJs("en");
+  assert.ok(js.includes("o.className='bb-bd-model-off'"));
+  assert.ok(birdDrawerCss().includes(".bb-bd-model-off{"));
+  // Never disabled: an operator may deliberately pick a model they are about
+  // to bring up in a window.
+  assert.ok(!js.includes("o.disabled=true"));
+});

--- a/tests/board-i18n-literals.test.js
+++ b/tests/board-i18n-literals.test.js
@@ -183,6 +183,7 @@ const DRAWER_JS_KEYS = [
   "botboard.bdEnvelopeModelPrefix", "botboard.bdEnvelopeModelUnset", "botboard.bdEnvelopeSkillsPrefix",
   "botboard.bdFilesQueuedPrefix", "botboard.bdFileUploaded", "botboard.bdFullEnvelopeRestored",
   "botboard.bdInterruptedNote",
+  "botboard.bdModelOnDemand", "botboard.bdModelUnavailable",
   "botboard.bdNarrowedToMid", "botboard.bdNarrowedToPrefix", "botboard.bdNarrowedToSuffix",
   "botboard.bdNarrowFailed", "botboard.bdNarrowNoteEmpty", "botboard.bdNarrowNoteSaved",
   "botboard.bdNarrowNoteUnknown", "botboard.bdNarrowRejected",
@@ -340,7 +341,13 @@ const DISPATCH_SSR_KEYS = [
 
 const DRAWER_SSR_KEYS = [
   "botboard.bdMoreAria", "botboard.bdStop", "botboard.bdHibernating",
-  "botboard.bdEnvelopeModelPrefix", "botboard.bdPermGuarded", "botboard.bdPermAsk",
+  // bdEnvelopeModelPrefix moved OUT of the SSR shell: it used to be the model
+  // select's aria-label, and the select now carries a visible
+  // bdModelSelectLabel instead. The key is still live in the client script
+  // (the envelope summary line), where DRAWER_JS_KEYS above covers it.
+  "botboard.bdModelSelectLabel", "botboard.bdThinkingSelectLabel",
+  "botboard.bdPermissionSelectLabel",
+  "botboard.bdPermGuarded", "botboard.bdPermAsk",
   "botboard.bdPermBypass", "botboard.bdPlanModeLabel", "botboard.bdBindsAtWake",
   "botboard.bdApplyNow", "botboard.bdEnvelopeToggle", "botboard.bdAttachCard",
   "botboard.bdAttachFile", "botboard.bdComposerPlaceholder", "botboard.bdSend", "botboard.bdAbort",

--- a/tests/model-availability.test.js
+++ b/tests/model-availability.test.js
@@ -1,0 +1,97 @@
+// The bot drawer's model picker used to list every model any provider row
+// declared, with no way to tell a model that is serving from one whose endpoint
+// nothing is listening on. On the R4 instance that meant `deepseek-v4-flash`
+// (127.0.0.1:8020, up only inside a dsv4-window) sat in the dropdown looking
+// exactly like a working choice, and picking it failed every turn on connection
+// refused.
+//
+// Three states, because "reachable" alone would be a lie about on-demand
+// providers: the gateway really will start those when a turn asks for them.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { annotateAvailability } from "../servers/gateway/model-availability.js";
+
+const MODELS = [
+  { id: "qwen3.6-35b-a3b", provider: "crow-local" },
+  { id: "qwen3.5-122b-a10b", provider: "crow-local-122b" },
+  { id: "deepseek-v4-flash", provider: "crow-dsv4" },
+  { id: "glm-5.1", provider: "zai-coding" },
+];
+
+function deps({ ready = [], warmable = {} } = {}) {
+  const readySet = new Set(ready);
+  return {
+    isProviderReady: async (name) => readySet.has(name),
+    resolveWarmable: (name) => warmable[name] ?? null,
+  };
+}
+
+test("a provider answering right now is up", async () => {
+  const out = await annotateAvailability(MODELS, deps({ ready: ["crow-local"] }));
+  assert.equal(out.find((m) => m.provider === "crow-local").availability, "up");
+});
+
+test("a silent provider this gateway can start is on_demand, not unavailable", async () => {
+  // crow-local-122b has no bundle of its own; the orchestrator resolves it to a
+  // sibling that does. Marking it unavailable would talk an operator out of a
+  // choice that works.
+  const out = await annotateAvailability(
+    MODELS,
+    deps({ warmable: { "crow-local-122b": "crow-local-122b" } })
+  );
+  assert.equal(out.find((m) => m.provider === "crow-local-122b").availability, "on_demand");
+});
+
+test("a silent provider nothing here can start is unavailable", async () => {
+  const out = await annotateAvailability(MODELS, deps({ ready: ["crow-local"] }));
+  assert.equal(out.find((m) => m.provider === "crow-dsv4").availability, "unavailable");
+});
+
+test("up wins over warmable — a running provider is never labelled on_demand", async () => {
+  const out = await annotateAvailability(
+    MODELS,
+    deps({ ready: ["crow-local"], warmable: { "crow-local": "crow-chat" } })
+  );
+  assert.equal(out.find((m) => m.provider === "crow-local").availability, "up");
+});
+
+test("each provider is probed once however many models it carries", async () => {
+  const calls = [];
+  const many = [
+    { id: "a", provider: "crow-local" },
+    { id: "b", provider: "crow-local" },
+    { id: "c", provider: "crow-local" },
+  ];
+  await annotateAvailability(many, {
+    isProviderReady: async (name) => { calls.push(name); return true; },
+    resolveWarmable: () => null,
+  });
+  assert.deepEqual(calls, ["crow-local"]);
+});
+
+test("a probe that throws leaves the model listed, never the whole call failing", async () => {
+  const out = await annotateAvailability(MODELS, {
+    isProviderReady: async () => { throw new Error("network gone"); },
+    resolveWarmable: () => null,
+  });
+  assert.equal(out.length, MODELS.length);
+  assert.ok(out.every((m) => m.availability === "unavailable"));
+});
+
+test("annotation is additive — every original field survives", async () => {
+  const out = await annotateAvailability(
+    [{ id: "x", provider: "p", name: "X", baseUrl: "http://h/v1", extra: 1 }],
+    deps({ ready: ["p"] })
+  );
+  assert.deepEqual(out[0], {
+    id: "x", provider: "p", name: "X", baseUrl: "http://h/v1", extra: 1,
+    availability: "up",
+  });
+});
+
+test("an empty or missing model list is not an error", async () => {
+  assert.deepEqual(await annotateAvailability([], deps()), []);
+  assert.deepEqual(await annotateAvailability(null, deps()), []);
+});

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -179,7 +179,15 @@ before(async () => {
   app.use(perchApiRouter(fakeAuth, {
     interactiveEngine: () => engineImpl,
   }));
-  app.use(perchInteractiveApiRouter(fakeAuth, { engine: () => engineImpl }));
+  // `annotate` is injected for the same reason `engine` is: the real one
+  // dynamically imports gpu-orchestrator and probes every provider's baseUrl
+  // over the network. Availability itself is covered in
+  // tests/model-availability.test.js; here the seam only has to prove the
+  // route threads it through.
+  app.use(perchInteractiveApiRouter(fakeAuth, {
+    engine: () => engineImpl,
+    annotate: async (models) => models.map((m) => ({ ...m, availability: "up" })),
+  }));
 
   await new Promise((r) => { server = app.listen(0, "127.0.0.1", r); });
   base = "http://127.0.0.1:" + server.address().port + "/dashboard/perch-api";
@@ -812,15 +820,29 @@ test("POST /interactive/:sid/cycle maps cycle_busy and session_stopped", async (
 // GET /interactive/:sid/options
 // ---------------------------------------------------------------------------
 
-test("GET /interactive/:sid/options 200s with the engine's models/thinkingLevels", async () => {
+test("GET /interactive/:sid/options 200s with the engine's models/thinkingLevels, each model carrying its availability", async () => {
   engineImpl.options = async (sid) => {
     engineCalls.options.push({ sid });
     return { models: [{ provider: "crow-local", id: "qwen3.6-35b-a3b" }], thinkingLevels: ["low", "high"] };
   };
   const { status, body } = await getJson("/interactive/sess-1/options");
   assert.equal(status, 200);
-  assert.deepEqual(body, { models: [{ provider: "crow-local", id: "qwen3.6-35b-a3b" }], thinkingLevels: ["low", "high"] });
+  assert.deepEqual(body, {
+    models: [{ provider: "crow-local", id: "qwen3.6-35b-a3b", availability: "up" }],
+    thinkingLevels: ["low", "high"],
+  });
   assert.deepEqual(engineCalls.options, [{ sid: "sess-1" }]);
+});
+
+test("GET /interactive/:sid/options passes models:null through — a hibernating session is not annotated", async () => {
+  // The null arrays are how the engine says "I did not wake a child just to
+  // list", and the drawer disables both pickers on them. Annotating would turn
+  // that into an empty list, which reads as "no models exist".
+  engineImpl.options = async () => ({ models: null, thinkingLevels: null });
+  const { status, body } = await getJson("/interactive/sess-1/options");
+  assert.equal(status, 200);
+  assert.equal(body.models, null);
+  assert.equal(body.thinkingLevels, null);
 });
 
 test("GET /interactive/:sid/options 404s no_such_session", async () => {

--- a/tests/roost-strip-ui.test.js
+++ b/tests/roost-strip-ui.test.js
@@ -286,3 +286,55 @@ test("roost i18n keys exist in both languages and are not identical placeholders
     assert.notEqual(entry.en, entry.es, `${key} es must be a real translation, not a copy of en`);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Talk is a visible control, not an overflow item
+// ---------------------------------------------------------------------------
+//
+// Talk is the ONLY way to start a session that is not tied to a card: it POSTs
+// /bots/<id>/interactive, which takes cardId = null. It lived in the ⋯ menu, so
+// the only visible action on an idle bird was "Send out" — the card dispatch —
+// and the card-less path read as though it did not exist.
+//
+// It stays off an `observing` bird, where perch is not attached and the same
+// POST would 403.
+
+function birdMarkup(html, id) {
+  const start = html.indexOf(`data-bot="${id}"`);
+  return html.slice(start, html.indexOf("</div>", html.indexOf("bb-roost-menu", start)) + 6);
+}
+
+test("every perch-attached bird carries a visible Talk control, whatever its state", async () => {
+  const html = await render();
+  for (const id of ["empty-bot", "chatty", "asker", "sleepy"]) {
+    const bird = birdMarkup(html, id);
+    assert.ok(
+      /<button[^>]*class="bb-roost-secondary"[^>]*data-roost-action="talk"/.test(bird),
+      `${id} needs Talk as a visible control`
+    );
+  }
+});
+
+test("an observing bird offers no Talk — perch is not attached and the POST would 403", async () => {
+  const bird = birdMarkup(await render(), "quiet");
+  assert.ok(bird.includes("bb-roost-primary bb-roost-link"), "observing still links to Bot Builder");
+  assert.ok(!bird.includes('data-roost-action="talk"'), "no Talk on a bot that cannot hold a session");
+});
+
+test("Talk is not duplicated into the overflow menu", async () => {
+  const bird = birdMarkup(await render(), "empty-bot");
+  const menuStart = bird.indexOf("bb-roost-menu");
+  assert.ok(!bird.slice(menuStart).includes('data-roost-action="talk"'),
+    "one Talk per bird — the visible one");
+  // The rest of the menu is untouched.
+  assert.ok(bird.slice(menuStart).includes('data-roost-action="sessions"'));
+});
+
+test("an idle bird shows BOTH the card dispatch and the card-less Talk", async () => {
+  const bird = birdMarkup(await render(), "empty-bot");
+  assert.ok(bird.includes('data-roost-action="dispatch"'), "Send out stays the primary");
+  const dispatchAt = bird.indexOf('data-roost-action="dispatch"');
+  const talkAt = bird.indexOf('data-roost-action="talk"');
+  assert.ok(dispatchAt > -1 && talkAt > dispatchAt, "Talk sits after the primary, before the ⋯");
+  assert.ok(talkAt < bird.indexOf("bb-roost-more"), "Talk is outside the overflow toggle");
+});


### PR DESCRIPTION
Four defects sat in the interactive drawer's controls row at once. All four are visible in one phone screenshot of a bot dispatched on a card.

## 1. The plan-mode label loses a specificity fight

`.bb-bd-plan-label` (0,1,0) was written to override `css.js`'s `.bb-drawer label` (0,1,1) — it sets `display:flex`, `text-transform:none`, `letter-spacing:normal` — and **loses every one of them**. So the control renders as a block with uppercase letter-spaced text and the checkbox stranded above it. Wrong at every width, not just narrow ones.

Every rule that has to beat that selector is now `.bb-drawer`-qualified.

## 2. Two of the three selects have no label

The row is `[model] [thinking] [permission] [plan mode]`, and only the model select carried even an aria-label. That reads fine as a wide row where the grouping carries the meaning. The moment it wraps you get a bare `off` and a bare `Guarded` with nothing to say what they set.

Each control now names itself. The labels are `<span>` + `aria-labelledby`, deliberately not `<label>` — `.bb-drawer label` is exactly the block/uppercase rule from (1).

## 3. Models listed as `provider/id`

The option text read `m.label`, which no provider row sets, so every entry fell through to `crow-local/qwen3.6-35b-a3b` while the human `name` — "Qwen3.6 35B A3B (Crow, Q5_K_XL MTP+vision, 256K)" — sat unused in the same payload.

## 4. Nothing said whether a model was actually serving

A provider row pointing at an endpoint that only comes up inside a hand-run window looked exactly like a working choice. `crow-dsv4` → `127.0.0.1:8020` is the live example: it validates in `resolveModel`, nothing listens, and every turn that picks it fails on connection refused.

`GET /interactive/:sid/options` now annotates each model, and the picker shows it. **Three** states, because "reachable" alone would be a lie about on-demand providers — the gateway genuinely will start those when a turn asks:

| state | meaning | shown as |
|---|---|---|
| `up` | answers a probe now | undecorated — a working choice should read as the plain default |
| `on_demand` | silent, but this gateway can warm it (own bundle, or the alias→sibling resolution `resolveWarmableProviderName` already does) | `… — starts on demand` |
| `unavailable` | silent, and nothing here will start it | `… — not running`, greyed |

An unavailable model is greyed but **never disabled**: an operator may deliberately pick one they are about to bring up in a window.

`models: null` — the engine's "I did not wake a child just to list" — passes through untouched. Annotating it would turn it into an empty list, which reads as "no models exist".

`gpu-orchestrator` is imported dynamically, and only when the caller injects no seams, keeping its `child_process`/db chain out of the dashboard render path and out of the unit test — the discipline `provider-health.js`'s header spells out, for the same reason. Providers are probed once each, not once per model, and a probe that throws resolves to `unavailable` rather than failing the call.

## Verified against the real cascade, not just the source

Rendered through `renderLayout` at 390 px with dark emulation, driven over CDP, on the same markup path the dashboard uses.

**Before:** the model select reads `crow-local/qwen3.6-35b-a3b`; below it an unlabelled `off` and an unlabelled `Guarded` share a row; below that a checkbox on its own line above uppercase letter-spaced `PLAN MODE`.

**After:** a `MODEL` label over the model select on its own full-width line; `THINKING` and `PERMISSIONS` labels over the two short selects sharing the next line; `Plan mode` in sentence case with its checkbox inline beside it.

Computed styles on the plan label, read out of the live document:

```
{"display":"flex","textTransform":"none","letterSpacing":"normal"}
```

Rendered option list, read out of the live `<select>`:

```
[default        ] disabled=False  Qwen3.6 35B A3B (Crow, Q5_K_XL MTP+vision, 256K)
[default        ] disabled=False  Qwen3.5-122B-A10B MTP Q4 (local, on-demand) — starts on demand
[bb-bd-model-off] disabled=False  DeepSeek-V4-Flash (windowed, 127.0.0.1:8020) — not running
```

## Tests

- `tests/model-availability.test.js`, 8 new: the three states, `up` beating warmable, one probe per provider however many models it carries, a throwing probe leaving every model listed, additive annotation, empty/null input.
- `tests/bird-drawer-controls.test.js`, 6 new: the cascade fix (and that no bare `.bb-bd-plan-label` rule survives), each select naming itself, spans rather than labels, the name fallback chain, the availability suffixes with `up` left undecorated, greyed-but-selectable.
- `tests/perch-interactive-routes.test.js`: the annotated contract, plus `models: null` passing through.

The i18n key lists move `bdEnvelopeModelPrefix` from the SSR shell to the client-script list, where it is still live on the envelope summary line.

Full runs green: `model-availability` 8, `bird-drawer-controls` 47, `perch-interactive-routes` 77, `board-i18n-literals` 10, `i18n-global-parity` 7, `perch-narrowing` 16, `perch-interactive` 56, `perch-interactive-controls` 26, `perch-interactive-dispatch` 29, `perch-interactive-statebridge` 11, `perch-interactive-capacity` 16.
