### PR TITLE
Perch: start a session when every bot is busy, and close the ones you can't

### DIFF
--- a/docs/superpowers/specs/2026-09-09-perch-hub-design.md
+++ b/docs/superpowers/specs/2026-09-09-perch-hub-design.md
@@ -135,9 +135,17 @@ Rules learned the hard way on 2026-09-09 and non-negotiable here:
 
 - `100dvh`, never bare `100vh` — `100vh` is the large viewport and hides whatever
   sits in the last strip behind the browser chrome.
-- The composer is `position:sticky; bottom:0` with its own background, so Send is
-  reachable at any scroll position rather than only at the bottom of a long
-  transcript.
+- Send's reachability comes from the flex chain, not from the composer.
+  `#perch-chat{flex:1;min-height:0}` and `#perch-transcript{flex:1;overflow:auto;
+  min-height:0}` make the transcript the only scroller, so the page itself never
+  scrolls and the composer is always on screen. `position:sticky; bottom:0` on the
+  composer is a backstop that does nothing until that chain breaks — measured,
+  removing it from the shipped layout moves Send by zero pixels.
+  **Corrected 2026-09-10.** This bullet previously said sticky was the reason,
+  which is the inverse. It was written when Perch owned the viewport at `100dvh`;
+  once Perch moved inside the dashboard shell, `.content-body` took over the
+  scroll and the flex chain became the mechanism. The old wording survived the
+  move and would have led a maintainer to delete the load-bearing rule.
 - No control is unlabelled. A row of bare dropdowns reads fine wide and becomes
   meaningless the moment it wraps.
 - Full-bleed width on a phone. `min(480px, 92vw)` leaves a dead gutter.

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -90,6 +90,26 @@ export function perchHubJs(lang = "en") {
     return out;
   }
 
+  /* Every perch-attached bot, whether or not it already has a live session.
+     listRows() deliberately drops a bot's idle row the moment it has one live
+     session, which is correct for a SESSION list and is exactly why the
+     launcher cannot be derived from rows: on an instance where the one
+     attached bot has eight live sessions there is no idle row left, and that
+     is the state Kevin reported with no way to start a ninth. Same filter as
+     listRows (perch_attached), same reason: POST /bots/<id>/interactive 403s
+     for a bot with no perch gateway record. Reads the /roost payload
+     loadList() already fetched — no second request. */
+  function spawnableBots(roost){
+    var birds=(roost&&roost.birds)||[];
+    var out=[];
+    birds.forEach(function(b){
+      if(!b||!b.perch_attached) return;
+      out.push({id:b.id,name:b.name||b.id});
+    });
+    out.sort(function(a,b){ return String(a.name).localeCompare(String(b.name)); });
+    return out;
+  }
+
   /* tJs escapes \\, ', \` and \${, so these interpolate safely. */
   var NO_SESSIONS='${tJs("perch.noSessions", lang)}';
   var WAITING_ON_YOU='${tJs("perch.waitingOnYou", lang)}';
@@ -115,6 +135,10 @@ export function perchHubJs(lang = "en") {
   var ASK_DENY='${tJs("perch.askDeny", lang)}';
   var ASK_CANCEL='${tJs("perch.askCancel", lang)}';
   var ASK_SUBMIT='${tJs("perch.askSubmit", lang)}';
+  var NO_ATTACHED_BOTS='${tJs("perch.noAttachedBots", lang)}';
+  var CLOSE_LABEL='${tJs("perch.close", lang)}';
+  var CLOSE_CONFIRM='${tJs("perch.closeConfirm", lang)}';
+  var CLOSE_FAILED='${tJs("perch.closeFailed", lang)}';
 
   var pendingNote=null;                 /* survives the loadList that follows a note */
   function showListNote(text){
@@ -147,10 +171,121 @@ export function perchHubJs(lang = "en") {
         ? function(){ rowIndex[r.sessionId]=r; location.hash=r.sessionId; }
         : function(){ startSession(r.botId,r.botName); };
       row.appendChild(b);
+      /* Only a live session can be closed; an idle bot row has nothing to
+         stop. Second button, not a swipe or a long-press: this has to work
+         with a thumb on a 412px screen. */
+      if(r.sessionId){
+        var x=document.createElement('button');
+        x.type='button'; x.className='roost-close'; x.textContent=CLOSE_LABEL;
+        x.onclick=function(){ stopSession(r.sessionId); };
+        row.appendChild(x);
+      }
       if(r.sessionId) rowIndex[r.sessionId]=r;
       body.appendChild(row);
     });
     flushPendingNote();               /* a parked note must survive this render */
+  }
+
+  /* The bots the launcher can spawn against, refreshed by every loadList().
+     Empty until the first /roost answers — which is why #perch-new ships
+     disabled in the markup rather than enabled-and-lying. */
+  var launchBots=[];
+
+  function sameBotIds(a,b){
+    if(a.length!==b.length) return false;
+    for(var i=0;i<a.length;i++){ if(a[i].id!==b[i].id) return false; }
+    return true;
+  }
+
+  function renderLauncher(bots){
+    var btn=el('perch-new'), sel=el('perch-new-bot'),
+        lbl=el('perch-new-bot-label'), note=el('perch-launch-note');
+    if(!btn) return;
+    var changed=!sameBotIds(launchBots,bots);
+    launchBots=bots;
+    if(!bots.length){
+      /* Never offer a spawn that is guaranteed to 403 — say why instead. */
+      btn.disabled=true;
+      if(sel){ sel.hidden=true; if(changed) clearEl(sel); }
+      if(lbl) lbl.hidden=true;
+      if(note){ note.textContent=NO_ATTACHED_BOTS; note.hidden=false; }
+      return;
+    }
+    btn.disabled=false;
+    if(note){ note.textContent=''; note.hidden=true; }
+    /* One attached bot is the common case (and Kevin's): no picker, one tap. */
+    if(bots.length===1){
+      if(sel){ sel.hidden=true; if(changed) clearEl(sel); }
+      if(lbl) lbl.hidden=true;
+      return;
+    }
+    if(lbl) lbl.hidden=false;
+    if(sel){
+      sel.hidden=false;
+      /* Rebuild ONLY when the roster actually changed: this runs on every
+         10s poll, and repopulating unconditionally would throw away the
+         operator's pick mid-tap. */
+      if(changed){
+        var keep=sel.value;
+        clearEl(sel);
+        bots.forEach(function(b){
+          var opt=document.createElement('option');
+          opt.value=b.id; opt.textContent=b.name;
+          sel.appendChild(opt);
+        });
+        if(keep&&bots.filter(function(b){ return b.id===keep; }).length) sel.value=keep;
+      }
+    }
+  }
+
+  /* The launch control's own handler. Resolves the bot from the picker when
+     there is one, then hands off to startSession() verbatim — the 409/403/
+     missing-sessionId handling, the rowIndex write, the hash navigation and
+     the current.sid identity guard all live there and are not duplicated. */
+  function startNewSession(){
+    if(!launchBots.length){ showListNote(NO_ATTACHED_BOTS); return; }
+    var pick=launchBots[0];
+    if(launchBots.length>1){
+      var sel=el('perch-new-bot');
+      var want=sel?String(sel.value||''):'';
+      var hit=launchBots.filter(function(b){ return b.id===want; })[0];
+      if(hit) pick=hit;
+    }
+    startSession(pick.id,pick.name);
+  }
+  el('perch-new').onclick=startNewSession;
+
+  /* engine.stop() (perch-interactive.js:1955) kills the pi child and parks the
+     row: TERMINAL, no resume. Hence the confirm, whose copy says so — an
+     accidental thumb on a phone must not destroy a conversation. The
+     dashboard's own idiom for this is a native confirm guarded by an early
+     return (bot-board/drawer.js:941), so that is what this uses.
+     No mySid capture: this is keyed on the sid being STOPPED, not on whatever
+     is open, so a stop fired from a list row while another session is open
+     resolves against the right session. current.sid is consulted only to
+     decide WHERE the outcome is shown — and, on success, to leave a chat view
+     whose SSE stream the engine has just closed. */
+  function stopSession(sid){
+    if(!sid) return;
+    if(!confirm(CLOSE_CONFIRM)) return;
+    perchApi('POST','/interactive/'+encodeURIComponent(sid)+'/stop').then(function(r){
+      /* 404 no_such_session / 410 already stopped: the operator's goal is
+         already true. Refresh, show nothing — an error there would be a lie. */
+      if(r.ok||r.status===404||r.status===410){
+        /* location.hash='' rather than closeSession(): applyHash ->
+           closeSession runs, history stays correct, and closeSession already
+           does setView('list') + startListPolling() + loadList(). */
+        if(current.sid===sid){ location.hash=''; return; }
+        loadList();
+        return;
+      }
+      /* showListNote writes into #perch-list-body, invisible from the chat
+         view — so a failure while that session is open goes to the transcript
+         instead, the same split every other in-chat failure in this file
+         uses (SEND_FAILED, ASK_STALE). */
+      if(current.sid===sid) appendNote((r.j&&r.j.error)||CLOSE_FAILED);
+      else showListNote(CLOSE_FAILED);
+    });
   }
 
   /* A bot with no session: spawn, then let the hash router open it, so history
@@ -172,7 +307,10 @@ export function perchHubJs(lang = "en") {
   var listTimer=null;
   function loadList(){
     return perchApi('GET','/roost').then(function(r){
-      if(r.ok&&r.j) renderList(listRows(r.j));
+      /* One payload, two renders: the rows AND the launcher's bot roster.
+         Deriving the launcher from the same /roost response is what keeps
+         this to a single request per poll. */
+      if(r.ok&&r.j){ renderLauncher(spawnableBots(r.j)); renderList(listRows(r.j)); }
       else renderList([]);
     });
   }
@@ -645,6 +783,7 @@ export function perchHubJs(lang = "en") {
     perchApi('POST','/interactive/'+encodeURIComponent(current.sid)+'/abort');
   }
   el('perch-abort').onclick=abortTurn;
