### PR TITLE
Bot drawer on a phone: reach Send, and stop printing [object Object]

### DIFF
--- a/servers/gateway/dashboard/panels/bot-board/css.js
+++ b/servers/gateway/dashboard/panels/bot-board/css.js
@@ -93,7 +93,7 @@ export function botBoardStyles() {
   .bb-nojs-move{display:flex;gap:.25rem;flex-wrap:wrap;margin-top:.4rem}
   .bb-nojs-move button{font-size:.66rem;padding:.15rem .4rem;background:var(--crow-bg-surface);border:1px solid var(--crow-border);border-radius:var(--crow-radius-control);color:var(--crow-text-secondary);cursor:pointer}
   body.bb-js .bb-nojs-move{display:none}
-  .bb-drawer{position:fixed;top:0;right:0;height:100vh;width:min(480px,92vw);background:var(--crow-bg-surface);border-left:1px solid var(--crow-border);box-shadow:-8px 0 24px rgba(0,0,0,.3);transform:translateX(100%);transition:transform .18s ease;z-index:50;overflow-y:auto;padding:1rem}
+  .bb-drawer{position:fixed;top:0;right:0;height:100vh;height:100dvh;width:min(480px,92vw);background:var(--crow-bg-surface);border-left:1px solid var(--crow-border);box-shadow:-8px 0 24px rgba(0,0,0,.3);transform:translateX(100%);transition:transform .18s ease;z-index:50;overflow-y:auto;padding:1rem}
   .bb-drawer.bb-open{transform:translateX(0)}
   .bb-drawer label{display:block;font-size:.75rem;color:var(--crow-text-muted);text-transform:uppercase;letter-spacing:.05em;margin:.7rem 0 .25rem}
   .bb-drawer input,.bb-drawer select,.bb-drawer textarea{width:100%;padding:.45rem;background:var(--crow-bg-elevated);border:1px solid var(--crow-border);border-radius:6px;color:var(--crow-text-primary);font:inherit}

--- a/servers/gateway/dashboard/panels/bot-board/drawer.js
+++ b/servers/gateway/dashboard/panels/bot-board/drawer.js
@@ -69,6 +69,17 @@ export function birdDrawerCss() {
   /* A model whose endpoint nothing is serving stays listed and stays readable,
      but must not look like the plain working choice next to it. */
   .bb-bd-model-off{color:var(--crow-text-muted)}
+  /* PHONES. Reported from one: "I can't even scroll down far enough to hit the
+     send button." The transcript and the composer each carried a 220px floor,
+     which is 440px of minimum under ~400px of header and controls, and nothing
+     pinned the composer. Below 640px the floors come down and the composer
+     sticks to the bottom of the scroller, so Send is reachable at any scroll
+     position instead of only at the very end of a long transcript. */
+  @media (max-width: 640px) {
+    .bb-bd-transcript{min-height:120px}
+    #bb-bd-input{min-height:90px}
+    #bb-bd-composer{position:sticky;bottom:0;background:var(--crow-bg-surface);padding-top:.4rem;margin-top:.2rem;border-top:1px solid var(--crow-border);z-index:2}
+  }
   .bb-bd-controls-toggle-wrap{display:flex;gap:.4rem;flex-wrap:wrap;margin:.3rem 0}
   .bb-bd-controls-pane{margin:.4rem 0;padding:.5rem;background:var(--crow-bg-elevated);border:1px solid var(--crow-border);border-radius:8px}
   .bb-bd-tools{display:flex;flex-direction:column;gap:.25rem;margin:.4rem 0}
@@ -642,6 +653,18 @@ export function birdDrawerJs(lang) {
     return '';
   }
 
+  /* pi's plan state is an OBJECT: {enabled, executing, todosDone, todosTotal,
+   * todos}. This listener used to hand it straight to bdAppendNote, whose
+   * textContent turned it into the literal "[object Object]" on every freshly
+   * opened drawer. An inactive plan is the normal case and says nothing. */
+  function bdPlanStateText(st){
+    if(!st||typeof st!=='object') return typeof st==='string'?st:'';
+    if(!st.enabled&&!st.executing) return '';
+    var total=Number(st.todosTotal||0), done=Number(st.todosDone||0);
+    var head=st.executing?'${tJs("botboard.bdPlanExecuting", lang)}':'${tJs("botboard.bdPlanOn", lang)}';
+    return total>0?head+' ('+done+'/'+total+')':head;
+  }
+
   function bdLoadTranscript(){
     if(!bd.botId||!bd.threadId) return;
     var mySid=bd.sid;
@@ -839,7 +862,8 @@ export function birdDrawerJs(lang) {
     });
     es.addEventListener('plan_state',function(e){
       if(bd.sid!==mySid) return;
-      bdAppendNote('',(parsed(e).state||''));
+      var txt=bdPlanStateText(parsed(e).state);
+      if(txt) bdAppendNote('',txt);
     });
     es.addEventListener('error',function(e){
       if(bd.sid!==mySid) return;

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -1449,6 +1449,8 @@ export const translations = {
   "botboard.bdPermissionSelectLabel": { en: "Permissions", es: "Permisos" },
   // Model availability (see servers/gateway/model-availability.js). "up" needs
   // no suffix — a working choice should read as the plain default.
+  "botboard.bdPlanOn": { en: "plan mode on", es: "modo de plan activado" },
+  "botboard.bdPlanExecuting": { en: "executing the plan", es: "ejecutando el plan" },
   "botboard.bdModelOnDemand": { en: "starts on demand", es: "se inicia bajo demanda" },
   "botboard.bdModelUnavailable": { en: "not running", es: "no está en ejecución" },
   // T3-10 honesty: a permission/model change only binds at the NEXT wake —

--- a/tests/bird-drawer-controls.test.js
+++ b/tests/bird-drawer-controls.test.js
@@ -862,3 +862,80 @@ test("an unavailable model is greyed but still listed and still selectable", asy
   // to bring up in a window.
   assert.ok(!js.includes("o.disabled=true"));
 });
+
+// ---------------------------------------------------------------------------
+// The drawer has to be usable on a phone
+// ---------------------------------------------------------------------------
+//
+// Reported from an actual phone: "I can't even scroll down far enough to hit
+// the send button." Three causes, all in this file's own CSS:
+//
+//   1. `.bb-drawer` was `height:100vh`. On mobile browsers 100vh is the LARGE
+//      viewport — it excludes the URL bar and the bottom nav — so the drawer is
+//      taller than the visible area and its last ~90px, which is exactly where
+//      Send lives, sits permanently behind the browser chrome. Scrolling the
+//      container cannot reach what the container itself renders off-screen.
+//   2. The transcript and the composer each carried `min-height:220px`. That is
+//      440px of floor before the buttons, under ~400px of header and controls.
+//   3. Nothing pinned the composer, so Send is only ever reachable by scrolling
+//      to the very bottom of a long transcript.
+
+test("the drawer sizes to the VISIBLE viewport, not the large one", async () => {
+  const { botBoardStyles } = await import("../servers/gateway/dashboard/panels/bot-board/css.js");
+  const css = botBoardStyles();
+  assert.ok(/\.bb-drawer\{[^}]*height:100vh/.test(css), "the 100vh fallback stays for old engines");
+  assert.ok(/\.bb-drawer\{[^}]*height:100dvh/.test(css),
+    "100dvh tracks the viewport as the browser chrome shows and hides");
+  const rule = css.match(/\.bb-drawer\{[^}]*\}/)[0];
+  assert.ok(rule.indexOf("100dvh") > rule.indexOf("100vh"),
+    "dvh must come AFTER vh or the fallback wins everywhere");
+});
+
+test("on a narrow screen the composer is pinned so Send is always reachable", async () => {
+  const { birdDrawerCss } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const css = birdDrawerCss();
+  const narrow = css.slice(css.indexOf("@media (max-width:"));
+  assert.ok(narrow.length > 0, "there is a narrow-width block");
+  assert.ok(/#bb-bd-composer\{[^}]*position:sticky/.test(narrow), "the composer sticks");
+  assert.ok(/#bb-bd-composer\{[^}]*bottom:0/.test(narrow), "pinned to the bottom of the scroller");
+  assert.ok(/#bb-bd-composer\{[^}]*background:/.test(narrow),
+    "it needs its own background or the transcript shows through it");
+});
+
+test("on a narrow screen the two 220px floors come down", async () => {
+  const { birdDrawerCss } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const narrow = birdDrawerCss().slice(birdDrawerCss().indexOf("@media (max-width:"));
+  const transcript = narrow.match(/\.bb-bd-transcript\{[^}]*min-height:(\d+)px/);
+  const textarea = narrow.match(/#bb-bd-input\{[^}]*min-height:(\d+)px/);
+  assert.ok(transcript && Number(transcript[1]) < 220, "the transcript floor drops below 220px");
+  assert.ok(textarea && Number(textarea[1]) < 220, "the composer floor drops below 220px");
+});
+
+// ---------------------------------------------------------------------------
+// plan_state carries an object, and the drawer printed it
+// ---------------------------------------------------------------------------
+//
+// The engine emits {type:"plan_state", state:{enabled,executing,todosDone,
+// todosTotal,todos}}. The listener did bdAppendNote('', parsed(e).state), and
+// textContent of an object is the literal string "[object Object]" — which is
+// what a freshly opened drawer showed, every time, right under "No transcript
+// yet."
+
+test("plan_state renders a sentence, never a stringified object", async () => {
+  const { birdDrawerJs } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const js = birdDrawerJs("en");
+  assert.ok(!/bdAppendNote\('',\s*\(?parsed\(e\)\.state/.test(js),
+    "the raw state object must never reach bdAppendNote");
+  assert.ok(js.includes("bdPlanStateText"), "it goes through a formatter");
+});
+
+test("an inactive plan says nothing at all — no empty note, no noise line", async () => {
+  const { birdDrawerJs } = await import("../servers/gateway/dashboard/panels/bot-board/drawer.js");
+  const js = birdDrawerJs("en");
+  const fn = js.slice(js.indexOf("function bdPlanStateText"));
+  assert.ok(fn.includes("return ''"), "a disabled, non-executing plan formats to nothing");
+  // And the listener must not append an empty note when the formatter returns "".
+  const listener = js.slice(js.indexOf("addEventListener('plan_state'"));
+  assert.ok(/if\s*\(\s*txt\s*\)/.test(listener.slice(0, 400)),
+    "only append when there is something to say");
+});

--- a/tests/board-i18n-literals.test.js
+++ b/tests/board-i18n-literals.test.js
@@ -184,6 +184,7 @@ const DRAWER_JS_KEYS = [
   "botboard.bdFilesQueuedPrefix", "botboard.bdFileUploaded", "botboard.bdFullEnvelopeRestored",
   "botboard.bdInterruptedNote",
   "botboard.bdModelOnDemand", "botboard.bdModelUnavailable",
+  "botboard.bdPlanOn", "botboard.bdPlanExecuting",
   "botboard.bdNarrowedToMid", "botboard.bdNarrowedToPrefix", "botboard.bdNarrowedToSuffix",
   "botboard.bdNarrowFailed", "botboard.bdNarrowNoteEmpty", "botboard.bdNarrowNoteSaved",
   "botboard.bdNarrowNoteUnknown", "botboard.bdNarrowRejected",


### PR DESCRIPTION
Reported from an actual phone, with a screenshot: *"I can't even scroll down far enough to hit the send button."* Three separate causes.

## 1. The composer was not pinned

`.bb-bd-transcript` carried `min-height:220px` and the composer textarea another `220px` — 440px of floor under ~400px of header and controls — and Send is the **last** element in the drawer. So Send was only ever reachable at the very bottom of the scroll, and with a real transcript in the box it was off-screen the entire time.

Below 640px the composer is now `position:sticky` at the bottom of the scroller with its own background, and the two floors come down to 120px and 90px.

**Measured**, at a 412×730 viewport with a 16-line transcript, scrolled to the **top** (where a user actually starts):

```
before -> {"viewport":730,"sendTop":785,"sendBottom":814,"reachable":false}
after  -> {"viewport":730,"sendTop":685,"sendBottom":714,"reachable":true}
```

## 2. `.bb-drawer` was `height:100vh`

On mobile browsers `100vh` is the **large** viewport: it excludes the URL bar and the bottom nav. So the drawer renders taller than the visible area, and its final strip — exactly where Send lives — sits behind the browser chrome, where no amount of scrolling reaches it. Now `height:100vh` followed by `height:100dvh`, so the fallback stays for engines without `dvh`.

**Stated plainly:** CDP device emulation reports an honest `innerHeight`, so this half does **not** reproduce in the harness and is *not* proven by the measurement above. It is the documented behaviour of `vh` vs `dvh`, and the ordering is unit-tested, but the observed fix is (1).

## 3. `[object Object]` on every freshly opened drawer

The engine emits:

```json
{"type":"plan_state","state":{"enabled":false,"executing":false,"todosDone":0,"todosTotal":0,"todos":[]}}
```

and the listener did `bdAppendNote('', parsed(e).state)` — `textContent` of an object is the literal string. Captured live: that frame arrives on attach for **every** session, so every drawer printed it under "No transcript yet."

`bdPlanStateText` now formats it, and an **inactive plan — the normal case — formats to `""` and appends nothing**, so the noise line disappears entirely rather than being reworded:

```
""                           the exact live payload
"plan mode on"               plan on, no todos
"plan mode on (2/5)"         plan on with progress
"executing the plan (3/7)"   executing
"legacy text"                a plain string
""                           undefined
```

## Tests

Six new in `bird-drawer-controls`: the `dvh`-after-`vh` ordering, the sticky composer (position, bottom, and its own background), both narrow-width floors dropping below 220px, that the raw state object can never reach `bdAppendNote`, and that an inactive plan appends nothing at all.

Green: `bird-drawer-controls` 52, `bird-drawer-core` 17, `board-i18n-literals` 10, `i18n-global-parity` 7, `roost-strip-ui` 17, `model-availability` 14, `perch-interactive-routes` 77.
