### PR TITLE
Sharing: the stdio MCP server never races the primary for the feed lock

### DIFF
--- a/servers/sharing/index.js
+++ b/servers/sharing/index.js
@@ -12,6 +12,18 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createSharingServer } from "./server.js";
 import { createDbClient, verifyDb } from "../db.js";
 import { generateInstructions } from "../shared/instructions.js";
+import { stdioCompanionEnv } from "./instance-sync.js";
+
+// Companion-process sync gate: this stdio entry must never own the
+// instance-sync Hypercore feeds (the primary gateway does). Applied to
+// process.env before any manager construction; see stdioCompanionEnv for the
+// doctrine and the explicit =0 override.
+const gatedEnv = stdioCompanionEnv(process.env);
+if (gatedEnv.CROW_DISABLE_INSTANCE_SYNC === undefined) {
+  delete process.env.CROW_DISABLE_INSTANCE_SYNC;
+} else {
+  process.env.CROW_DISABLE_INSTANCE_SYNC = gatedEnv.CROW_DISABLE_INSTANCE_SYNC;
+}
 
 try {
   await verifyDb(createDbClient());

--- a/servers/sharing/instance-sync.js
+++ b/servers/sharing/instance-sync.js
@@ -404,6 +404,30 @@ export function shouldInitInstanceSync({ argv = [], env = {} } = {}) {
   return true;
 }
 
+/**
+ * The stdio MCP entrypoint (servers/sharing/index.js) is ALWAYS a companion
+ * to the primary gateway — same class as the --no-auth loopback gateway above.
+ * Apply the instance-sync kill-switch by default so a per-session MCP spawn
+ * never grabs the on-disk Hypercore feed lock and starves the primary ("File
+ * descriptor could not be locked"). An explicit CROW_DISABLE_INSTANCE_SYNC=0
+ * opts back in (standalone host with no gateway). Nostr is gated separately
+ * (CROW_DISABLE_NOSTR), so messaging/sharing tools stay live either way.
+ * Pure: takes an env-shaped object, returns a new one. Called at module top
+ * of the stdio entrypoint before any manager construction.
+ * @param {Record<string,string|undefined>} env
+ * @returns {Record<string,string|undefined>}
+ */
+export function stdioCompanionEnv(env = {}) {
+  const out = { ...env };
+  const current = out.CROW_DISABLE_INSTANCE_SYNC;
+  if (current === undefined) {
+    out.CROW_DISABLE_INSTANCE_SYNC = "1";
+  } else if (current === "0") {
+    delete out.CROW_DISABLE_INSTANCE_SYNC;
+  }
+  return out;
+}
+
 /* ------------------------------------------------- ramble natural-key apply */
 
 /**

--- a/tests/instance-sync-noauth-feeds.test.js
+++ b/tests/instance-sync-noauth-feeds.test.js
@@ -12,13 +12,31 @@ import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDbClient } from "../servers/db.js";
-import { InstanceSyncManager, shouldInitInstanceSync } from "../servers/sharing/instance-sync.js";
+import { InstanceSyncManager, shouldInitInstanceSync, stdioCompanionEnv } from "../servers/sharing/instance-sync.js";
 import * as ed from "../node_modules/@noble/ed25519/index.js";
 
 test("shouldInitInstanceSync: enabled by default, disabled on --no-auth or kill-switch", () => {
   assert.equal(shouldInitInstanceSync({ argv: ["node", "index.js"], env: {} }), true, "default enabled");
   assert.equal(shouldInitInstanceSync({ argv: ["node", "index.js", "--no-auth"], env: {} }), false, "--no-auth disables");
   assert.equal(shouldInitInstanceSync({ argv: ["node", "index.js"], env: { CROW_DISABLE_INSTANCE_SYNC: "1" } }), false, "env kill-switch disables");
+});
+
+test("stdioCompanionEnv: the stdio MCP entry defaults the kill-switch ON, explicit =0 opts out", () => {
+  // Unset → defaulted to "1": a per-session MCP spawn must never race the
+  // primary gateway for the on-disk feed lock ("File descriptor could not be
+  // locked" on the loser; silent replication starvation if the companion wins).
+  assert.equal(stdioCompanionEnv({}).CROW_DISABLE_INSTANCE_SYNC, "1", "unset defaults to disabled");
+  assert.equal(stdioCompanionEnv({ CROW_DISABLE_INSTANCE_SYNC: "0" }).CROW_DISABLE_INSTANCE_SYNC, undefined,
+    "explicit =0 removes the var (standalone host with no gateway owns the feeds)");
+  assert.equal(stdioCompanionEnv({ CROW_DISABLE_INSTANCE_SYNC: "1" }).CROW_DISABLE_INSTANCE_SYNC, "1", "explicit =1 passes through");
+  const untouched = { PATH: "/usr/bin" };
+  const out = stdioCompanionEnv(untouched);
+  assert.equal(untouched.CROW_DISABLE_INSTANCE_SYNC, undefined, "pure: input env not mutated");
+  assert.equal(out.PATH, "/usr/bin", "other keys preserved");
+  // And the default actually gates: a manager constructed with the companion env
+  // reports feeds disabled.
+  assert.equal(shouldInitInstanceSync({ argv: ["node", "servers/sharing/index.js"], env: stdioCompanionEnv({}) }), false,
+    "companion env disables instance sync");
 });
 
 test("feedsDisabled manager: initInstance + emitChange are no-ops (no feed dir, no throw)", async () => {


### PR DESCRIPTION
Every pi/Claude session spawns `servers/sharing/index.js` against the same CROW_HOME as the systemd gateway. The companion loses the race for the instance-sync Hypercore feed lock and logs `Failed to init sync feed ... File descriptor could not be locked` on every boot — and if it starts FIRST it silently starves the primary's replication (the exact failure mode the `--no-auth` gate was built for).

**Fix:** the stdio entry is by definition a companion (HTTP transport lives in the gateway), so it defaults `CROW_DISABLE_INSTANCE_SYNC=1` via a new pure `stdioCompanionEnv()` helper, with an explicit `=0` escape hatch for a standalone host with no gateway. Nostr is gated separately (`CROW_DISABLE_NOSTR`), so messaging/sharing tools stay fully live.

**Verification (measured):**
- `npm test -- tests/instance-sync-noauth-feeds.test.js` — 6/6 green
- Live scratch-home boot: zero feed-init attempts; explicit `=0` boot joins the instance-sync topic as before