+  el('perch-close').onclick=function(){ stopSession(current.sid); };
 
   /* iOS does not shrink the layout viewport for the keyboard, so dvh alone
      leaves the composer behind it. Offset the chat column by the hidden part. */

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -139,6 +139,35 @@ export function perchHubJs(lang = "en") {
   var CLOSE_LABEL='${tJs("perch.close", lang)}';
   var CLOSE_CONFIRM='${tJs("perch.closeConfirm", lang)}';
   var CLOSE_FAILED='${tJs("perch.closeFailed", lang)}';
+  var CLOSE_FAILED_FOR='${tJs("perch.closeFailedFor", lang)}';
+  var ROW_CARD='${tJs("perch.rowCard", lang)}';
+  var ROOST_UNREACHABLE='${tJs("perch.roostUnreachable", lang)}';
+
+  /* Row identity. One bot with eight sessions renders eight rows that read
+     "R4 Assistant / awake" and nothing else — measured verbatim in a browser
+     as "R4AssistantawakeOpenCloseR4Assistant..." — so telling the mistakes
+     from the real work meant Open, read the meta, Back, once per candidate,
+     each pass sitting on top of an irreversible Close. Open is recoverable;
+     Close is not, which is what makes identity load-bearing here rather than
+     decorative. The engine mints "perchlive-" + 8 hex, so the hex alone is
+     the short, unambiguous handle. */
+  function shortSid(sid){ return String(sid==null?'':sid).replace(/^perchlive-/,''); }
+  function rowSubtitle(r){
+    if(!r) return '';
+    var parts=[r.pendingUi?WAITING_ON_YOU:r.state];
+    if(r.sessionId) parts.push(shortSid(r.sessionId));
+    /* The card a session is working is the most human handle there is, when
+       it has one. cardId is already on every row listRows() builds. */
+    if(r.cardId!=null) parts.push(ROW_CARD.replace('{id}',String(r.cardId)));
+    return parts.filter(Boolean).join(' \\u00b7 ');
+  }
+  /* What the confirm calls the session it is about to destroy. A confirm that
+     names nothing cannot correct a mis-tap, which is the only thing it is
+     there to do. */
+  function sessionLabel(sid){
+    var r=rowIndex[sid], short=shortSid(sid);
+    return (r&&r.botName)?(r.botName+' '+short):short;
+  }
 
   var pendingNote=null;                 /* survives the loadList that follows a note */
   function showListNote(text){
@@ -163,7 +192,7 @@ export function perchHubJs(lang = "en") {
       row.appendChild(line('roost-dot',''));
       var main=document.createElement('div'); main.className='roost-main';
       main.appendChild(line('roost-cwd',r.botName));
-      main.appendChild(line('roost-when',r.pendingUi?WAITING_ON_YOU:r.state));
+      main.appendChild(line('roost-when',rowSubtitle(r)));
       row.appendChild(main);
       var b=document.createElement('button');
       b.type='button'; b.textContent=r.sessionId?OPEN_LABEL:TALK_LABEL;
@@ -197,9 +226,18 @@ export function perchHubJs(lang = "en") {
     return true;
   }
 
+  /* The launcher's one-line explainer. Factored out because loadList()'s
+     failure branch needs it too — a greyed button with no reason beside it is
+     the thing finding 3 was about. */
+  function setLaunchNote(text){
+    var note=el('perch-launch-note'); if(!note) return;
+    note.textContent=text||'';
+    note.hidden=!text;
+  }
+
   function renderLauncher(bots){
     var btn=el('perch-new'), sel=el('perch-new-bot'),
-        lbl=el('perch-new-bot-label'), note=el('perch-launch-note');
+        lbl=el('perch-new-bot-label');
     if(!btn) return;
     var changed=!sameBotIds(launchBots,bots);
     launchBots=bots;
@@ -208,11 +246,11 @@ export function perchHubJs(lang = "en") {
       btn.disabled=true;
       if(sel){ sel.hidden=true; if(changed) clearEl(sel); }
       if(lbl) lbl.hidden=true;
-      if(note){ note.textContent=NO_ATTACHED_BOTS; note.hidden=false; }
+      setLaunchNote(NO_ATTACHED_BOTS);
       return;
     }
     btn.disabled=false;
-    if(note){ note.textContent=''; note.hidden=true; }
+    setLaunchNote('');
     /* One attached bot is the common case (and Kevin's): no picker, one tap. */
     if(bots.length===1){
       if(sel){ sel.hidden=true; if(changed) clearEl(sel); }
@@ -243,7 +281,7 @@ export function perchHubJs(lang = "en") {
      missing-sessionId handling, the rowIndex write, the hash navigation and
      the current.sid identity guard all live there and are not duplicated. */
   function startNewSession(){
-    if(!launchBots.length){ showListNote(NO_ATTACHED_BOTS); return; }
+    if(!launchBots.length){ setLaunchNote(NO_ATTACHED_BOTS); return; }
     var pick=launchBots[0];
     if(launchBots.length>1){
       var sel=el('perch-new-bot');
@@ -267,24 +305,38 @@ export function perchHubJs(lang = "en") {
      whose SSE stream the engine has just closed. */
   function stopSession(sid){
     if(!sid) return;
-    if(!confirm(CLOSE_CONFIRM)) return;
+    if(!confirm(CLOSE_CONFIRM.replace('{session}',sessionLabel(sid)))) return;
     perchApi('POST','/interactive/'+encodeURIComponent(sid)+'/stop').then(function(r){
       /* 404 no_such_session / 410 already stopped: the operator's goal is
          already true. Refresh, show nothing — an error there would be a lie. */
       if(r.ok||r.status===404||r.status===410){
-        /* location.hash='' rather than closeSession(): applyHash ->
-           closeSession runs, history stays correct, and closeSession already
-           does setView('list') + startListPolling() + loadList(). */
-        if(current.sid===sid){ location.hash=''; return; }
+        /* Navigate rather than call closeSession() directly, so applyHash ->
+           closeSession runs and closeSession's setView('list') +
+           startListPolling() + loadList() all fire.
+           REPLACE, not assign: the #perchlive-<sid> entry we are leaving now
+           points at a session that no longer exists. Pushing a new entry on
+           top of it means Back lands on the dead deep link, which
+           openSession's cold /roost miss bounces through
+           noteAndReturnToList -> another entry -> Back again forever. The
+           operator could never get behind this page. */
+        if(current.sid===sid){ leaveToList(); return; }
         loadList();
         return;
       }
-      /* showListNote writes into #perch-list-body, invisible from the chat
-         view — so a failure while that session is open goes to the transcript
-         instead, the same split every other in-chat failure in this file
-         uses (SEND_FAILED, ASK_STALE). */
-      if(current.sid===sid) appendNote((r.j&&r.j.error)||CLOSE_FAILED);
-      else showListNote(CLOSE_FAILED);
+      var text=(r.j&&r.j.error)||CLOSE_FAILED;
+      /* showListNote writes into #perch-list-body, which the chat view
+         display:none's below 900px — so an in-chat failure goes to the
+         transcript instead, the same split every other in-chat failure in
+         this file uses (SEND_FAILED, ASK_STALE). */
+      if(current.sid===sid){ appendNote(text); return; }
+      /* Not the session on screen, but still IN a chat view: the operator
+         closed this session, the POST was slow, and they moved on. The list
+         body is hidden, so showListNote here is an invisible error about a
+         session that is still alive and still costing a pi child. Park it —
+         renderList flushes it the moment they come back to the list — and
+         name the session, because it is no longer the one in front of them. */
+      if(current.sid){ pendingNote=CLOSE_FAILED_FOR.replace('{session}',sessionLabel(sid)); return; }
+      showListNote(text);
     });
   }
 
@@ -296,9 +348,17 @@ export function perchHubJs(lang = "en") {
                                                 yank them out of it */
     perchApi('POST','/bots/'+encodeURIComponent(botId)+'/interactive').then(function(r){
       if(current.sid!==mySid) return;
-      if(r.status===409){ showListNote(ENGINE_REQUIRED); return; }
-      if(r.status===403){ showListNote(NOT_ATTACHED); return; }
-      if(!r.ok||!r.j||!r.j.sessionId){ showListNote(START_FAILED); return; }
+      /* setLaunchNote, not showListNote: a FAILED SPAWN is a fact about the
+         launcher, and showListNote clears #perch-list-body — which would wipe
+         every session row and, with them, every Close button, for up to the
+         10s until the next poll. That was tolerable while the only spawn
+         trigger was an idle row (a list with idle rows has nothing much to
+         lose); the always-present launcher makes it routine, and it lands
+         hardest on an operator whose actual job right now is closing
+         sessions. The note belongs next to the control that produced it. */
+      if(r.status===409){ setLaunchNote(ENGINE_REQUIRED); return; }
+      if(r.status===403){ setLaunchNote(NOT_ATTACHED); return; }
+      if(!r.ok||!r.j||!r.j.sessionId){ setLaunchNote(START_FAILED); return; }
       rowIndex[r.j.sessionId]={botId:botId,botName:botName,sessionId:r.j.sessionId};
       location.hash=r.j.sessionId;
     });
@@ -310,8 +370,29 @@ export function perchHubJs(lang = "en") {
       /* One payload, two renders: the rows AND the launcher's bot roster.
          Deriving the launcher from the same /roost response is what keeps
          this to a single request per poll. */
-      if(r.ok&&r.j){ renderLauncher(spawnableBots(r.j)); renderList(listRows(r.j)); }
-      else renderList([]);
+      if(r.ok&&r.j){ renderLauncher(spawnableBots(r.j)); renderList(listRows(r.j)); return; }
+      /* A failed /roost is NOT an empty roost, and the old else branch said
+         both of the wrong things at once: it rendered "No live sessions." (a
+         lie) and skipped renderLauncher entirely, leaving #perch-new greyed
+         out with no reason given. Measured live against a 503: greyed button,
+         hidden note, false empty list — which is precisely the "I can only
+         interact with what already exists" state this whole task exists to
+         end, re-created by a gateway blip. Self-heals on the next 10s poll;
+         permanent if the failure is.
+         rowIndex is cleared but pendingNote is deliberately NOT flushed here:
+         a parked note ("That session is gone.") survives the blip and lands
+         on the next successful render, which is where it was going anyway. */
+      rowIndex={};
+      showListNote(ROOST_UNREACHABLE);
+      if(launchBots.length){
+        /* A roster we already know stays usable — the bots did not vanish
+           because one poll failed, and spawning is still worth attempting. */
+        var btn=el('perch-new'); if(btn) btn.disabled=false;
+      } else {
+        /* Never seen a roster: the button has nothing to spawn against, so
+           say why rather than just greying out. */
+        setLaunchNote(ROOST_UNREACHABLE);
+      }
     });
   }
   /* Poll only while the list is showing. In the chat view the SSE stream is
@@ -352,6 +433,10 @@ export function perchHubJs(lang = "en") {
       if(current.sid!==mySid) return;       /* the hash moved on while we waited */
       var hit=r.ok&&r.j?listRows(r.j).filter(function(x){return x.sessionId===mySid;})[0]:null;
       if(!hit){ noteAndReturnToList(SESSION_GONE); return; }
+      /* Cache it: sessionLabel() reads rowIndex to name the session in the
+         close confirm, and without this a cold deep link would offer an
+         irreversible "Close 22222222?" with no bot name on it. */
+      rowIndex[mySid]=hit;
       showHeader(hit.botId,hit.botName); afterHeader(mySid,hit.botId);
     });
   }
@@ -368,7 +453,19 @@ export function perchHubJs(lang = "en") {
   /* A note set before loadList() resolves is wiped by renderList. Park it and
      let renderList re-append it — otherwise "That session is gone." is never
      seen, on exactly the dead-deep-link path it exists for. */
-  function noteAndReturnToList(text){ pendingNote=text; location.hash=''; }   /* pendingNote: Task 2 */
+  /* Leave a session that no longer exists, WITHOUT stacking a history entry
+     on top of a dead deep link. location.hash='' pushes one, so Back returns
+     to #perchlive-<gone> -> openSession -> cold /roost miss ->
+     noteAndReturnToList -> another entry: the operator can never get behind
+     this page with Back.
+     location.replace('#') is the form that works, and the alternative is a
+     trap worth naming: location.replace(location.pathname+location.search)
+     gives a tidier URL, adds no history entry either — and fires NO
+     hashchange, so applyHash -> closeSession never runs and the view stays on
+     a dead chat. Measured both in a real browser; '#' fires hashchange and
+     leaves location.hash === ''. Do not "clean up" the trailing #. */
+  function leaveToList(){ location.replace('#'); }
+  function noteAndReturnToList(text){ pendingNote=text; leaveToList(); }   /* pendingNote: Task 2 */
 
   function applyHash(){
     var hit=parseHash(location.hash);

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -44,7 +44,22 @@ export function perchHubCss() {
 #perch-hub-root .machines a{text-decoration:none;color:var(--dim);padding:5px 12px;border-radius:999px;border:1px solid var(--line)}
 #perch-hub-root a:focus-visible,#perch-hub-root button:focus-visible,#perch-hub-root input:focus-visible,#perch-hub-root textarea:focus-visible{outline:2px solid var(--teal);outline-offset:2px}
 #perch-hub-root h2{font-size:12px;text-transform:uppercase;letter-spacing:.09em;color:var(--dim);font-weight:600;margin:30px 0 12px}
-#perch-hub-root .perch-head{display:flex;justify-content:space-between;align-items:center;gap:10px}
+/* wrap: at 412px the bot name, the state word and Close must not force a
+   horizontal scrollbar onto the chat column. */
+#perch-hub-root .perch-head{display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap}
+#perch-close{white-space:nowrap;padding:8px 12px;font-size:13px}
+/* The unconditional launcher. Wraps rather than overflowing on a phone, and
+   its select is capped so a long bot name cannot push the button off-screen. */
+#perch-launch{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:0 0 12px}
+/* Same 44px floor as the row controls: this is the primary action on the page
+   and it is tapped with a thumb. Scoped to #perch-new — NOT the shared button
+   rule, which also sizes #perch-send inside the sticky composer whose box is
+   what keeps Send reachable. */
+#perch-new{min-height:44px}
+#perch-launch select{font:14px Inter,system-ui,sans-serif;padding:9px 10px;border:1px solid var(--line);
+border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-width:0;max-width:100%}
+#perch-launch .empty{padding:0;flex:1 1 100%}
+#perch-launch [hidden]{display:none}
 #perch-hub-root .title{font-weight:600;font-size:17px}
 #perch-hub-root .meta{color:var(--dim);font-size:13px;margin-top:2px;word-break:break-all}
 #perch-hub-root .state{font-size:13px;color:var(--alive);font-weight:500;white-space:nowrap}
@@ -59,7 +74,13 @@ export function perchHubCss() {
 #perch-hub-root .roost-main{flex:1;min-width:180px}
 #perch-hub-root .roost-cwd{font-weight:500;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 #perch-hub-root .roost-when{color:var(--dim);font-size:12.5px;font-family:"JetBrains Mono",ui-monospace,monospace}
-#perch-hub-root .roost-row button{padding:8px 12px;font-size:13px}
+/* min-height, not more padding: the base button rule's 10px/14px line box
+   comes out 36px tall and these rows carry TWO controls now (Open and Close).
+   44px is the smallest reliable thumb target; measured live at 412x730 in
+   perch-hub-render.test.js, which is what caught the 36px in the first place. */
+#perch-hub-root .roost-row button{padding:8px 12px;font-size:13px;min-height:44px}
+/* Close is destructive and must not compete with Open for a thumb. */
+#perch-hub-root .roost-close{color:var(--dim)}
 #perch-hub-root .empty{color:var(--dim);padding:16px;font-size:14px}
 /* --- chat transcript + ask cards, ported from the deleted bundle's own
    equivalents (42f39160^:bundles/perch-hub/payload/hub/bots-page.mjs

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -47,7 +47,12 @@ export function perchHubCss() {
 /* wrap: at 412px the bot name, the state word and Close must not force a
    horizontal scrollbar onto the chat column. */
 #perch-hub-root .perch-head{display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap}
-#perch-close{white-space:nowrap;padding:8px 12px;font-size:13px}
+/* TWO ids, deliberately. A bare "#perch-close" is (1,0,0) and LOSES to
+   "#perch-hub-root button" at (1,0,1) further down this sheet — the first
+   version of this rule was dead, and the irreversible control measured 36px
+   live while the launch buttons it shipped alongside measured 44px. Verified
+   by computed style at 412x730, not by reading the cascade. */
+#perch-hub-root #perch-close{white-space:nowrap;padding:8px 12px;font-size:13px;min-height:44px}
 /* The unconditional launcher. Wraps rather than overflowing on a phone, and
    its select is capped so a long bot name cannot push the button off-screen. */
 #perch-launch{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:0 0 12px}
@@ -58,7 +63,10 @@ export function perchHubCss() {
 #perch-new{min-height:44px}
 #perch-launch select{font:14px Inter,system-ui,sans-serif;padding:9px 10px;border:1px solid var(--line);
 border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-width:0;max-width:100%}
-#perch-launch .empty{padding:0;flex:1 1 100%}
+/* By id, for the same reason as #perch-close above: "#perch-launch .empty" is
+   (1,1,0) and ties with "#perch-hub-root .empty" further down, which then wins
+   on source order. Measured dead: computed padding stayed 16px. */
+#perch-hub-root #perch-launch-note{padding:0;flex:1 1 100%}
 #perch-launch [hidden]{display:none}
 #perch-hub-root .title{font-weight:600;font-size:17px}
 #perch-hub-root .meta{color:var(--dim);font-size:13px;margin-top:2px;word-break:break-all}

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -57,10 +57,11 @@ export function perchHubCss() {
    its select is capped so a long bot name cannot push the button off-screen. */
 #perch-launch{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:0 0 12px}
 /* Same 44px floor as the row controls: this is the primary action on the page
-   and it is tapped with a thumb. Scoped to #perch-new — NOT the shared button
-   rule, which also sizes #perch-send inside the sticky composer whose box is
-   what keeps Send reachable. */
-#perch-new{min-height:44px}
+   and it is tapped with a thumb. Two ids, matching #perch-close: one id ties
+   with #perch-hub-root button on specificity and wins only on source order, and
+   that near-miss is exactly how #perch-close shipped at 36px. Deliberately NOT
+   the shared button rule, which also sizes #perch-send. */
+#perch-hub-root #perch-new{min-height:44px}
 #perch-launch select{font:14px Inter,system-ui,sans-serif;padding:9px 10px;border:1px solid var(--line);
 border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-width:0;max-width:100%}
 /* By id, for the same reason as #perch-close above: "#perch-launch .empty" is

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -43,6 +43,20 @@ ${engineBanner(engine, lang)}
 <div class="hub-split">
   <div id="perch-list">
     <h2>${escapeHtml(t("perch.sessionsHeading", lang))}</h2>
+    <!-- The launcher sits OUTSIDE #perch-list-body on purpose. renderList()
+         and showListNote() both clearEl() that body, so a launch control
+         living inside it would be wiped by every poll and every note — and
+         the defect this fixes is precisely that the only way to start a
+         session was a row that disappears once the bot is busy. Out here it
+         is unconditional, independent of what the rows contain.
+         It ships disabled: renderLauncher() enables it once the first
+         /roost answers, so the pre-data frame never claims "no bots". -->
+    <div id="perch-launch">
+      <label class="field-label" id="perch-new-bot-label" for="perch-new-bot" hidden>${escapeHtml(t("perch.newSessionBot", lang))}</label>
+      <select id="perch-new-bot" aria-labelledby="perch-new-bot-label" hidden></select>
+      <button type="button" class="primary" id="perch-new" disabled>${escapeHtml(t("perch.newSession", lang))}</button>
+      <div class="empty" id="perch-launch-note" hidden></div>
+    </div>
     <div id="perch-list-body"><div class="empty">${escapeHtml(t("perch.loading", lang))}</div></div>
   </div>
   <!-- ⚠ #perch-chat is now GLOBALLY significant, not just a local handle:
@@ -52,9 +66,15 @@ ${engineBanner(engine, lang)}
        inherits that clamp. Rename here and that rule goes dead too. -->
   <div id="perch-chat">
     <button type="button" id="perch-back" class="quiet">${escapeHtml(t("perch.back", lang))}</button>
+    <!-- Close lives in .perch-head, NOT in #perch-composer: the composer's
+         sticky box is what keeps Send reachable at any scroll position
+         (css.js:89-91), and .perch-head is already a non-scrolling child of
+         the #perch-chat flex column, so a control here is permanently on
+         screen without touching that box. -->
     <div class="perch-head"><div><div class="title" id="perch-bot-name"></div>
       <div class="meta" id="perch-session-meta"></div></div>
-      <div class="state" id="perch-state"></div></div>
+      <div class="state" id="perch-state"></div>
+      <button type="button" id="perch-close" class="quiet">${escapeHtml(t("perch.close", lang))}</button></div>
     <div class="field-row">
       <div class="field"><span class="field-label" id="perch-model-label">${escapeHtml(t("perch.modelLabel", lang))}</span>
         <select id="perch-model" aria-labelledby="perch-model-label" disabled></select></div>

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2267,6 +2267,18 @@ export const translations = {
   "perch.attachFile": { en: "Attach image", es: "Adjuntar imagen" },
   "perch.fileQueued": { en: "Image attached to the next message.", es: "Imagen adjunta al siguiente mensaje." },
   "perch.fileFailed": { en: "The image did not upload.", es: "La imagen no se subió." },
+  "perch.newSession": { en: "New session", es: "Nueva sesión" },
+  "perch.newSessionBot": { en: "Bot", es: "Bot" },
+  "perch.noAttachedBots": {
+    en: "No bot has a Perch channel attached, so there is nothing to start.",
+    es: "Ningún bot tiene un canal Perch, así que no hay nada que iniciar.",
+  },
+  "perch.close": { en: "Close", es: "Cerrar" },
+  "perch.closeConfirm": {
+    en: "Close this session? It cannot be reopened.",
+    es: "¿Cerrar esta sesión? No se podrá volver a abrir.",
+  },
+  "perch.closeFailed": { en: "That session did not close.", es: "Esa sesión no se cerró." },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2275,10 +2275,16 @@ export const translations = {
   },
   "perch.close": { en: "Close", es: "Cerrar" },
   "perch.closeConfirm": {
-    en: "Close this session? It cannot be reopened.",
-    es: "¿Cerrar esta sesión? No se podrá volver a abrir.",
+    en: "Close {session}? It cannot be reopened.",
+    es: "¿Cerrar {session}? No se podrá volver a abrir.",
   },
   "perch.closeFailed": { en: "That session did not close.", es: "Esa sesión no se cerró." },
+  "perch.closeFailedFor": { en: "{session} did not close.", es: "{session} no se cerró." },
+  "perch.rowCard": { en: "card {id}", es: "tarjeta {id}" },
+  "perch.roostUnreachable": {
+    en: "Could not reach the session list.",
+    es: "No se pudo obtener la lista de sesiones.",
+  },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/tests/i18n-global-parity.test.js
+++ b/tests/i18n-global-parity.test.js
@@ -64,6 +64,7 @@ const IDENTICAL_OK = new Set([
   "botboard.jsLeasePrefix", // prefixes a raw English enum value — translating only the prefix buys nothing
   "botboard.labelBotSwitcher", // "Bot"
   "botboard.colBot",
+  "perch.newSessionBot", // "Bot" — same as botboard.colBot above
   "settings.ed25519", // key-algorithm name
   "settings.serif",
   "settings.local",

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -444,14 +444,16 @@ function makeResponse(status, body) {
  *  path, opts)` decides how every perchApi call resolves; the default 200s
  *  everything with `{}`. Returns the fake DOM pieces and every fetch call
  *  made, in order, so a test can assert on both wiring and traffic. */
-async function mountHub({ fetchImpl } = {}) {
+async function mountHub({ fetchImpl, confirmImpl } = {}) {
   const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
   const js = perchHubJs("en");
 
   const IDS = ["perch-list-body", "perch-transcript", "perch-ask", "perch-bot-name",
     "perch-session-meta", "perch-state", "perch-model", "perch-thinking", "perch-permission",
     "perch-plan-mode", "perch-input", "perch-send", "perch-back", "perch-abort",
-    "perch-attach", "perch-file-input", "perch-chat"];
+    "perch-attach", "perch-file-input", "perch-chat",
+    // Task C: the unconditional launcher and the two close controls.
+    "perch-new", "perch-new-bot", "perch-new-bot-label", "perch-launch-note", "perch-close"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
@@ -483,8 +485,15 @@ async function mountHub({ fetchImpl } = {}) {
   // handle past the end of every test that mounts this harness.
   let timerSeq = 1;
   const timers = new Map();
+  // Every confirm() the script asks is recorded with the exact prompt text, so
+  // a test can prove BOTH that the gate was consulted and what it said.
+  // Default: the operator cancels. A stop that fires anyway under this default
+  // is a stop with no gate, which is the failure mode the confirmation exists
+  // to prevent.
+  const confirms = [];
   const sandbox = {
     document: doc,
+    confirm(msg) { confirms.push(String(msg)); return confirmImpl ? confirmImpl(String(msg)) : false; },
     window: win,
     location,
     EventSource: FakeEventSource,
@@ -515,7 +524,7 @@ async function mountHub({ fetchImpl } = {}) {
   // fetchCalls or the DOM it produced.
   await new Promise((r) => setTimeout(r, 0));
 
-  return { els, doc, win, location, fetchCalls, sandbox, timers };
+  return { els, doc, win, location, fetchCalls, sandbox, timers, confirms };
 }
 
 /** Opens a chat session the same way a real click does: seed a /roost
@@ -724,4 +733,351 @@ test("I2: applyVV is bound to BOTH visualViewport events, not two different hand
   vv._dispatch("scroll", {});
   assert.equal(hub.els["perch-chat"].style.paddingBottom, "",
     "scroll must run the identical calculation, not a stub bound separately");
+});
+
+// ---------------------------------------------------------------------------
+// Task C — Perch owns its own session lifecycle.
+//
+// Kevin, verbatim: "there is no way to launch a new session, rather you can
+// only interact with already existing sessions" and "it looks like there are 8
+// sessions running, most of which were started by mistake, and I cannot close
+// them".
+//
+// Every test below drives a REAL onclick handler through mountHub() and
+// asserts on the REAL fetch bodies. Extracting the new pure functions and
+// asserting on their return values would prove nothing about whether anything
+// is bound to a control — which is the exact class of miss this file already
+// carries a scar for (see "perch-send, perch-back and perch-abort are actually
+// wired to handlers" above, where send() was correct, unit-tested, and wired
+// to nothing).
+// ---------------------------------------------------------------------------
+
+/** Kevin's instance, reduced: ONE perch-attached bot, and it is busy. There is
+ *  no idle row here, because listRows() drops a bot's idle row the moment it
+ *  has a live session — so a launcher derived from rows would be absent. A
+ *  fixture with an empty roost, or with one idle bot, would NOT reproduce the
+ *  reported bug and would pass against the broken code. */
+const ROOST_ALL_BUSY = {
+  birds: [{
+    id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
+    sessions: [
+      { sessionId: "perchlive-11111111", state: "awake", cardId: null, pendingUi: false },
+      { sessionId: "perchlive-22222222", state: "awake", cardId: null, pendingUi: false },
+      { sessionId: "perchlive-33333333", state: "hibernating", cardId: null, pendingUi: false },
+    ],
+  }],
+};
+
+const ROOST_TWO_BOTS = {
+  birds: [
+    { id: "alpha", name: "Alpha", perch_attached: true, state: "working",
+      sessions: [{ sessionId: "perchlive-aaaa1111", state: "awake", cardId: null, pendingUi: false }] },
+    { id: "beta", name: "Beta", perch_attached: true, state: "working",
+      sessions: [{ sessionId: "perchlive-bbbb2222", state: "awake", cardId: null, pendingUi: false }] },
+    { id: "quiet", name: "Quiet", perch_attached: false, state: "observing", sessions: [] },
+  ],
+};
+
+const ROOST_NO_ATTACHED = {
+  birds: [{ id: "quiet", name: "Quiet", perch_attached: false, state: "observing", sessions: [] }],
+};
+
+/** A fetchImpl serving a fixed roost, with the spawn/stop/session routes
+ *  answering 200 by default and overridable per test. */
+function roostFetch(roost, overrides = {}) {
+  return (method, path) => {
+    for (const [matcher, fn] of Object.entries(overrides)) {
+      if (path.includes(matcher)) return fn(method, path);
+    }
+    if (path === "/roost") return makeResponse(200, roost);
+    if (path.endsWith("/interactive")) return makeResponse(200, { sessionId: "perchlive-99999999" });
+    if (path.endsWith("/stop")) return makeResponse(200, { ok: true });
+    if (path.endsWith("/options")) return makeResponse(200, { models: [], thinkingLevels: [] });
+    if (path.endsWith("/transcript")) return makeResponse(200, { events: [] });
+    return makeResponse(200, {});
+  };
+}
+
+/** Every button rendered into the list, flattened, with the row it came from. */
+function listButtons(hub) {
+  const out = [];
+  for (const row of hub.els["perch-list-body"].children) {
+    for (const child of row.children || []) {
+      if (child.tagName === "BUTTON") out.push({ row, btn: child, text: child.textContent });
+    }
+  }
+  return out;
+}
+
+const notesIn = (el) => el.children.filter((c) => String(c.className).includes("note"))
+  .map((c) => c.textContent);
+
+// ---- C1: a launcher that exists when every attached bot is already busy ----
+
+test("C1: the launch control is live while EVERY attached bot already has a session", async () => {
+  // The reported state exactly. Before this change the ONLY way to spawn was
+  // an idle row, and listRows() emits none here.
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+
+  assert.equal(hub.els["perch-new"].disabled, false,
+    "the launcher must be usable even though no bot is idle");
+  assert.equal(listButtons(hub).some((b) => b.text === "Talk"), false,
+    "fixture check: there is genuinely no idle row to spawn from, which is the bug");
+
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  const spawns = hub.fetchCalls.filter((c) => c.path.endsWith("/interactive"));
+  assert.equal(spawns.length, 1, "one spawn went out");
+  assert.equal(spawns[0].method, "POST");
+  assert.equal(spawns[0].path, "/bots/r4-assistant/interactive",
+    "spawned against the perch-attached bot from the roost the list already fetched");
+  assert.equal(hub.location.hash, "perchlive-99999999",
+    "startSession()'s own hash navigation ran — the launcher reuses it rather than respawning it");
+});
+
+test("C1: the launcher issues no extra request — the bot list rides the list's own /roost", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  const gets = hub.fetchCalls.filter((c) => c.method === "GET");
+  assert.equal(gets.length, 1, "exactly one GET on first paint: " + JSON.stringify(gets.map((g) => g.path)));
+  assert.equal(gets[0].path, "/roost");
+});
+
+test("C1: with more than one attached bot the picker decides, and only attached bots are offered", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_TWO_BOTS) });
+  const sel = hub.els["perch-new-bot"];
+  assert.equal(sel.hidden, false, "two bots means the operator picks");
+  assert.deepEqual(sel.children.map((o) => o.value), ["alpha", "beta"],
+    "the un-attached bot must not be offered — POST /bots/quiet/interactive 403s");
+
+  sel.value = "beta";
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const spawns = hub.fetchCalls.filter((c) => c.path.endsWith("/interactive"));
+  assert.equal(spawns[0].path, "/bots/beta/interactive", "the picked bot, not the first one");
+});
+
+test("C1: one attached bot spawns with no picker at all", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  assert.equal(hub.els["perch-new-bot"].hidden, true, "a one-item dropdown is a tap for nothing");
+  assert.equal(hub.els["perch-new-bot-label"].hidden, true);
+});
+
+test("C1: with no attached bot the launcher says so instead of offering a guaranteed 403", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_NO_ATTACHED) });
+  assert.equal(hub.els["perch-new"].disabled, true);
+  assert.equal(hub.els["perch-launch-note"].hidden, false);
+  assert.equal(hub.els["perch-launch-note"].textContent,
+    "No bot has a Perch channel attached, so there is nothing to start.");
+
+  // Even driven directly — a stale enabled button, a keyboard activation — it
+  // must not fire a spawn that cannot succeed.
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.fetchCalls.filter((c) => c.path.endsWith("/interactive")).length, 0);
+});
+
+test("C1: the launcher's picker survives a poll, so a mid-tap refresh cannot change the bot", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_TWO_BOTS) });
+  hub.els["perch-new-bot"].value = "beta";
+  // Re-run the poll body exactly as the 10s interval would.
+  for (const fn of hub.timers.values()) fn();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-new-bot"].value, "beta", "a poll must not reset the operator's pick");
+  assert.deepEqual(hub.els["perch-new-bot"].children.map((o) => o.value), ["alpha", "beta"],
+    "and must not duplicate the options either");
+});
+
+test("C1: the idle-row Talk button still spawns — same call, not a second path", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST) });
+  const talk = listButtons(hub).find((b) => b.text === "Talk");
+  assert.ok(talk, "an attached bot with no session keeps its row");
+  talk.btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const spawns = hub.fetchCalls.filter((c) => c.path.endsWith("/interactive"));
+  assert.equal(spawns[0].path, "/bots/idle-bot/interactive");
+});
+
+// ---- C2: closing a session ------------------------------------------------
+
+test("C2: a row's Close asks first, and a cancelled confirm posts nothing at all", async () => {
+  // confirmImpl defaults to false: the operator says no.
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  const close = listButtons(hub).find((b) => b.text === "Close");
+  assert.ok(close, "every live row needs a close control");
+  close.btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(hub.confirms.length, 1, "the gate was consulted");
+  assert.match(hub.confirms[0], /cannot be reopened/i,
+    "stop() is terminal — the copy has to say so, or the confirm is decoration");
+  assert.equal(hub.fetchCalls.filter((c) => c.path.endsWith("/stop")).length, 0,
+    "a declined confirm must leave the conversation alive");
+});
+
+test("C2: a confirmed row Close posts /interactive/<sid>/stop and refreshes the list", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY), confirmImpl: () => true });
+  const before = hub.fetchCalls.filter((c) => c.path === "/roost").length;
+  const close = listButtons(hub).find((b) => b.text === "Close");
+  close.btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  const stops = hub.fetchCalls.filter((c) => c.path.endsWith("/stop"));
+  assert.equal(stops.length, 1);
+  assert.equal(stops[0].method, "POST");
+  assert.equal(stops[0].path, "/interactive/perchlive-11111111/stop");
+  assert.ok(hub.fetchCalls.filter((c) => c.path === "/roost").length > before,
+    "the stopped row has to leave the list, which takes a re-poll");
+});
+
+test("C2: closing the session you are IN returns to the list — no chat view on a dead stream", async () => {
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY), confirmImpl: () => true,
+  });
+  hub.location.hash = "perchlive-11111111";
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.doc.body.getAttribute("data-view"), "chat", "precondition: we are in the chat view");
+
+  hub.els["perch-close"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(hub.fetchCalls.filter((c) => c.path.endsWith("/stop")).at(-1).path,
+    "/interactive/perchlive-11111111/stop");
+  assert.equal(hub.location.hash, "", "history stays correct: the hash drives the view, not a direct call");
+  assert.equal(hub.doc.body.getAttribute("data-view"), "list");
+  assert.equal(FakeEventSource.instances.at(-1).closed, true, "the SSE stream must not be left open");
+});
+
+test("C2: closing a DIFFERENT session while a chat is open does not yank the operator out of it", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY), confirmImpl: () => true });
+  hub.location.hash = "perchlive-22222222";
+  await new Promise((r) => setTimeout(r, 0));
+  // The desktop split keeps the list rendered beside the chat, so its rows —
+  // and their Close buttons — are still reachable while a session is open.
+  const close = listButtons(hub).find((b) => b.text === "Close");
+  close.btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(hub.fetchCalls.filter((c) => c.path.endsWith("/stop")).at(-1).path,
+    "/interactive/perchlive-11111111/stop", "the row's own session, not the open one");
+  assert.equal(hub.location.hash, "perchlive-22222222", "the open session stays open");
+  assert.equal(hub.doc.body.getAttribute("data-view"), "chat");
+});
+
+test("C2: a 410 means it is already gone — refresh, and show no error", async () => {
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/stop": () => makeResponse(410, { error: "stopped" }) }),
+    confirmImpl: () => true,
+  });
+  const before = hub.fetchCalls.filter((c) => c.path === "/roost").length;
+  listButtons(hub).find((b) => b.text === "Close").btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.ok(hub.fetchCalls.filter((c) => c.path === "/roost").length > before, "still refreshes");
+  const shown = hub.els["perch-list-body"].children.map((c) => c.textContent);
+  assert.equal(shown.includes("That session did not close."), false,
+    "the operator's goal is already true — an error here would be a lie");
+});
+
+test("C2: a 404 is treated the same way as a 410", async () => {
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/stop": () => makeResponse(404, { error: "no_such_session" }) }),
+    confirmImpl: () => true,
+  });
+  listButtons(hub).find((b) => b.text === "Close").btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const shown = hub.els["perch-list-body"].children.map((c) => c.textContent);
+  assert.equal(shown.includes("That session did not close."), false);
+});
+
+test("C2: any other failure is an error note, not a silent no-op", async () => {
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/stop": () => makeResponse(500, null) }),
+    confirmImpl: () => true,
+  });
+  listButtons(hub).find((b) => b.text === "Close").btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const shown = hub.els["perch-list-body"].children.map((c) => c.textContent);
+  assert.ok(shown.includes("That session did not close."),
+    "a stop that failed must say so — the row is still there and the operator needs to know why");
+});
+
+test("C2: a failure while that session is OPEN reaches the transcript, not the hidden list", async () => {
+  // showListNote() writes into #perch-list-body, which the chat view hides on
+  // a phone — routing an in-chat failure there would be an invisible error.
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/stop": () => makeResponse(500, { error: "engine_down" }) }),
+    confirmImpl: () => true,
+  });
+  hub.location.hash = "perchlive-11111111";
+  await new Promise((r) => setTimeout(r, 0));
+  hub.els["perch-close"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.ok(notesIn(hub.els["perch-transcript"]).includes("engine_down"));
+  assert.equal(hub.doc.body.getAttribute("data-view"), "chat",
+    "a session that did NOT stop must not be abandoned as though it had");
+});
+
+test("C2: an idle bot row offers no Close — there is nothing to stop", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST) });
+  const idleRow = hub.els["perch-list-body"].children
+    .find((row) => row.children.some((c) => c.textContent === "Talk"));
+  assert.ok(idleRow);
+  assert.equal(idleRow.children.some((c) => c.textContent === "Close"), false);
+});
+
+test("C2: every live row gets its own Close, bound to its own session id", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY), confirmImpl: () => true });
+  const closes = listButtons(hub).filter((b) => b.text === "Close");
+  assert.equal(closes.length, 3, "three live sessions, three close controls");
+  closes[2].btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.fetchCalls.filter((c) => c.path.endsWith("/stop")).at(-1).path,
+    "/interactive/perchlive-33333333/stop", "each row closes ITS session, not a shared one");
+});
+
+test("C2: the session id is encoded into the stop path, never concatenated raw", async () => {
+  const js = (await import("../servers/gateway/dashboard/perch-hub/client.js")).perchHubJs("en");
+  const code = maskComments(js);
+  assert.ok(/interactive\/'\+encodeURIComponent\([^)]*\)\+'\/stop/.test(code),
+    "this value reaches an API path — every use site encodes it");
+  // parseHash must stay strict: it is the gate that keeps ".." out of the ids
+  // this file concatenates into paths.
+  assert.ok(/\/\^perchlive-\[0-9a-f\]\{8\}\$\//.test(code),
+    "the engine-minted id pattern must not be loosened to admit the new controls");
+});
+
+test("C: the new controls are wired at bootstrap, not merely defined", async () => {
+  const js = (await import("../servers/gateway/dashboard/perch-hub/client.js")).perchHubJs("en");
+  const code = maskComments(js);   // a comment quoting the binding must not satisfy this
+  assert.ok(/el\(\s*['"]perch-new['"]\s*\)\.onclick\s*=/.test(code), "#perch-new has no handler bound");
+  assert.ok(/el\(\s*['"]perch-close['"]\s*\)\.onclick\s*=/.test(code), "#perch-close has no handler bound");
+});
+
+test("C: no hardcoded English — every new string comes from the perch.* i18n block", async () => {
+  const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
+  const en = perchHubJs("en"), es = perchHubJs("es");
+  const { translations } = await import("../servers/gateway/dashboard/shared/i18n.js");
+  // Asserted against the RAW table, not through t(): t() falls back to en for a
+  // missing es, so a key with no Spanish at all still returns a string and a
+  // t()-based check passes on exactly the omission it is meant to catch.
+  for (const key of ["perch.newSession", "perch.newSessionBot", "perch.noAttachedBots",
+                     "perch.close", "perch.closeConfirm", "perch.closeFailed"]) {
+    const entry = translations[key];
+    assert.ok(entry, key + " is not in the translations table");
+    assert.equal(typeof entry.en, "string", key + " has no en string");
+    assert.equal(typeof entry.es, "string", key + " has no es string");
+    // "Bot" is "Bot" in Spanish; every key that carries a real sentence must
+    // actually differ.
+    if (entry.en.includes(" ")) {
+      assert.notEqual(entry.es, entry.en, key + " is untranslated — es must not be the English string");
+    }
+  }
+  // The client-side ones must actually reach the emitted script, in BOTH langs.
+  for (const [key, text] of [["perch.close", "Close"], ["perch.closeConfirm", "cannot be reopened"]]) {
+    assert.ok(en.includes(text), key + " must be interpolated into the en script");
+  }
+  assert.ok(es.includes("No se podrá volver a abrir") || es.includes("No se podr"),
+    "the es script must carry the es confirm copy, not the English one");
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -380,7 +380,7 @@ function makeEventTarget() {
 function makeFakeElement(tag) {
   const target = makeEventTarget();
   const attrs = {};
-  return Object.assign(target, {
+  const node = Object.assign(target, {
     tagName: String(tag || "div").toUpperCase(),
     children: [],
     style: {},
@@ -394,7 +394,6 @@ function makeFakeElement(tag) {
     files: null,
     appendChild(child) { this.children.push(child); return child; },
     removeChild(child) { const i = this.children.indexOf(child); if (i >= 0) this.children.splice(i, 1); return child; },
-    get firstChild() { return this.children[0] || null; },
     insertBefore(node, ref) {
       const i = ref ? this.children.indexOf(ref) : -1;
       if (i < 0) this.children.unshift(node); else this.children.splice(i, 0, node);
@@ -404,6 +403,18 @@ function makeFakeElement(tag) {
     getAttribute(name) { return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null; },
     click() { if (this.onclick) this.onclick(); },
   });
+  // defineProperty, NOT a `get firstChild()` in the object literal above:
+  // Object.assign copies a getter's VALUE, not the getter, so firstChild was
+  // frozen at null (children was empty at creation) for the life of every
+  // element. clearEl()'s `while(node.firstChild)` therefore never removed
+  // anything, and #perch-list-body silently ACCUMULATED every render on top of
+  // the last. Found while debugging an off-by-four row count; the assertions
+  // it weakened were the ones that read the list body.
+  Object.defineProperty(node, "firstChild", {
+    get() { return this.children[0] || null; },
+    configurable: true,
+  });
+  return node;
 }
 
 /** A fake EventSource that keeps addEventListener('error', ...) listeners
@@ -444,7 +455,7 @@ function makeResponse(status, body) {
  *  path, opts)` decides how every perchApi call resolves; the default 200s
  *  everything with `{}`. Returns the fake DOM pieces and every fetch call
  *  made, in order, so a test can assert on both wiring and traffic. */
-async function mountHub({ fetchImpl, confirmImpl } = {}) {
+async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
   const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
   const js = perchHubJs("en");
 
@@ -473,10 +484,26 @@ async function mountHub({ fetchImpl, confirmImpl } = {}) {
   const visualViewport = Object.assign(vvTarget, { height: 700, offsetTop: 0 });
   const win = Object.assign(winTarget, { visualViewport, innerHeight: 800 });
 
-  const locState = { hash: "" };
+  // history is counted, not simulated: assigning location.hash pushes an entry,
+  // location.replace('#') does not. Both fire hashchange — verified in a real
+  // browser, where the tidier-looking location.replace(pathname) fires NONE and
+  // would leave the operator on a dead chat view. `replaced` records the raw
+  // argument so a test can prove the terminal path took the replace form.
+  // initialHash is set BEFORE the script runs, which is the only way to reach
+  // the genuinely cold deep-link path: the bootstrap branches on
+  // parseHash(location.hash) at load, so a hash assigned afterwards has always
+  // been preceded by a list render that already populated rowIndex.
+  const locState = { hash: initialHash };
+  const history = { pushes: 0, replaces: 0 };
   const location = {
     get hash() { return locState.hash; },
-    set hash(v) { locState.hash = v; winTarget._dispatch("hashchange", {}); },
+    set hash(v) { locState.hash = v; history.pushes++; winTarget._dispatch("hashchange", {}); },
+    replace(v) {
+      const next = String(v);
+      locState.hash = next === "#" || next === "" ? "" : next;
+      history.replaces++;
+      winTarget._dispatch("hashchange", {});
+    },
     href: "",
   };
 
@@ -524,7 +551,7 @@ async function mountHub({ fetchImpl, confirmImpl } = {}) {
   // fetchCalls or the DOM it produced.
   await new Promise((r) => setTimeout(r, 0));
 
-  return { els, doc, win, location, fetchCalls, sandbox, timers, confirms };
+  return { els, doc, win, location, fetchCalls, sandbox, timers, confirms, history };
 }
 
 /** Opens a chat session the same way a real click does: seed a /roost
@@ -1080,4 +1107,289 @@ test("C: no hardcoded English — every new string comes from the perch.* i18n b
   }
   assert.ok(es.includes("No se podrá volver a abrir") || es.includes("No se podr"),
     "the es script must carry the es confirm copy, not the English one");
+});
+
+// ---------------------------------------------------------------------------
+// Task C — fix round 1.
+// ---------------------------------------------------------------------------
+
+/** ROOST_ALL_BUSY, but with a card on the first session, so the row subtitle
+ *  has all three parts to show. Mirrors routes/perch.js:484-513: cardId is a
+ *  number or null on every session entry. */
+const ROOST_ALL_BUSY_CARDED = {
+  birds: [{
+    id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
+    sessions: [
+      { sessionId: "perchlive-11111111", state: "awake", cardId: 248, pendingUi: false },
+      { sessionId: "perchlive-22222222", state: "awake", cardId: null, pendingUi: false },
+      { sessionId: "perchlive-33333333", state: "hibernating", cardId: null, pendingUi: false },
+    ],
+  }],
+};
+
+const subtitles = (hub) => hub.els["perch-list-body"].children
+  .map((row) => (row.children || []).filter((c) => String(c.className) === "roost-main")[0])
+  .filter(Boolean)
+  .map((main) => main.children.filter((c) => String(c.className) === "roost-when")[0])
+  .map((w) => (w ? w.textContent : null));
+
+// ---- Finding 1: eight identical rows ----
+
+test("F1: a row says WHICH session it is, not just which bot", async () => {
+  const rowSubtitle = await extract("rowSubtitle",
+    "var WAITING_ON_YOU='waiting on you', ROW_CARD='card {id}';" +
+    "function shortSid(s){return String(s==null?'':s).replace(/^perchlive-/,'');}");
+  assert.equal(rowSubtitle({ state: "awake", sessionId: "perchlive-11111111", cardId: 248 }),
+    "awake · 11111111 · card 248");
+  assert.equal(rowSubtitle({ state: "awake", sessionId: "perchlive-22222222", cardId: null }),
+    "awake · 22222222");
+  assert.equal(rowSubtitle({ state: "awake", sessionId: "perchlive-33333333", cardId: null, pendingUi: true }),
+    "waiting on you · 33333333", "pendingUi still outranks the state word");
+  // An idle bot row is unchanged: no session, so nothing to disambiguate.
+  assert.equal(rowSubtitle({ state: "idle", sessionId: null, cardId: null }), "idle");
+  // cardId 0 is a real id, not an absence.
+  assert.equal(rowSubtitle({ state: "awake", sessionId: "perchlive-abcdef01", cardId: 0 }),
+    "awake · abcdef01 · card 0");
+});
+
+test("F1: eight sessions on one bot render eight DISTINGUISHABLE rows", async () => {
+  // The reported shape. Before this fix every row read "R4 Assistant / awake"
+  // and the only way to tell them apart was Open -> read the meta -> Back,
+  // once per candidate, each pass sitting on top of an irreversible Close.
+  const eight = {
+    birds: [{
+      id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
+      sessions: Array.from({ length: 8 }, (_, i) => ({
+        sessionId: "perchlive-" + String(i).repeat(8), state: "awake", cardId: null, pendingUi: false,
+      })),
+    }],
+  };
+  const hub = await mountHub({ fetchImpl: roostFetch(eight) });
+  const seen = subtitles(hub);
+  assert.equal(seen.length, 8);
+  assert.equal(new Set(seen).size, 8, "every row must be distinguishable: " + JSON.stringify(seen));
+});
+
+test("F1: the irreversible confirm names the session it is about to destroy", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY_CARDED), confirmImpl: () => false });
+  listButtons(hub).filter((b) => b.text === "Close")[1].btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.confirms.length, 1);
+  assert.match(hub.confirms[0], /R4 Assistant 22222222/,
+    "a confirm that names nothing cannot correct a mis-tap, which is all it is for");
+  assert.match(hub.confirms[0], /cannot be reopened/i);
+});
+
+test("F1: a cold deep link can still name its session in the confirm", async () => {
+  // A GENUINELY cold link: the hash is set before the script runs, so the
+  // bootstrap goes straight to openSession and no list render has populated
+  // rowIndex. An earlier version of this test assigned the hash afterwards,
+  // which meant renderList had already cached every row and openSession took
+  // its warm branch — the cold path was never executed, and removing the
+  // rowIndex write left the test green. The mutation was right; the test was
+  // not exercising what it named.
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY_CARDED),
+    confirmImpl: () => false,
+    initialHash: "perchlive-22222222",
+  });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.doc.body.getAttribute("data-view"), "chat", "precondition: opened cold");
+  assert.equal(hub.els["perch-list-body"].children.length, 0,
+    "precondition: nothing rendered the list, so rowIndex was never warmed");
+  hub.els["perch-close"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.match(hub.confirms.at(-1), /R4 Assistant 22222222/,
+    "without the cold-path rowIndex write this reads 'Close 22222222?' — an " +
+    "irreversible prompt with no bot name on it");
+});
+
+// ---- Finding 3: a failed /roost must not re-create the original symptom ----
+
+test("F3: a failed /roost says so instead of showing a false empty list", async () => {
+  const hub = await mountHub({ fetchImpl: () => makeResponse(503, { error: "upstream" }) });
+  const shown = hub.els["perch-list-body"].children.map((c) => c.textContent);
+  assert.equal(shown.includes("No live sessions."), false,
+    "a failed roost is not an empty roost — saying so is a lie");
+  assert.ok(shown.includes("Could not reach the session list."));
+  assert.equal(hub.els["perch-launch-note"].hidden, false,
+    "and a greyed-out New session button with no reason beside it is the exact " +
+    "'I can only interact with what already exists' state this task ends");
+  assert.equal(hub.els["perch-launch-note"].textContent, "Could not reach the session list.");
+});
+
+test("F3: a roster we already know survives a blip and stays spawnable", async () => {
+  let fail = false;
+  const hub = await mountHub({
+    fetchImpl: (method, path) => (path === "/roost" && fail)
+      ? makeResponse(503, { error: "upstream" })
+      : roostFetch(ROOST_ALL_BUSY)(method, path),
+  });
+  assert.equal(hub.els["perch-new"].disabled, false, "precondition: a good first poll");
+
+  fail = true;
+  for (const fn of hub.timers.values()) fn();          // the 10s poll, failing
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-new"].disabled, false,
+    "the bots did not vanish because one poll failed — spawning is still worth attempting");
+
+  fail = false;
+  for (const fn of hub.timers.values()) fn();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-launch-note"].hidden, true, "and it self-heals on the next good poll");
+  assert.equal(hub.els["perch-list-body"].children.length, 3);
+});
+
+// ---- Finding 5: a stop failure you navigated away from must still land ----
+
+test("F5: a stop that fails after you move on surfaces on the next list render", async () => {
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY_CARDED, {
+      "/stop": () => gate.then(() => makeResponse(500, { error: "engine_down" })),
+    }),
+    confirmImpl: () => true,
+  });
+
+  hub.location.hash = "perchlive-11111111";
+  await new Promise((r) => setTimeout(r, 0));
+  hub.els["perch-close"].onclick();                    // slow POST, still in flight
+  await new Promise((r) => setTimeout(r, 0));
+
+  hub.location.hash = "perchlive-22222222";            // the operator moves on
+  await new Promise((r) => setTimeout(r, 0));
+
+  release();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+
+  // Nothing may be written into the hidden list body while a chat is open.
+  assert.equal(hub.doc.body.getAttribute("data-view"), "chat");
+
+  hub.els["perch-back"].onclick();                     // back to the list
+  await new Promise((r) => setTimeout(r, 0));
+  const shown = hub.els["perch-list-body"].children.map((c) => c.textContent);
+  assert.ok(shown.some((t) => /11111111 did not close/.test(String(t))),
+    "the session is still alive and still costing a pi child — the operator has to be told, " +
+    "and told WHICH one: " + JSON.stringify(shown));
+});
+
+// ---- Finding 7: Back after a close must not be a one-way trap ----
+
+test("F7: closing the open session REPLACES the dead entry instead of stacking one", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY), confirmImpl: () => true });
+  hub.location.hash = "perchlive-11111111";
+  await new Promise((r) => setTimeout(r, 0));
+  const pushesBefore = hub.history.pushes;
+
+  hub.els["perch-close"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(hub.history.pushes, pushesBefore,
+    "pushing on top of #perchlive-<gone> means Back lands on the dead deep link, " +
+    "which bounces through noteAndReturnToList into another entry, forever");
+  assert.equal(hub.history.replaces, 1);
+  assert.equal(hub.location.hash, "", "and it still reaches the list");
+  assert.equal(hub.doc.body.getAttribute("data-view"), "list");
+});
+
+test("F7: a dead deep link also replaces rather than stacking", async () => {
+  // noteAndReturnToList is the other terminal path — the one Back would land
+  // on if the close path stacked. It must not stack either.
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  hub.location.hash = "perchlive-deadbeef";            // valid shape, absent from /roost
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.history.replaces, 1, "the bounce back off a gone session must replace");
+  const shown = hub.els["perch-list-body"].children.map((c) => c.textContent);
+  assert.ok(shown.includes("That session is gone."), "and the parked note must still land");
+});
+
+test("F7: an ordinary Back out of a live session still uses a normal navigation", async () => {
+  // Only the TERMINAL paths replace. Leaving a session that still exists is
+  // ordinary navigation and must stay in history, or Back stops working.
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  hub.location.hash = "perchlive-11111111";
+  await new Promise((r) => setTimeout(r, 0));
+  const replacesBefore = hub.history.replaces;
+  hub.els["perch-back"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.history.replaces, replacesBefore, "#perch-back is not a terminal path");
+  assert.equal(hub.doc.body.getAttribute("data-view"), "list");
+});
+
+test("F1/F3/F5: the new strings are translated, with matching placeholders", async () => {
+  const { translations } = await import("../servers/gateway/dashboard/shared/i18n.js");
+  for (const key of ["perch.rowCard", "perch.roostUnreachable", "perch.closeFailedFor", "perch.closeConfirm"]) {
+    const e = translations[key];
+    assert.ok(e, key + " missing");
+    assert.equal(typeof e.es, "string", key + " has no es string");
+    assert.notEqual(e.es, e.en, key + " is untranslated");
+    const ph = (s) => (s.match(/\{[a-z]+\}/gi) || []).sort().join(",");
+    assert.equal(ph(e.es), ph(e.en), key + "'s placeholders differ between en and es");
+  }
+  // {session} has to survive into the emitted script, or the confirm names nothing.
+  const es = (await import("../servers/gateway/dashboard/perch-hub/client.js")).perchHubJs("es");
+  assert.ok(es.includes("{session}"), "the es confirm must still carry the placeholder");
+});
+
+test("harness integrity: clearEl actually clears, so a re-render replaces rather than accumulates", async () => {
+  // This harness's fake element used `get firstChild()` inside an object
+  // literal handed to Object.assign, which copies the getter's VALUE. It was
+  // frozen at null, clearEl()'s `while(node.firstChild)` never removed
+  // anything, and every render piled on top of the last. Every assertion that
+  // read #perch-list-body was weaker than it looked: `includes(...)` checks
+  // could be satisfied by a stale render from three polls ago.
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  assert.equal(hub.els["perch-list-body"].children.length, 3);
+  for (let i = 0; i < 3; i++) {
+    for (const fn of hub.timers.values()) fn();
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  assert.equal(hub.els["perch-list-body"].children.length, 3,
+    "four polls must leave three rows, not twelve");
+  // And the primitive itself, directly.
+  const node = hub.doc.createElement("div");
+  node.appendChild(hub.doc.createElement("span"));
+  assert.ok(node.firstChild, "firstChild must be a live getter, not a value snapshotted at creation");
+  node.removeChild(node.firstChild);
+  assert.equal(node.firstChild, null);
+});
+
+// ---- Finding 6: a failed spawn must not blank the rows you came to close ----
+
+test("F6: a failed spawn keeps the session rows and their Close buttons on screen", async () => {
+  // showListNote clears #perch-list-body. With the launcher now always
+  // present, a spawn failure became a routine way to lose every row — and
+  // every Close — for up to 10s, for an operator whose whole task is closing
+  // sessions. The note belongs on the launcher that produced it.
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/interactive": () => makeResponse(409, { error: "engine_required" }) }),
+  });
+  assert.equal(hub.els["perch-list-body"].children.length, 3, "precondition");
+
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(hub.els["perch-launch-note"].hidden, false, "the failure must still be reported");
+  assert.equal(hub.els["perch-launch-note"].textContent, "The bot engine is not installed.");
+  assert.equal(hub.els["perch-list-body"].children.length, 3,
+    "and the rows the operator came to close must survive it");
+  assert.equal(listButtons(hub).filter((b) => b.text === "Close").length, 3);
+});
+
+test("F6: a 403 and a shapeless 200 report on the launcher too", async () => {
+  for (const [resp, expected] of [
+    [makeResponse(403, { error: "perch_not_attached" }), "That bot has no Perch channel attached."],
+    [makeResponse(200, {}), "Could not start a session."],
+  ]) {
+    const hub = await mountHub({
+      fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/interactive": () => resp }),
+    });
+    hub.els["perch-new"].onclick();
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(hub.els["perch-launch-note"].textContent, expected);
+    assert.equal(hub.els["perch-list-body"].children.length, 3, "rows survive: " + expected);
+  }
 });

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -268,3 +268,75 @@ test("every control in the chat header carries a visible label", async () => {
     assert.ok(new RegExp(`id="${id}"[^>]*aria-labelledby="${id}-label"`).test(html));
   }
 });
