### PR TITLE
Docs: backtick the bare <placeholder> tokens in the ramble guides (Deploy Docs red since they landed)

### DIFF
--- a/docs/es/guide/ramble.md
+++ b/docs/es/guide/ramble.md
@@ -133,7 +133,7 @@ La cola es por instancia: solo el Crow desde el que escribiste envía una marca,
 
 ## Regalos e intercambios
 
-Cualquier huevo sin eclosionar de tu estante — recogido de un nido o recibido de alguien — se puede **regalar** a un contacto (`POST /api/ramble/eggs/:id/gift { crow_id }`, herramienta `ramble_gift_egg`). El huevo sale de tu estante como `gifted` y llega al suyo como `received`, aún sin eclosionar: el cable solo lleva `{ egg_id, warmth, found_cell, found_week }`, nunca una especie ni una semilla — quien lo haga eclosionar tira el pájaro. Un huevo recibido se muestra como "Un regalo · de <nombre>" y se puede incubar, regalar de nuevo u ofrecer en un intercambio. Los huevos recibidos no ocupan ninguna de las cinco plazas de recogida. Un regalo entregado dos veces se guarda una sola vez; un huevo que diste y te devuelven simplemente vuelve a tu estante.
+Cualquier huevo sin eclosionar de tu estante — recogido de un nido o recibido de alguien — se puede **regalar** a un contacto (`POST /api/ramble/eggs/:id/gift { crow_id }`, herramienta `ramble_gift_egg`). El huevo sale de tu estante como `gifted` y llega al suyo como `received`, aún sin eclosionar: el cable solo lleva `{ egg_id, warmth, found_cell, found_week }`, nunca una especie ni una semilla — quien lo haga eclosionar tira el pájaro. Un huevo recibido se muestra como "Un regalo · de `<nombre>`" y se puede incubar, regalar de nuevo u ofrecer en un intercambio. Los huevos recibidos no ocupan ninguna de las cinco plazas de recogida. Un regalo entregado dos veces se guarda una sola vez; un huevo que diste y te devuelven simplemente vuelve a tu estante.
 
 Un **intercambio** es una oferta de uno de tus huevos por uno de los suyos (`POST /api/ramble/trades { egg_id, crow_id }`, herramienta `ramble_propose_swap`). El contacto ve la oferta en su pantalla Bandada y responde con un huevo de su elección (**Aceptar**, `POST /api/ramble/trades/:id/accept { egg_id }`) o **Rechazar**; tú puedes **Retirar** una oferta sin respuesta. Los huevos cambian de manos solo cuando el intercambio se completa — en cada lado, de forma atómica — y un huevo nombrado por una oferta abierta queda bloqueado (no se puede incubar, regalar ni ofrecer de nuevo hasta que la oferta se cierre). Las ofertas caducan a los siete días en cada lado; una oferta caducada libera el huevo. Si tu respuesta llega cuando la oferta ya caducó en su lado, responden con un rechazo y tu huevo queda libre. Aceptar y rechazar son acciones del panel (no hay herramienta MCP para ellas).
 
@@ -209,7 +209,7 @@ Cada peso de la tabla anterior es también un override de `ramble_settings`, le�
 |---|---|
 | `ramble_leave_mark` | Dejar una marca en una ubicación. |
 | `ramble_caw` | Emitir un marcador de presencia público y efímero. |
-| `ramble_query_world` | Listar marcas y caws cercanos en la celda que contiene una ubicación; cada fila lleva un `label` ("your mark", "mark by <contacto>", "mark by <nombre en el mundo> · <clave4>" o "mark by <clave8>"). |
+| `ramble_query_world` | Listar marcas y caws cercanos en la celda que contiene una ubicación; cada fila lleva un `label` ("your mark", "mark by `<contacto>`", "mark by `<nombre en el mundo>` · `<clave4>`" o "mark by `<clave8>`"). |
 | `ramble_unlock` | Desbloquear una marca bloqueada probando proximidad a su ancla. |
 | `ramble_pet_state` | Ánimo, energía, contadores semanales, pájaro activo y progreso del huevo de la mascota compañera. |
 | `ramble_egg_state` | El progreso de calor del huevo incubando y la lista de comprobación hacia la eclosión. |

