### PR TITLE
model-availability: probe the endpoint, not the orchestrator's residency view

### DIFF
--- a/servers/gateway/model-availability.js
+++ b/servers/gateway/model-availability.js
@@ -11,20 +11,49 @@
  * Three states, because "reachable" alone would be a lie about on-demand
  * providers — the gateway genuinely will start those when a turn asks:
  *
- *   "up"          the provider answers a probe right now
- *   "on_demand"   silent, but this gateway can warm it (a bundle it owns,
- *                 directly or through the alias→sibling resolution
- *                 resolveWarmableProviderName does)
- *   "unavailable" silent, and nothing here will start it — a windowed
- *                 endpoint, or a bundle that belongs to a peer instance
+ *   "up"          something answered at the model's baseUrl
+ *   "on_demand"   nothing answered (or there is no baseUrl), but this gateway
+ *                 can warm the provider — a bundle it owns, directly or through
+ *                 the alias→sibling resolution resolveWarmableProviderName does
+ *   "unavailable" nothing answered, and nothing here will start it
  *
- * gpu-orchestrator is imported DYNAMICALLY, and only when the caller does not
- * inject its own seams. That keeps the orchestrator's child_process/db chain
- * out of the dashboard render path and out of the unit test, the same
- * discipline provider-health.js's header spells out for the same reason.
+ * WHY THIS PROBES RATHER THAN ASKING THE ORCHESTRATOR. The first version
+ * delegated to gpu-orchestrator's `isProviderReady()`. On a live instance that
+ * marked 14 of 16 models "not running", including seven Z.AI cloud models that
+ * work perfectly, for two independent reasons:
+ *
+ *   1. `isProviderReady` requires a 2xx, because it answers a RESIDENCY
+ *      question. An authenticated cloud API answers 401 to an unauthenticated
+ *      probe, and a 401 proves the endpoint is up.
+ *   2. It resolves the provider through the orchestrator's own provider config.
+ *      `crow-local-122b` answered 200 on :8004 and was still reported
+ *      unavailable, because that lookup did not carry the row.
+ *
+ * Availability and residency are different questions. This asks only "did
+ * anything answer at this address", against the `baseUrl` pi already puts on
+ * every model entry, so neither the 2xx rule nor the config lookup applies.
+ * A refused connection — nothing listening at all — stays the real negative.
+ *
+ * gpu-orchestrator is still imported DYNAMICALLY, and only for the warmability
+ * question, and only when the caller injects no seams. That keeps its
+ * child_process/db chain out of the dashboard render path and out of the unit
+ * test, the same discipline provider-health.js's header spells out.
  */
 
 /** @typedef {"up"|"on_demand"|"unavailable"} Availability */
