### PR TITLE
Board: give cards a project by default, and stop the sync's two silent failures

### DIFF
--- a/bundles/pm-workspace/server/sync/monday.js
+++ b/bundles/pm-workspace/server/sync/monday.js
@@ -47,6 +47,11 @@ const MONDAY_API = "https://api.monday.com/v2";
 const MONDAY_TIMEOUT_MS = 30_000;
 const PAGE_SIZE = 100;
 
+// Statuses that mean "this card is finished". Used only to decide whether a
+// never-mapped card may be CREATED on Monday (see syncTwowayBoard); it never
+// stops an already-mapped card from syncing.
+const TERMINAL_STATUSES = ["done", "cancelled"];
+
 // tasks_items columns the column_map may address on kanban targets.
 const KANBAN_FIELDS = new Set(["title", "description", "due_date", "priority", "owner", "tags", "phase"]);
 
@@ -367,12 +372,26 @@ async function flagRemoteDeletions(db, board, seenItemIds, totals) {
   });
   for (const row of rows) {
     if (seenItemIds.has(String(row.item_id))) continue;
-    await logSync(db, {
-      direction: "pull", board_id: board.board_id, action: "delete_flagged",
-      item_ref: `monday:${row.item_id}`,
-      detail: `Monday item ${row.item_id} no longer in pull (deleted, archived, or moved out of group_ids); local ${row.local_kind} ${row.local_id} kept`,
-      ok: true,
+    // Flag each vanished item ONCE, not once per run. A mapping whose Monday
+    // item is gone stays gone, so re-logging it every 15 minutes writes the
+    // same line forever: on one instance 74 dead mappings had produced
+    // 178,525 rows, 94% of pm_sync_log, in a database that has already been
+    // rebuilt twice. The mapping row is deliberately KEPT (dropping it would
+    // let the create step publish the card to Monday again), so silence here
+    // is the whole fix. totals.flagged still counts every dead mapping, so the
+    // run summary keeps reporting the true number.
+    const { rows: already } = await db.execute({
+      sql: "SELECT 1 FROM pm_sync_log WHERE action = 'delete_flagged' AND item_ref = ? LIMIT 1",
+      args: [`monday:${row.item_id}`],
     });
+    if (!already.length) {
+      await logSync(db, {
+        direction: "pull", board_id: board.board_id, action: "delete_flagged",
+        item_ref: `monday:${row.item_id}`,
+        detail: `Monday item ${row.item_id} no longer in pull (deleted, archived, or moved out of group_ids); local ${row.local_kind} ${row.local_id} kept`,
+        ok: true,
+      });
+    }
     totals.flagged++;
   }
 }
@@ -625,10 +644,19 @@ export async function syncTwowayBoard(db, tdb, board, items, token, totals) {
   // not have converged through migration 0004 yet.
   if (board.target.project_id != null) {
     const archivedClause = archivedAtCol ? " AND archived_at IS NULL" : "";
+    // A card that reached a TERMINAL status without ever being mapped is work
+    // that finished somewhere else; creating it on Monday now would publish a
+    // backlog of completed items nobody asked for. This is the same concern the
+    // archived guard above addresses -- archiving is just the other way a
+    // finished card leaves the board -- so the two exclusions belong together.
+    // Terminal cards that ARE already mapped keep syncing normally; this only
+    // governs first creation.
+    const terminalList = TERMINAL_STATUSES.map(() => "?").join(", ");
     const { rows: candidates } = await tdb.execute({
       sql: `SELECT * FROM tasks_items
-            WHERE project_id = ? AND parent_id IS NULL AND status != 'cancelled'${archivedClause}`,
-      args: [Number(board.target.project_id)],
+            WHERE project_id = ? AND parent_id IS NULL
+              AND status NOT IN (${terminalList})${archivedClause}`,
+      args: [Number(board.target.project_id), ...TERMINAL_STATUSES],
     });
     const { rows: mapped } = await db.execute({
       sql: "SELECT local_id FROM pm_sync_state WHERE board_id = ? AND local_kind = 'kanban'",
@@ -646,6 +674,12 @@ export async function syncTwowayBoard(db, tdb, board, items, token, totals) {
           content_hash: contentHash(kanbanRowShape(board, row)),
           monday_updated_at: created.updated_at || null,
         });
+        // `seen` was built from THIS run's pull, which happened before the item
+        // existed. flagRemoteDeletions runs after this loop and treats anything
+        // outside `seen` as vanished, so without this an item reports as
+        // deleted in the very run that created it — on a bulk backfill that
+        // turned one run's flagged count from 74 into 128.
+        seen.add(String(created.id));
         await logSync(db, {
           direction: "push", board_id: board.board_id, action: "create_remote",
           item_ref: row.title, detail: `Monday item ${created.id}`, ok: true,

--- a/servers/gateway/board/card-service.js
+++ b/servers/gateway/board/card-service.js
@@ -115,6 +115,34 @@ function lockExemptMatches(lock, lockExempt) {
 
 // ---- card side ----
 
+/**
+ * The project a card belongs to when the caller named none.
+ *
+ * A card with a NULL project_id is invisible: the Bot Board renders
+ * `WHERE project_id = ?` and the Monday sync creates remote items for the same
+ * scope, so an unprojected card exists only to whoever queries the database
+ * directly. On one instance this silently hid 97 of 190 live cards, because
+ * every card a session created arrived without one while every card pulled from
+ * Monday inherited it.
+ *
+ * When the instance has exactly ONE project board there is no ambiguity to
+ * resolve, so adopt it. With zero or several, the caller genuinely has to say,
+ * and the field stays null as before.
+ */
+async function soleProjectId(tdb) {
+  try {
+    const { rows } = await tdb.execute({
+      sql: "SELECT DISTINCT project_id FROM board_defs WHERE project_id IS NOT NULL",
+      args: [],
+    });
+    return rows.length === 1 ? Number(rows[0].project_id) : null;
+  } catch {
+    // board_defs is a Track 0 table; a store that has not migrated onto it yet
+    // keeps the old behaviour rather than failing the create.
+    return null;
+  }
+}
+
 export async function createCard(tdb, fields, actor) {
   const f = fields || {};
   let projectId = f.project_id == null ? null : Number(f.project_id);
@@ -124,6 +152,8 @@ export async function createCard(tdb, fields, actor) {
     const parent = await getCard(tdb, parentId);
     if (!parent) throw fail(`parent card not found: ${parentId}`, "bad_parent", 400);
     projectId = parent.project_id == null ? null : Number(parent.project_id);
+  } else if (projectId == null) {
+    projectId = await soleProjectId(tdb);
   }
 
   const def = await resolveBoardDef(tdb, { projectId });

--- a/tests/board-card-service.test.js
+++ b/tests/board-card-service.test.js
@@ -178,11 +178,49 @@ test("updateCard records a field diff and refuses archived cards", async () => {
   });
 });
 
+// ---- createCard project default ----
+
+test("createCard: adopts the sole project board when the caller names none", async () => {
+  await withStore(async ({ tdb }) => {
+    // The fixture defines exactly one project board (project_id 1) alongside a
+    // slug-scoped tracker board, which is the shape of a single-project
+    // instance. A card created without a project must land on that board, or it
+    // renders nowhere: the Bot Board and the Monday sync both scope by project.
+    const { id } = await createCard(tdb, { title: "unprojected", status: "pending" }, HUMAN);
+    const row = await getCard(tdb, id);
+    assert.equal(row.project_id, 1);
+  });
+});
+
+test("createCard: an explicit project_id still wins over the default", async () => {
+  await withStore(async ({ tdb }) => {
+    const { id } = await createCard(tdb, { title: "explicit", status: "pending", project_id: 1 }, HUMAN);
+    assert.equal((await getCard(tdb, id)).project_id, 1);
+  });
+});
+
+test("createCard: no default when the instance has several project boards", async () => {
+  await withStore(async ({ tdb }) => {
+    // Two project boards make the choice genuinely ambiguous, so the caller has
+    // to say which one and the field stays null rather than guessing.
+    await tdb.execute({
+      sql: "INSERT INTO board_defs (project_id, display_name, status_values, terminal_values, fields_json) VALUES (2,'Second',?,?,'[]')",
+      args: ['["pending","done"]', '["done"]'],
+    });
+    const { id } = await createCard(tdb, { title: "ambiguous", status: "pending" }, HUMAN);
+    assert.equal((await getCard(tdb, id)).project_id, null);
+  });
+});
+
 // ---- Track 1 review fix wave (Finding 1 + Finding 3) ----
 
 test("updateCard: project_id is a plain set (no re-inheritance), recorded in the diff", async () => {
   await withStore(async ({ tdb }) => {
     const { id } = await createCard(tdb, { title: "orphan", status: "pending" }, HUMAN);
+    // createCard adopts the instance's sole project board when the caller names
+    // none, so clear it explicitly: this test's subject is updateCard's
+    // project_id semantics, which need a genuinely unprojected starting card.
+    await updateCard(tdb, id, { project_id: null }, HUMAN);
     let row = await getCard(tdb, id);
     assert.equal(row.project_id, null);
 

--- a/tests/pm-monday-archive.test.js
+++ b/tests/pm-monday-archive.test.js
@@ -230,6 +230,145 @@ test("syncTwowayBoard: archived+unmapped done card is not created remotely (no r
 });
 
 // ---------------------------------------------------------------------------
+// 2b. an unarchived-but-FINISHED unmapped card is not created remotely either
+// ---------------------------------------------------------------------------
+test("syncTwowayBoard: unmapped card in a terminal status is not created remotely", async () => {
+  const f = fixture();
+  // stubFetchOk, NOT stubFetchThrows: with every create failing, a test that
+  // merely checks "no mapping for the done card" passes even with the guard
+  // removed. Letting creates SUCCEED is what makes the assertion discriminate.
+  const fetchStub = stubFetchOk();
+  try {
+    const { createDbClient } = await import("../servers/db.js");
+    const { syncTwowayBoard } = await import("../bundles/pm-workspace/server/sync/monday.js");
+
+    const t = new Database(f.tasksDbPath);
+    // None of these are archived, they are merely finished. Archiving is only
+    // ONE of the ways a card leaves the board; a card can sit done-and-live
+    // indefinitely, and publishing it would announce completed work as new.
+    const ids = {};
+    for (const [title, status] of [["Done Card", "done"], ["Cancelled Card", "cancelled"], ["Open Card", "pending"]]) {
+      ids[title] = Number(
+        t.prepare("INSERT INTO tasks_items (title, status, project_id) VALUES (?,?,?)")
+          .run(title, status, PROJECT_ID).lastInsertRowid
+      );
+    }
+    t.close();
+
+    const cdb = createDbClient(f.crowDbPath);
+    const tdb = createDbClient(f.tasksDbPath);
+    const totals = { created: 0, updated: 0, pushed: 0, conflicts: 0, flagged: 0, errors: 0 };
+
+    await syncTwowayBoard(cdb, tdb, kanbanBoard(), [], "test-token", totals);
+
+    assert.equal(totals.errors, 0);
+    assert.equal(totals.created, 1, "exactly one of the three cards may reach Monday");
+
+    const mapped = (await cdb.execute({
+      sql: "SELECT local_id FROM pm_sync_state WHERE local_kind='kanban'", args: [],
+    })).rows.map((r) => Number(r.local_id));
+    assert.deepEqual(mapped, [ids["Open Card"]], "and it is the open one");
+
+    await cdb.close();
+    await tdb.close();
+  } finally {
+    fetchStub.restore();
+    cleanup(f);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2b-ii. an item created during the run is not then reported as vanished
+// ---------------------------------------------------------------------------
+test("syncTwowayBoard: a freshly created item is not flagged as deleted in the same run", async () => {
+  const f = fixture();
+  const fetchStub = stubFetchOk();
+  try {
+    const { createDbClient } = await import("../servers/db.js");
+    const { syncTwowayBoard } = await import("../bundles/pm-workspace/server/sync/monday.js");
+
+    const t = new Database(f.tasksDbPath);
+    t.prepare("INSERT INTO tasks_items (title, status, project_id) VALUES (?,?,?)")
+      .run("Brand New Card", "pending", PROJECT_ID);
+    t.close();
+
+    const cdb = createDbClient(f.crowDbPath);
+    const tdb = createDbClient(f.tasksDbPath);
+    const totals = { created: 0, updated: 0, pushed: 0, conflicts: 0, flagged: 0, errors: 0 };
+
+    // The pull list is empty because the item did not exist when it was taken.
+    await syncTwowayBoard(cdb, tdb, kanbanBoard(), [], "test-token", totals);
+
+    assert.equal(totals.created, 1);
+    assert.equal(totals.flagged, 0, "the item it just created must not count as vanished");
+    const flags = (await cdb.execute({
+      sql: "SELECT count(*) AS n FROM pm_sync_log WHERE action='delete_flagged'", args: [],
+    })).rows[0];
+    assert.equal(Number(flags.n), 0);
+
+    await cdb.close();
+    await tdb.close();
+  } finally {
+    fetchStub.restore();
+    cleanup(f);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2c. a vanished Monday item is flagged ONCE, not once per run
+// ---------------------------------------------------------------------------
+test("syncTwowayBoard: a dead mapping is flagged once, not on every run", async () => {
+  const f = fixture();
+  const fetchStub = stubFetchThrows();
+  try {
+    const { createDbClient } = await import("../servers/db.js");
+    const { syncTwowayBoard } = await import("../bundles/pm-workspace/server/sync/monday.js");
+
+    const t = new Database(f.tasksDbPath);
+    const rowId = Number(
+      t.prepare("INSERT INTO tasks_items (title, status, project_id, archived_at) VALUES (?,?,?,?)")
+        .run("Vanished Card", "done", PROJECT_ID, "2026-08-15T00:00:00Z").lastInsertRowid
+    );
+    t.close();
+
+    const c = new Database(f.crowDbPath);
+    c.prepare(
+      "INSERT INTO pm_sync_state (source, board_id, item_id, local_kind, local_id, content_hash, monday_updated_at) VALUES ('monday',?,?,?,?,?,?)"
+    ).run(BOARD_ID, "item-gone", "kanban", rowId, "h", "2026-01-01T00:00:00Z");
+    c.close();
+
+    const cdb = createDbClient(f.crowDbPath);
+    const tdb = createDbClient(f.tasksDbPath);
+    const board = kanbanBoard();
+
+    // Three runs with the item absent from the pull, as the real cron does
+    // every 15 minutes for as long as the mapping survives.
+    for (let i = 0; i < 3; i++) {
+      const totals = { created: 0, updated: 0, pushed: 0, conflicts: 0, flagged: 0, errors: 0 };
+      await syncTwowayBoard(cdb, tdb, board, [], "test-token", totals);
+      assert.equal(totals.flagged, 1, "every run still COUNTS the dead mapping");
+    }
+
+    const logged = (await cdb.execute({
+      sql: "SELECT count(*) AS n FROM pm_sync_log WHERE action='delete_flagged' AND item_ref='monday:item-gone'",
+      args: [],
+    })).rows[0];
+    assert.equal(Number(logged.n), 1, "but it is written to the log exactly once");
+
+    const state = (await cdb.execute({
+      sql: "SELECT count(*) AS n FROM pm_sync_state WHERE item_id='item-gone'", args: [],
+    })).rows[0];
+    assert.equal(Number(state.n), 1, "the mapping is KEPT — dropping it would let the card be re-created on Monday");
+
+    await cdb.close();
+    await tdb.close();
+  } finally {
+    fetchStub.restore();
+    cleanup(f);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // 3. pull targeting an archived row updates in place, stays archived, logs
 //    pull_archived_update, does not re-INSERT
 // ---------------------------------------------------------------------------
@@ -444,9 +583,14 @@ test("syncTwowayBoard: a store without archived_at (legacy shape) runs all paths
       t.prepare("INSERT INTO tasks_items (title, status, project_id) VALUES (?,?,?)")
         .run("Legacy Old Title", "in_progress", PROJECT_ID).lastInsertRowid
     );
-    // unmapped row → create-scan path
+    // unmapped OPEN row → create-scan path
     t.prepare("INSERT INTO tasks_items (title, status, project_id) VALUES (?,?,?)")
-      .run("Legacy Unmapped Card", "done", PROJECT_ID);
+      .run("Legacy Unmapped Card", "pending", PROJECT_ID);
+    // unmapped FINISHED row → excluded by the terminal-status guard. On a legacy
+    // store there is no archived_at to guard on, so the status check is the only
+    // thing standing between a finished card and a surprise Monday item.
+    t.prepare("INSERT INTO tasks_items (title, status, project_id) VALUES (?,?,?)")
+      .run("Legacy Unmapped Done Card", "done", PROJECT_ID);
     t.close();
 
     const c = new Database(f.crowDbPath);
@@ -482,7 +626,7 @@ test("syncTwowayBoard: a store without archived_at (legacy shape) runs all paths
 
     assert.equal(totals.errors, 0);
     assert.equal(totals.updated, 1, "the pull-target row updates");
-    assert.equal(totals.created, 1, "the unmapped done card creates remotely (no archived_at to guard on)");
+    assert.equal(totals.created, 1, "the unmapped OPEN card creates remotely; the done one is held back by the terminal-status guard");
 
     const logRows = (await cdb.execute({ sql: "SELECT action FROM pm_sync_log", args: [] })).rows;
     assert.ok(logRows.some((r) => r.action === "update_local"), "legacy row uses the normal action, not pull_archived_update");


### PR DESCRIPTION
## The bug

A card with a NULL `project_id` is invisible. The Bot Board renders `WHERE t.project_id = ?` (`dashboard/panels/bot-board/html.js`) and the Monday twoway sync creates remote items for the same scope (`sync/monday.js`), so a card without one exists only to whoever queries the database directly.

Cards pulled from Monday inherit the project from the sync target. Cards created in crow never got one. On one instance the split was perfectly clean — every projected card was Monday-mapped, every unprojected card was not:

| | done | in_progress | pending |
|---|---|---|---|
| projected (visible) | 37 | 15 | 41 |
| unprojected (**invisible**) | 43 | 6 | 48 |

97 of 190 live cards rendered nowhere, and the Monday board had been frozen for weeks. Nothing errored.

## The fix

`createCard` adopts the instance's sole project board when the caller names none. With zero or several project boards the choice is genuinely ambiguous, so the field stays null exactly as before. Subtask inheritance from the parent is unchanged and still takes precedence.

## Two more, found by backfilling a real store

- **A never-mapped card in a terminal status was created on Monday.** Restoring a project would publish a backlog of finished work as if it were new. The existing guard covered archived rows; archiving is only one of the ways a card leaves the board, and a card can sit done-and-live indefinitely.
- **`flagRemoteDeletions` re-logged every dead mapping on every run.** One instance carried 74 and had accumulated **178,525** `delete_flagged` rows — 94% of `pm_sync_log`, growing ~6,700 a day. It now logs each vanished item once and still counts them all in the run summary. The mapping row is deliberately **kept**: dropping it would let the create step republish the card.
- **`seen` was built from the run's pull**, which happens before any create, so an item was reported as vanished by the very run that created it (a 54-card backfill took one run's flagged count from 74 to 128).

## Verification

211 tests pass across `tests/board-*`, `tests/pm-monday-*` and `tests/track1-migration`.

Each new behaviour was **mutation-checked**: reverting any one of the three changes fails that change's own test and no others. The first version of the terminal-status test used a throwing fetch stub and would have passed with the guard removed — every create failed, so "no mapping for the done card" proved nothing. It was rewritten against a succeeding stub so it actually discriminates.

One existing test changed its premise rather than its subject: `updateCard: project_id is a plain set` now clears the project explicitly to get the unprojected starting card it needs.