--- a/docs/guide/ramble.md
+++ b/docs/guide/ramble.md
@@ -133,7 +133,7 @@ The queue is per instance: only the Crow you authored on sends a mark, a gift or
 
 ## Gifts and swaps
 
-Any unhatched egg on your shelf — claimed from a nest or received from someone — can be **gifted** to a contact (`POST /api/ramble/eggs/:id/gift { crow_id }`, tool `ramble_gift_egg`). The egg leaves your shelf as `gifted` and arrives on theirs as `received`, still unhatched: the wire carries only `{ egg_id, warmth, found_cell, found_week }`, never a species or seed — whoever hatches it rolls the bird. A received egg shows "A gift · from <name>" and can be incubated, gifted on, or offered in a swap. Received eggs do not use one of the five nest-claim spots. A gift delivered twice is stored once; an egg you gave away that comes back to you simply returns to your shelf.
+Any unhatched egg on your shelf — claimed from a nest or received from someone — can be **gifted** to a contact (`POST /api/ramble/eggs/:id/gift { crow_id }`, tool `ramble_gift_egg`). The egg leaves your shelf as `gifted` and arrives on theirs as `received`, still unhatched: the wire carries only `{ egg_id, warmth, found_cell, found_week }`, never a species or seed — whoever hatches it rolls the bird. A received egg shows "A gift · from `<name>`" and can be incubated, gifted on, or offered in a swap. Received eggs do not use one of the five nest-claim spots. A gift delivered twice is stored once; an egg you gave away that comes back to you simply returns to your shelf.
 
 A **swap** is an offer of one of your eggs for one of theirs (`POST /api/ramble/trades { egg_id, crow_id }`, tool `ramble_propose_swap`). The contact sees the offer on their Flock screen and answers with an egg of their choice (**Accept**, `POST /api/ramble/trades/:id/accept { egg_id }`) or **Decline**; you can **Withdraw** an unanswered offer. Eggs change hands only when the swap completes — on each side, atomically — and an egg named by an open offer is locked (it cannot be incubated, gifted or offered again until the offer closes). Offers lapse after seven days on each side; a lapsed offer releases the egg. If your answer arrives after the offer lapsed on their side, they reply with a decline and your egg is released. Accept and decline are panel actions (there is no MCP tool for them).
 
@@ -209,7 +209,7 @@ Every weight from the table above is also a `ramble_settings` override, read liv
 |---|---|
 | `ramble_leave_mark` | Leave a mark at a location. |
 | `ramble_caw` | Broadcast a short-lived public presence marker. |
-| `ramble_query_world` | List nearby marks and caws in the cell containing a location; each row carries a `label` ("your mark", "mark by <contact>", "mark by <world name> · <key4>", or "mark by <key8>"). |
+| `ramble_query_world` | List nearby marks and caws in the cell containing a location; each row carries a `label` ("your mark", "mark by `<contact>`", "mark by `<world name>` · `<key4>`", or "mark by `<key8>`"). |
 | `ramble_unlock` | Unlock a locked mark by proving proximity to its anchor. |
 | `ramble_pet_state` | The companion pet's mood, energy, weekly counters, active bird, and egg progress. |
 | `ramble_egg_state` | The incubating egg's warmth progress and hatch checklist. |


### PR DESCRIPTION
The **Deploy Docs** workflow has been failing on every push to main since `ramble.md` landed — the docs site has not been deploying. Pre-existing; surfaced while verifying CI for #359/#360.

**Cause:** VitePress compiles every `.md` through the Vue SFC parser, so a bare `<nombre>`/`<name>`-style placeholder in prose is an unclosed HTML element → `Element is missing end tag` (reported at compiled `es/guide/ramble.md 154:569`; the source tokens are on the gift-received line and in the `ramble_query_world` label table row).

**Fix:** wrapped each placeholder in inline-code backticks in **both** locales (the build fails fast, so `en` would have been the next red), matching the files' own `` `group:<uid>` `` idiom.

**Verification:** `cd docs && npm run build` → `✓ building client + server bundles… build complete in 7.70s` (was: hard SyntaxError).