### PR TITLE
Perch open-anywhere PR2: cwd plumbing (Phase B) + browse API (C1)

### DIFF
--- a/docs/superpowers/handoffs/2026-09-12-perch-open-anywhere-pr2-shipped.md
+++ b/docs/superpowers/handoffs/2026-09-12-perch-open-anywhere-pr2-shipped.md
@@ -1,0 +1,154 @@
+# Perch open-anywhere — PR2 shipped, PR3 (C2 + D + E) resume brief
+
+**Date:** 2026-09-12
+**Plan:** `docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md` (operator-approved; its "Operator decisions" + "Architecture" sections are load-bearing — read them first)
+**Branch:** `feat/perch-open-anywhere` (worktree `/home/kh0pp/crow-wt-openperch`)
+**PR2:** #360 — Phases B (B1–B4) + C1. Full suite 4686/0 green at push.
+
+> The session that produced Phase A + B1 was a local-model run that died at
+> ~300k tokens; this brief exists so PR3 does not have to re-derive state from
+> scratch. Everything below was measured, not asserted.
+
+## What is already done (do NOT redo)
+
+- **Phase A (A1–A4)** — merged to `main` (`bb3500c6` and predecessors). The
+  row's `model` column means an explicit choice only; `control()` validates the
+  model pair; a dead recorded model fails open at wake; the subscribe/history
+  duplicate bubble is deduped.
+- **B1** `bot_sessions.cwd` schema (`f92d3ce7`) — nullable TEXT, additive-only,
+  **no `SCHEMA_GENERATION` bump** (the `kind`/`narrowed_tools`/`label`
+  precedent). It is in the CREATE body, the guarded `addColumnIfMissing` ALTER
+  (placed BEFORE the control-CHECK rebuild block — ordering is load-bearing),
+  and `BOT_SESSIONS_CANONICAL_COLUMNS` so the dedicated rebuild carries it
+  instead of aborting on it as drift. Tests: `init-db-bot-tables` 13/13.
+- **B2** `buildBotWorld({cwd})` (`979a267e`, `scripts/pi-bots/bot-world.mjs`) —
+  validates cwd (absolute/existing/dir → typed `bad_cwd`) BEFORE any side
+  effect; **relocates the per-bot `.mcp.json` to the cwd** (the in-body
+  `writeBotMcp(def, { sessionDir: resolvedCwd, … })` call — pi-lab's mcp-client
+  reads `cwd/.mcp.json`, so writing it at the world root would silently strip
+  every MCP tool); `no_session_dir` throw REPLACED by a
+  `<crowHome>/pi-bots/<botId>` fallback; world root (`sessionDir`) keeps
+  storage duty (`sessions/`, `outputs/<sid>`, uploads); `selfAuthoringDir`
+  stays keyed on `def.session_dir` by design (review Q1). Returns `cwd`.
+- **B3** `PiRpc` (`4634d861`, `scripts/pi-bots/bridge.mjs`) — `spawnCwd =
+  opts.cwd || sessionDir` used as the child's process cwd; `--session-dir`
+  STILL points at the world root; `prepareSpawn`'s `piRpcOpts` stay cwd-free so
+  every channel caller (gmail/discord/job_runner) is byte-identical. The split
+  belongs to the interactive caller (B4), not prepareSpawn.
+- **B4** engine (`08132c52`, `servers/gateway/perch-interactive.js`) — `s.cwd`
+  through newSession/spawn/startChild/writeRow/adoptRow/snapshot/stateEvent/
+  control. Key decisions actually implemented:
+  - `startChild` sets `s.cwd = world.cwd || world.sessionDir` (snapshot reports
+    the truth even for a default session) and passes `cwd: world.cwd` into
+    PiRpc opts.
+  - **`extraWritePaths` widens ONLY when `world.cwd !== world.sessionDir`** —
+    i.e. the chosen dir is writable (decision 2), but a DEFAULT session's
+    `write_paths` stays byte-identical `[outputsDir]`. (The plan's B4 bullet
+    list omitted the write_paths step; decision 2 + the E1 walk require it, so
+    it lives here. This is the one named deviation from the B4 text.)
+  - `writeRow` stamps `cwd=COALESCE(?, cwd)`; `writeCwd()` is the targeted
+    single-column writer (no status restamp, mirrors `writeModel`). INSERT
+    gained the `cwd` column — **11 cols / 9 SELECT placeholders + 2 WHERE = 11
+    args**, re-verified against a live `better-sqlite3` prepare (an off-by-one
+    here throws `near "WHERE": syntax error` / `10 values for 11 columns`).
+  - `control({cwd})`: validates (absolute/existing/dir → `bad_request`),
+    refuses `turn_in_progress`, persists via `writeCwd`, and because pi's cwd
+    is fixed at spawn (no live chdir) **hibernates an awake child** with a
+    `working directory → <dir>` log frame; reported under `bindsAtWake.cwd`.
+    Runs LAST among the controls so a combined `{planMode, cwd}` never
+    hibernates the child out from under the planMode branch.
+- **C1** routes (`bcde286b`, `servers/gateway/routes/perch-interactive-api.js`)
+  — `GET /dashboard/perch-api/browse?path=` (directory NAMES + paths only,
+  never contents/file entries; `~` expansion; `resolve()` collapses `..`;
+  realpath; 404 `{error:'unreadable'}`; symlinks followed only to real dirs;
+  dot-dirs last; cap 500; `parent` from the RESOLVED realpath). Under the same
+  `dashboardAuth`, **NOT** in `PUBLIC_FUNNEL_PREFIXES` (network invariant
+  holds; `auth-network` 20/20). `POST /bots/:id/interactive` accepts optional
+  `{cwd}` (route-validated → 400 `bad_cwd`, new `ERROR_MAP` row);
+  `POST /interactive/:sid/control` forwards an explicit `cwd` (presence-keyed).
+
+### Test seams already updated (so PR3 does not re-break them)
+- `tests/perch-interactive-controls.test.js` — the fake `buildBotWorld` seam
+  returns `cwd: args.cwd || join(dir,"bots",args.botId)` (mirrors B2). 7 new
+  B4 tests appended.
+- `tests/perch-interactive-routes.test.js` — the fake `spawn` captures `cwd`;
+  the two existing `engineCalls.spawn` deepEquals were updated to carry the new
+  `cwd` key (`cwd:null` interactive / `cwd:undefined` dispatch). 10 new C1 tests.
+- `tests/bot-world.test.js` — 4 B2 tests + 1 B3 PiRpc-seam test appended.
+- `tests/perch-interactive-dispatch.test.js` — the old `no_session_dir` throw
+  test was rewritten to assert the B2 fallback.
+
+## What PR3 must do (C2 + Phase D + Phase E)
+
+Follow the plan's steps **C2, D1, D2, D3, E1, E2** verbatim — they are
+unchanged and already adversarially reviewed (see the plan's Review table).
+The relevant files and the load-bearing constraints:
+
+- **C2** (`perch-hub/html.js`, `client.js`, `css.js`, `shared/i18n.js`):
+  `#perch-new-cwd` text input + `#perch-browse-btn` beside the model select in
+  the `#perch-launch` row (html.js ~:63-66); `startNewSession()` (client.js
+  ~:508) reads the field and sends `cwd` ONLY when non-empty (empty = "the
+  bot's default", never send the key). Picker = a modal overlay listing
+  `/browse` results (header shows current path, `..` row → `parent`, tap a dir
+  → navigate, a **labelled "Choose"** writes the path into `#perch-new-cwd`).
+  **Explicit Escape handler + a visible "Cancel" button** (dismiss must not
+  depend on either alone — review S5). Register listeners through the hub's
+  generation-checked registry (`on(...)`, client.js ~:93) so the Turbo-leak
+  guard (`perch-hub-stream-leak.test.js`) covers them. i18n: EN+ES keys
+  `perch.cwdLabel`, `perch.cwdPlaceholder`, `perch.browse`, `perch.choose`,
+  `perch.browseFailed`, `perch.cwdDefaultNote` (the parity test
+  `i18n-global-parity.test.js` fails loudly on one-sided keys). Add the matching
+  `tJs(...)` constants near client.js ~:247.
+- **D1** (html.js, css.js): `#perch-tabs` `role="tablist"` with four buttons
+  (chat|session|files|activity) + four `<section id="perch-tab-<name>">`
+  wrappers inside `#perch-chat`. Desktop (≥`PERCH_SPLIT_MIN_WIDTH`): top strip
+  in the right pane; phone: fixed bottom tab bar with the composer ABOVE it.
+  **The flex chain has already killed one Send button** — keep
+  `#perch-chat{flex:1;min-height:0}` and the transcript as the only scroller;
+  the tab bar joins as a non-shrinking sibling. CDP-measure Send reachable at
+  412×730 and 1280×900 in EVERY tab.
+- **D2** (client.js, i18n): tab state is a plain `var tab='chat'` reset on
+  session open; switching is **pure visibility toggling — never touch the
+  EventSource/`openStream`/`closeSession`/any SSE lifecycle** (review S6).
+  Route `log`/`tool`-start/note/`error` frames to `#perch-activity-list`
+  (chat keeps user/bot messages, ask cards, hard failures). Session tab gets
+  the model/thinking/permission/plan controls + rename/close + a read-only cwd
+  display with a "Change directory" button that reopens the browse modal and
+  POSTs `control({cwd})`. Deliberately NOT in the hash.
+- **D3** (routes + client.js + css.js + i18n): `GET /interactive/:sid/files/list`
+  → outputsDir-relative `{name,size,mtime}`, flat, skip dotfiles + symlinks
+  (`lstatSync`), sort mtime desc, cap 200, reuse `snap.outputsDir`, same 409
+  shapes as the download route, NEVER lists uploadsDir. Mirror the jail's attack
+  inventory at the LIST level in `perch-interactive-routes.test.js`.
+- **E1**: full `npm test`; `node servers/gateway/index.js --no-auth` boots
+  clean; **the live Perch walk** (start a session in a chosen non-default dir →
+  it writes a file there → **one tool call through a per-bot MCP server from
+  that dir** — this is the silent-failure guard for the `.mcp.json` relocation
+  — → switch model while hibernating → restart gateway → adopts on the switched
+  model in the chosen dir → disable the provider → fail-open log in Activity →
+  change cwd mid-session refused in-turn, works idle). CDP render checks at
+  412×730 + 1280×900 + no horizontal scroll at 320px. **These need a running
+  gateway + headless Chrome** — they could not be run in the PR2 session.
+- **E2**: `docs/architecture/gateway-server.md` (perch cwd model + new
+  endpoints), the `docs/guide` perch walkthrough, and a status footer on
+  `docs/reviews/2026-09-11-perch-pr356-review-completion.md`
+  ("R1/R2/R4 closed by <PR#>"). `cd docs && npm run dev` spot-check.
+
+## Repo discipline reminders (bite if forgotten)
+- Commit with **positional path args**: `git commit <path> -m "…"` (parallel
+  sessions share the tree). Verify `git show --stat HEAD`.
+- `git pull --rebase` before pushing; CI red blocks ALL merges.
+- The branch is checked out in the **worktree** `/home/kh0pp/crow-wt-openperch`
+  (not the main `/home/kh0pp/crow` clone) — `git checkout feat/perch-open-anywhere`
+  there, or work in the worktree directly.
+- No new host ports (would fail `check-ports`); no bundle-manifest bumps (all
+  core gateway code); do not touch `PUBLIC_FUNNEL_PREFIXES`/`isAllowedNetwork()`.
+
+## Unrelated fix shipped alongside (separate PR)
+The `[sharing] Failed to init sync feed … File descriptor could not be locked`
+warning in pi sessions was **not** perch work and **not** a broken harness: the
+systemd gateway holds the instance-sync feed lock and each pi session's
+`.mcp.json` spawned a second `servers/sharing/index.js` on the same `~/.crow`
+that lost the race. Fixed in PR **#359** (`fix/stdio-sharing-sync-gate`): the
+stdio entry defaults `CROW_DISABLE_INSTANCE_SYNC=1` via a pure
+`stdioCompanionEnv()` helper (explicit `=0` opts back in), Nostr stays live.

--- a/docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md
+++ b/docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md
@@ -7,9 +7,14 @@
 > 1. This plan: `docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md`
 > 2. The review it implements Phase A from: `docs/reviews/2026-09-11-perch-pr356-review-completion.md`
 > 3. The surface spec it slots under: `docs/superpowers/specs/2026-09-09-perch-hub-design.md`
-> Execution state: **no code written yet** — if work has begun, tick progress against the
-> numbered steps (A1…E2) and record any named deviation in the "Risk notes" section's spirit:
-> measured, not asserted. PR shape: PR 1 = Phase A, PR 2 = Phases B+C, PR 3 = Phase D+E.
+> Execution state: **Phases A + B + C1 SHIPPED; C2 + D + E remain.** Phase A
+> (A1–A4) merged to `main`. Phase B (B1–B4) + C1 shipped as PR2 (#360, branch
+> `feat/perch-open-anywhere`, full suite 4686/0 green). Remaining: **C2**
+> (launcher directory-picker UI), **Phase D** (Chat/Session/Files/Activity tabs),
+> **Phase E** (docs + the mandated live CDP browser walk). Resume brief:
+> `docs/superpowers/handoffs/2026-09-12-perch-open-anywhere-pr2-shipped.md`.
+> Record any named deviation in the "Risk notes" section's spirit: measured, not
+> asserted. PR shape: PR 1 = Phase A (DONE), PR 2 = B+C1 (DONE #360), PR 3 = C2+D+E.
 
 **Status:** approved by operator 2026-09-11 (four decisions captured below)
 **Supersedes:** the directory-containment decisions of the M3 project-native workspace model *for Perch sessions*, and completes the outstanding review of PR #356 → `docs/reviews/2026-09-11-perch-pr356-review-completion.md` (findings R1, R2, R4-adjacent become Phase A).

--- a/scripts/init-db.js
+++ b/scripts/init-db.js
@@ -2614,6 +2614,7 @@ await initTable("bot_sessions table", `
     control           TEXT NOT NULL DEFAULT 'run'
                         CHECK (control IN ('run','stop','interrupted')),
     model             TEXT,
+    cwd               TEXT,
     escalated         INTEGER DEFAULT 0,
     kind              TEXT NOT NULL DEFAULT 'chat',
     narrowed_tools    TEXT,
@@ -2655,6 +2656,17 @@ await addColumnIfMissing("bot_sessions", "narrowed_tools", "TEXT");
 // Additive-only — no SCHEMA_GENERATION bump.
 await addColumnIfMissing("bot_sessions", "label", "TEXT");
 
+// bot_sessions.cwd: the operator-chosen working directory for a Perch session
+// (open-anywhere plan, Phase B). NULL means "no explicit choice" — the world
+// builder falls back to the bot's configured dir / project workspace, exactly
+// as before this column existed. Like `label` it is operator state persisted
+// on the session's own row, and the same both-places idiom applies: CREATE
+// body above for fresh installs, this guarded ALTER for pre-existing ones,
+// and listed in BOT_SESSIONS_CANONICAL_COLUMNS so the control-CHECK rebuild
+// carries it instead of aborting on it as drift. Additive-only — no
+// SCHEMA_GENERATION bump (the `kind`/`narrowed_tools`/`label` precedent).
+await addColumnIfMissing("bot_sessions", "cwd", "TEXT");
+
 // bot_sessions.control CHECK widen, 'run'/'stop' -> 'run'/'stop'/'interrupted'
 // (Track 3 Task 7): stopAll() parks a session that was genuinely mid-turn
 // when the gateway shut down with control='interrupted' instead of 'run', so
@@ -2686,7 +2698,7 @@ await addColumnIfMissing("bot_sessions", "label", "TEXT");
 // is never reached, so the next run retries the migration.
 //
 // I13: PRAGMA table_info(bot_sessions) is diffed against the canonical
-// 17-column list BEFORE any DDL — an unrecognized host-present column (or a
+// 19-column list BEFORE any DDL — an unrecognized host-present column (or a
 // canonical column gone missing) aborts the migration instead of silently
 // vanishing with its data, matching the reference rebuild's C2/N1 guard.
 //
@@ -2703,8 +2715,8 @@ await addColumnIfMissing("bot_sessions", "label", "TEXT");
 const BOT_SESSIONS_CANONICAL_COLUMNS = [
   "id", "bot_id", "pi_session_id", "pi_session_dir", "gateway_type",
   "gateway_thread_id", "project_id", "card_id", "plan_path", "status",
-  "control", "model", "escalated", "kind", "narrowed_tools", "label",
-  "created_at", "updated_at",
+  "control", "model", "cwd", "escalated", "kind", "narrowed_tools",
+  "label", "created_at", "updated_at",
 ];
 await (async () => {
   const tableInfo = await db.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='bot_sessions'");
@@ -2762,6 +2774,7 @@ await (async () => {
         control           TEXT NOT NULL DEFAULT 'run'
                             CHECK (control IN ('run','stop','interrupted')),
         model             TEXT,
+        cwd               TEXT,
         escalated         INTEGER DEFAULT 0,
         kind              TEXT NOT NULL DEFAULT 'chat',
         narrowed_tools    TEXT,

--- a/scripts/pi-bots/bot-world.mjs
+++ b/scripts/pi-bots/bot-world.mjs
@@ -35,7 +35,7 @@
  * loadBridge()). Everything taken from bridge is part of its public export
  * surface — which job_runner.mjs also consumes, so those names are stable.
  */
-import { mkdirSync, writeFileSync, appendFileSync, mkdtempSync } from "node:fs";
+import { mkdirSync, writeFileSync, appendFileSync, mkdtempSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeBotMcp } from "./mcp_writer.mjs";
@@ -52,7 +52,8 @@ function loadBridge() { return import("./bridge.mjs"); }
  * Phase A — identity. The exact sequence handleInbound ran inline before C-11.
  *
  * @param {{botId: string, threadId: string, gatewayType?: string,
- *          log?: (m: string) => void, jobId?: string|null, cardBound?: boolean}} opts
+ *          log?: (m: string) => void, jobId?: string|null, cardBound?: boolean,
+ *          cwd?: string|null}} opts
  *   `jobId` (Track 1 Task 7 — the missing link in the job_id chain):
  *   job_runner.runCardExecute passes job.job_id through here so it reaches
  *   writeBotMcp's board-entry headers (X-Crow-Job-Id) — without it the
@@ -62,11 +63,15 @@ function loadBridge() { return import("./bridge.mjs"); }
  *   card. Like a job turn, it must be able to call board_report_result (the
  *   dispatch brief ends the run with that call), so the board MCP entry is
  *   ensured regardless of the def's own crow_mcp selection.
+ *   `cwd` (open-anywhere plan, Phase B): the operator's chosen working
+ *   directory — pi's process cwd AND the home of the per-bot `.mcp.json`
+ *   (pi-lab's mcp-client reads `cwd/.mcp.json`). NULL/unset keeps today's
+ *   behavior byte-identically: cwd === sessionDir (the world root).
  * @returns {Promise<{def, bot, crowHome, projectId, projectSpace, projectMembers,
- *          sessionDir, tasksDbPath, remoteEnabled, peerGatewayUrls, session,
+ *          sessionDir, cwd, tasksDbPath, remoteEnabled, peerGatewayUrls, session,
  *          narrowedTools, gatewayType}>}
  */
-export async function buildBotWorld({ botId, threadId, gatewayType = "perch", log = () => {}, jobId = null, cardBound = false }) {
+export async function buildBotWorld({ botId, threadId, gatewayType = "perch", log = () => {}, jobId = null, cardBound = false, cwd = null }) {
   const B = await loadBridge();
   const bot = B.loadBot(botId);
   const def = bot.def;
@@ -83,32 +88,49 @@ export async function buildBotWorld({ botId, threadId, gatewayType = "perch", lo
   // (new project-native bots). Legacy bots without a project_space row, or
   // whose row has no workspace_dir, fall back to def.session_dir (the
   // pre-M3 ~/.crow-mpa/pi-bots/<bot_id>/ path).
+  // Open-anywhere B2: a bot with NEITHER is no longer refused — the world
+  // root falls back to <crowHome>/pi-bots/<botId> (mkdir'd below via the
+  // sessions mkdir). The old no_session_dir throw made an unconfigured bot
+  // unspawnable on every rail; with the cwd/world-root split there is always
+  // a sane storage root, and a perch operator can point the session anywhere.
   const sessionDir = (projectSpace && projectSpace.workspace_dir)
     ? (projectSpace.workspace_dir + "/bots/" + botId)
-    : def.session_dir;
-  const tasksDbPath = (projectSpace && projectSpace.tasks_db_uri) || B.TASKS_DB;
-  // Track 3 Task 6: a bot with neither a project-space workspace nor its own
-  // def.session_dir has nowhere to run — the pre-existing code below would
-  // silently mkdir "undefined/sessions" (the literal `undefined/` bug, for
-  // EVERY rail this function serves: gmail, discord, job_runner, perch). Fail
-  // loud and typed instead, so the caller (perch's free-chat spawn above all —
-  // a bot with no bound project and no session_dir configured) gets an
-  // actionable refusal rather than a mangled path on disk.
-  if (!sessionDir) {
-    throw Object.assign(
-      new Error("bot has no working directory — set one in Bot Builder (session_dir) or bind the bot to a project space"),
-      { code: "no_session_dir" }
-    );
+    : (def.session_dir || join(crowHome, "pi-bots", botId));
+  // The operator's chosen working directory (open-anywhere). Defaults to the
+  // world root, which keeps every pre-existing caller byte-identical. It is
+  // pi's process cwd, the directory added to write_paths at spawn, and where
+  // the per-bot .mcp.json lives — so validate it hard, before any side effect:
+  // absolute, existing, a directory. The gateway route validates first; this
+  // is the belt-and-braces second gate (engineError-shaped code for the map).
+  const resolvedCwd = cwd || sessionDir;
+  if (cwd) {
+    let ok = typeof cwd === "string" && cwd.startsWith("/");
+    if (ok) { try { ok = statSync(cwd).isDirectory(); } catch { ok = false; } }
+    if (!ok) {
+      throw Object.assign(
+        new Error("cwd is not an existing directory: " + JSON.stringify(cwd)),
+        { code: "bad_cwd" }
+      );
+    }
   }
+  const tasksDbPath = (projectSpace && projectSpace.tasks_db_uri) || B.TASKS_DB;
+  // World root storage: pi session files, outputs/<sid>, uploads — always
+  // under sessionDir, NEVER inside the operator's chosen cwd (a session's
+  // deliverables must not litter the project directory).
   mkdirSync(sessionDir + "/sessions", { recursive: true });
 
-  // Keep the per-bot <sessionDir>/.mcp.json in sync with the def on every
+  // Keep the per-bot <cwd>/.mcp.json in sync with the def on every
   // turn (best-effort; additive merge — homedir ~/.pi/agent/mcp.json still
   // wins on collision, so a writer hiccup can never break a turn). Primary
   // writer is the GUI save handler; this is the defensive backstop.
   // M3b: pass the resolved sessionDir (which may differ from def.session_dir
   // when the bot has a project_space workspace) so the .mcp.json lives next
   // to where pi actually runs.
+  // Open-anywhere B2: "where pi actually runs" is now the operator's cwd, not
+  // the world root — pi-lab's mcp-client reads `cwd/.mcp.json` (bridge.mjs's
+  // own comment says so), so writing it anywhere else would silently strip
+  // the bot of every MCP tool. writeBotMcp is an additive merge, so a chosen
+  // dir that carries its own .mcp.json survives.
   // F4a L2b: read the remote_invocation flag + trusted peer gateway URLs once
   // (local-only, default off). With the flag off, remoteEnabled=false ⇒
   // writeBotMcp mints no remote blocks and toolAllowlist adds no remote entries
@@ -123,7 +145,7 @@ export async function buildBotWorld({ botId, threadId, gatewayType = "perch", lo
     // acceptance F2: a card-bound session (or a job turn) must be able to
     // call board_report_result — ensure the board entry is minted.
     const w = writeBotMcp(def, {
-      sessionDir, crowHome, remoteEnabled, peerGatewayUrls, botId, jobId,
+      sessionDir: resolvedCwd, crowHome, remoteEnabled, peerGatewayUrls, botId, jobId,
       ensureServers: (jobId || cardBound) ? ["board"] : [],
     });
     if (w.warnings.length) log("mcp.json warnings: " + w.warnings.join("; "));
@@ -155,8 +177,10 @@ export async function buildBotWorld({ botId, threadId, gatewayType = "perch", lo
 
   // gatewayType is carried through inert (no behavior depends on it here) so a
   // caller that only holds the world still knows which channel asked for it.
+  // cwd: the resolved working directory (=== sessionDir when not chosen).
   return { def, bot, crowHome, projectId, projectSpace, projectMembers, sessionDir,
-    tasksDbPath, remoteEnabled, peerGatewayUrls, session, narrowedTools, gatewayType };
+    cwd: resolvedCwd, tasksDbPath, remoteEnabled, peerGatewayUrls, session,
+    narrowedTools, gatewayType };
 }
 
 /**
@@ -190,7 +214,10 @@ export async function prepareSpawn(world, { escalate = false, log = () => {} } =
   // true, the bot MAY draft a new skill into a CONFINED staging dir. The dir is
   // keyed on def.session_dir (NOT the resolved sessionDir, which for a
   // project-native bot is <workspace>/bots/<id>) so it is the exact location the
-  // Bot Builder review UI scans — no write-here/scan-there split. We mkdir it,
+  // Bot Builder review UI scans — no write-here/scan-there split. Open-anywhere
+  // B2 (review Q1): it also does NOT follow the operator's perch cwd — a
+  // session working in an arbitrary project directory still stages proposals
+  // where the review UI looks. We mkdir it,
   // make it writable for the write tool (PiRpc augments write_paths below), and
   // inject the directive + full skill-writing guidance into the system prompt.
   // A staged file stays INERT (skill_resolver loads only by name from the skill

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -143,6 +143,17 @@ export function readPeerGatewayUrls(conn) {
 export class PiRpc {
   constructor(opts) {
     const def = opts.def, sessionDir = opts.sessionDir;
+    // Open-anywhere B3: pi's process cwd is the operator's chosen directory
+    // when one was passed; the world root (sessionDir) remains the storage
+    // root — --session-dir below still points at sessionDir + "/sessions", so
+    // pi session files never land in the chosen project directory. Callers
+    // that pass no cwd (every channel caller — prepareSpawn's piRpcOpts stay
+    // cwd-free by design) get spawnCwd === sessionDir: byte-identical spawn.
+    // --no-approve keeps project-trust DENY in the chosen cwd too (the bot
+    // must never load .pi/ config from an arbitrary directory), and pi-lab's
+    // mcp-client reads spawnCwd/.mcp.json — which is why buildBotWorld writes
+    // the per-bot .mcp.json there (B2).
+    const spawnCwd = opts.cwd || sessionDir;
     // Phase 3.0 (R3): provider+model are resolved per-turn by
     // model_resolver.resolveModel() and passed in via opts.resolved — there
     // is NO hardcoded crow-local anywhere in the spawn path anymore.
@@ -273,7 +284,7 @@ export class PiRpc {
     // the whole tree (pi + its MCP children). Without this, killing pi leaves
     // its MCP server children (brave-search, google-workspace, github, etc.)
     // running indefinitely — observed leak of ~5 MCP procs per turn.
-    this.proc = spawn(nodeBin, args, { cwd: sessionDir, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
+    this.proc = spawn(nodeBin, args, { cwd: spawnCwd, env, stdio: ["pipe", "pipe", "pipe"], detached: true });
     this.events = []; this.responses = []; this.stderr = ""; this._b = ""; this._w = []; this.badStdout = 0;
     this._exitCode = null;
     // C-12: monotonic per-message sequence number, stamped on every parsed

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -139,9 +139,9 @@
  * (spec §9).
  */
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 import { createDbClient } from "../db.js";
 import { jobLockFor } from "./routes/board-lock.js";
@@ -395,6 +395,13 @@ export function createInteractiveEngine({
       /** Operator-set name, persisted on the row. NULL means "no name", and
        *  every render falls back to the short session id. */
       label: null,
+      /** Open-anywhere B4: the session's working directory. NULL until the
+       *  first startChild resolves it (world.cwd), or an operator chooses one
+       *  via spawn({cwd}) / control({cwd}). It is pi's process cwd, the dir
+       *  added to write_paths, and where the per-bot .mcp.json lives — but the
+       *  world root (sessionDir) keeps storage duty (sessions/outputs/uploads).
+       *  Persisted on the row so a wake after restart runs in the same place. */
+      cwd: null,
       // Track 3 Task 4: binds at wake, never applied to a live child (pi's
       // permission policy is fixed via env at spawn time). Reset to
       // "guarded" on every adoptRow (gateway restart) — see adoptRow's
@@ -473,6 +480,10 @@ export function createInteractiveEngine({
       label: s.label || null,
       permissionMode: s.permissionMode,
       planMode: s.planMode,
+      // Open-anywhere B4: the effective working directory (world.cwd, set by
+      // startChild; null until the first spawn/wake). The Session/Files tabs
+      // and the launcher read it to show where the bot actually runs.
+      cwd: s.cwd || null,
       // I3 (final review): neither stateEvent() nor snapshot() used to
       // expose whether a turn is actually in flight, and drawer.js's
       // bd.turnInFlight was set only by the SENDING tab — so on the primary
@@ -541,6 +552,7 @@ export function createInteractiveEngine({
       label: s.label || null,
       permissionMode: s.permissionMode,
       planMode: s.planMode,
+      cwd: s.cwd || null,
       // I3 (final review): same addition, same reasoning, as snapshot()
       // above — see its comment.
       turnInFlight: !!s.turn,
@@ -684,7 +696,7 @@ export function createInteractiveEngine({
           sql:
             "UPDATE bot_sessions SET kind='perch-live', gateway_type='perch', status=?, control=?, " +
             "card_id=?, project_id=COALESCE(?, project_id), pi_session_dir=COALESCE(?, pi_session_dir), " +
-            "model=COALESCE(?, model), updated_at=datetime('now') " +
+            "model=COALESCE(?, model), cwd=COALESCE(?, cwd), updated_at=datetime('now') " +
             "WHERE id=(SELECT id FROM bot_sessions WHERE bot_id=? AND gateway_thread_id=? ORDER BY id DESC LIMIT 1)",
           // Track 3 Task 6: card_id is COALESCE-free — this row is owned
           // entirely by this engine session (never shared with a bridge.mjs
@@ -698,16 +710,23 @@ export function createInteractiveEngine({
           // was measurably unobservable (a mutation turning it into a COALESCE
           // left the whole suite green), so it is one writer, not two that have
           // to agree.
-          args: [status, control, s.cardId, s.projectId, piSessionDir, model, s.botId, s.threadId],
+          // Open-anywhere B4: `cwd` is COALESCE'd like model/pi_session_dir —
+          // the engine owns this row, so every write carries the effective
+          // working directory (s.cwd, resolved by startChild). COALESCE means a
+          // pre-spawn write (s.cwd null) never erases a directory a prior wake
+          // or control({cwd}) stamped. writeCwd() is the targeted single-column
+          // writer for a control() change (no status restamp), exactly as
+          // writeModel() is for the model column.
+          args: [status, control, s.cardId, s.projectId, piSessionDir, model, s.cwd || null, s.botId, s.threadId],
         },
         {
           sql:
-            "INSERT INTO bot_sessions (bot_id,gateway_type,gateway_thread_id,kind,status,control,card_id,project_id,pi_session_dir,model) " +
-            "SELECT ?,'perch',?,'perch-live',?,?,?,?,?,? " +
+            "INSERT INTO bot_sessions (bot_id,gateway_type,gateway_thread_id,kind,status,control,card_id,project_id,pi_session_dir,model,cwd) " +
+            "SELECT ?,'perch',?,'perch-live',?,?,?,?,?,?,? " +
             "WHERE NOT EXISTS (SELECT 1 FROM bot_sessions WHERE bot_id=? AND gateway_thread_id=?)",
           // A row this INSERT mints is brand new and cannot have a name yet;
           // label defaults to NULL and writeLabel() owns it from there.
-          args: [s.botId, s.threadId, status, control, s.cardId, s.projectId, piSessionDir, model, s.botId, s.threadId],
+          args: [s.botId, s.threadId, status, control, s.cardId, s.projectId, piSessionDir, model, s.cwd || null, s.botId, s.threadId],
         },
       ]);
       const { rows } = await db.execute({
@@ -763,6 +782,36 @@ export function createInteractiveEngine({
       });
     } catch (e) {
       log(s.sessionId + ": model not persisted (non-fatal): " + ((e && e.message) || e));
+    } finally {
+      try { db.close(); } catch { /* already closed */ }
+    }
+  }
+
+  /** Persist the operator's chosen working directory for this session.
+   *
+   * Open-anywhere B4. Targeted UPDATE by row id — the same shape and rationale
+   * as writeModel(): a cwd change must NOT restamp `status` or reset `control`
+   * to 'run' (writeRow does both), so it gets its own single-column writer.
+   * The in-memory s.cwd is the operative state startChild reads at the next
+   * wake; the row is what carries the choice across a gateway restart
+   * (adoptRow restores it). Non-fatal — a failed write leaves the in-memory
+   * choice intact for this process's lifetime.
+   *
+   * A session with no row yet (rowId null) has nothing to persist to; unlike
+   * writeLabel this is a silent no-op rather than a throw, because control({cwd})
+   * on the awake path is immediately followed by hibernate() → writeRow, which
+   * stamps s.cwd then, and the hibernating path's next wake reads the in-memory
+   * s.cwd. So the choice is never lost; it just rides the next writeRow. */
+  async function writeCwd(s) {
+    if (s.rowId == null) return;
+    const db = createDbClient();
+    try {
+      await db.execute({
+        sql: "UPDATE bot_sessions SET cwd=?, updated_at=datetime('now') WHERE id=?",
+        args: [s.cwd || null, s.rowId],
+      });
+    } catch (e) {
+      log(s.sessionId + ": cwd not persisted (non-fatal): " + ((e && e.message) || e));
     } finally {
       try { db.close(); } catch { /* already closed */ }
     }
@@ -857,7 +906,7 @@ export function createInteractiveEngine({
     try {
       const { rows } = await db.execute({
         sql:
-          "SELECT id, bot_id, gateway_thread_id, status, model, pi_session_id, project_id, card_id, label " +
+          "SELECT id, bot_id, gateway_thread_id, status, model, pi_session_id, project_id, card_id, label, cwd " +
           "FROM bot_sessions WHERE gateway_thread_id=? AND kind='perch-live' ORDER BY id DESC LIMIT 1",
         args: [sessionId],
       });
@@ -868,6 +917,11 @@ export function createInteractiveEngine({
       s.piSessionId = row.pi_session_id || null;
       s.projectId = row.project_id == null ? null : Number(row.project_id);
       s.cardId = row.card_id == null ? null : Number(row.card_id);
+      // Open-anywhere B4: restore the operator's chosen working directory so a
+      // wake after a gateway restart runs pi in the SAME dir (startChild passes
+      // s.cwd into buildBotWorld, which resolves cwd || sessionDir). NULL means
+      // no explicit choice — the world builder keeps its own resolution.
+      s.cwd = row.cwd || null;
       // Unlike permissionMode just below, the label IS restored: it is a name
       // the operator chose, carries no authority, and losing it on every
       // gateway restart would make renaming pointless.
@@ -1175,7 +1229,7 @@ export function createInteractiveEngine({
     // board MCP entry whatever the def's own tool selection says.
     const world = await buildWorldSerialized(S, {
       botId: s.botId, threadId: s.threadId, gatewayType: "perch", log: slog,
-      cardBound: s.cardId != null,
+      cardBound: s.cardId != null, cwd: s.cwd || null,
     });
     // Acceptance F4: narrate the rebuild for the drawer (spawn, wake and
     // cycle all come through here). The world itself does not expose what
@@ -1189,6 +1243,13 @@ export function createInteractiveEngine({
     s.tasksDbPath = world.tasksDbPath;
     s.projectSpace = world.projectSpace;
     s.projectMembers = world.projectMembers;
+    // Open-anywhere B4: the world builder resolved the effective working
+    // directory (the operator's choice if one was passed, else the world root).
+    // Record it as the session's truth so snapshot()/stateEvent() report where
+    // pi actually runs, even for a default session. world.cwd is always set by
+    // the real builder (B2); the `|| world.sessionDir` guard keeps a test seam
+    // that returns no cwd from poisoning s.cwd with undefined.
+    s.cwd = world.cwd || world.sessionDir || null;
     // Track 3 Task 4 (wake fidelity, review finding 8): if the engine tracks a
     // model different from what prepareSpawn just resolved fresh (a live
     // model_select or a control() switch made while this session was awake or
@@ -1251,6 +1312,10 @@ export function createInteractiveEngine({
     const resume = (world.session && world.session.pi_session_id) || s.piSessionId || null;
     const pi = new S.PiRpc(Object.assign({}, prep.piRpcOpts, {
       piSessionId: resume,
+      // Open-anywhere B3/B4: pi's process cwd is the operator's chosen dir.
+      // Undefined when a test seam returns no world.cwd — PiRpc then falls back
+      // to its own sessionDir, byte-identical to before.
+      cwd: world.cwd || undefined,
       onEvent: (m) => onChildEvent(s, m),
       // The ONE thing the interactive engine adds to a bot's spawn: pi-lab's
       // ask-user ctx.ui unlock (PL-3). C-12's spawn_env hygiene guarantees a
@@ -1263,7 +1328,13 @@ export function createInteractiveEngine({
       permissionMode: s.permissionMode,
       // Track 3 Task 6 (Task 3's extraWritePaths option): the child's ONLY
       // confined write target for deliverables it wants the operator to see.
-      extraWritePaths: [outputsDir],
+      // Open-anywhere decision 2: when the operator CHOSE a working directory
+      // (world.cwd differs from the world root), it is added too so the bot can
+      // do real work there like bare pi did. A DEFAULT session (cwd === the
+      // world root) keeps its exact pre-change write_paths — no widening.
+      extraWritePaths: (world.cwd && world.cwd !== world.sessionDir)
+        ? [outputsDir, world.cwd]
+        : [outputsDir],
     }));
     s.pi = pi;
     s.piSessionId = resume;
@@ -1651,7 +1722,7 @@ export function createInteractiveEngine({
 
   // ---- public surface ------------------------------------------------------
 
-  async function spawn({ botId, cardId = null }) {
+  async function spawn({ botId, cardId = null, cwd = null }) {
     if (!botId) throw engineError("bad_request");
     const S = await loadSeams();
     const cid = cardId == null ? null : Number(cardId);
@@ -1667,6 +1738,11 @@ export function createInteractiveEngine({
     // the card claim) ----
     const threadId = "perchlive-" + randomUUID().slice(0, 8);
     const s = newSession(String(botId), threadId);
+    // Open-anywhere B4: store the operator's chosen working directory before
+    // startChild so the world builder resolves it (buildBotWorld validates it
+    // hard and throws bad_cwd on a non-directory; the route maps that to 400).
+    // NULL = no explicit choice — the world builder keeps its own resolution.
+    s.cwd = cwd || null;
     // Track 3 Task 7: added to `sessions` BEFORE the reservation attempt, not
     // after — reserveWithEviction's eviction path awaits the victim's
     // hibernate() before this call resumes, and a concurrent second caller's
@@ -1964,18 +2040,32 @@ export function createInteractiveEngine({
     const hasThinking = opts.thinking != null;
     const hasPermissionMode = opts.permissionMode != null;
     const hasPlanMode = Object.prototype.hasOwnProperty.call(opts, "planMode");
+    // Open-anywhere B4: like `model`, an explicit cwd is keyed on presence
+    // (undefined = "not in this request"), so a caller can send cwd without
+    // disturbing the other controls.
+    const hasCwd = opts.cwd !== undefined;
 
     // Model/thinking/planMode switches share the one child clock a turn
     // already owns (commandSince/promptAckOnly ride the SAME correlated
     // response stream promptTurn does) — refused mid-turn rather than racing
     // it. permissionMode never touches the live child, so it alone is never
     // refused here.
-    if ((hasModel || hasThinking || hasPlanMode) && s.turn) throw engineError("turn_in_progress");
+    if ((hasModel || hasThinking || hasPlanMode || hasCwd) && s.turn) throw engineError("turn_in_progress");
 
     if (hasModel && opts.model !== null && (!opts.model.provider || !opts.model.modelId)) throw engineError("bad_request");
     if (hasThinking && !THINKING_LEVELS.has(opts.thinking)) throw engineError("bad_request");
     if (hasPermissionMode && !PERMISSION_MODES.has(opts.permissionMode)) throw engineError("bad_request");
     if (hasPlanMode && typeof opts.planMode !== "boolean") throw engineError("bad_request");
+    // Open-anywhere B4: validate the cwd exactly like the route does (C1) —
+    // non-empty absolute path that exists and is a directory. The engine is
+    // the second gate (buildBotWorld is the third); a bad value is a 400-class
+    // bad_request, never a persisted poison pill that every wake replays.
+    if (hasCwd) {
+      const c = opts.cwd;
+      let ok = typeof c === "string" && c.length > 0 && isAbsolute(c);
+      if (ok) { try { ok = statSync(c).isDirectory(); } catch { ok = false; } }
+      if (!ok) throw engineError("bad_request");
+    }
 
     const S = await loadSeams();
     const applied = {};
@@ -2096,6 +2186,24 @@ export function createInteractiveEngine({
       // — `applied.planMode` here only echoes the requested on/off intent,
       // confirming the ack succeeded, not the full state object.
       applied.planMode = opts.planMode;
+    }
+
+    if (hasCwd) {
+      // Open-anywhere B4: a cwd change can NEVER apply to a live child — pi's
+      // process cwd is fixed at spawn (there is no live chdir). So an awake
+      // session is hibernated; the next message() wakes it in the new directory
+      // with a fresh pi context there (the operator sees exactly that in the log
+      // frame). Persist the choice first (targeted writeCwd — no status
+      // restamp), report it under bindsAtWake like permissionMode, and run LAST
+      // among the controls so a combined control({planMode, cwd}) never
+      // hibernates the child out from under the planMode branch above.
+      const dir = opts.cwd;
+      s.cwd = dir;
+      await writeCwd(s);
+      applied.cwd = dir;
+      bindsAtWake.cwd = dir;
+      if (s.pi) await hibernate(s);
+      emit(s, { type: "log", text: "working directory → " + dir + " — resumes there on the next message" });
     }
 
     emit(s, stateEvent(s));

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -37,9 +37,12 @@ import {
   ftruncateSync,
   writeSync,
   createReadStream,
+  readdirSync,
+  statSync,
   constants as fsConstants,
 } from "node:fs";
-import { basename, extname, join, sep } from "node:path";
+import { homedir } from "node:os";
+import { basename, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
 import { jsonError } from "./_error.js";
 import { openAuthedStream } from "../streams/authed-stream.js";
 import { resolveEngineStatus } from "../dashboard/panels/bot-builder/engine-gate.js";
@@ -135,6 +138,10 @@ const ERROR_MAP = {
   // Track 3 Task 9 additions.
   card_occupied: [409, "card_occupied"],
   no_session_dir: [409, "no_session_dir"],
+  // Open-anywhere C1: spawn/control with a cwd that is not an existing
+  // directory. The route validates first (400 bad_cwd); buildBotWorld is the
+  // belt-and-braces second gate and throws the same typed code.
+  bad_cwd: [400, "bad_cwd"],
   cycle_busy: [409, "cycle_busy"],
   // control({planMode}) on a hibernating session (perch-interactive.js's own
   // `if (!s.pi) throw engineError("not_awake")` — plan mode always needs a
@@ -271,6 +278,56 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
     return typeof engine === "function" ? engine() : engine;
   }
 
+  // ---- GET /browse — server-backed directory listing for the launcher's
+  // "open anywhere" picker (open-anywhere C1). Directory NAMES + paths only,
+  // NEVER file contents, never file entries. Behind the same dashboardAuth as
+  // every perch-api route (router.use(P, dashboardAuth) above) and NOT in
+  // PUBLIC_FUNNEL_PREFIXES — the network invariant holds: private routes are
+  // never funnel-reachable. The dashboard operator IS the machine owner, so
+  // this is a picker, not a trust boundary.
+  router.get(P + "/browse", (req, res) => {
+    try {
+      const q = req.query.path;
+      const raw = (q == null || q === "") ? homedir() : String(q);
+      // Expand a leading ~ (the shell idiom an operator pastes).
+      const expanded = raw === "~" ? homedir()
+        : raw.startsWith("~/") ? join(homedir(), raw.slice(2))
+        : raw;
+      // resolve() collapses any `..`/`.` harmlessly; the result is always
+      // absolute, so traversal in the query can't escape into a relative read.
+      const target = resolve(expanded);
+      let real;
+      try { real = realpathSync(target); } catch { return jsonError(res, 404, "unreadable"); }
+      let entries;
+      try { entries = readdirSync(real, { withFileTypes: true }); }
+      catch { return jsonError(res, 404, "unreadable"); }
+      const dirs = [];
+      for (const e of entries) {
+        // Keep directories; follow a symlink only when it resolves to a real
+        // directory (statSync on the joined path), skipping one that errors or
+        // lands on a file — never leak a file entry, never throw on a broken link.
+        let isDir = false;
+        if (e.isDirectory()) isDir = true;
+        else if (e.isSymbolicLink()) {
+          try { isDir = statSync(join(real, e.name)).isDirectory(); } catch { isDir = false; }
+        }
+        if (isDir) dirs.push({ name: e.name, path: join(real, e.name) });
+      }
+      // Dot-dirs kept but sorted last; alphabetical within each group. Cap 500
+      // so a huge home dir can't balloon the response.
+      dirs.sort((a, b) => {
+        const ad = a.name.startsWith("."), bd = b.name.startsWith(".");
+        if (ad !== bd) return ad ? 1 : -1;
+        return a.name.localeCompare(b.name);
+      });
+      // `parent` is derived from the RESOLVED realpath (not the raw input) so
+      // `..` navigation out of a symlinked dir doesn't ping-pong.
+      res.json({ path: real, parent: dirname(real), dirs: dirs.slice(0, 500) });
+    } catch (err) {
+      mapEngineError(res, err);
+    }
+  });
+
   // ---- POST /bots/:id/interactive — spawn a long-lived session ----
   router.post(P + "/bots/:id/interactive", async (req, res) => {
     const botId = String(req.params.id);
@@ -287,8 +344,23 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
       const def = row ? parseDef(row) : {};
       if (!perchAttached(def)) return jsonError(res, 403, "perch_not_attached");
 
+      // Open-anywhere C1: an optional { cwd } points the session at an
+      // operator-chosen directory. Validate here (the route is the first gate;
+      // buildBotWorld is the second) — absolute, existing, a directory — else
+      // 400 bad_cwd. An absent/empty cwd means "the bot's default" and is
+      // never sent to the engine.
+      const body = req.body && typeof req.body === "object" ? req.body : {};
+      let cwd = null;
+      if (body.cwd != null && body.cwd !== "") {
+        const c = String(body.cwd);
+        let ok = isAbsolute(c);
+        if (ok) { try { ok = statSync(c).isDirectory(); } catch { ok = false; } }
+        if (!ok) return jsonError(res, 400, "bad_cwd");
+        cwd = c;
+      }
+
       const eng = resolveEngine();
-      const result = await eng.spawn({ botId });
+      const result = await eng.spawn({ botId, cwd });
       res.status(201).json(result);
     } catch (err) {
       mapEngineError(res, err);
@@ -621,6 +693,11 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
     if (body.thinking != null) opts.thinking = body.thinking;
     if (body.permission_mode != null) opts.permissionMode = body.permission_mode;
     if (Object.prototype.hasOwnProperty.call(body, "plan_mode")) opts.planMode = body.plan_mode;
+    // Open-anywhere C1: forward an explicit cwd to control() — the engine
+    // validates it (absolute/existing/directory → bad_request) and hibernates
+    // an awake child so the next message wakes in the new dir. Keyed on
+    // presence, like plan_mode, so a body without cwd leaves it untouched.
+    if (Object.prototype.hasOwnProperty.call(body, "cwd")) opts.cwd = body.cwd;
     try {
       const eng = resolveEngine();
       const result = await eng.control(sid, opts);

--- a/tests/bot-world.test.js
+++ b/tests/bot-world.test.js
@@ -69,6 +69,18 @@ writeFileSync(process.env.PI_MODELS_JSON, JSON.stringify({
   providers: { stub: { models: [{ id: "m1" }] } },
 }));
 
+// mcp_writer pins CANONICAL_MCP_PATH = $HOME/.pi/agent/mcp.json at MODULE LOAD
+// (the bridge import below triggers it). buildBotWorld's writeBotMcp throws —
+// non-fatally, caught — when that canonical is unreadable, so the golden legs
+// (which never assert the file) pass either way, but B2's placement assertion
+// needs writeBotMcp to actually SUCCEED. A clean CI runner has no pi installed
+// there. Point HOME at a scratch dir carrying a minimal valid canonical BEFORE
+// the import so the write is deterministic and hermetic. Isolated: node --test
+// runs each file in its own process, so this never leaks to another suite.
+process.env.HOME = join(dir, "fakehome");
+mkdirSync(join(process.env.HOME, ".pi", "agent"), { recursive: true });
+writeFileSync(join(process.env.HOME, ".pi", "agent", "mcp.json"), JSON.stringify({ mcpServers: {} }));
+
 // Skills must resolve inside the SCRATCH crowHome: skill_resolver falls back to
 // ~/.crow/skills and ~/crow/skills, whose contents differ per host — the
 // sysFile sha would not be reproducible in CI.

--- a/tests/bot-world.test.js
+++ b/tests/bot-world.test.js
@@ -422,3 +422,57 @@ test("GOLDEN: job_runner.runJob spawn (the second bridge consumer)", async () =>
   assert.equal(r.sessionId, "golden-uuid");
   check("runjob", readCapture());
 });
+
+// ---------------------------------------------------------------------------
+// Open-anywhere B2 — the cwd / world-root split (buildBotWorld direct units).
+// The golden legs above ARE the byte-identity guard for callers that pass no
+// cwd (every leg's spawn surface is unchanged); these cover the new seam.
+// ---------------------------------------------------------------------------
+
+test("B2: an explicit cwd is honored and returned; the world root keeps storage duty", async () => {
+  const { buildBotWorld } = await import("../scripts/pi-bots/bot-world.mjs");
+  const chosen = mkdtempSync(join(dir, "chosen-"));
+  const world = await buildBotWorld({ botId: "goldenbot", threadId: "b2-cwd", gatewayType: "perch", cwd: chosen });
+  assert.equal(world.cwd, chosen, "cwd is the operator's chosen directory");
+  assert.equal(world.sessionDir, join(dir, "bots", "goldenbot"), "world root is unchanged by a chosen cwd");
+  assert.ok(existsSync(join(chosen, ".mcp.json")),
+    ".mcp.json is written at the chosen cwd — pi-lab's mcp-client reads cwd/.mcp.json, so anywhere else silently strips every MCP tool");
+  assert.ok(existsSync(join(dir, "bots", "goldenbot", "sessions")),
+    "sessions/ is minted under the WORLD root");
+  assert.ok(!existsSync(join(chosen, "sessions")),
+    "no sessions/ dir littering the operator's chosen directory");
+});
+
+test("B2: a bad cwd is refused as bad_cwd, before any side effect", async () => {
+  const { buildBotWorld } = await import("../scripts/pi-bots/bot-world.mjs");
+  await assert.rejects(
+    () => buildBotWorld({ botId: "goldenbot", threadId: "b2-bad-rel", cwd: "relative/path" }),
+    (e) => e.code === "bad_cwd", "relative path refused");
+  await assert.rejects(
+    () => buildBotWorld({ botId: "goldenbot", threadId: "b2-bad-missing", cwd: join(dir, "does-not-exist") }),
+    (e) => e.code === "bad_cwd", "nonexistent path refused");
+  const filePath = join(dir, "b2-a-file.txt");
+  writeFileSync(filePath, "not a directory");
+  await assert.rejects(
+    () => buildBotWorld({ botId: "goldenbot", threadId: "b2-bad-file", cwd: filePath }),
+    (e) => e.code === "bad_cwd", "a file is not a directory");
+});
+
+test("B2: no session_dir + no project space falls back to <crowHome>/pi-bots/<botId> instead of throwing", async () => {
+  const { buildBotWorld } = await import("../scripts/pi-bots/bot-world.mjs");
+  const botId = "homelessbot";
+  const c = new Database(DB_FILE);
+  c.prepare("INSERT OR REPLACE INTO pi_bot_defs (bot_id, display_name, definition, enabled) VALUES (?,?,?,?)")
+    .run(botId, "Homeless Bot", JSON.stringify({
+      system_prompt: "You are a test bot.",
+      models: { default: "stub/m1" },
+      tools: { pi_builtin: ["read"] },
+      // deliberately no session_dir, no project binding
+    }), 1);
+  c.close();
+  const world = await buildBotWorld({ botId, threadId: "b2-fallback", gatewayType: "perch" });
+  const expected = join(process.env.CROW_HOME, "pi-bots", botId);
+  assert.equal(world.sessionDir, expected, "the old no_session_dir refusal is now a fallback world root");
+  assert.equal(world.cwd, expected, "cwd defaults to the world root");
+  assert.ok(existsSync(join(expected, "sessions")), "fallback root is mkdir'd");
+});

--- a/tests/bot-world.test.js
+++ b/tests/bot-world.test.js
@@ -476,3 +476,46 @@ test("B2: no session_dir + no project space falls back to <crowHome>/pi-bots/<bo
   assert.equal(world.cwd, expected, "cwd defaults to the world root");
   assert.ok(existsSync(join(expected, "sessions")), "fallback root is mkdir'd");
 });
+
+test("B3: PiRpc spawns pi in opts.cwd; no cwd keeps the world root; --session-dir never follows the cwd", async () => {
+  const { PiRpc } = await import("../scripts/pi-bots/bridge.mjs");
+  const stub = join(dir, "b3-stub.mjs");
+  writeFileSync(stub, [
+    'import { writeFileSync } from "node:fs";',
+    'writeFileSync(process.env.B3_REPORT, JSON.stringify({ cwd: process.cwd(), argv: process.argv.slice(2) }));',
+    'process.exit(0);',
+  ].join("\n"));
+  const def = {
+    system_prompt: "x", models: { default: "stub/m1" },
+    tools: { pi_builtin: ["read"] },
+    permission_policy: { bash: "deny", write_paths: [] },
+  };
+  async function spawnRecord(tag, opts) {
+    const report = join(dir, `b3-report-${tag}.json`);
+    const pi = new PiRpc(Object.assign({
+      def,
+      resolved: { provider: "stub", model: "m1" },
+      nodeBin: process.execPath,
+      cliPath: stub,
+      extraEnv: { B3_REPORT: report },
+    }, opts));
+    for (let i = 0; i < 100 && !existsSync(report); i++) await new Promise((r) => setTimeout(r, 50));
+    try { await pi.close(); } catch {}
+    return JSON.parse(readFileSync(report, "utf8"));
+  }
+
+  const chosen = mkdtempSync(join(dir, "b3-chosen-"));
+  const worldRoot = join(dir, "b3-world");
+  mkdirSync(worldRoot, { recursive: true });
+
+  const withCwd = await spawnRecord("cwd", { sessionDir: worldRoot, cwd: chosen });
+  assert.equal(withCwd.cwd, chosen, "pi's process cwd is the operator's chosen directory");
+  const sd = withCwd.argv.indexOf("--session-dir");
+  assert.ok(sd >= 0, "--session-dir is still pinned");
+  assert.equal(withCwd.argv[sd + 1], join(worldRoot, "sessions"),
+    "pi session files stay in the WORLD root, never the chosen directory");
+
+  const noCwd = await spawnRecord("default", { sessionDir: worldRoot });
+  assert.equal(noCwd.cwd, worldRoot, "no opts.cwd → spawn cwd is the world root (byte-identical for every channel caller)");
+  assert.equal(noCwd.argv[noCwd.argv.indexOf("--session-dir") + 1], join(worldRoot, "sessions"));
+});

--- a/tests/init-db-bot-tables.test.js
+++ b/tests/init-db-bot-tables.test.js
@@ -29,6 +29,7 @@ test("bot_sessions exists with model + escalated columns", () => {
   const c = cols("bot_sessions");
   assert.ok(c.includes("model"));
   assert.ok(c.includes("escalated"));
+  assert.ok(c.includes("cwd"), "cwd (the operator-chosen working directory, open-anywhere B1)");
 });
 
 test("bot_skill_events exists with action column", () => {
@@ -141,6 +142,7 @@ test("bot_sessions pre-existing WITHOUT kind: re-running init-db.js adds it", ()
       // exactly here, on the hosts least able to afford it.
       assert.ok(postCols.includes("narrowed_tools"), "narrowed_tools must be added too");
       assert.ok(postCols.includes("label"), "label (the session name) must be added too");
+      assert.ok(postCols.includes("cwd"), "cwd (the chosen working directory) must be added too");
       assert.ok(!post.prepare("SELECT sql FROM sqlite_master WHERE name='bot_sessions'").get().sql
         .includes("CHECK (control IN ('run','stop'))"),
         "and the control-CHECK rebuild must have run, not aborted on the new column as drift");

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -200,6 +200,11 @@ function makeBridge(opts = {}) {
         projectSpace: null,
         projectMembers: [],
         sessionDir: join(dir, "bots", args.botId),
+        // Mirror the real B2 builder: the effective working directory is the
+        // operator's choice when one was passed, else the world root. The
+        // engine reads world.cwd into s.cwd, so a spawn/control({cwd}) can be
+        // observed end-to-end through the fake seam.
+        cwd: args.cwd || join(dir, "bots", args.botId),
         tasksDbPath: join(dir, "tasks.db"),
         remoteEnabled: false,
         peerGatewayUrls: {},
@@ -1249,4 +1254,109 @@ test("R2b: an adopted session whose recorded model died falls open to the def, w
   assert.equal(rowModelOf(s.sessionId), "crow-chat/big-model",
     "the ROW keeps the choice — a temporarily disabled provider must not erase it");
   sub.off();
+});
+
+// ---------------------------------------------------------------------------
+// 9. Open-anywhere B4 — cwd is a session property: spawn, wake, adopt, control
+// ---------------------------------------------------------------------------
+
+/** A real on-disk dir under the scratch root (control() validates with statSync). */
+function workDir(name) {
+  const d = join(dir, name);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+test("B4: spawn({cwd}) runs pi in the chosen dir, makes it writable, and reports it in the snapshot", async () => {
+  const { engine, state } = makeEngine();
+  const chosen = workDir("b4-spawn-chosen");
+  const r = await engine.spawn({ botId: "botty", cwd: chosen });
+  await tick();
+  assert.equal(state.worlds[0].cwd, chosen, "the chosen dir reaches buildBotWorld");
+  const pi = state.instances[0];
+  assert.equal(pi.opts.cwd, chosen, "pi's process cwd is the chosen dir");
+  assert.ok(pi.opts.extraWritePaths.includes(chosen), "the chosen dir is added to write_paths (decision 2)");
+  assert.ok(pi.opts.extraWritePaths.some((p) => p === join(dir, "bots", "botty", "outputs", r.sessionId)),
+    "outputsDir stays writable alongside the chosen dir");
+  assert.equal((await engine.get(r.sessionId)).cwd, chosen, "snapshot reports the chosen cwd");
+});
+
+test("B4: spawn() without cwd keeps the default world root — no write_paths widening", async () => {
+  const { engine, state } = makeEngine();
+  const r = await engine.spawn({ botId: "botty" });
+  await tick();
+  const pi = state.instances[0];
+  const worldRoot = join(dir, "bots", "botty");
+  assert.equal(pi.opts.cwd, worldRoot, "default cwd is the world root");
+  assert.deepEqual(pi.opts.extraWritePaths, [join(worldRoot, "outputs", r.sessionId)],
+    "a default session's write_paths is exactly [outputsDir] — byte-identical, no widening");
+  assert.equal((await engine.get(r.sessionId)).cwd, worldRoot, "snapshot reports the effective (default) cwd");
+});
+
+test("B4: spawn({cwd}) survives a simulated restart — a fresh engine adopts the row and reports the same cwd", async () => {
+  const { engine: engineA } = makeEngine();
+  const chosen = workDir("b4-restart-chosen");
+  const s = await engineA.spawn({ botId: "botty", cwd: chosen });
+  await tick();
+  await engineA.stopAll();
+
+  const { engine: engineB } = makeEngine();
+  const snap = await engineB.get(s.sessionId);
+  assert.ok(snap, "the row is adopted");
+  assert.equal(snap.cwd, chosen, "the chosen cwd is persisted on the row and restored on adopt");
+});
+
+test("B4: control({cwd}) while hibernating binds at the next wake — the fresh PiRpc runs in the new dir", async () => {
+  const { engine, clock, state } = makeEngine();
+  const s = await spawned(engine);
+  clock.advance(600_001);
+  await tick();
+  assert.equal((await engine.get(s.sessionId)).state, "hibernating");
+
+  const chosen = workDir("b4-control-hib");
+  const r = await engine.control(s.sessionId, { cwd: chosen });
+  assert.equal(r.bindsAtWake.cwd, chosen, "reported under bindsAtWake like permissionMode");
+  assert.equal((await engine.get(s.sessionId)).cwd, chosen, "snapshot reflects the new cwd immediately");
+
+  await engine.message(s.sessionId, "wake in the new dir");
+  await tick();
+  const wakePi = state.instances[1];
+  assert.equal(wakePi.opts.cwd, chosen, "the wake's PiRpc runs in the chosen dir");
+  assert.ok(wakePi.opts.extraWritePaths.includes(chosen), "and the chosen dir is writable after the wake");
+  wakePi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+});
+
+test("B4: control({cwd}) while awake hibernates the live child (no live chdir) and logs the change", async () => {
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  assert.equal((await engine.get(s.sessionId)).state, "awake", "a healthy spawn is awake");
+  const sub = await collect(engine, s.sessionId);
+  const chosen = workDir("b4-control-awake");
+  await engine.control(s.sessionId, { cwd: chosen });
+  assert.equal((await engine.get(s.sessionId)).state, "hibernating", "pi's cwd is fixed at spawn, so the child hibernates");
+  assert.equal(state.instances[0].closed, 1, "the live child was closed");
+  assert.ok(sub.ofType("log").some((e) => /working directory/.test(e.text || "")),
+    "a visible log frame states the directory change");
+  sub.off();
+});
+
+test("B4: control({cwd}) is refused turn_in_progress while a turn is in flight", async () => {
+  const { engine, state } = makeEngine();
+  const s = await spawned(engine);
+  await engine.message(s.sessionId, "long one");
+  const chosen = workDir("b4-midturn");
+  await assert.rejects(() => engine.control(s.sessionId, { cwd: chosen }), (e) => e.code === "turn_in_progress");
+  state.instances[0].lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+});
+
+test("B4: control({cwd}) refuses a relative path, a nonexistent path, and a file — all bad_request", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  await assert.rejects(() => engine.control(s.sessionId, { cwd: "relative/path" }), (e) => e.code === "bad_request", "relative refused");
+  await assert.rejects(() => engine.control(s.sessionId, { cwd: join(dir, "does-not-exist") }), (e) => e.code === "bad_request", "nonexistent refused");
+  const filePath = join(dir, "b4-a-file.txt");
+  writeFileSync(filePath, "not a dir");
+  await assert.rejects(() => engine.control(s.sessionId, { cwd: filePath }), (e) => e.code === "bad_request", "a file is not a directory");
 });

--- a/tests/perch-interactive-dispatch.test.js
+++ b/tests/perch-interactive-dispatch.test.js
@@ -492,7 +492,7 @@ test("spawn passes cardBound to buildBotWorld: true for a card-bound spawn, fals
   assert.equal(byBot.freebot.cardBound, false, "free chat keeps the def's closed-world selection");
 });
 
-test("buildBotWorld with no def.session_dir and no project workspace throws code no_session_dir", async () => {
+test("buildBotWorld with no def.session_dir and no project workspace falls back to <crowHome>/pi-bots/<botId> (open-anywhere B2)", async () => {
   const { buildBotWorld } = await import("../scripts/pi-bots/bot-world.mjs");
   const botId = "nowhereBot";
   const c = raw();
@@ -505,10 +505,14 @@ test("buildBotWorld with no def.session_dir and no project workspace throws code
     }), 1);
   c.close();
 
-  await assert.rejects(
-    () => buildBotWorld({ botId, threadId: "perchlive-nowhere", gatewayType: "perch" }),
-    (e) => e.code === "no_session_dir"
-  );
+  // The old behavior was a typed no_session_dir refusal; the open-anywhere
+  // split gives every bot a storage root: the world root falls back to
+  // <crowHome>/pi-bots/<botId>, and cwd defaults to it.
+  const world = await buildBotWorld({ botId, threadId: "perchlive-nowhere", gatewayType: "perch" });
+  const expected = join(CROW_HOME, "pi-bots", botId);
+  assert.equal(world.sessionDir, expected, "world root falls back to <crowHome>/pi-bots/<botId>");
+  assert.equal(world.cwd, expected, "cwd defaults to the world root when unchosen");
+  assert.ok(existsSync(join(expected, "sessions")), "sessions dir minted under the fallback world root");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -21,7 +21,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, symlinkSync, lstatSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import http from "node:http";
 import Database from "better-sqlite3";
 
@@ -218,8 +218,8 @@ beforeEach(() => {
     checkCardFree: [], attachCard: [], control: [], cycle: [], options: [], rename: [],
   };
   engineImpl = {
-    async spawn({ botId, cardId }) {
-      engineCalls.spawn.push({ botId, cardId });
+    async spawn({ botId, cardId, cwd }) {
+      engineCalls.spawn.push({ botId, cardId, cwd });
       return { sessionId: "perchlive-abc", threadId: "perchlive-abc", state: "awake" };
     },
     async message(sid, text, images) {
@@ -340,7 +340,7 @@ test("POST /bots/:id/interactive 201s and passes botId through to the engine", a
   const { status, body } = await postJson("/bots/chatty/interactive", {});
   assert.equal(status, 201);
   assert.deepEqual(body, { sessionId: "perchlive-abc", threadId: "perchlive-abc", state: "awake" });
-  assert.deepEqual(engineCalls.spawn, [{ botId: "chatty", cardId: undefined }]);
+  assert.deepEqual(engineCalls.spawn, [{ botId: "chatty", cardId: undefined, cwd: null }]);
 });
 
 test("POST /bots/:id/interactive 409s engine_required before ever touching the engine", async () => {
@@ -544,7 +544,7 @@ test("POST /bots/:id/dispatch 201s, spawns with cardId, writes assigned_bot, and
   const { status, body } = await postJson("/bots/chatty/dispatch", { card_id: liveCardId, note: "please work this" });
   assert.equal(status, 201);
   assert.deepEqual(body, { sessionId: "perchlive-abc", threadId: "perchlive-abc", state: "awake" });
-  assert.deepEqual(engineCalls.spawn, [{ botId: "chatty", cardId: liveCardId }]);
+  assert.deepEqual(engineCalls.spawn, [{ botId: "chatty", cardId: liveCardId, cwd: undefined }]);
   // Fix round 1: dispatch keeps calling checkCardFree WITHOUT an exclusion —
   // a fresh spawn always mints a brand-new sessionId, so it can never
   // collide with its own not-yet-existent row.
@@ -1653,4 +1653,95 @@ test("perchAttached is imported from the shared module, not redefined locally (T
     "perch-interactive-api.js must import perchAttached from the shared module");
   assert.doesNotMatch(src, /function perchAttached\(/,
     "perch-interactive-api.js must not define its own local perchAttached — that is the duplication this task removes");
+});
+
+// ---------------------------------------------------------------------------
+// Open-anywhere C1 — GET /browse (directory names only) + spawn/control cwd
+// ---------------------------------------------------------------------------
+
+test("GET /browse lists only directories, alphabetical with dot-dirs last, echoing the resolved path", async () => {
+  const root = join(dir, "browse-root");
+  mkdirSync(join(root, "zeta"), { recursive: true });
+  mkdirSync(join(root, "alpha"), { recursive: true });
+  mkdirSync(join(root, ".hidden"), { recursive: true });
+  writeFileSync(join(root, "a-file.txt"), "not a dir");
+  const { status, body } = await getJson("/browse?path=" + encodeURIComponent(root));
+  assert.equal(status, 200);
+  assert.equal(body.path, root, "the resolved path is echoed");
+  assert.equal(body.parent, dirname(root), "parent is the resolved dir's parent");
+  assert.deepEqual(body.dirs.map((d) => d.name), ["alpha", "zeta", ".hidden"],
+    "dirs only, alphabetical, dot-dirs sorted last, no file entries");
+  assert.ok(body.dirs.every((d) => typeof d.name === "string" && typeof d.path === "string"),
+    "each entry carries name + path only — never contents");
+  assert.ok(!body.dirs.some((d) => d.name === "a-file.txt"), "a plain file is never listed");
+});
+
+test("GET /browse follows a symlink to a directory but never lists a symlink to a file", async () => {
+  const root = join(dir, "browse-sym");
+  mkdirSync(join(root, "real-dir"), { recursive: true });
+  writeFileSync(join(root, "real-file.txt"), "x");
+  symlinkSync(join(root, "real-dir"), join(root, "link-to-dir"));
+  symlinkSync(join(root, "real-file.txt"), join(root, "link-to-file"));
+  const { status, body } = await getJson("/browse?path=" + encodeURIComponent(root));
+  assert.equal(status, 200);
+  const names = body.dirs.map((d) => d.name);
+  assert.ok(names.includes("link-to-dir"), "a symlink resolving to a directory is listed");
+  assert.ok(!names.includes("link-to-file"), "a symlink to a file is never listed");
+  assert.ok(!names.includes("real-file.txt"), "a plain file is never listed");
+});
+
+test("GET /browse collapses .. traversal via resolve", async () => {
+  const root = join(dir, "browse-dotdot", "child");
+  mkdirSync(root, { recursive: true });
+  const { status, body } = await getJson("/browse?path=" + encodeURIComponent(join(root, "..")));
+  assert.equal(status, 200);
+  assert.equal(body.path, join(dir, "browse-dotdot"), "the .. collapsed harmlessly to the parent");
+});
+
+test("GET /browse 404s unreadable for a nonexistent path", async () => {
+  const { status, body } = await getJson("/browse?path=" + encodeURIComponent(join(dir, "no-such-dir")));
+  assert.equal(status, 404);
+  assert.equal(body.error, "unreadable");
+});
+
+test("POST /bots/:id/interactive with a real cwd validates it and passes it to the engine", async () => {
+  const chosen = join(dir, "spawn-cwd-ok");
+  mkdirSync(chosen, { recursive: true });
+  const { status } = await postJson("/bots/chatty/interactive", { cwd: chosen });
+  assert.equal(status, 201);
+  assert.equal(engineCalls.spawn[0].cwd, chosen, "the validated cwd reaches the engine");
+});
+
+test("POST /bots/:id/interactive 400s bad_cwd for a nonexistent cwd, before the engine", async () => {
+  const { status, body } = await postJson("/bots/chatty/interactive", { cwd: join(dir, "does-not-exist") });
+  assert.equal(status, 400);
+  assert.equal(body.error, "bad_cwd");
+  assert.equal(engineCalls.spawn.length, 0, "the route validates before the engine is ever called");
+});
+
+test("POST /bots/:id/interactive 400s bad_cwd for a relative cwd", async () => {
+  const { status, body } = await postJson("/bots/chatty/interactive", { cwd: "relative/path" });
+  assert.equal(status, 400);
+  assert.equal(body.error, "bad_cwd");
+  assert.equal(engineCalls.spawn.length, 0);
+});
+
+test("POST /bots/:id/interactive without cwd passes cwd:null (the bot's default)", async () => {
+  const { status } = await postJson("/bots/chatty/interactive", {});
+  assert.equal(status, 201);
+  assert.equal(engineCalls.spawn[0].cwd, null, "an absent cwd → null, never a phantom value");
+});
+
+test("POST /interactive/:sid/control forwards an explicit cwd to the engine", async () => {
+  const chosen = join(dir, "control-cwd-fwd");
+  mkdirSync(chosen, { recursive: true });
+  const { status } = await postJson("/interactive/sess-1/control", { cwd: chosen });
+  assert.equal(status, 200);
+  assert.deepEqual(engineCalls.control[0], { sid: "sess-1", opts: { cwd: chosen } });
+});
+
+test("POST /interactive/:sid/control without cwd does not add the key (presence-keyed)", async () => {
+  const { status } = await postJson("/interactive/sess-1/control", { thinking: "high" });
+  assert.equal(status, 200);
+  assert.ok(!("cwd" in engineCalls.control[0].opts), "a body without cwd leaves opts.cwd absent");
 });


### PR DESCRIPTION
Implements Phases B + C1 of `docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md` (PR2 of 3; Phase A already merged in #356/#357, C2 picker UI + Phase D tabs + Phase E deferred to PR3).

## What this adds
A Perch session's **working directory (`cwd`) is split from its world root (`sessionDir`)**. The operator can point a bot at any directory on the host; the world root keeps storage duty (pi session files, `outputs/<sid>`, uploads) so a session's deliverables never litter the chosen dir.

**Phase B — cwd plumbing (schema → world → engine):**
- **B1** `bot_sessions.cwd` — nullable TEXT, additive-only (no `SCHEMA_GENERATION` bump; `kind`/`narrowed_tools`/`label` precedent), added to the CREATE body, the guarded ALTER, and `BOT_SESSIONS_CANONICAL_COLUMNS` so the dedicated control-CHECK rebuild carries it instead of aborting on drift. NULL = 'no explicit choice'.
- **B2** `buildBotWorld({cwd})` — validates hard (absolute/existing/dir → typed `bad_cwd`) before any side effect; relocates the per-bot `.mcp.json` to the cwd (pi-lab's mcp-client reads `cwd/.mcp.json`, so writing it elsewhere would silently strip every MCP tool); `no_session_dir` throw becomes a `<crowHome>/pi-bots/<botId>` fallback; `selfAuthoringDir` stays keyed on `def.session_dir` by design (review Q1).
- **B3** `PiRpc` gains `opts.cwd` — `spawnCwd = opts.cwd || sessionDir`; `--session-dir` still points at the world root; `prepareSpawn`'s opts stay cwd-free so every channel caller is byte-identical.
- **B4** the engine carries `s.cwd` through spawn/wake/adopt/control; `writeRow` stamps `cwd=COALESCE(?,cwd)`; `writeCwd()` is the targeted single-column writer (no status restamp, like `writeModel`); the chosen dir joins `write_paths` **only when it differs from the world root** (a default session's policy stays byte-identical); `control({cwd})` validates, refuses mid-turn, persists, and hibernates an awake child (pi's cwd is fixed at spawn — no live chdir) with a visible log frame.

**Phase C1 — browse API + route gate:**
- `GET /dashboard/perch-api/browse?path=` — directory **names + paths only, never contents, never file entries**. Expands `~`, `resolve()`s (so `..` collapses harmlessly), realpaths, 404s `{error:'unreadable'}`, follows symlinks only to real dirs, dot-dirs sorted last, capped 500, `parent` from the resolved realpath. Under the same `dashboardAuth`, **not** in `PUBLIC_FUNNEL_PREFIXES` (network invariant holds — `auth-network` 20/20).
- `POST /bots/:id/interactive` accepts an optional `{cwd}` (route-validated → 400 `bad_cwd`, new `ERROR_MAP` row); `POST /interactive/:sid/control` forwards an explicit `cwd`.

## Verification (measured)
- **Full suite: 4686 tests, 0 fail.**
- New tests: B2 bot-world (4) + B3 PiRpc seam (1); B4 control-seam (7: spawn/wake/adopt/awake-hibernate/mid-turn-refusal/bad-path); C1 routes (10: browse dir-only/dot-last/symlink/traversal/unreadable + spawn/control cwd).
- Golden byte-identity guard (`tests/bot-world.test.js`) green unchanged — callers that pass no cwd produce identical spawn surfaces.
- INSERT placeholder/arg count re-verified against a live `better-sqlite3` prepare.

## Deferred to PR3
C2 (launcher directory-picker UI), Phase D (Chat/Session/Files/Activity tabs), Phase E (docs + the plan's mandated **live CDP browser walk** at 412×730 / 1280×900 and a real tool-call through a relocated `.mcp.json`). Those acceptance items need a running gateway + headless Chrome and are left for the UI PR.