+
+// ---------------------------------------------------------------------------
+// Task C — structural properties the vm harness in perch-hub-client.test.js
+// cannot see. That harness serves elements from a FLAT id->element map with no
+// tree, so "the launcher is not inside the container that gets cleared" is
+// trivially and meaninglessly true there. It is load-bearing in a real
+// document: renderList() and showListNote() both clearEl(#perch-list-body) on
+// every 10s poll and every note, and a launch control living inside that body
+// would be wiped by both — which is a different flavour of the exact defect
+// this task fixes (a launcher that disappears).
+// ---------------------------------------------------------------------------
+
+test("the launch control lives outside the list body that every poll clears", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const launch = html.indexOf('id="perch-launch"');
+  const listOpen = html.indexOf('id="perch-list"');
+  const bodyOpen = html.indexOf('id="perch-list-body"');
+  assert.ok(launch > -1, "there is no launch control in the markup at all");
+  assert.ok(listOpen > -1 && bodyOpen > -1);
+  assert.ok(launch > listOpen, "the launcher belongs to the list view");
+  assert.ok(launch < bodyOpen,
+    "it must precede #perch-list-body, whose contents renderList()/showListNote() clear");
+  // And the launcher's own div must close before the body opens — "before it
+  // in source" is not the same as "not nested inside it".
+  const closeOfLaunch = html.indexOf("</div>", launch);
+  assert.ok(closeOfLaunch > -1 && closeOfLaunch < bodyOpen,
+    "#perch-launch must not wrap or contain #perch-list-body");
+});
+
+test("the launcher ships disabled, so the pre-data frame never claims there are no bots", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  assert.ok(/id="perch-new"[^>]*disabled/.test(html) || /disabled[^>]*id="perch-new"/.test(html),
+    "renderLauncher() enables it once /roost answers; before that it must not invite a tap");
+  assert.ok(/id="perch-new-bot"[^>]*hidden/.test(html), "and the picker starts hidden");
+  assert.ok(/id="perch-launch-note"[^>]*hidden/.test(html), "as does its note");
+});
+
+test("the chat-view close control is in the header, not in the sticky composer", async () => {
+  // #perch-composer{position:sticky;bottom:0} is the whole reason Send is
+  // reachable at any scroll position (the drawer's defining mobile failure).
+  // A control added INTO that box changes its height and puts that property
+  // back in play; .perch-head is a non-scrolling flex child of #perch-chat and
+  // is permanently on screen without touching the composer at all.
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const close = html.indexOf('id="perch-close"');
+  const head = html.indexOf('class="perch-head"');
+  const composer = html.indexOf('id="perch-composer"');
+  assert.ok(close > -1, "the open session needs a close control");
+  assert.ok(head > -1 && composer > -1);
+  assert.ok(close > head && close < composer, "close belongs to the header block");
+  // The composer's own markup must be untouched by this task.
+  const composerBlock = html.slice(composer, html.indexOf("</div>", html.indexOf("send-row")));
+  assert.ok(!composerBlock.includes("perch-close"), "nothing new inside the sticky box");
+});
+
+test("the launcher and the row close button cannot overflow a 412px column", async () => {
+  // Static counterpart to the live 412px CDP check: both new controls sit in
+  // wrapping flex containers, so a long bot name cannot force a horizontal
+  // scrollbar onto the list.
+  const { perchHubCss } = await import("../servers/gateway/dashboard/perch-hub/css.js");
+  const css = perchHubCss().replace(/\s+/g, "");
+  assert.ok(/#perch-launch\{[^}]*display:flex/.test(css));
+  assert.ok(/#perch-launch\{[^}]*flex-wrap:wrap/.test(css), "the launcher must wrap, not overflow");
+  assert.ok(/#perch-launchselect\{[^}]*min-width:0/.test(css),
+    "a flex item without min-width:0 refuses to shrink below its content width");
+  assert.ok(/\.roost-row\{[^}]*flex-wrap:wrap/.test(css), "two buttons per row must be able to wrap");
+  assert.ok(/\.perch-head\{[^}]*flex-wrap:wrap/.test(css),
+    "the bot name, the state word and Close must wrap rather than overflow the chat column");
+});

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -308,11 +308,20 @@ test("the launcher ships disabled, so the pre-data frame never claims there are 
 });
 
 test("the chat-view close control is in the header, not in the sticky composer", async () => {
-  // #perch-composer{position:sticky;bottom:0} is the whole reason Send is
-  // reachable at any scroll position (the drawer's defining mobile failure).
-  // A control added INTO that box changes its height and puts that property
-  // back in play; .perch-head is a non-scrolling flex child of #perch-chat and
-  // is permanently on screen without touching the composer at all.
+  // Send stays reachable because #perch-chat{flex:1;min-height:0} and
+  // #perch-transcript{flex:1;overflow:auto;min-height:0} make the TRANSCRIPT the
+  // only scroller, so .content-body never scrolls and the composer never leaves
+  // the viewport. #perch-composer{position:sticky;bottom:0} is the BACKSTOP, not
+  // the mechanism: measured, killing sticky in the shipped config is
+  // pixel-identical (Send 668-704 at 412x730), while removing the flex chain
+  // scrolls .content-body ~2962px with sticky still holding Send. Both matter;
+  // the order matters more, because a maintainer who believes sticky is the
+  // mechanism will delete the flex chain and the pre-existing reachability tests
+  // stay GREEN through that deletion.
+  //
+  // Either way a control added INTO the composer changes its box and puts the
+  // backstop in play, so .perch-head — a non-scrolling flex child of #perch-chat,
+  // permanently on screen — is where it belongs.
   const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
   const html = perchHubContent("en");
   const close = html.indexOf('id="perch-close"');

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -22,6 +22,54 @@ const HOST_FROM_CONTAINER = process.env.CROW_CDP_HOST_IP || "172.17.0.1";
 
 let available = false, server = null, port = 0;
 
+// ---------------------------------------------------------------------------
+// Task C — a scripted perch-api, so the real client can be driven into the
+// exact state Kevin reported: ONE perch-attached bot with several live
+// sessions and therefore NO idle row to spawn from. An empty roost would not
+// reproduce the bug; it passes against the broken build.
+// ---------------------------------------------------------------------------
+const SIDS = ["perchlive-11111111", "perchlive-22222222", "perchlive-33333333"];
+let liveSids = SIDS.slice();
+const stopped = [];
+function resetApi() { liveSids = SIDS.slice(); stopped.length = 0; }
+
+function serveApi(req, res) {
+  const url = req.url.split("?")[0];
+  const send = (code, obj) => {
+    res.writeHead(code, { "content-type": "application/json" });
+    res.end(JSON.stringify(obj));
+  };
+  if (url.endsWith("/roost")) {
+    return send(200, {
+      birds: [{
+        id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
+        sessions: liveSids.map((sid) => ({ sessionId: sid, state: "awake", cardId: null, pendingUi: false })),
+      }],
+      occupiedCardIds: [],
+    });
+  }
+  const stop = url.match(/\/interactive\/([^/]+)\/stop$/);
+  if (stop && req.method === "POST") {
+    const sid = decodeURIComponent(stop[1]);
+    stopped.push(sid);
+    liveSids = liveSids.filter((s) => s !== sid);      // the engine parks the row
+    return send(200, { ok: true });
+  }
+  if (url.endsWith("/events")) {
+    // A real SSE connection that stays open and sends nothing: without it the
+    // EventSource errors immediately and the client's terminal-status probe
+    // bounces the operator back to the list on its own, which would fake a
+    // pass on "closing the open session returns to the list".
+    res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+    res.write(": open\n\n");
+    return;
+  }
+  if (url.endsWith("/options")) return send(200, { models: [], thinkingLevels: [] });
+  if (url.endsWith("/transcript")) return send(200, { events: [] });
+  if (url.endsWith("/interactive") && req.method === "POST") return send(200, { sessionId: "perchlive-99999999" });
+  return send(200, {});
+}
+
 before(async () => {
   try {
     const r = await fetch(CDP + "/json/version", { signal: AbortSignal.timeout(2000) });
@@ -31,6 +79,10 @@ before(async () => {
   const { default: perchHubPanel } = await import("../servers/gateway/dashboard/panels/perch-hub.js");
   const { renderLayout } = await import("../servers/gateway/dashboard/shared/layout.js");
   server = http.createServer(async (req, res) => {
+    // Task C: the same real client script, in the same real browser, now with
+    // a scripted /dashboard/perch-api behind it — otherwise every fetch it
+    // makes 404s and the list can never reach the state being tested.
+    if (req.url.startsWith("/dashboard/perch-api/")) return serveApi(req, res);
     const layout = (opts) => renderLayout({ ...opts, activePanel: "perch", panels: [perchHubPanel], lang: "en" });
     const html = await perchHubPanel.handler(req, res, { lang: "en", layout });
     if (!res.headersSent) { res.writeHead(200, { "content-type": "text/html" }); res.end(html); }
@@ -196,3 +248,169 @@ test("both views are visible side by side at desktop width", async (t) => {
   assert.equal(visible.list, true, "the min-width:900px split keeps the list up");
   assert.equal(visible.chat, true);
 });
+
+// ---------------------------------------------------------------------------
+// Task C — live in a real browser, at both viewports. These drive the REAL
+// onclick handlers on the REAL rendered page against the scripted perch-api
+// above, and read the resulting DOM back. The vm harness in
+// perch-hub-client.test.js proves the calls and the bodies; only this proves
+// the controls are on screen, hit-testable, and inside the viewport at 412px.
+// ---------------------------------------------------------------------------
+
+/** A tab that stays open across several evaluations, unlike evaluate() above
+ *  which opens and closes one per call — clicking and then reading the result
+ *  has to happen in the same document. */
+async function session(width, height) {
+  const tab = await (await fetch(CDP + "/json/new?about:blank", { method: "PUT" })).json();
+  const { default: WebSocket } = await import("ws");
+  const ws = new WebSocket(tab.webSocketDebuggerUrl);
+  await new Promise((r, j) => { ws.once("open", r); ws.once("error", j); });
+  let id = 0;
+  const send = (method, params = {}) => new Promise((resolve, reject) => {
+    const mine = ++id;
+    const onMsg = (raw) => {
+      const m = JSON.parse(raw);
+      if (m.id !== mine) return;
+      ws.off("message", onMsg);
+      m.error ? reject(new Error(JSON.stringify(m.error))) : resolve(m.result || {});
+    };
+    ws.on("message", onMsg);
+    ws.send(JSON.stringify({ id: mine, method, params }));
+  });
+  await send("Emulation.setDeviceMetricsOverride",
+    { width, height, deviceScaleFactor: 2, mobile: width < 900 });
+  await send("Page.enable");
+  await send("Page.navigate", { url: `http://${HOST_FROM_CONTAINER}:${port}/dashboard/perch` });
+  await new Promise((r) => setTimeout(r, 1500));
+  const evalIn = async (expression) => {
+    const out = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+    if (out.exceptionDetails) throw new Error("page threw: " + JSON.stringify(out.exceptionDetails));
+    return out.result.value;
+  };
+  return {
+    evalIn,
+    json: async (expression) => JSON.parse(await evalIn(expression)),
+    close: async () => { ws.close(); await fetch(CDP + "/json/close/" + tab.id).catch(() => {}); },
+  };
+}
+
+/** confirm() blocks a real browser tab, so it is replaced with a recorder.
+ *  The gate itself is proved in perch-hub-client.test.js (a cancelled confirm
+ *  posts nothing); what these tests need is the path PAST it. */
+const STUB_CONFIRM = `(function(){ window.__asked=[];
+  window.confirm=function(m){ window.__asked.push(String(m)); return true; }; return 'ok'; })()`;
+
+const ROW_STATE = `JSON.stringify({
+  sids: Array.from(document.querySelectorAll('#perch-list-body .roost-row .roost-cwd')).length,
+  closes: Array.from(document.querySelectorAll('#perch-list-body .roost-close')).length,
+  rows: document.querySelectorAll('#perch-list-body .roost-row').length })`;
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`C1 live @${w}x${h}: the launch control is on screen while EVERY attached bot is busy`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      const seen = await s.json(`(function(){
+        var b=document.getElementById('perch-new');
+        var r=b.getBoundingClientRect();
+        var cs=getComputedStyle(b);
+        var doc=document.documentElement;
+        return JSON.stringify({
+          rows: document.querySelectorAll('#perch-list-body .roost-row').length,
+          talk: Array.from(document.querySelectorAll('#perch-list-body button'))
+                  .filter(function(x){return x.textContent==='Talk';}).length,
+          disabled: b.disabled, display: cs.display, visibility: cs.visibility,
+          w: Math.round(r.width), h: Math.round(r.height),
+          top: Math.round(r.top), bottom: Math.round(r.bottom),
+          inViewport: r.top>=0 && r.bottom<=innerHeight && r.left>=0 && r.right<=innerWidth,
+          // hit-testable: the point the thumb lands on resolves to this button
+          hit: (function(){ var e=document.elementFromPoint(r.left+r.width/2, r.top+r.height/2);
+                            return !!e && (e===b || b.contains(e)); })(),
+          hScroll: doc.scrollWidth > doc.clientWidth
+        });
+      })()`);
+      assert.equal(seen.rows, 3, "the roost fixture must actually be in the reported state");
+      assert.equal(seen.talk, 0,
+        "fixture check: every attached bot is busy, so listRows() emits NO idle row — this is the bug");
+      assert.equal(seen.disabled, false, "the launcher must be usable in exactly that state");
+      assert.equal(seen.display !== "none" && seen.visibility !== "hidden", true, "and visible");
+      assert.equal(seen.inViewport, true,
+        `the launcher sits at ${seen.top}-${seen.bottom} in a ${h}px viewport`);
+      assert.equal(seen.hit, true, "and nothing overlaps it — a thumb there hits the button");
+      assert.ok(seen.w >= 44 && seen.h >= 40, `tap target ${seen.w}x${seen.h} is too small for a thumb`);
+      assert.equal(seen.hScroll, false, "no horizontal scroll at " + w + "px");
+    } finally { await s.close(); }
+  });
+
+  test(`C2 live @${w}x${h}: closing a session removes it from the list`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(STUB_CONFIRM);
+      const before = await s.json(ROW_STATE);
+      assert.equal(before.rows, 3);
+      assert.equal(before.closes, 3, "every live row needs its own close control");
+
+      // A real click on the real button, dispatched by the browser.
+      await s.evalIn(`document.querySelectorAll('#perch-list-body .roost-close')[0].click(); 'clicked'`);
+      await new Promise((r) => setTimeout(r, 800));
+
+      const asked = await s.json(`JSON.stringify(window.__asked)`);
+      assert.equal(asked.length, 1, "the operator was asked before anything terminal happened");
+      assert.match(asked[0], /cannot be reopened/i);
+      assert.deepEqual(stopped, ["perchlive-11111111"], "the server saw exactly one stop, for that row");
+
+      const after = await s.json(ROW_STATE);
+      assert.equal(after.rows, 2, "the closed session must be gone from the list, not merely greyed");
+    } finally { await s.close(); }
+  });
+
+  test(`C2 live @${w}x${h}: closing the OPEN session returns to the list`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(STUB_CONFIRM);
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 800));
+      const inChat = await s.json(`JSON.stringify({
+        view: document.body.getAttribute('data-view'),
+        meta: document.getElementById('perch-session-meta').textContent })`);
+      assert.equal(inChat.view, "chat");
+      assert.equal(inChat.meta, "perchlive-22222222", "precondition: that session is the one open");
+
+      const btn = await s.json(`(function(){
+        var b=document.getElementById('perch-close'), r=b.getBoundingClientRect();
+        return JSON.stringify({ inViewport: r.top>=0 && r.bottom<=innerHeight,
+          hit: (function(){ var e=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
+                            return !!e && (e===b||b.contains(e)); })(),
+          w: Math.round(r.width), h: Math.round(r.height) });
+      })()`);
+      assert.equal(btn.inViewport, true, "close must be reachable without scrolling the chat");
+      assert.equal(btn.hit, true);
+
+      // Send must still be reachable — the close control must not have
+      // disturbed the sticky composer this page's mobile fix rests on.
+      const sendBox = await s.json(`(function(){
+        var r=document.getElementById('perch-send').getBoundingClientRect();
+        return JSON.stringify({ reachable: r.bottom<=innerHeight && r.top>=0,
+                                top: Math.round(r.top), bottom: Math.round(r.bottom), vp: innerHeight });
+      })()`);
+      assert.equal(sendBox.reachable, true,
+        `Send at ${sendBox.top}-${sendBox.bottom} in a ${sendBox.vp}px viewport`);
+
+      await s.evalIn(`document.getElementById('perch-close').click(); 'clicked'`);
+      await new Promise((r) => setTimeout(r, 800));
+
+      assert.deepEqual(stopped, ["perchlive-22222222"]);
+      const back = await s.json(`JSON.stringify({
+        view: document.body.getAttribute('data-view'), hash: location.hash,
+        rows: document.querySelectorAll('#perch-list-body .roost-row').length })`);
+      assert.equal(back.view, "list", "an operator must not be left in a chat whose stream is dead");
+      assert.equal(back.hash, "", "and the hash drives it, so Back still works");
+      assert.equal(back.rows, 2, "the list came back refreshed, without the closed session");
+    } finally { await s.close(); }
+  });
+}

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -31,8 +31,9 @@ let available = false, server = null, port = 0;
 const SIDS = ["perchlive-11111111", "perchlive-22222222", "perchlive-33333333"];
 let liveSids = SIDS.slice();
 const stopped = [];
