### PR TITLE
Perch: stop the transcript repeating, render markdown, and pick a model up front

### DIFF
--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -2617,6 +2617,7 @@ await initTable("bot_sessions table", `
     escalated         INTEGER DEFAULT 0,
     kind              TEXT NOT NULL DEFAULT 'chat',
     narrowed_tools    TEXT,
+    label             TEXT,
     created_at        TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
   );
@@ -2641,6 +2642,18 @@ await addColumnIfMissing("bot_sessions", "kind", "TEXT NOT NULL DEFAULT 'chat'")
 // idiom as `kind` above: CREATE body for fresh installs, guarded ALTER for
 // pre-existing ones. Additive-only — no SCHEMA_GENERATION bump.
 await addColumnIfMissing("bot_sessions", "narrowed_tools", "TEXT");
+
+// bot_sessions.label: an operator-settable name for a Perch session. The
+// machine-minted gateway_thread_id (perchlive-xxxxxxxx) is the IDENTITY and
+// stays so — this is a convenience the list and the chat header render
+// alongside it, never instead of it, and NULL/empty means "no name", which is
+// how clearing one works. Persisted on the session's own row rather than in a
+// second store, exactly like `status`. Same both-places idiom as `kind` and
+// `narrowed_tools` above: CREATE body for fresh installs, guarded ALTER for
+// pre-existing ones, and listed in BOT_SESSIONS_CANONICAL_COLUMNS below so the
+// control-CHECK rebuild carries it instead of aborting on it as drift.
+// Additive-only — no SCHEMA_GENERATION bump.
+await addColumnIfMissing("bot_sessions", "label", "TEXT");
 
 // bot_sessions.control CHECK widen, 'run'/'stop' -> 'run'/'stop'/'interrupted'
 // (Track 3 Task 7): stopAll() parks a session that was genuinely mid-turn
@@ -2690,8 +2703,8 @@ await addColumnIfMissing("bot_sessions", "narrowed_tools", "TEXT");
 const BOT_SESSIONS_CANONICAL_COLUMNS = [
   "id", "bot_id", "pi_session_id", "pi_session_dir", "gateway_type",
   "gateway_thread_id", "project_id", "card_id", "plan_path", "status",
-  "control", "model", "escalated", "kind", "narrowed_tools", "created_at",
-  "updated_at",
+  "control", "model", "escalated", "kind", "narrowed_tools", "label",
+  "created_at", "updated_at",
 ];
 await (async () => {
   const tableInfo = await db.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='bot_sessions'");
@@ -2752,6 +2765,7 @@ await (async () => {
         escalated         INTEGER DEFAULT 0,
         kind              TEXT NOT NULL DEFAULT 'chat',
         narrowed_tools    TEXT,
+        label             TEXT,
         created_at        TEXT NOT NULL DEFAULT (datetime('now')),
         updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
       )

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -1,4 +1,5 @@
 import { tJs } from "../shared/i18n.js";
+import { PERCH_SPLIT_MIN_WIDTH } from "./css.js";
 
 /** The hub's client script. Emitted INSIDE a template literal — a bare
  *  backtick or ${ anywhere in here breaks the module at import time.
@@ -133,7 +134,10 @@ export function perchHubJs(lang = "en") {
       if(!live.length){ out.push({botId:b.id,botName:b.name,sessionId:null,state:'idle',cardId:null,pendingUi:false}); return; }
       live.forEach(function(s){
         out.push({botId:b.id,botName:b.name,sessionId:s.sessionId,state:s.state,
-                  cardId:s.cardId==null?null:s.cardId,pendingUi:!!s.pendingUi});
+                  cardId:s.cardId==null?null:s.cardId,pendingUi:!!s.pendingUi,
+                  /* /roost carries the operator's name alongside the id
+                     (routes/perch.js) — null when there isn't one. */
+                  label:(s.label==null||s.label==='')?null:String(s.label)});
       });
     });
     /* Blocked-on-you first: those are the only rows that need you right now. */
@@ -198,6 +202,9 @@ export function perchHubJs(lang = "en") {
   var CLOSE_FAILED='${tJs("perch.closeFailed", lang)}';
   var CLOSE_FAILED_FOR='${tJs("perch.closeFailedFor", lang)}';
   var ROW_CARD='${tJs("perch.rowCard", lang)}';
+  var RENAME_LABEL='${tJs("perch.rename", lang)}';
+  var RENAME_PROMPT='${tJs("perch.renamePrompt", lang)}';
+  var RENAME_FAILED='${tJs("perch.renameFailed", lang)}';
   var ROOST_UNREACHABLE='${tJs("perch.roostUnreachable", lang)}';
 
   /* Row identity. One bot with eight sessions renders eight rows that read
@@ -221,9 +228,14 @@ export function perchHubJs(lang = "en") {
   /* What the confirm calls the session it is about to destroy. A confirm that
      names nothing cannot correct a mis-tap, which is the only thing it is
      there to do. */
+  /* Names the session in the close confirmation. The operator's own name
+     leads when there is one, but the bot and the short id STAY: an
+     irreversible confirm has to name something unambiguous, and two sessions
+     can carry the same name. */
   function sessionLabel(sid){
     var r=rowIndex[sid], short=shortSid(sid);
-    return (r&&r.botName)?(r.botName+' '+short):short;
+    var base=(r&&r.botName)?(r.botName+' '+short):short;
+    return (r&&r.label)?(r.label+' ('+base+')'):base;
   }
 
   var pendingNote=null;                 /* survives the loadList that follows a note */
@@ -249,6 +261,12 @@ export function perchHubJs(lang = "en") {
       row.appendChild(line('roost-dot',''));
       var main=document.createElement('div'); main.className='roost-main';
       main.appendChild(line('roost-cwd',r.botName));
+      /* The name on its OWN line, above the unchanged subtitle. Folding it
+         into rowSubtitle() instead would push state/id/card out of a 320px
+         column; this keeps "state · id · card" exactly as it was, which is
+         also the fallback when there is no name. textContent via line(),
+         never innerHTML — this string came from an operator. */
+      if(r.label) main.appendChild(line('roost-name',r.label));
       main.appendChild(line('roost-when',rowSubtitle(r)));
       row.appendChild(main);
       var b=document.createElement('button');
@@ -261,6 +279,11 @@ export function perchHubJs(lang = "en") {
          stop. Second button, not a swipe or a long-press: this has to work
          with a thumb on a 412px screen. */
       if(r.sessionId){
+        /* No confirm on this one: renaming is reversible and cheap. */
+        var n=document.createElement('button');
+        n.type='button'; n.className='roost-rename'; n.textContent=RENAME_LABEL;
+        n.onclick=function(){ renameSession(r.sessionId,r.label||''); };
+        row.appendChild(n);
         var x=document.createElement('button');
         x.type='button'; x.className='roost-close'; x.textContent=CLOSE_LABEL;
         x.onclick=function(){ stopSession(r.sessionId); };
@@ -440,6 +463,29 @@ export function perchHubJs(lang = "en") {
      resolves against the right session. current.sid is consulted only to
      decide WHERE the outcome is shown — and, on success, to leave a chat view
      whose SSE stream the engine has just closed. */
+  /* Rename, or clear a name. No confirm — this is reversible and touches no
+     child; the confirm on stopSession() below exists because THAT is
+     terminal. prompt() returning null is a CANCEL and must do nothing;
+     returning '' is a deliberate CLEAR and must go through, which is why this
+     branches on null rather than on falsiness. */
+  function renameSession(sid,currentLabel){
+    if(!sid) return;
+    var next=prompt(RENAME_PROMPT,String(currentLabel==null?'':currentLabel));
+    if(next===null) return;                       /* cancelled, not cleared */
+    perchApi('POST','/interactive/'+encodeURIComponent(sid)+'/rename',{label:next}).then(function(r){
+      if(!r.ok){
+        if(current.sid===sid) appendNote(RENAME_FAILED); else showListNote(RENAME_FAILED);
+        return;
+      }
+      /* The engine normalizes (trim, cap, empty -> null), so the stored value
+         is what comes BACK, never what was typed. */
+      var stored=(r.j&&r.j.label)||null;
+      if(rowIndex[sid]) rowIndex[sid].label=stored;
+      if(current.sid===sid) showSessionName(stored);
+      loadList();
+    });
+  }
+
   function stopSession(sid){
     if(!sid) return;
     if(!confirm(CLOSE_CONFIRM.replace('{session}',sessionLabel(sid)))) return;
@@ -561,9 +607,32 @@ export function perchHubJs(lang = "en") {
      still polling, still rendering rows, still opening streams. */
   function startListPolling(){ stopListPolling(); listTimer=setInterval(function(){ if(live()) loadList(); },10000); }
   function stopListPolling(){ if(listTimer){ clearInterval(listTimer); listTimer=null; } }
+
+  /* Whether the session list is ON SCREEN, which is the only thing that
+     decides whether it must keep polling — NOT which view is "current".
+     At and above the split breakpoint (perch-hub/css.js's
+     PERCH_SPLIT_MIN_WIDTH; the media query and this share the one constant)
+     .hub-split is a two-column grid and body[data-view="chat"] #perch-list is
+     display:block, so opening a session leaves the list right there beside it.
+     Stopping the poll on open therefore froze a VISIBLE list: an operator on a
+     1900px window saw "R4 Assistant / idle" with a Talk button next to the
+     awake session he was typing in, and no Close anywhere on that surface,
+     because Close only exists on a live row. */
+  var SPLIT=window.matchMedia?window.matchMedia('(min-width:${PERCH_SPLIT_MIN_WIDTH}px)'):null;
+  function listOnScreen(){ return body.getAttribute('data-view')==='list'||!!(SPLIT&&SPLIT.matches); }
+  function syncListPolling(){
+    if(listOnScreen()){ startListPolling(); loadList(); }
+    else stopListPolling();                    /* below the breakpoint it really is hidden */
+  }
+  /* Crossing the breakpoint changes the answer with no view change and no
+     navigation — the same class of problem shared/layout.js's own sidebar
+     matchMedia listener handles, and the same guard: a retired instance must
+     not start polling again from here. */
+  if(SPLIT&&SPLIT.addEventListener) SPLIT.addEventListener('change',function(){ if(live()) syncListPolling(); });
+
   window.addEventListener('focus',function(){
     if(!live()) return;
-    if(body.getAttribute('data-view')==='list') loadList();
+    if(listOnScreen()) loadList();
   });
 
   /* Engine-minted ids only: "perchlive-" + 8 hex (perch-interactive.js:1473).
@@ -588,7 +657,10 @@ export function perchHubJs(lang = "en") {
     current.sid=sid;
     var mySid=sid;                          /* identity guard for every await below */
     setView('chat');
-    stopListPolling();                      /* SSE is the live signal here */
+    /* SSE is the live signal for the CHAT. It says nothing about the list,
+       which in split view is still on screen — so the poll stops only when the
+       list is genuinely hidden. */
+    syncListPolling();
     clearEl(el('perch-transcript')); clearEl(el('perch-ask'));
     resetControls();                        /* the PREVIOUS session's picker must not bleed in */
     var known=rowIndex[sid];
@@ -721,6 +793,10 @@ export function perchHubJs(lang = "en") {
     on('state',function(d){
       setTurnInFlight(turnFlagFor(d));
       el('perch-state').textContent=d.state||'';
+      /* The engine echoes the label on every state frame, so a rename made
+         from the list row (or another tab) shows up here without a reload. */
+      if(rowIndex[sid]) rowIndex[sid].label=d.label||null;
+      showSessionName(d.label||null);
       /* Reflects the engine's own record (snapshot()/stateEvent() in
          perch-interactive.js), never the picker back at it — setting
          .value/.checked does not fire change, so this cannot loop. */
@@ -762,9 +838,20 @@ export function perchHubJs(lang = "en") {
     es.onerror=onStreamError;
   }
 
+  /* The name line in the chat header. textContent and \`hidden\` only — the
+     value is operator free text and must never reach an HTML sink. */
+  function showSessionName(label){
+    var e=el('perch-session-name'); if(!e) return;
+    e.textContent=label==null?'':String(label);
+    e.hidden=!label;
+  }
   function showHeader(botId,botName){
     el('perch-bot-name').textContent=botName||botId;
+    /* The session id stays here, unchanged and on its own: it is the identity
+       the close confirm and every API path use. */
     el('perch-session-meta').textContent=current.sid||'';
+    var known=rowIndex[current.sid];
+    showSessionName(known?known.label:null);
   }
   /* Bounded backoff. TWO separate operations, and conflating them is what made
      an earlier draft of this dead code: cancelling the TIMER must not reset the
@@ -869,6 +956,7 @@ export function perchHubJs(lang = "en") {
     var modelSel=el('perch-model'), thinkSel=el('perch-thinking');
     if(modelSel){ clearEl(modelSel); modelSel.disabled=true; }
     if(thinkSel){ clearEl(thinkSel); thinkSel.disabled=true; }
+    showSessionName(null);       /* the PREVIOUS session's name must not bleed in */
     var permSel=el('perch-permission'); if(permSel) permSel.value='guarded';
     var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=false;
     setTurnInFlight(false);      /* the PREVIOUS session's Steer/Stop state must not bleed in */
@@ -1072,6 +1160,10 @@ export function perchHubJs(lang = "en") {
   }
   el('perch-abort').onclick=abortTurn;
   el('perch-close').onclick=function(){ stopSession(current.sid); };
+  el('perch-rename').onclick=function(){
+    var known=rowIndex[current.sid];
+    renameSession(current.sid,(known&&known.label)||'');
+  };
 
   /* iOS does not shrink the layout viewport for the keyboard, so dvh alone
      leaves the composer behind it. Offset the chat column by the hidden part. */

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -898,7 +898,16 @@ export function perchHubJs(lang = "en") {
     /* MESSAGE-LEVEL, not delta-level (perch-interactive.js:1257 says so
        outright): one frame per COMPLETED assistant message, so each is
        rendered on arrival and nothing has to be patched afterwards. */
-    on('text',function(d){ appendMessage('bot','bot',d.text||'',d.html); turnRendered=true; });
+    on('text',function(d){
+      /* The engine only emits \`text\` for a NON-EMPTY assistant message
+         (perch-interactive.js's message_end branch), so an empty one here is a
+         frame whose JSON did not parse — on()'s \`d={}\` fallback. Appending it
+         put an empty entry in the transcript AND marked the turn rendered,
+         suppressing the real reply. Skip it entirely. */
+      if(!d.text) return;
+      appendMessage('bot','bot',d.text,d.html);
+      if(d.turnId) renderedTurn=d.turnId; else turnRendered=true;
+    });
     on('tool',function(d){ if(d.phase==='start') appendNote('['+(d.name||'?')+']'); });
     on('log',function(d){ if(d.text) appendNote(d.text); });
     /* \`reply\` carries replyTextOf(end) — every assistant message of the turn
@@ -914,7 +923,11 @@ export function perchHubJs(lang = "en") {
        streamed, and \`reply\` is the only copy of that answer they will get.
        Flag read BEFORE setTurnInFlight(false), which is what resets it. */
     on('reply',function(d){
-      if(!turnRendered&&d.text) appendMessage('bot','bot',d.text,d.html);
+      /* Judged against THIS turn when the frame names one, and only against the
+         client's transition flag when it does not. Read before
+         setTurnInFlight(false), which is what resets that flag. */
+      var already=d.turnId?(renderedTurn===d.turnId):turnRendered;
+      if(!already&&d.text) appendMessage('bot','bot',d.text,d.html);
       setTurnInFlight(false);
     });
     on('ask_user',function(d){ renderAsk(d); });
@@ -1105,6 +1118,7 @@ export function perchHubJs(lang = "en") {
     var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=false;
     setTurnInFlight(false);      /* the PREVIOUS session's Steer/Stop state must not bleed in */
     turnRendered=false;          /* nor its "this turn already rendered" bookkeeping */
+    renderedTurn=null;           /* nor the turn id that bookkeeping now keys on */
     pendingImages=[];            /* nor its queued-but-unsent image */
   }
 
@@ -1135,8 +1149,30 @@ export function perchHubJs(lang = "en") {
   }
 
   var turnInFlight=false;
-  /* Did anything render for the turn currently in flight? See the \`reply\`
-     listener for why this exists and why it is per TURN. */
+  /* Which turn the transcript has already rendered text for.
+
+     Fix round 2 N1: the previous version of this was a BOOLEAN reset on the
+     false->true turnInFlight transition, and it survived a stream teardown. A
+     reconnect that missed the separating turnInFlight:false frame — a 2s blip
+     inside the client's own backoff, with turn 1 ending and turn 2 running
+     inside it — therefore left the flag stale-true and suppressed turn 2's
+     reply entirely. The engine's replay-on-subscribe does NOT close that: the
+     replayed frame is turnInFlight:true and the client is already true, so
+     there is no transition and no reset. Measured: turn 2's answer never
+     rendered at all, which is worse than the duplicate the flag exists to
+     prevent.
+
+     Identity, not memory, is the fix: the frames now carry the turn they
+     belong to, so \`reply\` judges its OWN turn. A cross-turn reconnect sees a
+     different id and renders; a SAME-turn reconnect sees the same id and stays
+     suppressed. The bare alternative — resetting the flag in openStream() —
+     fixes the first case by reintroducing the second, and that trade is the
+     reason this is a turn id instead. */
+  var renderedTurn=null;
+  /* The fallback for a frame that carries NO turn id (the child speaking
+     outside a turn, or a gateway older than this script). Same transition-reset
+     rule as before, and the same reason for it: several turnInFlight:true
+     frames land inside one turn. */
   var turnRendered=false;
   function setTurnInFlight(flag){
     var next=!!flag;

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -185,6 +185,7 @@ export function perchHubJs(lang = "en") {
   var FILE_QUEUED='${tJs("perch.fileQueued", lang)}';
   var FILE_FAILED='${tJs("perch.fileFailed", lang)}';
   var NO_TRANSCRIPT='${tJs("perch.noTranscript", lang)}';
+  var TRANSCRIPT_FAILED='${tJs("perch.transcriptFailed", lang)}';
   var RECONNECTING='${tJs("perch.reconnecting", lang)}';
   var RECONNECT_FAILED='${tJs("perch.reconnectFailed", lang)}';
   var ASK_STALE='${tJs("perch.askStale", lang)}';
@@ -879,7 +880,13 @@ export function perchHubJs(lang = "en") {
     perchApi('GET','/bots/'+encodeURIComponent(botId)+'/sessions/'+encodeURIComponent(sid)+'/transcript')
       .then(function(r){
         if(current.sid!==mySid) return;            /* identity guard, as everywhere */
-        var events=(r.ok&&r.j&&r.j.events)||[];
+        /* A FAILED FETCH IS NOT AN EMPTY TRANSCRIPT. The old
+           \`(r.ok&&r.j&&r.j.events)||[]\` collapsed a 500, a dropped tunnel and
+           a logged-out session into the same "No transcript yet." — a
+           reassuring sentence about a conversation that is still there. Say
+           which happened. */
+        if(!r.ok||!r.j){ appendNote(TRANSCRIPT_FAILED); return; }
+        var events=r.j.events||[];
         if(!events.length){ appendNote(NO_TRANSCRIPT); return; }
         events.filter(function(e){ return e&&e.type==='message'; }).forEach(function(e){
           var m=e.message||{};

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -112,11 +112,31 @@ export function perchHubJs(lang = "en") {
     tr.appendChild(line('entry note',text));
     tr.scrollTop=tr.scrollHeight;
   }
-  function appendMessage(cls,who,text){
+  /* THE ONLY innerHTML assignment in this file, and the only one there may be.
+
+     \`html\` is produced on the SERVER by servers/blog/renderer.js — marked
+     plus sanitize-html with an explicit allow-list, the same path the memory
+     panel uses — and reaches here on the transcript payload and on the SSE
+     frame. Bot output is model-generated and can carry tool results read from
+     files, so the RAW text is never trusted: appendMessage falls back to
+     line()'s textContent whenever \`html\` is absent or empty, which is what a
+     failed render, an older gateway, or a non-prose frame all produce. */
+  function setSanitizedHtml(node,html){ node.innerHTML=html; }
+
+  /* \`html\` is optional and server-rendered; without it this is byte-for-byte
+     the old textContent behaviour. */
+  function appendMessage(cls,who,text,html){
     var tr=el('perch-transcript'); if(!tr) return;
     var row=document.createElement('div'); row.className='entry '+cls;
     row.appendChild(line('who',who));
-    row.appendChild(line('what',text));      /* textContent, never innerHTML */
+    if(html&&typeof html==='string'){
+      var what=document.createElement('div');
+      what.className='what md';
+      setSanitizedHtml(what,html);
+      row.appendChild(what);
+    } else {
+      row.appendChild(line('what',text));   /* textContent, never innerHTML */
+    }
     tr.appendChild(row);
     tr.scrollTop=tr.scrollHeight;
   }
@@ -878,7 +898,7 @@ export function perchHubJs(lang = "en") {
     /* MESSAGE-LEVEL, not delta-level (perch-interactive.js:1257 says so
        outright): one frame per COMPLETED assistant message, so each is
        rendered on arrival and nothing has to be patched afterwards. */
-    on('text',function(d){ appendMessage('bot','bot',d.text||''); turnRendered=true; });
+    on('text',function(d){ appendMessage('bot','bot',d.text||'',d.html); turnRendered=true; });
     on('tool',function(d){ if(d.phase==='start') appendNote('['+(d.name||'?')+']'); });
     on('log',function(d){ if(d.text) appendNote(d.text); });
     /* \`reply\` carries replyTextOf(end) — every assistant message of the turn
@@ -894,7 +914,7 @@ export function perchHubJs(lang = "en") {
        streamed, and \`reply\` is the only copy of that answer they will get.
        Flag read BEFORE setTurnInFlight(false), which is what resets it. */
     on('reply',function(d){
-      if(!turnRendered&&d.text) appendMessage('bot','bot',d.text);
+      if(!turnRendered&&d.text) appendMessage('bot','bot',d.text,d.html);
       setTurnInFlight(false);
     });
     on('ask_user',function(d){ renderAsk(d); });
@@ -979,7 +999,11 @@ export function perchHubJs(lang = "en") {
         if(!events.length){ appendNote(NO_TRANSCRIPT); return; }
         events.filter(function(e){ return e&&e.type==='message'; }).forEach(function(e){
           var m=e.message||{};
-          appendMessage(String(m.role||'?')==='user'?'user':'bot', String(m.role||'?'), messageText(m));
+          /* e.html is present only for an ASSISTANT message that had text
+             (routes/perch.js's assistantHtml) — the operator's own typing is
+             not markdown, and a pure tool-call message still renders as
+             messageText()'s "[tool: name]" line. */
+          appendMessage(String(m.role||'?')==='user'?'user':'bot', String(m.role||'?'), messageText(m), e.html);
         });
       });
   }

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -875,10 +875,28 @@ export function perchHubJs(lang = "en") {
       if(d.permissionMode){ var permSel=el('perch-permission'); if(permSel) permSel.value=d.permissionMode; }
       var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=!!d.planMode;
     });
-    on('text',function(d){ appendMessage('bot','bot',d.text||''); });
+    /* MESSAGE-LEVEL, not delta-level (perch-interactive.js:1257 says so
+       outright): one frame per COMPLETED assistant message, so each is
+       rendered on arrival and nothing has to be patched afterwards. */
+    on('text',function(d){ appendMessage('bot','bot',d.text||''); turnRendered=true; });
     on('tool',function(d){ if(d.phase==='start') appendNote('['+(d.name||'?')+']'); });
     on('log',function(d){ if(d.text) appendNote(d.text); });
-    on('reply',function(d){ appendMessage('bot','bot',d.text||''); setTurnInFlight(false); });
+    /* \`reply\` carries replyTextOf(end) — every assistant message of the turn
+       CONCATENATED — so appending it unconditionally rendered a two-message
+       turn three times: each message, then both again as one block. It cannot
+       simply stop being handled either: it clears the turn flag, and its text
+       comes from the agent_end the engine was handed rather than the child's
+       accumulating log (which trimLog() empties), so it is the more
+       authoritative source when it is the only one.
+       So: append ONLY when nothing rendered for this turn. That case is real,
+       not theoretical — the stream carries no backlog, so an operator who
+       opens the drawer mid-turn sees no \`text\` frames for the messages already
+       streamed, and \`reply\` is the only copy of that answer they will get.
+       Flag read BEFORE setTurnInFlight(false), which is what resets it. */
+    on('reply',function(d){
+      if(!turnRendered&&d.text) appendMessage('bot','bot',d.text);
+      setTurnInFlight(false);
+    });
     on('ask_user',function(d){ renderAsk(d); });
     on('error',function(d){ appendNote(d.text||'error'); });
     on('plan_state',function(d){ var t=planStateText(d.state); if(t) appendNote(t); });
@@ -1062,6 +1080,7 @@ export function perchHubJs(lang = "en") {
     var permSel=el('perch-permission'); if(permSel) permSel.value='guarded';
     var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=false;
     setTurnInFlight(false);      /* the PREVIOUS session's Steer/Stop state must not bleed in */
+    turnRendered=false;          /* nor its "this turn already rendered" bookkeeping */
     pendingImages=[];            /* nor its queued-but-unsent image */
   }
 
@@ -1092,8 +1111,18 @@ export function perchHubJs(lang = "en") {
   }
 
   var turnInFlight=false;
+  /* Did anything render for the turn currently in flight? See the \`reply\`
+     listener for why this exists and why it is per TURN. */
+  var turnRendered=false;
   function setTurnInFlight(flag){
-    turnInFlight=!!flag;
+    var next=!!flag;
+    /* Reset on the false->TRUE TRANSITION only. stateEvent() is emitted for
+       model_select, ask_user and aborts as well as turn start, so several
+       frames carrying turnInFlight:true can land between the first \`text\` and
+       the \`reply\` — resetting on every true frame would put the duplicate
+       straight back. */
+    if(next&&!turnInFlight) turnRendered=false;
+    turnInFlight=next;
     el('perch-send').textContent=turnInFlight?STEER_LABEL:SEND_LABEL;
     el('perch-abort').style.display=turnInFlight?'':'none';
   }

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -191,6 +191,8 @@ export function perchHubJs(lang = "en") {
   var ASK_CANCEL='${tJs("perch.askCancel", lang)}';
   var ASK_SUBMIT='${tJs("perch.askSubmit", lang)}';
   var NO_ATTACHED_BOTS='${tJs("perch.noAttachedBots", lang)}';
+  var MODEL_BOT_DEFAULT='${tJs("perch.modelBotDefault", lang)}';
+  var LAUNCH_MODEL_FAILED='${tJs("perch.launchModelFailed", lang)}';
   var CLOSE_LABEL='${tJs("perch.close", lang)}';
   var CLOSE_CONFIRM='${tJs("perch.closeConfirm", lang)}';
   var CLOSE_FAILED='${tJs("perch.closeFailed", lang)}';
@@ -302,14 +304,18 @@ export function perchHubJs(lang = "en") {
       if(sel){ sel.hidden=true; if(changed) clearEl(sel); }
       if(lbl) lbl.hidden=true;
       setLaunchNote(NO_ATTACHED_BOTS);
+      hideLaunchModels();          /* no bot, no model list that means anything */
       return;
     }
     btn.disabled=false;
     setLaunchNote('');
-    /* One attached bot is the common case (and Kevin's): no picker, one tap. */
+    /* One attached bot is the common case (and Kevin's): no BOT picker, one
+       tap. The MODEL picker is still offered — it is per-bot, not per-roster,
+       and this is the path his instance actually takes. */
     if(bots.length===1){
       if(sel){ sel.hidden=true; if(changed) clearEl(sel); }
       if(lbl) lbl.hidden=true;
+      syncLaunchModels();
       return;
     }
     if(lbl) lbl.hidden=false;
@@ -329,7 +335,79 @@ export function perchHubJs(lang = "en") {
         if(keep&&bots.filter(function(b){ return b.id===keep; }).length) sel.value=keep;
       }
     }
+    syncLaunchModels();
   }
+
+  /* ---- the launcher's model picker ------------------------------------
+     Models are per-bot, and the session whose model this chooses does not
+     exist yet — so this reads GET /bots/<id>/models (perch-model-catalog.js
+     behind it), NOT /interactive/<sid>/options, which is keyed on a session
+     id. It follows whichever bot the roster select is on.
+
+     \`botId\` is the roster the list belongs to; \`want\` is the fetch in
+     flight. Fetching only when the bot CHANGES matters: renderLauncher runs
+     on every 10s poll, and repopulating unconditionally would throw away the
+     operator's pick mid-tap — the same reason the bot roster itself is
+     rebuilt only on a real change. */
+  var launchModels={botId:null,default:null,want:null};
+
+  /* Which bot the launcher would spawn against right now. startNewSession()
+     resolves the same thing for the same reason; both go through here so the
+     model list and the spawn can never disagree about the bot. */
+  function launchBotId(){
+    if(!launchBots.length) return null;
+    if(launchBots.length>1){
+      var sel=el('perch-new-bot');
+      var want=sel?String(sel.value||''):'';
+      var hit=launchBots.filter(function(b){ return b.id===want; })[0];
+      if(hit) return hit.id;
+    }
+    return launchBots[0].id;
+  }
+
+  function hideLaunchModels(){
+    var sel=el('perch-new-model'), lbl=el('perch-new-model-label');
+    if(sel){ sel.hidden=true; clearEl(sel); }
+    if(lbl) lbl.hidden=true;
+    /* want cleared too, so the next poll retries a list that failed to load
+       rather than leaving the picker permanently absent. */
+    launchModels={botId:null,default:null,want:null};
+  }
+
+  function renderLaunchModels(list,dflt){
+    var sel=el('perch-new-model'), lbl=el('perch-new-model-label');
+    if(!sel) return;
+    clearEl(sel);
+    list.forEach(function(m){
+      var opt=document.createElement('option');
+      var key=(m&&m.provider)+'/'+(m&&m.id);
+      opt.value=key;
+      /* modelOptionText carries the availability annotation, so an
+         unavailable model reads as unavailable here exactly as it does in
+         the drawer — never a silently selectable dead choice. */
+      opt.textContent=modelOptionText(m)+(key===dflt?' \u2014 '+MODEL_BOT_DEFAULT:'');
+      sel.appendChild(opt);
+    });
+    /* Pre-selected on the bot's own configured model: an operator who does
+       not care taps the button and gets what the bot was built with. */
+    if(dflt&&list.filter(function(m){ return (m&&m.provider)+'/'+(m&&m.id)===dflt; }).length) sel.value=dflt;
+    sel.hidden=false;
+    if(lbl) lbl.hidden=false;
+  }
+
+  function syncLaunchModels(){
+    var botId=launchBotId();
+    if(!botId){ hideLaunchModels(); return; }
+    if(launchModels.botId===botId||launchModels.want===botId) return;   /* shown, or in flight */
+    launchModels.want=botId;
+    perchApi('GET','/bots/'+encodeURIComponent(botId)+'/models').then(function(r){
+      if(launchModels.want!==botId) return;      /* the operator moved to another bot */
+      if(!r.ok||!r.j||!Array.isArray(r.j.models)||!r.j.models.length){ hideLaunchModels(); return; }
+      launchModels={botId:botId,default:r.j['default']||null,want:null};
+      renderLaunchModels(r.j.models,launchModels.default);
+    });
+  }
+  el('perch-new-bot').onchange=function(){ syncLaunchModels(); };
 
   /* The launch control's own handler. Resolves the bot from the picker when
      there is one, then hands off to startSession() verbatim — the 409/403/
@@ -344,7 +422,11 @@ export function perchHubJs(lang = "en") {
       var hit=launchBots.filter(function(b){ return b.id===want; })[0];
       if(hit) pick=hit;
     }
-    startSession(pick.id,pick.name);
+    /* Only a list that belongs to THIS bot may speak for it — a picker still
+       showing the previous bot's models must not choose for this spawn. */
+    var msel=el('perch-new-model');
+    var model=(msel&&!msel.hidden&&launchModels.botId===pick.id)?String(msel.value||''):'';
+    startSession(pick.id,pick.name,model);
   }
   el('perch-new').onclick=startNewSession;
 
@@ -396,8 +478,10 @@ export function perchHubJs(lang = "en") {
   }
 
   /* A bot with no session: spawn, then let the hash router open it, so history
-     stays correct and the cold-deep-link path is the same code. */
-  function startSession(botId,botName){
+     stays correct and the cold-deep-link path is the same code.
+     \`modelKey\` ("provider/id", optional) is the launcher's pick. A row-driven
+     spawn passes none and behaves exactly as it always has. */
+  function startSession(botId,botName,modelKey){
     var mySid=current.sid;                  /* identity guard: a spawn resolving after the
                                                 operator has opened another session must not
                                                 yank them out of it */
@@ -414,8 +498,28 @@ export function perchHubJs(lang = "en") {
       if(r.status===409){ setLaunchNote(ENGINE_REQUIRED); return; }
       if(r.status===403){ setLaunchNote(NOT_ATTACHED); return; }
       if(!r.ok||!r.j||!r.j.sessionId){ setLaunchNote(START_FAILED); return; }
-      rowIndex[r.j.sessionId]={botId:botId,botName:botName,sessionId:r.j.sessionId};
-      location.hash=r.j.sessionId;
+      var sid=r.j.sessionId;
+      rowIndex[sid]={botId:botId,botName:botName,sessionId:sid};
+      /* The model, applied BEFORE the first message and before the operator
+         can send one. spawn() takes no model on purpose — the engine's
+         control-before-wake path already exists (perch-interactive.js:78-92)
+         and is the one the drawer's own picker uses. On a session this fresh
+         the child is up but has never run a turn, so control() warms the
+         chosen provider and set_model's it while nothing is in flight: the
+         first turn is served by it, not a later switch.
+         Nothing to do when the pick IS the bot's default — that is what the
+         spawn already resolved, and a redundant switch would warm a provider
+         twice for no change. */
+      if(!modelKey||modelKey===launchModels.default){ location.hash=sid; return; }
+      perchApi('POST','/interactive/'+encodeURIComponent(sid)+'/control',controlBody('model',modelKey))
+        .then(function(c){
+          if(current.sid!==mySid) return;   /* same identity guard as the spawn above */
+          /* A refused switch is not a refused session: the session is real
+             and usable on the bot's own model, so say what happened and open
+             it rather than stranding a live child behind an error. */
+          if(!c.ok) setLaunchNote(LAUNCH_MODEL_FAILED);
+          location.hash=sid;
+        });
     });
   }
 
@@ -698,10 +802,15 @@ export function perchHubJs(lang = "en") {
   }
 
   /* Track 3 Task 4: session controls — model, thinking level, permission
-     mode, plan mode. Both models and thinkingLevels are null while the
-     session hibernates (perch-interactive.js:1877): the engine will not
-     wake a child merely to list, so optionsUsable() gates a DISABLED pair
-     of selects rather than an empty-but-enabled one. */
+     mode, plan mode.
+     The two lists are gated SEPARATELY, because they no longer arrive or
+     fail together. A hibernating session now answers with the instance's
+     provider catalogue for \`models\` and \`thinkingLevels: null\` (the engine's
+     options() doc says why: a model switch made while asleep binds at the
+     next wake and really works, a thinking switch does nothing at all). A
+     single shared gate would therefore disable the picker that WORKS because
+     of the one that does not — which is exactly the empty, dead model
+     dropdown this fixes. */
   /* "up" is deliberately undecorated: a working choice should read as the
      plain default. The name is on the payload; the drawer read m.label, which
      no provider row sets, and every model listed as provider/id for months. */
@@ -712,9 +821,11 @@ export function perchHubJs(lang = "en") {
     return text;
   }
 
+  /* One list, one answer: a non-empty array is usable, anything else (null,
+     [], absent, a non-array) is not. */
+  function listUsable(a){ return !!(Array.isArray(a)&&a.length); }
   function optionsUsable(o){
-    return !!(o&&Array.isArray(o.models)&&o.models.length
-              &&Array.isArray(o.thinkingLevels)&&o.thinkingLevels.length);
+    return !!o&&listUsable(o.models)&&listUsable(o.thinkingLevels);
   }
 
   /* Populates #perch-model / #perch-thinking from GET .../options, or
@@ -724,19 +835,23 @@ export function perchHubJs(lang = "en") {
     var modelSel=el('perch-model'), thinkSel=el('perch-thinking');
     if(!modelSel||!thinkSel) return;
     clearEl(modelSel); clearEl(thinkSel);
-    if(!optionsUsable(o)){ modelSel.disabled=true; thinkSel.disabled=true; return; }
-    o.models.forEach(function(m){
+    var models=(o&&listUsable(o.models))?o.models:null;
+    var levels=(o&&listUsable(o.thinkingLevels))?o.thinkingLevels:null;
+    if(models) models.forEach(function(m){
       var opt=document.createElement('option');
       opt.value=(m&&m.provider)+'/'+(m&&m.id);
       opt.textContent=modelOptionText(m);
       modelSel.appendChild(opt);
     });
-    o.thinkingLevels.forEach(function(lv){
+    if(levels) levels.forEach(function(lv){
       var opt=document.createElement('option');
       opt.value=lv; opt.textContent=lv;
       thinkSel.appendChild(opt);
     });
-    modelSel.disabled=false; thinkSel.disabled=false;
+    /* Each select is enabled iff ITS OWN list arrived — never an empty
+       dropdown that looks like a broken page, and never a disabled one for a
+       list that is right there. */
+    modelSel.disabled=!models; thinkSel.disabled=!levels;
   }
 
   function loadOptions(sid){

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -18,6 +18,61 @@ export function perchHubJs(lang = "en") {
   function line(cls,text){ var d=document.createElement('div');
     if(cls) d.className=cls; d.textContent=text==null?'':String(text); return d; }
 
+  /* ── ONE ACTIVE INSTANCE PER DOCUMENT ─────────────────────────────────────
+     The dashboard runs Turbo Drive (shared/layout.js's turboHead(), on unless
+     CROW_ENABLE_TURBO=0). A Turbo visit REPLACES <body> WITHOUT reloading the
+     JS realm, so this script runs again while every closure the previous run
+     created is still alive — its EventSource, its 10s list-poll interval, and
+     the listeners it put on \`window\` (hashchange, focus, visualViewport),
+     which survive because \`window\` does.
+
+     Those survivors are not inert. \`el()\` resolves by id AT CALL TIME, so an
+     old instance writes into the NEW document. Measured, not theorised
+     (tests/perch-hub-stream-leak.test.js, and the scratch reproduction it was
+     written from): four visits to /dashboard/perch, then ONE tap on a session
+     row, gives four openSession()s, four loadHistory()s, four live
+     EventSource objects and four server-side /events connections — and
+     "No transcript yet." four times. The operator's own typed message is the
+     ONE thing not duplicated, because \`el('perch-send').onclick=\` is a single
+     slot the newest instance owns outright: exactly the asymmetry in the
+     transcript Kevin pasted (every streamed element ×6, his message ×1).
+
+     So instances are made mutually exclusive HERE, rather than by closing one
+     more path. A window-level registry gives two things a closure variable
+     cannot:
+       • streams closable BY IDENTITY. \`stream\` below only ever names THIS
+         instance's connection; a previous instance's is unreachable from this
+         closure, and the registry is the only thing that can still name it.
+       • a generation counter, so a retired instance's window listeners become
+         no-ops instead of a second writer. Every listener that outlives a
+         document — including any added later, e.g. a matchMedia breakpoint
+         listener — must be guarded with live().
+     ──────────────────────────────────────────────────────────────────────── */
+  var HUB=window.__crowPerchHub||(window.__crowPerchHub={gen:0,streams:{},retire:null});
+  /* Retire the previous instance BEFORE this one wires anything up.
+     BACKSTOP, not the mechanism: with Turbo present the outgoing instance has
+     already retired itself on turbo:before-render below, and deleting this
+     line leaves the whole leak suite green (measured). It is what still runs
+     if that event never fires — a Turbo upgrade that renames it, or any other
+     path that re-executes this script in a live document. */
+  if(HUB.retire){ try{ HUB.retire(); }catch(e){} }
+  var GEN=++HUB.gen, retired=false;
+  /* True only for the instance that owns the document right now. */
+  function live(){ return !retired&&HUB.gen===GEN; }
+  HUB.retire=function(){
+    retired=true;
+    stopListPolling(); cancelReconnect(); closeStream();
+    /* Anything left in the registry belongs to an instance older still (or to
+       a session this one never held): close it by identity — that is the
+       whole point of keeping the registry. */
+    for(var k in HUB.streams){ try{ HUB.streams[k].close(); }catch(e){} delete HUB.streams[k]; }
+  };
+  /* Turbo tears the document down before the next instance's script runs, so
+     retire on the way out too: without it this instance keeps a live SSE
+     connection (and a gateway-side subscriber) for the whole time the
+     operator is looking at some other panel. */
+  document.addEventListener('turbo:before-render',function(){ if(live()) HUB.retire(); });
+
   /* The two transcript writers. Defined HERE because the error and
      empty-transcript paths call them, and those are the FIRST paths a user
      hits when something goes wrong — a ReferenceError there is invisible to a
@@ -397,9 +452,15 @@ export function perchHubJs(lang = "en") {
   }
   /* Poll only while the list is showing. In the chat view the SSE stream is
      already the live signal, so polling there is pure waste. */
-  function startListPolling(){ stopListPolling(); listTimer=setInterval(loadList,10000); }
+  /* Every timer and window listener below is gated on live(): they outlive
+     the document Turbo replaces, and an ungated one is a retired instance
+     still polling, still rendering rows, still opening streams. */
+  function startListPolling(){ stopListPolling(); listTimer=setInterval(function(){ if(live()) loadList(); },10000); }
   function stopListPolling(){ if(listTimer){ clearInterval(listTimer); listTimer=null; } }
-  window.addEventListener('focus',function(){ if(body.getAttribute('data-view')==='list') loadList(); });
+  window.addEventListener('focus',function(){
+    if(!live()) return;
+    if(body.getAttribute('data-view')==='list') loadList();
+  });
 
   /* Engine-minted ids only: "perchlive-" + 8 hex (perch-interactive.js:1473).
      A loose pattern would admit ".." and this value is concatenated into an
@@ -471,7 +532,7 @@ export function perchHubJs(lang = "en") {
     var hit=parseHash(location.hash);
     if(hit) openSession(hit.sessionId); else closeSession();
   }
-  window.addEventListener('hashchange',applyHash);
+  window.addEventListener('hashchange',function(){ if(live()) applyHash(); });
 
   function planStateText(st){
     if(!st||typeof st!=='object') return typeof st==='string'?st:'';
@@ -512,21 +573,35 @@ export function perchHubJs(lang = "en") {
 
   var stream=null;
 
+  /** Drop \`es\` from the shared registry, whoever put it there. */
+  function unregisterStream(es){
+    for(var k in HUB.streams){ if(HUB.streams[k]===es) delete HUB.streams[k]; }
+  }
+
   function closeStream(){
     cancelReconnect();                 /* timer only — NOT the retry counter */
     var es=stream; stream=null;        /* null FIRST: idempotent under a double call
                                           from openSession + hashchange */
-    if(es){ try{ es.close(); }catch(e){} }
+    if(es){ try{ es.close(); }catch(e){} unregisterStream(es); }
   }
 
   function openStream(sid){
     closeStream();
+    /* EXPLICIT REPLACE, by identity. closeStream() above can only reach the
+       connection THIS instance holds; a stream opened for this session by an
+       older instance (or by a path that lost its handle) is named only by the
+       registry, and leaving it open is what multiplied every streamed event
+       by the number of surviving instances. */
+    var prev=HUB.streams[sid];
+    if(prev){ try{ prev.close(); }catch(e){} delete HUB.streams[sid]; }
     var es=new EventSource(API+'/interactive/'+encodeURIComponent(sid)+'/events');
     stream=es;
+    HUB.streams[sid]=es;
     es.onopen=function(){ resetBackoff(); };
 
     var on=function(type,fn){
       es.addEventListener(type,function(ev){
+        if(!live()) return;                           /* a retired instance never writes */
         if(current.sid!==sid) return;                 /* identity guard, every listener */
         /* A native EventSource connection failure delivers a type "error"
            Event to every listener registered for "error" via addEventListener
@@ -602,6 +677,7 @@ export function perchHubJs(lang = "en") {
     appendNote(RECONNECTING);
     var mySid=current.sid;                          /* no parameter to get wrong */
     retryTimer=setTimeout(function(){
+      if(!live()) return;                           /* retired mid-backoff */
       if(current.sid!==mySid) return;               /* navigated away mid-backoff */
       openStream(mySid);
     },2000);
@@ -887,6 +963,7 @@ export function perchHubJs(lang = "en") {
   if(window.visualViewport){
     var vv=window.visualViewport;
     var applyVV=function(){
+      if(!live()) return;
       var hidden=Math.max(0,window.innerHeight-vv.height-vv.offsetTop);
       el('perch-chat').style.paddingBottom=hidden?hidden+'px':'';
     };

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -68,11 +68,40 @@ export function perchHubJs(lang = "en") {
        whole point of keeping the registry. */
     for(var k in HUB.streams){ try{ HUB.streams[k].close(); }catch(e){} delete HUB.streams[k]; }
   };
+
+  /* ONE listener per realm, forwarding to whichever instance is current.
+
+     live() alone made a retired instance's listeners inert but left them
+     ATTACHED: measured with DOMDebugger.getEventListeners, five Turbo visits
+     took window.focus and window.hashchange from 1 to 5 while the shell's own
+     listeners stayed flat, and each retained closure holds rowIndex,
+     launchBots, launchModels and pendingImages — the last carrying base64
+     image data from any attach. The shell solves this two files away
+     (layout.js:390 / :610, "Guarded so Turbo re-executing this script does not
+     stack a new listener on every navigation"), and this is that guard with
+     one addition it does not need: the shell's handlers act on the document by
+     id, while these need INSTANCE state, so the single bound listener
+     dispatches through HUB.handlers, which each new instance overwrites with
+     its own. Bind once, always current, no growth.
+
+     live() is kept inside each handler: a retired instance with no successor
+     is still the registered handler, and must stay inert. */
+  HUB.handlers=HUB.handlers||{};
+  HUB.bound=HUB.bound||{};
+  function bindOnce(target,type,key,fn){
+    HUB.handlers[key]=fn;
+    if(HUB.bound[key]||!target||!target.addEventListener) return;
+    HUB.bound[key]=true;
+    target.addEventListener(type,function(ev){
+      var h=HUB.handlers[key]; if(h) h(ev);
+    });
+  }
+
   /* Turbo tears the document down before the next instance's script runs, so
      retire on the way out too: without it this instance keeps a live SSE
      connection (and a gateway-side subscriber) for the whole time the
      operator is looking at some other panel. */
-  document.addEventListener('turbo:before-render',function(){ if(live()) HUB.retire(); });
+  bindOnce(document,'turbo:before-render','beforeRender',function(){ if(live()) HUB.retire(); });
 
   /* The two transcript writers. Defined HERE because the error and
      empty-transcript paths call them, and those are the FIRST paths a user
@@ -197,6 +226,8 @@ export function perchHubJs(lang = "en") {
   var ASK_SUBMIT='${tJs("perch.askSubmit", lang)}';
   var NO_ATTACHED_BOTS='${tJs("perch.noAttachedBots", lang)}';
   var MODEL_BOT_DEFAULT='${tJs("perch.modelBotDefault", lang)}';
+  var MODEL_BOT_RESOLVES='${tJs("perch.modelBotResolves", lang)}';
+  var MODEL_CURRENT_UNLISTED='${tJs("perch.modelCurrentUnlisted", lang)}';
   var LAUNCH_MODEL_FAILED='${tJs("perch.launchModelFailed", lang)}';
   var CLOSE_LABEL='${tJs("perch.close", lang)}';
   var CLOSE_CONFIRM='${tJs("perch.closeConfirm", lang)}';
@@ -402,6 +433,22 @@ export function perchHubJs(lang = "en") {
     var sel=el('perch-new-model'), lbl=el('perch-new-model-label');
     if(!sel) return;
     clearEl(sel);
+    var listed=dflt&&list.filter(function(m){ return (m&&m.provider)+'/'+(m&&m.id)===dflt; }).length>0;
+    /* NO CONFIGURED DEFAULT — the common case on this instance: 3 of 5 R4 bot
+       defs carry models:null, and a def naming a since-disabled provider row
+       lands here too. Without this option nothing was preselected, the browser
+       picked option 0, and startSession() then saw a value different from the
+       (null) default and fired a REAL control() switch — so one tap on
+       "New session" silently moved the session onto whatever sorted first in
+       provider order, where spawn would have resolved model_resolver.mjs's own
+       fallback. An empty value means "send no control at all", which is
+       exactly what letting the spawn decide has to mean. */
+    if(!listed){
+      var none=document.createElement('option');
+      none.value='';                                   /* startSession(): falsy => no control() */
+      none.textContent=MODEL_BOT_RESOLVES;
+      sel.appendChild(none);
+    }
     list.forEach(function(m){
       var opt=document.createElement('option');
       var key=(m&&m.provider)+'/'+(m&&m.id);
@@ -412,9 +459,12 @@ export function perchHubJs(lang = "en") {
       opt.textContent=modelOptionText(m)+(key===dflt?' \u2014 '+MODEL_BOT_DEFAULT:'');
       sel.appendChild(opt);
     });
-    /* Pre-selected on the bot's own configured model: an operator who does
-       not care taps the button and gets what the bot was built with. */
-    if(dflt&&list.filter(function(m){ return (m&&m.provider)+'/'+(m&&m.id)===dflt; }).length) sel.value=dflt;
+    /* Pre-selected on the bot's own configured model when there IS one: an
+       operator who does not care taps the button and gets what the bot was
+       built with. With no default the sentinel above is option 0 and the
+       browser selects it unaided — an explicit sel.value='' here was measured
+       redundant (removing it left every test green), so it is not written. */
+    if(listed) sel.value=dflt;
     sel.hidden=false;
     if(lbl) lbl.hidden=false;
   }
@@ -619,7 +669,9 @@ export function perchHubJs(lang = "en") {
      1900px window saw "R4 Assistant / idle" with a Talk button next to the
      awake session he was typing in, and no Close anywhere on that surface,
      because Close only exists on a live row. */
-  var SPLIT=window.matchMedia?window.matchMedia('(min-width:${PERCH_SPLIT_MIN_WIDTH}px)'):null;
+  /* ONE MediaQueryList per realm: window.matchMedia() mints a new object every
+     call, so a per-instance one could never be bound once. */
+  var SPLIT=HUB.split||(HUB.split=(window.matchMedia?window.matchMedia('(min-width:${PERCH_SPLIT_MIN_WIDTH}px)'):null));
   function listOnScreen(){ return body.getAttribute('data-view')==='list'||!!(SPLIT&&SPLIT.matches); }
   function syncListPolling(){
     if(listOnScreen()){ startListPolling(); loadList(); }
@@ -629,9 +681,23 @@ export function perchHubJs(lang = "en") {
      navigation — the same class of problem shared/layout.js's own sidebar
      matchMedia listener handles, and the same guard: a retired instance must
      not start polling again from here. */
-  if(SPLIT&&SPLIT.addEventListener) SPLIT.addEventListener('change',function(){ if(live()) syncListPolling(); });
+  /* addListener is the pre-2019 Safari spelling; still the only one there —
+     the shell's own breakpoint listener carries the same fallback
+     (layout.js:~620), and without it the re-evaluation silently never binds on
+     that browser. bindOnce handles the modern spelling; the legacy branch
+     repeats its bookkeeping because MediaQueryList.addListener is not
+     addEventListener. */
+  if(SPLIT&&SPLIT.addEventListener){
+    bindOnce(SPLIT,'change','splitChange',function(){ if(live()) syncListPolling(); });
+  } else if(SPLIT&&SPLIT.addListener){
+    HUB.handlers.splitChange=function(){ if(live()) syncListPolling(); };
+    if(!HUB.bound.splitChange){
+      HUB.bound.splitChange=true;
+      SPLIT.addListener(function(ev){ var h=HUB.handlers.splitChange; if(h) h(ev); });
+    }
+  }
 
-  window.addEventListener('focus',function(){
+  bindOnce(window,'focus','focus',function(){
     if(!live()) return;
     if(listOnScreen()) loadList();
   });
@@ -709,7 +775,7 @@ export function perchHubJs(lang = "en") {
     var hit=parseHash(location.hash);
     if(hit) openSession(hit.sessionId); else closeSession();
   }
-  window.addEventListener('hashchange',function(){ if(live()) applyHash(); });
+  bindOnce(window,'hashchange','hashchange',function(){ if(live()) applyHash(); });
 
   function planStateText(st){
     if(!st||typeof st!=='object') return typeof st==='string'?st:'';
@@ -801,6 +867,11 @@ export function perchHubJs(lang = "en") {
       /* Reflects the engine's own record (snapshot()/stateEvent() in
          perch-interactive.js), never the picker back at it — setting
          .value/.checked does not fire change, so this cannot loop. */
+      /* d.model is servingModel(): pi's own /model, an auto-fallback, or the
+         echo of our own switch. It was on the wire all along and ignored —
+         which is how the picker came to assert a model nobody measured. */
+      var modelSel=el('perch-model');
+      if(modelSel&&d.model&&!modelSel.disabled) selectCurrentModel(modelSel,d.model);
       if(d.permissionMode){ var permSel=el('perch-permission'); if(permSel) permSel.value=d.permissionMode; }
       var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=!!d.planMode;
     });
@@ -916,14 +987,37 @@ export function perchHubJs(lang = "en") {
   }
 
   /* One list, one answer: a non-empty array is usable, anything else (null,
-     [], absent, a non-array) is not. */
+     [], absent, a non-array) is not. THE gate for both pickers — an
+     \`optionsUsable()\` that ANDed the two lists together lived here until fix
+     round 1 Q5 found it was called by nothing but its own tests. */
   function listUsable(a){ return !!(Array.isArray(a)&&a.length); }
-  function optionsUsable(o){
-    return !!o&&listUsable(o.models)&&listUsable(o.thinkingLevels);
+
+  /* Point the model select at the model the session is ACTUALLY on.
+
+     Fix round 1 Q1: nothing ever assigned modelSel.value, so a populated
+     select read whichever option sorted first and asserted a model the
+     session had never been measured on — on the one control this feature
+     exists for, answering "which model is this session running?" wrongly.
+     The empty disabled select it replaced was unhelpful but honest.
+
+     A key the list does not carry is still the truth (a provider row removed
+     since the session started, or a model pi resolved on its own), so it is
+     PREPENDED rather than dropped: selecting nothing at all would report the
+     same "don't know" as before. */
+  function selectCurrentModel(sel,current){
+    if(!sel||!current) return;
+    for(var i=0;i<sel.options.length;i++){
+      if(sel.options[i].value===current){ sel.value=current; return; }
+    }
+    var opt=document.createElement('option');
+    opt.value=current;
+    opt.textContent=current+' \u2014 '+MODEL_CURRENT_UNLISTED;
+    sel.insertBefore(opt,sel.firstChild);
+    sel.value=current;
   }
 
   /* Populates #perch-model / #perch-thinking from GET .../options, or
-     disables both rather than leaving an empty-but-enabled dropdown — that
+     disables each rather than leaving an empty-but-enabled dropdown — that
      is what made a hibernating session look broken. */
   function renderOptions(o){
     var modelSel=el('perch-model'), thinkSel=el('perch-thinking');
@@ -946,6 +1040,7 @@ export function perchHubJs(lang = "en") {
        dropdown that looks like a broken page, and never a disabled one for a
        list that is right there. */
     modelSel.disabled=!models; thinkSel.disabled=!levels;
+    if(models) selectCurrentModel(modelSel,o&&o.current);
   }
 
   function loadOptions(sid){
@@ -1181,8 +1276,8 @@ export function perchHubJs(lang = "en") {
       var hidden=Math.max(0,window.innerHeight-vv.height-vv.offsetTop);
       el('perch-chat').style.paddingBottom=hidden?hidden+'px':'';
     };
-    vv.addEventListener('resize',applyVV);
-    vv.addEventListener('scroll',applyVV);
+    bindOnce(vv,'resize','vvResize',applyVV);
+    bindOnce(vv,'scroll','vvScroll',applyVV);
   }
 
   /* BOOTSTRAP — a hashchange event fires only on a LATER change to the hash;

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -129,6 +129,53 @@ border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-wid
 #perch-hub-root .who{flex:0 0 64px;font:11px/1.6 "JetBrains Mono",ui-monospace,monospace;text-transform:uppercase;color:var(--dim)}
 #perch-hub-root .entry.user .who{color:var(--teal)}
 #perch-hub-root .what{flex:1;min-width:0;white-space:pre-wrap;word-break:break-word}
+/* Rendered markdown. TWO ids' worth of weight is not needed here (nothing
+   competes), but \`white-space:pre-wrap\` from .what above IS: markdown output
+   is real block elements, and pre-wrap would double every blank line between
+   them. */
+/* #perch-transcript is a GRID (see its own rule below), so every row in it is
+   a grid ITEM, and a grid item's automatic minimum size is its MIN-CONTENT.
+   One unbreakable table cell therefore widened the whole row past the column
+   and made the transcript scroll sideways instead of the table scrolling
+   inside itself. Measured at 412x730: row 666px in a 380px column, table
+   clipped by nothing; with this, row 380, table 306 wide scrolling its own
+   475px of content. min-width:0 on the ITEM is the item-side half of the
+   standard remedy (grid-template-columns:minmax(0,1fr) is the container-side
+   half); applied to every row, not just .entry, because an ask card can carry
+   the same unbreakable content. */
+#perch-transcript > *{min-width:0}
+#perch-hub-root .what.md{white-space:normal}
+#perch-hub-root .what.md > :first-child{margin-top:0}
+#perch-hub-root .what.md > :last-child{margin-bottom:0}
+#perch-hub-root .what.md p{margin:0 0 8px}
+#perch-hub-root .what.md h1,#perch-hub-root .what.md h2,#perch-hub-root .what.md h3,
+#perch-hub-root .what.md h4,#perch-hub-root .what.md h5,#perch-hub-root .what.md h6{
+font-size:15px;font-weight:600;margin:10px 0 6px;text-transform:none;letter-spacing:0;color:var(--ink)}
+#perch-hub-root .what.md ul,#perch-hub-root .what.md ol{margin:0 0 8px;padding-left:20px}
+#perch-hub-root .what.md li{margin:2px 0}
+#perch-hub-root .what.md a{color:var(--teal)}
+#perch-hub-root .what.md code{font:12.5px/1.5 "JetBrains Mono",ui-monospace,monospace;
+background:var(--sky);border:1px solid var(--line);border-radius:5px;padding:1px 4px;word-break:break-word}
+#perch-hub-root .what.md blockquote{margin:0 0 8px;padding-left:10px;border-left:2px solid var(--line);color:var(--dim)}
+#perch-hub-root .what.md hr{border:none;border-top:1px solid var(--line);margin:10px 0}
+/* WIDE CONTENT SCROLLS INSIDE ITSELF. A table or a long code fence is the one
+   thing in a bot answer that cannot be wrapped, and at 412px an unscoped one
+   would give the whole page a horizontal scrollbar — .roost-when's own
+   clipping rules exist for the same reason. max-width:100% needs the min-width:0
+   already on .what to actually bind inside the flex row. */
+#perch-hub-root .what.md pre{margin:0 0 8px;padding:9px 10px;background:var(--sky);
+border:1px solid var(--line);border-radius:8px;max-width:100%;overflow-x:auto}
+#perch-hub-root .what.md pre code{background:none;border:none;padding:0;white-space:pre;word-break:normal}
+#perch-hub-root .what.md table{display:block;max-width:100%;overflow-x:auto;
+border-collapse:collapse;margin:0 0 8px;font-size:13px}
+/* word-break:normal UNDOES .what's break-word inside a table. A data table
+   whose long tokens are shredded mid-character is unreadable; the honest
+   behaviour is to keep the cell intact and let the table scroll inside its own
+   box, which is what overflow-x above is for. Without this the table can never
+   overflow, and that rule would be dead. */
+#perch-hub-root .what.md th,#perch-hub-root .what.md td{border:1px solid var(--line);padding:5px 8px;text-align:left;word-break:normal}
+#perch-hub-root .what.md th{background:var(--sky);font-weight:600}
+#perch-hub-root .what.md img{max-width:100%;height:auto}
 #perch-hub-root .note{color:var(--dim);font-size:12.5px;font-style:italic}
 #perch-hub-root .ask-card{border:1px solid var(--line);border-radius:10px;padding:11px 12px;display:grid;gap:8px;background:var(--sky)}
 #perch-hub-root .ask-title{font-weight:600}

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -64,6 +64,17 @@ export function perchHubCss() {
 #perch-hub-root #perch-new{min-height:44px}
 #perch-launch select{font:14px Inter,system-ui,sans-serif;padding:9px 10px;border:1px solid var(--line);
 border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-width:0;max-width:100%}
+/* The model picker. TWO ids (2,0,0), for the same reason #perch-new carries
+   two: "#perch-launch select" above is (1,0,1) and a single-id override would
+   only tie-and-win on source order — the near-miss that shipped #perch-close
+   at 36px.
+   min-height IS load-bearing: drop it and the picker measures under the 44px
+   thumb floor at both viewports (measured; perch-hub-render.test.js's M1 goes
+   red). The flex-basis is a LAYOUT choice, not a safety rule — a model name is
+   long and reads better on its own row — and it is honest to say so: dropping
+   it leaves every M1 measurement green, because the shared select rule's
+   140px basis plus flex-wrap already keeps New session on screen at 412px. */
+#perch-launch #perch-new-model{min-height:44px;flex:1 1 100%}
 /* By id, for the same reason as #perch-close above: "#perch-launch .empty" is
    (1,1,0) and ties with "#perch-hub-root .empty" further down, which then wins
    on source order. Measured dead: computed padding stayed 16px. */

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -19,6 +19,13 @@
  * ID selectors (#perch-list, #perch-chat, #perch-transcript, #perch-composer,
  * #perch-back) are left unprefixed — they're already unique in the page.
  */
+/** The split-view breakpoint, in px. EXPORTED because the client script needs
+ *  the same number: at and above this width `.hub-split` is a two-column grid
+ *  and the session list stays on screen while a chat is open, so the list must
+ *  keep polling there. A second hardcoded 900 in client.js would go stale the
+ *  first time this one moved. */
+export const PERCH_SPLIT_MIN_WIDTH = 900;
+
 export function perchHubCss() {
   return `
 #perch-hub-root{--sky:#eef1f3;--card:#fff;--ink:#22303a;--dim:#6b7c88;--teal:#0e6b62;--teal-soft:#dcecea;
@@ -53,6 +60,16 @@ export function perchHubCss() {
    live while the launch buttons it shipped alongside measured 44px. Verified
    by computed style at 412x730, not by reading the cascade. */
 #perch-hub-root #perch-close{white-space:nowrap;padding:8px 12px;font-size:13px;min-height:44px}
+/* Rename: same two-id rule and the same 44px floor, for the same reason. It is
+   NOT destructive, so unlike Close it needs no confirmation — but a thumb has
+   to be able to hit it. */
+#perch-hub-root #perch-rename{white-space:nowrap;padding:8px 12px;font-size:13px;min-height:44px}
+/* The operator's session name, in the chat header and on a list row. Clipped
+   the same way .roost-cwd is: a name is free text and must not be able to give
+   the 320px list column a horizontal scrollbar. */
+#perch-hub-root .session-name{font-weight:500;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#perch-hub-root .roost-name{font-weight:500;font-size:14px;color:var(--teal);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#perch-hub-root .perch-head [hidden],#perch-hub-root .roost-main [hidden]{display:none}
 /* The unconditional launcher. Wraps rather than overflowing on a phone, and
    its select is capped so a long bot name cannot push the button off-screen. */
 #perch-launch{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:0 0 12px}
@@ -149,7 +166,7 @@ body[data-view="chat"] #perch-chat{display:flex;flex-direction:column;flex:1;min
 #perch-hub-root .field-row{display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin:10px 0}
 #perch-hub-root .field{display:flex;flex-direction:column;gap:3px;flex:1 1 150px;min-width:0}
 #perch-hub-root .field-label{font:11px/1 "JetBrains Mono",ui-monospace,monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--dim)}
-@media (min-width:900px){
+@media (min-width:${PERCH_SPLIT_MIN_WIDTH}px){
   #perch-hub-root{max-width:1100px}
   body[data-view="chat"] #perch-list{display:block}
   #perch-hub-root .hub-split{display:grid;grid-template-columns:320px 1fr;gap:20px;align-items:stretch}

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -141,8 +141,11 @@ border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-wid
    clipped by nothing; with this, row 380, table 306 wide scrolling its own
    475px of content. min-width:0 on the ITEM is the item-side half of the
    standard remedy (grid-template-columns:minmax(0,1fr) is the container-side
-   half); applied to every row, not just .entry, because an ask card can carry
-   the same unbreakable content. */
+   half). Written as a child selector rather than as .entry so a future row type
+   is covered too — NOT, as an earlier version of this comment claimed, because
+   it reaches the ask card: #perch-ask is a SIBLING of #perch-transcript
+   (html.js), never a child, and at 412px the card sits in its own pane
+   untouched by this rule. */
 #perch-transcript > *{min-width:0}
 #perch-hub-root .what.md{white-space:normal}
 #perch-hub-root .what.md > :first-child{margin-top:0}

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -79,9 +79,15 @@ ${engineBanner(engine, lang)}
          (css.js:89-91), and .perch-head is already a non-scrolling child of
          the #perch-chat flex column, so a control here is permanently on
          screen without touching that box. -->
+    <!-- The session's operator-set name sits between the bot name and the
+         session id, never replacing either: the id stays the identity (the
+         close confirmation names it), the name is the convenience. Hidden
+         until there is one; rendered with textContent, never markup. -->
     <div class="perch-head"><div><div class="title" id="perch-bot-name"></div>
+      <div class="session-name" id="perch-session-name" hidden></div>
       <div class="meta" id="perch-session-meta"></div></div>
       <div class="state" id="perch-state"></div>
+      <button type="button" id="perch-rename" class="quiet">${escapeHtml(t("perch.rename", lang))}</button>
       <button type="button" id="perch-close" class="quiet">${escapeHtml(t("perch.close", lang))}</button></div>
     <div class="field-row">
       <div class="field"><span class="field-label" id="perch-model-label">${escapeHtml(t("perch.modelLabel", lang))}</span>

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -54,6 +54,14 @@ ${engineBanner(engine, lang)}
     <div id="perch-launch">
       <label class="field-label" id="perch-new-bot-label" for="perch-new-bot" hidden>${escapeHtml(t("perch.newSessionBot", lang))}</label>
       <select id="perch-new-bot" aria-labelledby="perch-new-bot-label" hidden></select>
+      <!-- The model for the session about to be started. Populated from
+           GET /bots/<id>/models (session-free — there is no session yet to
+           ask), pre-selected on the bot's own configured default, so the
+           common case stays one tap on the button beside it. Hidden until
+           that list arrives: an empty-but-visible picker is the state this
+           whole task exists to stop shipping. -->
+      <label class="field-label" id="perch-new-model-label" for="perch-new-model" hidden>${escapeHtml(t("perch.newSessionModel", lang))}</label>
+      <select id="perch-new-model" aria-labelledby="perch-new-model-label" hidden></select>
       <button type="button" class="primary" id="perch-new" disabled>${escapeHtml(t("perch.newSession", lang))}</button>
       <div class="empty" id="perch-launch-note" hidden></div>
     </div>

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2275,6 +2275,11 @@ export const translations = {
   "perch.newSessionBot": { en: "Bot", es: "Bot" },
   "perch.newSessionModel": { en: "Model", es: "Modelo" },
   "perch.modelBotDefault": { en: "bot default", es: "predeterminado del bot" },
+  "perch.modelBotResolves": {
+    en: "The bot's own model",
+    es: "El modelo propio del bot",
+  },
+  "perch.modelCurrentUnlisted": { en: "current", es: "actual" },
   "perch.launchModelFailed": {
     en: "The session started on the bot's own model; the switch did not take.",
     es: "La sesión se inició con el modelo propio del bot; el cambio no se aplicó.",

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2248,6 +2248,10 @@ export const translations = {
   "perch.sessionGone": { en: "That session is gone.", es: "Esa sesión ya no existe." },
   "perch.steer": { en: "Steer", es: "Guiar" },
   "perch.noTranscript": { en: "No transcript yet.", es: "Aún no hay transcripción." },
+  "perch.transcriptFailed": {
+    en: "Could not load this session's history.",
+    es: "No se pudo cargar el historial de esta sesión.",
+  },
   "perch.reconnecting": { en: "Reconnecting…", es: "Reconectando…" },
   "perch.reconnectFailed": { en: "Lost the connection to this session.", es: "Se perdió la conexión con esta sesión." },
   "perch.modelLabel": { en: "Model", es: "Modelo" },

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2269,6 +2269,12 @@ export const translations = {
   "perch.fileFailed": { en: "The image did not upload.", es: "La imagen no se subió." },
   "perch.newSession": { en: "New session", es: "Nueva sesión" },
   "perch.newSessionBot": { en: "Bot", es: "Bot" },
+  "perch.newSessionModel": { en: "Model", es: "Modelo" },
+  "perch.modelBotDefault": { en: "bot default", es: "predeterminado del bot" },
+  "perch.launchModelFailed": {
+    en: "The session started on the bot's own model; the switch did not take.",
+    es: "La sesión se inició con el modelo propio del bot; el cambio no se aplicó.",
+  },
   "perch.noAttachedBots": {
     en: "No bot has a Perch channel attached, so there is nothing to start.",
     es: "Ningún bot tiene un canal Perch, así que no hay nada que iniciar.",

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2287,6 +2287,12 @@ export const translations = {
   "perch.closeFailed": { en: "That session did not close.", es: "Esa sesión no se cerró." },
   "perch.closeFailedFor": { en: "{session} did not close.", es: "{session} no se cerró." },
   "perch.rowCard": { en: "card {id}", es: "tarjeta {id}" },
+  "perch.rename": { en: "Rename", es: "Renombrar" },
+  "perch.renamePrompt": {
+    en: "Name this session. Leave it empty to clear the name.",
+    es: "Nombra esta sesión. Déjalo vacío para quitar el nombre.",
+  },
+  "perch.renameFailed": { en: "That session was not renamed.", es: "Esa sesión no se renombró." },
   "perch.roostUnreachable": {
     en: "Could not reach the session list.",
     es: "No se pudo obtener la lista de sesiones.",

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -211,6 +211,20 @@ const PERMISSION_MODES = new Set(["guarded", "ask", "bypass"]);
  * come back as an opaque `command_failed`. */
 const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
 
+/** Operator-set session name cap. Long enough for "the Nov package copy pass",
+ *  short enough that a 320px list column renders it without a scrollbar. The
+ *  value is stored TEXT and rendered with textContent everywhere — never
+ *  markup — because it reaches the list, the chat header and a confirm string. */
+const LABEL_CAP = 80;
+
+/** Normalize an operator-supplied label: trimmed, capped, and EMPTY IS NULL —
+ *  clearing a name is a valid action, not a way to make a session anonymous
+ *  (the row falls back to the machine-minted id it always had). */
+function normalizeLabel(raw) {
+  const text = String(raw == null ? "" : raw).replace(/\s+/g, " ").trim().slice(0, LABEL_CAP);
+  return text ? text : null;
+}
+
 /**
  * Build a pendingUi card from an `extension_ui_request`.
  *
@@ -364,6 +378,9 @@ export function createInteractiveEngine({
       // string snapshot()/stateEvent() report.
       currentModelParts: null,
       currentModel: null,
+      /** Operator-set name, persisted on the row. NULL means "no name", and
+       *  every render falls back to the short session id. */
+      label: null,
       // Track 3 Task 4: binds at wake, never applied to a live child (pi's
       // permission policy is fixed via env at spawn time). Reset to
       // "guarded" on every adoptRow (gateway restart) — see adoptRow's
@@ -430,6 +447,7 @@ export function createInteractiveEngine({
       // control() switch), so the lens reports the model actually serving
       // the NEXT turn, not just the one the last spawn/wake resolved to.
       model: s.currentModel || (s.resolved ? s.resolved.key : null),
+      label: s.label || null,
       permissionMode: s.permissionMode,
       planMode: s.planMode,
       // I3 (final review): neither stateEvent() nor snapshot() used to
@@ -497,6 +515,7 @@ export function createInteractiveEngine({
       pendingUi: s.pendingUi || null,
       // Track 3 Task 4: same three additions as snapshot(), same rule.
       model: s.currentModel || (s.resolved ? s.resolved.key : null),
+      label: s.label || null,
       permissionMode: s.permissionMode,
       planMode: s.planMode,
       // I3 (final review): same addition, same reasoning, as snapshot()
@@ -651,6 +670,11 @@ export function createInteractiveEngine({
           // Track 3 Task 7: `control` defaults to 'run' — only stopAll's
           // interrupted-mid-turn park passes 'interrupted'; every OTHER write
           // (including this row's own NEXT normal write) resets it to 'run'.
+          // NOTE: no `label` here. writeLabel() is its single writer — a
+          // targeted UPDATE that can clear it — and adding it to this statement
+          // was measurably unobservable (a mutation turning it into a COALESCE
+          // left the whole suite green), so it is one writer, not two that have
+          // to agree.
           args: [status, control, s.cardId, s.projectId, piSessionDir, model, s.botId, s.threadId],
         },
         {
@@ -658,6 +682,8 @@ export function createInteractiveEngine({
             "INSERT INTO bot_sessions (bot_id,gateway_type,gateway_thread_id,kind,status,control,card_id,project_id,pi_session_dir,model) " +
             "SELECT ?,'perch',?,'perch-live',?,?,?,?,?,? " +
             "WHERE NOT EXISTS (SELECT 1 FROM bot_sessions WHERE bot_id=? AND gateway_thread_id=?)",
+          // A row this INSERT mints is brand new and cannot have a name yet;
+          // label defaults to NULL and writeLabel() owns it from there.
           args: [s.botId, s.threadId, status, control, s.cardId, s.projectId, piSessionDir, model, s.botId, s.threadId],
         },
       ]);
@@ -666,6 +692,24 @@ export function createInteractiveEngine({
         args: [s.botId, s.threadId],
       });
       if (rows[0]) s.rowId = Number(rows[0].id);
+    } finally {
+      try { db.close(); } catch { /* already closed */ }
+    }
+  }
+
+  /** Persist the operator's session name. Targeted UPDATE by row id — see
+   * rename()'s doc for why this is not writeRow. A session with no row yet
+   * (rowId null) has nothing to write to, and minting one here would create a
+   * phantom row for a session that never spawned; the in-memory label still
+   * rides the next writeRow the normal lifecycle performs. */
+  async function writeLabel(s) {
+    if (s.rowId == null) return;
+    const db = createDbClient();
+    try {
+      await db.execute({
+        sql: "UPDATE bot_sessions SET label=?, updated_at=datetime('now') WHERE id=?",
+        args: [s.label || null, s.rowId],
+      });
     } finally {
       try { db.close(); } catch { /* already closed */ }
     }
@@ -737,7 +781,7 @@ export function createInteractiveEngine({
     try {
       const { rows } = await db.execute({
         sql:
-          "SELECT id, bot_id, gateway_thread_id, status, model, pi_session_id, project_id, card_id " +
+          "SELECT id, bot_id, gateway_thread_id, status, model, pi_session_id, project_id, card_id, label " +
           "FROM bot_sessions WHERE gateway_thread_id=? AND kind='perch-live' ORDER BY id DESC LIMIT 1",
         args: [sessionId],
       });
@@ -748,6 +792,10 @@ export function createInteractiveEngine({
       s.piSessionId = row.pi_session_id || null;
       s.projectId = row.project_id == null ? null : Number(row.project_id);
       s.cardId = row.card_id == null ? null : Number(row.card_id);
+      // Unlike permissionMode just below, the label IS restored: it is a name
+      // the operator chose, carries no authority, and losing it on every
+      // gateway restart would make renaming pointless.
+      s.label = row.label ? String(row.label) : null;
       s.state = row.status === "stopped" ? "stopped" : "hibernating";
       // Track 3 Task 4 (spec §5.3, RESTART SEMANTICS — named for the
       // reviewer): deliberately NOT restoring permissionMode from anywhere.
@@ -1996,6 +2044,39 @@ export function createInteractiveEngine({
     return abortInFlight(s);
   }
 
+  /**
+   * Name a session, or clear its name (Task: "there is not a way to rename the
+   * sessions").
+   *
+   * The `perchlive-xxxxxxxx` id stays the IDENTITY — this is a convenience
+   * rendered ALONGSIDE it, never instead of it, so the close confirmation and
+   * every log line keep naming something unambiguous. An empty or
+   * whitespace-only label CLEARS the name (normalizeLabel returns null), which
+   * is a real action and not a way to make a session anonymous.
+   *
+   * Persisted on the session's own bot_sessions row through the SAME writeRow
+   * every other state change goes through — no second store to keep in sync —
+   * and adoptRow restores it, so a rename survives a gateway restart.
+   *
+   * A STOPPED session is still renameable: the row and its transcript outlive
+   * the child, and naming one while sorting through what happened is exactly
+   * when an operator wants to. Renaming is reversible and touches no child, so
+   * unlike stop() it is never refused mid-turn.
+   */
+  async function rename(sessionId, label) {
+    const s = await resolveSession(sessionId);
+    if (!s) throw engineError("no_such_session");
+    s.label = normalizeLabel(label);
+    // A targeted UPDATE, not writeRow: writeRow also stamps `status` and
+    // resets `control` to 'run', and a rename must not quietly clear the
+    // 'interrupted' flag stopAll() sets on a session that was mid-turn when
+    // the gateway went down — the drawer reads that to say "interrupted, not
+    // answered". Same shape and same idiom as writePiSessionId().
+    await writeLabel(s);
+    emit(s, stateEvent(s));
+    return { label: s.label };
+  }
+
   async function stop(sessionId) {
     const s = await resolveSession(sessionId);
     if (!s) throw engineError("no_such_session");
@@ -2202,6 +2283,7 @@ export function createInteractiveEngine({
     cycle,
     control,
     options,
+    rename,
     answer,
     abort,
     stop,

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -239,6 +239,11 @@ function cardFrom(m) {
  *   Default is a LAZY import of bot-world.mjs + bridge.mjs + pi_lifecycle.mjs +
  *   warm.mjs + metering.mjs (the perch.js `loadBridge` idiom — gateway boot
  *   must not pay for the bot engine).
+ * @param {Function} [opts.providerModels] test seam: `() => Array<model>`, the
+ *   session-free provider catalogue `options()` falls back to when a session
+ *   has no live child. Default is a LAZY import of perch-model-catalog.js —
+ *   same discipline as `bridge` above: a gateway that never lists models must
+ *   not pay for the provider registry at construction time.
  * @param {Function} [opts.now] injectable clock (lease expiry is testable).
  * @param {Function} [opts.setTimer] injectable timer factory.
  * @param {Function} [opts.clearTimer]
@@ -248,6 +253,7 @@ export function createInteractiveEngine({
   env = process.env,
   crowHome = env.CROW_HOME || join(homedir(), ".crow"),
   bridge = null,
+  providerModels = null,
   now = Date.now,
   setTimer = setTimeout,
   clearTimer = clearTimeout,
@@ -1866,22 +1872,60 @@ export function createInteractiveEngine({
   }
 
   /**
-   * Track 3 Task 4: live model/thinking-level menus for the drawer (Task 8).
-   * Wakes are NEVER required just to list — a hibernating session (or one this
-   * process has never held; resolveSession adopts) returns null arrays so the
-   * caller can disable the pickers instead of spawning a child on a mere GET.
+   * Track 3 Task 4: model/thinking-level menus for the drawer (Task 8).
+   * Wakes are NEVER required just to list.
+   *
+   * A LIVE child is authoritative: it is the process that will actually route
+   * the next turn, so its `get_available_models` wins whenever there is one.
+   *
+   * With NO child the answer used to be `models: null`, and the drawer
+   * rendered an empty, disabled picker. That is wrong for a session that is
+   * merely asleep — the engine hibernates idle sessions by design and
+   * `adoptRow` brings a restart-orphaned row back hibernating too, so the
+   * commonest state of a perfectly healthy session reported the same thing a
+   * broken page would. Worse, the switch itself WORKS while hibernating:
+   * `control()` stores `currentModelParts` and `startChild` reads it BEFORE
+   * `warmModel`/`PiRpc` construction, so the next wake serves and prices the
+   * chosen provider from turn 1. Only the list was missing. It now falls back
+   * to the session-free provider catalogue — the SAME list the launcher's
+   * `GET /bots/:id/models` offers (perch-model-catalog.js), never a second
+   * one that could disagree.
+   *
+   * `thinkingLevels` stays null in that state on purpose: `control()`'s
+   * thinking branch is a no-op with no child (pi's own session file owns the
+   * level across a `--session` resume, and this engine deliberately persists
+   * nothing), so offering the picker would promise a change that never
+   * happens. `source` names which half answered, so a caller never has to
+   * infer it from the shape.
    */
   async function options(sessionId) {
     const s = await resolveSession(sessionId);
     if (!s) throw engineError("no_such_session");
-    if (!s.pi) return { models: null, thinkingLevels: null };
+    if (!s.pi) return { models: await catalogModels(), thinkingLevels: null, source: "providers" };
     const [modelsRes, levelsRes] = await Promise.all([
       s.pi.commandSince({ type: "get_available_models" }),
       s.pi.commandSince({ type: "get_available_thinking_levels" }),
     ]);
     const models = (modelsRes && modelsRes.data && modelsRes.data.models) || [];
     const thinkingLevels = (levelsRes && levelsRes.data && levelsRes.data.levels) || [];
-    return { models, thinkingLevels };
+    return { models, thinkingLevels, source: "child" };
+  }
+
+  /**
+   * The session-free model catalogue, lazily resolved. Never throws: a
+   * provider registry this process cannot read is an EMPTY list, which the
+   * drawer renders as a disabled picker — the honest answer — rather than an
+   * options() call that 500s a session the operator was only looking at.
+   */
+  async function catalogModels() {
+    try {
+      if (providerModels) return providerModels() || [];
+      const mod = await import("./perch-model-catalog.js");
+      return mod.providerModelList() || [];
+    } catch (e) {
+      log("provider catalogue unavailable: " + (e && e.message));
+      return [];
+    }
   }
 
   /** Resolve a session this process holds, or adopt its row (gateway restart).

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -190,6 +190,17 @@ function replyTextOf(end) {
   return out.trim();
 }
 
+/** Split a stored "provider/id" model key on its FIRST slash — the same rule
+ *  control()'s route body and the drawer's <option value> both use. Anything
+ *  that is not two non-empty halves yields null, and the caller leaves its
+ *  model tracking alone. */
+function splitModelKey(key) {
+  const text = typeof key === "string" ? key : "";
+  const i = text.indexOf("/");
+  if (i <= 0 || i === text.length - 1) return null;
+  return { provider: text.slice(0, i), modelId: text.slice(i + 1) };
+}
+
 /** The four ask_user methods that produce an operator-facing card. Everything
  * else pi's extension UI channel carries is chrome we deliberately ignore. */
 const ASK_METHODS = new Set(["select", "input", "confirm", "editor"]);
@@ -706,6 +717,35 @@ export function createInteractiveEngine({
     }
   }
 
+  /** Persist the model the engine now considers this session's.
+   *
+   * Fix round 2 N2: the row's `model` column was only written by onTurnEnd and
+   * by a turn's own `active` stamp, so a switch made and then left un-exercised
+   * — control() to another model, then a gateway restart before the next turn —
+   * was not in the row at all, and adoptRow had nothing to restore. That is
+   * exactly the sequence the operator reported: switch the model, a deploy
+   * restarts the gateway, open the session again.
+   *
+   * Targeted UPDATE by row id, for the same reason writeLabel() is one:
+   * writeRow() also stamps `status` and resets `control` to 'run', and a model
+   * switch must not restamp either. Non-fatal — the switch's operative effect
+   * is the in-memory tracking that startChild reads; the row is what carries it
+   * across a restart. */
+  async function writeModel(s) {
+    if (s.rowId == null) return;
+    const db = createDbClient();
+    try {
+      await db.execute({
+        sql: "UPDATE bot_sessions SET model=?, updated_at=datetime('now') WHERE id=?",
+        args: [servingModel(s), s.rowId],
+      });
+    } catch (e) {
+      log(s.sessionId + ": model not persisted (non-fatal): " + ((e && e.message) || e));
+    } finally {
+      try { db.close(); } catch { /* already closed */ }
+    }
+  }
+
   /** Persist the operator's session name. Targeted UPDATE by row id, and the
    * ONLY writer of `label` — see rename()'s doc for why it is not writeRow,
    * and note that writeRow deliberately does not touch the column either.
@@ -810,6 +850,30 @@ export function createInteractiveEngine({
       // the operator chose, carries no authority, and losing it on every
       // gateway restart would make renaming pointless.
       s.label = row.label ? String(row.label) : null;
+      // Fix round 2 N2: the row's `model` column was SELECTed and then thrown
+      // away, so servingModel() returned null for EVERY adopted session and the
+      // drawer's picker — populated, enabled — fell back to whichever option
+      // sorted first. That is verbatim the defect fix round 1 Q1 exists for,
+      // surviving in the one case the !s.pi branch of options() was added to
+      // serve: a session hibernating after a gateway restart, which is the
+      // common way an operator opens an old one.
+      //
+      // Restored into the ENGINE'S OWN tracking, not just into a reporting
+      // field, so the report and the next wake agree: startChild reads
+      // currentModelParts before warmModel/PiRpc, so the session resumes on the
+      // model it was actually on rather than snapping back to the def's
+      // default. Reporting one and serving the other would be a subtler lie
+      // than the one being fixed.
+      //
+      // A row naming a provider this instance no longer has is not a wedge:
+      // warmModel() is best-effort and never throws (warm.mjs), and pi surfaces
+      // the real connection error — the same outcome as picking that model in
+      // the drawer.
+      const restored = splitModelKey(row.model);
+      if (restored) {
+        s.currentModelParts = restored;
+        s.currentModel = restored.provider + "/" + restored.modelId;
+      }
       s.state = row.status === "stopped" ? "stopped" : "hibernating";
       // Track 3 Task 4 (spec §5.3, RESTART SEMANTICS — named for the
       // reviewer): deliberately NOT restoring permissionMode from anywhere.
@@ -1256,7 +1320,12 @@ export function createInteractiveEngine({
       case "message_end": {
         // Message-level streaming; delta-level is a recorded non-goal.
         const text = assistantTextOf(m.message);
-        if (text) emit(s, { type: "text", text });
+        // Fix round 2 N1: the turn this message belongs to rides the frame, so
+        // the drawer can judge a `reply` against its OWN turn instead of
+        // against a client-side memory of one that a reconnect invalidates.
+        // null when the child speaks outside a turn — the client falls back to
+        // its transition flag there.
+        if (text) emit(s, { type: "text", text, turnId: s.turn ? s.turn.id : null });
         return;
       }
       case "extension_ui_request":
@@ -1417,7 +1486,10 @@ export function createInteractiveEngine({
     // abort that landed during the metering awaits still silences the reply.
     if (!turn.aborted) {
       const replyText = replyTextOf(end);
-      emit(s, { type: "reply", text: replyText });
+      // The id of the turn this reply COMPLETES (see the text frame above):
+      // without it a reconnected drawer cannot tell "I already rendered this
+      // turn" from "I already rendered a different one".
+      emit(s, { type: "reply", text: replyText, turnId: turn.id });
       // Track 3 Task 8: an operator watching the drawer live (any live
       // subscriber) already sees the reply — the push is for someone who
       // is AWAY, and only for a turn that actually took a while.
@@ -1867,6 +1939,7 @@ export function createInteractiveEngine({
         s.currentModel = rKey;
         s.resolved = Object.assign({}, s.resolved, { provider: rProvider, model: rId, key: rKey });
         applied.model = rKey;
+        await writeModel(s);                           // survives a restart (N2)
         // The child's OWN model_select event for this same switch will also
         // arrive shortly — onModelSelect dedupes on an unchanged value, so
         // this is the only "now on <key>" log line the operator sees.
@@ -1877,6 +1950,7 @@ export function createInteractiveEngine({
         const key = provider + "/" + modelId;
         s.currentModelParts = { provider, modelId };
         s.currentModel = key;
+        await writeModel(s);                           // survives a restart (N2)
         bindsAtWake.model = key;
       }
     }

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -433,6 +433,15 @@ export function createInteractiveEngine({
     };
   }
 
+  /** The model this session is actually on: the engine's own tracking (a live
+   *  `model_select`, or a `control()` switch) wins over the raw prepareSpawn
+   *  resolution once one is known. ONE expression, because snapshot(),
+   *  stateEvent() and options() must never disagree about it — the drawer
+   *  cross-checks the picker against exactly this value. */
+  function servingModel(s) {
+    return s.currentModel || (s.resolved ? s.resolved.key : null);
+  }
+
   function snapshot(s) {
     return {
       sessionId: s.sessionId,
@@ -446,7 +455,7 @@ export function createInteractiveEngine({
       // prepareSpawn resolution once one is known (a live model_select or a
       // control() switch), so the lens reports the model actually serving
       // the NEXT turn, not just the one the last spawn/wake resolved to.
-      model: s.currentModel || (s.resolved ? s.resolved.key : null),
+      model: servingModel(s),
       label: s.label || null,
       permissionMode: s.permissionMode,
       planMode: s.planMode,
@@ -514,7 +523,7 @@ export function createInteractiveEngine({
       lastError: s.lastError || null,
       pendingUi: s.pendingUi || null,
       // Track 3 Task 4: same three additions as snapshot(), same rule.
-      model: s.currentModel || (s.resolved ? s.resolved.key : null),
+      model: servingModel(s),
       label: s.label || null,
       permissionMode: s.permissionMode,
       planMode: s.planMode,
@@ -697,13 +706,18 @@ export function createInteractiveEngine({
     }
   }
 
-  /** Persist the operator's session name. Targeted UPDATE by row id — see
-   * rename()'s doc for why this is not writeRow. A session with no row yet
-   * (rowId null) has nothing to write to, and minting one here would create a
-   * phantom row for a session that never spawned; the in-memory label still
-   * rides the next writeRow the normal lifecycle performs. */
+  /** Persist the operator's session name. Targeted UPDATE by row id, and the
+   * ONLY writer of `label` — see rename()'s doc for why it is not writeRow,
+   * and note that writeRow deliberately does not touch the column either.
+   *
+   * A session with no row (rowId null) cannot be persisted to at all, and
+   * minting one here would create a phantom row for a session that never
+   * spawned. Nothing later repairs it either — writeRow does not carry the
+   * label — so this THROWS rather than returning quietly: fix round 1 Q4
+   * found the silent version answering HTTP 200 with the label, painting it
+   * into the list and the header, and storing nothing. */
   async function writeLabel(s) {
-    if (s.rowId == null) return;
+    if (s.rowId == null) throw engineError("not_persisted");
     const db = createDbClient();
     try {
       await db.execute({
@@ -1945,18 +1959,27 @@ export function createInteractiveEngine({
    * nothing), so offering the picker would promise a change that never
    * happens. `source` names which half answered, so a caller never has to
    * infer it from the shape.
+   *
+   * `current` is the model the session is ACTUALLY on — the same value
+   * `snapshot()`/`stateEvent()` report. Fix round 1 Q1: without it a caller
+   * has a list and no way to know which entry is live, and the drawer showed
+   * whichever option sorted first. A list that asserts the wrong answer is
+   * worse than the empty one it replaced, on the one control this feature
+   * exists for.
    */
   async function options(sessionId) {
     const s = await resolveSession(sessionId);
     if (!s) throw engineError("no_such_session");
-    if (!s.pi) return { models: await catalogModels(), thinkingLevels: null, source: "providers" };
+    if (!s.pi) return { models: await catalogModels(), thinkingLevels: null, current: servingModel(s), source: "providers" };
     const [modelsRes, levelsRes] = await Promise.all([
       s.pi.commandSince({ type: "get_available_models" }),
       s.pi.commandSince({ type: "get_available_thinking_levels" }),
     ]);
     const models = (modelsRes && modelsRes.data && modelsRes.data.models) || [];
     const thinkingLevels = (levelsRes && levelsRes.data && levelsRes.data.levels) || [];
-    return { models, thinkingLevels, source: "child" };
+    // Read AFTER the RPCs: a model_select the child emitted while we were
+    // waiting is the newest truth, and the picker is about to be set from it.
+    return { models, thinkingLevels, current: servingModel(s), source: "child" };
   }
 
   /**
@@ -1967,9 +1990,11 @@ export function createInteractiveEngine({
    */
   async function catalogModels() {
     try {
-      if (providerModels) return providerModels() || [];
+      if (providerModels) return (await providerModels()) || [];
       const mod = await import("./perch-model-catalog.js");
-      return mod.providerModelList() || [];
+      // The WARM variant: a cold provider cache would otherwise answer [] and
+      // put the drawer back into the empty-disabled-picker state this fixes.
+      return (await mod.providerModelListWarm()) || [];
     } catch (e) {
       log("provider catalogue unavailable: " + (e && e.message));
       return [];
@@ -2054,9 +2079,14 @@ export function createInteractiveEngine({
    * whitespace-only label CLEARS the name (normalizeLabel returns null), which
    * is a real action and not a way to make a session anonymous.
    *
-   * Persisted on the session's own bot_sessions row through the SAME writeRow
-   * every other state change goes through — no second store to keep in sync —
-   * and adoptRow restores it, so a rename survives a gateway restart.
+   * Persisted on the session's own bot_sessions row — no second store to keep
+   * in sync — by writeLabel(), which is its single writer. Deliberately NOT
+   * through writeRow: that stamps `status` and resets `control` to 'run', and
+   * a rename must not quietly clear the 'interrupted' flag stopAll() sets on a
+   * session that was mid-turn when the gateway went down (the drawer reads it
+   * to say "interrupted, not answered"). writeRow's own args list says the
+   * same thing from the other side. adoptRow restores the label, so a rename
+   * survives a gateway restart.
    *
    * A STOPPED session is still renameable: the row and its transcript outlive
    * the child, and naming one while sorting through what happened is exactly
@@ -2066,13 +2096,18 @@ export function createInteractiveEngine({
   async function rename(sessionId, label) {
     const s = await resolveSession(sessionId);
     if (!s) throw engineError("no_such_session");
-    s.label = normalizeLabel(label);
-    // A targeted UPDATE, not writeRow: writeRow also stamps `status` and
-    // resets `control` to 'run', and a rename must not quietly clear the
-    // 'interrupted' flag stopAll() sets on a session that was mid-turn when
-    // the gateway went down — the drawer reads that to say "interrupted, not
-    // answered". Same shape and same idiom as writePiSessionId().
-    await writeLabel(s);
+    const next = normalizeLabel(label);
+    // Persist FIRST, then adopt it in memory: a rename that could not be
+    // written must not leave the engine reporting a name the row does not
+    // carry (writeLabel throws `not_persisted` for a session with no row).
+    const previous = s.label;
+    s.label = next;
+    try {
+      await writeLabel(s);
+    } catch (e) {
+      s.label = previous;
+      throw e;
+    }
     emit(s, stateEvent(s));
     return { label: s.label };
   }
@@ -2311,6 +2346,11 @@ export function createInteractiveEngine({
       if (!s) throw engineError("no_such_session");
       return hibernate(s);
     },
+    /** Fix round 1 Q4 test surface: the internal session record, so a test can
+     * produce the "no row yet" state (rowId null) that rename() must refuse.
+     * No public method exposes it, and spawning a session that fails to get a
+     * row is not reachable through the API. */
+    _sessionRecordForTest: (sessionId) => sessions.get(String(sessionId)) || null,
     /** M2 (final review) test-only reach into the internal `cardClaims` map
      * — the DB rail (checkCardFree) always 409s correctly regardless of this
      * map's state, so no PUBLIC method exposes WHICH sessionId currently

--- a/servers/gateway/perch-model-catalog.js
+++ b/servers/gateway/perch-model-catalog.js
@@ -29,8 +29,35 @@
  * Availability is deliberately NOT decided here: this says what is
  * configured, `annotateAvailability()` says what is reachable, and the two
  * questions stay separable (a probe-free caller can still list).
+ *
+ * USABILITY, though, IS decided here. `annotateAvailability()` answers
+ * "did anything answer at this address", which an embedding endpoint does —
+ * on this instance `grackle-embed/qwen3-embedding-0.6b` and
+ * `grackle-rerank/qwen3-reranker-0.6b` were listed reading "up" and were one
+ * tap from becoming a session's model, which would fail every turn. Provider
+ * rows tag those entries (`task: "embed"`, `task: "score"`; the model catalog
+ * spells the same vocabulary "embedding"/"rerank" —
+ * scripts/validate-model-catalog.js:75), so they are filtered out below.
+ * Entries with NO task are kept: that is most of them (every `crow-local`
+ * row), and they are chat models. `task: "vision"` is kept too, matching
+ * models/manager.js's own `isChatClassRow` — a `-vl-…-instruct` model serves
+ * chat completions.
  */
 import { loadProviders } from "../shared/providers.js";
+
+/**
+ * Tasks a Perch session can never be driven by. An entry is EXCLUDED only
+ * when it names one of these — absence means "chat" for every provider row
+ * this instance has ever carried, and a strict allowlist would silently empty
+ * the picker on any row that simply does not tag its models.
+ */
+const NON_CHAT_TASKS = new Set(["embed", "embedding", "rerank", "score", "classify"]);
+
+/** Can a Perch session actually be served by this entry? */
+export function chatCapable(m) {
+  const task = m && typeof m.task === "string" ? m.task.toLowerCase() : null;
+  return !(task && NON_CHAT_TASKS.has(task));
+}
 
 /**
  * Every model every enabled provider row declares, as pi-shaped entries.
@@ -58,6 +85,7 @@ export function providerModelList({ load = loadProviders } = {}) {
       const entry = typeof m === "string" ? { id: m } : m;
       const id = entry && entry.id;
       if (!id) continue;
+      if (!chatCapable(entry)) continue;          // an embedding endpoint is not a model to talk to
       out.push({ ...entry, id: String(id), provider, baseUrl: row.baseUrl || null });
     }
   }
@@ -68,4 +96,35 @@ export function providerModelList({ load = loadProviders } = {}) {
  *  body and the drawer's `<option value>` all speak. */
 export function modelKey(m) {
   return m && m.provider && m.id ? m.provider + "/" + m.id : null;
+}
+
+/**
+ * The same list, but never the EMPTY-because-cold one.
+ *
+ * `loadProviders()` is synchronous by contract (providers.js: hot-path callers
+ * that cannot be made async), so on a cold process it returns
+ * `_cache || loadFromModelsJson()` and fires an UNAWAITED DB refresh. This
+ * instance ships no models.json, so the first call after a gateway start
+ * answers 0 models and the second, ~1.5 s later, answers all of them.
+ *
+ * Both of this module's callers are in the async path already and both are
+ * harmed by that window: the launcher route would serve `{models: []}`, and a
+ * hibernating session's `options()` would answer `[]` — which the drawer
+ * renders as the empty, disabled dropdown this whole task exists to remove,
+ * and `loadOptions` runs once per `openSession` and never retries.
+ *
+ * So: when the sync answer is empty, await ONE real refresh and ask again.
+ * Discarding the cache is free in exactly that case, because the cache being
+ * discarded is the empty one.
+ */
+export async function providerModelListWarm(deps) {
+  const first = providerModelList(deps);
+  if (first.length || (deps && deps.load)) return first;   // injected loader: no cache to warm
+  try {
+    const providers = await import("../shared/providers.js");
+    await providers.invalidateAndRefreshProvidersCache();
+  } catch {
+    return first;                                          // no registry reachable; [] is the honest answer
+  }
+  return providerModelList(deps);
 }

--- a/servers/gateway/perch-model-catalog.js
+++ b/servers/gateway/perch-model-catalog.js
@@ -1,0 +1,71 @@
+/**
+ * perch-model-catalog — the SESSION-FREE model list.
+ *
+ * `perch-interactive.js`'s `options()` asks the live pi child what models it
+ * has (`get_available_models`). That is authoritative for a running session
+ * and useless for every other case: a hibernating session has no child (the
+ * engine closes one on idle by design, and `adoptRow` brings a restart-
+ * orphaned row back hibernating too), and the LAUNCHER has no session at all
+ * — it is choosing a model for one that does not exist yet.
+ *
+ * Both of those need the same answer, so both get it from here. One source,
+ * two callers: the hibernating fallback in `options()` and the launcher's
+ * `GET /dashboard/perch-api/bots/:id/models`. Two lists that could disagree
+ * about what this instance can serve is the defect class this module exists
+ * to avoid.
+ *
+ * WHY `loadProviders()`. It is the DB-first, models.json-fallback registry
+ * that already backs `model-availability.js`'s own `defaultDeps()` (:66) —
+ * the established session-free path — and the DB read filters `disabled`
+ * rows out for us (providers-db.js's `WHERE disabled = 0`).
+ *
+ * SHAPE. Entries mirror pi's own Model object (its rpc docs' `Model`:
+ * `{id, name, provider, baseUrl, …}`), because the drawer, the launcher and
+ * `annotateAvailability()` all read them by those names — `baseUrl` in
+ * particular is what the availability probe addresses. Every field the
+ * provider row carries on the model is preserved; `provider` and `baseUrl`
+ * are stamped from the row that owns it.
+ *
+ * Availability is deliberately NOT decided here: this says what is
+ * configured, `annotateAvailability()` says what is reachable, and the two
+ * questions stay separable (a probe-free caller can still list).
+ */
+import { loadProviders } from "../shared/providers.js";
+
+/**
+ * Every model every enabled provider row declares, as pi-shaped entries.
+ *
+ * @param {{load?: () => {providers?: object}}} [deps] test seam — inject a
+ *   provider config instead of reading the DB/models.json.
+ * @returns {Array<{provider: string, id: string, baseUrl: string|null}>}
+ */
+export function providerModelList({ load = loadProviders } = {}) {
+  let cfg = null;
+  try {
+    cfg = load();
+  } catch {
+    return [];                                   // no registry is an empty list, never a throw
+  }
+  const providers = (cfg && cfg.providers) || {};
+  const out = [];
+  for (const [provider, row] of Object.entries(providers)) {
+    // `$`-prefixed keys are models.json schema meta, not providers.
+    if (!row || provider.startsWith("$")) continue;
+    const models = Array.isArray(row.models) ? row.models : [];
+    for (const m of models) {
+      // A provider row's `models` may hold bare id strings (the shape
+      // loadModelOptions() in bot-builder tolerates) or full objects.
+      const entry = typeof m === "string" ? { id: m } : m;
+      const id = entry && entry.id;
+      if (!id) continue;
+      out.push({ ...entry, id: String(id), provider, baseUrl: row.baseUrl || null });
+    }
+  }
+  return out;
+}
+
+/** "provider/id" — the key `definition.models.default`, `control()`'s model
+ *  body and the drawer's `<option value>` all speak. */
+export function modelKey(m) {
+  return m && m.provider && m.id ? m.provider + "/" + m.id : null;
+}

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -589,6 +589,32 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
     }
   });
 
+  // ---- POST /interactive/:sid/rename — name a session, or clear its name ----
+  // The operator's report was "there is not a way to rename the sessions".
+  // The engine's `perchlive-xxxxxxxx` stays the identity; this is the
+  // convenience name rendered beside it. An empty/whitespace body CLEARS the
+  // name (the engine's normalizeLabel returns null) — clearing is a real
+  // action, and the row falls back to the short id it always had. No
+  // confirmation anywhere on this path: renaming is reversible and cheap,
+  // unlike /stop.
+  //
+  // The body cap lives in the ENGINE (LABEL_CAP), not here: the value is
+  // written to a row and re-rendered from it, so the one place that can
+  // guarantee what is stored is the writer. The route's own slice is only a
+  // parser guard against a megabyte of JSON string.
+  router.post(P + "/interactive/:sid/rename", async (req, res) => {
+    const sid = String(req.params.sid);
+    const body = req.body && typeof req.body === "object" ? req.body : {};
+    const label = String(body.label == null ? "" : body.label).slice(0, MESSAGE_CAP);
+    try {
+      const eng = resolveEngine();
+      const result = await eng.rename(sid, label);
+      res.json(result);
+    } catch (err) {
+      mapEngineError(res, err);
+    }
+  });
+
   // ---- POST /interactive/:sid/cycle — force a respawn ----
   router.post(P + "/interactive/:sid/cycle", async (req, res) => {
     try {

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -49,6 +49,7 @@ import { getInteractiveEngine } from "../perch-interactive.js";
 import { tasksDbPath } from "../../../scripts/pi-bots/instance-paths.mjs";
 import { updateCard } from "../board/card-service.js";
 import { annotateAvailability } from "../model-availability.js";
+import { providerModelList } from "../perch-model-catalog.js";
 
 /** Mount prefix. Every route below is registered under it, after the auth gate. */
 const P = "/dashboard/perch-api";
@@ -245,7 +246,7 @@ async function loadBotRow(db, botId) {
  *   directly — what every fake-engine test below injects, so a turn is never
  *   driven and no pi is ever spawned.
  */
-export default function perchInteractiveApiRouter(dashboardAuth, { engine = getInteractiveEngine, annotate = annotateAvailability } = {}) {
+export default function perchInteractiveApiRouter(dashboardAuth, { engine = getInteractiveEngine, annotate = annotateAvailability, providerModels = providerModelList } = {}) {
   const router = Router();
 
   // FIRST statement: auth-gate the whole prefix (perch.js / bot-board-api idiom).
@@ -284,6 +285,47 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
       const eng = resolveEngine();
       const result = await eng.spawn({ botId });
       res.status(201).json(result);
+    } catch (err) {
+      mapEngineError(res, err);
+    } finally {
+      try { db.close(); } catch { /* already closed */ }
+    }
+  });
+
+  // ---- GET /bots/:id/models — the launcher's model list, no session needed ----
+  // The picker beside "New session" has to offer a model BEFORE the session
+  // that would list one exists, and `GET /interactive/:sid/options` cannot
+  // help: it is keyed on a session id. This is that list, from the same
+  // session-free catalogue options() falls back to (perch-model-catalog.js) —
+  // one source, so the launcher and a hibernating session's drawer can never
+  // show two different answers about what this instance serves.
+  //
+  // SAME GATES AS THE SPAWN ROUTE ABOVE, in the same order and for the same
+  // reasons: a bot that would 403 on spawn must not be offered a model list.
+  // Anything else would let the launcher build a picker for a session it can
+  // never start.
+  //
+  // `default` is the bot's own configured model (definition.models.default,
+  // the "provider/id" key model_resolver.mjs reads), so the client can open
+  // pre-selected on it and launching stays one tap. It is reported even when
+  // no catalogue entry matches it — a default naming a provider row that has
+  // since been disabled is a fact the operator should see, not one to hide.
+  router.get(P + "/bots/:id/models", async (req, res) => {
+    const botId = String(req.params.id);
+    const db = createDbClient();
+    try {
+      const row = await loadBotRow(db, botId);
+      if (resolveEngineStatus().state !== "ready") return jsonError(res, 409, "engine_required");
+      const def = row ? parseDef(row) : {};
+      if (!perchAttached(def)) return jsonError(res, 403, "perch_not_attached");
+
+      // Annotated for the same reason the options route annotates: an
+      // unavailable model must be visibly unavailable, never silently
+      // selectable (model-availability.js's header).
+      const models = await annotate(providerModels());
+      const dflt = def.models && typeof def.models.default === "string" && def.models.default
+        ? def.models.default : null;
+      res.json({ models, default: dflt });
     } catch (err) {
       mapEngineError(res, err);
     } finally {
@@ -563,8 +605,15 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
   // picker can say which choices actually work. Without it a provider row
   // pointing at a windowed endpoint (`crow-dsv4` → 127.0.0.1:8020) is
   // indistinguishable from a serving one, and picking it fails every turn on
-  // connection refused. `models: null` is the hibernating contract and is
-  // passed through untouched — the drawer disables the picker on it.
+  // connection refused.
+  //
+  // A HIBERNATING session no longer answers `models: null` here: the engine
+  // falls back to the session-free provider catalogue (perch-interactive.js's
+  // options() doc), so the list annotated below is the child's when there is a
+  // child and the instance's otherwise. `thinkingLevels` is still null in that
+  // state — control()'s thinking branch does nothing without a child — and a
+  // null of either kind is passed through untouched for the drawer to disable
+  // that one picker on.
   router.get(P + "/interactive/:sid/options", async (req, res) => {
     try {
       const eng = resolveEngine();

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -50,6 +50,7 @@ import { tasksDbPath } from "../../../scripts/pi-bots/instance-paths.mjs";
 import { updateCard } from "../board/card-service.js";
 import { annotateAvailability } from "../model-availability.js";
 import { providerModelListWarm } from "../perch-model-catalog.js";
+import { renderMarkdown } from "../../blog/renderer.js";
 
 /** Mount prefix. Every route below is registered under it, after the auth gate. */
 const P = "/dashboard/perch-api";
@@ -401,7 +402,33 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
     // ask_user card, if any) synchronously into this callback before it
     // resolves — the "on connect, replay" contract lives THERE, once, so
     // every subscriber (this route, and any future one) gets it for free.
-    const forward = (event) => stream.send(event.type, event);
+    /* Bot output is markdown. It is rendered HERE, on the server, by the same
+       `renderMarkdown` (marked + sanitize-html with an explicit allow-list)
+       the memory panel already uses — the client cannot import a server
+       module, and must never be handed a markdown parser plus untrusted model
+       output. Carried ALONGSIDE the raw text rather than replacing it: a
+       frame whose render fails arrives with no `html` and the client falls
+       back to textContent, which is exactly today's behaviour.
+
+       On the frame rather than through a per-message endpoint, because that
+       would cost a round trip per message on a phone; and every bot message
+       already passes through this one function. Message-level streaming means
+       every frame carries a COMPLETE message (perch-interactive.js:1257), so
+       there is no partial markdown to render and nothing to swap afterwards.
+
+       `text` and `reply` only: `log`, `tool` and `error` are gateway chrome,
+       not model prose. */
+    const withHtml = (event) => {
+      if (!event || (event.type !== "text" && event.type !== "reply")) return event;
+      if (typeof event.text !== "string" || !event.text.trim()) return event;
+      try {
+        const html = renderMarkdown(event.text);
+        return html ? { ...event, html } : event;
+      } catch {
+        return event;                                // the client's textContent path
+      }
+    };
+    const forward = (event) => { const e = withHtml(event); stream.send(e.type, e); };
 
     // Register the close handler BEFORE the subscribe await (fix-round F1): a
     // client abort DURING that await (subscribe→resolveSession→adoptRow does a

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -49,7 +49,7 @@ import { getInteractiveEngine } from "../perch-interactive.js";
 import { tasksDbPath } from "../../../scripts/pi-bots/instance-paths.mjs";
 import { updateCard } from "../board/card-service.js";
 import { annotateAvailability } from "../model-availability.js";
-import { providerModelList } from "../perch-model-catalog.js";
+import { providerModelListWarm } from "../perch-model-catalog.js";
 
 /** Mount prefix. Every route below is registered under it, after the auth gate. */
 const P = "/dashboard/perch-api";
@@ -140,6 +140,10 @@ const ERROR_MAP = {
   // live child, never queued).
   not_awake: [409, "not_awake"],
   command_failed: [502, "command_failed"],
+  // rename() on a session with no bot_sessions row yet: there is nothing to
+  // write to, and minting a row would leave a phantom for a session that never
+  // spawned. 409, not 500 — the refusal is honest and the session is fine.
+  not_persisted: [409, "not_persisted"],
 };
 
 function mapEngineError(res, err) {
@@ -246,7 +250,7 @@ async function loadBotRow(db, botId) {
  *   directly — what every fake-engine test below injects, so a turn is never
  *   driven and no pi is ever spawned.
  */
-export default function perchInteractiveApiRouter(dashboardAuth, { engine = getInteractiveEngine, annotate = annotateAvailability, providerModels = providerModelList } = {}) {
+export default function perchInteractiveApiRouter(dashboardAuth, { engine = getInteractiveEngine, annotate = annotateAvailability, providerModels = providerModelListWarm } = {}) {
   const router = Router();
 
   // FIRST statement: auth-gate the whole prefix (perch.js / bot-board-api idiom).
@@ -322,7 +326,9 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
       // Annotated for the same reason the options route annotates: an
       // unavailable model must be visibly unavailable, never silently
       // selectable (model-availability.js's header).
-      const models = await annotate(providerModels());
+      // awaited: the catalogue warms a cold provider cache rather than
+      // serving the empty list loadProviders() answers on a fresh process.
+      const models = await annotate(await providerModels());
       const dflt = def.models && typeof def.models.default === "string" && def.models.default
         ? def.models.default : null;
       res.json({ models, default: dflt });

--- a/servers/gateway/routes/perch.js
+++ b/servers/gateway/routes/perch.js
@@ -447,7 +447,7 @@ export default function perchApiRouter(dashboardAuth, { interactiveEngine = getI
       const rowById = new Map();
       try {
         const { rows: sessRows } = await db.execute({
-          sql: "SELECT gateway_thread_id, card_id, control FROM bot_sessions WHERE kind='perch-live' AND status != 'stopped'",
+          sql: "SELECT gateway_thread_id, card_id, control, label FROM bot_sessions WHERE kind='perch-live' AND status != 'stopped'",
           args: [],
         });
         for (const r of sessRows) rowById.set(String(r.gateway_thread_id), r);
@@ -496,6 +496,11 @@ export default function perchApiRouter(dashboardAuth, { interactiveEngine = getI
             cardId,
             pendingUi: !!s.pendingUi,
             control: dbRow ? dbRow.control : null,
+            // The operator's name for this session, ALONGSIDE the id — never
+            // instead of it. Same backfill rule as cardId above: the engine
+            // snapshot wins when this process holds the session, and the row
+            // fills in for an entry eng.list() built from the DB alone.
+            label: (s.label != null ? s.label : (dbRow && dbRow.label)) || null,
           };
         });
         // spec §3.2 priority fold: waiting-on-you > working > hibernating >

--- a/servers/gateway/routes/perch.js
+++ b/servers/gateway/routes/perch.js
@@ -63,6 +63,7 @@ import { sessionBirdState, foldBirdStates } from "../dashboard/panels/bot-board/
 import { perchAttached } from "../shared/perch-attached.js";
 import { getInteractiveEngine } from "../perch-interactive.js";
 import { JOB_LOCK_STATUSES } from "./board-lock.js";
+import { renderMarkdown } from "../../blog/renderer.js";
 
 /** Mount prefix. Every route below is registered under it, after the auth gate. */
 const P = "/dashboard/perch-api";
@@ -331,13 +332,62 @@ function readTailBytes(file, maxBytes) {
  * genuinely unknown and reporting 0 would be a lie. The lens words the notice
  * without a count in that case.
  */
+/**
+ * The markdown rendering of an assistant message, or null.
+ *
+ * Bot output IS markdown — headings, tables, bold, code fences — and rendered
+ * as literal text until this. It is rendered on the SERVER, by the same
+ * `renderMarkdown` (marked + sanitize-html with an explicit allow-list) the
+ * memory panel already uses (dashboard/panels/memory.js:20), because the
+ * client cannot import a server module and must never be handed a markdown
+ * parser plus untrusted model output.
+ *
+ * TEXT BLOCKS ONLY, and only for the assistant: a tool-call block renders as
+ * the client's own "[tool: name]" line, and the operator's own typing is not
+ * markdown. A message with no text block gets null and the client falls back
+ * to textContent, which is exactly today's behaviour.
+ *
+ * Measured cost: 0.075 ms for a typical message, so the 2000-line tail cap
+ * above bounds a history load at ~150 ms, and the 2 MB byte cap bounds the
+ * pathological case at roughly half a second. Once per session open.
+ */
+function assistantHtml(event) {
+  const message = event && event.message;
+  if (!message || message.role !== "assistant") return null;
+  const content = message.content;
+  const text = typeof content === "string"
+    ? content
+    : (Array.isArray(content)
+      ? content.filter((c) => c && typeof c.text === "string").map((c) => c.text).join("\n")
+      : "");
+  // A SHORT-CIRCUIT, not the correctness gate: `renderMarkdown("") || null` is
+  // already null, and removing this line leaves the whole suite green
+  // (measured). It is here so a tool-call-only message — most of a busy turn —
+  // does not pay for a parse that can only return nothing.
+  if (!text.trim()) return null;
+  try {
+    return renderMarkdown(text) || null;
+  } catch {
+    // A render failure must not cost the operator the message: the client
+    // falls back to textContent whenever `html` is absent.
+    return null;
+  }
+}
+
 function readTranscript(file) {
   const { text, headDropped } = readTailBytes(file, TRANSCRIPT_TAIL_BYTES);
   const all = text.split("\n").filter((l) => l.trim());
   const kept = all.length > TRANSCRIPT_TAIL_LINES ? all.slice(-TRANSCRIPT_TAIL_LINES) : all;
   const events = [];
   for (const line of kept) {
-    try { events.push(JSON.parse(line)); } catch { /* skip: not our business to guess */ }
+    try {
+      const event = JSON.parse(line);
+      // Additive: `html` rides ALONGSIDE the untouched pi event, so the
+      // client keeps its own messageText() fallback and nothing downstream
+      // that reads `message` sees a changed shape.
+      const html = event && event.type === "message" ? assistantHtml(event) : null;
+      events.push(html ? { ...event, html } : event);
+    } catch { /* skip: not our business to guess */ }
   }
   return {
     events,

--- a/servers/gateway/routes/perch.js
+++ b/servers/gateway/routes/perch.js
@@ -360,10 +360,17 @@ function assistantHtml(event) {
     : (Array.isArray(content)
       ? content.filter((c) => c && typeof c.text === "string").map((c) => c.text).join("\n")
       : "");
-  // A SHORT-CIRCUIT, not the correctness gate: `renderMarkdown("") || null` is
-  // already null, and removing this line leaves the whole suite green
-  // (measured). It is here so a tool-call-only message — most of a busy turn —
-  // does not pay for a parse that can only return nothing.
+  // THE correctness gate, and a short-circuit as well.
+  //
+  // An earlier version of this comment called it only a short-circuit, on the
+  // grounds that `renderMarkdown(…) || null` is already null for whitespace.
+  // That is true of THIS tree — measured: "", " ", "   ", "\n" and "\t" all
+  // render to "" — but it is marked's behaviour, not ours, and the reviewer
+  // measured `<p> </p>` from the same call on their own harness. Betting a
+  // "no html for a message with no text" guarantee on a third party's
+  // whitespace handling is the wrong way round, so the guard stays and the
+  // guarantee is stated here. It also spares a parse on every tool-call-only
+  // message, which is most of a busy turn.
   if (!text.trim()) return null;
   try {
     return renderMarkdown(text) || null;

--- a/tests/init-db-bot-tables.test.js
+++ b/tests/init-db-bot-tables.test.js
@@ -133,6 +133,17 @@ test("bot_sessions pre-existing WITHOUT kind: re-running init-db.js adds it", ()
       assert.ok(postCols.includes("kind"), "kind must be added by a second init-db.js run");
       assert.ok(postCols.includes("model") && postCols.includes("escalated"),
         "pre-existing columns must survive the migration");
+      // Every later post-hoc column takes the same path, and each one has to
+      // be in BOT_SESSIONS_CANONICAL_COLUMNS as well: this fixture's narrow
+      // control CHECK also triggers the table REBUILD, whose drift guard
+      // aborts init-db (exit non-zero) on any column it does not recognise.
+      // A new column added to the CREATE body and forgotten there would fail
+      // exactly here, on the hosts least able to afford it.
+      assert.ok(postCols.includes("narrowed_tools"), "narrowed_tools must be added too");
+      assert.ok(postCols.includes("label"), "label (the session name) must be added too");
+      assert.ok(!post.prepare("SELECT sql FROM sqlite_master WHERE name='bot_sessions'").get().sql
+        .includes("CHECK (control IN ('run','stop'))"),
+        "and the control-CHECK rebuild must have run, not aborted on the new column as drift");
     } finally {
       post.close();
     }

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -1934,3 +1934,108 @@ test("the breakpoint listener binds through addListener where that is the only s
   assert.ok(hub.timers.size > 0,
     "on that browser the re-evaluation would otherwise silently never bind");
 });
+
+// ---------------------------------------------------------------------------
+// TASK-3 item 1 — every turn's output was rendered TWICE.
+//
+// The engine streams message-level (perch-interactive.js:1257, "delta-level is
+// a recorded non-goal"), so `text` fires once per completed assistant message.
+// At turn end `reply` carries replyTextOf(end) — every assistant message of
+// that turn CONCATENATED. A two-message turn therefore rendered three entries:
+// each message, then both again as one block.
+//
+// COUNT assertions throughout: a contains-assertion passes through a duplicate
+// happily, which is how this survived.
+// ---------------------------------------------------------------------------
+
+/** Bot entries currently in the transcript, in order. */
+function botEntries(hub) {
+  return hub.els["perch-transcript"].children
+    .filter((c) => String(c.className).includes("entry") && String(c.className).includes("bot"))
+    .map((c) => (c.children.find((k) => String(k.className).includes("what")) || {}).textContent);
+}
+
+/** Drive one turn on the open session's stream. */
+function runTurn(hub, texts, replyText) {
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  for (const t of texts) es._serverFrame("text", { text: t });
+  if (replyText !== null) es._serverFrame("reply", { text: replyText });
+  return es;
+}
+
+test("a several-message turn renders one entry per message, not per message plus the join", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  runTurn(hub, ["Let me check.", "There are four boards."], "Let me check.There are four boards.");
+  assert.deepEqual(botEntries(hub), ["Let me check.", "There are four boards."],
+    "the concatenated reply must not be appended on top of the messages it is made of");
+});
+
+test("a one-message turn renders exactly one entry", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  runTurn(hub, ["Just the one."], "Just the one.");
+  assert.deepEqual(botEntries(hub), ["Just the one."]);
+});
+
+test("a ZERO-message turn still renders its reply — that text arrived by no other path", async () => {
+  // The decisive case, and it is reachable for a real operator: the stream
+  // carries NO backlog, so anyone who opens the drawer mid-turn sees no `text`
+  // frames for the messages already streamed. `reply` is then the only source
+  // of that turn's answer, and it is the more authoritative one anyway
+  // (replyTextOf reads the agent_end the engine was handed, never the child's
+  // accumulating log, which trimLog() empties).
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  runTurn(hub, [], "The whole answer, and the only copy of it.");
+  assert.deepEqual(botEntries(hub), ["The whole answer, and the only copy of it."]);
+});
+
+test("an ABORTED turn renders nothing extra and still leaves the composer usable", async () => {
+  // An aborted turn emits no reply at all (perch-interactive.js:1418 — the
+  // invariant is stated over the turn, so an abort landing during the metering
+  // awaits still silences it). The flag is cleared by the state frame, which is
+  // why dropping the append from `reply` could never have stranded it.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._serverFrame("text", { text: "half an answer" });
+  es._serverFrame("state", { state: "awake", turnInFlight: false });   // the abort's own state event
+  assert.deepEqual(botEntries(hub), ["half an answer"]);
+  assert.equal(hub.els["perch-send"].textContent, "Send", "back to Send, not stuck on Steer");
+});
+
+test("two turns in a row: the second turn's reply is judged on ITS OWN turn", async () => {
+  // The per-turn flag has to reset when a turn STARTS, or turn 2's
+  // reply-only answer would be swallowed by turn 1 having rendered.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  runTurn(hub, ["turn one streamed"], "turn one streamed");
+  runTurn(hub, [], "turn two arrived only as a reply");
+  assert.deepEqual(botEntries(hub), ["turn one streamed", "turn two arrived only as a reply"]);
+});
+
+test("a mid-turn state frame does not reset the per-turn flag and re-admit the duplicate", async () => {
+  // stateEvent() is emitted for model_select, ask_user, aborts — several can
+  // land between the first `text` and the `reply`, all carrying
+  // turnInFlight:true. Resetting on every true frame instead of on the
+  // false->true transition would put the duplicate straight back.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._serverFrame("text", { text: "the answer" });
+  es._serverFrame("state", { state: "awake", turnInFlight: true, model: "crow-local/qwen" });
+  es._serverFrame("reply", { text: "the answer" });
+  assert.deepEqual(botEntries(hub), ["the answer"]);
+});
+
+test("an empty reply on a turn that rendered nothing appends no empty entry", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  runTurn(hub, [], "");
+  assert.deepEqual(botEntries(hub), []);
+  assert.equal(hub.els["perch-send"].textContent, "Send", "and the flag is still cleared");
+});

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -191,14 +191,15 @@ test("async continuations are guarded — a fast back button must not cross sess
   // The guards are load-bearing and were previously pinned only by a commit
   // message. openSession's /roost fetch, loadHistory, onStreamError's options
   // fetch, the reconnect timer, answerAsk, and every SSE listener.
-  // 11 as of this fix wave: openSession's /roost fetch, startSession's spawn
-  // continuation, every SSE listener (shared through on()), onStreamError's
-  // options probe, the reconnect timer, loadHistory, loadOptions, send(),
-  // answerAsk, and attachFile's upload continuation. A regression that drops
-  // one — the count that shipped with only 6 asserted — is invisible until
-  // an operator hits the exact race the dropped guard covered.
+  // 12 as of the launch-model wave: openSession's /roost fetch, startSession's
+  // spawn continuation AND its launch-model control continuation, every SSE
+  // listener (shared through on()), onStreamError's options probe, the
+  // reconnect timer, loadHistory, loadOptions, send(), answerAsk, and
+  // attachFile's upload continuation. A regression that drops one — the count
+  // that shipped with only 6 asserted — is invisible until an operator hits
+  // the exact race the dropped guard covered.
   const guards = (js.match(/current\.sid\s*!==/g) || []).length;
-  assert.equal(guards, 11, "expected exactly 11 identity guards, found " + guards);
+  assert.equal(guards, 12, "expected exactly 12 identity guards, found " + guards);
 });
 
 test("the emitted script never assigns to an innerHTML-class sink", async () => {
@@ -250,12 +251,26 @@ test("a model option shows its human name and says when it is not serving", asyn
   assert.equal(modelOptionText({ provider: "p", id: "m", availability: "up" }), "p/m");
 });
 
-test("a hibernating session disables the pickers rather than emptying them", async () => {
-  const optionsUsable = await extract("optionsUsable");
+test("a missing list disables its OWN picker rather than emptying it", async () => {
+  const optionsUsable = await extract("optionsUsable", "function listUsable(a){ return !!(Array.isArray(a)&&a.length); }\n");
   assert.equal(optionsUsable({ models: null, thinkingLevels: null }), false);
   assert.equal(optionsUsable({ models: [], thinkingLevels: [] }), false);
   assert.equal(optionsUsable({ models: [{ id: "m", provider: "p" }], thinkingLevels: ["off"] }), true);
   assert.equal(optionsUsable(null), false);
+});
+
+test("the two pickers are gated separately — the fallback list must not be disabled by a missing thinking list", async () => {
+  // The engine's hibernating answer is now {models: <provider catalogue>,
+  // thinkingLevels: null}: a model switch made while asleep binds at the next
+  // wake and really works, a thinking switch does nothing at all. One shared
+  // gate would disable the picker that WORKS because of the one that does not,
+  // which is the dead dropdown this wave exists to end.
+  const listUsable = await extract("listUsable");
+  assert.equal(listUsable([{ id: "m" }]), true);
+  assert.equal(listUsable([]), false);
+  assert.equal(listUsable(null), false);
+  assert.equal(listUsable(undefined), false);
+  assert.equal(listUsable("crow-local/qwen"), false, "a string is not a list");
 });
 
 test("control bodies use the exact keys the route reads, not camelCase", async () => {
@@ -464,7 +479,9 @@ async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
     "perch-plan-mode", "perch-input", "perch-send", "perch-back", "perch-abort",
     "perch-attach", "perch-file-input", "perch-chat",
     // Task C: the unconditional launcher and the two close controls.
-    "perch-new", "perch-new-bot", "perch-new-bot-label", "perch-launch-note", "perch-close"];
+    "perch-new", "perch-new-bot", "perch-new-bot-label", "perch-launch-note", "perch-close",
+    // The launch-model picker.
+    "perch-new-model", "perch-new-model-label"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
@@ -827,9 +844,18 @@ function roostFetch(roost, overrides = {}) {
     if (path.endsWith("/stop")) return makeResponse(200, { ok: true });
     if (path.endsWith("/options")) return makeResponse(200, { models: [], thinkingLevels: [] });
     if (path.endsWith("/transcript")) return makeResponse(200, { events: [] });
+    if (path.endsWith("/models")) return makeResponse(200, { models: LAUNCH_MODELS, default: "crow-local/qwen" });
     return makeResponse(200, {});
   };
 }
+
+/** The launcher's session-free list, as GET /bots/:id/models answers it:
+ *  annotated entries plus the bot's own configured default. */
+const LAUNCH_MODELS = [
+  { provider: "crow-local", id: "qwen", name: "Qwen", availability: "up" },
+  { provider: "raven-flash", id: "flash-next", name: "Flash Next", availability: "on_demand" },
+  { provider: "crow-dsv4", id: "deepseek-v4", name: "DeepSeek V4", availability: "unavailable" },
+];
 
 /** Every button rendered into the list, flattened, with the row it came from. */
 function listButtons(hub) {
@@ -869,11 +895,13 @@ test("C1: the launch control is live while EVERY attached bot already has a sess
     "startSession()'s own hash navigation ran — the launcher reuses it rather than respawning it");
 });
 
-test("C1: the launcher issues no extra request — the bot list rides the list's own /roost", async () => {
+test("C1: the bot ROSTER still rides the list's own /roost — the models call is the only addition", async () => {
   const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
-  const gets = hub.fetchCalls.filter((c) => c.method === "GET");
-  assert.equal(gets.length, 1, "exactly one GET on first paint: " + JSON.stringify(gets.map((g) => g.path)));
-  assert.equal(gets[0].path, "/roost");
+  const gets = hub.fetchCalls.filter((c) => c.method === "GET").map((g) => g.path);
+  // Two, not one: the roster comes off /roost as it always has, and the model
+  // picker needs a list /roost does not carry. It is fetched per BOT, not per
+  // poll — the test below pins that.
+  assert.deepEqual(gets, ["/roost", "/bots/r4-assistant/models"], JSON.stringify(gets));
 });
 
 test("C1: with more than one attached bot the picker decides, and only attached bots are offered", async () => {
@@ -1398,4 +1426,133 @@ test("F6: a 403 and a shapeless 200 report on the launcher too", async () => {
     assert.equal(hub.els["perch-launch-note"].textContent, expected);
     assert.equal(hub.els["perch-list-body"].children.length, 3, "rows survive: " + expected);
   }
+});
+
+// ---------------------------------------------------------------------------
+// The launcher's model picker — "I would like to choose the model I want to
+// use for the session up front."
+// ---------------------------------------------------------------------------
+
+test("the picker lists the bot's models, opens on its configured default, and says which are unavailable", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  const sel = hub.els["perch-new-model"];
+  assert.equal(sel.hidden, false, "one attached bot still gets a MODEL picker — models are per bot, not per roster");
+  assert.equal(hub.els["perch-new-model-label"].hidden, false);
+  assert.deepEqual(sel.children.map((o) => o.value),
+    ["crow-local/qwen", "raven-flash/flash-next", "crow-dsv4/deepseek-v4"]);
+  assert.equal(sel.value, "crow-local/qwen", "pre-selected on the bot's own model, so launching stays one tap");
+  assert.deepEqual(sel.children.map((o) => o.textContent), [
+    "Qwen — bot default",
+    "Flash Next — starts on demand",
+    "DeepSeek V4 — not running",
+  ], "an unavailable model must be visibly unavailable, never silently selectable");
+});
+
+test("launching on the default spawns and opens — no redundant model switch", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const posts = hub.fetchCalls.filter((c) => c.method === "POST").map((c) => c.path);
+  assert.deepEqual(posts, ["/bots/r4-assistant/interactive"],
+    "the spawn already resolved this model; switching to it would warm a provider twice for no change");
+  assert.equal(hub.location.hash, "perchlive-99999999");
+});
+
+test("launching on a NON-default model switches it before the session is opened at all", async () => {
+  let releaseControl;
+  const controlPending = new Promise((r) => { releaseControl = r; });
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, {
+      "/control": () => controlPending.then(() => makeResponse(200, { applied: { model: "raven-flash/flash-next" } })),
+    }),
+  });
+  hub.els["perch-new-model"].value = "raven-flash/flash-next";
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+
+  const control = hub.fetchCalls.filter((c) => c.path.includes("/control"));
+  assert.equal(control.length, 1, "the model is applied through control(), not through a new spawn parameter");
+  assert.equal(control[0].path, "/interactive/perchlive-99999999/control");
+  assert.deepEqual(JSON.parse(control[0].opts.body), { model: { provider: "raven-flash", id: "flash-next" } },
+    "the exact body the route reads — {provider, id}, mapped to modelId engine-side");
+  // THE POINT: the chat is not reachable until the switch has landed, so the
+  // first message cannot go out on the model the spawn happened to resolve.
+  assert.equal(hub.location.hash, "", "the session must not open while the switch is still in flight");
+  releaseControl();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.location.hash, "perchlive-99999999", "and it opens once the switch has landed");
+});
+
+test("a refused model switch opens the session anyway and says what happened", async () => {
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/control": () => makeResponse(409, { error: "turn_in_progress" }) }),
+  });
+  hub.els["perch-new-model"].value = "raven-flash/flash-next";
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-launch-note"].textContent,
+    "The session started on the bot's own model; the switch did not take.");
+  assert.equal(hub.location.hash, "perchlive-99999999",
+    "the session is real and usable — stranding a live child behind an error would be worse");
+});
+
+test("the model list is fetched per BOT, not per poll", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_ALL_BUSY) });
+  const modelGets = () => hub.fetchCalls.filter((c) => c.path.endsWith("/models")).length;
+  assert.equal(modelGets(), 1);
+  hub.els["perch-new-model"].value = "raven-flash/flash-next";
+  for (const fn of hub.timers.values()) fn();          // the 10s poll body, verbatim
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(modelGets(), 1, "a poll must not refetch — repopulating would throw away a mid-tap pick");
+  assert.equal(hub.els["perch-new-model"].value, "raven-flash/flash-next", "and the pick survives");
+});
+
+test("with several bots the model list follows the roster select", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_TWO_BOTS) });
+  const modelPaths = () => hub.fetchCalls.filter((c) => c.path.endsWith("/models")).map((c) => c.path);
+  assert.deepEqual(modelPaths(), ["/bots/alpha/models"], "the bot the launcher would spawn against");
+  hub.els["perch-new-bot"].value = "beta";
+  hub.els["perch-new-bot"].onchange();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(modelPaths(), ["/bots/alpha/models", "/bots/beta/models"],
+    "models are per-bot; a picker still showing alpha's models must not choose for beta");
+});
+
+test("a model list that does not arrive leaves NO picker, rather than an empty enabled one", async () => {
+  const hub = await mountHub({
+    fetchImpl: roostFetch(ROOST_ALL_BUSY, { "/models": () => makeResponse(503, { error: "upstream" }) }),
+  });
+  assert.equal(hub.els["perch-new-model"].hidden, true);
+  assert.equal(hub.els["perch-new-model-label"].hidden, true);
+  assert.equal(hub.els["perch-new"].disabled, false, "and the launcher still works — the model is optional");
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const posts = hub.fetchCalls.filter((c) => c.method === "POST").map((c) => c.path);
+  assert.deepEqual(posts, ["/bots/r4-assistant/interactive"], "no control from a picker that is not there");
+});
+
+test("with no attached bot there is no model picker either", async () => {
+  const hub = await mountHub({ fetchImpl: roostFetch(ROOST_NO_ATTACHED) });
+  assert.equal(hub.els["perch-new-model"].hidden, true);
+  assert.equal(hub.fetchCalls.filter((c) => c.path.endsWith("/models")).length, 0,
+    "no bot to ask about");
+});
+
+test("the drawer's model picker is ENABLED on a hibernating session's fallback list", async () => {
+  // Kevin's actual bug: he switched a session's model, a deploy restarted the
+  // gateway, and the picker "stopped working". The switch itself was always
+  // honoured (control() stores it, startChild reads it before warmModel); only
+  // the list was missing, and an empty dropdown reads as a broken page.
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/options": () => makeResponse(200, {
+      models: [{ provider: "crow-local", id: "qwen", name: "Qwen", availability: "up" }],
+      thinkingLevels: null, source: "providers" }) }),
+  });
+  await openChatSession(hub);
+  const modelSel = hub.els["perch-model"], thinkSel = hub.els["perch-thinking"];
+  assert.equal(modelSel.disabled, false, "the fallback list is a real list and the switch really binds at the next wake");
+  assert.deepEqual(modelSel.children.map((o) => o.value), ["crow-local/qwen"]);
+  assert.equal(thinkSel.disabled, true,
+    "thinking stays disabled: control()'s thinking branch is a no-op with no child, so offering it would lie");
+  assert.equal(thinkSel.children.length, 0);
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -472,12 +472,18 @@ async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
   const fetchCalls = [];
   const fetchFn = fetchImpl || (() => Promise.resolve(makeResponse(200, {})));
 
-  const doc = {
+  // addEventListener on the DOCUMENT, not just window: the hub script now
+  // listens for Turbo's turbo:before-render to retire itself when the shell
+  // swaps the body out from under it (perch-hub/client.js's ONE ACTIVE
+  // INSTANCE block). A document without it throws at script-run time, which
+  // would fail every test in this harness for the wrong reason.
+  const docTarget = makeEventTarget();
+  const doc = Object.assign(docTarget, {
     cookie: "crow_csrf=test-csrf-token",
     body: bodyEl,
     getElementById(id) { return els[id] || null; },
     createElement(tag) { return makeFakeElement(tag); },
-  };
+  });
 
   const winTarget = makeEventTarget();
   const vvTarget = makeEventTarget();

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -251,14 +251,6 @@ test("a model option shows its human name and says when it is not serving", asyn
   assert.equal(modelOptionText({ provider: "p", id: "m", availability: "up" }), "p/m");
 });
 
-test("a missing list disables its OWN picker rather than emptying it", async () => {
-  const optionsUsable = await extract("optionsUsable", "function listUsable(a){ return !!(Array.isArray(a)&&a.length); }\n");
-  assert.equal(optionsUsable({ models: null, thinkingLevels: null }), false);
-  assert.equal(optionsUsable({ models: [], thinkingLevels: [] }), false);
-  assert.equal(optionsUsable({ models: [{ id: "m", provider: "p" }], thinkingLevels: ["off"] }), true);
-  assert.equal(optionsUsable(null), false);
-});
-
 test("the two pickers are gated separately — the fallback list must not be disabled by a missing thinking list", async () => {
   // The engine's hibernating answer is now {models: <provider catalogue>,
   // thinkingLevels: null}: a model switch made while asleep binds at the next
@@ -429,6 +421,14 @@ function makeFakeElement(tag) {
     get() { return this.children[0] || null; },
     configurable: true,
   });
+  // A real <select> exposes its options BOTH as .children and as .options;
+  // the client reads .options (the idiomatic API) and this harness had only
+  // the former, which surfaced as a TypeError rather than as a failed
+  // assertion the first time production code used it.
+  Object.defineProperty(node, "options", {
+    get() { return this.children; },
+    configurable: true,
+  });
   return node;
 }
 
@@ -470,7 +470,8 @@ function makeResponse(status, body) {
  *  path, opts)` decides how every perchApi call resolves; the default 200s
  *  everything with `{}`. Returns the fake DOM pieces and every fetch call
  *  made, in order, so a test can assert on both wiring and traffic. */
-async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", split = false } = {}) {
+async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", split = false,
+                          legacyMediaQuery = false } = {}) {
   const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
   const js = perchHubJs("en");
 
@@ -517,6 +518,15 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     media: "(min-width:900px)",
     _set(v) { this.matches = !!v; this._dispatch("change", { matches: this.matches }); },
   });
+  // Q8: pre-2019 Safari exposes only addListener on a MediaQueryList. Drop the
+  // modern spelling and map the legacy one onto the same dispatcher, so a test
+  // can prove the fallback binds rather than silently doing nothing.
+  if (legacyMediaQuery) {
+    const modern = mq.addEventListener.bind(mqTarget);
+    mq.addListener = (fn) => modern("change", fn);
+    mq.removeListener = () => {};
+    delete mq.addEventListener;                    // the only spelling that browser has
+  }
   const win = Object.assign(winTarget, {
     visualViewport, innerHeight: 800,
     matchMedia: () => mq,
@@ -1571,12 +1581,14 @@ test("the drawer's model picker is ENABLED on a hibernating session's fallback l
   const hub = await mountHub({
     fetchImpl: stdFetch({ "/options": () => makeResponse(200, {
       models: [{ provider: "crow-local", id: "qwen", name: "Qwen", availability: "up" }],
-      thinkingLevels: null, source: "providers" }) }),
+      thinkingLevels: null, current: "crow-local/qwen", source: "providers" }) }),
   });
   await openChatSession(hub);
   const modelSel = hub.els["perch-model"], thinkSel = hub.els["perch-thinking"];
   assert.equal(modelSel.disabled, false, "the fallback list is a real list and the switch really binds at the next wake");
   assert.deepEqual(modelSel.children.map((o) => o.value), ["crow-local/qwen"]);
+  assert.equal(modelSel.value, "crow-local/qwen",
+    "and it must SAY which one is live — enabled-and-listing was the assertion this bug walked through");
   assert.equal(thinkSel.disabled, true,
     "thinking stays disabled: control()'s thinking branch is a no-op with no child, so offering it would lie");
   assert.equal(thinkSel.children.length, 0);
@@ -1795,4 +1807,130 @@ test("the emitted script is syntactically valid JS", async () => {
     const js = perchHubJs(lang);          // throws on its own if the literal broke
     assert.doesNotThrow(() => new Function(js), lang + " must emit parseable JS");
   }
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q1 — the select must report the model the session is ON.
+// ---------------------------------------------------------------------------
+
+const THREE_MODELS = [
+  { provider: "crow-local", id: "qwen", name: "Qwen", availability: "up" },
+  { provider: "raven-flash", id: "flash-next", name: "Flash Next", availability: "on_demand" },
+  { provider: "crow-dsv4", id: "deepseek-v4", name: "DeepSeek V4", availability: "unavailable" },
+];
+const optionsWith = (current) => stdFetch({
+  "/options": () => makeResponse(200, { models: THREE_MODELS, thinkingLevels: ["off", "high"], current }),
+});
+
+test("the drawer's model select reads the session's model, not whichever option sorts first", async () => {
+  // The measured bug: nothing ever assigned modelSel.value, so the picker
+  // asserted crow-local/qwen — the first entry — for a session running
+  // flash-next, on the one control this feature exists for.
+  const hub = await mountHub({ fetchImpl: optionsWith("raven-flash/flash-next") });
+  await openChatSession(hub);
+  assert.equal(hub.els["perch-model"].value, "raven-flash/flash-next");
+  assert.notEqual(hub.els["perch-model"].value, hub.els["perch-model"].children[0].value,
+    "fixture check: the live model is deliberately NOT option 0, or this proves nothing");
+});
+
+test("a state frame moves the select — pi's own /model and auto-fallbacks were on the wire all along", async () => {
+  const hub = await mountHub({ fetchImpl: optionsWith("crow-local/qwen") });
+  await openChatSession(hub);
+  assert.equal(hub.els["perch-model"].value, "crow-local/qwen");
+  FakeEventSource.instances[0]._serverFrame("state",
+    { state: "awake", turnInFlight: false, model: "crow-dsv4/deepseek-v4" });
+  assert.equal(hub.els["perch-model"].value, "crow-dsv4/deepseek-v4");
+});
+
+test("a model the list does not carry is added and selected, not silently dropped", async () => {
+  // A provider row removed since the session started, or a model pi resolved
+  // on its own. Leaving the select on nothing would report the same "don't
+  // know" the empty dropdown did.
+  const hub = await mountHub({ fetchImpl: optionsWith("retired-provider/old-model") });
+  await openChatSession(hub);
+  const sel = hub.els["perch-model"];
+  assert.equal(sel.value, "retired-provider/old-model");
+  assert.equal(sel.children[0].value, "retired-provider/old-model", "prepended, so it reads first");
+  assert.equal(sel.children[0].textContent, "retired-provider/old-model — current");
+  assert.equal(sel.children.length, 4, "and the catalogue is still all there");
+});
+
+test("a disabled model select is never given a value — there is no list to be right about", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/options": () => makeResponse(200, { models: [], thinkingLevels: [], current: "crow-local/qwen" }) }),
+  });
+  await openChatSession(hub);
+  assert.equal(hub.els["perch-model"].disabled, true);
+  assert.equal(hub.els["perch-model"].children.length, 0,
+    "an unlisted-current option must not resurrect a picker with no catalogue behind it");
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q2 — a bot with no configured default
+// ---------------------------------------------------------------------------
+
+const modelsFetch = (dflt) => roostFetch(ROOST_ALL_BUSY, {
+  "/models": () => makeResponse(200, { models: LAUNCH_MODELS, default: dflt }),
+});
+
+test("a bot with NO configured default offers 'the bot's own model', preselected", async () => {
+  // Measured: 3 of 5 R4 bot defs carry models:null. Without this option nothing
+  // was preselected, the browser picked option 0, and tapping New session fired
+  // a REAL control() switch onto whatever sorted first in provider order.
+  const hub = await mountHub({ fetchImpl: modelsFetch(null) });
+  const sel = hub.els["perch-new-model"];
+  assert.equal(sel.children[0].value, "");
+  assert.equal(sel.children[0].textContent, "The bot's own model");
+  assert.equal(sel.value, "", "preselected, so one tap means what it always meant");
+});
+
+test("launching on 'the bot's own model' sends NO control at all", async () => {
+  const hub = await mountHub({ fetchImpl: modelsFetch(null) });
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const posts = hub.fetchCalls.filter((c) => c.method === "POST").map((c) => c.path);
+  assert.deepEqual(posts, ["/bots/r4-assistant/interactive"],
+    "letting the spawn resolve the model is the whole point of the option");
+});
+
+test("a default naming a model the catalogue no longer carries falls back the same way", async () => {
+  // A def pointing at a provider row that has since been disabled.
+  const hub = await mountHub({ fetchImpl: modelsFetch("retired-provider/gone") });
+  const sel = hub.els["perch-new-model"];
+  assert.equal(sel.value, "", "no silent switch onto option 0");
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(hub.fetchCalls.filter((c) => c.method === "POST").map((c) => c.path),
+    ["/bots/r4-assistant/interactive"]);
+});
+
+test("a bot WITH a configured default gets no sentinel — it already has an answer", async () => {
+  const hub = await mountHub({ fetchImpl: modelsFetch("raven-flash/flash-next") });
+  const sel = hub.els["perch-new-model"];
+  assert.equal(sel.children.filter((o) => o.value === "").length, 0);
+  assert.equal(sel.value, "raven-flash/flash-next");
+});
+
+test("the sentinel is still an explicit choice: picking a real model from it switches", async () => {
+  const hub = await mountHub({ fetchImpl: modelsFetch(null) });
+  hub.els["perch-new-model"].value = "crow-dsv4/deepseek-v4";
+  hub.els["perch-new"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const control = hub.fetchCalls.filter((c) => c.path.includes("/control"));
+  assert.equal(control.length, 1, "an operator who DID choose still gets their choice");
+  assert.deepEqual(JSON.parse(control[0].opts.body), { model: { provider: "crow-dsv4", id: "deepseek-v4" } });
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q8 — the pre-2019 MediaQueryList spelling
+// ---------------------------------------------------------------------------
+
+test("the breakpoint listener binds through addListener where that is the only spelling", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch(), split: false, legacyMediaQuery: true });
+  await openChatSession(hub);
+  assert.equal(hub.timers.size, 0, "precondition: narrow, chat open, list hidden, nothing polling");
+  hub.mq._set(true);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.ok(hub.timers.size > 0,
+    "on that browser the re-evaluation would otherwise silently never bind");
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -212,10 +212,21 @@ test("the emitted script never assigns to an innerHTML-class sink", async () => 
   // Matches both plain (=) and compound (+=) assignment — a compound
   // assignment against these sinks parses and executes the same injection
   // and a narrower regex let it through undetected.
-  assert.ok(!/\.innerHTML\s*\+?=/.test(js), "no .innerHTML assignment");
   assert.ok(!/\.outerHTML\s*\+?=/.test(js), "no .outerHTML assignment");
   assert.ok(!/\.insertAdjacentHTML\s*\(/.test(js), "no insertAdjacentHTML call");
   assert.ok(!/document\.write\s*\(/.test(js), "no document.write call");
+
+  // ONE innerHTML assignment is now permitted — server-rendered, sanitized
+  // markdown for a bot message — and the permission is written as a COUNT plus
+  // a location, not as a hole. A second one, anywhere, fails here.
+  const assignments = js.match(/\.innerHTML\s*\+?=/g) || [];
+  assert.equal(assignments.length, 1, "exactly one .innerHTML assignment: " + assignments.length);
+  assert.match(js, /function setSanitizedHtml\(node,html\)\{ node\.innerHTML=html; \}/,
+    "and it is the single named sink, so a reader can find every path into it at once");
+  // …and that sink has exactly one caller. Reusing it for anything that is not
+  // server-sanitized is the way this permission would rot.
+  const calls = js.match(/setSanitizedHtml\(/g) || [];
+  assert.equal(calls.length, 2, "one definition, one call site: " + calls.length);
 });
 
 /** A function's OWN source, brace-matched. Never a fixed-size window: every
@@ -421,6 +432,11 @@ function makeFakeElement(tag) {
     get() { return this.children[0] || null; },
     configurable: true,
   });
+  // innerHTML: the ONE sanitized sink the client has (server-rendered
+  // markdown). Recorded rather than parsed — this harness is not a DOM, and
+  // what matters here is WHICH path appendMessage took and with what string.
+  // The rendered result itself is measured live in perch-hub-render.test.js.
+  node.innerHTML = "";
   // A real <select> exposes its options BOTH as .children and as .options;
   // the client reads .options (the idiomatic API) and this harness had only
   // the former, which surfaced as a TypeError rather than as a failed
@@ -2038,4 +2054,81 @@ test("an empty reply on a turn that rendered nothing appends no empty entry", as
   runTurn(hub, [], "");
   assert.deepEqual(botEntries(hub), []);
   assert.equal(hub.els["perch-send"].textContent, "Send", "and the flag is still cleared");
+});
+
+// ---------------------------------------------------------------------------
+// TASK-3 item 2 — bot markdown is rendered, from server-sanitized HTML.
+// ---------------------------------------------------------------------------
+
+/** The .what node of the last bot entry. */
+function lastWhat(hub) {
+  const entries = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("entry"));
+  const row = entries[entries.length - 1];
+  return row && row.children.find((k) => String(k.className).includes("what"));
+}
+
+test("a bot message with server-rendered html takes the sanitized-HTML path", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  FakeEventSource.instances[0]._serverFrame("state", { state: "awake", turnInFlight: true });
+  FakeEventSource.instances[0]._serverFrame("text",
+    { text: "## Boards\n\nThere are **four**.", html: "<h2>Boards</h2><p>There are <strong>four</strong>.</p>" });
+  const what = lastWhat(hub);
+  assert.equal(what.className, "what md", "a distinct class, so the stylesheet can undo pre-wrap for real blocks");
+  assert.equal(what.innerHTML, "<h2>Boards</h2><p>There are <strong>four</strong>.</p>");
+  assert.equal(what.textContent, "", "the raw markdown must not ALSO be written as text");
+});
+
+test("a message with no html falls back to textContent — byte-for-byte the old behaviour", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  FakeEventSource.instances[0]._serverFrame("state", { state: "awake", turnInFlight: true });
+  // What a failed render, an older gateway, or a non-prose frame all produce.
+  FakeEventSource.instances[0]._serverFrame("text", { text: "## not rendered" });
+  const what = lastWhat(hub);
+  assert.equal(what.className, "what");
+  assert.equal(what.textContent, "## not rendered");
+  assert.equal(what.innerHTML, "", "nothing may reach the sink without server-rendered html");
+});
+
+test("the operator's own message is never routed through the HTML sink", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  hub.els["perch-input"].value = "**not mine to render**";
+  hub.els["perch-send"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const what = lastWhat(hub);
+  assert.equal(what.className, "what");
+  assert.equal(what.textContent, "**not mine to render**");
+});
+
+test("history renders each message's own html, and still one entry per message", async () => {
+  const events = [
+    { type: "message", message: { role: "user", content: "how many boards?" } },
+    { type: "message", message: { role: "assistant", content: [{ type: "text", text: "**four**" }] },
+      html: "<p><strong>four</strong></p>" },
+    { type: "message", message: { role: "assistant", content: [{ type: "toolCall", name: "board_list_boards" }] } },
+  ];
+  const hub = await mountHub({ fetchImpl: stdFetch({ "/transcript": () => makeResponse(200, { events }) }) });
+  await openChatSession(hub);
+  const rows = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("entry"));
+  assert.equal(rows.length, 3, "one entry per message, unchanged by rendering");
+  const whats = rows.map((r) => r.children.find((k) => String(k.className).includes("what")));
+  assert.equal(whats[0].className, "what", "the user's line stays plain");
+  assert.equal(whats[1].className, "what md");
+  assert.equal(whats[1].innerHTML, "<p><strong>four</strong></p>");
+  assert.equal(whats[2].className, "what", "a tool-call message keeps the [tool: name] line");
+  assert.equal(whats[2].textContent, "[tool: board_list_boards]");
+});
+
+test("rendering does not re-open the duplicate: a turn with html still renders once", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._serverFrame("text", { text: "**one**", html: "<p><strong>one</strong></p>" });
+  es._serverFrame("text", { text: "**two**", html: "<p><strong>two</strong></p>" });
+  es._serverFrame("reply", { text: "**one****two**", html: "<p><strong>one</strong><strong>two</strong></p>" });
+  const rows = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("entry bot"));
+  assert.equal(rows.length, 2, "the concatenated reply is still suppressed when the messages rendered");
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -470,7 +470,7 @@ function makeResponse(status, body) {
  *  path, opts)` decides how every perchApi call resolves; the default 200s
  *  everything with `{}`. Returns the fake DOM pieces and every fetch call
  *  made, in order, so a test can assert on both wiring and traffic. */
-async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
+async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", split = false } = {}) {
   const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
   const js = perchHubJs("en");
 
@@ -481,7 +481,9 @@ async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
     // Task C: the unconditional launcher and the two close controls.
     "perch-new", "perch-new-bot", "perch-new-bot-label", "perch-launch-note", "perch-close",
     // The launch-model picker.
-    "perch-new-model", "perch-new-model-label"];
+    "perch-new-model", "perch-new-model-label",
+    // Session rename: the header control and the name line it writes.
+    "perch-rename", "perch-session-name"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
@@ -505,7 +507,20 @@ async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
   const winTarget = makeEventTarget();
   const vvTarget = makeEventTarget();
   const visualViewport = Object.assign(vvTarget, { height: 700, offsetTop: 0 });
-  const win = Object.assign(winTarget, { visualViewport, innerHeight: 800 });
+  // The split-view media query. `split: true` puts the harness at >=900px,
+  // where .hub-split is a two-column grid and the session list stays on screen
+  // with a chat open — the state finding 1 is about. `mq._set(matches)` fires a
+  // real change event, which is how a window crossing the breakpoint behaves.
+  const mqTarget = makeEventTarget();
+  const mq = Object.assign(mqTarget, {
+    matches: !!split,
+    media: "(min-width:900px)",
+    _set(v) { this.matches = !!v; this._dispatch("change", { matches: this.matches }); },
+  });
+  const win = Object.assign(winTarget, {
+    visualViewport, innerHeight: 800,
+    matchMedia: () => mq,
+  });
 
   // history is counted, not simulated: assigning location.hash pushes an entry,
   // location.replace('#') does not. Both fire hashchange — verified in a real
@@ -541,9 +556,19 @@ async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
   // is a stop with no gate, which is the failure mode the confirmation exists
   // to prevent.
   const confirms = [];
+  // Renaming asks through prompt(), the same native primitive the close gate
+  // uses for confirm(). Recorded with its prefill so a test can prove BOTH
+  // that the operator was asked and what they were shown. Default: cancelled
+  // (null) — a rename that posts under this default is a rename with no
+  // operator input at all.
+  const prompts = [];
   const sandbox = {
     document: doc,
     confirm(msg) { confirms.push(String(msg)); return confirmImpl ? confirmImpl(String(msg)) : false; },
+    prompt(msg, prefill) {
+      prompts.push({ msg: String(msg), prefill: prefill == null ? null : String(prefill) });
+      return promptImpl ? promptImpl(String(msg), prefill) : null;
+    },
     window: win,
     location,
     EventSource: FakeEventSource,
@@ -574,7 +599,7 @@ async function mountHub({ fetchImpl, confirmImpl, initialHash = "" } = {}) {
   // fetchCalls or the DOM it produced.
   await new Promise((r) => setTimeout(r, 0));
 
-  return { els, doc, win, location, fetchCalls, sandbox, timers, confirms, history };
+  return { els, doc, win, location, fetchCalls, sandbox, timers, confirms, prompts, history, mq };
 }
 
 /** Opens a chat session the same way a real click does: seed a /roost
@@ -1555,4 +1580,191 @@ test("the drawer's model picker is ENABLED on a hibernating session's fallback l
   assert.equal(thinkSel.disabled, true,
     "thinking stays disabled: control()'s thinking branch is a no-op with no child, so offering it would lie");
   assert.equal(thinkSel.children.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Finding 1 — in split view the list is VISIBLE, so it must keep polling.
+// ---------------------------------------------------------------------------
+
+test("below the breakpoint, opening a session stops the list poll — the list really is hidden there", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch(), split: false });
+  assert.equal(hub.timers.size > 0, true, "the list view polls");
+  await openChatSession(hub);
+  assert.equal(hub.timers.size, 0, "nothing left ticking behind a hidden list");
+});
+
+test("in SPLIT view, opening a session keeps the list polling and refreshes it at once", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch(), split: true });
+  const roostsBefore = hub.fetchCalls.filter((c) => c.path === "/roost").length;
+  await openChatSession(hub);
+  assert.ok(hub.timers.size > 0,
+    "the list is on screen beside the chat; a frozen list is what showed an idle row for an awake session");
+  const roosts = hub.fetchCalls.filter((c) => c.path === "/roost").length;
+  assert.ok(roosts > roostsBefore, "and it refreshes immediately, so the session just opened appears as a row");
+});
+
+test("crossing the breakpoint with a chat open starts and stops the poll, with no navigation at all", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch(), split: false });
+  await openChatSession(hub);
+  assert.equal(hub.timers.size, 0);
+  hub.mq._set(true);                       // the operator widened the window
+  await new Promise((r) => setTimeout(r, 0));
+  assert.ok(hub.timers.size > 0, "the list just came on screen; it must not sit there stale");
+  hub.mq._set(false);                      // and narrowed it again
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.timers.size, 0);
+});
+
+test("in split view the poll renders the newly opened session as a live row with a Close", async () => {
+  // Kevin's screenshot: an awake session open on the right, and on the left a
+  // single "R4 Assistant / idle" row with a Talk button. Close lives on live
+  // rows only, so that surface offered no way to end anything.
+  let roost = { birds: [{ id: "r4", name: "R4 Assistant", perch_attached: true, state: "idle", sessions: [] }] };
+  const hub = await mountHub({ fetchImpl: stdFetch({ "/roost": () => makeResponse(200, roost) }), split: true });
+  assert.deepEqual(listButtons(hub).map((b) => b.text), ["Talk"], "precondition: an idle bot, nothing live");
+
+  // The session exists now — exactly what the frozen list never learned.
+  roost = { birds: [{ id: "r4", name: "R4 Assistant", perch_attached: true, state: "working",
+    sessions: [{ sessionId: "perchlive-aaaaaaaa", state: "awake", cardId: null, pendingUi: false }] }] };
+  await openChatSession(hub);
+  await new Promise((r) => setTimeout(r, 0));
+  for (const fn of hub.timers.values()) fn();          // the 10s poll body, verbatim
+  await new Promise((r) => setTimeout(r, 0));
+
+  const texts = listButtons(hub).map((b) => b.text);
+  assert.ok(texts.includes("Open"), "the live session must be a row: " + JSON.stringify(texts));
+  assert.ok(texts.includes("Close"), "and it must offer the Close the operator went looking for");
+  assert.equal(texts.includes("Talk"), false, "the bot is no longer idle");
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3 — sessions can be named. "It seems like there is not a way to
+// rename the sessions."
+// ---------------------------------------------------------------------------
+
+const ROOST_NAMED = {
+  birds: [{ id: "r4", name: "R4 Assistant", perch_attached: true, state: "working",
+    sessions: [{ sessionId: "perchlive-aaaaaaaa", state: "awake", cardId: 248, pendingUi: false,
+      label: "Nov package copy pass" }] }],
+};
+
+test("a named session renders its name AND keeps the id subtitle it always had", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch({ "/roost": () => makeResponse(200, ROOST_NAMED) }) });
+  const rowEl = hub.els["perch-list-body"].children[0];
+  const texts = rowEl.children.find((c) => c.className === "roost-main").children.map((c) => c.textContent);
+  assert.deepEqual(texts, ["R4 Assistant", "Nov package copy pass", "awake · aaaaaaaa · card 248"],
+    "the name is a convenience; the machine id is the identity and stays visible");
+});
+
+test("an unnamed session falls back to exactly the subtitle it had before", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  const rowEl = hub.els["perch-list-body"].children[0];
+  const texts = rowEl.children.find((c) => c.className === "roost-main").children.map((c) => c.textContent);
+  assert.deepEqual(texts, ["R4 Assistant", "awake · aaaaaaaa"], "no empty name line, no change to the old rendering");
+});
+
+test("a name containing markup is rendered as TEXT, in the row and in the confirm", async () => {
+  const nasty = "<img src=x onerror=alert(1)>";
+  const roost = { birds: [{ id: "r4", name: "R4 Assistant", perch_attached: true, state: "working",
+    sessions: [{ sessionId: "perchlive-aaaaaaaa", state: "awake", cardId: null, pendingUi: false, label: nasty }] }] };
+  const hub = await mountHub({ fetchImpl: stdFetch({ "/roost": () => makeResponse(200, roost) }) });
+  const rowEl = hub.els["perch-list-body"].children[0];
+  const nameLine = rowEl.children.find((c) => c.className === "roost-main").children
+    .find((c) => c.className === "roost-name");
+  // line() builds with textContent; the value is never assigned to an HTML
+  // sink (the whole-script no-innerHTML test above covers that structurally).
+  assert.equal(nameLine.textContent, nasty);
+  const close = listButtons(hub).find((b) => b.text === "Close");
+  close.btn.onclick();
+  assert.equal(hub.confirms.length, 1);
+  assert.ok(hub.confirms[0].includes(nasty), "the confirm carries it as text too: " + hub.confirms[0]);
+  assert.ok(hub.confirms[0].includes("aaaaaaaa"),
+    "and still names the id — two sessions can carry the same name: " + hub.confirms[0]);
+});
+
+test("renaming from a row asks first, posts the new name, and needs no confirmation", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/rename": () => makeResponse(200, { label: "Nov package" }) }),
+    promptImpl: () => "  Nov   package  ",
+  });
+  const rename = listButtons(hub).find((b) => b.text === "Rename");
+  assert.ok(rename, "a live row must offer it");
+  rename.btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.prompts.length, 1, "the operator was asked");
+  assert.equal(hub.confirms.length, 0, "renaming is reversible — no confirmation gate");
+  const posts = hub.fetchCalls.filter((c) => c.path.includes("/rename"));
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0].path, "/interactive/perchlive-aaaaaaaa/rename");
+  assert.deepEqual(JSON.parse(posts[0].opts.body), { label: "  Nov   package  " },
+    "raw as typed — the ENGINE normalizes, so what is stored is what comes back");
+});
+
+test("a cancelled rename posts nothing at all", async () => {
+  // promptImpl defaults to null, which is what Cancel gives.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  listButtons(hub).find((b) => b.text === "Rename").btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.prompts.length, 1);
+  assert.equal(hub.fetchCalls.filter((c) => c.path.includes("/rename")).length, 0);
+});
+
+test("an EMPTY answer clears the name — that is an action, not a cancel", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/roost": () => makeResponse(200, ROOST_NAMED),
+                          "/rename": () => makeResponse(200, { label: null }) }),
+    promptImpl: () => "",
+  });
+  const rename = listButtons(hub).find((b) => b.text === "Rename");
+  assert.equal(hub.prompts[0], undefined);
+  rename.btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.prompts[0].prefill, "Nov package copy pass", "the prompt is prefilled with the current name");
+  const posts = hub.fetchCalls.filter((c) => c.path.includes("/rename"));
+  assert.equal(posts.length, 1, "an empty string must reach the engine; only null (Cancel) is a no-op");
+  assert.deepEqual(JSON.parse(posts[0].opts.body), { label: "" });
+});
+
+test("the chat header shows the name, and a state frame keeps it current", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch({ "/roost": () => makeResponse(200, ROOST_NAMED) }) });
+  await openChatSession(hub);
+  assert.equal(hub.els["perch-session-name"].textContent, "Nov package copy pass");
+  assert.equal(hub.els["perch-session-name"].hidden, false);
+  assert.equal(hub.els["perch-session-meta"].textContent, "perchlive-aaaaaaaa",
+    "the id line is untouched — it is the identity");
+
+  // Renamed from somewhere else (another tab, a list row): the engine echoes
+  // the label on every state frame.
+  FakeEventSource.instances[0]._serverFrame("state", { state: "awake", turnInFlight: false, label: "Renamed elsewhere" });
+  assert.equal(hub.els["perch-session-name"].textContent, "Renamed elsewhere");
+
+  FakeEventSource.instances[0]._serverFrame("state", { state: "awake", turnInFlight: false, label: null });
+  assert.equal(hub.els["perch-session-name"].hidden, true, "a cleared name hides the line rather than showing an empty one");
+});
+
+test("the header's Rename control is wired and prefilled from the open session", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/roost": () => makeResponse(200, ROOST_NAMED),
+                          "/rename": () => makeResponse(200, { label: "Renamed" }) }),
+    promptImpl: () => "Renamed",
+  });
+  await openChatSession(hub);
+  hub.els["perch-rename"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.prompts[0].prefill, "Nov package copy pass");
+  const posts = hub.fetchCalls.filter((c) => c.path.includes("/rename"));
+  assert.equal(posts[0].path, "/interactive/perchlive-aaaaaaaa/rename");
+  assert.equal(hub.els["perch-session-name"].textContent, "Renamed",
+    "the header reflects what the engine STORED, not what was typed");
+});
+
+test("a refused rename says so instead of silently keeping the old name", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/rename": () => makeResponse(404, { error: "no_such_session" }) }),
+    promptImpl: () => "whatever",
+  });
+  listButtons(hub).find((b) => b.text === "Rename").btn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const noteText = hub.els["perch-list-body"].children.map((c) => c.textContent).join(" ");
+  assert.ok(noteText.includes("That session was not renamed."), noteText);
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -2132,3 +2132,102 @@ test("rendering does not re-open the duplicate: a turn with html still renders o
   const rows = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("entry bot"));
   assert.equal(rows.length, 2, "the concatenated reply is still suppressed when the messages rendered");
 });
+
+// ---------------------------------------------------------------------------
+// Fix round 2 N1 — a reconnect across a turn boundary silently ate the answer.
+//
+// The suppression flag was client state that survived a stream teardown and
+// reset only on a turnInFlight false->true transition. A reconnect that never
+// saw the separating false frame therefore carried a stale "already rendered"
+// across into the NEXT turn and dropped its reply. The engine's
+// replay-on-subscribe does not close it: the replayed frame is true and the
+// client is already true, so there is no transition.
+//
+// The frames now carry the turn they belong to, so `reply` judges its own turn.
+// BOTH reconnect shapes are driven below, with entry COUNTS.
+// ---------------------------------------------------------------------------
+
+/** Drop the live stream the way a blip does, and let the backoff timer
+ *  re-open it — the real path (onStreamError -> options probe ->
+ *  scheduleReconnect -> openStream), not a reach into the closure. */
+async function reconnect(hub) {
+  const before = FakeEventSource.instances.length;
+  FakeEventSource.instances[before - 1]._nativeError();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  for (const fn of hub.timers.values()) fn();          // the 2s backoff, fired
+  await new Promise((r) => setTimeout(r, 0));
+  assert.ok(FakeEventSource.instances.length > before, "the reconnect must actually open a new stream");
+  return FakeEventSource.instances[FakeEventSource.instances.length - 1];
+}
+
+test("N1 CROSS-turn reconnect: the next turn's reply still renders", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es1 = FakeEventSource.instances[0];
+  es1._serverFrame("state", { state: "awake", turnInFlight: true });
+  es1._serverFrame("text", { text: "turn 1 streamed half", turnId: "turn-1" });
+  assert.deepEqual(botEntries(hub), ["turn 1 streamed half"]);
+
+  // The blip: turn 1 ends and turn 2 runs inside it, so the client never sees
+  // the turnInFlight:false that separates them.
+  const es2 = await reconnect(hub);
+  es2._serverFrame("state", { state: "awake", turnInFlight: true });   // the engine's replay
+  es2._serverFrame("reply", { text: "turn 2's whole answer", turnId: "turn-2" });
+
+  assert.deepEqual(botEntries(hub), ["turn 1 streamed half", "turn 2's whole answer"],
+    "measured before the fix: turn 2 never rendered at all");
+});
+
+test("N1 SAME-turn reconnect: the reply is still suppressed, no duplicate", async () => {
+  // The case a bare reset in openStream() would have broken — which is why
+  // this is a turn id and not a reset.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es1 = FakeEventSource.instances[0];
+  es1._serverFrame("state", { state: "awake", turnInFlight: true });
+  es1._serverFrame("text", { text: "the answer", turnId: "turn-1" });
+
+  const es2 = await reconnect(hub);
+  es2._serverFrame("state", { state: "awake", turnInFlight: true });
+  es2._serverFrame("reply", { text: "the answer", turnId: "turn-1" });   // the SAME turn ends
+
+  assert.deepEqual(botEntries(hub), ["the answer"], "one entry, not two");
+});
+
+test("N1: a reply for a turn whose text was never seen renders, reconnect or not", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._serverFrame("text", { text: "turn 1", turnId: "turn-1" });
+  es._serverFrame("state", { state: "awake", turnInFlight: false });
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._serverFrame("reply", { text: "turn 2, reply only", turnId: "turn-2" });
+  assert.deepEqual(botEntries(hub), ["turn 1", "turn 2, reply only"]);
+});
+
+test("N1 fallback: frames with no turn id still use the transition flag", async () => {
+  // A gateway older than this script, or the child speaking outside a turn.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._serverFrame("text", { text: "streamed" });                       // no turnId
+  es._serverFrame("reply", { text: "streamed" });                      // no turnId
+  assert.deepEqual(botEntries(hub), ["streamed"], "the old mechanism still suppresses the join");
+});
+
+test("N1 sibling: an unparseable text frame appends nothing and suppresses nothing", async () => {
+  // on()'s JSON.parse failure hands the listener d={}. That used to append an
+  // empty .entry.bot AND mark the turn rendered, so the real reply was dropped
+  // too — one malformed frame cost the whole answer.
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  es._t._dispatch("text", { data: "{ this is not json" });             // the real failure shape
+  assert.deepEqual(botEntries(hub), [], "no empty entry");
+  es._serverFrame("reply", { text: "the real answer", turnId: "turn-1" });
+  assert.deepEqual(botEntries(hub), ["the real answer"]);
+});

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -1768,3 +1768,31 @@ test("a refused rename says so instead of silently keeping the old name", async 
   const noteText = hub.els["perch-list-body"].children.map((c) => c.textContent).join(" ");
   assert.ok(noteText.includes("That session was not renamed."), noteText);
 });
+
+test("a transcript that FAILED to load says so, instead of reporting an empty one", async () => {
+  // The old code collapsed a 500, a dropped tunnel and a logged-out session
+  // into "No transcript yet." — a reassuring sentence about a conversation
+  // that is still there. Flagged twice before this fix.
+  const hub = await mountHub({ fetchImpl: stdFetch({ "/transcript": () => makeResponse(503, { error: "upstream" }) }) });
+  await openChatSession(hub);
+  assert.deepEqual(notesIn(hub.els["perch-transcript"]), ["Could not load this session's history."]);
+});
+
+test("a genuinely empty transcript still reports empty, not failed", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });      // 200 with events: []
+  await openChatSession(hub);
+  assert.deepEqual(notesIn(hub.els["perch-transcript"]), ["No transcript yet."]);
+});
+
+test("the emitted script is syntactically valid JS", async () => {
+  // Cheap guard for a trap this file has hit three times: the whole client is
+  // emitted INSIDE a template literal, so one unescaped backtick — in a
+  // COMMENT is the usual way — terminates the literal and turns the rest of
+  // the script into code evaluated at emit time. The symptom is a
+  // ReferenceError from perchHubJs() itself, nowhere near the typo.
+  const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
+  for (const lang of ["en", "es"]) {
+    const js = perchHubJs(lang);          // throws on its own if the literal broke
+    assert.doesNotThrow(() => new Function(js), lang + " must emit parseable JS");
+  }
+});

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -252,9 +252,15 @@ test("the on-screen keyboard is accounted for", async () => {
   // stay where the flex column it's compensating for actually lives.
   const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
   const js = perchHubJs("en");
-  assert.match(js, /vv\.addEventListener\(\s*['"]resize['"]/,
+  // Both listeners now go through bindOnce() — the fix-round-1 Q3 guard that
+  // stops a Turbo visit stacking another copy of each. Still a SOURCE check
+  // (this file has no DOM harness), and still not a behavioural one: the
+  // proof that applyVV is really bound to both events AND really moves the
+  // padding lives in tests/perch-hub-client.test.js's "I2: applyVV is bound
+  // to BOTH visualViewport events" against a fake visualViewport.
+  assert.match(js, /bindOnce\(\s*vv\s*,\s*['"]resize['"]/,
     "the resize listener must be bound, not just the visualViewport token present");
-  assert.match(js, /vv\.addEventListener\(\s*['"]scroll['"]/,
+  assert.match(js, /bindOnce\(\s*vv\s*,\s*['"]scroll['"]/,
     "the scroll listener must be bound, not just the visualViewport token present");
   assert.match(js, /el\(\s*['"]perch-chat['"]\s*\)\.style\.paddingBottom/,
     "the keyboard-avoidance padding must land on #perch-chat, the flex column it's compensating for");

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -68,6 +68,17 @@ function serveApi(req, res) {
     return;
   }
   if (url.endsWith("/options")) return send(200, { models: [], thinkingLevels: [] });
+  // The launcher's session-free list, with a long name on purpose: the thing
+  // that must never happen at 412px is a model name pushing New session off
+  // the screen.
+  if (url.endsWith("/models")) return send(200, {
+    models: [
+      { provider: "crow-local", id: "qwen3.6-35b-a3b",
+        name: "Qwen3.6 35B A3B (Crow, Q5_K_XL MTP+vision, 256K)", availability: "up" },
+      { provider: "crow-dsv4", id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash", availability: "unavailable" },
+    ],
+    default: "crow-local/qwen3.6-35b-a3b",
+  });
   if (url.endsWith("/transcript")) return send(200, { events: [] });
   if (url.endsWith("/interactive") && req.method === "POST") return send(200, { sessionId: "perchlive-99999999" });
   return send(200, {});
@@ -505,5 +516,70 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.notePadding, "0px",
         "the note's own padding rule must win the cascade, not merely exist");
     } finally { roostFails = false; await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The launcher's model picker, live at both viewports. A 44px floor argued
+// from the cascade is how #perch-close shipped at 36px; these measure it.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`M1 live @${w}x${h}: the model picker is on screen, thumb-sized, and does not push New session off`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      const seen = await s.json(`(function(){
+        var box=function(id){ var e=document.getElementById(id), r=e.getBoundingClientRect();
+          return { hidden:e.hidden, w:Math.round(r.width), h:Math.round(r.height),
+                   top:Math.round(r.top), bottom:Math.round(r.bottom),
+                   inViewport: r.top>=0 && r.bottom<=innerHeight && r.left>=0 && r.right<=innerWidth,
+                   hit:(function(){ var el=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
+                                    return !!el && (el===e || e.contains(el)); })() }; };
+        var sel=document.getElementById('perch-new-model');
+        var doc=document.documentElement;
+        return JSON.stringify({ model:box('perch-new-model'), newBtn:box('perch-new'),
+          value: sel.value, options: Array.prototype.map.call(sel.options,function(o){return o.textContent;}),
+          hScroll: doc.scrollWidth > doc.clientWidth });
+      })()`);
+      assert.equal(seen.model.hidden, false, "the picker must be there once the list arrives");
+      assert.equal(seen.model.inViewport, true,
+        `the picker sits at ${seen.model.top}-${seen.model.bottom} in a ${h}px viewport`);
+      assert.equal(seen.model.hit, true, "and nothing overlaps it");
+      assert.ok(seen.model.h >= 44, `tap target ${seen.model.w}x${seen.model.h} is too small for a thumb`);
+      assert.equal(seen.value, "crow-local/qwen3.6-35b-a3b", "opened on the bot's configured model");
+      assert.match(seen.options[1], /not running/, "an unavailable model must read as unavailable");
+      // The regression a long model name would cause.
+      assert.equal(seen.newBtn.inViewport, true,
+        `New session at ${seen.newBtn.top}-${seen.newBtn.bottom} in a ${h}px viewport`);
+      assert.equal(seen.newBtn.hit, true);
+      assert.ok(seen.newBtn.h >= 44, `New session is ${seen.newBtn.w}x${seen.newBtn.h}`);
+      assert.equal(seen.hScroll, false, "no horizontal scroll at " + w + "px");
+    } finally { await s.close(); }
+  });
+
+  test(`M1 live @${w}x${h}: the picker does not disturb Send reachability`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      const m = await s.json(`(function(){
+        document.body.setAttribute('data-view','chat');
+        var tr=document.getElementById('perch-transcript');
+        for(var i=0;i<60;i++){ var d=document.createElement('div');
+          d.textContent='bot: a transcript line long enough to take a row or two, number '+i;
+          tr.appendChild(d); }
+        tr.scrollTop=0;
+        var cb=document.querySelector('.content-body');
+        var b=document.getElementById('perch-send').getBoundingClientRect();
+        return JSON.stringify({ viewport:innerHeight, top:Math.round(b.top), bottom:Math.round(b.bottom),
+          reachable: b.bottom<=innerHeight && b.top>=0,
+          contentBodyScroll: cb.scrollHeight-cb.clientHeight });
+      })()`);
+      assert.equal(m.reachable, true, `Send at ${m.top}-${m.bottom} in a ${m.viewport}px viewport`);
+      assert.equal(m.contentBodyScroll, 0,
+        "the flex chain must still be the mechanism — a taller launcher must not make .content-body scroll");
+    } finally { await s.close(); }
   });
 }

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -34,9 +34,12 @@ const stopped = [];
 /** The bot's configured default, as GET /bots/:id/models reports it. null is
  *  the common case on the reporting instance (3 of 5 R4 bot defs). */
 let modelsDefault = "crow-local/qwen3.6-35b-a3b";
+/** Transcript history, so a test can seed rendered markdown into the real DOM. */
+let transcriptEvents = [];
 function resetApi() {
   liveSids = SIDS.slice(); stopped.length = 0; roostFails = false;
   modelsDefault = "crow-local/qwen3.6-35b-a3b";
+  transcriptEvents = [];
 }
 
 let roostFails = false;
@@ -100,7 +103,7 @@ function serveApi(req, res) {
     ],
     default: modelsDefault,
   });
-  if (url.endsWith("/transcript")) return send(200, { events: [] });
+  if (url.endsWith("/transcript")) return send(200, { events: transcriptEvents });
   if (url.endsWith("/rename")) return send(200, { label: "renamed" });
   if (url.endsWith("/interactive") && req.method === "POST") return send(200, { sessionId: "perchlive-99999999" });
   return send(200, {});
@@ -827,6 +830,119 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.index, 0);
       assert.equal(seen.value, "", "an empty value is what makes startSession send no control()");
       assert.equal(seen.shown, "The bot's own model");
+    } finally { resetApi(); await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// TASK-3 item 2, live — rendered markdown in a real browser. A wide table is
+// the one thing in a bot answer that cannot be wrapped, and 412px is where an
+// unscoped one gives the whole page a horizontal scrollbar.
+// ---------------------------------------------------------------------------
+
+/** What the server sends: rendered by servers/blog/renderer.js, sanitized. */
+async function renderedTranscript() {
+  const { renderMarkdown } = await import("../servers/blog/renderer.js");
+  const wide = "## Boards\n\n" +
+    "| id | board | cards | owner | updated | status | notes |\n" +
+    "|---|---|---|---|---|---|---|\n" +
+    "| 1 | TEHCY resource grant | 12 | Kevin Hopper | 2026-09-10 | in review | " +
+    // An unbreakable token, deliberately: a table of ordinary prose wraps and
+    // never overflows, so it would prove nothing about the scroll container.
+    "outputs/2026-09-10T14-22-05Z_november-package-copy-pass_en-es_final.tar.gz |\n" +
+    "| 2 | Comms | 3 | Edrice Bell | 2026-09-08 | approved | waiting on the translation answer |\n\n" +
+    "```js\nconst aVeryLongLineOfCodeThatCannotWrapAnywhereAtAllBecauseItIsOneToken = 1;\n```\n";
+  const hostile = "<img src=x onerror=\"window.__pwned=1\">\n\n" +
+    "<script>window.__pwned=1</script>\n\n[click me](javascript:window.__pwned=1)";
+  return [
+    { type: "message", message: { role: "user", content: "how many boards?" } },
+    { type: "message", message: { role: "assistant", content: [{ type: "text", text: wide }] },
+      html: renderMarkdown(wide) },
+    { type: "message", message: { role: "assistant", content: [{ type: "text", text: hostile }] },
+      html: renderMarkdown(hostile) },
+  ];
+}
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`MD live @${w}x${h}: markdown renders as elements, wide content scrolls itself, page does not`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    transcriptEvents = await renderedTranscript();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 1200));
+      const seen = await s.json(`(function(){
+        var tr=document.getElementById('perch-transcript');
+        var md=tr.querySelectorAll('.what.md');
+        var table=tr.querySelector('.what.md table');
+        var pre=tr.querySelector('.what.md pre');
+        var doc=document.documentElement;
+        var box=function(e){ var r=e.getBoundingClientRect(); return {right:Math.round(r.right),width:Math.round(r.width)}; };
+        var send=document.getElementById('perch-send').getBoundingClientRect();
+        return JSON.stringify({
+          whiteSpace: md.length ? getComputedStyle(md[0]).whiteSpace : null,
+          mdHeight: md.length ? Math.round(md[0].getBoundingClientRect().height) : null,
+          mdBlocks: md.length,
+          headings: tr.querySelectorAll('.what.md h2').length,
+          tables: tr.querySelectorAll('.what.md table').length,
+          tableScrolls: table ? table.scrollWidth > table.clientWidth : null,
+          tableWithin: table ? box(table).right <= box(tr).right + 1 : null,
+          preScrolls: pre ? pre.scrollWidth > pre.clientWidth : null,
+          preWithin: pre ? box(pre).right <= box(tr).right + 1 : null,
+          pageHScroll: doc.scrollWidth > doc.clientWidth,
+          transcriptHScroll: tr.scrollWidth > tr.clientWidth,
+          sendReachable: send.bottom<=innerHeight && send.top>=0,
+          sendTop: Math.round(send.top), sendBottom: Math.round(send.bottom), vp: innerHeight,
+          scripts: tr.querySelectorAll('script').length,
+          iframes: tr.querySelectorAll('iframe').length,
+          jsHrefs: Array.prototype.filter.call(tr.querySelectorAll('a'),
+            function(a){ return /^javascript:/i.test(a.getAttribute('href')||''); }).length,
+          pwned: !!window.__pwned
+        });
+      })()`);
+      assert.equal(seen.mdBlocks, 2, "both assistant messages rendered as markdown");
+      assert.equal(seen.headings, 1, "a heading is a real <h2>, not literal '## Boards'");
+      // .what carries white-space:pre-wrap for plain text; rendered markdown is
+      // real block elements, so inheriting it honours the SOURCE newlines and
+      // pads every gap between blocks. Measured at 412x730: 287px with the
+      // override, 410px without — 123px of blank space in one answer.
+      assert.equal(seen.whiteSpace, "normal",
+        "rendered markdown must not inherit .what's pre-wrap");
+      if (w < 900) {
+        assert.ok(seen.mdHeight < 350,
+          `the rendered block is ${seen.mdHeight}px; pre-wrap measured 410px for the same content`);
+      }
+      assert.equal(seen.tables, 1);
+
+      // The wide-content rule. The code fence is the guaranteed-overflow
+      // element at BOTH widths (an unbreakable 74-char line against a 304px
+      // and a 560px column); the table overflows at 412 and happens to fit at
+      // 1280, so its scroll is asserted only where it is real.
+      assert.equal(seen.preScrolls, true,
+        "the code fence must genuinely exceed its box, or the scroll container proves nothing");
+      assert.equal(seen.preWithin, true, "and it is contained by the transcript rather than spilling out");
+      assert.equal(seen.tableWithin, true);
+      if (w < 900) {
+        assert.equal(seen.tableScrolls, true, "at 412px the table exceeds the column and must scroll itself");
+      }
+      assert.equal(seen.pageHScroll, false, "no horizontal PAGE scroll at " + w + "px");
+      // THE invariant this needed a CSS fix for: the transcript is a grid, and
+      // a grid item's automatic minimum size is its min-content, so one
+      // unbreakable cell used to widen the whole row (measured 666px in a
+      // 380px column) and the transcript scrolled sideways.
+      assert.equal(seen.transcriptHScroll, false, "the transcript column must not scroll sideways either");
+
+      // Send reachability, re-measured: the flex chain is the mechanism.
+      assert.equal(seen.sendReachable, true,
+        `Send at ${seen.sendTop}-${seen.sendBottom} in a ${seen.vp}px viewport`);
+
+      // Sanitization, in a real browser: not "the string looks safe" but
+      // "nothing executed and no such element exists".
+      assert.equal(seen.pwned, false, "the hostile payload must not have fired");
+      assert.equal(seen.scripts, 0);
+      assert.equal(seen.iframes, 0);
+      assert.equal(seen.jsHrefs, 0);
     } finally { resetApi(); await s.close(); }
   });
 }

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -36,10 +36,15 @@ const stopped = [];
 let modelsDefault = "crow-local/qwen3.6-35b-a3b";
 /** Transcript history, so a test can seed rendered markdown into the real DOM. */
 let transcriptEvents = [];
+/** The /options answer. Defaults to the awake shape; a test flips it to the
+ *  HIBERNATING one (thinkingLevels null, source "providers") to stand in the
+ *  state an operator is in after a gateway restart. */
+let optionsHibernating = false;
 function resetApi() {
   liveSids = SIDS.slice(); stopped.length = 0; roostFails = false;
   modelsDefault = "crow-local/qwen3.6-35b-a3b";
   transcriptEvents = [];
+  optionsHibernating = false;
 }
 
 let roostFails = false;
@@ -88,9 +93,9 @@ function serveApi(req, res) {
       { provider: "crow-local", id: "qwen3.6-35b-a3b", name: "Qwen3.6 35B", availability: "up" },
       { provider: "raven-flash-next", id: "qwen3.8-flash-next", name: "Flash Next", availability: "on_demand" },
     ],
-    thinkingLevels: ["off", "high"],
+    thinkingLevels: optionsHibernating ? null : ["off", "high"],
     current: "raven-flash-next/qwen3.8-flash-next",
-    source: "child",
+    source: optionsHibernating ? "providers" : "child",
   });
   // The launcher's session-free list, with a long name on purpose: the thing
   // that must never happen at 412px is a model name pushing New session off
@@ -943,6 +948,44 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.scripts, 0);
       assert.equal(seen.iframes, 0);
       assert.equal(seen.jsHrefs, 0);
+    } finally { resetApi(); await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fix round 2 N2, live — the state the operator is actually in.
+//
+// A session hibernating after a gateway restart: options() answers from the
+// provider catalogue, and `current` is the model adoptRow restored from the
+// row. Measured null before the fix, which is what made the picker show
+// whichever model sorted first while the session was on another one.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`N2 live @${w}x${h}: a hibernating session's picker names the model it is on`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    optionsHibernating = true;
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 900));
+      const seen = await s.json(`(function(){
+        var sel=document.getElementById('perch-model'), th=document.getElementById('perch-thinking');
+        return JSON.stringify({
+          disabled: sel.disabled, thinkingDisabled: th.disabled,
+          value: sel.value, index: sel.selectedIndex,
+          shown: sel.selectedIndex>=0?sel.options[sel.selectedIndex].textContent:null,
+          first: sel.options.length?sel.options[0].value:null });
+      })()`);
+      assert.equal(seen.disabled, false, "the fallback list is a real list");
+      assert.equal(seen.thinkingDisabled, true, "thinking still has no list, and still says so");
+      assert.equal(seen.first, "crow-local/qwen3.6-35b-a3b",
+        "fixture check: the live model is deliberately NOT option 0");
+      assert.equal(seen.value, "raven-flash-next/qwen3.8-flash-next");
+      assert.equal(seen.index, 1, "the browser's own selection");
+      assert.match(seen.shown, /Flash Next/,
+        "what the operator reads after a restart — measured as the FIRST option before the fix");
     } finally { resetApi(); await s.close(); }
   });
 }

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -31,7 +31,13 @@ let available = false, server = null, port = 0;
 const SIDS = ["perchlive-11111111", "perchlive-22222222", "perchlive-33333333"];
 let liveSids = SIDS.slice();
 const stopped = [];
-function resetApi() { liveSids = SIDS.slice(); stopped.length = 0; roostFails = false; }
+/** The bot's configured default, as GET /bots/:id/models reports it. null is
+ *  the common case on the reporting instance (3 of 5 R4 bot defs). */
+let modelsDefault = "crow-local/qwen3.6-35b-a3b";
+function resetApi() {
+  liveSids = SIDS.slice(); stopped.length = 0; roostFails = false;
+  modelsDefault = "crow-local/qwen3.6-35b-a3b";
+}
 
 let roostFails = false;
 function serveApi(req, res) {
@@ -72,7 +78,17 @@ function serveApi(req, res) {
     res.write(": open\n\n");
     return;
   }
-  if (url.endsWith("/options")) return send(200, { models: [], thinkingLevels: [] });
+  // A real drawer list whose CURRENT entry is deliberately not the first one:
+  // the picker asserting option 0 is exactly the fix-round-1 Q1 defect.
+  if (url.endsWith("/options")) return send(200, {
+    models: [
+      { provider: "crow-local", id: "qwen3.6-35b-a3b", name: "Qwen3.6 35B", availability: "up" },
+      { provider: "raven-flash-next", id: "qwen3.8-flash-next", name: "Flash Next", availability: "on_demand" },
+    ],
+    thinkingLevels: ["off", "high"],
+    current: "raven-flash-next/qwen3.8-flash-next",
+    source: "child",
+  });
   // The launcher's session-free list, with a long name on purpose: the thing
   // that must never happen at 412px is a model name pushing New session off
   // the screen.
@@ -82,7 +98,7 @@ function serveApi(req, res) {
         name: "Qwen3.6 35B A3B (Crow, Q5_K_XL MTP+vision, 256K)", availability: "up" },
       { provider: "crow-dsv4", id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash", availability: "unavailable" },
     ],
-    default: "crow-local/qwen3.6-35b-a3b",
+    default: modelsDefault,
   });
   if (url.endsWith("/transcript")) return send(200, { events: [] });
   if (url.endsWith("/rename")) return send(200, { label: "renamed" });
@@ -551,6 +567,7 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
         var doc=document.documentElement;
         return JSON.stringify({ model:box('perch-new-model'), newBtn:box('perch-new'),
           value: sel.value, options: Array.prototype.map.call(sel.options,function(o){return o.textContent;}),
+          selectedText: sel.options[sel.selectedIndex]?sel.options[sel.selectedIndex].textContent:null,
           hScroll: doc.scrollWidth > doc.clientWidth });
       })()`);
       assert.equal(seen.model.hidden, false, "the picker must be there once the list arrives");
@@ -559,6 +576,8 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.model.hit, true, "and nothing overlaps it");
       assert.ok(seen.model.h >= 44, `tap target ${seen.model.w}x${seen.model.h} is too small for a thumb`);
       assert.equal(seen.value, "crow-local/qwen3.6-35b-a3b", "opened on the bot's configured model");
+      assert.equal(seen.selectedText, seen.options[0],
+        "and the browser really shows that entry, not merely stores the value");
       assert.match(seen.options[1], /not running/, "an unavailable model must read as unavailable");
       // The regression a long model name would cause.
       assert.equal(seen.newBtn.inViewport, true,
@@ -744,5 +763,70 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.sendReachable, true, "a second header control must not disturb the composer");
       assert.equal(seen.hScroll, false);
     } finally { await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q1, live — the drawer picker must report the session's model.
+// A jsdom-free browser check, because `selectedIndex` is the browser's own
+// answer to "what does the operator see selected".
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`Q1 live @${w}x${h}: the model select shows the model the session is on`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 900));
+      const seen = await s.json(`(function(){
+        var sel=document.getElementById('perch-model');
+        return JSON.stringify({
+          disabled: sel.disabled,
+          value: sel.value,
+          index: sel.selectedIndex,
+          shown: sel.selectedIndex>=0?sel.options[sel.selectedIndex].textContent:null,
+          first: sel.options.length?sel.options[0].value:null,
+          count: sel.options.length });
+      })()`);
+      assert.equal(seen.disabled, false);
+      assert.equal(seen.count, 2, "fixture check");
+      assert.equal(seen.first, "crow-local/qwen3.6-35b-a3b",
+        "fixture check: the live model is deliberately NOT option 0");
+      assert.equal(seen.value, "raven-flash-next/qwen3.8-flash-next");
+      assert.equal(seen.index, 1, "the browser's own selection, not just an attribute we set");
+      assert.match(seen.shown, /Flash Next/,
+        "what the operator actually reads off the control this feature exists for");
+    } finally { await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q2, live — a bot with no configured default. The unit assertion
+// for this is weak on its own (a fake select's .value starts ""), so the
+// browser's own selectedIndex is what settles it.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`Q2 live @${w}x${h}: with no configured default the launcher preselects "the bot's own model"`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    modelsDefault = null;
+    const s = await session(w, h);
+    try {
+      const seen = await s.json(`(function(){
+        var sel=document.getElementById('perch-new-model');
+        return JSON.stringify({
+          index: sel.selectedIndex,
+          value: sel.value,
+          shown: sel.selectedIndex>=0?sel.options[sel.selectedIndex].textContent:null,
+          count: sel.options.length });
+      })()`);
+      assert.equal(seen.count, 3, "the sentinel plus the two catalogue entries");
+      assert.equal(seen.index, 0);
+      assert.equal(seen.value, "", "an empty value is what makes startSession send no control()");
+      assert.equal(seen.shown, "The bot's own model");
+    } finally { resetApi(); await s.close(); }
   });
 }

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -46,7 +46,12 @@ function serveApi(req, res) {
       birds: [{
         id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
         sessions: liveSids.map((sid) => ({ sessionId: sid, state: "awake",
-          cardId: sid === "perchlive-11111111" ? 248 : null, pendingUi: false })),
+          cardId: sid === "perchlive-11111111" ? 248 : null, pendingUi: false,
+          // One named session, with a name long enough to test the clipping:
+          // free operator text must never give the 320px list column a
+          // horizontal scrollbar.
+          label: sid === "perchlive-22222222"
+            ? "November package copy pass, English and Spanish together" : null })),
       }],
       occupiedCardIds: [],
     });
@@ -80,6 +85,7 @@ function serveApi(req, res) {
     default: "crow-local/qwen3.6-35b-a3b",
   });
   if (url.endsWith("/transcript")) return send(200, { events: [] });
+  if (url.endsWith("/rename")) return send(200, { label: "renamed" });
   if (url.endsWith("/interactive") && req.method === "POST") return send(200, { sessionId: "perchlive-99999999" });
   return send(200, {});
 }
@@ -304,6 +310,10 @@ async function session(width, height) {
   return {
     evalIn,
     json: async (expression) => JSON.parse(await evalIn(expression)),
+    /** Resize the emulated viewport mid-session, so a test can cross the
+     *  split breakpoint the way an operator dragging a window does. */
+    metrics: async (w, h) => send("Emulation.setDeviceMetricsOverride",
+      { width: w, height: h, deviceScaleFactor: 1, mobile: w < 900 }),
     close: async () => { ws.close(); await fetch(CDP + "/json/close/" + tab.id).catch(() => {}); },
   };
 }
@@ -580,6 +590,159 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(m.reachable, true, `Send at ${m.top}-${m.bottom} in a ${m.viewport}px viewport`);
       assert.equal(m.contentBodyScroll, 0,
         "the flex chain must still be the mechanism — a taller launcher must not make .content-body scroll");
+    } finally { await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Finding 1 — the list column in split view. Measured at the width where the
+// defect exists; a unit test cannot see it, because what makes the list
+// visible with a chat open is a CSS media query.
+// ---------------------------------------------------------------------------
+
+const ROW_COUNT = `JSON.stringify({
+  rows: document.querySelectorAll('#perch-list-body .roost-row').length,
+  listVisible: getComputedStyle(document.getElementById('perch-list')).display !== 'none',
+  view: document.body.getAttribute('data-view') })`;
+
+test("F1b live @1280x900: with a chat open the VISIBLE list keeps polling", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  resetApi();
+  const s = await session(1280, 900);
+  try {
+    await s.evalIn(`location.hash='perchlive-11111111'; 'go'`);
+    await new Promise((r) => setTimeout(r, 900));
+    const before = await s.json(ROW_COUNT);
+    assert.equal(before.view, "chat");
+    assert.equal(before.listVisible, true, "precondition: this is the split view, the list is on screen");
+    assert.equal(before.rows, 3);
+
+    // The world moves on: one session ends elsewhere.
+    liveSids = liveSids.slice(0, 2);
+    await new Promise((r) => setTimeout(r, 11000));   // one 10s poll interval
+
+    const after = await s.json(ROW_COUNT);
+    assert.equal(after.rows, 2,
+      "a visible list that stopped polling is what showed an idle row beside an awake session");
+  } finally { await s.close(); }
+});
+
+test("F1b live @412x730: with a chat open the HIDDEN list stops polling", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  resetApi();
+  const s = await session(412, 730);
+  try {
+    await s.evalIn(`location.hash='perchlive-11111111'; 'go'`);
+    await new Promise((r) => setTimeout(r, 900));
+    const before = await s.json(ROW_COUNT);
+    assert.equal(before.listVisible, false, "precondition: below the breakpoint the list really is hidden");
+    assert.equal(before.rows, 3);
+
+    liveSids = liveSids.slice(0, 2);
+    await new Promise((r) => setTimeout(r, 11000));
+
+    const after = await s.json(ROW_COUNT);
+    assert.equal(after.rows, 3,
+      "the other direction: nothing may keep polling behind a hidden list — SSE is the live signal there");
+  } finally { await s.close(); }
+});
+
+test("F1b live: crossing the breakpoint with a chat open refreshes the list that just appeared", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  resetApi();
+  const s = await session(412, 730);
+  try {
+    await s.evalIn(`location.hash='perchlive-11111111'; 'go'`);
+    await new Promise((r) => setTimeout(r, 900));
+    liveSids = liveSids.slice(0, 2);       // changed while the list was hidden and frozen
+    assert.equal((await s.json(ROW_COUNT)).rows, 3, "still stale, as it should be at this width");
+
+    await s.metrics(1280, 900);            // the operator widens the window
+    await new Promise((r) => setTimeout(r, 1200));
+
+    const after = await s.json(ROW_COUNT);
+    assert.equal(after.listVisible, true);
+    assert.equal(after.rows, 2,
+      "a breakpoint crossing is not a navigation, so nothing else would have refreshed it");
+  } finally { await s.close(); }
+});
+
+// ---------------------------------------------------------------------------
+// Finding 3 — the rename controls, measured. A third button on a row and a
+// second one in the chat header are exactly where a 412px layout breaks.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`F3 live @${w}x${h}: a named row shows the name, clips it, and keeps three thumb-sized controls`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      const seen = await s.json(`(function(){
+        var rows=document.querySelectorAll('#perch-list-body .roost-row');
+        var named=null;
+        for(var i=0;i<rows.length;i++){ if(rows[i].querySelector('.roost-name')) named=rows[i]; }
+        var nameEl=named&&named.querySelector('.roost-name');
+        var btns=named?Array.prototype.map.call(named.querySelectorAll('button'),function(b){
+          var r=b.getBoundingClientRect();
+          return { text:b.textContent, w:Math.round(r.width), h:Math.round(r.height),
+                   inViewport: r.top>=0 && r.bottom<=innerHeight && r.left>=0 && r.right<=innerWidth,
+                   hit:(function(){ var e=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
+                                    return !!e && (e===b||b.contains(e)); })() };
+        }):[];
+        var doc=document.documentElement;
+        return JSON.stringify({
+          rows: rows.length,
+          name: nameEl?nameEl.textContent:null,
+          nameClipped: nameEl? nameEl.scrollWidth > nameEl.clientWidth + 1 : null,
+          nameOverflowsRow: nameEl? nameEl.getBoundingClientRect().right > named.getBoundingClientRect().right + 1 : null,
+          btns: btns,
+          hScroll: doc.scrollWidth > doc.clientWidth });
+      })()`);
+      assert.equal(seen.rows, 3, "fixture check");
+      assert.equal(seen.name, "November package copy pass, English and Spanish together");
+      assert.equal(seen.nameOverflowsRow, false,
+        "an 80-char operator name must be clipped inside its row, not spill out of it");
+      assert.deepEqual(seen.btns.map((b) => b.text), ["Open", "Rename", "Close"],
+        "the row grew a third control: " + JSON.stringify(seen.btns.map((b) => b.text)));
+      for (const b of seen.btns) {
+        assert.ok(b.h >= 44, `${b.text} is ${b.w}x${b.h}; every row control clears the 44px thumb target`);
+        assert.equal(b.inViewport, true, `${b.text} must be on screen`);
+        assert.equal(b.hit, true, `${b.text} must be hit-testable`);
+      }
+      assert.equal(seen.hScroll, false, "no horizontal scroll at " + w + "px");
+    } finally { await s.close(); }
+  });
+
+  test(`F3 live @${w}x${h}: the chat header's Rename is reachable and Send still is`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 900));
+      const seen = await s.json(`(function(){
+        var b=document.getElementById('perch-rename'), r=b.getBoundingClientRect();
+        var nm=document.getElementById('perch-session-name');
+        var send=document.getElementById('perch-send').getBoundingClientRect();
+        return JSON.stringify({
+          name: nm.hidden?null:nm.textContent,
+          meta: document.getElementById('perch-session-meta').textContent,
+          w:Math.round(r.width), h:Math.round(r.height),
+          inViewport: r.top>=0 && r.bottom<=innerHeight,
+          hit:(function(){ var e=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
+                           return !!e && (e===b||b.contains(e)); })(),
+          sendReachable: send.bottom<=innerHeight && send.top>=0,
+          hScroll: document.documentElement.scrollWidth > document.documentElement.clientWidth });
+      })()`);
+      assert.equal(seen.name, "November package copy pass, English and Spanish together",
+        "the open session's name is in the header");
+      assert.equal(seen.meta, "perchlive-22222222", "and the id line is untouched — it is the identity");
+      assert.ok(seen.h >= 44, `Rename is ${seen.w}x${seen.h}`);
+      assert.equal(seen.inViewport, true);
+      assert.equal(seen.hit, true);
+      assert.equal(seen.sendReachable, true, "a second header control must not disturb the composer");
+      assert.equal(seen.hScroll, false);
     } finally { await s.close(); }
   });
 }

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -211,6 +211,28 @@ test("four Turbo visits, one session: ONE stream, ONE subscriber, ONE empty-stat
   } finally { await s.close(); }
 });
 
+test("a two-message turn renders two entries, not two plus the concatenation", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    // The real shape of a turn: a state frame opening it, one `text` per
+    // completed assistant message (message-level streaming), then `reply`
+    // carrying replyTextOf(end) — both messages CONCATENATED. Appending that
+    // rendered every turn twice, on this branch and on deployed main.
+    broadcast("state", { state: "awake", turnInFlight: true });
+    broadcast("text", { text: "Let me check." });
+    broadcast("text", { text: "There are four boards." });
+    broadcast("reply", { text: "Let me check.There are four boards." });
+    await sleep(500);
+    const seen = await s.json(`JSON.stringify(
+      Array.from(document.querySelectorAll('#perch-transcript .entry.bot .what')).map(function(n){return n.textContent;}))`);
+    // A COUNT assertion: a contains-assertion passes through a duplicate.
+    assert.equal(seen.length, 2, "rendered entries: " + JSON.stringify(seen));
+    assert.deepEqual(seen, ["Let me check.", "There are four boards."]);
+  } finally { await s.close(); }
+});
+
 test("a streamed reply is appended once, not once per surviving instance", async (t) => {
   if (!available) return t.skip("no CDP endpoint at " + CDP);
   const s = await session();
@@ -219,6 +241,9 @@ test("a streamed reply is appended once, not once per surviving instance", async
     await s.open();
     // This is the operator's actual symptom: the bot answered ONCE and the
     // transcript showed the answer six times.
+    // No `text` frames: the zero-message path, where `reply` IS the only copy
+    // of the answer — which is what an operator who opened the drawer mid-turn
+    // sees, since the stream carries no backlog.
     broadcast("reply", { text: "the one and only answer" });
     await sleep(500);
     const seen = await s.json(PAGE_STATE);

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -136,6 +136,20 @@ async function session(width = 1900, height = 900) {
     if (out.exceptionDetails) throw new Error("page threw: " + JSON.stringify(out.exceptionDetails));
     return out.result.value;
   };
+  await send("DOM.enable");
+  await send("Runtime.enable");
+  /** Real registered listeners on window/document, counted by type. Not a
+   *  page-side proxy: DOMDebugger reads the browser's own listener table, so a
+   *  handler that is inert but still ATTACHED is still counted. */
+  const listenerCounts = async () => {
+    const out = {};
+    for (const [label, expr] of [["window", "window"], ["document", "document"]]) {
+      const handle = await send("Runtime.evaluate", { expression: expr, returnByValue: false });
+      const { listeners } = await send("DOMDebugger.getEventListeners", { objectId: handle.result.objectId, depth: 0 });
+      for (const l of listeners) { const k = label + "." + l.type; out[k] = (out[k] || 0) + 1; }
+    }
+    return out;
+  };
   // Count the EventSource objects the page constructs. The wrapper survives
   // Turbo visits (window does), which is exactly why it can see the leak.
   await evalIn(`(function(){
@@ -150,6 +164,7 @@ async function session(width = 1900, height = 900) {
     evalIn,
     json: async (expr) => JSON.parse(await evalIn(expr)),
     turboLoaded: async () => (await evalIn(`typeof window.Turbo`)) === "object",
+    listenerCounts,
     visit: async (url) => { await evalIn(`Turbo.visit(${JSON.stringify(url)},{action:'replace'}); 'go'`); await sleep(1200); },
     open: async () => { await evalIn(`location.hash='${SID}'; 'go'`); await sleep(2200); },
     close: async () => { ws.close(); await fetch(CDP + "/json/close/" + tab.id).catch(() => {}); },
@@ -262,5 +277,33 @@ test("a stream this instance never opened is still closable — by identity, fro
     assert.equal(openStreams.length, 1,
       `exactly one connection may remain; ${openStreams.length} are open`);
     assert.equal(seen.esLive, 1);
+  } finally { await s.close(); }
+});
+
+test("five Turbo visits retain five instances but not five listeners", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    const before = await s.listenerCounts();
+    assert.equal(await s.evalIn("window.__crowPerchHub.gen"), 1, "one instance so far");
+    for (let i = 0; i < 4; i++) await s.visit("/dashboard/perch");
+    const gen = await s.evalIn("window.__crowPerchHub.gen");
+    assert.equal(gen, 5, "fixture check: five script instances really did run, or this proves nothing");
+
+    const after = await s.listenerCounts();
+    // Fix round 1 Q3. live() made a retired instance's listeners inert but
+    // left them ATTACHED, and each retained closure holds rowIndex,
+    // launchBots, launchModels and pendingImages — the last carrying base64
+    // image data from any attach. Measured before the fix: 1 -> 5 on each of
+    // these, while the shell's own listeners stayed flat because it guards
+    // its bindings (layout.js:390 / :610).
+    for (const key of ["window.focus", "window.hashchange", "document.turbo:before-render"]) {
+      assert.equal(after[key], 1, `${key} grew to ${after[key]} across ${gen} instances`);
+      assert.equal(before[key], 1, `${key} must start at 1`);
+    }
+    // The shell's own, as the control: if THESE grew, the page is stacking
+    // listeners for a reason that has nothing to do with this script.
+    assert.equal(after["document.keydown"], before["document.keydown"],
+      "control: the shell's listeners must be flat too, or the measurement is about something else");
   } finally { await s.close(); }
 });

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -1,0 +1,266 @@
+// Perch's transcript duplicated EVERY streamed element ~6x for one operator,
+// while his own typed message appeared exactly once. This file reproduces that
+// asymmetry and pins the fix.
+//
+// WHY IT NEEDS A REAL BROWSER *AND* A REAL TURBO. The cause is not inside the
+// hub script's own logic, which is why every existing unit test stayed green
+// through it: the dashboard shell ships Turbo Drive (shared/layout.js's
+// turboHead()), a Turbo visit REPLACES <body> without reloading the JS realm,
+// and the previous run of the inline hub script keeps its closure, its
+// EventSource, its poll interval and its `window` listeners. `el()` resolves
+// by id at call time, so those survivors write into the NEW document. Four
+// visits, one tap on a session: four openSession()s, four EventSources, four
+// server-side /events connections, four "No transcript yet." notes — and the
+// operator's own message only once, because `el('perch-send').onclick=` is a
+// single slot the newest instance owns outright.
+//
+// tests/perch-hub-render.test.js renders through the same real shell but never
+// serves /vendor/turbo-8.0.5.umd.js, so Turbo never loads there and the whole
+// mechanism is invisible to it. This file serves it deliberately.
+import { test, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { readFileSync } from "node:fs";
+
+const CDP = process.env.CROW_CDP_URL ||
+  ("http://127.0.0.1:" + (process.env.CROW_BROWSER_CDP_PORT || "9223"));
+const HOST_FROM_CONTAINER = process.env.CROW_CDP_HOST_IP || "172.17.0.1";
+const REPO = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+const SID = "perchlive-aaaaaaaa";
+
+let available = false, server = null, port = 0;
+/** Every open SSE response, so a test can count concurrency and broadcast. */
+let openStreams = [];
+
+function serveApi(req, res) {
+  const url = req.url.split("?")[0];
+  const send = (code, obj) => {
+    res.writeHead(code, { "content-type": "application/json" });
+    res.end(JSON.stringify(obj));
+  };
+  if (url.endsWith("/roost")) {
+    return send(200, {
+      birds: [{
+        id: "r4-assistant", name: "R4 Assistant", perch_attached: true, state: "working",
+        sessions: [{ sessionId: SID, state: "awake", cardId: null, pendingUi: false }],
+      }],
+      occupiedCardIds: [],
+    });
+  }
+  if (url.endsWith("/events")) {
+    res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+    res.write(": open\n\n");
+    openStreams.push(res);
+    req.on("close", () => { openStreams = openStreams.filter((r) => r !== res); });
+    return;
+  }
+  // An EMPTY transcript, which is what a freshly spawned session has and what
+  // made "No transcript yet." the correct line to print — once.
+  if (url.endsWith("/transcript")) return send(200, { events: [] });
+  if (url.endsWith("/options")) return send(200, { models: [], thinkingLevels: [] });
+  return send(200, {});
+}
+
+/** Push one named SSE frame to every connection the page currently holds. */
+function broadcast(type, data) {
+  for (const res of openStreams) res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+before(async () => {
+  try {
+    const r = await fetch(CDP + "/json/version", { signal: AbortSignal.timeout(2000) });
+    available = r.ok;
+  } catch { available = false; }
+  if (!available) return;
+  const { default: perchHubPanel } = await import("../servers/gateway/dashboard/panels/perch-hub.js");
+  const { renderLayout } = await import("../servers/gateway/dashboard/shared/layout.js");
+  const turbo = readFileSync(REPO + "/servers/gateway/public/vendor/turbo-8.0.5.umd.js");
+  server = http.createServer(async (req, res) => {
+    if (req.url.startsWith("/dashboard/perch-api/")) return serveApi(req, res);
+    // The bit tests/perch-hub-render.test.js does not serve, and the reason
+    // the leak never showed up there.
+    if (req.url.startsWith("/vendor/turbo")) {
+      res.writeHead(200, { "content-type": "application/javascript" });
+      return res.end(turbo);
+    }
+    const layout = (opts) => renderLayout({ ...opts, activePanel: "perch", panels: [perchHubPanel], lang: "en" });
+    // A second shell page, so a test can Turbo-navigate AWAY from Perch.
+    if (req.url.startsWith("/dashboard/elsewhere")) {
+      // text/html, explicitly: Turbo only takes over a navigation whose
+      // response it recognises as a document. Without the header it falls back
+      // to a full page load, which would tear the stream down for the wrong
+      // reason and fake a pass on the test below.
+      res.writeHead(200, { "content-type": "text/html" });
+      return res.end(renderLayout({ title: "Elsewhere", content: "<div id='elsewhere'>elsewhere</div>",
+        activePanel: "perch", panels: [perchHubPanel], lang: "en" }));
+    }
+    const html = await perchHubPanel.handler(req, res, { lang: "en", layout });
+    if (!res.headersSent) { res.writeHead(200, { "content-type": "text/html" }); res.end(html); }
+  });
+  await new Promise((r) => server.listen(0, "0.0.0.0", r));
+  port = server.address().port;
+});
+
+beforeEach(() => { openStreams = []; });
+after(() => { if (server) server.close(); });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** A tab held open across several evaluations (perch-hub-render.test.js's
+ *  session() helper, plus the EventSource instrumentation these tests need). */
+async function session(width = 1900, height = 900) {
+  const tab = await (await fetch(CDP + "/json/new?about:blank", { method: "PUT" })).json();
+  const { default: WebSocket } = await import("ws");
+  const ws = new WebSocket(tab.webSocketDebuggerUrl);
+  await new Promise((r, j) => { ws.once("open", r); ws.once("error", j); });
+  let id = 0;
+  const send = (method, params = {}) => new Promise((resolve, reject) => {
+    const mine = ++id;
+    const onMsg = (raw) => {
+      const m = JSON.parse(raw);
+      if (m.id !== mine) return;
+      ws.off("message", onMsg);
+      m.error ? reject(new Error(JSON.stringify(m.error))) : resolve(m.result || {});
+    };
+    ws.on("message", onMsg);
+    ws.send(JSON.stringify({ id: mine, method, params }));
+  });
+  await send("Emulation.setDeviceMetricsOverride",
+    { width, height, deviceScaleFactor: 1, mobile: width < 900 });
+  await send("Page.enable");
+  await send("Page.navigate", { url: `http://${HOST_FROM_CONTAINER}:${port}/dashboard/perch` });
+  await sleep(1800);
+  const evalIn = async (expression) => {
+    const out = await send("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+    if (out.exceptionDetails) throw new Error("page threw: " + JSON.stringify(out.exceptionDetails));
+    return out.result.value;
+  };
+  // Count the EventSource objects the page constructs. The wrapper survives
+  // Turbo visits (window does), which is exactly why it can see the leak.
+  await evalIn(`(function(){
+    if(window.__es) return 'already';
+    window.__es=[];
+    var E=window.EventSource;
+    window.EventSource=function(u,o){ var e=new E(u,o); window.__es.push(e); return e; };
+    window.EventSource.prototype=E.prototype;
+    return 'patched';
+  })()`);
+  return {
+    evalIn,
+    json: async (expr) => JSON.parse(await evalIn(expr)),
+    turboLoaded: async () => (await evalIn(`typeof window.Turbo`)) === "object",
+    visit: async (url) => { await evalIn(`Turbo.visit(${JSON.stringify(url)},{action:'replace'}); 'go'`); await sleep(1200); },
+    open: async () => { await evalIn(`location.hash='${SID}'; 'go'`); await sleep(2200); },
+    close: async () => { ws.close(); await fetch(CDP + "/json/close/" + tab.id).catch(() => {}); },
+  };
+}
+
+const PAGE_STATE = `JSON.stringify({
+  notes: Array.from(document.querySelectorAll('#perch-transcript .note')).map(function(n){return n.textContent;}),
+  botLines: Array.from(document.querySelectorAll('#perch-transcript .entry.bot .what')).map(function(n){return n.textContent;}),
+  esLive: window.__es.filter(function(e){ return e.readyState!==2; }).length,
+  esBuilt: window.__es.length,
+  view: document.body.getAttribute('data-view')
+})`;
+
+// ---------------------------------------------------------------------------
+
+test("Turbo really is loaded on this page — without it these tests prove nothing", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    assert.equal(await s.turboLoaded(), true,
+      "the shell ships Turbo Drive; a fixture that does not serve it cannot see this class of defect");
+  } finally { await s.close(); }
+});
+
+test("four Turbo visits, one session: ONE stream, ONE subscriber, ONE empty-state note", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    // The operator path: land on Perch, then reach it again a few times (nav
+    // tap, back, a link). Each visit re-runs the inline script.
+    for (let i = 0; i < 3; i++) await s.visit("/dashboard/perch");
+    await s.open();
+    const seen = await s.json(PAGE_STATE);
+    assert.equal(seen.view, "chat", "precondition: the session is actually open");
+    // Measured before the fix, same fixture: 4 / 4 / 4.
+    assert.equal(seen.esBuilt, 1,
+      `each surviving script instance builds its own EventSource; ${seen.esBuilt} were built`);
+    assert.equal(seen.esLive, 1, "and only one may still be open");
+    assert.equal(openStreams.length, 1,
+      `the GATEWAY's own count is the one that matters: ${openStreams.length} concurrent /events connections`);
+    assert.deepEqual(seen.notes, ["No transcript yet."],
+      "one openSession, so one history load, so one note: " + JSON.stringify(seen.notes));
+  } finally { await s.close(); }
+});
+
+test("a streamed reply is appended once, not once per surviving instance", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    for (let i = 0; i < 3; i++) await s.visit("/dashboard/perch");
+    await s.open();
+    // This is the operator's actual symptom: the bot answered ONCE and the
+    // transcript showed the answer six times.
+    broadcast("reply", { text: "the one and only answer" });
+    await sleep(500);
+    const seen = await s.json(PAGE_STATE);
+    assert.deepEqual(seen.botLines, ["the one and only answer"],
+      "one reply frame must produce one transcript line: " + JSON.stringify(seen.botLines));
+  } finally { await s.close(); }
+});
+
+test("navigating away from Perch closes the stream instead of leaving a subscriber behind", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    assert.equal(openStreams.length, 1, "precondition: the session is streaming");
+    await s.visit("/dashboard/elsewhere");
+    await sleep(400);
+    assert.equal(openStreams.length, 0,
+      "a Turbo visit off Perch must not leave a live SSE connection (and a gateway subscriber) behind");
+  } finally { await s.close(); }
+});
+
+test("a Turbo visit BACK to Perch while a session is open leaves one stream, not two", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    assert.equal(openStreams.length, 1, "precondition: the session is streaming");
+    await s.visit("/dashboard/perch");
+    await sleep(400);
+    // The visit drops the hash, so the fresh instance lands on the list and
+    // opens nothing. What must NOT survive is the retired instance's stream.
+    assert.equal(openStreams.length, 0,
+      `the retired instance's connection must be gone; ${openStreams.length} still open`);
+  } finally { await s.close(); }
+});
+
+test("a stream this instance never opened is still closable — by identity, from the registry", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    // Stand in for the connection a previous script instance left behind: the
+    // running instance has no variable naming it, and only the shared registry
+    // can. This is the case `closeStream()` alone can never reach.
+    await s.evalIn(`(function(){
+      var hub=window.__crowPerchHub;
+      window.__orphan=new window.EventSource('/dashboard/perch-api/interactive/${SID}/events');
+      hub.streams['${SID}']=window.__orphan;
+      return 'planted';
+    })()`);
+    await sleep(400);
+    assert.equal(openStreams.length, 1, "precondition: the orphan is connected");
+    await s.open();
+    const seen = await s.json(`JSON.stringify({ orphanState: window.__orphan.readyState,
+      esLive: window.__es.filter(function(e){ return e.readyState!==2; }).length })`);
+    assert.equal(seen.orphanState, 2, "the orphan must have been closed, not merely replaced in the map");
+    assert.equal(openStreams.length, 1,
+      `exactly one connection may remain; ${openStreams.length} are open`);
+    assert.equal(seen.esLive, 1);
+  } finally { await s.close(); }
+});

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -332,3 +332,69 @@ test("five Turbo visits retain five instances but not five listeners", async (t)
       "control: the shell's listeners must be flat too, or the measurement is about something else");
   } finally { await s.close(); }
 });
+
+// ---------------------------------------------------------------------------
+// Fix round 2 N1, live — a real EventSource, really dropped, really reconnected.
+// The unit harness fires the backoff timer by hand; this one lets the browser
+// do it, over a connection the server actually closes.
+// ---------------------------------------------------------------------------
+
+/** Close every open SSE response, the way a blip or a gateway restart does. */
+function dropStreams() {
+  for (const res of openStreams) { try { res.end(); } catch { /* already gone */ } }
+  openStreams = [];
+}
+
+const BOT_TEXTS = `JSON.stringify(
+  Array.from(document.querySelectorAll('#perch-transcript .entry.bot .what')).map(function(n){return n.textContent;}))`;
+
+test("N1 live: a reconnect ACROSS a turn boundary still renders the next turn's reply", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    broadcast("state", { state: "awake", turnInFlight: true });
+    broadcast("text", { text: "turn 1 streamed half", turnId: "turn-1" });
+    await sleep(300);
+    assert.deepEqual(await s.json(BOT_TEXTS), ["turn 1 streamed half"], "precondition");
+
+    // The blip. Turn 1 ends and turn 2 runs inside it, so the client never sees
+    // the turnInFlight:false that separates them.
+    dropStreams();
+    await sleep(3500);                       // the client's own 2s backoff, plus slack
+    assert.equal(openStreams.length, 1, "the client must have reconnected on its own");
+
+    broadcast("state", { state: "awake", turnInFlight: true });   // the engine's replay
+    broadcast("reply", { text: "turn 2's whole answer", turnId: "turn-2" });
+    await sleep(500);
+
+    const seen = await s.json(BOT_TEXTS);
+    assert.equal(seen.length, 2, "entries: " + JSON.stringify(seen));
+    assert.deepEqual(seen, ["turn 1 streamed half", "turn 2's whole answer"],
+      "measured before the fix: turn 2 never rendered at all");
+  } finally { await s.close(); }
+});
+
+test("N1 live: a reconnect WITHIN a turn does not duplicate that turn's answer", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    broadcast("state", { state: "awake", turnInFlight: true });
+    broadcast("text", { text: "the answer", turnId: "turn-1" });
+    await sleep(300);
+
+    dropStreams();
+    await sleep(3500);
+    assert.equal(openStreams.length, 1, "reconnected");
+
+    broadcast("state", { state: "awake", turnInFlight: true });
+    broadcast("reply", { text: "the answer", turnId: "turn-1" });   // the SAME turn ends
+    await sleep(500);
+
+    const seen = await s.json(BOT_TEXTS);
+    assert.equal(seen.length, 1, "entries: " + JSON.stringify(seen));
+    assert.deepEqual(seen, ["the answer"],
+      "the case a bare reset in openStream() would have broken — which is why this is a turn id");
+  } finally { await s.close(); }
+});

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -767,3 +767,126 @@ test("options(): unknown session is refused with no_such_session", async () => {
   const { engine } = makeEngine();
   await assert.rejects(() => engine.options("perchlive-nope"), (e) => e.code === "no_such_session");
 });
+
+// ---------------------------------------------------------------------------
+// 8. rename() — "it seems like there is not a way to rename the sessions"
+// ---------------------------------------------------------------------------
+
+function labelOf(threadId) {
+  const c = raw();
+  const row = c.prepare("SELECT label FROM bot_sessions WHERE gateway_thread_id=? ORDER BY id DESC LIMIT 1").get(threadId);
+  c.close();
+  return row ? row.label : undefined;
+}
+
+test("rename(): the name lands on the session's OWN row — no second store", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  const r = await engine.rename(s.sessionId, "Nov package copy pass");
+  assert.deepEqual(r, { label: "Nov package copy pass" });
+  assert.equal(labelOf(s.sessionId), "Nov package copy pass");
+  assert.equal((await engine.get(s.sessionId)).label, "Nov package copy pass");
+});
+
+test("rename(): a name survives a gateway restart, because adoptRow restores it", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  await engine.rename(s.sessionId, "survives a deploy");
+
+  // A FRESH engine on the same DB: exactly what a restart is, and the state in
+  // which the operator hit the empty model picker.
+  _resetInteractiveEngineForTest();
+  const { engine: reborn } = makeEngine();
+  const snap = await reborn.get(s.sessionId);
+  assert.equal(snap.state, "hibernating", "precondition: adopted, not held");
+  assert.equal(snap.label, "survives a deploy", "a name lost on every restart would make renaming pointless");
+});
+
+test("rename(): trimmed, whitespace-collapsed and capped — the WRITER guarantees what is stored", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  assert.deepEqual(await engine.rename(s.sessionId, "   spaced   out   name  "), { label: "spaced out name" });
+  const long = "x".repeat(200);
+  const capped = await engine.rename(s.sessionId, long);
+  assert.equal(capped.label.length, 80, "80 chars: long enough to be useful, short enough for a 320px column");
+  assert.equal(labelOf(s.sessionId).length, 80, "and the ROW holds the capped value, not the raw one");
+});
+
+test("rename(): empty CLEARS the name — a real action, not a way to go anonymous", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  await engine.rename(s.sessionId, "temporary");
+  assert.deepEqual(await engine.rename(s.sessionId, "   "), { label: null });
+  assert.equal(labelOf(s.sessionId), null, "a COALESCE here would make clearing impossible");
+  assert.equal((await engine.get(s.sessionId)).label, null);
+});
+
+test("rename(): a later lifecycle write does not resurrect a cleared name", async () => {
+  // End-state property, mechanism-independent: whatever writeRow does on the
+  // next hibernate, a name the operator cleared stays cleared.
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  await engine.rename(s.sessionId, "gone in a moment");
+  await engine.rename(s.sessionId, "");
+  clock.advance(600_001);
+  await tick();
+  assert.equal((await engine.get(s.sessionId)).state, "hibernating", "the hibernate wrote the row");
+  assert.equal(labelOf(s.sessionId), null);
+});
+
+test("rename(): pushes a state event, so an open drawer sees a rename made elsewhere", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  const sub = await collect(engine, s.sessionId);
+  await engine.rename(s.sessionId, "watch this");
+  const states = sub.ofType("state");
+  assert.ok(states.length >= 1);
+  assert.equal(states[states.length - 1].label, "watch this");
+  sub.off();
+});
+
+test("rename(): a STOPPED session can still be named, and an unknown one is refused", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  await engine.stop(s.sessionId);
+  // Naming a finished session while sorting through what happened is exactly
+  // when an operator wants to — and it touches no child, so nothing to refuse.
+  assert.deepEqual(await engine.rename(s.sessionId, "the one that failed"), { label: "the one that failed" });
+  assert.equal(labelOf(s.sessionId), "the one that failed");
+  await assert.rejects(() => engine.rename("perchlive-nope", "x"), (e) => e.code === "no_such_session");
+});
+
+test("rename(): a mid-turn rename is never refused — it touches no child", async () => {
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  await engine.message(s.sessionId, "go");                 // turn in flight
+  assert.deepEqual(await engine.rename(s.sessionId, "named mid-turn"), { label: "named mid-turn" });
+  state.instances[0].lastTurn().resolve({
+    type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }],
+  });
+  await tick();
+});
+
+test("rename(): does not clear the 'interrupted' flag a shutdown left on the row", async () => {
+  // writeRow() stamps `status` and resets `control` to 'run' on every call, so
+  // rename() deliberately uses a targeted UPDATE instead. stopAll() marks a
+  // session that was mid-turn when the gateway went down control='interrupted'
+  // and the drawer reads that to say "interrupted, not answered" — a rename
+  // must not quietly erase it.
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  const c = raw();
+  c.prepare("UPDATE bot_sessions SET control='interrupted', status='waiting-user' WHERE gateway_thread_id=?")
+    .run(s.sessionId);
+  c.close();
+
+  await engine.rename(s.sessionId, "named after the crash");
+
+  const after = raw();
+  const row = after.prepare("SELECT control, status, label FROM bot_sessions WHERE gateway_thread_id=?")
+    .get(s.sessionId);
+  after.close();
+  assert.equal(row.label, "named after the crash");
+  assert.equal(row.control, "interrupted", "a rename must not reset the control flag");
+  assert.equal(row.status, "waiting-user", "nor restamp the status");
+});

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -935,3 +935,160 @@ test("rename(): a session with no row is refused, not answered 200 with nothing 
   assert.equal(rec.label, "before",
     "and the in-memory label is rolled back — the engine must not report a name the row lacks");
 });
+
+// ---------------------------------------------------------------------------
+// Fix round 2 N2 — Q1 survived for every session adopted after a restart.
+//
+// adoptRow SELECTed the row's `model` and threw it away, so servingModel()
+// returned null for every adopted session and options() answered
+// `current: null`. The drawer then enabled the picker, populated the whole
+// catalogue, and selected option 0 — the exact defect Q1 exists for, in the
+// one case the !s.pi branch of options() was added to serve.
+//
+// This is Kevin's sequence: switch the model, the gateway restarts, open the
+// session again.
+// ---------------------------------------------------------------------------
+
+function rowModelOf(threadId) {
+  const c = raw();
+  const row = c.prepare("SELECT model FROM bot_sessions WHERE gateway_thread_id=? ORDER BY id DESC LIMIT 1").get(threadId);
+  c.close();
+  return row ? row.model : undefined;
+}
+
+test("N2: a session adopted after a restart reports the model its ROW carries", async () => {
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  // Deliberately NOT the spawn model, and deliberately not first in the
+  // fixture catalogue — option 0 must not be able to pass by accident.
+  await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  clock.advance(600_001);
+  await tick();
+  assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model", "precondition: the row carries it");
+
+  // The restart.
+  _resetInteractiveEngineForTest();
+  const { engine: reborn } = makeEngine({ providerModels: () => CATALOGUE });
+  const snap = await reborn.get(s.sessionId);
+  assert.equal(snap.state, "hibernating", "precondition: adopted, not held");
+  assert.equal(snap.model, "crow-chat/big-model",
+    "measured null before the fix, which made the drawer show whichever model sorted first");
+
+  const opts = await reborn.options(s.sessionId);
+  assert.equal(opts.source, "providers");
+  assert.equal(opts.current, "crow-chat/big-model", "and the picker is told which entry is live");
+  assert.notEqual(opts.current, opts.models[0].provider + "/" + opts.models[0].id,
+    "fixture check: the live model is not option 0, or this proves nothing");
+});
+
+test("N2: the report and the next WAKE agree — turn 1 runs on the adopted model", async () => {
+  // Restoring only a reporting field would swap one lie for a subtler one: the
+  // picker saying flash-next while the next turn quietly ran on the def's
+  // default. startChild reads currentModelParts before warmModel/PiRpc, so the
+  // adopted value is what actually serves.
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  clock.advance(600_001);
+  await tick();
+
+  _resetInteractiveEngineForTest();
+  const { engine: reborn, state } = makeEngine();
+  await reborn.message(s.sessionId, "after the restart");
+  await tick();
+  const pi = state.instances[state.instances.length - 1];
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+  assert.equal(state.meter.length, 1);
+  assert.equal(state.meter[0].resolved.key, "crow-chat/big-model",
+    "the wake serves the model the row recorded, not the def's default");
+  assert.ok(state.warm.includes("crow-chat"), "and warms that provider before spawning");
+});
+
+test("N2: a row with no usable model key leaves the tracking alone", async () => {
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  clock.advance(600_001);
+  await tick();
+  for (const bad of ["", "no-slash", "/leading", "trailing/"]) {
+    const c = raw();
+    c.prepare("UPDATE bot_sessions SET model=? WHERE gateway_thread_id=?").run(bad, s.sessionId);
+    c.close();
+    _resetInteractiveEngineForTest();
+    const { engine: reborn } = makeEngine();
+    const snap = await reborn.get(s.sessionId);
+    assert.equal(snap.model, null, JSON.stringify(bad) + " must not be parsed into a model");
+  }
+});
+
+test("N2: a switch made while HIBERNATING also survives the restart", async () => {
+  // The other half of the operator's sequence: the session was already asleep
+  // when the model was changed, so nothing wakes to write a turn row.
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  clock.advance(600_001);
+  await tick();
+  const r = await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  assert.equal(r.bindsAtWake.model, "crow-chat/big-model", "precondition: the hibernating path, not the live one");
+  assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model",
+    "and it reaches the row, or a restart before the next turn loses it");
+
+  _resetInteractiveEngineForTest();
+  const { engine: reborn } = makeEngine({ providerModels: () => CATALOGUE });
+  assert.equal((await reborn.get(s.sessionId)).model, "crow-chat/big-model");
+  assert.equal((await reborn.options(s.sessionId)).current, "crow-chat/big-model");
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 2 N1, engine side — the frames must NAME their turn.
+//
+// The drawer judges a `reply` against the turn it completes rather than against
+// a client-side memory that a reconnect invalidates. That only works if the
+// engine stamps the id, and the client tests build their own frames, so
+// nothing over there can prove this half.
+// ---------------------------------------------------------------------------
+
+test("N1: text and reply frames carry the id of the turn they belong to", async () => {
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  const sub = await collect(engine, s.sessionId);
+  const pi = state.instances[0];
+
+  const t1 = await engine.message(s.sessionId, "one");
+  pi.emit({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "streamed" }] } });
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "streamed" }] }] });
+  await tick();
+
+  const text1 = sub.ofType("text");
+  const reply1 = sub.ofType("reply");
+  assert.equal(text1.length, 1);
+  assert.equal(reply1.length, 1);
+  assert.equal(text1[0].turnId, t1.turnId, "the text frame names the turn message() returned");
+  assert.equal(reply1[0].turnId, t1.turnId, "and the reply names the SAME turn it completes");
+
+  const t2 = await engine.message(s.sessionId, "two");
+  assert.notEqual(t2.turnId, t1.turnId, "fixture check: a second turn is a different turn");
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "again" }] }] });
+  await tick();
+  const reply2 = sub.ofType("reply");
+  assert.equal(reply2.length, 2);
+  assert.equal(reply2[1].turnId, t2.turnId,
+    "turn 2's reply must be distinguishable from turn 1's — that is the whole mechanism");
+  sub.off();
+});
+
+test("N1: a child speaking OUTSIDE a turn emits a text frame with a null turn id", async () => {
+  // The honest answer, and what the client's fallback flag is for.
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  const sub = await collect(engine, s.sessionId);
+  state.instances[0].emit({
+    type: "message_end",
+    message: { role: "assistant", content: [{ type: "text", text: "unsolicited" }] },
+  });
+  await tick();
+  const texts = sub.ofType("text");
+  assert.equal(texts.length, 1);
+  assert.equal(texts[0].turnId, null);
+  sub.off();
+});

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -735,6 +735,9 @@ test("options(): a hibernating session lists the provider catalogue, and still n
   assert.deepEqual(r.models, CATALOGUE, "an empty picker on a live session is the bug this ends");
   assert.equal(calls, 1);
   assert.equal(r.source, "providers", "the caller must not have to infer which half answered");
+  // Fix round 1 Q1: a list with no "which one is live" is how the picker came
+  // to assert whichever model sorted first.
+  assert.equal(r.current, "crow-local/qwen3.6-35b-a3b", "the model this session is actually on");
   // Deliberately still null: control()'s thinking branch is a no-op with no
   // child (pi's own session file owns the level across a --session resume),
   // so offering that picker would promise a change that never happens.
@@ -750,7 +753,35 @@ test("options(): a LIVE child stays authoritative — the catalogue is not even 
   assert.deepEqual(r.models, [{ provider: "crow-local", id: "qwen3.6-35b-a3b" }, { provider: "crow-chat", id: "big-model" }],
     "pi is the process that will route the next turn; its list wins whenever there is one");
   assert.equal(r.source, "child");
+  assert.equal(r.current, "crow-local/qwen3.6-35b-a3b");
   assert.equal(calls, 0);
+});
+
+test("options(): `current` follows a model switch, in both the live and the hibernating answer", async () => {
+  const { engine, clock, state } = makeEngine({ providerModels: () => CATALOGUE });
+  const s = await spawned(engine);
+  await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  assert.equal((await engine.options(s.sessionId)).current, "crow-chat/big-model",
+    "a live session reports the model control() moved it to, not the spawn-resolved one");
+
+  clock.advance(600_001);
+  await tick();
+  const asleep = await engine.options(s.sessionId);
+  assert.equal(asleep.source, "providers");
+  assert.equal(asleep.current, "crow-chat/big-model",
+    "and hibernating it still reports it — that switch binds at the next wake and really works");
+  assert.equal(state.instances.length, 1, "still no second child");
+});
+
+test("options(): `current` reflects a model pi chose ON ITS OWN, read after the RPCs", async () => {
+  // An auto-fallback, or the operator's own /model in the TUI: the engine
+  // learns it from a model_select frame, and the picker is about to be set
+  // from this value.
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  state.instances[0].emit({ type: "model_select", model: { provider: "crow-chat", id: "big-model" },
+    previousModel: null, source: "user" });
+  assert.equal((await engine.options(s.sessionId)).current, "crow-chat/big-model");
 });
 
 test("options(): a catalogue that throws degrades to an empty list, never a failed GET", async () => {
@@ -889,4 +920,18 @@ test("rename(): does not clear the 'interrupted' flag a shutdown left on the row
   assert.equal(row.label, "named after the crash");
   assert.equal(row.control, "interrupted", "a rename must not reset the control flag");
   assert.equal(row.status, "waiting-user", "nor restamp the status");
+});
+
+test("rename(): a session with no row is refused, not answered 200 with nothing written", async () => {
+  // Fix round 1 Q4. The silent version returned {label}, the route answered
+  // 200, and the list and header painted a name that no row carried and that
+  // nothing later repaired — writeRow does not touch the column.
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  const rec = engine._sessionRecordForTest(s.sessionId);
+  rec.rowId = null;                                  // a session that never got a row
+  rec.label = "before";
+  await assert.rejects(() => engine.rename(s.sessionId, "after"), (e) => e.code === "not_persisted");
+  assert.equal(rec.label, "before",
+    "and the in-memory label is rolled back — the engine must not report a name the row lacks");
 });

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -253,6 +253,10 @@ function makeEngine(o = {}) {
     crowHome: CROW_HOME,
     env,
     bridge,
+    // The session-free provider catalogue options() falls back to with no live
+    // child. Injected so a test never depends on this machine's provider DB or
+    // models.json; omitted, the engine lazily imports perch-model-catalog.js.
+    providerModels: o.providerModels,
     now: clock.now,
     setTimer: clock.setTimer,
     clearTimer: clock.clearTimer,
@@ -469,6 +473,33 @@ test("control() model switch (awake): updates currentModel/resolved so snapshot(
   assert.equal(state.audit[0].payload.model, "crow-chat/big-model");
 });
 
+// The launcher's path, end to end on the engine side: the operator picks a
+// model beside "New session", the client spawns and then control()s it BEFORE
+// any message. The point is that turn 1 is served and priced by the picked
+// model, not that a later switch corrects it.
+test("launch path: a control() between spawn and the first message serves turn 1 on the picked model", async () => {
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  assert.equal((await engine.get(s.sessionId)).model, "crow-local/qwen3.6-35b-a3b", "the bot's own default, as spawned");
+  const spawnWarms = state.warm.length;
+
+  const r = await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  assert.equal(r.applied.model, "crow-chat/big-model");
+  assert.equal(state.warm[spawnWarms], "crow-chat",
+    "the picked provider is warmed before the switch, so the first turn does not race a cold endpoint");
+  assert.equal((await engine.get(s.sessionId)).model, "crow-chat/big-model");
+
+  await engine.message(s.sessionId, "hello - can you see the board?");
+  state.instances[0].lastTurn().resolve({
+    type: "agent_end",
+    messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }],
+  });
+  await tick();
+  assert.equal(state.meter.length, 1, "exactly one turn ran");
+  assert.equal(state.meter[0].resolved.key, "crow-chat/big-model",
+    "TURN ONE is priced on the picked model — not the spawn-resolved one with a switch after it");
+});
+
 test("control() model switch while hibernating: nothing live to command — tracked for the next wake under bindsAtWake", async () => {
   const { engine, clock, state } = makeEngine();
   const s = await spawned(engine);
@@ -682,15 +713,54 @@ test("options(): awake session returns the live models + thinking levels from th
   assert.deepEqual(r.thinkingLevels, ["off", "low", "high"]);
 });
 
-test("options(): hibernating session returns {models: null, thinkingLevels: null} — never wakes a child just to list", async () => {
-  const { engine, clock, state } = makeEngine();
+// The defect Kevin hit: he switched a session to another model, a deploy
+// restarted the gateway, and the picker "stopped working". The engine
+// hibernates idle sessions by design and adoptRow brings a restart-orphaned
+// row back hibernating too, so `models: null` was the answer for the
+// commonest state of a perfectly healthy session — and an empty dropdown is
+// indistinguishable from a broken page.
+const CATALOGUE = [
+  { provider: "crow-local", id: "qwen3.6-35b-a3b", name: "Qwen", baseUrl: "http://x:8003/v1" },
+  { provider: "raven-flash", id: "flash-next", name: "Flash", baseUrl: "http://y:8010/v1" },
+];
+
+test("options(): a hibernating session lists the provider catalogue, and still never wakes a child", async () => {
+  let calls = 0;
+  const { engine, clock, state } = makeEngine({ providerModels: () => { calls++; return CATALOGUE; } });
   const s = await spawned(engine);
   clock.advance(600_001);
   await tick();
   assert.equal((await engine.get(s.sessionId)).state, "hibernating");
   const r = await engine.options(s.sessionId);
-  assert.deepEqual(r, { models: null, thinkingLevels: null });
+  assert.deepEqual(r.models, CATALOGUE, "an empty picker on a live session is the bug this ends");
+  assert.equal(calls, 1);
+  assert.equal(r.source, "providers", "the caller must not have to infer which half answered");
+  // Deliberately still null: control()'s thinking branch is a no-op with no
+  // child (pi's own session file owns the level across a --session resume),
+  // so offering that picker would promise a change that never happens.
+  assert.equal(r.thinkingLevels, null);
   assert.equal(state.instances.length, 1, "no second child was spawned");
+});
+
+test("options(): a LIVE child stays authoritative — the catalogue is not even consulted", async () => {
+  let calls = 0;
+  const { engine } = makeEngine({ providerModels: () => { calls++; return CATALOGUE; } });
+  const s = await spawned(engine);
+  const r = await engine.options(s.sessionId);
+  assert.deepEqual(r.models, [{ provider: "crow-local", id: "qwen3.6-35b-a3b" }, { provider: "crow-chat", id: "big-model" }],
+    "pi is the process that will route the next turn; its list wins whenever there is one");
+  assert.equal(r.source, "child");
+  assert.equal(calls, 0);
+});
+
+test("options(): a catalogue that throws degrades to an empty list, never a failed GET", async () => {
+  const { engine, clock } = makeEngine({ providerModels: () => { throw new Error("no provider registry"); } });
+  const s = await spawned(engine);
+  clock.advance(600_001);
+  await tick();
+  const r = await engine.options(s.sessionId);
+  assert.deepEqual(r.models, [], "the drawer renders a disabled picker on this — an honest answer");
+  assert.equal(r.thinkingLevels, null);
 });
 
 test("options(): unknown session is refused with no_such_session", async () => {

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -1267,6 +1267,72 @@ test("GET /interactive/:sid/events streams text | tool | log | reply | error eve
   try { await reader.cancel(); } catch { /* already closed */ }
 });
 
+test("GET /interactive/:sid/events carries rendered markdown ALONGSIDE the raw text, on prose frames only", async () => {
+  let push;
+  engineImpl.subscribe = async (sid, fn) => {
+    fn({ type: "state", sessionId: sid, state: "awake", lastError: null, pendingUi: null });
+    push = fn;
+    return () => {};
+  };
+  const res = await fetch(base + "/interactive/sess-1/events");
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+  const readUntil = async (n) => {
+    while (sseEvents(buf).length < n) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+    }
+  };
+  await readUntil(1);
+  push({ type: "text", text: "## Boards\n\nThere are **four**." });
+  push({ type: "reply", text: "Done, see [the docs](https://example.com)." });
+  push({ type: "log", text: "warm crow-local -> 200" });
+  push({ type: "tool", name: "bash", phase: "start", isError: false });
+  await readUntil(5);
+
+  const text = sseDataAt(buf, "text", 0);
+  assert.equal(text.text, "## Boards\n\nThere are **four**.", "the raw text still rides the frame");
+  assert.match(text.html, /<h2[^>]*>Boards<\/h2>/, "rendered on the SERVER — the client has no parser");
+  assert.match(text.html, /<strong>four<\/strong>/);
+
+  const reply = sseDataAt(buf, "reply", 0);
+  assert.match(reply.html, /<a href="https:\/\/example\.com">the docs<\/a>/);
+
+  // Gateway chrome is not model prose: a log line saying "warm crow-local ->
+  // 200" must not be handed to a markdown parser.
+  assert.equal(sseDataAt(buf, "log", 0).html, undefined);
+  assert.equal(sseDataAt(buf, "tool", 0).html, undefined);
+  try { await reader.cancel(); } catch { /* already closed */ }
+});
+
+test("GET /interactive/:sid/events omits html for an empty or whitespace text frame", async () => {
+  let push;
+  engineImpl.subscribe = async (sid, fn) => {
+    fn({ type: "state", sessionId: sid, state: "awake", lastError: null, pendingUi: null });
+    push = fn;
+    return () => {};
+  };
+  const res = await fetch(base + "/interactive/sess-1/events");
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+  const readUntil = async (n) => {
+    while (sseEvents(buf).length < n) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+    }
+  };
+  await readUntil(1);
+  push({ type: "reply", text: "   " });
+  await readUntil(2);
+  assert.equal(sseDataAt(buf, "reply", 0).html, undefined,
+    "no html means the client takes its textContent path, which is today's behaviour");
+  try { await reader.cancel(); } catch { /* already closed */ }
+});
+
 test("GET /interactive/:sid/events unsubscribes when the client disconnects — no leaked subscriber", async () => {
   const subscribers = new Set();
   engineImpl.subscribe = async (sid, fn) => {

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -215,7 +215,7 @@ beforeEach(() => {
   ];
   engineCalls = {
     spawn: [], message: [], steer: [], answer: [], abort: [], stop: [], get: [], subscribe: [],
-    checkCardFree: [], attachCard: [], control: [], cycle: [], options: [],
+    checkCardFree: [], attachCard: [], control: [], cycle: [], options: [], rename: [],
   };
   engineImpl = {
     async spawn({ botId, cardId }) {
@@ -239,6 +239,10 @@ beforeEach(() => {
     async attachCard(sid, cardId) {
       engineCalls.attachCard.push({ sid, cardId });
       return { ok: true, cardId, botId: "chatty" };
+    },
+    async rename(sid, label) {
+      engineCalls.rename.push({ sid, label });
+      return { label: label.trim() || null };
     },
     async control(sid, opts) {
       engineCalls.control.push({ sid, opts });
@@ -863,6 +867,38 @@ test("GET /interactive/:sid/options passes a null list through unannotated", asy
 test("GET /interactive/:sid/options 404s no_such_session", async () => {
   engineImpl.options = async () => { throw engineErr("no_such_session"); };
   const { status, body } = await getJson("/interactive/sess-1/options");
+  assert.equal(status, 404);
+  assert.equal(body.error, "no_such_session");
+});
+
+// ---------------------------------------------------------------------------
+// POST /interactive/:sid/rename
+// ---------------------------------------------------------------------------
+
+test("POST /interactive/:sid/rename passes the label through and returns what was STORED", async () => {
+  const { status, body } = await postJson("/interactive/perchlive-abc/rename", { label: "  Nov package  " });
+  assert.equal(status, 200);
+  assert.deepEqual(body, { label: "Nov package" }, "the engine normalizes; the route reports its answer");
+  assert.deepEqual(engineCalls.rename, [{ sid: "perchlive-abc", label: "  Nov package  " }]);
+});
+
+test("POST /interactive/:sid/rename with an empty label clears the name rather than 400ing", async () => {
+  const { status, body } = await postJson("/interactive/perchlive-abc/rename", { label: "" });
+  assert.equal(status, 200);
+  assert.equal(body.label, null);
+  assert.deepEqual(engineCalls.rename, [{ sid: "perchlive-abc", label: "" }],
+    "clearing a name is an action; refusing it would leave no way to undo a rename");
+});
+
+test("POST /interactive/:sid/rename with no label at all is a clear, not a crash", async () => {
+  const { status, body } = await postJson("/interactive/perchlive-abc/rename", {});
+  assert.equal(status, 200);
+  assert.equal(body.label, null);
+});
+
+test("POST /interactive/:sid/rename maps the engine's refusals", async () => {
+  engineImpl.rename = async () => { throw engineErr("no_such_session"); };
+  const { status, body } = await postJson("/interactive/perchlive-abc/rename", { label: "x" });
   assert.equal(status, 404);
   assert.equal(body.error, "no_such_session");
 });

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -50,6 +50,12 @@ let liveCardId, archivedCardId, itemId;
  * individual tests overwrite whichever methods they need to observe or fail. */
 let engineImpl;
 let engineCalls;
+/** The session-free provider catalogue GET /bots/:id/models serves. Injected
+ * for the same reason `annotate` is: the real one reads this host's provider
+ * DB / models.json. Its own shaping is covered in
+ * tests/perch-model-catalog.test.js. */
+let catalogueImpl;
+let catalogueCalls;
 
 function raw() {
   return new Database(DB_FILE);
@@ -187,6 +193,7 @@ before(async () => {
   app.use(perchInteractiveApiRouter(fakeAuth, {
     engine: () => engineImpl,
     annotate: async (models) => models.map((m) => ({ ...m, availability: "up" })),
+    providerModels: () => { catalogueCalls++; return catalogueImpl; },
   }));
 
   await new Promise((r) => { server = app.listen(0, "127.0.0.1", r); });
@@ -201,6 +208,11 @@ after(() => {
 
 beforeEach(() => {
   _setEngineStatusForTest({ state: "ready", source: "test", cliPath: "/nonexistent/pi" });
+  catalogueCalls = 0;
+  catalogueImpl = [
+    { provider: "local", id: "qwen", name: "Qwen", baseUrl: "http://x:8003/v1" },
+    { provider: "raven-flash", id: "flash-next", name: "Flash", baseUrl: "http://y:8010/v1" },
+  ];
   engineCalls = {
     spawn: [], message: [], steer: [], answer: [], abort: [], stop: [], get: [], subscribe: [],
     checkCardFree: [], attachCard: [], control: [], cycle: [], options: [],
@@ -834,10 +846,13 @@ test("GET /interactive/:sid/options 200s with the engine's models/thinkingLevels
   assert.deepEqual(engineCalls.options, [{ sid: "sess-1" }]);
 });
 
-test("GET /interactive/:sid/options passes models:null through — a hibernating session is not annotated", async () => {
-  // The null arrays are how the engine says "I did not wake a child just to
-  // list", and the drawer disables both pickers on them. Annotating would turn
-  // that into an empty list, which reads as "no models exist".
+test("GET /interactive/:sid/options passes a null list through unannotated", async () => {
+  // A null is how the engine says "there is no list for this one", and the
+  // drawer disables that ONE picker on it. Annotating would turn it into an
+  // empty array, which reads as "no models exist". The real engine now sends
+  // null only for thinkingLevels (a hibernating session's models come from the
+  // provider catalogue); the passthrough is pinned for both, because the route
+  // must not start inventing a shape the engine did not send.
   engineImpl.options = async () => ({ models: null, thinkingLevels: null });
   const { status, body } = await getJson("/interactive/sess-1/options");
   assert.equal(status, 200);
@@ -850,6 +865,60 @@ test("GET /interactive/:sid/options 404s no_such_session", async () => {
   const { status, body } = await getJson("/interactive/sess-1/options");
   assert.equal(status, 404);
   assert.equal(body.error, "no_such_session");
+});
+
+// ---------------------------------------------------------------------------
+// GET /bots/:id/models — the launcher's session-free list
+// ---------------------------------------------------------------------------
+
+test("GET /bots/:id/models 200s with the annotated catalogue and the bot's configured default", async () => {
+  const { status, body } = await getJson("/bots/chatty/models");
+  assert.equal(status, 200);
+  assert.deepEqual(body.models, [
+    { provider: "local", id: "qwen", name: "Qwen", baseUrl: "http://x:8003/v1", availability: "up" },
+    { provider: "raven-flash", id: "flash-next", name: "Flash", baseUrl: "http://y:8010/v1", availability: "up" },
+  ], "annotated for the same reason the options route annotates: an unavailable model must read as unavailable");
+  assert.equal(body.default, "local/qwen", "so the picker can open pre-selected and launching stays one tap");
+});
+
+test("GET /bots/:id/models 409s engine_required, and never builds a list for a spawn that cannot happen", async () => {
+  _setEngineStatusForTest({ state: "absent" });
+  const { status, body } = await getJson("/bots/chatty/models");
+  assert.equal(status, 409);
+  assert.equal(body.error, "engine_required");
+  assert.equal(catalogueCalls, 0, "the same gate, in the same order, as the sibling spawn route");
+});
+
+test("GET /bots/:id/models 403s perch_not_attached — a bot that would 403 on spawn offers no models", async () => {
+  const { status, body } = await getJson("/bots/quiet/models");
+  assert.equal(status, 403);
+  assert.equal(body.error, "perch_not_attached");
+  assert.equal(catalogueCalls, 0);
+});
+
+test("GET /bots/:id/models on an unknown bot resolves to perch_not_attached, exactly like the spawn route", async () => {
+  const { status, body } = await getJson("/bots/does-not-exist/models");
+  assert.equal(status, 403);
+  assert.equal(body.error, "perch_not_attached");
+});
+
+test("GET /bots/:id/models reports a default with no catalogue entry rather than hiding it", async () => {
+  // A default naming a provider row that has since been disabled is a fact the
+  // operator should see (the picker will show nothing selected), not one to
+  // quietly drop.
+  catalogueImpl = [{ provider: "raven-flash", id: "flash-next", baseUrl: "http://y:8010/v1" }];
+  const { status, body } = await getJson("/bots/chatty/models");
+  assert.equal(status, 200);
+  assert.equal(body.default, "local/qwen");
+  assert.deepEqual(body.models.map((m) => m.provider + "/" + m.id), ["raven-flash/flash-next"]);
+});
+
+test("GET /bots/:id/models on a bot with no configured model answers default:null, not \"undefined\"", async () => {
+  seedBot("modelless", { gateways: [{ type: "perch" }], tools: {} }, { name: "Modelless" });
+  const { status, body } = await getJson("/bots/modelless/models");
+  assert.equal(status, 200);
+  assert.equal(body.default, null);
+  assert.equal(body.models.length, 2);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -898,9 +898,44 @@ test("POST /interactive/:sid/rename with no label at all is a clear, not a crash
 
 test("POST /interactive/:sid/rename maps the engine's refusals", async () => {
   engineImpl.rename = async () => { throw engineErr("no_such_session"); };
-  const { status, body } = await postJson("/interactive/perchlive-abc/rename", { label: "x" });
-  assert.equal(status, 404);
-  assert.equal(body.error, "no_such_session");
+  let r = await postJson("/interactive/perchlive-abc/rename", { label: "x" });
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, "no_such_session");
+
+  // Fix round 1 Q4: a session with no row cannot be persisted to. 409 with an
+  // honest code, never a 200 carrying a label nothing stored.
+  engineImpl.rename = async () => { throw engineErr("not_persisted"); };
+  r = await postJson("/interactive/perchlive-abc/rename", { label: "x" });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, "not_persisted");
+});
+
+test("GET /bots/:id/models awaits the catalogue, so a cold provider cache is not served as an empty list", async () => {
+  // Fix round 1 Q6: the seam is async here on purpose — providerModelListWarm
+  // awaits a real refresh when the synchronous loader answers empty.
+  catalogueImpl = null;
+  let resolveIt;
+  const pending = new Promise((r) => { resolveIt = r; });
+  const slow = () => { catalogueCalls++; return pending; };
+  const { default: router } = await import("../servers/gateway/routes/perch-interactive-api.js");
+  const { default: express } = await import("express");
+  const app = express();
+  app.use(express.json());
+  app.use(router((req, res, next) => next(), {
+    engine: () => engineImpl,
+    annotate: async (models) => models.map((m) => ({ ...m, availability: "up" })),
+    providerModels: slow,
+  }));
+  const srv = await new Promise((r) => { const x = app.listen(0, "127.0.0.1", () => r(x)); });
+  try {
+    const url = "http://127.0.0.1:" + srv.address().port + "/dashboard/perch-api/bots/chatty/models";
+    const inFlight = fetch(url).then(async (res) => ({ status: res.status, body: await res.json() }));
+    resolveIt([{ provider: "local", id: "qwen", baseUrl: "u" }]);
+    const { status, body } = await inFlight;
+    assert.equal(status, 200);
+    assert.deepEqual(body.models.map((m) => m.provider + "/" + m.id), ["local/qwen"],
+      "a route that did not await would have served the unresolved value as an empty list");
+  } finally { srv.close(); }
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/perch-model-catalog-warm.test.js
+++ b/tests/perch-model-catalog-warm.test.js
@@ -1,0 +1,65 @@
+// Fix round 1 Q6 — the session-free catalogue was EMPTY on its first call.
+//
+// `loadProviders()` is synchronous by contract (providers.js: hot-path callers
+// that cannot be made async), so on a cold process it returns
+// `_cache || loadFromModelsJson()` and fires an UNAWAITED DB refresh. With no
+// models.json — which is the shipped state — the first call answers 0 models
+// and the second, ~1.5 s later, answers all of them. Measured against
+// ~/.crow-r4: 0, then 32.
+//
+// In that window `GET /bots/:id/models` served `{models: []}` (the client
+// self-heals on the next poll) and a hibernating session's `options()` served
+// `[]`, which the drawer renders as the empty, disabled dropdown this whole
+// task exists to remove — and `loadOptions` runs once per `openSession` and
+// never retries.
+//
+// SEPARATE FILE, deliberately: the provider cache is module-level, so this has
+// to be the FIRST call in its process. Any sibling test that lists models
+// first would warm the cache and turn this into a tautology.
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+
+const dir = mkdtempSync(join(tmpdir(), "perch-catalog-warm-"));
+process.env.CROW_DATA_DIR = dir;
+process.env.CROW_HOME = join(dir, "home");
+delete process.env.CROW_DB_PATH;
+// "" means "no models.json anywhere" (models-json-paths.js). Without this the
+// sync loader could find a repo-local file and answer non-empty, which would
+// make the assertion below pass for the wrong reason.
+process.env.CROW_MODELS_JSON = "";
+
+const REPO = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+before(() => {
+  execFileSync(process.execPath, ["scripts/init-db.js"], {
+    env: { ...process.env, CROW_DATA_DIR: dir }, stdio: "pipe", cwd: REPO,
+  });
+  const db = new Database(join(dir, "crow.db"));
+  db.prepare(
+    "INSERT INTO providers (id, base_url, host, models, disabled) VALUES (?,?,?,?,0)"
+  ).run("crow-local", "http://127.0.0.1:8003/v1",
+    "local", JSON.stringify([{ id: "qwen3.6-35b-a3b", name: "Qwen" }]));
+  db.close();
+});
+
+after(() => { rmSync(dir, { recursive: true, force: true }); });
+
+test("the FIRST call answers the real catalogue, not the cold-cache empty one", async () => {
+  const { providerModelList, providerModelListWarm } =
+    await import("../servers/gateway/perch-model-catalog.js");
+
+  // The sync loader, cold, on a host with no models.json: this is the [] the
+  // route and the drawer were being served. Asserted so the test below cannot
+  // silently stop proving anything if that ever changes.
+  assert.deepEqual(providerModelList(), [],
+    "precondition: the synchronous loader really is empty on a cold cache");
+
+  const warm = await providerModelListWarm();
+  assert.deepEqual(warm.map((m) => m.provider + "/" + m.id), ["crow-local/qwen3.6-35b-a3b"],
+    "the awaited variant must not hand back the empty list the sync one has");
+});

--- a/tests/perch-model-catalog.test.js
+++ b/tests/perch-model-catalog.test.js
@@ -4,7 +4,7 @@
 // class the module exists to prevent, so this pins the SHAPE both consume.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { providerModelList, modelKey } from "../servers/gateway/perch-model-catalog.js";
+import { providerModelList, providerModelListWarm, modelKey, chatCapable } from "../servers/gateway/perch-model-catalog.js";
 
 const cfg = (providers) => ({ load: () => ({ providers }) });
 
@@ -85,4 +85,55 @@ test("the default source really is loadProviders — the established session-fre
   // to bite the first operator who opens the launcher on a live box.
   const list = providerModelList();
   assert.ok(Array.isArray(list), "the DB/models.json-backed default must return a list, whatever this host has");
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q7 — an endpoint that answers is not a model you can talk to.
+// ---------------------------------------------------------------------------
+
+test("embedding and reranker entries are not offered as session models", async () => {
+  // Measured on the live R4 registry: grackle-embed/qwen3-embedding-0.6b and
+  // grackle-rerank/qwen3-reranker-0.6b were listed reading "— up", because
+  // annotateAvailability answers "did anything answer at this address" and an
+  // embedding server does. One tap from being a session's model, and every
+  // turn on it would fail.
+  const list = providerModelList(cfg({
+    "grackle-embed": { baseUrl: "http://g:9100/v1", models: [{ id: "qwen3-embedding-0.6b", task: "embed", dim: 1024 }] },
+    "grackle-rerank": { baseUrl: "http://g:9101/v1", models: [{ id: "qwen3-reranker-0.6b", task: "score" }] },
+    "crow-local": { baseUrl: "http://c:8003/v1", models: [{ id: "qwen3.6-35b-a3b" }] },
+  }));
+  assert.deepEqual(list.map(modelKey), ["crow-local/qwen3.6-35b-a3b"]);
+});
+
+test("the exclusion is by TASK, and covers both spellings the repo uses", async () => {
+  // Provider rows on this instance say task:"embed"/"score"; the model catalog
+  // vocabulary (scripts/validate-model-catalog.js:75) says
+  // "embedding"/"rerank". Both are non-chat and both are excluded.
+  for (const task of ["embed", "embedding", "rerank", "score", "classify", "EMBED"]) {
+    assert.equal(chatCapable({ id: "m", task }), false, task + " must not be offered");
+  }
+});
+
+test("no task at all means chat — most provider rows never tag their models", async () => {
+  // A strict allowlist would empty the picker on this instance: not one
+  // crow-local/zai-coding/qwen-cloud entry carries a task field.
+  assert.equal(chatCapable({ id: "m" }), true);
+  assert.equal(chatCapable({ id: "m", task: null }), true);
+  assert.equal(chatCapable({ id: "m", task: "chat" }), true);
+  // vision, deliberately: models/manager.js's own isChatClassRow counts
+  // task:"vision" as chat-class, and a -vl-…-instruct model serves chat
+  // completions. Filtering it out would drop a model an operator can use.
+  assert.equal(chatCapable({ id: "qwen3-vl-4b-instruct-fp8", task: "vision" }), true);
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 1 Q6 — the cold-cache window
+// ---------------------------------------------------------------------------
+
+test("the warm variant does not try to warm an INJECTED loader", async () => {
+  // A test seam has no cache to refresh, and warming one would reach for the
+  // real DB from a hermetic test.
+  assert.deepEqual(await providerModelListWarm(cfg({})), []);
+  assert.deepEqual((await providerModelListWarm(cfg({ p: { baseUrl: "u", models: [{ id: "m" }] } }))).map(modelKey),
+    ["p/m"]);
 });

--- a/tests/perch-model-catalog.test.js
+++ b/tests/perch-model-catalog.test.js
@@ -1,0 +1,88 @@
+// The session-free model list: one source for the launcher's picker (which has
+// no session yet) and for options()'s fallback on a session with no live child.
+// Two lists that could disagree about what this instance serves is the defect
+// class the module exists to prevent, so this pins the SHAPE both consume.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { providerModelList, modelKey } from "../servers/gateway/perch-model-catalog.js";
+
+const cfg = (providers) => ({ load: () => ({ providers }) });
+
+test("every model of every provider row becomes a pi-shaped entry", async () => {
+  // pi's own Model object (its rpc docs) is {id, name, provider, baseUrl, …},
+  // and that is what the drawer, the launcher and annotateAvailability read.
+  const list = providerModelList(cfg({
+    "crow-local": { baseUrl: "http://x:8003/v1", models: [{ id: "qwen3.6-35b-a3b", name: "Qwen" }] },
+    "zai-coding": { baseUrl: "https://api.z.ai/v4", models: [{ id: "glm-5.1" }, { id: "glm-5" }] },
+  }));
+  assert.deepEqual(list, [
+    { id: "qwen3.6-35b-a3b", name: "Qwen", provider: "crow-local", baseUrl: "http://x:8003/v1" },
+    { id: "glm-5.1", provider: "zai-coding", baseUrl: "https://api.z.ai/v4" },
+    { id: "glm-5", provider: "zai-coding", baseUrl: "https://api.z.ai/v4" },
+  ]);
+});
+
+test("baseUrl rides along on every entry — it is what the availability probe addresses", async () => {
+  const list = providerModelList(cfg({ p: { baseUrl: "http://probe-me/v1", models: [{ id: "m" }] } }));
+  assert.equal(list[0].baseUrl, "http://probe-me/v1");
+  // A row with no baseUrl is still listed; annotateAvailability falls through
+  // to the warmability question for it rather than dropping the model.
+  const noUrl = providerModelList(cfg({ p: { models: [{ id: "m" }] } }));
+  assert.equal(noUrl.length, 1);
+  assert.equal(noUrl[0].baseUrl, null);
+});
+
+test("every field the provider row carries on a model is preserved", async () => {
+  const list = providerModelList(cfg({
+    p: { baseUrl: "u", models: [{ id: "m", name: "M", reasoning: true, contextWindow: 262144 }] },
+  }));
+  assert.equal(list[0].reasoning, true);
+  assert.equal(list[0].contextWindow, 262144);
+});
+
+test("a bare id string is a model too — the shape bot-builder's loader also tolerates", async () => {
+  const list = providerModelList(cfg({ p: { baseUrl: "u", models: ["plain-id"] } }));
+  assert.deepEqual(list, [{ id: "plain-id", provider: "p", baseUrl: "u" }]);
+});
+
+test("models.json schema meta keys are not providers", async () => {
+  const list = providerModelList(cfg({
+    $schema: { models: [{ id: "nope" }] },
+    real: { baseUrl: "u", models: [{ id: "yes" }] },
+  }));
+  assert.deepEqual(list.map((m) => m.id), ["yes"]);
+});
+
+test("junk is skipped, never rendered as an entry with no id", async () => {
+  const list = providerModelList(cfg({
+    empty: { baseUrl: "u", models: [] },
+    nullish: null,
+    notArray: { baseUrl: "u", models: "qwen" },
+    idless: { baseUrl: "u", models: [{ name: "no id here" }, { id: "" }, null] },
+    good: { baseUrl: "u", models: [{ id: "keep" }] },
+  }));
+  assert.deepEqual(list.map((m) => m.id), ["keep"]);
+});
+
+test("no registry at all is an empty list, never a throw", async () => {
+  // loadProviders() reads a DB and a file; a caller listing models must not
+  // 500 a page because neither is readable.
+  assert.deepEqual(providerModelList({ load: () => { throw new Error("no db"); } }), []);
+  assert.deepEqual(providerModelList({ load: () => null }), []);
+  assert.deepEqual(providerModelList({ load: () => ({}) }), []);
+  assert.deepEqual(providerModelList(cfg({})), []);
+});
+
+test("modelKey speaks the one key definition.models.default and control() both use", async () => {
+  assert.equal(modelKey({ provider: "crow-local", id: "qwen3.6-35b-a3b" }), "crow-local/qwen3.6-35b-a3b");
+  assert.equal(modelKey({ provider: "p" }), null);
+  assert.equal(modelKey(null), null);
+});
+
+test("the default source really is loadProviders — the established session-free path", async () => {
+  // A precondition test, not a behaviour one: prove the module resolves its
+  // real dependency and returns an array here, so a renamed export cannot wait
+  // to bite the first operator who opens the launcher on a live box.
+  const list = providerModelList();
+  assert.ok(Array.isArray(list), "the DB/models.json-backed default must return a list, whatever this host has");
+});

--- a/tests/perch-routes.test.js
+++ b/tests/perch-routes.test.js
@@ -408,6 +408,77 @@ test("GET transcript resolves the session file by GLOB and skips unparseable lin
   assert.equal(body.omitted, 0);
 });
 
+test("GET transcript renders assistant markdown, and ONLY assistant text", async () => {
+  const sessions = join(dir, "sessions-md");
+  mkdirSync(sessions, { recursive: true });
+  const uuid = "019eeb17-0000-7000-8000-bbbbbbbbbbbb";
+  const asst = (content) => JSON.stringify({ type: "message", id: "m", message: { role: "assistant", content } });
+  writeFileSync(join(sessions, "2026-06-21T16-50-50-013Z_" + uuid + ".jsonl"),
+    JSON.stringify({ type: "message", id: "u", message: { role: "user", content: "**not mine to render**" } }) + "\n" +
+    asst([{ type: "text", text: "## Boards\n\nThere are **four**.\n\n| id | name |\n|---|---|\n| 1 | TEHCY |" }]) + "\n" +
+    asst([{ type: "toolCall", id: "c1", name: "board_list_boards", arguments: {} }]) + "\n" +
+    asst([{ type: "text", text: "   " }]) + "\n");
+  const c = raw();
+  c.prepare(
+    "INSERT INTO bot_sessions (bot_id,gateway_type,gateway_thread_id,pi_session_dir,pi_session_id,status) " +
+    "VALUES ('chatty','perch','t-md',?,?,'waiting-user')"
+  ).run(sessions, uuid);
+  c.close();
+
+  const { status, body } = await getJson("/bots/chatty/sessions/t-md/transcript");
+  assert.equal(status, 200);
+  const [user, prose, toolOnly, blank] = body.events;
+
+  assert.equal(user.html, undefined, "the operator's own typing is not markdown");
+  assert.equal(user.message.content, "**not mine to render**", "and it is untouched");
+
+  assert.match(prose.html, /<h2[^>]*>Boards<\/h2>/);
+  assert.match(prose.html, /<strong>four<\/strong>/);
+  assert.match(prose.html, /<table>[\s\S]*TEHCY[\s\S]*<\/table>/, "gfm tables, which is most of what a bot answers with");
+  assert.equal(prose.message.content[0].text.startsWith("## Boards"), true,
+    "the RAW text still rides the payload — the client falls back to it");
+
+  assert.equal(toolOnly.html, undefined, "a pure tool-call message keeps the client's own [tool: name] line");
+  assert.equal(blank.html, undefined, "and whitespace renders nothing rather than an empty block");
+});
+
+test("GET transcript SANITIZES: a hostile bot message reaches the client with nothing executable", async () => {
+  // Bot output is model-generated and can carry tool results read from files,
+  // so this is untrusted input that ends up in the ONE innerHTML sink the
+  // client has. The rendering path is servers/blog/renderer.js — marked plus
+  // sanitize-html with an explicit allow-list.
+  const sessions = join(dir, "sessions-xss");
+  mkdirSync(sessions, { recursive: true });
+  const uuid = "019eeb17-0000-7000-8000-cccccccccccc";
+  const hostile = [
+    "<img src=x onerror=\"window.__pwned=1\">",
+    "<script>window.__pwned=1</script>",
+    "[click me](javascript:window.__pwned=1)",
+    "<a href=\"javascript:window.__pwned=1\">or me</a>",
+    "<iframe src=\"https://evil.example\"></iframe>",
+    "<div onclick=\"window.__pwned=1\">or this</div>",
+  ].join("\n\n");
+  writeFileSync(join(sessions, "2026-06-21T16-50-50-013Z_" + uuid + ".jsonl"),
+    JSON.stringify({ type: "message", id: "m", message: { role: "assistant", content: [{ type: "text", text: hostile }] } }) + "\n");
+  const c = raw();
+  c.prepare(
+    "INSERT INTO bot_sessions (bot_id,gateway_type,gateway_thread_id,pi_session_dir,pi_session_id,status) " +
+    "VALUES ('chatty','perch','t-xss',?,?,'waiting-user')"
+  ).run(sessions, uuid);
+  c.close();
+
+  const { body } = await getJson("/bots/chatty/sessions/t-xss/transcript");
+  const html = body.events[0].html;
+  assert.ok(html, "it still renders — sanitizing is not dropping the message");
+  assert.ok(!/<script/i.test(html), "no script element: " + html);
+  assert.ok(!/onerror/i.test(html), "no inline event handler: " + html);
+  assert.ok(!/onclick/i.test(html), "no inline event handler: " + html);
+  assert.ok(!/javascript:/i.test(html), "no javascript: URL: " + html);
+  assert.ok(!/<iframe/i.test(html), "no iframe: " + html);
+  assert.ok(!/__pwned/.test(html) || !/<[^>]*__pwned/.test(html),
+    "the payload may survive as TEXT, but never inside a tag: " + html);
+});
+
 test("GET transcript TAIL-truncates: the newest turns survive, the oldest are counted", async () => {
   const sessions = join(dir, "sessions-big");
   mkdirSync(sessions, { recursive: true });

--- a/tests/roost-strip-data.test.js
+++ b/tests/roost-strip-data.test.js
@@ -60,9 +60,9 @@ const ENGINE_SESSIONS = [
   { sessionId: "asker-b", botId: "asker", state: "hibernating", pendingUi: null, cardId: null },
   { sessionId: "sleepy-1", botId: "sleepy", state: "hibernating", pendingUi: null, cardId: null },
 ];
-// asker-b's label is deliberately absent from the engine snapshot and present
-// on its ROW: the DB backfill has to cover an entry eng.list() built without
-// one, exactly as it does for cardId.
+// chatty-1 carries its label on the ENGINE snapshot, which must win.
+// (asker-b gets the mirror case — a label on its ROW only — seeded in
+// before(), so the DB backfill is covered too.)
 ENGINE_SESSIONS[0].label = "Nov package copy pass";
 
 let server, noEngineServer, defaultServer, base, noEngineBase, defaultBase;
@@ -90,6 +90,9 @@ before(async () => {
   insSession.run("chatty", "perch", "chatty-2", "perch-live", "stopped", 99, "run");
   insSession.run("asker", "perch", "asker-a", "perch-live", "active", 11, "run");
   insSession.run("asker", "perch", "asker-b", "perch-live", "waiting-user", null, "run");
+  // The mirror of chatty-1 above: no label on the engine snapshot, one on the
+  // row — the DB backfill has to cover an entry eng.list() built without one,
+  // exactly as it does for cardId.
   c.prepare("UPDATE bot_sessions SET label=? WHERE gateway_thread_id=?").run("named on the row only", "asker-b");
   insSession.run("sleepy", "perch", "sleepy-1", "perch-live", "waiting-user", null, "run");
 

--- a/tests/roost-strip-data.test.js
+++ b/tests/roost-strip-data.test.js
@@ -60,6 +60,10 @@ const ENGINE_SESSIONS = [
   { sessionId: "asker-b", botId: "asker", state: "hibernating", pendingUi: null, cardId: null },
   { sessionId: "sleepy-1", botId: "sleepy", state: "hibernating", pendingUi: null, cardId: null },
 ];
+// asker-b's label is deliberately absent from the engine snapshot and present
+// on its ROW: the DB backfill has to cover an entry eng.list() built without
+// one, exactly as it does for cardId.
+ENGINE_SESSIONS[0].label = "Nov package copy pass";
 
 let server, noEngineServer, defaultServer, base, noEngineBase, defaultBase;
 
@@ -86,6 +90,7 @@ before(async () => {
   insSession.run("chatty", "perch", "chatty-2", "perch-live", "stopped", 99, "run");
   insSession.run("asker", "perch", "asker-a", "perch-live", "active", 11, "run");
   insSession.run("asker", "perch", "asker-b", "perch-live", "waiting-user", null, "run");
+  c.prepare("UPDATE bot_sessions SET label=? WHERE gateway_thread_id=?").run("named on the row only", "asker-b");
   insSession.run("sleepy", "perch", "sleepy-1", "perch-live", "waiting-user", null, "run");
 
   const insJob = c.prepare(
@@ -169,6 +174,19 @@ test("GET /roost's session shape merges engine state with bot_sessions card_id/c
   assert.equal(askerSessions["asker-a"].pendingUi, true);
   assert.equal(askerSessions["asker-a"].cardId, 11);
   assert.equal(askerSessions["asker-b"].cardId, null);
+});
+
+test("GET /roost carries each session's operator-set label, ALONGSIDE its id", async () => {
+  const { body } = await getJson(base, "/roost");
+  const b = byId(body.birds);
+  const chatty = Object.fromEntries(b.chatty.sessions.map((s) => [s.sessionId, s]));
+  const asker = Object.fromEntries(b.asker.sessions.map((s) => [s.sessionId, s]));
+
+  assert.equal(chatty["chatty-1"].label, "Nov package copy pass", "the engine snapshot wins when it has one");
+  assert.equal(chatty["chatty-1"].sessionId, "chatty-1", "the id is still the identity and still shipped");
+  assert.equal(asker["asker-b"].label, "named on the row only",
+    "same DB backfill as cardId — an entry eng.list() built without a label still gets one");
+  assert.equal(asker["asker-a"].label, null, "an unnamed session is null, never undefined or an empty string");
 });
 
 test("GET /roost's occupiedCardIds is the session rail (non-stopped) union the job rail (queued/running)", async () => {


### PR DESCRIPTION
Seven commits fixing five operator-reported defects and adding two features. **Merged under time pressure with one review round outstanding — see "Outstanding review" at the bottom.**

## The defects

**Every streamed line repeated ~6x.** The dashboard shell ships Turbo Drive, and a Turbo visit replaces `<body>` without reloading the JS realm — so the inline hub script re-ran while the previous run's closure, EventSource, poll timer and window listeners stayed alive, and `el()` resolves by id at call time so old instances wrote into the new document. Measured 4 visits → 4 EventSource objects → 4 gateway `/events` connections; 1/1/1 after. Fixed with a window-level registry keyed by identity, a generation counter every document-outliving listener checks, and a `turbo:before-render` self-retire. **This arrived with the shell move in #352** — as a standalone document Perch was immune.

**Every turn rendered twice.** `on('text')` appends once per completed assistant message; `on('reply')` then appended `replyTextOf(end)`, every message of that turn concatenated. The 6x multiplication was hiding it. Fixed by turn identity on the frames so `reply` judges its own turn — not a client-side flag, which fixes the cross-turn case by reintroducing the same-turn duplicate.

**The model and thinking selectors were empty on any hibernating session.** `options()` sourced its list from the live pi child and returned `null` when there wasn't one. Now falls back to a session-free catalogue built from `loadProviders()`, the same source `model-availability.js` already uses — one source shared with the launcher, not two that can disagree.

**The session list went stale in the >=900px split view.** Polling stopped when a session opened, though the list stays on screen — so an awake session showed no row and therefore no Close. Now keyed to the layout, re-evaluated on breakpoint change.

**Bot markdown rendered as literal text.** Rendered server-side through the existing `renderMarkdown` (`marked` + `sanitize-html`, the house pattern in the memory panel), on the SSE frame and the transcript payload — both single choke points, so no new endpoint and no per-message round trip. `html` rides alongside the raw text and falls back to `textContent` on failure. One named sink, `setSanitizedHtml`.

## The features

A model picker beside New session, defaulting to the bot's configured model, with an explicit "The bot's own model" option when there is none (3 of 5 bot defs on the reporting instance have `models: null`). Session rename, persisted, text-only, length-capped.

## What review changed

Two adversarial reviews and two fix rounds, all measuring rather than reading:

- The picker never assigned its value and ignored the model on the state frame — it showed the *first* option regardless of what the session was running, on the one control the task existed for. Now routed through a single `servingModel()` so the four reporting sites cannot drift.
- That fix still missed adopted sessions: `adoptRow` read the row's `model` and assigned neither `resolved` nor `currentModel`, so every session opened after a gateway restart got option 0. Restored into the engine's tracking, so the report and the next wake agree.
- Underneath that, the row's `model` column was only written by `onTurnEnd` — an operator who switched model and restarted before the next turn never had the switch persisted at all. `control()` now writes it directly.
- A reconnect across a turn boundary silently ate the answer: `turnRendered` survived a stream teardown and reset only on a false→true transition, so a two-second blip suppressed the next turn's reply entirely. A regression from the double-render fix, caught by measurement after the reasoning that it was safe proved untested.
- Every Turbo visit retained a dead script instance: `focus`, `hashchange` and `before-render` measured 1→5 over five visits, each closure holding `rowIndex`, `launchBots` and any attached base64 image data. Bound once per realm, measured flat at 1.
- The transcript is a CSS grid, so a row's minimum is its min-content — one unbreakable table cell widened a row to 801px inside a 380px column and scrolled the transcript sideways on a phone. `min-width:0` per row.
- Embedding and rerank endpoints were offered as session models (34 enabled → 32). Vision kept: `isChatClassRow` counts it and a `-vl-instruct` model serves chat completions.
- Comments asserting the inverse of the code, in three places, including one claiming `position:sticky` is what keeps Send reachable — measured, the flex chain is the mechanism and sticky is the backstop, and the pre-existing tests stay green through a flex-chain deletion.

## Verification

696 assertions green. Sanitization proven in a real browser through both delivery paths with fourteen payloads including the mXSS `<math><mtext><table><mglyph><style>` namespace confusion and the `<noscript>` parser differential: nothing fired, no node survived, every `href` stripped. Send reachability measured with `getBoundingClientRect()` against `innerHeight` at 412x730 and 1280x900 with the transcript scrolled to top.

## Outstanding review

The final scoped re-review of `75a006ee` was **stopped part-way for budget reasons** and this was merged on the operator's explicit instruction. Two things in that commit have therefore had one fewer pair of eyes than the rest:

1. **Restoring the model into engine tracking changes wake behaviour**, not only reporting — an adopted session now resumes on the model its row records rather than re-resolving from the bot definition. Believed correct (an explicit operator choice should survive a restart), but it is beyond the defect that was reported.
2. **The wake path when the recorded model no longer exists** — provider deleted, disabled or renamed — was not driven. `crow-dsv4` was disabled on this fleet the same day, so the case is live rather than theoretical. `perch-interactive.js:1181` compares `currentModelParts` against `prep.resolved`; `:863-875` is the restore.

Also unverified by that round: the `control()` targeted UPDATE not clobbering neighbouring columns (`writeRow` documents an `'interrupted'`-status clobber nearby), and two mutations the implementer judged wrong rather than green.

Worth a look when there is budget.