### PR TITLE
Perch: model provenance, dead-model rails, and the history-window duplicate (open-anywhere Phase A)

### DIFF
--- a/docs/reviews/2026-09-11-perch-pr356-review-completion.md
+++ b/docs/reviews/2026-09-11-perch-pr356-review-completion.md
@@ -1,0 +1,104 @@
+# PR #356 — completion of the outstanding review of `75a006ee`
+
+**Date:** 2026-09-11 · **Reviewer:** pi session (following Kevin's rushed merge of PR #356, 2026-09-10 22:08 UTC)
+**Scope:** exactly what the PR's "Outstanding review" section named — the final scoped re-review of commit `75a006ee` ("Perch: judge a reply by its turn, and restore an adopted session's model") that was stopped part-way for budget.
+
+State of the world: `75a006ee` is merged to `main` (`85feb555` = merge of #356). No formal GitHub reviews exist; all review rounds lived in Claude Code sessions. This document closes them out.
+
+---
+
+## Findings
+
+### R1 — CONFIRMED, MEDIUM — the adopted-model restore pins the *resolved default*, not just explicit choices
+
+The PR flagged this as "believed correct but beyond the defect." It is worse than believed, and the mechanism is now identified:
+
+- The row's `model` column is stamped **unconditionally** at every spawn/wake/turn-end:
+  - `perch-interactive.js:1228` (`startChild` → `writeRow(…, model: prep.resolved.key)`)
+  - `perch-interactive.js:1512` (`onTurnEnd` → `writeRow(…, model: s.resolved.key)`)
+  - `perch-interactive.js:1710` (spawn-active stamp)
+- `adoptRow` (`:873-877`) restores **whatever the row carries** into `s.currentModelParts` / `s.currentModel`.
+- `startChild`'s override (`:1181-1192`) then treats that value as an operator override and forces it over `prepareSpawn`'s fresh resolution.
+
+There is **no provenance distinction** between "the operator picked this" and "this is what the resolver happened to return at the last wake." Consequences:
+
+1. **Sticky defaults across restarts.** Change a bot def's default model in Bot Builder → any session that survives in memory keeps following the def (override is skipped when `currentModelParts` is null — the common case), but after a gateway restart every existing session snaps back to whatever its row stamped and **ignores the def change forever**. The stamp is self-perpetuating: each wake re-stamps the row with the same value.
+2. **Asymmetry is the confusing part.** Two identical sessions, one adopted across a restart and one not, behave differently after a def change. "It worked before I restarted the gateway" is the bug report this will generate.
+
+The comment's justification ("an explicit operator choice should survive a restart") is sound **for explicit choices**; the implementation grants that authority to every value the row has ever held.
+
+**Recommendation:** record provenance. Cheapest shape: stop stamping `model` from `startChild`/`onTurnEnd` and let `writeModel()` (called only from `control()` and `onModelSelect`) be the sole writer — then a non-NULL `model` column *means* "operator chose this," and the restore's authority is exactly as wide as the justification. (Check: `writeRow`'s default is `model = null` and its UPDATE list — confirm it does not already null other writers' values; today `writeRow` at `:1294` etc. pass no model, so the column would need to stay out of `writeRow` entirely.) Alternative: a `model_explicit` boolean column. The first option is a deletion, the second a migration — prefer the first.
+
+### R2 — CONFIRMED, MEDIUM — a well-formed but dead model key bypasses every fail-closed rail; unvalidated at write, unprobed at wake
+
+The named "crow-dsv4 disabled the same day" case, traced:
+
+- **Write side:** `routes/perch-interactive-api.js:610` maps `body.model` → `{provider, modelId}` with only object-shape checks; `control()` (`perch-interactive.js:1914`) checks truthiness only. Any string pair is accepted **and now persisted** by `writeModel()` — the API can plant a poison pill that outlives restarts. The drawer's picker only offers catalogue values, so this is API-hardening, not a UI defect.
+- **Wake side:** `resolveModel()` (model_resolver.mjs) is fail-closed — an invalid key resolves to `LOCAL_FALLBACK`. But the `startChild` override injects `currentModelParts` **after** that resolution and **without validation**, so the restore path skips the resolver's only safety rail.
+- **Actual failure mode:** `warmModel()` is genuinely best-effort and never throws (`warm.mjs` — verified). pi is spawned with `--provider <dead> --model <dead>` (`bridge.mjs:166`). If pi rejects at startup, `attachExit` parks the session (`s.pi=null`, state → hibernating, `lastError = "pi exited unexpectedly"`) and the `s.pi !== pi` bail at `:1259` prevents the "awake" lie — this is the I-1 rail and it holds. If pi starts and only fails per-request, every turn errors or replies nothing.
+- **Recovery exists but is undiscoverable:** the operator *can* fix it — `options()` serves the catalogue without a child, and `control()` while hibernating stores + persists the new model. But nothing in the error names the model as the cause, and every retry re-attempts the dead model first. The PR's own N2 tests cover *malformed* keys (`splitModelKey` shape) but **no test drives a well-formed key naming a deleted/disabled provider**.
+
+**Recommendation (two small, layered changes):**
+1. **Validate at control() time:** reject `model` pairs not present in `providerModelListWarm()` (the module built exactly for this, `perch-model-catalog.js` — same single source the picker uses) with `bad_request`. Makes the pill un-plantable.
+2. **Fail-open at wake:** in the `startChild` override, if `s.currentModelParts` names a key absent from the catalogue, drop the override (serve the fresh def resolution), clear the tracking fields, and `emit` a visible `log` frame ("row model X no longer available — resumed on Y"). Turns the opaque crash-park loop into one honest sentence.
+   - Do **not** clear the row in this path silently — if the provider is *temporarily* disabled, clearing loses a real operator choice. With R1's provenance split, "keep the row, log the fallback" is coherent.
+
+### R3 — VERIFIED CLEAN — `writeModel()`'s targeted UPDATE does not clobber
+
+The PR asked for a second pair of eyes on this specifically:
+
+- `bot_sessions` schema (`scripts/init-db.js:2601-2629`): no CHECK on `model`, no generated columns, **no triggers on the table at all** (grep for `TRIGGER` + session/bot returns nothing).
+- The statement is `UPDATE bot_sessions SET model=?, updated_at=datetime('now') WHERE id=?` — two columns, parameterized, keyed on row id.
+- The documented `writeRow` clobber (status restamp + `control` reset to `'run'`, `perch-interactive.js:691`, and the rename doc at `:2159-2161`) is exactly what `writeModel` avoids by not going through `writeRow`.
+- Null-safety: `servingModel(s)` = `s.currentModel || s.resolved?.key`; both `control()` call sites assign `s.currentModel` **before** calling `writeModel`, so a NULL overwrite of a good value is not constructible from these paths. `s.rowId == null` early-returns.
+- Race with `onTurnEnd`'s `writeRow`: `control()` throws `turn_in_progress` while `s.turn` is set, so the two writers are serialized by design.
+
+No action.
+
+### R4 — VERIFIED CLEAN — turn-id reply logic (the N1 half of the commit)
+
+- Turn ids are `randomUUID()` per turn (`perch-interactive.js:1701`) — no reuse across the reconnect window, so `renderedTurn===d.turnId` can never match a stale turn.
+- `text` frames carry `s.turn?.id ?? null`; the `null` fallback keeps the legacy transition-flag path intact for out-of-turn child speech (verified the client handles the mixed cases at `client.js:909,929`).
+- `if(!d.text) return` correctly distinguishes malformed-JSON `d={}` from real frames given the engine only emits `text` for non-empty messages (`:1328`).
+- Session switch resets `renderedTurn` (`client.js:1121`) alongside `turnRendered` — no bleed between sessions.
+- Coverage: both reconnect shapes driven in the unit harness (`tests/perch-hub-client.test.js:2169-2231`, including the no-turn-id legacy shape and the malformed-frame test) and live over a server-closed connection (`tests/perch-hub-stream-leak.test.js:357-392`).
+
+**One adjacent, pre-existing race, NOT a regression from this commit** (noted so it lands on the radar rather than being blamed on it): `afterHeader` opens the stream **before** the transcript fetch resolves (`client.js:769`). A message that completes between the subscribe and the transcript landing renders twice — once from the `text` frame, once inside the fetched history. The `reply` itself stays suppressed (`renderedTurn` matches), so the blast radius is a duplicated bubble, same visual class as the defect this commit killed. Candidate for the integration-issues list.
+
+### R5 — RESOLVED BY INSPECTION, re-run pending — the two mutations "judged wrong rather than green"
+
+The commit names them: (a) a partial pre-fix client, (b) engine-side edits tested against client tests that build their own frames.
+
+- (b) is addressed by real tests that read **engine-emitted** frames from a live `message()` turn and assert `turnId` on both `text` and `reply` (`tests/perch-interactive-controls.test.js:1066-1092`) — an engine-side stamping deletion is now red-able.
+- (a) is addressed by the two reconnect tests shaping each case separately (unit + live, see R4).
+
+By inspection these are right. The mutation matrix should still be re-run once (see verification) since the round that was supposed to confirm it never finished.
+
+---
+
+## Verification checklist (for execution, in budget order)
+
+1. `npm test -- tests/perch-hub-client.test.js tests/perch-hub-stream-leak.test.js tests/perch-interactive-controls.test.js tests/perch-hub-render.test.js` — green on current `main`.
+2. Mutation re-run, each restored alone, expect the named red:
+   - delete `turnId` from the `reply` emit (`perch-interactive.js:1492`) → engine stamping test red
+   - delete `turnId` from the `text` emit (`:1328`) → two stamping tests red
+   - remove `adoptRow` restore (`:873-877`) → three N2 tests red
+   - make `writeModel` a no-op → three N2 tests red
+   - revert `renderedTurn` client logic → cross-turn test red
+3. New drives the old suite lacks (become regression tests for R1/R2 fixes):
+   - **Dead-provider wake:** stamp a session's row with `provider/model`, disable/remove that provider row, restart the engine, `message()` → assert the session serves on the fresh def resolution (or the validated rejection, per fix shape) **and** that a `log` frame naming the fallback reaches subscribers. Today this scenario is untested end to end.
+   - **Def-change pin:** spawn a session on def default A, change def default to B, restart engine (adopt), `message()` → today it silently serves A (the bug); after the fix, serves B when the row carries no explicit choice.
+
+---
+
+## Verdict
+
+The rushed merge did not break anything that the merged tests cover — the client half (N1/R4) and the DB hygiene (R3) hold up. The two genuine gaps are exactly the two the PR flagged as its own leftovers, and both live in the wake path:
+
+| # | Issue | Severity | Fix size |
+|---|-------|----------|----------|
+| R1 | Row-stamped *defaults* get operator-choice authority; def changes silently pinned across restarts | Medium | small — stop stamping `model` outside `control()`/`onModelSelect` |
+| R2 | Well-formed dead model key: unvalidated at write, unprobed at wake, opaque failure | Medium | small — catalogue validation at `control()`, fail-open + log at wake |
+| R4-adjacent | openStream/loadHistory duplicate bubble race (pre-existing) | Low | separate issue — belongs to the integration-issues plan |
+
+R1 and R2 share a root: the engine grants the row's `model` column more trust than the column's writers deserve. They should ship as one change, and they are candidates to fold into the perch-hub integration issue plan (next section, awaiting Kevin's notes).

--- a/docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md
+++ b/docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md
@@ -1,0 +1,247 @@
+# Perch Hub: open-anywhere + tab surface (combined plan)
+
+> **NEXT SESSION — START HERE.** This is the active, operator-approved plan for the Perch Hub
+> integration work of 2026-09-11 (Session 64 continuation, crow repo). Read this file top to
+> bottom; it is self-contained — its "Operator decisions" + "Architecture" sections replace any
+> conversation context. Related artifacts, in reading order:
+> 1. This plan: `docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md`
+> 2. The review it implements Phase A from: `docs/reviews/2026-09-11-perch-pr356-review-completion.md`
+> 3. The surface spec it slots under: `docs/superpowers/specs/2026-09-09-perch-hub-design.md`
+> Execution state: **no code written yet** — if work has begun, tick progress against the
+> numbered steps (A1…E2) and record any named deviation in the "Risk notes" section's spirit:
+> measured, not asserted. PR shape: PR 1 = Phase A, PR 2 = Phases B+C, PR 3 = Phase D+E.
+
+**Status:** approved by operator 2026-09-11 (four decisions captured below)
+**Supersedes:** the directory-containment decisions of the M3 project-native workspace model *for Perch sessions*, and completes the outstanding review of PR #356 → `docs/reviews/2026-09-11-perch-pr356-review-completion.md` (findings R1, R2, R4-adjacent become Phase A).
+**Companion spec:** `docs/superpowers/specs/2026-09-09-perch-hub-design.md` (surface model, mobile rules, and API map there all still hold).
+
+> **Execute on current `main` (≥ `85feb555`). Line numbers below cite that state — re-grep the quoted string before editing; trust the string, not the number.**
+
+## Operator decisions (load-bearing)
+
+1. **Abandon structural containment.** Crow bots in Perch Hub open in **any directory** on this host, chosen through a **clickable browse picker** (server-backed directory listing). The barrier between the Region-4 crow bots and personal bots is the per-instance project MCP/tools (`~/r4-tehcy` runs as its own crow instance), *not* directory jailing on this device. Applies to **all** sessions, card-bound included.
+2. **The chosen directory is writable** — added to the child's `write_paths` at spawn so the bot can do real work there, like bare pi did. Permission modes (guarded/ask/bypass), `--no-approve`, and spawn_env hygiene are unchanged.
+3. **R1/R2 wake fixes ship inside this plan**, as the first phase.
+4. **Tabs** (Chat / Session / Files / Activity, like the original pi-lab hub) are ported into the crow hub **keeping crow's visual aesthetic**, and the layout must work at phone width AND in the ≥900px split view (crow port is currently better on desktop; the original's tabs are better on mobile — this plan keeps both halves).
+
+## Architecture (the shape, with rationale)
+
+**Split "cwd" from "world root".** Today one value (`world.sessionDir`, derived from `projectSpace.workspace_dir + "/bots/<botId>"` or `def.session_dir`) serves as: pi's process cwd, the pi session-file store (`sessionDir/sessions`), the per-bot `.mcp.json` home, and the parent of `outputs/<sid>` and `.pi/uploads/<sid>` (`scripts/pi-bots/bot-world.mjs:86-103`, `servers/gateway/perch-interactive.js:1196-1205`, `scripts/pi-bots/bridge.mjs:276` `spawn(..., { cwd: sessionDir, ... })`). After this change:
+
+- **`cwd`** — operator's choice, persisted per session in a new `bot_sessions.cwd` column; falls back to today's sessionDir resolution when unset; used as pi's process cwd **and** as the directory added to `write_paths`, **and** as where `.mcp.json` lives (pi-lab's mcp-client reads `cwd/.mcp.json` — bridge.mjs's own comment at ~:165 confirms cwd is where the extension looks, so an arbitrary cwd without relocating `.mcp.json` would silently strip every bot of its MCP tools). Writing `.mcp.json` into the chosen dir is pi's native pattern and `writeBotMcp` is already an additive merge, so a dir that carries its own `.mcp.json` survives.
+- **world root** — `sessionDir` stays as the *storage* root: pi session files, `outputs/<sid>`, uploads. A session's deliverables never litter the chosen directory, and the existing outputs-download jail (`tests/perch-workspace-jail.test.js`) is untouched.
+- **no configured dir anywhere** → world root falls back to `join(crowHome, "pi-bots", botId)` (mkdir) instead of the `no_session_dir` throw (`bot-world.mjs:97-102`), which is deleted. cwd then defaults to the world root. Other-channel callers (gmail/discord bridge, job_runner) keep the existing resolution order; only the throw becomes a fallback.
+
+**Mid-session cwd change:** `control({cwd})` persists it and hibernates the live child with a visible `log` frame — the next message wakes in the new directory. Never a live chdir (pi's child process cwd is fixed at spawn).
+
+**Browse endpoint security:** `GET /dashboard/perch-api/browse?path=` — directory *names* only (plus `parent`), never file contents; behind the same `dashboardAuth` as every perch-api route; not added to `PUBLIC_FUNNEL_PREFIXES` (invariant: private routes never funnel-reachable). The dashboard operator is the machine owner — this is a picker, not a trust boundary.
+
+**Do-not-do list (all retired by prior decisions — do not resurrect):**
+- Do **not** restore the old bundle's tmux spawner (`/api/hub/spawn`), its on-disk pi-session list, or its per-session web-server reverse proxy (`docs/reviews` + deletion `42f39160`; the 2026-09-09 spec retired them by design).
+- Do **not** make `/perch` its own document again — it lives inside the dashboard shell (PR #352 nav decision). Tabs live inside the shell.
+- Do **not** create a second chat surface; the drawer is gone and stays gone.
+- Do **not** add a new host port (would fail `check-ports` against `docs/developers/port-allocation.md`).
+- Do **not** bump bundle manifests — everything here is core gateway code.
+- Do **not** touch `PUBLIC_FUNNEL_PREFIXES` or `isAllowedNetwork()` allow-lists.
+
+**Test inventory (what exists to update):** `tests/perch-hub-client.test.js` (client-script unit harness), `perch-hub-page.test.js` (markup), `perch-hub-render.test.js` (markdown/sanitize), `perch-hub-stream-leak.test.js` (Turbo instance leaks, live reconnects), `perch-interactive.test.js` (engine core), `perch-interactive-controls.test.js` (control/options/wake/turnId), `perch-interactive-routes.test.js` (the 77 API cases), `perch-interactive-dispatch.test.js` (card dispatch spawn), `perch-interactive-capacity.test.js`, `perch-interactive-statebridge.test.js`, `perch-model-catalog(-warm).test.js`, `perch-narrowing.test.js`, `perch-routes.test.js`, `perch-workspace-jail.test.js`, `perch-retirement.test.js`, `board-lock-perch-live.test.js`, `bot-board-perch-link.test.js`, `init-db-bot-tables.test.js`, `i18n-global-parity.test.js`, `auth-network.test.js`.
+
+**Commit discipline (repo rule):** always `git commit <path> -m "..."` with positional paths; `git pull --rebase` before pushing.
+
+---
+
+## Phase A — PR #356 wake-path fixes (R1, R2, +R4-adjacent)
+
+### Step A1 — R1: give `writeModel` sole authority over the row's `model`
+
+**Files:** `servers/gateway/perch-interactive.js`
+**Do:**
+- Remove the `model:` argument from the three automatic stamps so `writeRow`'s `model=COALESCE(?, model)` passes NULL through and the column keeps only explicit choices. **Do NOT also touch `writeRow` itself**: its parameter is a destructured object (`async function writeRow(s, { status, piSessionDir = null, model = null }, control = "run")`), so an omitted `model:` arrives as `null` — the UPDATE's COALESCE preserves the existing column value and the INSERT mints NULL. Placeholder counts are unchanged. (A review round claimed this breaks the INSERT arg count; it does not — verified 2026-09-11 against `perch-interactive.js:676-711`. Do not "fix" a non-issue.)
+  - `startChild`'s stamp — `writeRow(s, { status: "active", ..., model: prep.resolved.key })` (search `piSessionDir: world.sessionDir + "/sessions"`)
+  - `onTurnEnd` — search `"status: \"waiting-user\", model: s.resolved ? s.resolved.key : null"` (there are two identical tails; fix both — the turn-end write and the active-spawn write near `spawn()`'s `"status": "active"`)
+- In `onModelSelect` (search `function onModelSelect`), after it assigns `s.currentModelParts`/`s.currentModel` for a *changed* value, call `writeModel(s)` so a `/model` typed in the TUI is also an operator choice that survives restart.
+- **Early-event belt (second review round C2):** `writeModel` returns silently when `s.rowId == null`, and a child's first `model_select` CAN land after `new PiRpc(...)` but before `startChild`'s `await writeRow(...)` resolves — a switch during that window would never be retried (every later `writeRow` COALESCE-preserves, it does not re-write from tracking). Fix: at the tail of `startChild`, just before the final `if (s.pi !== pi) return pi;` bail (search `if (s.pi !== pi) return pi;`), add `if (s.currentModelParts && servingModel(s) !== prep.resolved.key) await writeModel(s);` — a no-op unless the window actually fired. New test: stub child emits `model_select` before the row write completes; after spawn, the row carries the switched model.
+- **Legacy-row escape hatch:** every pre-A1 row already carries an auto-stamped `model` that `adoptRow` will honor — cleansing them is wrong (each value WAS the serving model at stamp time; a bulk NULL would silently move live sessions back to the def default on next wake). Instead make the choice revocable: `control()` accepts `model: { provider: null, modelId: null }` (the drawer's existing "the bot's own model" option, which today only skips the launch-time switch) meaning *clear the explicit choice* — set `s.currentModelParts = null` / `s.currentModel = null` and have `writeModel` write NULL (drop its implicit reliance on `servingModel(s)` being non-null; make it `servingModel(s)`-or-null explicitly). Next wake then re-resolves from the def, and the picker shows the def's current model as a plain non-user value. Tests: clear-then-adopt serves the def default; clear persists NULL to the row.
+- Grep consumers of the row's `model` column to confirm nothing displays it directly: `grep -rn "bot_sessions" servers/gateway/routes/perch.js servers/gateway/dashboard | grep model` — if the roost strip reads `row.model` for a session the engine no longer holds, leave it (NULL reads as "no explicit choice", same as today for non-perch rows).
+**Verify:** `npm test -- tests/perch-interactive-controls.test.js` — the three N2 tests must stay green (they set the model via control()). Add one new test in the same file: *spawn a session on the def default without any switch, re-stamp rows by running a turn, then adopt with a fresh engine and assert `snapshot().model` equals the def default* **after changing the def default between adopt and wake** — i.e. the pin scenario from the review: def default A → row stamped A → def changed to B → fresh engine → `message()` serves **B** when the row never had an explicit choice. Run it red before making it green by deleting the stamps.
+**Commit:** `Perch: the row's model column means an explicit choice, nothing else`
+
+### Step A2 — R2a: validate the model pair at `control()` time
+
+**Files:** `servers/gateway/perch-interactive.js`, `servers/gateway/routes/perch-interactive-api.js`
+**Do:**
+- `control()`'s `hasModel` branch (search `if (hasModel && (!opts.model.provider`): after the truthiness check, validate `{provider, modelId}` against the session-free catalogue — import `providerModelListWarm` + `modelKey` from `./perch-model-catalog.js` (it is already a gateway-shared module; engine module keeps seams injectable: take the catalogue through `loadSeams()`/an `opts.catalogProvider` test seam so tests don't read the real DB).
+- Unknown pair → `throw engineError("bad_request")` (already mapped in routes; message-level detail is not part of the error contract).
+- This makes the persisted poison pill un-plantable through the API.
+**Verify:** `npm test -- tests/perch-interactive-controls.test.js tests/perch-interactive-routes.test.js`; add a test: control() with `{provider:"ghost",model:"nope"}` → `bad_request`, row untouched.
+**Commit:** `Perch: control() refuses a model the instance cannot serve, before persisting it`
+
+### Step A3 — R2b: fail-open at wake when a recorded model died after it was chosen
+
+**Files:** `servers/gateway/perch-interactive.js`
+**Do:** in `startChild`'s override block (search `if (s.currentModelParts &&`), before applying the override, check `s.currentModel` against the injected catalogue (`providerModelListWarm()` — via the same seam as A2; on a catalogue fetch failure treat the recorded model as valid — fail-open toward the operator's choice, never lock out a session because the registry is unreadable). If the key is absent: clear `s.currentModelParts`/`s.currentModel` **in memory only** (keep the row — a temporarily disabled provider must not erase a real choice, per the review), let `prep.resolved` stand (fresh def resolution), and `emit(s, { type: "log", text: "row model <key> is not available — resumed on <prep.resolved.key>" })` so the drawer/Activity rail states the truth instead of parking on "pi exited unexpectedly".
+**Verify:** `npm test -- tests/perch-interactive-controls.test.js`; new test drives the review's exact scenario: adopted session whose row names a well-formed, disabled provider → wake serves the fresh def resolution, a `log` frame with `not available` reaches a subscriber, row's `model` still holds the old key. Then run the full Phase-A mutation matrix from `docs/reviews/2026-09-11-perch-pr356-review-completion.md` §"Verification checklist" items 1–2 (five named mutations, each restored alone → its named test reds), restoring each.
+**Commit:** `Perch: a dead recorded model falls open at wake, in the log, not the crash`
+
+### Step A4 — R4-adjacent: stop the duplicate bubble at the openStream/loadHistory seam
+
+**Files:** `servers/gateway/dashboard/perch-hub/client.js`
+**Do:** keep the current subscribe-before-history order (it is the no-loss guarantee — see the 2026-09-09 spec §Chat view; reversing it trades a duplicate for a lost reply). Deduplicate instead: `appendMessage` for a bot entry skips when the transcript's last entry has the identical text (compare the raw `what` string, last 1 entry is sufficient — the race window is one message). Comment it as the sequence-guard, naming the race (frame lands between subscribe and the transcript fetch resolving).
+**Verify:** `npm test -- tests/perch-hub-client.test.js tests/perch-hub-stream-leak.test.js`; add a unit-harness test: open a session, fire a `text` frame, then resolve a transcript fetch containing that message — assert one entry.
+**Commit:** `Perch: a message that lands between subscribe and history renders once`
+
+---
+
+## Phase B — cwd plumbing (schema → world → engine)
+
+### Step B1 — Schema: `bot_sessions.cwd`
+
+**Files:** `scripts/init-db.js`, `tests/init-db-bot-tables.test.js`
+**Do:**
+- Add `cwd TEXT,` to the `CREATE TABLE IF NOT EXISTS bot_sessions` body (after `model TEXT,`).
+- Add `await addColumnIfMissing("bot_sessions", "cwd", "TEXT");` beside the `label` one (search `addColumnIfMissing("bot_sessions", "label"`). Follow the same comment idiom — **additive-only, NO `SCHEMA_GENERATION` bump** (precedent: `kind`/`narrowed_tools`/`label`, and the explicit note at ~:2585 "additive-only, no SCHEMA_GENERATION bump"). The manual migration rail is therefore not required; say so in the commit body so nobody second-guesses it.
+- **The dedicated `bot_sessions` control-CHECK rebuild block (~:2658-2790) is the trap.** It diffs `PRAGMA table_info(bot_sessions)` against a canonical column list (I13, ~:2688) and rebuilds `bot_sessions_new` (~:2750) with an explicit `colList` carried across ("schema drift from the canonical shape" throws at ~:2726). Add `cwd` to **all three**: the `bot_sessions_new` CREATE body, the canonical shape list I13 diffs against, and (implicitly) the carried `colList` derived from them. If the drift check is not updated, a host that still needs the CHECK migration will hard-throw at boot — this exact class of green-suite-broken-migration is why it is spelled out.
+- Also check `rebuildMainFKsToProjectSpaces` (~:775): if it enumerates `bot_sessions` columns anywhere, carry `cwd` there too (its unknown-column guard at ~:919 fails loudly).
+**Verify:** `npm test -- tests/init-db-bot-tables.test.js` (extend it with the new column, same assertions as `label`, PLUS a drift-case: a DB built with the OLD shape that then runs the CHECK-migration rebuild must come out carrying `cwd`). `grep -n "cwd" scripts/init-db.js` should show every site listed above.
+**Commit:** `Schema: bot_sessions.cwd — the operator's chosen working directory, per session`
+
+### Step B2 — `buildBotWorld`: accept `cwd`, relocate `.mcp.json`, fallback replaces the refusal
+
+**Files:** `scripts/pi-bots/bot-world.mjs`
+**Do:**
+- Signature becomes `buildBotWorld({ botId, threadId, gatewayType = "perch", log = () => {}, jobId = null, cardBound = false, cwd = null })`. `sessionDir` (world root) resolution is UNCHANGED except: when it would be falsy (no project space, no `def.session_dir`), fall back to `join(crowHome, "pi-bots", botId)` instead of throwing `no_session_dir` — delete the throw block (search `bot has no working directory`).
+- `const resolvedCwd = cwd || sessionDir`. Validate: absolute path, exists, `statSync(...).isDirectory()` — on failure throw `engineError`-shaped `{ code: "bad_cwd" }` (the gateway route maps it; the engine never gets here with junk — the route validates first, belt-and-braces).
+- **Edit the `writeBotMcp` call site INSIDE `buildBotWorld`'s own body** (search `writeBotMcp(def, {` — bot-world.mjs ~:125), changing its `sessionDir` option from the world-root `sessionDir` to `resolvedCwd`. The `.mcp.json` must sit where pi runs — mcp-client reads `cwd/.mcp.json` (bridge.mjs comment ~:165). Changing only a caller accomplishes nothing.
+- Keep `mkdirSync(sessionDir + "/sessions", ...)` keyed on the WORLD root, unconditional; do NOT create `sessions/` inside the operator's project directory.
+- `selfAuthoringDir` (prepareSpawn ~:194) stays keyed on `def.session_dir` BY DESIGN — the Bot Builder review UI scans that location; a perch session whose cwd moved elsewhere does not move the staging dir. Add a one-line comment saying so (review Q1).
+- Return object gains `cwd: resolvedCwd` alongside `sessionDir`.
+**Verify:** `npm test -- tests/bot-world.test.js tests/perch-workspace-jail.test.js` (jail unchanged — outputsDir still under world root). New tests in `bot-world.test.js`: (1) `cwd` honored and returned; (2) no project/no session_dir bot falls back to `<crowHome>/pi-bots/<botId>` instead of throwing; (3) `.mcp.json` written at `cwd`, not at world root, when they differ; (4) `sessions/` dir created under world root when cwd differs (assert no `sessions/` minted inside the chosen dir). Golden guard: callers that pass no `cwd` produce byte-identical opts (extend the existing golden assertions).
+**Commit:** `Perch world: cwd separated from the world root; no_session_dir becomes a fallback`
+
+### Step B3 — `PiRpc`: spawn cwd option
+
+**Files:** `scripts/pi-bots/bridge.mjs`
+**Do:** in the constructor, `const spawnCwd = opts.cwd || sessionDir;` and use it in the `spawn(nodeBin, args, { cwd: spawnCwd, env, ... })` call (~:276). The value arrives as `opts.cwd` through the opts bag `startChild` builds — `new S.PiRpc(Object.assign({}, prep.piRpcOpts, { cwd: world.cwd, piSessionId: resume, ... }))` — `prepareSpawn`'s own `piRpcOpts` stays cwd-free so every channel caller (bridge handleInbound, job_runner) is byte-identical (B2's default `cwd = null` makes `world.cwd === sessionDir` there, so even if it were passed it would be a no-op — but do not pass it from prepareSpawn; the split belongs to the interactive caller). Everything else — `--session-dir sessionDir + "/sessions"`, `--no-approve`, policy — unchanged.
+**Verify:** `npm test -- tests/perch-interactive-controls.test.js tests/bot-world.test.js` (the stub PiRpc in the test seams records opts; assert `spawnCwd`). Add a stub-level assertion in the interactive controls harness: a session with cwd gets `spawn` invoked with that cwd and `--session-dir` still pointing at the world root.
+**Commit:** `Perch: pi runs where the operator chose, sessions still land in the world root`
+
+### Step B4 — Engine: `s.cwd` through spawn / wake / adopt / control
+
+**Files:** `servers/gateway/perch-interactive.js`
+**Do:**
+- `newSession()` gains `cwd: null`.
+- `spawn({ botId, cardId = null, cwd = null })` stores `s.cwd = cwd` before `startChild`.
+- `startChild` passes `cwd: s.cwd` into `buildWorldSerialized` (into `buildBotWorld`'s new param) and `cwd: world.cwd` into the PiRpc opts; after the fresh world build, set `s.cwd = world.cwd` (so snapshot reports the truth even for the default).
+- `writeRow`: add `cwd` to the UPDATE as `cwd=COALESCE(?, cwd)` and to the INSERT column list, argued in a comment exactly as `card_id`'s is — the engine owns its row; the stamp carries the chosen dir at every write.
+- `adoptRow`: SELECT gains `cwd` → `s.cwd = row.cwd || null`.
+- `snapshot()` and `stateEvent()` gain `cwd: s.cwd || null` (drawer + Files/Session tab read it).
+- `control()` gains `hasCwd` (search the `hasModel` gate block): validated like the model — non-empty string, absolute, exists, is a directory (the seams already import fs? then validate there; else map failures to `bad_request`); `if (hasCwd && s.turn) throw engineError("turn_in_progress")`. On accept: set `s.cwd`, `await writeRow`-free persist via a targeted `writeCwd(s)` UPDATE by row id (copy `writeModel`'s shape and its docstring rationale — no status restamp), then if `s.pi`: `await hibernate(s)` with reason, and `emit(s, { type: "log", text: "working directory → <dir> — resumes there on the next message" })`. `bindsAtWake.cwd = dir`.
+**Verify:** `npm test -- tests/perch-interactive.test.js tests/perch-interactive-controls.test.js tests/perch-interactive-dispatch.test.js tests/perch-interactive-capacity.test.js`. New tests: spawn-with-cwd wakes with the same cwd after simulated restart (fresh engine over the same row); control({cwd}) while hibernating binds at next wake; control({cwd}) mid-turn refused; relative path refused `bad_request`.
+**Commit:** `Perch: cwd is a session property — spawn, wake, adopt, control`
+
+---
+
+## Phase C — browse API + launcher picker
+
+### Step C1 — Browse endpoint + route validation
+
+**Files:** `servers/gateway/routes/perch-interactive-api.js`
+**Do:**
+- `GET P + "/browse"`: `const p = String(req.query.path || homedir())`; expand leading `~`; `path.resolve`; must be absolute; `readdirSync(p, { withFileTypes: true })` inside a try/catch → `{ error: "unreadable" }` 404; filter to `d.isDirectory()` (follow symlinks via `d.name` join + `statSync` try/catch; a symlink that errors or lands on a file is skipped); dot-dirs kept but sorted last; cap 500 entries; respond `{ path: realpath, parent, dirs: [{ name, path }] }` — **names and paths only, never contents, never file entries**. `parent` is derived from the RESOLVED realpath (not the raw input) so `..` navigation from a symlinked dir does not ping-pong.
+- `POST P + "/bots/:id/interactive"`: accept `{ cwd }` from the body; when present validate the same way (`fs.existsSync` + `statSync().isDirectory()` + absolute) and pass to `eng.spawn({ botId, cwd })`; invalid → 400 `{error:"bad_cwd"}`. Add `bad_cwd: [400, "bad_cwd"]` to the error map (search `no_session_dir: [409`).
+- Route stays under the existing `dashboardAuth`-mounted perch-api umbrella — no new mount point, no funnel change.
+**Verify:** `npm test -- tests/perch-interactive-routes.test.js tests/auth-network.test.js`. New tests: browse on a temp tree returns only dirs, dot-dirs last, traversal through `..` in the query collapses harmlessly via `resolve`, unreadable dir → 404 shape; spawn with a real temp cwd succeeds and `snapshot().cwd` reports it; spawn with `/nonexistent` → 400.
+
+### Step C2 — Launcher: directory field + picker modal
+
+**Files:** `servers/gateway/dashboard/perch-hub/html.js`, `client.js`, `css.js`, `servers/gateway/dashboard/shared/i18n.js`
+**Do:**
+- Launch row (search `id="perch-new"` in `html.js`): add a `#perch-new-cwd` text input (placeholder = t("perch.cwdPlaceholder")) + a `#perch-browse-btn` button beside the model select, all inside the existing flex field row; empty field = "the bot's default" (never send `cwd`).
+- `client.js`: `startSession()` reads the field; sends `cwd` only when non-empty. Picker: modal overlay listing `/browse` results — header shows the current path, `..` row for `parent`, tap a dir → navigate; an "Choose" button writes the path into `#perch-new-cwd` and closes. **Explicit Escape handler + a visible "Cancel" button** (dismiss must not depend on either alone); register the listener through the hub's generation-checked registry so the Turbo-leak guard covers it. All buttons carry visible labels (house rule: no unlabelled controls).
+- `css.js`: modal inherits the hub's tokens; full-bleed at phone width; `max-width:min(560px, 92vw)` desktop.
+- i18n: EN+ES keys in `shared/i18n.js` perch block (`perch.cwdLabel`, `perch.cwdPlaceholder`, `perch.browse`, `perch.choose`, `perch.browseFailed`, `perch.cwdDefaultNote`) — the parity test fails loudly on one-sided keys.
+**Verify:** `npm test -- tests/perch-hub-client.test.js tests/perch-hub-page.test.js tests/i18n-global-parity.test.js`. Live check over CDP (headless chrome on the gateway): open `/dashboard/perch`, browse from `$HOME` two levels, choose, start a session, `snapshot().cwd` reflects it. (Remember the standing rule: `Page.bringToFront` before driving anything over CDP.)
+
+---
+
+## Phase D — tab surface (Chat / Session / Files / Activity)
+
+### Step D1 — Markup + layout skeleton
+
+**Files:** `servers/gateway/dashboard/perch-hub/html.js`, `css.js`
+**Do:** inside `#perch-chat`, below the head block, insert `<nav id="perch-tabs" role="tablist">` with four buttons (data-tab `chat|session|files|activity`; inline SVG glyphs ported from the original's `I` icon set in `~/pi-lab/extensions/web/public/app.html` lines ~250-254 — recolor via `currentColor` so crow's teal owns them) and four `<section id="perch-tab-<name>">` wrappers: chat keeps `#perch-transcript` + `#perch-ask` + composer; session gets the existing controls row + rename/state/close moved in; files gets `#perch-files-list`; activity gets `#perch-activity-list`. Desktop (≥`PERCH_SPLIT_MIN_WIDTH`): tabs as a top strip in the right pane; phone: fixed bottom tab bar — composer sits ABOVE it inside the chat tab (flex chain untouched: keep `#perch-chat{flex:1;min-height:0}` and the transcript as the only scroller; the tab bar joins the chain as a non-shrinking sibling). Only the active tab section is displayed; composer visibility: chat tab only (sending from other tabs stays possible via a note? No — keep composer on `chat` only; ask cards remain chat-scoped).
+**Verify:** `npm test -- tests/perch-hub-page.test.js`. CDP measurements at 412x730 and 1280x900: Send reachable (`getBoundingClientRect().bottom <= innerHeight`) with the transcript scrolled to top, on the chat tab, in every tab actually — assert the tab bar itself never overlaps it.
+
+### Step D2 — Client routing + Activity + Session tab content
+
+**Files:** `servers/gateway/dashboard/perch-hub/client.js`, `shared/i18n.js`
+**Do:**
+- Tab state: a plain `var tab='chat'` re-evaluated per session open (reset to chat in the session-switch block that already clears `renderedTurn`); `#perch-tabs` click handlers toggle `hidden` on the sections. **Tab switching is pure visibility toggling — it must never touch the EventSource, `openStream`, `closeSession`, or any SSE lifecycle** (the stream belongs to the session, not the tab). Note: there is no session drawer to move controls out of — it was deleted in the 2026-09-09 plan's Phase 2; "move" below means the chat view's own controls row within this page. Deliberately NOT in the hash (the hash is the session router; `#<sid>:<tab>` would fight deep links — note this).
+- Activity: route `log`, `tool`-start, note/`error` frames (everything `appendNote` writes today) to `#perch-activity-list` instead of the transcript; chat keeps only user/bot messages, ask cards, and hard failures (transcript-load failure stays in chat — the operator must see it where they read). Port the drawer's `[tool: name]` formatting.
+- Session tab: move model/thinking/permission/plan controls, session state pill, rename and close into it, plus the read-only cwd display with a "Change directory" button that reopens the browse modal and POSTs `control({cwd})` (note in the modal: "the session wakes in the new directory; the next message starts a fresh pi context there" — the hibernate-on-change is visible).
+- `snapshot().cwd`/state frames refresh the Session tab fields; the existing `servingModel` sync code (`bd.setPicker`) keeps running unchanged.
+**Verify:** `npm test -- tests/perch-hub-client.test.js tests/perch-hub-stream-leak.test.js` (extend: tool frame lands in activity list only; session switch resets tab to chat; the 6x-leak guard still passes for the new listeners — everything registered goes through the existing generation-checked registry).
+
+### Step D3 — Files tab: outputs list endpoint + UI
+
+**Files:** `servers/gateway/routes/perch-interactive-api.js`, `perch-hub/client.js`, `css.js`, `shared/i18n.js`
+**Do:**
+- `GET P + "/interactive/:sid/files/list"` → `{ outputsDir-relative items: [{ name, size, mtime }] }` for the session's outputsDir ONLY: `readdirSync` entries, skip dotfiles, skip symlinks outright (`lstatSync`), skip subdirectory recursion (flat list; the jail is one directory deep by construction), sort mtime desc, cap 200. Reuse `snap.outputsDir`; same 409 `no_session_dir`/`no_such_session` shapes as the download route. Never lists uploadsDir.
+- Client: fetch on tab activation (not on open — keeps the chat fast path one less round trip), render rows linking the existing `workspace/<name>` download route; empty state text t("perch.filesEmpty"); refresh button (labelled).
+**Verify:** `npm test -- tests/perch-interactive-routes.test.js` — new tests mirror the jail's attack inventory at the LIST level: symlink in outputsDir absent from the listing; dotfile absent; `..` impossible (no user path input on this endpoint at all). Live: write a file into a session's outputsDir from the bot, see it, download it.
+
+---
+
+## Phase E — whole-branch verification + docs
+
+### Step E1 — Full suite + server boot + live walk
+
+**Commands:**
+1. `npm test` (full scratch suite — must be 100% green; CI red blocks merges, including this one).
+2. `node servers/gateway/index.js --no-auth` boots clean (Ctrl-C to exit).
+3. Live Perch walk on the real gateway: start a bot session in a chosen non-default dir → send → it writes a file to the dir (proves write_paths) → **make one tool call through a per-bot MCP server from that non-default directory (e.g. a `crow_mcp` memory search) and assert the tool actually answers — a silently-missing MCP tool is the failure mode of the `.mcp.json` relocation** → switch model while hibernating → restart the gateway → session adopts on the switched model, in the chosen dir → disable that provider → send → fail-open log line in Activity, session runs on the def default → change cwd mid-session → refused in-turn, works idle.
+4. CDP render checks (412x730 + 1280x900): Send reachable in all four tabs; picker usable at phone width; tab bar no horizontal scroll at 320px.
+**Verify:** each numbered item recorded (measured, not read) in the PR body; deviations from this plan listed as named call-outs, per the repo's PR style.
+
+### Step E2 — Docs
+
+**Files:** `docs/architecture/gateway-server.md` (perch section: cwd model + new endpoints), `docs/guide` perch walkthrough (open-in-any-directory + tabs), `docs/reviews/2026-09-11-perch-pr356-review-completion.md` gets a status footer "R1/R2/R4 closed by <PR#>". `CLAUDE.md`: only if the deep layout story changed — it hasn't.
+**Verify:** `cd docs && npm run dev` renders (spot-check sidebar); `git show --stat HEAD` — only intended files (repo rule).
+**Commit:** `Docs: Perch opens anywhere — the cwd model, the picker, and the tabs`
+
+---
+
+## Sequencing and PR shape
+
+- **PR 1:** Phase A alone (steps A1-A4). Small, self-contained, keeps `main` healthy mid-flight and independently revertable.
+- **PR 2:** Phases B + C (plumbing + picker) — the product decision lands.
+- **PR 3:** Phase D + E (tab surface) — visual/UX change on top.
+Each PR: `npm test` green before push; `git pull --rebase` first; positional-path commits only.
+
+## Risk notes for the executor
+
+- **`.mcp.json` relocation (B2) is the deepest cut.** If MCP servers stop loading after cwd separation, the failure is silent per-tool, not loud — the acceptance walk in E1 must include one tool call through a per-bot MCP server (e.g. `crow_mcp` search) in a non-default directory before merging PR 2.
+- **Step B1's dedicated `bot_sessions` CHECK-rebuild** (~:2658-2790, I13 canonical-shape diff) is the only way a green suite can still ship a broken migration — the rebuild fires only on hosts that predate the 'interrupted' widening. Read that whole block, plus `rebuildMainFKsToProjectSpaces`, before editing.
+- **Composer/tab-bar flex chain** has already killed one Send button. Measurements in D1 are non-optional.
+- If the catalogue seam in A2/A3 fights the engine's lazy `loadSeams()`, prefer passing the validator through `createInteractiveEngine({ opts })` the way `providerModels` already is (search `opts.providerModels` in the module header ~:267) — do not make the engine import the DB directly.
+
+---
+
+## Review
+
+**2026-09-11 — adversarial design review (staff-engineer pattern, dispatched subagent).** Verdict: **REVISE**. All findings re-verified line-by-line against the code before adoption.
+
+| Finding | Disposition |
+|---|---|
+| Reviewer "C1": removing `model:` from the three stamps breaks `writeRow`'s INSERT placeholder count | **REJECTED as factually wrong** — `writeRow`'s second parameter is a destructured object with `model = null` default (`perch-interactive.js:676`); omitting the key passes NULL into the same arg position. A tripwire note now sits in step A1 so the executor does not "fix" the non-issue. |
+| Reviewer "C2": `onModelSelect`→`writeModel` drops a switch landing before `s.rowId` exists, never retried | **ADOPTED** — A1 gained an end-of-`startChild` belt (`if (s.currentModelParts && servingModel(s) !== prep.resolved.key) await writeModel(s);`) plus a driving test. |
+| Reviewer "C3": `.mcp.json` relocation instruction ambiguous about which call site changes | **ADOPTED** — B2 now names the in-body call site (`writeBotMcp(def, {`, bot-world.mjs ~:125) and spells out what stays at the world root. |
+| Reviewer "C4": CREATE-body site of `cwd` not pinned | **ADOPTED (already covered)** — plan already gives the search string `CREATE TABLE IF NOT EXISTS bot_sessions`; B1 additionally names the dedicated CHECK-rebuild's three lists (I13 canonical diff ~:2688/~:2726, `bot_sessions_new` ~:2750, carried `colList`). |
+| Q1: `selfAuthoringDir` under cwd split | **ADOPTED** — stays keyed on `def.session_dir` by design (Bot Builder scans there); comment required in B2. |
+| Q2: channel callers and the removed stamps | **N/A** — `onTurnEnd`/`startChild` are interactive-engine-only; channel turns meter/persist through bridge.mjs's own paths, untouched. |
+| Q3: exact field path for cwd into PiRpc | **ADOPTED** — B3 names it: `new S.PiRpc(Object.assign({}, prep.piRpcOpts, { cwd: world.cwd, … }))`; `prepareSpawn`'s opts stay cwd-free. |
+| Q5: "does the drawer still exist?" | **Clarified** — the drawer was deleted by the 2026-09-09 plan's Phase 2; D2's "move" is the in-page controls row, and tab switching must never touch the SSE lifecycle. |
+| S4 (`parent` from realpath), S5 (Escape + Cancel), S6 (tabs don't touch EventSource), S7 (MCP tool-call checkpoint in the live walk) | **ADOPTED** in C1/C2/D2/E1 respectively. |
+| Gap raised in the review prompt, absent from the reviewer's report: **legacy auto-stamped rows** | **ADOPTED** — A1 gained a revocation path: "the bot's own model" now clears the explicit choice (writes NULL, next wake re-resolves from the def); no bulk cleanse (each legacy value really was the serving model at stamp time). |
+
+**Post-revision state:** all adopted fixes are edits to this file (steps A1, B2, B3, C1, C2, D2, E1); the plan's structure and PR shape are unchanged. The one rejected finding is documented above and guarded by an in-step tripwire.

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -1080,6 +1080,18 @@ export function perchHubJs(lang = "en") {
     clearEl(modelSel); clearEl(thinkSel);
     var models=(o&&listUsable(o.models))?o.models:null;
     var levels=(o&&listUsable(o.thinkingLevels))?o.thinkingLevels:null;
+    if(models){
+      /* Fix round 3 R1: "the bot's own model" is also the REVOCATION option
+         in the session picker (it already means "choose nothing" in the
+         launcher). Selecting it POSTs control {model:null}: the engine clears
+         the explicit choice and NULLs the row, so the next wake re-resolves
+         from the def. Without this, a legacy row stamped before the column
+         meant "explicit choice" could never be un-pinned from the UI. */
+      var none=document.createElement('option');
+      none.value='';
+      none.textContent=MODEL_BOT_RESOLVES;
+      modelSel.appendChild(none);
+    }
     if(models) models.forEach(function(m){
       var opt=document.createElement('option');
       opt.value=(m&&m.provider)+'/'+(m&&m.id);
@@ -1127,8 +1139,13 @@ export function perchHubJs(lang = "en") {
      flipping the permission mode gets a 200 and nothing changes. Every other
      body in this file is camelCase JS; these two stay snake_case on purpose. */
   function controlBody(kind,value){
-    if(kind==='model'){ var i=value.indexOf('/');
-      return {model:{provider:value.slice(0,i),id:value.slice(i+1)}}; }
+    if(kind==='model'){
+      /* '' is the revocation sentinel — see renderOptions. The route maps a
+         present-but-null model to "clear the explicit choice". */
+      if(value==='') return {model:null};
+      var i=value.indexOf('/');
+      return {model:{provider:value.slice(0,i),id:value.slice(i+1)}};
+    }
     if(kind==='thinking') return {thinking:value};
     if(kind==='permission') return {permission_mode:value};   /* snake_case */
     return {plan_mode:!!value};                                /* snake_case */

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -905,8 +905,8 @@ export function perchHubJs(lang = "en") {
          put an empty entry in the transcript AND marked the turn rendered,
          suppressing the real reply. Skip it entirely. */
       if(!d.text) return;
-      appendMessage('bot','bot',d.text,d.html);
-      if(d.turnId) renderedTurn=d.turnId; else turnRendered=true;
+      if(!histSettled){ histBuf.push(d); return; }   /* round 3 R4, see flushHistBuf */
+      renderTextFrame(d);
     });
     on('tool',function(d){ if(d.phase==='start') appendNote('['+(d.name||'?')+']'); });
     on('log',function(d){ if(d.text) appendNote(d.text); });
@@ -925,9 +925,18 @@ export function perchHubJs(lang = "en") {
     on('reply',function(d){
       /* Judged against THIS turn when the frame names one, and only against the
          client's transition flag when it does not. Read before
-         setTurnInFlight(false), which is what resets that flag. */
-      var already=d.turnId?(renderedTurn===d.turnId):turnRendered;
-      if(!already&&d.text) appendMessage('bot','bot',d.text,d.html);
+         setTurnInFlight(false), which is what resets that flag.
+         Round 3 R4: while the history batch is still in flight the APPEND
+         decision is buffered with the text frames — judging it now would
+         compare against a transcript the batch has not filled yet. The
+         composer state is NOT buffered: it never appears in the batch, and
+         delaying Steer/Stop back to "sendable" is worse than one frame of
+         lag on the prose. */
+      if(!histSettled) histBuf.push({ reply:true, text:d.text, html:d.html, turnId:d.turnId });
+      else {
+        var already=d.turnId?(renderedTurn===d.turnId):turnRendered;
+        if(!already&&d.text) appendMessage('bot','bot',d.text,d.html);
+      }
       setTurnInFlight(false);
     });
     on('ask_user',function(d){ renderAsk(d); });
@@ -1007,18 +1016,58 @@ export function perchHubJs(lang = "en") {
            a logged-out session into the same "No transcript yet." — a
            reassuring sentence about a conversation that is still there. Say
            which happened. */
-        if(!r.ok||!r.j){ appendNote(TRANSCRIPT_FAILED); return; }
+        if(!r.ok||!r.j){ appendNote(TRANSCRIPT_FAILED); flushHistBuf([]); return; }
         var events=r.j.events||[];
-        if(!events.length){ appendNote(NO_TRANSCRIPT); return; }
+        if(!events.length){ appendNote(NO_TRANSCRIPT); flushHistBuf([]); return; }
+        var batchTexts=[];
         events.filter(function(e){ return e&&e.type==='message'; }).forEach(function(e){
           var m=e.message||{};
           /* e.html is present only for an ASSISTANT message that had text
              (routes/perch.js's assistantHtml) — the operator's own typing is
              not markdown, and a pure tool-call message still renders as
              messageText()'s "[tool: name]" line. */
-          appendMessage(String(m.role||'?')==='user'?'user':'bot', String(m.role||'?'), messageText(m), e.html);
+          var txt=messageText(m);
+          if(String(m.role||'?')!=='user') batchTexts.push(txt);
+          appendMessage(String(m.role||'?')==='user'?'user':'bot', String(m.role||'?'), txt, e.html);
         });
+        flushHistBuf(batchTexts);
       });
+  }
+
+  /* Round 3 R4 — the subscribe/fetch seam. openStream subscribes BEFORE
+     loadHistory resolves, and both writers hit the same completed message:
+     the frame on arrival, the batch when the fetch lands after it. Measured
+     shape of the duplicate the review named — and it is not adjacent to
+     anything (the frame writes first, the whole batch appends behind it),
+     so a last-entry comparison could never catch it. Transcript-writing
+     text/reply frames park in histBuf until the batch settles; the flush
+     renders each buffered entry unless its EXACT text is already on screen
+     from the batch (bookkeeping still applies — that turn IS rendered), so
+     a message that completed between subscribe and snapshot lands once.
+     Failed or empty history flushes against nothing: the frames are then
+     the only copy. Notes and state frames are never buffered — they are
+     not in the batch, and delaying them delays the composer. */
+  var histSettled=false;
+  var histBuf=[];
+  function renderTextFrame(d){
+    appendMessage('bot','bot',d.text,d.html);
+    if(d.turnId) renderedTurn=d.turnId; else turnRendered=true;
+  }
+  function flushHistBuf(batchTexts){
+    histSettled=true;
+    var buf=histBuf; histBuf=[];
+    buf.forEach(function(f){
+      if(f.reply){
+        var already=f.turnId?(renderedTurn===f.turnId):turnRendered;
+        if(!already&&f.text&&batchTexts.indexOf(f.text)<0) appendMessage('bot','bot',f.text,f.html);
+        return;
+      }
+      if(batchTexts.indexOf(f.text)>=0){
+        if(f.turnId) renderedTurn=f.turnId; else turnRendered=true;
+        return;
+      }
+      renderTextFrame(f);
+    });
   }
 
   /* Track 3 Task 4: session controls — model, thinking level, permission
@@ -1131,6 +1180,10 @@ export function perchHubJs(lang = "en") {
     setTurnInFlight(false);      /* the PREVIOUS session's Steer/Stop state must not bleed in */
     turnRendered=false;          /* nor its "this turn already rendered" bookkeeping */
     renderedTurn=null;           /* nor the turn id that bookkeeping now keys on */
+    /* Round 3 R4: nor its history seam — closed again until THIS session's
+       batch lands, with any frames still parked in it. */
+    histSettled=false;
+    histBuf=[];
     pendingImages=[];            /* nor its queued-but-unsent image */
   }
 

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -389,6 +389,9 @@ export function createInteractiveEngine({
       // string snapshot()/stateEvent() report.
       currentModelParts: null,
       currentModel: null,
+      // Round 3 belt (writeModel's docstring): true when a model choice was
+      // made before this session had any rowId; writeRow's tail replays it.
+      _modelWritePending: false,
       /** Operator-set name, persisted on the row. NULL means "no name", and
        *  every render falls back to the short session id. */
       label: null,
@@ -712,32 +715,51 @@ export function createInteractiveEngine({
         args: [s.botId, s.threadId],
       });
       if (rows[0]) s.rowId = Number(rows[0].id);
+      // Round 3 belt (writeModel's docstring): a model choice made while this
+      // session had no rowId at all is replayed here, once, the moment the
+      // row exists. Cleared BEFORE the call so a failing write never loops.
+      if (rows[0] && s._modelWritePending) {
+        s._modelWritePending = false;
+        await writeModel(s);
+      }
     } finally {
       try { db.close(); } catch { /* already closed */ }
     }
   }
 
-  /** Persist the model the engine now considers this session's.
+  /** Persist the engine's EXPLICIT model choice for this session.
    *
-   * Fix round 2 N2: the row's `model` column was only written by onTurnEnd and
-   * by a turn's own `active` stamp, so a switch made and then left un-exercised
-   * — control() to another model, then a gateway restart before the next turn —
-   * was not in the row at all, and adoptRow had nothing to restore. That is
-   * exactly the sequence the operator reported: switch the model, a deploy
-   * restarts the gateway, open the session again.
+   * Fix round 2 N2: a switch made and then left un-exercised — control() to
+   * another model, then a gateway restart before the next turn — used to never
+   * reach the row, and adoptRow had nothing to restore. That is exactly the
+   * sequence the operator reported: switch the model, a deploy restarts the
+   * gateway, open the session again.
+   *
+   * Fix round 3 R1: writes `s.currentModel` — the explicit choice ONLY — not
+   * servingModel(), which falls back to the resolver's `s.resolved.key`. A
+   * null here is a real value: "the operator revoked the choice"
+   * (control() model:null), so the next wake re-resolves from the bot def.
+   * The automatic stamps (startChild, onTurnEnd, spawn-active) stopped
+   * writing this column: stamped defaults were being adopted as overrides and
+   * silently pinned every session to its spawn-time model across restarts.
    *
    * Targeted UPDATE by row id, for the same reason writeLabel() is one:
    * writeRow() also stamps `status` and resets `control` to 'run', and a model
    * switch must not restamp either. Non-fatal — the switch's operative effect
    * is the in-memory tracking that startChild reads; the row is what carries it
-   * across a restart. */
+   * across a restart.
+   *
+   * Round 3 belt (staff review C2): a child's first `model_select` CAN land
+   * before this process has any rowId (construction-to-writeRow window on a
+   * fresh spawn). Rather than drop that choice, park a pending flag; the tail
+   * of writeRow() replays it the moment the row exists. */
   async function writeModel(s) {
-    if (s.rowId == null) return;
+    if (s.rowId == null) { s._modelWritePending = true; return; }
     const db = createDbClient();
     try {
       await db.execute({
         sql: "UPDATE bot_sessions SET model=?, updated_at=datetime('now') WHERE id=?",
-        args: [servingModel(s), s.rowId],
+        args: [s.currentModel || null, s.rowId],
       });
     } catch (e) {
       log(s.sessionId + ": model not persisted (non-fatal): " + ((e && e.message) || e));
@@ -1231,7 +1253,11 @@ export function createInteractiveEngine({
       // resolveTranscriptFile(row.pi_session_dir, …) 404s and the resume pane
       // is dead.
       piSessionDir: world.sessionDir + "/sessions",
-      model: prep.resolved.key,
+      // Fix round 3 R1: NO model here. The row's `model` column means "the
+      // operator explicitly chose this model" and nothing else; the resolver's
+      // answer at spawn/wake is not a choice, and stamping it here is what
+      // pinned bot defs to their old default across restarts (adoptRow treats
+      // every stamped value as an override). writeModel() owns the column.
     });
 
     const st = await pi.getState().catch(() => null);
@@ -1362,6 +1388,12 @@ export function createInteractiveEngine({
     // s.resolved says NOW, not what the turn started on — so the model that
     // actually served the reply is what gets metered.
     s.resolved = Object.assign({}, s.resolved, { provider: model.provider, model: model.id, key });
+    // Fix round 3 R1: a /model typed in the TUI is an operator choice exactly
+    // like the drawer's switch, and must survive a restart too. Never throws
+    // (writeModel's own contract); pending-belted when the row is not yet
+    // written. Without this, the drawer's switch persisted but the TUI's did
+    // not — one action, two durabilities.
+    writeModel(s);
     emit(s, stateEvent(s));
     emit(s, { type: "log", text: "now on " + key });
   }
@@ -1509,7 +1541,8 @@ export function createInteractiveEngine({
     // r2 S7: bound the child's accumulating log now that nothing is waiting on
     // it. trimLog preserves _seq, so the next turn's `since` correlation holds.
     try { if (s.pi) s.pi.trimLog(); } catch { /* non-fatal */ }
-    await writeRow(s, { status: "waiting-user", model: s.resolved ? s.resolved.key : null }).catch(() => {});
+    // Fix round 3 R1: no model stamp — see the startChild writeRow above.
+    await writeRow(s, { status: "waiting-user" }).catch(() => {});
     // M-4: the turn is released HERE, after reply + trimLog — never at the top.
     if (s.turn === turn) s.turn = null;
     s.lastEventAt = now();                            // Track 3 Task 7: became idle now
@@ -1707,7 +1740,8 @@ export function createInteractiveEngine({
         await assertRowClaimable(s);
         await startChild(S, s);
       } else {
-        await writeRow(s, { status: "active", model: s.resolved ? s.resolved.key : null });
+        // Fix round 3 R1: no model stamp — see the startChild writeRow above.
+        await writeRow(s, { status: "active" });
       }
     } catch (e) {
       s.turn = null;
@@ -1900,7 +1934,11 @@ export function createInteractiveEngine({
     if (!s) throw engineError("no_such_session");
     if (s.state === "stopped") throw engineError("session_stopped");
 
-    const hasModel = opts.model != null;
+    // Fix round 3 R1: `model: null` is a MEANINGFUL value here — "revoke the
+    // explicit choice, follow the bot's own model again" — so presence is
+    // keyed on undefined, not truthiness. (The route maps an explicit JSON
+    // null to this; an absent key stays undefined and does nothing.)
+    const hasModel = opts.model !== undefined;
     const hasThinking = opts.thinking != null;
     const hasPermissionMode = opts.permissionMode != null;
     const hasPlanMode = Object.prototype.hasOwnProperty.call(opts, "planMode");
@@ -1912,7 +1950,7 @@ export function createInteractiveEngine({
     // refused here.
     if ((hasModel || hasThinking || hasPlanMode) && s.turn) throw engineError("turn_in_progress");
 
-    if (hasModel && (!opts.model.provider || !opts.model.modelId)) throw engineError("bad_request");
+    if (hasModel && opts.model !== null && (!opts.model.provider || !opts.model.modelId)) throw engineError("bad_request");
     if (hasThinking && !THINKING_LEVELS.has(opts.thinking)) throw engineError("bad_request");
     if (hasPermissionMode && !PERMISSION_MODES.has(opts.permissionMode)) throw engineError("bad_request");
     if (hasPlanMode && typeof opts.planMode !== "boolean") throw engineError("bad_request");
@@ -1922,6 +1960,21 @@ export function createInteractiveEngine({
     const bindsAtWake = {};
 
     if (hasModel) {
+      if (opts.model === null) {
+        // Revoke the explicit choice (the drawer's "the bot's own model"
+        // option). In-memory tracking clears immediately so snapshot() and
+        // options() report the fallback honestly; the ROW gets NULL, so the
+        // next adopt re-resolves from the def instead of honoring a choice
+        // nobody stands behind. A live child keeps its model until the next
+        // wake — the log line says exactly that rather than implying an
+        // immediate switch.
+        s.currentModelParts = null;
+        s.currentModel = null;
+        await writeModel(s);                            // writes NULL
+        applied.model = null;
+        bindsAtWake.model = null;
+        emit(s, { type: "log", text: "model choice cleared — the next wake follows the bot's own model" });
+      } else {
       const { provider, modelId } = opts.model;
       if (s.pi) {
         // Warm BEFORE the switch (spec: pi-lab's local-models starter
@@ -1952,6 +2005,7 @@ export function createInteractiveEngine({
         s.currentModel = key;
         await writeModel(s);                           // survives a restart (N2)
         bindsAtWake.model = key;
+      }
       }
     }
 

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -1200,6 +1200,28 @@ export function createInteractiveEngine({
     // NEW model, but those two fields do not feed metering or spawn args, so
     // leaving them as prepareSpawn resolved them is harmless — only
     // provider/model/key are load-bearing here).
+    // Fix round 3 R2b: a recorded choice can outlive its provider —
+    // crow-dsv4 was disabled on this fleet the day PR #356 merged, and the
+    // adopt-restore hands whatever the row says straight to the override
+    // below, which skips model_resolver.mjs's fail-closed rail entirely.
+    // Validate against the same catalogue the picker offers; when the key
+    // is gone, fall open to the def's fresh resolution with an honest log
+    // line instead of spawning a child on a provider that cannot answer
+    // (whose only report would be attachExit's "pi exited unexpectedly").
+    // The ROW keeps the key — a temporarily disabled provider must not
+    // erase a real choice — and a re-enabled one is honored again next
+    // restart. Empty catalogue fails open, same contract as control()'s
+    // gate (R2a).
+    if (s.currentModelParts) {
+      const catalogue = await catalogModels();
+      const chosen = servingModel(s);
+      if (catalogue.length && chosen &&
+          !catalogue.some((m) => m && (m.provider + "/" + m.id) === chosen)) {
+        s.currentModelParts = null;
+        s.currentModel = null;
+        emit(s, { type: "log", text: "recorded model " + chosen + " is not available — resumed on " + (prep.resolved && prep.resolved.key) });
+      }
+    }
     if (s.currentModelParts &&
         (s.currentModelParts.provider !== prep.resolved.provider ||
          s.currentModelParts.modelId !== prep.resolved.model)) {
@@ -1959,6 +1981,25 @@ export function createInteractiveEngine({
     const applied = {};
     const bindsAtWake = {};
 
+    if (hasModel && opts.model !== null) {
+      // Fix round 3 R2a: an explicit pair must be one this instance can
+      // actually serve. The drawer only ever offers catalogue entries, but
+      // the API accepts any strings, and writeModel() now makes the choice
+      // DURABLE — without this gate a typo or a retired name becomes a
+      // poison pill that every future wake replays. Fail-OPEN on an empty
+      // catalogue: catalogModels() answers [] when the registry is
+      // unreadable, and a registry hiccup must not lock an operator out of
+      // a session that is working fine (catalogModels' own never-throw
+      // contract). Key shape matches providerModelList(): pi-shaped
+      // {provider, id} entries.
+      const catalogue = await catalogModels();
+      if (catalogue.length) {
+        const want = opts.model.provider + "/" + opts.model.modelId;
+        if (!catalogue.some((m) => m && (m.provider + "/" + m.id) === want)) {
+          throw engineError("bad_request");
+        }
+      }
+    }
     if (hasModel) {
       if (opts.model === null) {
         // Revoke the explicit choice (the drawer's "the bot's own model"

--- a/servers/gateway/routes/bot-board-api.js
+++ b/servers/gateway/routes/bot-board-api.js
@@ -212,8 +212,17 @@ function wantsArchived(req) {
 
 // Fail-closed pi-liveness (Step-1 pinned pattern, recorded in the plan's
 // Verified Claims): a process is "the live pi holding bot_sessions row R"
-// iff basename(/proc/<pid>/comm) === "node" AND /proc/<pid>/cmdline contains
-// the substring `--session-dir <R.pi_session_dir>`. Returns:
+// iff basename(argv0 of /proc/<pid>/cmdline) is node/nodejs AND the cmdline
+// contains the substring `--session-dir <R.pi_session_dir>`. Returns:
+//
+// The predicate used to test /proc/<pid>/comm === "node". That is silently
+// FALSE on Node 24, which renames the main thread "MainThread" (measured:
+// v20.20.2 and v22.23.1 → "node"; v24.21.0 → "MainThread") — and this fleet's
+// gateway runs 24, so every LIVE pi read as dead: the job rail could
+// force-unlock a card a running child still held. argv0 is the honest
+// identity: the kernel's comm is a 15-char thread label, not the executable.
+// A bash -c wrapper whose command string carries the needle stays correctly
+// excluded — its argv0 is "bash".
 //   "alive"   — a matching live pi process was positively found
 //   "dead"    — scanned cleanly, no matching process exists
 //   "unknown" — anything ambiguous/errored/unverifiable (⇒ caller refuses)
@@ -228,22 +237,27 @@ function piLiveness(piSessionDir) {
   }
   let scannedAny = false;
   for (const pid of pids) {
-    let comm, cmdline;
     try {
-      comm = readFileSync("/proc/" + pid + "/comm", "utf8").trim();
+      // The comm read is no longer the identity test (Node ≥ 24 renames the
+      // main thread — see the header); it is kept as the cheap mid-scan
+      // exit skip, so a vanished process is stepped over before its cmdline
+      // is consulted.
+      readFileSync("/proc/" + pid + "/comm", "utf8");
     } catch {
       continue; // process exited mid-scan — fine, keep scanning
     }
+    let cmdline;
     try {
       cmdline = readFileSync("/proc/" + pid + "/cmdline").toString("utf8");
     } catch {
       continue;
     }
     scannedAny = true;
-    // /proc/<pid>/comm is the argv0 basename (truncated to 15 chars by the
-    // kernel; "node" is 4 so exact compare is safe). cmdline is NUL-joined;
-    // normalise NUL→space for the substring test.
-    if (comm === "node" && cmdline.replace(/\0/g, " ").includes(needle)) {
+    // Identity from argv0: the first NUL-terminated field of cmdline, by
+    // basename. Normalise NUL→space for the substring test.
+    const argv0 = (cmdline.split("\0")[0] || "").trim();
+    const exe = argv0.slice(argv0.lastIndexOf("/") + 1);
+    if (/^node(js)?$/.test(exe) && cmdline.replace(/\0/g, " ").includes(needle)) {
       return "alive";
     }
   }

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -603,12 +603,20 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
   // engine's camelCase here, the ONE place that translation happens. `model`
   // accepts {provider, id} (the shape options()'s listings hand back) and
   // maps id→modelId for the engine.
+  //
+  // Fix round 3 R1: an explicit `"model": null` in the body REVOKES the
+  // operator's choice (the drawer's "the bot's own model" option) — the next
+  // wake re-resolves from the def. Presence is therefore keyed on the key,
+  // not on truthiness, the same hasOwnProperty idiom plan_mode already uses;
+  // a body without `model` stays untouched, exactly as before.
   router.post(P + "/interactive/:sid/control", async (req, res) => {
     const sid = String(req.params.sid);
     const body = req.body && typeof req.body === "object" ? req.body : {};
     const opts = {};
-    if (body.model != null && typeof body.model === "object") {
-      opts.model = { provider: body.model.provider, modelId: body.model.id };
+    if (Object.prototype.hasOwnProperty.call(body, "model")) {
+      opts.model = body.model && typeof body.model === "object"
+        ? { provider: body.model.provider, modelId: body.model.id }
+        : null;
     }
     if (body.thinking != null) opts.thinking = body.thinking;
     if (body.permission_mode != null) opts.permissionMode = body.permission_mode;

--- a/tests/board-job-lock.test.js
+++ b/tests/board-job-lock.test.js
@@ -309,8 +309,14 @@ function piVisible(sessionDir) {
   const needle = "--session-dir " + sessionDir;
   for (const pid of readdirSync("/proc").filter((n) => /^\d+$/.test(n))) {
     try {
-      if (readFileSync("/proc/" + pid + "/comm", "utf8").trim() !== "node") continue;
-      if (readFileSync("/proc/" + pid + "/cmdline").toString("utf8").replace(/\0/g, " ").includes(needle)) return true;
+      // Mirrors piLiveness()'s current predicate: identity from argv0, not
+      // comm — Node 24 renames the main thread "MainThread", which made the
+      // comm === "node" test silently false on this fleet's gateway (the
+      // fixture's 5s timeout was the canary).
+      const cmdline = readFileSync("/proc/" + pid + "/cmdline").toString("utf8");
+      const argv0 = (cmdline.split("\0")[0] || "").trim();
+      if (!/^node(js)?$/.test(argv0.slice(argv0.lastIndexOf("/") + 1))) continue;
+      if (cmdline.replace(/\0/g, " ").includes(needle)) return true;
     } catch { /* exited mid-scan */ }
   }
   return false;

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -2259,3 +2259,89 @@ test("N1 sibling: an unparseable text frame appends nothing and suppresses nothi
   es._serverFrame("reply", { text: "the real answer", turnId: "turn-1" });
   assert.deepEqual(botEntries(hub), ["the real answer"]);
 });
+
+// ---------------------------------------------------------------------------
+// Fix round 3 R4 — the openStream/loadHistory seam.
+//
+// The stream subscribes BEFORE the transcript batch lands, and both writers
+// render the same completed message: the frame on arrival, the batch behind
+// it — the duplicate bubble the review named, measured NOT adjacent, which
+// is why a last-entry comparison could never catch it and the frames are
+// buffered against the batch instead. The pending-promise fetch override is
+// the whole trick: it freezes the batch so a test can park frames inside the
+// real window.
+// ---------------------------------------------------------------------------
+
+function batchEvents(msgs) {
+  return { events: msgs.map((m) => ({ type: "message", message: m })) };
+}
+const asst = (text) => ({ role: "assistant", content: [{ type: "text", text }] });
+
+test("R4: a message completed inside the subscribe/fetch window renders once", async () => {
+  let settleBatch;
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/transcript": () => new Promise((r) => { settleBatch = r; }) }),
+  });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+
+  es._serverFrame("text", { text: "the answer", turnId: "turn-9" });
+  assert.deepEqual(botEntries(hub), [],
+    "buffered until the batch settles — rendering now is exactly the duplicate");
+
+  settleBatch(makeResponse(200, batchEvents([asst("the answer")])));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(botEntries(hub), ["the answer"], "ONE entry, the batch's");
+
+  // And the turn's reply, arriving live AFTER the settle, is judged against
+  // the buffered text frame's bookkeeping — renderedTurn was set even though
+  // the frame's own append was dropped.
+  es._serverFrame("reply", { text: "the answer", turnId: "turn-9" });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(botEntries(hub), ["the answer"], "reply suppressed — that turn IS on screen");
+});
+
+test("R4: frames newer than the batch snapshot flush behind it, in arrival order", async () => {
+  let settleBatch;
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/transcript": () => new Promise((r) => { settleBatch = r; }) }),
+  });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("text", { text: "streamed after the snapshot", turnId: "turn-10" });
+  settleBatch(makeResponse(200, batchEvents([asst("older message")])));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(botEntries(hub), ["older message", "streamed after the snapshot"],
+    "batch first, buffered frames behind it — the order the browser could not get by writing live");
+});
+
+test("R4: a FAILED history fetch flushes the buffer — frames are the only copy", async () => {
+  let settleBatch;
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/transcript": () => new Promise((r) => { settleBatch = r; }) }),
+  });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("text", { text: "the only copy", turnId: "turn-11" });
+  settleBatch(makeResponse(503, { error: "upstream" }));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(botEntries(hub), ["the only copy"], "nothing to dedup against — render it");
+  assert.ok(String(hub.els["perch-transcript"].children.map((c) => c.textContent).join(" "))
+    .includes("Could not load"), "and the failure note still says history is missing");
+});
+
+test("R4: a reply buffered across the window is judged at flush, not lost", async () => {
+  // Zero-text-frame turn opened mid-stream: the reply is the answer's only
+  // copy on the wire; it was parked WITH nothing to dedup against, and the
+  // flush must still render it.
+  let settleBatch;
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/transcript": () => new Promise((r) => { settleBatch = r; }) }),
+  });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("reply", { text: "arrived while history was in flight", turnId: "turn-12" });
+  settleBatch(makeResponse(200, batchEvents([])));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(botEntries(hub), ["arrived while history was in flight"]);
+});

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -1602,7 +1602,10 @@ test("the drawer's model picker is ENABLED on a hibernating session's fallback l
   await openChatSession(hub);
   const modelSel = hub.els["perch-model"], thinkSel = hub.els["perch-thinking"];
   assert.equal(modelSel.disabled, false, "the fallback list is a real list and the switch really binds at the next wake");
-  assert.deepEqual(modelSel.children.map((o) => o.value), ["crow-local/qwen"]);
+  // Round 3 R1: the picker now LEADS with the revocation sentinel (value '')
+  // — "the bot's own model" POSTs control {model:null} — with the live model
+  // still second and still selected.
+  assert.deepEqual(modelSel.children.map((o) => o.value), ["", "crow-local/qwen"]);
   assert.equal(modelSel.value, "crow-local/qwen",
     "and it must SAY which one is live — enabled-and-listing was the assertion this bug walked through");
   assert.equal(thinkSel.disabled, true,
@@ -1868,7 +1871,32 @@ test("a model the list does not carry is added and selected, not silently droppe
   assert.equal(sel.value, "retired-provider/old-model");
   assert.equal(sel.children[0].value, "retired-provider/old-model", "prepended, so it reads first");
   assert.equal(sel.children[0].textContent, "retired-provider/old-model — current");
-  assert.equal(sel.children.length, 4, "and the catalogue is still all there");
+  // Round 3 R1: +1 for the revocation sentinel the picker now always leads with.
+  assert.equal(sel.children.length, 5, "and the catalogue is still all there");
+});
+
+test("the drawer's picker leads with 'the bot's own model', and picking it POSTs the revocation", async () => {
+  // Round 3 R1 (client half): the sentinel is how a legacy auto-stamped row
+  // becomes recoverable from the UI. It must be the FIRST option, must not
+  // out-select a live current model, and must speak the engine's revocation
+  // vocabulary — control body {model:null}, not an omitted field.
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/options": () => makeResponse(200, {
+      models: [{ provider: "crow-local", id: "qwen", name: "Qwen" },
+               { provider: "crow-chat", id: "big", name: "Big" }],
+      thinkingLevels: null, current: "crow-local/qwen", source: "providers" }) }),
+  });
+  await openChatSession(hub);
+  const sel = hub.els["perch-model"];
+  assert.equal(sel.children[0].value, "", "sentinel is option 0");
+  assert.match(sel.children[0].textContent, /own model/i, "labelled, never a bare blank");
+  assert.equal(sel.value, "crow-local/qwen", "a live current still wins the selection");
+  // Operate it: select '' and fire the change handler, as the browser would.
+  sel.value = "";
+  sel.onchange({ target: sel });
+  const ctl = hub.fetchCalls.filter((c) => c.path.endsWith("/control"));
+  assert.equal(ctl.length, 1, "one POST, and it is exactly the revocation");
+  assert.deepEqual(JSON.parse(ctl[0].opts.body), { model: null });
 });
 
 test("a disabled model select is never given a value — there is no list to be right about", async () => {

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -799,11 +799,13 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
           count: sel.options.length });
       })()`);
       assert.equal(seen.disabled, false);
-      assert.equal(seen.count, 2, "fixture check");
-      assert.equal(seen.first, "crow-local/qwen3.6-35b-a3b",
-        "fixture check: the live model is deliberately NOT option 0");
+      // Round 3 R1: the drawer picker leads with the revocation sentinel
+      // (value '') — the recovery path for a session pinned by a pre-A1
+      // auto-stamped row. The live model must still be selected over it.
+      assert.equal(seen.count, 3, "fixture check: the sentinel plus the two catalogue entries");
+      assert.equal(seen.first, "", "option 0 is the revocation sentinel");
       assert.equal(seen.value, "raven-flash-next/qwen3.8-flash-next");
-      assert.equal(seen.index, 1, "the browser's own selection, not just an attribute we set");
+      assert.equal(seen.index, 2, "the browser's own selection, not just an attribute we set");
       assert.match(seen.shown, /Flash Next/,
         "what the operator actually reads off the control this feature exists for");
     } finally { await s.close(); }
@@ -980,10 +982,14 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       })()`);
       assert.equal(seen.disabled, false, "the fallback list is a real list");
       assert.equal(seen.thinkingDisabled, true, "thinking still has no list, and still says so");
-      assert.equal(seen.first, "crow-local/qwen3.6-35b-a3b",
-        "fixture check: the live model is deliberately NOT option 0");
+      // Round 3 R1: sentinel first, the live model selected over it — the
+      // defect this guards ("measured as the FIRST option before the fix")
+      // still cannot pass: option 0 now reads "the bot's own model", which
+      // is exactly what a wrong selection WOULD look like, and the
+      // assertion below still demands the real model instead.
+      assert.equal(seen.first, "", "option 0 is the revocation sentinel");
       assert.equal(seen.value, "raven-flash-next/qwen3.8-flash-next");
-      assert.equal(seen.index, 1, "the browser's own selection");
+      assert.equal(seen.index, 2, "the browser's own selection");
       assert.match(seen.shown, /Flash Next/,
         "what the operator reads after a restart — measured as the FIRST option before the fix");
     } finally { resetApi(); await s.close(); }

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -1092,3 +1092,84 @@ test("N1: a child speaking OUTSIDE a turn emits a text frame with a null turn id
   assert.equal(texts[0].turnId, null);
   sub.off();
 });
+
+// ---------------------------------------------------------------------------
+// Fix round 3 R1 — the row's `model` column means "explicit operator choice"
+// and nothing else. The spawn/wake/turn-end stamps wrote the RESOLVER's answer
+// into it, and adoptRow then treated every such value as an override: after a
+// gateway restart, a changed bot-def default was silently ignored by every
+// existing session, forever, self-perpetuated by the next wake's re-stamp.
+// ---------------------------------------------------------------------------
+
+test("R1: a def-default change reaches a session whose row carries no explicit choice", async () => {
+  // The exact pin the review flagged: spawn on default A, hibernate, change
+  // the def to B, restart (adopt), send — turn 1 must run on B. Pre-fix this
+  // served A: the row held the stamped default and the restore treated it as
+  // the operator's override.
+  const { engine, bridge, clock } = makeEngine();
+  const s = await spawned(engine);
+  clock.advance(600_001);
+  await tick();
+  assert.equal(rowModelOf(s.sessionId), null, "round 3: a plain spawn leaves the row choiceless");
+
+  bridge._state.modelKey = "crow-chat/big-model";           // the def's new default
+  _resetInteractiveEngineForTest();
+  const { engine: reborn, state } = makeEngine({ bridge });
+  await reborn.message(s.sessionId, "after the def change");
+  await tick();
+  const pi = state.instances[state.instances.length - 1];
+  assert.equal(pi.opts.resolved.key, "crow-chat/big-model",
+    "wake follows the DEF, not the old stamped value — this is the whole fix");
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+  assert.equal(state.meter[state.meter.length - 1].resolved.key, "crow-chat/big-model",
+    "and metering prices the new default, not the pinned one");
+});
+
+test("R1: control({model:null}) revokes the choice — row NULLed, next wake re-resolves from the def", async () => {
+  // Revocation is what makes a legacy auto-stamped row recoverable from the
+  // UI (the drawer's "the bot's own model" option POSTs model:null).
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model", "precondition: an explicit choice is stamped");
+
+  const r = await engine.control(s.sessionId, { model: null });
+  assert.equal(r.applied.model, null, "the engine speaks the revocation back");
+  assert.equal(rowModelOf(s.sessionId), null, "and it reaches the row");
+
+  // Honest reporting: the live child keeps its model until the next wake —
+  // snapshot() must not claim null while it is still serving big-model.
+  const snap = await engine.get(s.sessionId);
+  assert.equal(snap.model, "crow-chat/big-model", "servingModel falls back to s.resolved — truthful for the live child");
+
+  clock.advance(600_001);
+  await tick();
+  _resetInteractiveEngineForTest();
+  const { engine: reborn, state } = makeEngine();
+  await reborn.message(s.sessionId, "wake");
+  await tick();
+  const pi = state.instances[state.instances.length - 1];
+  assert.equal(pi.opts.resolved.key, "crow-local/qwen3.6-35b-a3b",
+    "the next wake follows the def again — a revoked choice must not resurrect");
+});
+
+test("R1 belt: a model_select landing before any rowId is persisted when the row appears", async () => {
+  // Staff review C2: on a fresh spawn there is a window between PiRpc
+  // construction and writeRow completing where s.rowId is null. A child's
+  // FIRST model_select in that window used to be dropped forever — every
+  // later writeRow COALESCE-preserves, it does not re-write from tracking.
+  // The fake child emits the event synchronously from the constructor, the
+  // hardest shape the window can produce.
+  const { engine, bridge } = makeEngine();
+  const Base = bridge.PiRpc;
+  bridge.PiRpc = class ChattyPi extends Base {
+    constructor(o) {
+      super(o);
+      this.emit({ type: "model_select", model: { provider: "crow-chat", id: "big-model" }, source: "test" });
+    }
+  };
+  const s = await spawned(engine);
+  assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model",
+    "the writeRow-tail belt replayed the choice that arrived with no rowId");
+});

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -722,6 +722,10 @@ test("options(): awake session returns the live models + thinking levels from th
 const CATALOGUE = [
   { provider: "crow-local", id: "qwen3.6-35b-a3b", name: "Qwen", baseUrl: "http://x:8003/v1" },
   { provider: "raven-flash", id: "flash-next", name: "Flash", baseUrl: "http://y:8010/v1" },
+  // Round 3 R2a: the switch tests use crow-chat/big-model (it is in the real
+  // models.json fixture this mirrors), so the catalogue that GATES control()
+  // must carry it — the rejection cases (ghost/nope) stay valid regardless.
+  { provider: "crow-chat", id: "big-model", name: "Big", baseUrl: "http://z:8020/v1" },
 ];
 
 test("options(): a hibernating session lists the provider catalogue, and still never wakes a child", async () => {
@@ -1172,4 +1176,77 @@ test("R1 belt: a model_select landing before any rowId is persisted when the row
   const s = await spawned(engine);
   assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model",
     "the writeRow-tail belt replayed the choice that arrived with no rowId");
+});
+
+// ---------------------------------------------------------------------------
+// Fix round 3 R2 — a dead model key must not become a durable poison pill.
+//
+// model_resolver.mjs is fail-closed (an invalid key resolves to LOCAL_FALLBACK),
+// but control()'s switch and the adopt-restore bypass that resolver entirely:
+// the pair is written straight to s.currentModelParts and, now, to the row.
+// crow-dsv4 was disabled the very day PR #356 merged, so the case is live.
+// Two rails: validate at the switch (R2a), fall open with a log at wake (R2b).
+// ---------------------------------------------------------------------------
+
+test("R2a: control() refuses a model the catalogue does not carry, and changes nothing", async () => {
+  const { engine } = makeEngine({ providerModels: () => CATALOGUE });   // crow-local/qwen, raven-flash/flash-next
+  const s = await spawned(engine);
+  await assert.rejects(
+    engine.control(s.sessionId, { model: { provider: "ghost", modelId: "nope" } }),
+    /bad_request/,
+    "an arbitrary pair the instance cannot serve is rejected, not persisted",
+  );
+  assert.equal(rowModelOf(s.sessionId), null, "the rejection leaves the row choiceless — no pill planted");
+  const snap = await engine.get(s.sessionId);
+  assert.equal(snap.model, "crow-local/qwen3.6-35b-a3b", "and the in-memory tracking still reports the last-good model");
+});
+
+test("R2a: control() accepts a catalogue model even under an injected partial list (the switch's real target)", async () => {
+  const { engine } = makeEngine({ providerModels: () => CATALOGUE });
+  const s = await spawned(engine);
+  const r = await engine.control(s.sessionId, { model: { provider: "raven-flash", modelId: "flash-next" } });
+  assert.equal(r.applied.model, "raven-flash/flash-next", "a listed pair switches normally");
+  assert.equal(rowModelOf(s.sessionId), "raven-flash/flash-next");
+});
+
+test("R2a: an EMPTY catalogue fails open — a registry hiccup must not lock out a live session", async () => {
+  const { engine, clock } = makeEngine({ providerModels: () => [] });   // cold/unreadable registry
+  const s = await spawned(engine);
+  clock.advance(600_001);
+  await tick();
+  const r = await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  assert.equal(r.bindsAtWake.model, "crow-chat/big-model",
+    "with nothing to check against, the operator's choice is honored, not refused");
+});
+
+test("R2b: an adopted session whose recorded model died falls open to the def, with a log", async () => {
+  // The exact crow-dsv4 shape: the row carries crow-chat/big-model, a provider
+  // later disabled. On wake, servingModel is validated against the catalogue;
+  // absent => drop the override, serve the def's fresh resolution, and TELL
+  // the operator rather than spawning a child on a provider that cannot answer.
+  const { engine, clock } = makeEngine();
+  const s = await spawned(engine);
+  await engine.control(s.sessionId, { model: { provider: "crow-chat", modelId: "big-model" } });
+  assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model", "precondition: the durable choice is in the row");
+  clock.advance(600_001);
+  await tick();
+
+  _resetInteractiveEngineForTest();
+  // A fresh engine whose catalogue no longer lists crow-chat/big-model (it was
+  // disabled), while the def still resolves to crow-local's default.
+  const { engine: reborn, state } = makeEngine({ providerModels: () => [
+    { provider: "crow-local", id: "qwen3.6-35b-a3b", name: "Qwen" },
+  ] });
+  const sub = await collect(reborn, s.sessionId);
+  await reborn.message(s.sessionId, "wake after the provider died");
+  await tick();
+  const pi = state.instances[state.instances.length - 1];
+  assert.equal(pi.opts.resolved.key, "crow-local/qwen3.6-35b-a3b",
+    "the dead recorded model is NOT forced onto the wake — the def's resolution serves");
+  const logs = sub.ofType("log");
+  assert.ok(logs.some((l) => /not available/.test(l.text) && /crow-chat\/big-model/.test(l.text)),
+    "and the drawer is told why, naming the dead model");
+  assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model",
+    "the ROW keeps the choice — a temporarily disabled provider must not erase it");
+  sub.off();
 });

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -789,6 +789,17 @@ test("POST /interactive/:sid/control forwards plan_mode:false — a present fals
   assert.deepEqual(engineCalls.control[0].opts, { planMode: false });
 });
 
+test("POST /interactive/:sid/control forwards model:null as a revocation — present-but-null, not an omitted field", async () => {
+  // Round 3 R1: the drawer's "the bot's own model" option POSTs exactly this
+  // (client.js controlBody('model','') -> {model:null}). An engine that
+  // keyed model presence on truthiness would silently no-op the clear — the
+  // same silent-drop class as the old snake_case permission bug this file's
+  // own comment documents.
+  const { status } = await postJson("/interactive/sess-1/control", { model: null });
+  assert.equal(status, 200);
+  assert.deepEqual(engineCalls.control[0].opts, { model: null });
+});
+
 test("POST /interactive/:sid/control sends an empty opts object when the body carries no recognized fields", async () => {
   await postJson("/interactive/sess-1/control", {});
   assert.deepEqual(engineCalls.control[0].opts, {});

--- a/tests/perch-interactive.test.js
+++ b/tests/perch-interactive.test.js
@@ -363,7 +363,11 @@ test("spawn: builds the world, warms, constructs PiRpc with the FULL piRpcOpts +
   assert.equal(row.bot_id, "botty");
   // r1 C6: without pi_session_dir the P1 transcript endpoint 404s forever.
   assert.equal(row.pi_session_dir, join(dir, "bots", "botty") + "/sessions");
-  assert.equal(row.model, "crow-local/qwen3.6-35b-a3b");
+  // Round 3 R1: NO model stamp without an explicit choice — the resolver's
+  // answer is not the operator's override. (This read the spawn-resolved key
+  // before; the change IS the fix, and controls' N2 tests cover the explicit
+  // path.)
+  assert.equal(row.model, null);
   // get_state → pi_session_id persisted
   assert.equal(row.pi_session_id, state.instances[0].piSessionId);
 });
@@ -642,7 +646,10 @@ test("clean completion: meters + audits, emits reply, trims the log, and parks t
 
   const row = rowFor(s.threadId);
   assert.equal(row.status, "waiting-user");
-  assert.equal(row.model, "crow-local/qwen3.6-35b-a3b");
+  // Round 3 R1: a plain turn end no longer stamps the row — the audit line
+  // above still records what actually served (it reads s.resolved, not the
+  // row). The column means "explicit choice" now.
+  assert.equal(row.model, null);
   assert.equal((await engine.get(s.sessionId)).state, "awake");
 });
 


### PR DESCRIPTION
Phase A of the open-anywhere plan (`docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md`): the wake-path fixes left outstanding when #356 was merged under budget pressure, closed per `docs/reviews/2026-09-11-perch-pr356-review-completion.md`.

## R1 — the row's `model` column means an explicit choice, nothing else (#356 review finding 1)

The column was auto-stamped at every spawn/wake/turn-end with the **resolver's** answer, and `adoptRow` then treated any stamped value as the operator's override. Consequence: after a gateway restart, a changed bot-def default was silently ignored by every existing session, forever — self-perpetuated by the next wake's re-stamp. The review called the shipped justification sound ("an explicit choice survives a restart") but the implementation granted that authority to values that were never choices.

- `writeModel()` is the column's sole writer; it writes `s.currentModel` (NULL = choiceless), not `servingModel()`'s resolver fallback.
- `onModelSelect` now persists a `/model` typed in the TUI — same action as the drawer's switch, same durability.
- **Early-event belt** (staff-review C2): a child's first `model_select` can land while `s.rowId` is still null; instead of dropping it forever (later `writeRow`s COALESCE-preserve, they don't re-write from tracking), a pending flag replays it at `writeRow`'s tail.
- **Revocation**: `control({model:null})` (route: present-but-null JSON, the `hasOwnProperty` idiom `plan_mode` already uses) clears the choice, NULLs the row, next wake re-resolves from the def; the drawer's picker leads with the sentinel. Recovery path for legacy auto-stamped rows — no bulk cleanse (each legacy value really was the serving model at stamp time).

## R2 — a model the instance cannot serve dies at the gate, not in the row

`resolveModel()` is fail-closed, but control()'s pair and the adopt-restore bypass that rail entirely, and crow-dsv4 was disabled the day #356 merged — the live case.

- **At write**: `control()` validates `{provider, modelId}` against the session-free catalogue (`catalogModels()`, the same seam `options()` feeds the picker from) before tracking or persisting. Unknown → `bad_request`, row untouched — the pill becomes un-plantable through the API.
- **At wake**: `startChild` validates the recorded key before the `prep.resolved` override; a key that died after being chosen falls open to the def's fresh resolution with a log frame **naming** both models, instead of attachExit's opaque "pi exited unexpectedly". The ROW keeps the key: re-enable the provider and the choice is honored again at the next restart.
- Both rails **fail open on an empty catalogue** — a registry hiccup must not lock an operator out of a healthy session.

## R4 — the subscribe/fetch duplicate bubble (pre-existing, #356-adjacent)

The review's proposed last-entry comparison **cannot fix this**, and the mechanism is why: the frame writes first into the cleared transcript, the batch appends behind it — the copies are not adjacent. Transcript-writing `text`/`reply` frames now park until the batch settles and flush deduped against the batch's own bot texts (bookkeeping still applies, so the turn's reply stays suppressed). Failed/empty history flushes against nothing — the frames are then the only copy. The subscribe-before-history order (the no-loss guarantee) is unchanged.

## ⚠ Off-plan: `piLiveness()` is blind to Node 24 (commit ff425481)

This branch's full-suite verification failed `board-job-lock.test.js` for a reason unrelated to Perch — and the cause is a **live production bug**: Node ≥ 24 sets `/proc/<pid>/comm` to `MainThread` (measured: v20→"node", v22→"node", v24.21.0→"MainThread"), and this fleet's gateway runs v24.21.0. `piLiveness()`'s `comm === "node"` filter therefore matched nothing: **every live pi scanned as dead**, so the job rail's force-unlock could release a card whose child was still running — the hazard the fail-closed rail exists to prevent. CI cannot catch it: the workflow pins Node 22. Identity now comes from argv0 of `/proc/<pid>/cmdline` (basename `node|nodejs`) plus the `--session-dir` needle; `bash -c` wrappers quoting the needle stay excluded. The test's mirrored scan updated to match. Standalone commit — revertable without touching the Perch work. Only one `comm`-keyed scan exists in the repo (grepped).

## Verification

- **4665 / 4665 green** full suite on Node 24 (`npm test`, scratch env), zero failures.
- **Mutation-checked, each red one named**: restoring the startChild stamp → R1 pin test red; deleting the belt → belt test red; neutering revocation keying → revoke + route tests red; removing `onModelSelect` persist → belt test red; neutering the R2a gate → R2a red; neutering the R2b rail → R2b red; deleting the R4 buffer line → both R4 dedup tests red.
- The #356 review's mutation matrix re-run in full (reply/text lose `turnId` → engine stamping tests red; `adoptRow` restore removed → 3 N2 tests + R2b red; `writeModel` no-op → 3 N2 + revoke red; split loosened → malformed-key test red). All restored.
- Live CDP picker tests (Q1/N2 @412x730, 1280x900) updated for the sentinel (count 3, selection index 2) — the wrong-model-as-option-0 reading stays unforgiving: option 0 is now visibly "the bot's own model" and the tests demand the real model over it.
- New tests: 3 (controls R1) + 4 (controls R2) + 1 (routes revocation mapping) + 4 (client R4 window, driven with a deferred-promise `/transcript` that freezes the batch — the whole trick).

## Scope discipline

No schema change, no new endpoint, no funnel/mount surface touched (routes change is a body-mapping inside an existing private endpoint). Phases B–E (cwd plumbing, browse picker, tabs) follow as PRs 2–3 of the plan.