-function resetApi() { liveSids = SIDS.slice(); stopped.length = 0; }
+function resetApi() { liveSids = SIDS.slice(); stopped.length = 0; roostFails = false; }
 
+let roostFails = false;
 function serveApi(req, res) {
   const url = req.url.split("?")[0];
   const send = (code, obj) => {
@@ -40,10 +41,12 @@ function serveApi(req, res) {
     res.end(JSON.stringify(obj));
   };
   if (url.endsWith("/roost")) {
+    if (roostFails) return send(503, { error: "upstream" });
     return send(200, {
       birds: [{
         id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
-        sessions: liveSids.map((sid) => ({ sessionId: sid, state: "awake", cardId: null, pendingUi: false })),
+        sessions: liveSids.map((sid) => ({ sessionId: sid, state: "awake",
+          cardId: sid === "perchlive-11111111" ? 248 : null, pendingUi: false })),
       }],
       occupiedCardIds: [],
     });
@@ -338,7 +341,10 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.inViewport, true,
         `the launcher sits at ${seen.top}-${seen.bottom} in a ${h}px viewport`);
       assert.equal(seen.hit, true, "and nothing overlaps it — a thumb there hits the button");
-      assert.ok(seen.w >= 44 && seen.h >= 40, `tap target ${seen.w}x${seen.h} is too small for a thumb`);
+      // 44, not 40. The commit that introduced this asserted >=40 while its
+      // message and its CSS both claimed a 44px floor, so the suite did not pin
+      // the floor the code stated.
+      assert.ok(seen.w >= 44 && seen.h >= 44, `tap target ${seen.w}x${seen.h} is too small for a thumb`);
       assert.equal(seen.hScroll, false, "no horizontal scroll at " + w + "px");
     } finally { await s.close(); }
   });