+
+const PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Did anything answer at this base URL? Returns the HTTP status, or throws.
+ * Any status counts — see the header: a 401 from a cloud API means "up".
+ */
+async function defaultFetchStatus(baseUrl) {
+  const res = await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
+    signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+  });
+  return res.status;
+}
 
 async function defaultDeps() {
   const [orch, providers] = await Promise.all([
@@ -36,7 +65,7 @@ async function defaultDeps() {
   // wrapper around this same cached loader.
   const cfg = providers.loadProviders();
   return {
-    isProviderReady: orch.isProviderReady,
+    fetchStatus: defaultFetchStatus,
     resolveWarmable: (name) => orch.resolveWarmableProviderName(cfg, name),
   };
 }
@@ -45,16 +74,17 @@ async function defaultDeps() {
  * Annotate each model with `availability`. Additive: every field on the input
  * entry is preserved.
  *
- * Probes once per PROVIDER, not once per model — several models routinely share
- * one provider, and on an instance with a dozen rows the difference is a dozen
- * probes instead of one per dropdown entry.
+ * Probes once per distinct baseUrl, not once per model and not once per
+ * provider — several provider rows routinely alias the same endpoint (on this
+ * instance `crow-local`, `crow-chat`, `crow-swap-coder` and `crow-swap-deep`
+ * all point at :8003), so per-provider probing would hit one port four times.
  *
- * Never throws and never drops a model. A probe that fails for any reason
- * (network, a provider name the orchestrator does not know) resolves to
- * "unavailable", which is the honest answer: we could not confirm it works.
+ * Never throws and never drops a model. A probe that fails for any reason falls
+ * through to the warmability question, and then to "unavailable", which is the
+ * honest answer: we could not confirm anything is there.
  *
  * @param {Array<object>|null|undefined} models
- * @param {{isProviderReady?: (name:string)=>Promise<boolean>,
+ * @param {{fetchStatus?: (baseUrl:string)=>Promise<number>,
  *          resolveWarmable?: (name:string)=>string|null}} [deps]
  * @returns {Promise<Array<object & {availability: Availability}>>}
  */
@@ -62,31 +92,39 @@ export async function annotateAvailability(models, deps) {
   const list = Array.isArray(models) ? models : [];
   if (list.length === 0) return [];
 
-  const { isProviderReady, resolveWarmable } = deps || (await defaultDeps());
+  const { fetchStatus, resolveWarmable } = deps || (await defaultDeps());
 
-  const providers = [...new Set(list.map((m) => m && m.provider).filter(Boolean))];
-  const state = new Map();
+  const urls = [...new Set(list.map((m) => m && m.baseUrl).filter(Boolean))];
+  const answered = new Map();
   await Promise.all(
-    providers.map(async (name) => {
-      let ready = false;
+    urls.map(async (url) => {
       try {
-        ready = !!(await isProviderReady(name));
+        const status = await fetchStatus(url);
+        answered.set(url, Number.isFinite(status));
       } catch {
-        ready = false;
+        answered.set(url, false); // nothing listening
       }
-      if (ready) return void state.set(name, "up");
-      let warmable = null;
-      try {
-        warmable = resolveWarmable(name);
-      } catch {
-        warmable = null;
-      }
-      state.set(name, warmable ? "on_demand" : "unavailable");
     })
   );
 
-  return list.map((m) => ({
-    ...m,
-    availability: state.get(m && m.provider) || "unavailable",
-  }));
+  const warmable = new Map();
+  const warmableFor = (name) => {
+    if (!warmable.has(name)) {
+      let target = null;
+      try {
+        target = resolveWarmable(name);
+      } catch {
+        target = null;
+      }
+      warmable.set(name, target);
+    }
+    return warmable.get(name);
+  };
+
+  return list.map((m) => {
+    const url = m && m.baseUrl;
+    if (url && answered.get(url)) return { ...m, availability: "up" };
+    const name = m && m.provider;
+    return { ...m, availability: name && warmableFor(name) ? "on_demand" : "unavailable" };
+  });
 }

--- a/tests/model-availability.test.js
+++ b/tests/model-availability.test.js
@@ -14,22 +14,27 @@ import assert from "node:assert/strict";
 import { annotateAvailability } from "../servers/gateway/model-availability.js";
 
 const MODELS = [
-  { id: "qwen3.6-35b-a3b", provider: "crow-local" },
-  { id: "qwen3.5-122b-a10b", provider: "crow-local-122b" },
-  { id: "deepseek-v4-flash", provider: "crow-dsv4" },
-  { id: "glm-5.1", provider: "zai-coding" },
+  { id: "qwen3.6-35b-a3b", provider: "crow-local", baseUrl: "http://h:8003/v1" },
+  { id: "qwen3.5-122b-a10b", provider: "crow-local-122b", baseUrl: "http://h:8004/v1" },
+  { id: "deepseek-v4-flash", provider: "crow-dsv4", baseUrl: "http://127.0.0.1:8020/v1" },
+  { id: "glm-5.1", provider: "zai-coding", baseUrl: "https://api.z.ai/v4" },
 ];
 
-function deps({ ready = [], warmable = {} } = {}) {
-  const readySet = new Set(ready);
+/** `answering` lists the baseUrls something is listening on; everything else
+ *  refuses the connection. `warmable` maps provider name → warm target. */
+function deps({ answering = [], warmable = {} } = {}) {
+  const live = new Set(answering);
   return {
-    isProviderReady: async (name) => readySet.has(name),
+    fetchStatus: async (url) => {
+      if (!live.has(url)) throw new Error("ECONNREFUSED");
+      return 200;
+    },
     resolveWarmable: (name) => warmable[name] ?? null,
   };
 }
 
 test("a provider answering right now is up", async () => {
-  const out = await annotateAvailability(MODELS, deps({ ready: ["crow-local"] }));
+  const out = await annotateAvailability(MODELS, deps({ answering: ["http://h:8003/v1"] }));
   assert.equal(out.find((m) => m.provider === "crow-local").availability, "up");
 });
 
@@ -45,35 +50,35 @@ test("a silent provider this gateway can start is on_demand, not unavailable", a
 });
 
 test("a silent provider nothing here can start is unavailable", async () => {
-  const out = await annotateAvailability(MODELS, deps({ ready: ["crow-local"] }));
+  const out = await annotateAvailability(MODELS, deps({ answering: ["http://h:8003/v1"] }));
   assert.equal(out.find((m) => m.provider === "crow-dsv4").availability, "unavailable");
 });
 
 test("up wins over warmable — a running provider is never labelled on_demand", async () => {
   const out = await annotateAvailability(
     MODELS,
-    deps({ ready: ["crow-local"], warmable: { "crow-local": "crow-chat" } })
+    deps({ answering: ["http://h:8003/v1"], warmable: { "crow-local": "crow-chat" } })
   );
   assert.equal(out.find((m) => m.provider === "crow-local").availability, "up");
 });
 
-test("each provider is probed once however many models it carries", async () => {
+test("one probe however many models share an endpoint", async () => {
   const calls = [];
   const many = [
-    { id: "a", provider: "crow-local" },
-    { id: "b", provider: "crow-local" },
-    { id: "c", provider: "crow-local" },
+    { id: "a", provider: "crow-local", baseUrl: "http://h:8003/v1" },
+    { id: "b", provider: "crow-local", baseUrl: "http://h:8003/v1" },
+    { id: "c", provider: "crow-local", baseUrl: "http://h:8003/v1" },
   ];
   await annotateAvailability(many, {
-    isProviderReady: async (name) => { calls.push(name); return true; },
+    fetchStatus: async (url) => { calls.push(url); return 200; },
     resolveWarmable: () => null,
   });
-  assert.deepEqual(calls, ["crow-local"]);
+  assert.deepEqual(calls, ["http://h:8003/v1"]);
 });
 
 test("a probe that throws leaves the model listed, never the whole call failing", async () => {
   const out = await annotateAvailability(MODELS, {
-    isProviderReady: async () => { throw new Error("network gone"); },
+    fetchStatus: async () => { throw new Error("network gone"); },
     resolveWarmable: () => null,
   });
   assert.equal(out.length, MODELS.length);
@@ -83,7 +88,7 @@ test("a probe that throws leaves the model listed, never the whole call failing"
 test("annotation is additive — every original field survives", async () => {
   const out = await annotateAvailability(
     [{ id: "x", provider: "p", name: "X", baseUrl: "http://h/v1", extra: 1 }],
-    deps({ ready: ["p"] })
+    deps({ answering: ["http://h/v1"] })
   );
   assert.deepEqual(out[0], {
     id: "x", provider: "p", name: "X", baseUrl: "http://h/v1", extra: 1,
@@ -94,4 +99,83 @@ test("annotation is additive — every original field survives", async () => {
 test("an empty or missing model list is not an error", async () => {
   assert.deepEqual(await annotateAvailability([], deps()), []);
   assert.deepEqual(await annotateAvailability(null, deps()), []);
+});
+
+// ---------------------------------------------------------------------------
+// Probing the endpoint, not the orchestrator's residency view
+// ---------------------------------------------------------------------------
+//
+// The first version delegated to gpu-orchestrator's isProviderReady(). Live on
+// the R4 instance that marked 14 of 16 models "not running", including seven
+// Z.AI cloud models that work perfectly. Two separate causes:
+//
+//   1. isProviderReady requires a 2xx. An authenticated cloud API answers 401
+//      to an unauthenticated probe — which proves it is UP, not down.
+//   2. It resolves the provider through the orchestrator's own provider config.
+//      crow-local-122b answers 200 on :8004 and was still reported unavailable,
+//      because that lookup did not carry the row.
+//
+// Both go away by probing the baseUrl pi already puts on every model entry, and
+// by asking "did anything answer" rather than "did it answer 2xx". Residency and
+// availability are different questions; only the second one is being asked here.
+
+test("an endpoint that answers 401 is up — an authenticated API is not a down one", async () => {
+  const out = await annotateAvailability(
+    [{ id: "glm-5.1", provider: "zai-coding", baseUrl: "https://api.z.ai/v4" }],
+    { fetchStatus: async () => 401, resolveWarmable: () => null }
+  );
+  assert.equal(out[0].availability, "up");
+});
+
+test("any HTTP answer counts as up — 200, 401, 403, 404, 500", async () => {
+  for (const status of [200, 401, 403, 404, 500]) {
+    const out = await annotateAvailability(
+      [{ id: "m", provider: "p", baseUrl: "http://h/v1" }],
+      { fetchStatus: async () => status, resolveWarmable: () => null }
+    );
+    assert.equal(out[0].availability, "up", `status ${status} means something is listening`);
+  }
+});
+
+test("nothing listening is not up — a refused connection is the real negative", async () => {
+  const out = await annotateAvailability(
+    [{ id: "deepseek-v4-flash", provider: "crow-dsv4", baseUrl: "http://127.0.0.1:8020/v1" }],
+    { fetchStatus: async () => { throw new Error("ECONNREFUSED"); }, resolveWarmable: () => null }
+  );
+  assert.equal(out[0].availability, "unavailable");
+});
+
+test("the probe uses the baseUrl on the model entry, not a provider-config lookup", async () => {
+  const seen = [];
+  await annotateAvailability(
+    [{ id: "a", provider: "crow-local-122b", baseUrl: "http://100.118.41.122:8004/v1" }],
+    { fetchStatus: async (url) => { seen.push(url); return 200; }, resolveWarmable: () => null }
+  );
+  assert.equal(seen.length, 1);
+  assert.ok(seen[0].startsWith("http://100.118.41.122:8004/v1"),
+    "the entry's own baseUrl, so a row missing from the orchestrator config still probes");
+});
+
+test("a model with no baseUrl falls back to warmability rather than claiming up", async () => {
+  const out = await annotateAvailability(
+    [{ id: "a", provider: "p" }, { id: "b", provider: "q" }],
+    { fetchStatus: async () => { throw new Error("should not be called"); },
+      resolveWarmable: (n) => (n === "p" ? "p" : null) }
+  );
+  assert.equal(out[0].availability, "on_demand");
+  assert.equal(out[1].availability, "unavailable");
+});
+
+test("one probe per distinct baseUrl, not per provider — several rows share :8003", async () => {
+  const seen = [];
+  await annotateAvailability(
+    [
+      { id: "a", provider: "crow-local", baseUrl: "http://h:8003/v1" },
+      { id: "b", provider: "crow-chat", baseUrl: "http://h:8003/v1" },
+      { id: "c", provider: "crow-swap-deep", baseUrl: "http://h:8003/v1" },
+      { id: "d", provider: "other", baseUrl: "http://h:8004/v1" },
+    ],
+    { fetchStatus: async (u) => { seen.push(u); return 200; }, resolveWarmable: () => null }
+  );
+  assert.equal(seen.length, 2, "two distinct baseUrls, two probes");
 });


### PR DESCRIPTION
Follow-up to #346, which shipped model availability and got it wrong on contact with a real instance.

## What it looked like live

Deployed to an instance with 16 models, the picker reported **14 of them "not running"** — including seven Z.AI cloud models that work perfectly, and a local 122B that was answering `200` at that moment.

## Two independent causes, both from delegating to `isProviderReady()`

**1. It requires a 2xx, because it answers a residency question.** An authenticated cloud API answers `401` to an unauthenticated probe, and a 401 *proves the endpoint is up*. All seven `zai-coding` models were marked down by their own auth working correctly:

```
curl -o /dev/null -w '%{http_code}' https://api.z.ai/api/coding/paas/v4/models
401
```

`resolveWarmableProviderName` has its own cloud guard (`direct.host !== "local"` → not warmable), but it never fired either: that provider row carries `host = 'local'` despite its `https://api.z.ai/...` baseUrl. So the cloud path had no working detector anywhere.

**2. It resolves the provider through the orchestrator's provider config.** `crow-local-122b` answered `200` on `:8004` and was still reported unavailable, because that lookup did not carry the row.

## The fix

Availability and residency are different questions, and this was asking the wrong one. It now asks only **"did anything answer at this address"**, against the `baseUrl` pi already puts on every model entry — so neither the 2xx rule nor the config lookup applies.

A refused connection stays the real negative, which preserves the case the feature exists for: `crow-dsv4` on `127.0.0.1:8020`, where nothing listens outside a hand-run window.

Probing also moved from once-per-provider to **once-per-distinct-baseUrl**. On this instance `crow-local`, `crow-chat`, `crow-swap-coder` and `crow-swap-deep` all alias `:8003`, so per-provider probing hit one port four times.

## Verified against the live list, cross-checked independently

Run over the real 16-model payload, then checked against a port scan done separately:

```
counts: {"up":9,"unavailable":7}
  up          Qwen3.6 35B A3B (Crow, Q5_K_XL MTP+vision, 256K)
  up          Z.AI GLM-5.1 (Coding Devpack flagship)
  up          Z.AI GLM-5 / GLM-5 Turbo / GLM-4.7 / GLM-4.6 / GLM-4.5 / GLM-4.5 Air
  up          Qwen3.5-122B-A10B MTP Q4 (local, on-demand)
  unavailable gpt-oss-120b MXFP4
  unavailable Qwen3.8-27B dense Q6
  unavailable Nemotron 3 Super 120B-A12B IQ4
  unavailable Nemotron 3 Nano 30B A3B
  unavailable Qwen3.8-27B copilot
  unavailable DeepSeek-V4-Flash (windowed, 127.0.0.1:8020)
  unavailable Qwen3.8-27B 512k
```

The port scan agrees one for one: `8003` and `8004` answer 200, z.ai answers 401, and `8005/8006/8008/8009/8010/8014/8020` answer nothing.

## Tests

Six new, plus the original eight rewritten to the corrected contract:

- an endpoint answering 401 is up — an authenticated API is not a down one
- any HTTP answer counts as up (200, 401, 403, 404, 500)
- nothing listening is not up — a refused connection is the real negative
- the probe uses the baseUrl on the model entry, not a provider-config lookup
- a model with no baseUrl falls back to warmability rather than claiming up
- one probe per distinct baseUrl, not per provider

`model-availability` 14, `perch-interactive-routes` 77, `bird-drawer-controls` 47, `roost-strip-ui` 17, `board-i18n-literals` 10 — all green.
