### PR TITLE
Embedding: use last-token pooling, which is what Qwen3-Embedding is trained for

### DIFF
--- a/bundles/llamacpp-vulkan-qwen3-embed/docker-compose.yml
+++ b/bundles/llamacpp-vulkan-qwen3-embed/docker-compose.yml
@@ -27,8 +27,13 @@ services:
       - --alias
       - qwen3-embedding-0.6b
       - --embedding
+      # Qwen3-Embedding is trained with LAST-TOKEN (EOS) pooling. Mean pooling runs without
+      # error and produces vectors that cannot rank: measured 0/3 top-1 on a 5-doc/3-query
+      # retrieval check where the same model with native pooling scored 3/3, with a
+      # top1-to-top2 margin of +0.03 against +0.12. Changing this invalidates any index built
+      # against the old setting, so re-embed after changing it.
       - --pooling
-      - "mean"
+      - "last"
       - --host
       - "0.0.0.0"
       - --port


### PR DESCRIPTION
## The bug

`llamacpp-vulkan-qwen3-embed` ran `--pooling mean`. Qwen3-Embedding-0.6B is trained with last-token (EOS) pooling.

The container starts cleanly, reports healthy, serves 1024-dimension vectors and answers every request. Nothing about it looks broken. It simply cannot rank.

## Measured, not assumed

Five documents, three queries with known correct answers, same model both sides:

| pooling | top-1 correct | mean top1-to-top2 margin |
|---|---|---|
| `mean` (this container) | **0 / 3** | +0.03 |
| native (same model, vLLM) | **3 / 3** | +0.12 |

Identical input produces different vectors under the two settings, so indexes are not interchangeable between them.

## Blast radius

Changing this invalidates any index built against the old setting. On the box where it was found, the affected store held 1,251 vectors — all of them built on the configuration that scores 0/3, so the index being invalidated was already not doing useful work. Re-embed after deploying.

## Verification

The same three-query check is re-run against the container after restart and must reach 3/3 before anything is indexed against it. If it does not, revert this line.