@@ -386,10 +392,22 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
         return JSON.stringify({ inViewport: r.top>=0 && r.bottom<=innerHeight,
           hit: (function(){ var e=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
                             return !!e && (e===b||b.contains(e)); })(),
-          w: Math.round(r.width), h: Math.round(r.height) });
+          w: Math.round(r.width), h: Math.round(r.height),
+          padding: getComputedStyle(b).padding, fontSize: getComputedStyle(b).fontSize });
       })()`);
       assert.equal(btn.inViewport, true, "close must be reachable without scrolling the chat");
       assert.equal(btn.hit, true);
+      // The number this test already COLLECTED and never asserted. It measured
+      // 36px live: a bare "#perch-close" rule is (1,0,0) and loses to
+      // "#perch-hub-root button" at (1,0,1), so neither of its declarations
+      // applied — and the one irreversible control in the chat view shipped as
+      // the smallest target on a page whose reason for existing is a phone,
+      // in the same commit that raised the launch buttons to 44px.
+      assert.ok(btn.h >= 44,
+        `Close is ${btn.w}x${btn.h}; the irreversible control must clear the 44px thumb target`);
+      assert.equal(btn.padding, "8px 12px",
+        "the scoped rule must actually win the cascade, not merely be present in the sheet");
+      assert.equal(btn.fontSize, "13px");
 
       // Send must still be reachable — the close control must not have
       // disturbed the sticky composer this page's mobile fix rests on.
@@ -412,5 +430,80 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(back.hash, "", "and the hash drives it, so Back still works");
       assert.equal(back.rows, 2, "the list came back refreshed, without the closed session");
     } finally { await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fix round 1 — findings 1, 3 and 4 were each found live, so each is settled
+// live. A static argument about the cascade is what shipped finding 2.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`F1 live @${w}x${h}: rows on one bot are actually distinguishable`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      const seen = await s.json(`JSON.stringify({
+        subtitles: Array.from(document.querySelectorAll('#perch-list-body .roost-when')).map(e=>e.textContent),
+        flat: document.getElementById('perch-list-body').innerText.replace(/\\s+/g,''),
+        hScroll: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        overflow: Array.from(document.querySelectorAll('#perch-list-body .roost-when'))
+          .map(e=>e.scrollWidth > e.clientWidth + 1)
+      })`);
+      // Before the fix this read, verbatim:
+      // "R4AssistantawakeOpenCloseR4AssistantawakeOpenCloseR4AssistantawakeOpenClose"
+      assert.equal(seen.subtitles.length, 3);
+      assert.equal(new Set(seen.subtitles).size, 3,
+        "three sessions on one bot must read as three different things: " + JSON.stringify(seen.subtitles));
+      assert.match(seen.subtitles[0], /11111111/, "the short sid is the unambiguous handle");
+      assert.match(seen.subtitles[0], /card 248/, "and the card is the human one, when there is one");
+      assert.equal(seen.hScroll, false, "identity must not cost a horizontal scrollbar at " + w + "px");
+      assert.deepEqual(seen.overflow, [false, false, false],
+        "and must not be clipped inside its own row: " + JSON.stringify(seen.subtitles));
+    } finally { await s.close(); }
+  });
+
+  test(`F1 live @${w}x${h}: the close confirm names the session`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`(function(){ window.__asked=[];
+        window.confirm=function(m){ window.__asked.push(String(m)); return false; }; return 'ok'; })()`);
+      await s.evalIn(`document.querySelectorAll('#perch-list-body .roost-close')[1].click(); 'x'`);
+      await new Promise((r) => setTimeout(r, 400));
+      const asked = await s.json(`JSON.stringify(window.__asked)`);
+      assert.equal(asked.length, 1);
+      assert.match(asked[0], /R4 Assistant 22222222/,
+        "an irreversible confirm that names nothing cannot correct a mis-tap: " + asked[0]);
+      assert.deepEqual(stopped, [], "and a declined confirm still posts nothing");
+    } finally { await s.close(); }
+  });
+
+  test(`F3 live @${w}x${h}: a failed /roost says why instead of faking an empty list`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    roostFails = true;
+    const s = await session(w, h);
+    try {
+      const seen = await s.json(`JSON.stringify({
+        body: document.getElementById('perch-list-body').innerText.trim(),
+        newDisabled: document.getElementById('perch-new').disabled,
+        noteHidden: document.getElementById('perch-launch-note').hidden,
+        noteText: document.getElementById('perch-launch-note').textContent,
+        notePadding: getComputedStyle(document.getElementById('perch-launch-note')).padding })`);
+      // Measured before the fix: {newDisabled:true, noteHidden:true, body:"No live sessions."}
+      assert.notEqual(seen.body, "No live sessions.",
+        "a gateway blip must not report an empty roost — that is the exact symptom this task ends");
+      assert.match(seen.body, /Could not reach the session list/);
+      assert.equal(seen.noteHidden, false, "and the launcher must say why it cannot help");
+      assert.match(seen.noteText, /Could not reach the session list/);
+      // Finding 4, in the same read: "#perch-launch .empty" tied with
+      // "#perch-hub-root .empty" and lost on source order, so its padding:0
+      // never applied and the note box measured 74px tall at 412px.
+      assert.equal(seen.notePadding, "0px",
+        "the note's own padding rule must win the cascade, not merely exist");
+    } finally { roostFails = false; await s.close(); }
   });
 }


### PR DESCRIPTION
Two operator reports, neither of which needed a backend change.

> "in perch, it appears there is no way to launch a new session, rather you can only interact with already existing sessions."

> "there should also be a way to archive session in perch. right now it looks like there are 8 sessions running, most of which were started by mistake, and I cannot close them"

**The launcher was not missing — it vanished.** `listRows()` emits a startable row for a bot only when that bot has no live session, so once every perch-attached bot was busy the only rows left were existing sessions. `startSession()` existed, worked, and was unreachable. On the reporting instance one bot is perch-attached and it held eight sessions, so there was no launch affordance at all.

**Close was never wired.** `POST /interactive/:sid/stop` has been there the whole time — it closes the child, releases the card, parks the row, and `listRows` already filters stopped sessions out. The client never called it.

## Changes

`#perch-launch` lives in `#perch-list` but **outside** `#perch-list-body`, the container `renderList()`/`showListNote()` clear, so it survives every poll regardless of what the rows contain. Its roster comes from the `/roost` payload `loadList()` already fetches — no second request. One attached bot spawns with no picker; several offer a select; none says so rather than firing a request guaranteed to 403. It hands off to the existing `startSession()` verbatim.

Every live row and the open session carry a Close, gated behind a confirmation that names the session and says it cannot be reopened. 404/410 refresh quietly; closing the open session drives `applyHash → closeSession` so history stays correct.

Rows now identify themselves — `awake · 11111111 · card 248` rather than eight copies of `R4 Assistant awake`. Closing is irreversible, so telling sessions apart is a precondition for the feature, not a nicety.

## What review changed

- **Row identity** was absent in the first pass. With one bot and eight sessions the list read `R4AssistantawakeOpenCloseR4Assistantawake…` — Close existed and nothing was distinguishable. Half the second report was unserved.
- **`#perch-close` measured 36px** — it lost a specificity contest to `#perch-hub-root button`, in the same commit that raised the launch buttons to 44px on the ground that 36px is under the thumb target. The render test *collected* that height and asserted only that the element was in the viewport. Now scoped, floored, and the height asserted.
- **A failed `/roost` re-created the original symptom**: greyed-out New session beside a false "No live sessions." with no explanation. Now the launcher stays enabled and the failure is named.
- **`location.replace(pathname)`** — the obvious fix for the Back trap — fires no `hashchange`, so the close path never runs and the operator sits on a dead chat. Chosen by live measurement, not by reading.
- **A test-harness defect**: `Object.assign` copies a getter's value, so the fake element's `firstChild` was frozen at `null`, `clearEl` never removed anything, and the list body silently accumulated every render. Nothing was broken, but every list-body assertion was passing on less evidence than it claimed. Fixed and pinned.
- **A "cold deep link" test that was warm**: it set the hash after bootstrap had rendered the list, so the code took the warm branch and never ran the path the test was named for. The knob that makes it cold is itself pinned.
- **The inverted reachability claim.** A comment this branch added said `position:sticky` is "the whole reason Send is reachable". Measured, killing sticky in the shipped layout moves Send by zero pixels, while removing `#perch-chat`'s flex chain scrolls `.content-body` ~2962px with sticky still holding Send. The flex chain is the mechanism; sticky is the backstop. The pre-existing reachability tests stay **green** through a flex-chain deletion, so that comment was the only thing standing between a maintainer and deleting the rule that does the work. Corrected here and in the design record, which carried the same inversion from when Perch owned the viewport at `100dvh`.

## Verification

280 tests across nine suites, 0 skipped — the live CDP tests executed rather than skipping past a missing browser. 30 mutations confirmed red and restored.

Reviewed twice, both rounds measuring rather than reading. The second reviewer ran the reported scale — eight sessions on one bot — and confirmed eight distinct subtitles with no clipping at 412x730; deleted the `#perch-close` rule from the live stylesheet and reproduced 36px; ran the `/roost` blip in real time; and checked `history.length` across open, close and Back. It ran seven of its own client mutations beyond the assigned ones, all red in the expected tests.

Send reachability holds with a 60-line transcript scrolled to top: 668-704 in a 730px viewport, 854-890 in 900px, `.content-body` scroll 0 at both.

## Known, low, not fixed

If `/roost` fails between closing one session and confirming another, `rowIndex` is cleared and the confirm falls back to a bare short sid without the bot name. The sid is still unambiguous and the session's identity is rendered directly above the button, so the confirmation's job survives.