### PR TITLE
Perch open-anywhere PR3: launcher directory picker (C2) + Chat/Session/Files/Activity tabs (D) + live walk & docs (E)

### DIFF
--- a/docs/developers/bot-engine.md
+++ b/docs/developers/bot-engine.md
@@ -103,7 +103,25 @@ Five gateway types need the engine — `gmail`, `discord`, `telegram`, `slack`, 
 
 ## Long-lived (interactive) children
 
-Every mode above assumes a child that lives for exactly one turn: spawn, one `promptTurn`, close. Perch's interactive sessions (the board's roost strip + session drawer) are the one exception — a child spawned by `servers/gateway/perch-interactive.js` stays up across many turns, hibernating (closing) when idle and waking (respawning, resuming the same pi session file) on the next message. It is assembled through the same `buildBotWorld`/`prepareSpawn` path as every other engine channel and is gated by the same `ENGINE_CHANNELS` / attach-time engine check as a `perch` gateway generally, so nothing above this section changes for it. What is specific to the long-lived shape — its own state machine, its capacity accounting against this same `PIBOT_MAX_PI` budget, its stall/abort policy, and the `PI_BOT_INTERACTIVE` env marker it alone sets — lives entirely in `perch-interactive.js`'s own header comment, since none of it is reachable outside a spawned interactive session.
+Every mode above assumes a child that lives for exactly one turn: spawn, one `promptTurn`, close. Perch's interactive sessions (the `/dashboard/perch` hub) are the one exception — a child spawned by `servers/gateway/perch-interactive.js` stays up across many turns, hibernating (closing) when idle and waking (respawning, resuming the same pi session file) on the next message. It is assembled through the same `buildBotWorld`/`prepareSpawn` path as every other engine channel and is gated by the same `ENGINE_CHANNELS` / attach-time engine check as a `perch` gateway generally, so nothing above this section changes for it. What is specific to the long-lived shape — its own state machine, its capacity accounting against this same `PIBOT_MAX_PI` budget, its stall/abort policy, and the `PI_BOT_INTERACTIVE` env marker it alone sets — lives entirely in `perch-interactive.js`'s own header comment, since none of it is reachable outside a spawned interactive session.
+
+### Open-anywhere: cwd is split from the world root
+
+A Perch session runs in **any directory the operator picks**, not only its bot's configured workspace. Two values that used to be one are now separate (`buildBotWorld` returns both):
+
+- **`cwd`** — the operator's chosen working directory (`bot_sessions.cwd`, nullable; set at spawn via `POST /bots/:id/interactive {cwd}` or mid-session via `POST /interactive/:sid/control {cwd}`). It is pi's process cwd, the directory added to the child's `write_paths` (so the bot can do real work there, like bare pi did), and where the per-bot `.mcp.json` is written — pi-lab's mcp-client reads `cwd/.mcp.json`, so an arbitrary cwd without relocating that file would silently strip every MCP tool. A bot with no configured directory at all falls back to `<crowHome>/pi-bots/<botId>` rather than refusing to spawn.
+- **world root (`sessionDir`)** — still the *storage* root: pi session files (`sessions/`), `outputs/<sid>`, and uploads. A session's deliverables never litter the chosen directory, and the existing outputs-download jail is untouched.
+
+A mid-session cwd change persists to the row and **hibernates the live child** with a visible log frame; the next message wakes in the new directory. It is never a live `chdir` (pi's process cwd is fixed at spawn). `control({cwd})` is refused with `turn_in_progress` mid-turn.
+
+Supporting endpoints (all behind the same `dashboardAuth` as every perch-api route, and **not** in `PUBLIC_FUNNEL_PREFIXES`):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /dashboard/perch-api/browse?path=` | Server-backed directory **names** + paths only (never contents) for the launcher's picker. `~` expansion, `..` collapsed via `resolve()`, realpath'd, dot-dirs last, capped 500; `parent` derived from the resolved realpath so `..` from a symlinked dir doesn't ping-pong. |
+| `GET /dashboard/perch-api/interactive/:sid/files/list` | Flat listing of the session's **outputsDir only** (never uploadsDir): dotfiles and symlinks skipped (`lstatSync`), no recursion, mtime-desc, capped 200. Downloads still go through the existing `workspace/*` fd-based `O_NOFOLLOW` jail. |
+
+The hub's chat surface is four tabs (Chat / Session / Files / Activity). Tab switching is pure visibility toggling on the client — it never touches the SSE lifecycle, which belongs to the session, not the tab. Log/tool/error frames route to the Activity rail; the Chat transcript keeps only messages, ask cards, and hard failures.
 
 ## See also
 

--- a/docs/es/guide/bot-builder.md
+++ b/docs/es/guide/bot-builder.md
@@ -52,7 +52,7 @@ Vincular los lentes a un agente es uno a uno: un dispositivo dirige un agente a 
 
 ## Perch: habla con un agente desde tu propio panel
 
-Perch es la propia **franja de percha (roost)** del tablero: una fila de aves, una por agente, encima de las tarjetas — más un **panel lateral de sesión** que se abre junto al tablero al hacer clic en una de ellas. Juntos muestran las sesiones en vivo y recientes de cada agente, sus transcripciones, y un lugar para escribirles directamente. Es nativo del tablero: nada que instalar, nada que configurar más allá de adjuntar el canal.
+Perch es la superficie de chat del propio panel para los agentes — el **hub de Perch** en `/dashboard/perch` (una entrada del nav bajo Agents). Una sola página reúne una lista de sesiones en vivo, un lanzador para iniciar una sesión nueva y el chat. El tablero también lleva una compacta **franja de percha (roost)** encima de las tarjetas que enlaza al hub. No hay nada que instalar y nada que configurar más allá de adjuntar el canal.
 
 Nada de esto queda expuesto a internet. Corre como parte de la puerta de enlace, escucha solo ahí, y solo es accesible a través del inicio de sesión de tu panel.
 
@@ -62,48 +62,52 @@ Abre el agente en el Bot Builder, ve a la pestaña **Gateways**, elige **Perch (
 
 Los turnos de Perch corren sobre el mismo motor de bots que usan Gmail y Discord, así que si el motor todavía no está instalado, Crow te ofrecerá instalarlo antes de dejarte guardar.
 
-Los agentes sin el canal adjunto también aparecen en la franja de percha, como **Observando** — puedes saltar al Bot Builder para adjuntarlos, pero no hay sesión que abrir hasta que lo hagas.
+Los agentes sin el canal adjunto aun así aparecen en la lista del hub, pero no hay sesión que abrir hasta que lo adjuntes — salta al Bot Builder para hacerlo.
 
-### 2. Encuentra al agente en la franja de percha
+### 2. Inicia una sesión — opcionalmente en cualquier directorio
 
-Abre el tablero. Cada agente adjunto es un ave con un estado y una acción principal:
+Abre el hub de Perch. El lanzador en la parte superior de la lista inicia una sesión nueva: elige el agente (cuando hay más de uno), opcionalmente elige un modelo y **opcionalmente elige un directorio de trabajo**.
 
-- **Inactivo** — sin sesión en vivo. El botón es **Enviar**: escribe un mensaje, envíalo, y arranca una sesión nueva.
-- **Esperando tu respuesta** — el agente hizo una pregunta a mitad de la sesión y está en pausa esperando tu respuesta. El botón es **Responder**.
-- **Trabajando** / **Hibernando** — hay una sesión en vivo o que se puso inactiva sola. El botón es **Abrir**.
-- **Observando** — todavía sin canal adjunto (ver paso 1). El enlace va directo al Bot Builder.
+El campo de directorio es el control de abrir-en-cualquier-lugar. Déjalo vacío y la sesión corre en el directorio predeterminado del propio agente. Llénalo — escribiendo una ruta o tocando **Explorar…**, que abre un selector alimentado por el servidor (lista solo nombres de directorios, nunca contenido de archivos) — y el agente corre *ahí*: puede leer y escribir ese directorio, y sus herramientas MCP por agente lo siguen. Así es como apuntas un agente a un checkout de proyecto real en vez de a su propio sandbox. El directorio elegido ya debe existir; el selector solo ofrece directorios que existen.
 
-Un menú desplegable en cada ave también ofrece **Hablar** (iniciar una sesión nueva aunque ya haya una abierta), **Sesiones** (elegir entre las demás sesiones recientes del agente), **Retirar** (detener la sesión en vivo) y **Configurar** (saltar al agente en el Bot Builder).
+> Perch no enjaula a un agente en un directorio en esta máquina — el selector puede alcanzar cualquier directorio que el usuario de la puerta de enlace pueda. La barrera entre agentes son las herramientas y permisos de cada uno, no el directorio. Trata al hub de Perch como el acceso por shell que es (ver [Antes de adjuntarlo](#antes-de-adjuntarlo)).
 
-### 3. El panel lateral de sesión
+Toca **Nueva sesión**. El chat se abre en la conversación.
 
-Al hacer clic en un ave — o en una insignia de sesión de una tarjeta del tablero — se abre el panel lateral: la transcripción, un cuadro para enviar un mensaje o redirigir un turno en curso, y un botón **Abortar** mientras hay un turno corriendo. La actividad de las herramientas se transmite en tiempo real, así que puedes ver qué está haciendo el agente antes de que llegue la respuesta.
+### 3. El chat: cuatro pestañas
 
-Cada sesión lleva un estado: **Despierto** mientras el agente puede recibir un mensaje ahora mismo, hibernando una vez que ha estado inactiva y se apagó sola (no se pierde nada: el siguiente mensaje la despierta de nuevo a mitad de la conversación), y **Detenido** una vez que tú o Retirar la terminaron definitivamente. Una sesión detenida no se puede volver a despertar — inicia una nueva desde **Enviar** o **Hablar** si quieres seguir hablando con ese agente de esta forma.
+El chat tiene cuatro pestañas a lo ancho de la parte inferior (teléfono) o superior (escritorio). Cambiar de pestaña nunca interrumpe la sesión — la conexión en vivo pertenece a la sesión, no a la pestaña.
+
+- **Chat** — la transcripción, un cuadro para enviar un mensaje o redirigir un turno en curso, y cualquier tarjeta de pregunta que el agente esté esperando. La actividad de herramientas y las líneas de registro *no* atiborran esta vista; van a Actividad.
+- **Sesión** — los controles de modelo, nivel de razonamiento, modo de permisos y modo de plan; el estado de la sesión; Renombrar y Cerrar; y el directorio de trabajo con un botón **Cambiar directorio**. Cambiar el directorio duerme la sesión y la despierta en el directorio nuevo con tu siguiente mensaje (el proceso de un agente no puede cambiar de directorio a mitad de ejecución) — el botón lo advierte antes de que confirmes, y se rechaza mientras hay un turno en curso.
+- **Archivos** — lo que el agente ha escrito en su directorio de resultados esta sesión, lo más reciente primero, cada fila una descarga. Esta es la carpeta de entregables propia de la sesión, no el directorio de trabajo que elegiste.
+- **Actividad** — el riel de registro/herramientas/error con marca de tiempo: qué hizo el agente, qué herramientas llamó, y cualquier nota de la puerta de enlace, para que la pestaña Chat siga siendo una conversación limpia.
+
+Cada sesión lleva un estado: **Despierto** mientras el agente puede recibir un mensaje ahora mismo, hibernando una vez que ha estado inactiva y se apagó sola (no se pierde nada: el siguiente mensaje la despierta de nuevo a mitad de la conversación, en su directorio elegido y con su modelo elegido), y **Detenido** una vez que tú o Cerrar la terminaron definitivamente. Una sesión detenida no se puede volver a despertar — inicia una nueva si quieres seguir hablando con ese agente de esta forma.
 
 Por defecto solo una sesión por agente corre a la vez, y cada sesión compite por los mismos cupos de procesamiento que usa cualquier otro turno de agente: respuestas de Gmail, respuestas de Discord, trabajos en segundo plano. Dejar una sesión despierta e inactiva por un rato largo puede hacer que esos esperen; deja que hiberne (lo hará sola) o deténla cuando termines.
 
 ### 4. Acota las herramientas de un agente para una sola sesión
 
-Abre **Envoltura y herramientas** en el panel lateral. Verás el envelope completo del agente: todas las herramientas que tiene permitidas, cada una con una casilla, además de su modelo y sus skills.
+Abre **Envoltura y herramientas** de la sesión. Verás el envelope completo del agente: todas las herramientas que tiene permitidas, cada una con una casilla, además de su modelo y sus skills.
 
 Desmarca una herramienta y queda apagada **solo para esa sesión**, a partir del siguiente mensaje. La definición del agente no se toca, y todas las demás sesiones conservan el conjunto completo. Esto es para el momento en que quieres que un agente responda sin tocar tus archivos, sin editar nada, sin salir a la red: en esta sesión, ahora mismo.
 
-Las herramientas que aparecen con un candado son las que el agente no tiene permitidas en absoluto. Ahí no se pueden activar; enlazan al Bot Builder, que es el único lugar que otorga una herramienta. El panel lateral solo puede quitar, nunca dar.
+Las herramientas que aparecen con un candado son las que el agente no tiene permitidas en absoluto. Ahí no se pueden activar; enlazan al Bot Builder, que es el único lugar que otorga una herramienta. La sesión solo puede quitar, nunca dar.
 
 ### 5. Responder una pregunta que te hace el agente
 
-Algunas skills te preguntan algo a mitad de la tarea en vez de adivinar: elegir de una lista, confirmar antes de hacer algo, escribir texto libre, o editar un bloque de texto. Eso aparece en el panel lateral como una tarjeta en lugar de la respuesta: la pregunta, y la forma de responderla. Respóndela y el agente continúa justo donde se quedó. Si una tarjeta sigue esperando tu respuesta cuando sales de la página, ahí sigue cuando vuelves a la sesión — mientras tanto, el ave muestra **Esperando tu respuesta**.
+Algunas skills te preguntan algo a mitad de la tarea en vez de adivinar: elegir de una lista, confirmar antes de hacer algo, escribir texto libre, o editar un bloque de texto. Eso aparece en la pestaña Chat como una tarjeta en lugar de la respuesta: la pregunta, y la forma de responderla. Respóndela y el agente continúa justo donde se quedó. Si una tarjeta sigue esperando tu respuesta cuando sales de la página, ahí sigue cuando vuelves a la sesión — mientras tanto, la lista del hub muestra la sesión como **esperando tu respuesta**.
 
 ### 6. Volver más tarde
 
-Recarga el tablero y el estado de percha y la sesión más reciente de cada agente adjunto siguen justo donde los dejaste — reabre el panel lateral y la transcripción, el estado en vivo y cualquier pregunta pendiente siguen ahí. Nunca tienes que buscar cuál sesión era cuál.
+Recarga el hub y las sesiones de cada agente adjunto siguen justo donde las dejaste — reabre una sesión y la transcripción, el estado en vivo, el directorio y modelo elegidos, y cualquier pregunta pendiente siguen ahí. Nunca tienes que buscar cuál sesión era cuál.
 
 ### Antes de adjuntarlo
 
 Vale la pena saber varias cosas, porque Perch no las esconde.
 
-Cualquiera que pueda entrar a tu panel puede leer las transcripciones de **todos** los agentes en el panel lateral. No hay control de acceso por agente.
+Cualquiera que pueda entrar a tu panel puede leer las transcripciones de **todos** los agentes en el hub. No hay control de acceso por agente.
 
 Escribir o redirigir una sesión extiende eso de leer a conducir: cualquiera que pueda iniciar sesión puede sostener una conversación en vivo como cualquier agente, usando las herramientas y permisos propios de ese agente, no solo observar lo que ya hizo. No es un límite de confianza nuevo: una sesión del panel ya podía activar a un agente escribiéndole por su canal real (un correo, un mensaje de Discord). Perch solo lo hace alcanzable directamente desde el tablero, sin salir y volver por un canal.
 

--- a/docs/guide/bot-builder.md
+++ b/docs/guide/bot-builder.md
@@ -52,7 +52,7 @@ Binding glasses to an agent is one-to-one: a device drives one agent at a time, 
 
 ## Perch: talk to an agent from your own dashboard
 
-Perch is the board's own **roost strip** — a row of birds, one per agent, sitting above the cards — plus a **session drawer** that opens beside the board when you click one. Together they show every agent's live and recent sessions, their transcripts, and a place to message them directly. It is native to the board: nothing to install, nothing to configure beyond attaching the channel.
+Perch is the dashboard's own chat surface for agents — the **Perch hub** at `/dashboard/perch` (a nav entry under Agents). One page holds a live session list, a launcher to start a new session, and the chat itself. The board also carries a compact **roost strip** above the cards that links into the hub. There is nothing to install and nothing to configure beyond attaching the channel.
 
 Nothing about it is exposed to the internet. It runs as part of the gateway, listens only there, and is reachable only through your dashboard login.
 
@@ -62,48 +62,52 @@ Open the agent in Bot Builder, go to the **Gateways** tab, choose **Perch (dashb
 
 Perch turns run on the same bot engine that Gmail and Discord use, so if the engine is not installed yet Crow will offer to install it before letting you save.
 
-Agents without the channel attached appear in the roost strip too, as **Observing** — you can jump to Bot Builder to attach them, but there is no session to open until you do.
+Agents without the channel attached still appear in the hub's list, but there is no session to open until you attach them — jump to Bot Builder to do that.
 
-### 2. Find the agent in the roost strip
+### 2. Start a session — optionally in any directory
 
-Open the board. Each attached agent is a bird with a state and one primary action:
+Open the Perch hub. The launcher at the top of the list starts a new session: pick the agent (when there is more than one), optionally pick a model, and **optionally pick a working directory**.
 
-- **Idle** — no live session. The button is **Send out**: type a message, send it, and a new session starts.
-- **Waiting on you** — the agent asked a question mid-session and is paused for your answer. The button is **Answer**.
-- **Working** / **Hibernating** — a session is live or has gone quietly idle. The button is **Open**.
-- **Observing** — no channel attached yet (see step 1). The link goes straight to Bot Builder.
+The directory field is the open-anywhere control. Leave it empty and the session runs in the agent's own default directory. Fill it in — by typing a path or by tapping **Browse…**, which opens a picker fed by the server (it lists directory names only, never file contents) — and the agent runs *there*: it can read and write that directory, and its per-agent MCP tools follow it. This is how you point an agent at a real project checkout instead of its own sandbox. The chosen directory must already exist; the picker only ever offers directories that do.
 
-An overflow menu on every bird also offers **Talk** (start a fresh session even if one is already open), **Sessions** (pick from the agent's other recent sessions), **Recall** (stop the live session), and **Setup** (jump to the agent in Bot Builder).
+> Perch does not jail an agent to a directory on this machine — the picker can reach any directory the gateway user can. The barrier between agents is each one's own tools and permissions, not the directory. Treat the Perch hub like the shell access it is (see [Before you attach it](#before-you-attach-it)).
 
-### 3. The session drawer
+Tap **New session**. The chat opens on the conversation.
 
-Clicking a bird — or a session badge on a board card — opens the drawer: the transcript, a composer to send a message or steer a running turn, and an **Abort** button while a turn is in flight. Tool activity streams in as it happens, so you can see what the agent is doing before the reply lands.
+### 3. The chat: four tabs
 
-Each session carries a state: **Awake** while the agent can take a message right now, hibernating once it has gone idle and quietly shut itself down (nothing is lost — the next message wakes it back up mid-conversation), and **Stopped** once you or Recall have ended it for good. A stopped session cannot be woken again — start a new one from **Send out** or **Talk** if you want to keep talking to that agent this way.
+The chat has four tabs across the bottom (phone) or top (desktop). Switching tabs never interrupts the session — the live connection belongs to the session, not the tab.
+
+- **Chat** — the transcript, a composer to send a message or steer a running turn, and any question card the agent is waiting on. Tool activity and log lines do *not* clutter this view; they go to Activity.
+- **Session** — the model, thinking level, permission mode and plan-mode controls; the session's state; Rename and Close; and the working directory with a **Change directory** button. Changing the directory puts the session to sleep and wakes it in the new directory on your next message (an agent's process cannot change directory mid-run) — the button says so before you commit, and it is refused while a turn is in flight.
+- **Files** — what the agent has written to its outputs directory this session, newest first, each row a download. This is the session's own deliverables folder, not the working directory you chose.
+- **Activity** — the timestamped log/tool/error rail: what the agent did, which tools it called, and any gateway notes, so the Chat tab stays a clean conversation.
+
+Each session carries a state: **Awake** while the agent can take a message right now, hibernating once it has gone idle and quietly shut itself down (nothing is lost — the next message wakes it back up mid-conversation, in its chosen directory and on its chosen model), and **Stopped** once you or Close have ended it for good. A stopped session cannot be woken again — start a new one if you want to keep talking to that agent this way.
 
 Only one session per agent runs at a time by default, and every session competes for the same processing slots every other agent turn uses — Gmail replies, Discord replies, background jobs. Leaving a session awake and idle for a long stretch can make those wait; let it hibernate (it will, on its own) or stop it when you're done.
 
 ### 4. Narrow an agent's tools for one session
 
-Open **Envelope & tools** in the drawer. You see the agent's full envelope: every tool it is allowed to use, each with a checkbox, plus its model and skills.
+Open **Envelope & tools** for the session. You see the agent's full envelope: every tool it is allowed to use, each with a checkbox, plus its model and skills.
 
 Uncheck a tool and it is switched off **for that session only**, from the next message onward. The agent's definition is untouched, and every other session keeps the full set. This is for the moment when you want an agent to answer without touching your files, without editing anything, without reaching out over the network — for this one session, right now.
 
-Tools shown with a padlock are ones the agent is not allowed at all. They are not togglable here; they link to Bot Builder, which is the only place that grants a tool. The drawer can only ever take away.
+Tools shown with a padlock are ones the agent is not allowed at all. They are not togglable here; they link to Bot Builder, which is the only place that grants a tool. The session can only ever take away.
 
 ### 5. Answering a question the agent asks you
 
-Some skills ask you something mid-task instead of guessing — pick from a list, confirm before doing something, type free text, or edit a block of text. That shows up in the drawer as a card in place of the reply: the question, and the way to answer it. Answer it and the agent continues right where it left off. If a card is still waiting on you when you navigate away, it is there again when you come back to the session — the roost bird shows **Waiting on you** in the meantime.
+Some skills ask you something mid-task instead of guessing — pick from a list, confirm before doing something, type free text, or edit a block of text. That shows up on the Chat tab as a card in place of the reply: the question, and the way to answer it. Answer it and the agent continues right where it left off. If a card is still waiting on you when you navigate away, it is there again when you come back to the session — the hub's list shows the session as **waiting on you** in the meantime.
 
 ### 6. Coming back later
 
-Reload the board and every attached agent's roost state and most recent session pick up right where you left them — reopen the drawer and the transcript, live state, and any pending question are all still there. You never have to hunt for which session was which.
+Reload the hub and every attached agent's sessions pick up right where you left them — reopen a session and the transcript, live state, chosen directory and model, and any pending question are all still there. You never have to hunt for which session was which.
 
 ### Before you attach it
 
 A few things are worth knowing, because Perch does not hide them.
 
-Everyone who can sign in to your dashboard can read **every** agent's transcripts in the drawer. There is no per-agent access control.
+Everyone who can sign in to your dashboard can read **every** agent's transcripts in the hub. There is no per-agent access control.
 
 Messaging or steering a session extends that from reading to driving: anyone who can sign in can hold a live conversation as any agent, using that agent's own tools and permissions, not just watch what it already did. This is not a new trust boundary — a dashboard session could already trigger an agent by messaging it through its real channel (an email, a Discord message). Perch just makes that reachable straight from the board, without going out and back through a channel.
 

--- a/docs/reviews/2026-09-11-perch-pr356-review-completion.md
+++ b/docs/reviews/2026-09-11-perch-pr356-review-completion.md
@@ -102,3 +102,24 @@ The rushed merge did not break anything that the merged tests cover — the clie
 | R4-adjacent | openStream/loadHistory duplicate bubble race (pre-existing) | Low | separate issue — belongs to the integration-issues plan |
 
 R1 and R2 share a root: the engine grants the row's `model` column more trust than the column's writers deserve. They should ship as one change, and they are candidates to fold into the perch-hub integration issue plan (next section, awaiting Kevin's notes).
+
+---
+
+## Status footer (resolved 2026-09-12)
+
+All three findings are **closed**, shipped as Phase A of the operator-approved
+open-anywhere plan (`docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md`):
+
+| Finding | Closed by | Where |
+|---|---|---|
+| **R1** — row-stamped defaults got operator-choice authority | **PR #357** | `perch-interactive.js` A1: the `model` column means an explicit choice only (stamps dropped; `onModelSelect`→`writeModel`; revocation path clears to NULL) |
+| **R2** — well-formed dead model key: unvalidated at write, unprobed at wake | **PR #357** | A2: `control()` validates the pair against the catalogue before persisting; A3: a dead recorded model falls open at wake with a log frame naming the fallback |
+| **R4-adjacent** — openStream/loadHistory duplicate bubble | **PR #357** | A4: a message landing between subscribe and history renders once (the client's `histBuf`/`flushHistBuf` sequence-guard) |
+
+The verification checklist's mutation matrix and the two new drives (dead-provider
+wake, def-change pin) are covered by `tests/perch-interactive-controls.test.js`
+and were re-run green in PR #357 and again in the open-anywhere PR3 full suite
+(`npm test`, 4717/0). R1/R2's fail-open path was additionally walked live on a
+real gateway + real local model on 2026-09-12 (a disabled provider resumed on
+the def default with the `recorded model … is not available — resumed on …` log
+line; the row kept the dead key by design).

--- a/docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md
+++ b/docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md
@@ -7,14 +7,34 @@
 > 1. This plan: `docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md`
 > 2. The review it implements Phase A from: `docs/reviews/2026-09-11-perch-pr356-review-completion.md`
 > 3. The surface spec it slots under: `docs/superpowers/specs/2026-09-09-perch-hub-design.md`
-> Execution state: **Phases A + B + C1 SHIPPED; C2 + D + E remain.** Phase A
-> (A1–A4) merged to `main`. Phase B (B1–B4) + C1 shipped as PR2 (#360, branch
-> `feat/perch-open-anywhere`, full suite 4686/0 green). Remaining: **C2**
-> (launcher directory-picker UI), **Phase D** (Chat/Session/Files/Activity tabs),
-> **Phase E** (docs + the mandated live CDP browser walk). Resume brief:
-> `docs/superpowers/handoffs/2026-09-12-perch-open-anywhere-pr2-shipped.md`.
+> Execution state: **ALL PHASES SHIPPED.** Phase A
+> (A1–A4) merged to `main` (PR #357). Phase B (B1–B4) + C1 shipped as PR2
+> (#360, full suite 4686/0 green). **C2 + Phase D + Phase E** shipped as PR3
+> (branch `feat/perch-open-anywhere-pr3`): the launcher directory picker, the
+> Chat/Session/Files/Activity tabs, the Files-tab outputs endpoint, the full
+> `npm test` suite (4717/0), and the mandated live walk on a real gateway +
+> real local model (spawn-in-chosen-dir → file write → MCP tool call through
+> the relocated `.mcp.json` → model switch → gateway restart → adopt on the
+> switched model in the chosen dir → provider-disable fail-open → mid-turn cwd
+> refusal / idle accept) plus CDP render checks at 412×730 and 1280×900.
+> Resume brief (PR2): `docs/superpowers/handoffs/2026-09-12-perch-open-anywhere-pr2-shipped.md`.
 > Record any named deviation in the "Risk notes" section's spirit: measured, not
-> asserted. PR shape: PR 1 = Phase A (DONE), PR 2 = B+C1 (DONE #360), PR 3 = C2+D+E.
+> asserted. PR shape: PR 1 = Phase A (DONE #357), PR 2 = B+C1 (DONE #360), PR 3 = C2+D+E (DONE).
+>
+> **Named deviations (PR3), measured not asserted:** (1) The plan's E1 said
+> "switch model while hibernating"; the live walk switched while AWAKE (the
+> stronger `set_model`-the-live-child path) and proved the hibernate-bind path
+> separately via the cwd-change leg (which hibernates) + the restart-adopt leg;
+> the model `bindsAtWake` path stays covered by `perch-interactive-controls.test.js`.
+> (2) The scratch gateway's local model server (`qwen3.6-35b-a3b`) is a REASONING
+> model that spends its token budget on `reasoning_content`; a session recycled
+> 5× through repeated wakes eventually returned a dead pi child (`pi_gone`) with
+> degenerate output. A FRESH session on the same gateway wrote its file and
+> replied cleanly — environmental (model-server fatigue), not a PR3 regression.
+> (3) `docs/architecture/gateway-server.md` does not exist; the perch-interactive
+> architecture note landed in `docs/developers/bot-engine.md`'s "Long-lived
+> (interactive) children" section (its existing home) and the operator walkthrough
+> in `docs/guide/bot-builder.md`.
 
 **Status:** approved by operator 2026-09-11 (four decisions captured below)
 **Supersedes:** the directory-containment decisions of the M3 project-native workspace model *for Perch sessions*, and completes the outstanding review of PR #356 → `docs/reviews/2026-09-11-perch-pr356-review-completion.md` (findings R1, R2, R4-adjacent become Phase A).

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -258,6 +258,13 @@ export function perchHubJs(lang = "en") {
   var RENAME_PROMPT='${tJs("perch.renamePrompt", lang)}';
   var RENAME_FAILED='${tJs("perch.renameFailed", lang)}';
   var ROOST_UNREACHABLE='${tJs("perch.roostUnreachable", lang)}';
+  /* Open-anywhere C2: the directory picker's own strings. ASK_CANCEL
+     ("Cancel") doubles as the modal's visible Cancel — dismiss must never
+     depend on Escape alone (review S5). */
+  var BROWSE_TITLE='${tJs("perch.browseTitle", lang)}';
+  var CHOOSE_LABEL='${tJs("perch.choose", lang)}';
+  var BROWSE_FAILED='${tJs("perch.browseFailed", lang)}';
+  var CWD_INVALID='${tJs("perch.cwdInvalid", lang)}';
 
   /* Row identity. One bot with eight sessions renders eight rows that read
      "R4 Assistant / awake" and nothing else — measured verbatim in a browser
@@ -520,9 +527,127 @@ export function perchHubJs(lang = "en") {
        showing the previous bot's models must not choose for this spawn. */
     var msel=el('perch-new-model');
     var model=(msel&&!msel.hidden&&launchModels.botId===pick.id)?String(msel.value||''):'';
-    startSession(pick.id,pick.name,model);
+    /* Open-anywhere C2: the directory field. EMPTY means "the bot's
+       default" and the key is NEVER sent — an empty string must not reach
+       the route as a cwd it then validates and 400s. */
+    var cwdEl=el('perch-new-cwd');
+    var cwd=cwdEl?String(cwdEl.value||'').trim():'';
+    startSession(pick.id,pick.name,model,cwd||null);
   }
   el('perch-new').onclick=startNewSession;
+
+  /* ---- open-anywhere C2: the server-backed directory picker ------------
+     A modal overlay fed by GET /browse (directory NAMES + paths only, never
+     contents — routes/perch-interactive-api.js). One modal, two callers:
+     the launcher's Browse button (onChoose writes #perch-new-cwd) and, from
+     D2 on, the Session tab's "Change directory" (onChoose POSTs
+     control({cwd})). Built lazily with createElement/textContent only — the
+     house rule on innerHTML (setSanitizedHtml's comment) admits no second
+     sink, and a directory name is operator-adjacent free text. */
+  var browse={open:false,onChoose:null,path:''};
+
+  function closeBrowseModal(){
+    browse.open=false; browse.onChoose=null;
+    var m=el('perch-browse-modal'); if(m) m.hidden=true;
+  }
+
+  function buildBrowseModal(){
+    if(el('perch-browse-modal')) return;
+    var root=el('perch-hub-root'); if(!root) return;
+    var overlay=document.createElement('div'); overlay.id='perch-browse-modal'; overlay.hidden=true;
+    var box=document.createElement('div'); box.className='browse-box';
+    box.setAttribute('role','dialog'); box.setAttribute('aria-modal','true');
+    box.setAttribute('aria-label',BROWSE_TITLE);
+    var head=document.createElement('div'); head.className='browse-head';
+    var pathEl=document.createElement('div'); pathEl.className='browse-path'; pathEl.id='perch-browse-path';
+    head.appendChild(pathEl);
+    var hint=document.createElement('div'); hint.className='browse-hint'; hint.id='perch-browse-hint'; hint.hidden=true;
+    var list=document.createElement('div'); list.className='browse-list'; list.id='perch-browse-list';
+    var foot=document.createElement('div'); foot.className='browse-foot';
+    var choose=document.createElement('button'); choose.type='button'; choose.className='primary';
+    choose.id='perch-browse-choose'; choose.textContent=CHOOSE_LABEL;
+    var cancel=document.createElement('button'); cancel.type='button';
+    cancel.id='perch-browse-cancel'; cancel.textContent=ASK_CANCEL;
+    foot.appendChild(choose); foot.appendChild(cancel);
+    box.appendChild(head); box.appendChild(hint); box.appendChild(list); box.appendChild(foot);
+    overlay.appendChild(box);
+    root.appendChild(overlay);
+    /* Choose hands the CURRENT path (wherever navigation ended) to the
+       caller and closes BEFORE invoking it, so a failure note the callback
+       writes lands on a clean screen. */
+    choose.onclick=function(){
+      if(!browse.open) return;
+      var fn=browse.onChoose, p=browse.path;
+      closeBrowseModal();
+      if(fn&&p) fn(p);
+    };
+    cancel.onclick=closeBrowseModal;
+  }
+
+  function loadBrowseDir(p){
+    var q=p?('?path='+encodeURIComponent(p)):'';
+    return perchApi('GET','/browse'+q).then(function(r){
+      if(!browse.open) return;
+      var list=el('perch-browse-list'); if(!list) return;
+      if(!r.ok||!r.j||!Array.isArray(r.j.dirs)){
+        /* A failed fetch is not an empty directory: keep the rows the
+           operator can still navigate out of, and say what happened. */
+        clearEl(list); list.appendChild(line('empty',BROWSE_FAILED));
+        return;
+      }
+      browse.path=r.j.path;
+      var pathEl=el('perch-browse-path'); if(pathEl) pathEl.textContent=r.j.path;
+      clearEl(list);
+      /* The '..' row uses the RESOLVED parent the endpoint reports — never a
+         client-side string chop, which a symlinked dir would ping-pong. */
+      if(r.j.parent&&r.j.parent!==r.j.path){
+        var up=document.createElement('button'); up.type='button'; up.textContent='..';
+        up.onclick=function(){ loadBrowseDir(r.j.parent); };
+        list.appendChild(up);
+      }
+      r.j.dirs.forEach(function(d){
+        if(!d||!d.name) return;
+        var b=document.createElement('button'); b.type='button'; b.textContent=d.name;
+        b.onclick=function(){ loadBrowseDir(d.path); };
+        list.appendChild(b);
+      });
+      list.scrollTop=0;
+    });
+  }
+
+  function openBrowseModal(opts){
+    buildBrowseModal();
+    var m=el('perch-browse-modal'); if(!m) return;
+    browse.open=true;
+    browse.onChoose=(opts&&opts.onChoose)||null;
+    browse.path='';
+    var hint=el('perch-browse-hint');
+    if(hint){
+      var note=(opts&&opts.note)||'';
+      hint.textContent=note; hint.hidden=!note;
+    }
+    m.hidden=false;
+    loadBrowseDir((opts&&opts.initial)||'');
+    var c=el('perch-browse-cancel'); if(c&&c.focus) c.focus();
+  }
+
+  /* Escape closes the picker — the second dismiss path review S5 demands
+     beside the visible Cancel button. document OUTLIVES a Turbo body swap,
+     so this goes through the generation-checked registry like every other
+     window/document listener in this file. */
+  bindOnce(document,'keydown','browseEscape',function(ev){
+    if(!live()) return;
+    if(ev.key==='Escape'&&browse.open) closeBrowseModal();
+  });
+
+  var browseBtn=el('perch-browse-btn');
+  if(browseBtn) browseBtn.onclick=function(){
+    var f=el('perch-new-cwd');
+    openBrowseModal({
+      initial:f?String(f.value||'').trim():'',
+      onChoose:function(p){ var f2=el('perch-new-cwd'); if(f2) f2.value=p; }
+    });
+  };
 
   /* engine.stop() (perch-interactive.js:1955) kills the pi child and parks the
      row: TERMINAL, no resume. Hence the confirm, whose copy says so — an
@@ -597,12 +722,14 @@ export function perchHubJs(lang = "en") {
   /* A bot with no session: spawn, then let the hash router open it, so history
      stays correct and the cold-deep-link path is the same code.
      \`modelKey\` ("provider/id", optional) is the launcher's pick. A row-driven
-     spawn passes none and behaves exactly as it always has. */
-  function startSession(botId,botName,modelKey){
+     spawn passes none and behaves exactly as it always has.
+     \`cwd\` (open-anywhere C2, optional) is the launcher's directory field;
+     null means the key is never sent — the bot's default world root. */
+  function startSession(botId,botName,modelKey,cwd){
     var mySid=current.sid;                  /* identity guard: a spawn resolving after the
                                                 operator has opened another session must not
                                                 yank them out of it */
-    perchApi('POST','/bots/'+encodeURIComponent(botId)+'/interactive').then(function(r){
+    perchApi('POST','/bots/'+encodeURIComponent(botId)+'/interactive',cwd?{cwd:cwd}:undefined).then(function(r){
       if(current.sid!==mySid) return;
       /* setLaunchNote, not showListNote: a FAILED SPAWN is a fact about the
          launcher, and showListNote clears #perch-list-body — which would wipe
@@ -614,6 +741,10 @@ export function perchHubJs(lang = "en") {
          sessions. The note belongs next to the control that produced it. */
       if(r.status===409){ setLaunchNote(ENGINE_REQUIRED); return; }
       if(r.status===403){ setLaunchNote(NOT_ATTACHED); return; }
+      /* The route validated the directory before the engine ever saw it
+         (open-anywhere C1): a stale picker choice — deleted between browse
+         and spawn — lands here, and the note belongs beside the field. */
+      if(r.status===400&&r.j&&r.j.error==='bad_cwd'){ setLaunchNote(CWD_INVALID); return; }
       if(!r.ok||!r.j||!r.j.sessionId){ setLaunchNote(START_FAILED); return; }
       var sid=r.j.sessionId;
       rowIndex[sid]={botId:botId,botName:botName,sessionId:sid};

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -284,6 +284,9 @@ export function perchHubJs(lang = "en") {
   var CWD_CHANGE_NOTE='${tJs("perch.cwdChangeNote", lang)}';
   var CWD_BUSY='${tJs("perch.cwdBusy", lang)}';
   var CWD_CHANGE_FAILED='${tJs("perch.cwdChangeFailed", lang)}';
+  /* Phase D3: the Files tab. */
+  var FILES_EMPTY='${tJs("perch.filesEmpty", lang)}';
+  var FILES_FAILED='${tJs("perch.filesFailed", lang)}';
 
   /* Row identity. One bot with eight sessions renders eight rows that read
      "R4 Assistant / awake" and nothing else — measured verbatim in a browser
@@ -1606,9 +1609,8 @@ export function perchHubJs(lang = "en") {
       if(btn) btn.setAttribute('aria-selected',nm===name?'true':'false');
     });
     /* Files fetches on ACTIVATION, never on session open (D3) — the chat
-       fast path stays one less round trip. The typeof guard is temporary:
-       D3 lands loadFiles in the very next step. */
-    if(name==='files'&&typeof loadFiles==='function') loadFiles();
+       fast path stays one less round trip. */
+    if(name==='files') loadFiles();
   }
   TAB_NAMES.forEach(function(nm){
     var btn=el('perch-tab-btn-'+nm);
@@ -1653,6 +1655,41 @@ export function perchHubJs(lang = "en") {
     var shown=cwdEl?String(cwdEl.textContent||''):'';
     return (shown&&shown!==CWD_DEFAULT_TEXT)?shown:'';
   }
+
+  /* ---- Phase D3: the Files tab ------------------------------------------
+     One GET /interactive/<sid>/files/list per activation (never on session
+     open), rows linking the EXISTING workspace download route — the list
+     adds no new serving path, and the jail's O_NOFOLLOW fd discipline is
+     what makes each download safe, not anything about this markup. Rows are
+     built with createElement/textContent only: names come from a filesystem
+     a bot child can write to. */
+  function fmtSize(b){
+    b=Number(b)||0;
+    return b>1048576?(b/1048576).toFixed(1)+'M':b>1024?Math.round(b/1024)+'K':b+'B';
+  }
+  function loadFiles(){
+    var list=el('perch-files-list');
+    if(!list||!current.sid) return;
+    var mySid=current.sid;
+    perchApi('GET','/interactive/'+encodeURIComponent(mySid)+'/files/list').then(function(r){
+      if(current.sid!==mySid) return;                  /* identity guard, as everywhere */
+      clearEl(list);
+      if(!r.ok||!r.j||!Array.isArray(r.j.items)){ list.appendChild(line('empty',FILES_FAILED)); return; }
+      if(!r.j.items.length){ list.appendChild(line('empty',FILES_EMPTY)); return; }
+      r.j.items.forEach(function(it){
+        if(!it||!it.name) return;
+        var a=document.createElement('a'); a.className='file-row';
+        a.href=API+'/interactive/'+encodeURIComponent(mySid)+'/workspace/'+encodeURIComponent(it.name);
+        a.appendChild(line('file-name',it.name));
+        var meta=fmtSize(it.size);
+        try{ meta+=' \\u00b7 '+new Date(it.mtime).toLocaleString(); }catch(e){}
+        a.appendChild(line('file-meta',meta));
+        list.appendChild(a);
+      });
+    });
+  }
+  var filesRefresh=el('perch-files-refresh');
+  if(filesRefresh) filesRefresh.onclick=loadFiles;
 
   /* iOS does not shrink the layout viewport for the keyboard, so dvh alone
      leaves the composer behind it. Offset the chat column by the hidden part. */

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -112,6 +112,20 @@ export function perchHubJs(lang = "en") {
     tr.appendChild(line('entry note',text));
     tr.scrollTop=tr.scrollHeight;
   }
+  /* Phase D2: the Activity rail. Log-ish frames (log, tool starts, plan
+     state, soft error frames, the reconnect notice) land HERE, and the
+     transcript keeps only user/bot messages, ask cards and the hard
+     failures an operator must see where they read (a failed transcript
+     load, a failed send, a lost connection, a stale ask). A timestamp
+     leads each row because this rail is exactly where an operator
+     reconstructs WHEN something happened. */
+  function appendActivity(text){
+    var list=el('perch-activity-list'); if(!list) return;
+    var stamp='';
+    try{ stamp=new Date().toLocaleTimeString()+'  '; }catch(e){}
+    list.appendChild(line('activity-row',stamp+text));
+    list.scrollTop=list.scrollHeight;
+  }
   /* THE ONLY innerHTML assignment in this file, and the only one there may be.
 
      \`html\` is produced on the SERVER by servers/blog/renderer.js — marked
@@ -265,6 +279,11 @@ export function perchHubJs(lang = "en") {
   var CHOOSE_LABEL='${tJs("perch.choose", lang)}';
   var BROWSE_FAILED='${tJs("perch.browseFailed", lang)}';
   var CWD_INVALID='${tJs("perch.cwdInvalid", lang)}';
+  /* Phase D2: the Session tab's cwd readout + change flow. */
+  var CWD_DEFAULT_TEXT='${tJs("perch.cwdPlaceholder", lang)}';
+  var CWD_CHANGE_NOTE='${tJs("perch.cwdChangeNote", lang)}';
+  var CWD_BUSY='${tJs("perch.cwdBusy", lang)}';
+  var CWD_CHANGE_FAILED='${tJs("perch.cwdChangeFailed", lang)}';
 
   /* Row identity. One bot with eight sessions renders eight rows that read
      "R4 Assistant / awake" and nothing else — measured verbatim in a browser
@@ -880,6 +899,7 @@ export function perchHubJs(lang = "en") {
        list is genuinely hidden. */
     syncListPolling();
     clearEl(el('perch-transcript')); clearEl(el('perch-ask'));
+    clearEl(el('perch-activity-list'));   /* the previous session's log is not this one's */
     resetControls();                        /* the PREVIOUS session's picker must not bleed in */
     var known=rowIndex[sid];
     if(known){ showHeader(known.botId,known.botName); afterHeader(mySid,known.botId); return; }
@@ -1025,6 +1045,13 @@ export function perchHubJs(lang = "en") {
       if(modelSel&&d.model&&!modelSel.disabled) selectCurrentModel(modelSel,d.model);
       if(d.permissionMode){ var permSel=el('perch-permission'); if(permSel) permSel.value=d.permissionMode; }
       var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=!!d.planMode;
+      /* Open-anywhere D2: the Session tab's read-only cwd readout, refreshed
+         from the engine's own record on every state frame (subscribe replays
+         one on connect, so this is also how the tab learns cwd FIRST — there
+         is no separate snapshot fetch). null = the bot's default directory.
+         textContent only: the value is a filesystem path, never markup. */
+      var cwdEl=el('perch-session-cwd');
+      if(cwdEl) cwdEl.textContent=d.cwd||CWD_DEFAULT_TEXT;
     });
     /* MESSAGE-LEVEL, not delta-level (perch-interactive.js:1257 says so
        outright): one frame per COMPLETED assistant message, so each is
@@ -1039,8 +1066,8 @@ export function perchHubJs(lang = "en") {
       if(!histSettled){ histBuf.push(d); return; }   /* round 3 R4, see flushHistBuf */
       renderTextFrame(d);
     });
-    on('tool',function(d){ if(d.phase==='start') appendNote('['+(d.name||'?')+']'); });
-    on('log',function(d){ if(d.text) appendNote(d.text); });
+    on('tool',function(d){ if(d.phase==='start') appendActivity('[tool: '+(d.name||'?')+']'); });
+    on('log',function(d){ if(d.text) appendActivity(d.text); });
     /* \`reply\` carries replyTextOf(end) — every assistant message of the turn
        CONCATENATED — so appending it unconditionally rendered a two-message
        turn three times: each message, then both again as one block. It cannot
@@ -1071,8 +1098,8 @@ export function perchHubJs(lang = "en") {
       setTurnInFlight(false);
     });
     on('ask_user',function(d){ renderAsk(d); });
-    on('error',function(d){ appendNote(d.text||'error'); });
-    on('plan_state',function(d){ var t=planStateText(d.state); if(t) appendNote(t); });
+    on('error',function(d){ appendActivity(d.text||'error'); });
+    on('plan_state',function(d){ var t=planStateText(d.state); if(t) appendActivity(t); });
     /* No 'attention' listener: attention is not a stream event —
        perch-interactive.js:1243/:1360 push it through pushAttention into the
        notification pipeline, and perch-interactive-api.js:349-351 enumerates
@@ -1128,7 +1155,7 @@ export function perchHubJs(lang = "en") {
   function scheduleReconnect(){
     if(retries>=5){ appendNote(RECONNECT_FAILED); return; }
     retries++;
-    appendNote(RECONNECTING);
+    appendActivity(RECONNECTING);   /* D2: chatter to the rail; the CAP is a hard failure and stays in chat */
     var mySid=current.sid;                          /* no parameter to get wrong */
     retryTimer=setTimeout(function(){
       if(!live()) return;                           /* retired mid-backoff */
@@ -1302,12 +1329,14 @@ export function perchHubJs(lang = "en") {
      permission/plan state, cleared here so the PREVIOUS session's picker
      contents never bleed into this one while loadOptions() is in flight. */
   function resetControls(){
+    switchTab('chat');           /* D2: a session opens on the conversation, never on the tab the last one was left on */
     var modelSel=el('perch-model'), thinkSel=el('perch-thinking');
     if(modelSel){ clearEl(modelSel); modelSel.disabled=true; }
     if(thinkSel){ clearEl(thinkSel); thinkSel.disabled=true; }
     showSessionName(null);       /* the PREVIOUS session's name must not bleed in */
     var permSel=el('perch-permission'); if(permSel) permSel.value='guarded';
     var planCb=el('perch-plan-mode'); if(planCb) planCb.checked=false;
+    var cwdEl=el('perch-session-cwd'); if(cwdEl) cwdEl.textContent='';   /* nor its directory */
     setTurnInFlight(false);      /* the PREVIOUS session's Steer/Stop state must not bleed in */
     turnRendered=false;          /* nor its "this turn already rendered" bookkeeping */
     renderedTurn=null;           /* nor the turn id that bookkeeping now keys on */
@@ -1556,6 +1585,74 @@ export function perchHubJs(lang = "en") {
     var known=rowIndex[current.sid];
     renameSession(current.sid,(known&&known.label)||'');
   };
+
+  /* ---- Phase D2: the tab surface ----------------------------------------
+     Tab state is a plain variable, reset to 'chat' on every session open
+     (resetControls). Switching is PURE VISIBILITY TOGGLING — it must never
+     touch the EventSource, openStream, closeSession or any SSE lifecycle
+     (review S6): the stream belongs to the SESSION, not to the tab, and a
+     tab tap that reopened a stream would drop frames mid-turn. Deliberately
+     NOT in the hash: the hash is the session router (#<sid> deep links);
+     '#<sid>:<tab>' would fight every parseHash guard in this file for a
+     convenience nobody deep-links to. */
+  var TAB_NAMES=['chat','session','files','activity'];
+  var tab='chat';
+  function switchTab(name){
+    if(TAB_NAMES.indexOf(name)<0) name='chat';
+    tab=name;
+    TAB_NAMES.forEach(function(nm){
+      var sec=el('perch-tab-'+nm), btn=el('perch-tab-btn-'+nm);
+      if(sec) sec.hidden=(nm!==name);
+      if(btn) btn.setAttribute('aria-selected',nm===name?'true':'false');
+    });
+    /* Files fetches on ACTIVATION, never on session open (D3) — the chat
+       fast path stays one less round trip. The typeof guard is temporary:
+       D3 lands loadFiles in the very next step. */
+    if(name==='files'&&typeof loadFiles==='function') loadFiles();
+  }
+  TAB_NAMES.forEach(function(nm){
+    var btn=el('perch-tab-btn-'+nm);
+    if(btn) btn.onclick=function(){ switchTab(nm); };
+  });
+
+  /* Session tab: "Change directory" reopens the SAME browse modal the
+     launcher uses (one picker, two callers) and POSTs control({cwd}). The
+     engine refuses mid-turn (409) and hibernates an awake child on accept —
+     the modal's hint line says so BEFORE the operator chooses, and the
+     hibernate's own log frame lands in the Activity rail. */
+  var changeCwdBtn=el('perch-change-cwd');
+  if(changeCwdBtn) changeCwdBtn.onclick=function(){
+    if(!current.sid) return;
+    var mySid=current.sid;
+    openBrowseModal({
+      initial:launchCwdInitial(),
+      note:CWD_CHANGE_NOTE,
+      onChoose:function(p){
+        perchApi('POST','/interactive/'+encodeURIComponent(mySid)+'/control',{cwd:p}).then(function(r){
+          if(current.sid!==mySid) return;
+          var cwdEl=el('perch-session-cwd');
+          if(r.ok){
+            /* Optimistic write; the next state frame carries the engine's
+               own record and overwrites this with the truth. */
+            if(cwdEl) cwdEl.textContent=p;
+            return;
+          }
+          if(r.status===409&&r.j&&r.j.error==='turn_in_progress'){ appendNote(CWD_BUSY); return; }
+          if(r.status===400){ appendNote(CWD_INVALID); return; }
+          appendNote((r.j&&r.j.error)||CWD_CHANGE_FAILED);
+        });
+      }
+    });
+  };
+  /* The picker starts where the session is. The readout doubles as the
+     source (textContent, set only from state frames) because there is no
+     other client-side copy of cwd; the placeholder text means "default" and
+     must not ride into the picker as a path. */
+  function launchCwdInitial(){
+    var cwdEl=el('perch-session-cwd');
+    var shown=cwdEl?String(cwdEl.textContent||''):'';
+    return (shown&&shown!==CWD_DEFAULT_TEXT)?shown:'';
+  }
 
   /* iOS does not shrink the layout viewport for the keyboard, so dvh alone
      leaves the composer behind it. Offset the chat column by the hidden part. */

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -226,6 +226,51 @@ body[data-view="chat"] #perch-chat{display:flex;flex-direction:column;flex:1;min
 #perch-composer .send-row{display:flex;gap:8px}
 #perch-composer textarea{min-height:72px}
 #perch-back{align-self:flex-start}
+/* --- Phase D1: the tab surface ------------------------------------------
+   ONE strip, two placements. Desktop: a top strip in the right pane (natural
+   DOM order). Phone: order:10 makes the SAME element the last flex child of
+   #perch-chat — a bottom tab bar without position:fixed, so the flex chain
+   that keeps Send reachable (#perch-chat{flex:1;min-height:0} + the
+   transcript as the only scroller) is untouched and the composer sits above
+   the bar inside the chat tab. The chain has killed a Send button before;
+   the bar joins it as a NON-SHRINKING sibling and nothing else changes. */
+#perch-tabs{display:flex;gap:4px;flex-shrink:0;order:10;border-top:1px solid var(--line);
+padding:6px 0 calc(6px + env(safe-area-inset-bottom,0px))}
+/* Two ids: the base "#perch-hub-root button" rule (1,0,1) would otherwise
+   paint these with card background and ink border — the selected tab owns
+   its own highlight. 44px floor: a bottom bar is thumb territory. */
+#perch-hub-root #perch-tabs button{flex:1;display:flex;flex-direction:column;align-items:center;gap:3px;
+min-height:44px;padding:6px 4px;font-size:11px;border-color:transparent;background:transparent;color:var(--dim)}
+#perch-tabs svg{width:20px;height:20px;flex-shrink:0}
+#perch-hub-root #perch-tabs button[aria-selected="true"]{color:var(--teal);background:var(--teal-soft)}
+/* The four panels. Chat inherits the old column exactly: it IS the flex
+   column the transcript and the sticky composer lived in before the tabs
+   existed, so the reachability measurements carry over unchanged. The other
+   three are plain scrollers — a long directory path or file list must never
+   push the tab bar off screen. */
+#perch-tab-chat{order:1;flex:1;min-height:0;display:flex;flex-direction:column}
+#perch-tab-session,#perch-tab-files,#perch-tab-activity{order:1;flex:1;min-height:0;overflow-y:auto}
+/* [hidden] must outrank the display rules above — id + type + attribute is
+   (1,1,1) against their (1,0,0), so the client's pure-hidden-toggle works
+   without an !important anywhere. */
+#perch-hub-root section[hidden]{display:none}
+/* Session tab: the state pill + rename + close row. Wraps at phone width;
+   the two controls keep their own 44px two-id rules further up. */
+#perch-hub-root .session-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin:6px 0 12px}
+#perch-hub-root .session-row .state{flex:1;min-width:0}
+/* Files tab rows: the whole row is the download link (thumb target), name
+   breaks long, meta never does. */
+#perch-hub-root .files-bar{display:flex;justify-content:flex-end;padding:6px 0}
+#perch-hub-root .file-row{display:flex;justify-content:space-between;align-items:baseline;gap:10px;
+padding:11px 12px;border-bottom:1px solid var(--line);text-decoration:none;color:var(--ink);min-height:44px}
+#perch-hub-root .file-name{word-break:break-all;font-weight:500;font-size:14px}
+#perch-hub-root .file-meta{color:var(--dim);font-size:12px;white-space:nowrap;
+font-family:"JetBrains Mono",ui-monospace,monospace}
+/* Activity tab: monospace log lines, dimmest text on the page — this is the
+   rail you READ AFTER the conversation, never instead of it. */
+#perch-activity-list{display:grid;gap:6px;padding:12px 0;align-content:start}
+#perch-hub-root .activity-row{color:var(--dim);font-size:12.5px;word-break:break-word;
+font-family:"JetBrains Mono",ui-monospace,monospace}
 /* --- open-anywhere C2: the directory-picker modal ---------------------
    Built client-side (client.js buildBrowseModal) and appended INSIDE
    #perch-hub-root, so every class rule here stays scoped the way the
@@ -265,6 +310,10 @@ border-top:1px solid var(--line);flex-shrink:0}
   body[data-view="chat"] #perch-list{display:block}
   #perch-hub-root .hub-split{display:grid;grid-template-columns:320px 1fr;gap:20px;align-items:stretch}
   #perch-back{display:none}
+  /* Desktop: the strip returns to natural DOM order (top of the right pane)
+     and reads as a horizontal tab row, not a phone bar. */
+  #perch-tabs{order:0;border-top:none;border-bottom:1px solid var(--line);padding:6px 0}
+  #perch-hub-root #perch-tabs button{flex:0 0 auto;flex-direction:row;gap:6px;font-size:13px;padding:8px 14px}
 }
 `;
 }

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -96,6 +96,19 @@ border-radius:10px;background:var(--sky);color:var(--ink);flex:1 1 140px;min-wid
    (1,1,0) and ties with "#perch-hub-root .empty" further down, which then wins
    on source order. Measured dead: computed padding stayed 16px. */
 #perch-hub-root #perch-launch-note{padding:0;flex:1 1 100%}
+/* Open-anywhere C2: the launch row's directory field + Browse button.
+   TWO ids on the input, same reasoning as #perch-new-model above: the
+   shared "#perch-hub-root input" rule (1,0,1) gives width:100%, which in
+   this flex row would take the whole line and shove Browse onto the next
+   one; width:auto + a flex basis lets the two share a row and wrap as a
+   unit on a phone. 44px floor: thumb targets, same as every control here. */
+#perch-launch #perch-new-cwd{flex:1 1 180px;min-width:0;width:auto;min-height:44px;
+font:14px Inter,system-ui,sans-serif;padding:9px 10px;border:1px solid var(--line);
+border-radius:10px;background:var(--sky);color:var(--ink)}
+#perch-hub-root #perch-browse-btn{min-height:44px;white-space:nowrap;flex:0 0 auto}
+/* The "Empty = the bot's own directory." explainer. Two ids for the same
+   source-order reason as #perch-launch-note above. */
+#perch-hub-root #perch-cwd-note{padding:0;flex:1 1 100%;font-size:12.5px}
 #perch-launch [hidden]{display:none}
 #perch-hub-root .title{font-weight:600;font-size:17px}
 #perch-hub-root .meta{color:var(--dim);font-size:13px;margin-top:2px;word-break:break-all}
@@ -213,6 +226,37 @@ body[data-view="chat"] #perch-chat{display:flex;flex-direction:column;flex:1;min
 #perch-composer .send-row{display:flex;gap:8px}
 #perch-composer textarea{min-height:72px}
 #perch-back{align-self:flex-start}
+/* --- open-anywhere C2: the directory-picker modal ---------------------
+   Built client-side (client.js buildBrowseModal) and appended INSIDE
+   #perch-hub-root, so every class rule here stays scoped the way the
+   sheet's header comment demands. position:fixed + inset:0 covers the
+   whole viewport (the shell's own clamp gives .main-content no transform,
+   verified live at both breakpoints — a transformed ancestor would make
+   "fixed" resolve against it instead). The [hidden] rule must outrank the
+   display:flex on the same id selector, hence the attribute on an id. */
+#perch-browse-modal{position:fixed;inset:0;z-index:60;background:rgba(10,18,24,.45);
+display:flex;align-items:center;justify-content:center;padding:16px}
+#perch-browse-modal[hidden]{display:none}
+#perch-hub-root .browse-box{background:var(--card);border:1px solid var(--line);border-radius:14px;
+width:100%;max-width:min(560px,92vw);max-height:min(70vh,560px);display:flex;flex-direction:column;
+min-height:0;box-shadow:0 12px 40px rgba(0,0,0,.28)}
+#perch-hub-root .browse-head{padding:12px 14px;border-bottom:1px solid var(--line);flex-shrink:0}
+#perch-hub-root .browse-path{font:12.5px/1.4 "JetBrains Mono",ui-monospace,monospace;color:var(--dim);word-break:break-all}
+#perch-hub-root .browse-hint{padding:8px 14px 0;font-size:13px;color:var(--dim);flex-shrink:0}
+#perch-hub-root .browse-list{overflow-y:auto;flex:1;min-height:0;padding:8px;display:grid;gap:4px;align-content:start}
+/* Directory rows are buttons with the directory NAME as the visible label
+   (house rule: no unlabelled controls). break-all: one long directory name
+   must not give the modal a horizontal scrollbar at 320px. */
+#perch-hub-root .browse-list button{display:block;text-align:left;min-height:44px;padding:10px 12px;word-break:break-all}
+#perch-hub-root .browse-foot{display:flex;gap:8px;justify-content:flex-end;padding:10px 14px;
+border-top:1px solid var(--line);flex-shrink:0}
+#perch-hub-root .browse-foot button{min-height:44px}
+/* Full-bleed at phone width: a centered card with 8% gutters on a 360px
+   screen is a keyhole; the picker is the whole screen there. */
+@media (max-width:599px){
+  #perch-browse-modal{padding:0}
+  #perch-hub-root .browse-box{max-width:100%;height:100%;max-height:100%;border-radius:0}
+}
 #perch-hub-root .field-row{display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;margin:10px 0}
 #perch-hub-root .field{display:flex;flex-direction:column;gap:3px;flex:1 1 150px;min-width:0}
 #perch-hub-root .field-label{font:11px/1 "JetBrains Mono",ui-monospace,monospace;text-transform:uppercase;letter-spacing:.06em;color:var(--dim)}

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -62,6 +62,15 @@ ${engineBanner(engine, lang)}
            whole task exists to stop shipping. -->
       <label class="field-label" id="perch-new-model-label" for="perch-new-model" hidden>${escapeHtml(t("perch.newSessionModel", lang))}</label>
       <select id="perch-new-model" aria-labelledby="perch-new-model-label" hidden></select>
+      <!-- Open-anywhere C2: the directory the session about to be started
+           runs in. EMPTY means "the bot's default" and the key is never
+           sent — the route/engine treat an absent cwd as the world root.
+           The browse button opens the server-backed picker modal (built
+           client-side; GET /dashboard/perch-api/browse). -->
+      <label class="field-label" id="perch-new-cwd-label" for="perch-new-cwd">${escapeHtml(t("perch.cwdLabel", lang))}</label>
+      <input type="text" id="perch-new-cwd" aria-labelledby="perch-new-cwd-label" placeholder="${escapeHtml(t("perch.cwdPlaceholder", lang))}" autocomplete="off" spellcheck="false">
+      <button type="button" id="perch-browse-btn">${escapeHtml(t("perch.browse", lang))}</button>
+      <div class="empty" id="perch-cwd-note">${escapeHtml(t("perch.cwdDefaultNote", lang))}</div>
       <button type="button" class="primary" id="perch-new" disabled>${escapeHtml(t("perch.newSession", lang))}</button>
       <div class="empty" id="perch-launch-note" hidden></div>
     </div>

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -83,21 +83,61 @@ ${engineBanner(engine, lang)}
        inherits that clamp. Rename here and that rule goes dead too. -->
   <div id="perch-chat">
     <button type="button" id="perch-back" class="quiet">${escapeHtml(t("perch.back", lang))}</button>
-    <!-- Close lives in .perch-head, NOT in #perch-composer: the composer's
-         sticky box is what keeps Send reachable at any scroll position
-         (css.js:89-91), and .perch-head is already a non-scrolling child of
-         the #perch-chat flex column, so a control here is permanently on
-         screen without touching that box. -->
+    <!-- Identity stays in the head: the bot name, the operator's session name
+         and the session id are what tell the operator WHICH session any tab
+         below is about. Everything OPERATIONAL (state pill, rename, close,
+         the model/thinking/permission/plan controls) moved into the Session
+         tab in Phase D — the head is never a control surface, which is also
+         why the old "close lives in .perch-head so it is permanently on
+         screen" comment no longer applies: Close now lives in the Session
+         tab AND on every list row, and the sticky composer keeps Send (the
+         control that must never leave the screen) reachable. -->
     <!-- The session's operator-set name sits between the bot name and the
          session id, never replacing either: the id stays the identity (the
          close confirmation names it), the name is the convenience. Hidden
          until there is one; rendered with textContent, never markup. -->
     <div class="perch-head"><div><div class="title" id="perch-bot-name"></div>
       <div class="session-name" id="perch-session-name" hidden></div>
-      <div class="meta" id="perch-session-meta"></div></div>
-      <div class="state" id="perch-state"></div>
-      <button type="button" id="perch-rename" class="quiet">${escapeHtml(t("perch.rename", lang))}</button>
-      <button type="button" id="perch-close" class="quiet">${escapeHtml(t("perch.close", lang))}</button></div>
+      <div class="meta" id="perch-session-meta"></div></div></div>
+    <!-- Phase D1: the tab strip. FOUR buttons, inline SVG glyphs ported from
+         the original pi-lab hub's icon set (~/pi-lab/extensions/web/public/
+         app.html, the I set) recoloured via currentColor so crow's teal owns
+         them. Every button carries a visible text label beside its glyph
+         (house rule: no unlabelled controls). Desktop: a top strip in the
+         right pane. Phone: the strip joins the #perch-chat flex chain as a
+         non-shrinking LAST sibling (css.js order:10) — a bottom tab bar
+         without position:fixed, so the composer sits above it inside the
+         chat tab and the flex chain that keeps Send reachable is untouched.
+         aria-selected is flipped by the client's switchTab(). -->
+    <nav id="perch-tabs" role="tablist" aria-label="${escapeHtml(t("perch.tabsLabel", lang))}">
+      <button type="button" role="tab" id="perch-tab-btn-chat" data-tab="chat" aria-controls="perch-tab-chat" aria-selected="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><path d="M21 12a8 8 0 0 1-8 8H4l2-3a8 8 0 1 1 15-5z"/></svg>${escapeHtml(t("perch.tabChat", lang))}</button>
+      <button type="button" role="tab" id="perch-tab-btn-session" data-tab="session" aria-controls="perch-tab-session" aria-selected="false"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><path d="M2 9h20"/><circle cx="8" cy="9" r="2.4" fill="currentColor" stroke="none"/><path d="M4 20h16M8 11v4m0 0h8m-8 0-3 5m11-9v4m0 0 3 5"/></svg>${escapeHtml(t("perch.tabSession", lang))}</button>
+      <button type="button" role="tab" id="perch-tab-btn-files" data-tab="files" aria-controls="perch-tab-files" aria-selected="false"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M13 2v7h7"/></svg>${escapeHtml(t("perch.tabFiles", lang))}</button>
+      <button type="button" role="tab" id="perch-tab-btn-activity" data-tab="activity" aria-controls="perch-tab-activity" aria-selected="false"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 8L9 4l-3 8H2"/></svg>${escapeHtml(t("perch.tabActivity", lang))}</button>
+    </nav>
+    <!-- Chat tab: transcript + ask cards + composer, exactly the old column —
+         the section wrapper inherits the flex chain (#perch-tab-chat is
+         flex:1/min-height:0/display:flex column in css.js) so the transcript
+         stays the ONLY scroller and the sticky composer backstop is intact. -->
+    <section id="perch-tab-chat" role="tabpanel" aria-labelledby="perch-tab-btn-chat">
+    <div id="perch-transcript"></div>
+    <div id="perch-ask"></div>
+    <div id="perch-composer">
+      <textarea id="perch-input" placeholder="${escapeHtml(t("perch.composerPlaceholder", lang))}"></textarea>
+      <div class="send-row">
+        <button type="button" id="perch-attach" class="quiet">${escapeHtml(t("perch.attachFile", lang))}</button>
+        <input type="file" id="perch-file-input" style="display:none" accept="image/*">
+        <button type="button" class="primary" id="perch-send">${escapeHtml(t("perch.send", lang))}</button>
+        <button type="button" id="perch-abort" style="display:none">${escapeHtml(t("perch.abort", lang))}</button>
+      </div>
+    </div>
+    </section>
+    <!-- Session tab: the controls row (moved verbatim — ids unchanged, so
+         every client binding and state-frame sync keeps working), the
+         read-only cwd display with its "Change directory" button (D2 wires
+         it to the browse modal + control({cwd})), and the state pill beside
+         rename/close. -->
+    <section id="perch-tab-session" role="tabpanel" aria-labelledby="perch-tab-btn-session" hidden>
     <div class="field-row">
       <div class="field"><span class="field-label" id="perch-model-label">${escapeHtml(t("perch.modelLabel", lang))}</span>
         <select id="perch-model" aria-labelledby="perch-model-label" disabled></select></div>
@@ -112,17 +152,29 @@ ${engineBanner(engine, lang)}
       <div class="field"><span class="field-label" id="perch-plan-mode-label">${escapeHtml(t("perch.planModeLabel", lang))}</span>
         <input type="checkbox" id="perch-plan-mode" aria-labelledby="perch-plan-mode-label"></div>
     </div>
-    <div id="perch-transcript"></div>
-    <div id="perch-ask"></div>
-    <div id="perch-composer">
-      <textarea id="perch-input" placeholder="${escapeHtml(t("perch.composerPlaceholder", lang))}"></textarea>
-      <div class="send-row">
-        <button type="button" id="perch-attach" class="quiet">${escapeHtml(t("perch.attachFile", lang))}</button>
-        <input type="file" id="perch-file-input" style="display:none" accept="image/*">
-        <button type="button" class="primary" id="perch-send">${escapeHtml(t("perch.send", lang))}</button>
-        <button type="button" id="perch-abort" style="display:none">${escapeHtml(t("perch.abort", lang))}</button>
-      </div>
+    <div class="field-row">
+      <div class="field"><span class="field-label" id="perch-cwd-label">${escapeHtml(t("perch.cwdLabel", lang))}</span>
+        <div class="meta" id="perch-session-cwd"></div>
+        <button type="button" id="perch-change-cwd">${escapeHtml(t("perch.changeDirectory", lang))}</button></div>
     </div>
+    <div class="session-row">
+      <div class="state" id="perch-state"></div>
+      <button type="button" id="perch-rename" class="quiet">${escapeHtml(t("perch.rename", lang))}</button>
+      <button type="button" id="perch-close" class="quiet">${escapeHtml(t("perch.close", lang))}</button>
+    </div>
+    </section>
+    <!-- Files tab: the session's outputs, listed by D3's endpoint and linked
+         through the existing workspace download route. Populated on tab
+         activation, never on session open. -->
+    <section id="perch-tab-files" role="tabpanel" aria-labelledby="perch-tab-btn-files" hidden>
+    <div class="files-bar"><button type="button" id="perch-files-refresh" class="quiet">${escapeHtml(t("perch.filesRefresh", lang))}</button></div>
+    <div id="perch-files-list"></div>
+    </section>
+    <!-- Activity tab: log/tool/plan/error FRAMES land here (D2), so the chat
+         transcript stays a conversation. -->
+    <section id="perch-tab-activity" role="tabpanel" aria-labelledby="perch-tab-btn-activity" hidden>
+    <div id="perch-activity-list"></div>
+    </section>
   </div>
 </div>
 </div>

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2342,6 +2342,14 @@ export const translations = {
   },
   "perch.cwdChangeFailed": { en: "The directory did not change.", es: "El directorio no cambió." },
   "perch.filesRefresh": { en: "Refresh", es: "Actualizar" },
+  "perch.filesEmpty": {
+    en: "Nothing here yet — files the bot writes land in this list.",
+    es: "Aún no hay nada — los archivos que el bot escriba aparecerán en esta lista.",
+  },
+  "perch.filesFailed": {
+    en: "Could not list the files.",
+    es: "No se pudo listar los archivos.",
+  },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2306,6 +2306,26 @@ export const translations = {
     en: "Could not reach the session list.",
     es: "No se pudo obtener la lista de sesiones.",
   },
+  "perch.cwdLabel": { en: "Directory", es: "Directorio" },
+  "perch.cwdPlaceholder": {
+    en: "The bot's default directory",
+    es: "El directorio predeterminado del bot",
+  },
+  "perch.browse": { en: "Browse…", es: "Explorar…" },
+  "perch.browseTitle": { en: "Choose a directory", es: "Elige un directorio" },
+  "perch.choose": { en: "Choose", es: "Elegir" },
+  "perch.browseFailed": {
+    en: "Could not read that directory.",
+    es: "No se pudo leer ese directorio.",
+  },
+  "perch.cwdDefaultNote": {
+    en: "Empty = the bot's own directory.",
+    es: "Vacío = el directorio propio del bot.",
+  },
+  "perch.cwdInvalid": {
+    en: "That folder does not exist or is not a directory.",
+    es: "Esa carpeta no existe o no es un directorio.",
+  },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2326,6 +2326,22 @@ export const translations = {
     en: "That folder does not exist or is not a directory.",
     es: "Esa carpeta no existe o no es un directorio.",
   },
+  "perch.tabsLabel": { en: "Session views", es: "Vistas de la sesión" },
+  "perch.tabChat": { en: "Chat", es: "Chat" },
+  "perch.tabSession": { en: "Session", es: "Sesión" },
+  "perch.tabFiles": { en: "Files", es: "Archivos" },
+  "perch.tabActivity": { en: "Activity", es: "Actividad" },
+  "perch.changeDirectory": { en: "Change directory", es: "Cambiar directorio" },
+  "perch.cwdChangeNote": {
+    en: "The session sleeps and wakes in the new directory; the next message starts a fresh context there.",
+    es: "La sesión se duerme y despierta en el nuevo directorio; el siguiente mensaje inicia un contexto nuevo allí.",
+  },
+  "perch.cwdBusy": {
+    en: "The bot is mid-turn — the directory changes once it is idle.",
+    es: "El bot está a media vuelta — el directorio cambia cuando quede libre.",
+  },
+  "perch.cwdChangeFailed": { en: "The directory did not change.", es: "El directorio no cambió." },
+  "perch.filesRefresh": { en: "Refresh", es: "Actualizar" },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -39,6 +39,7 @@ import {
   createReadStream,
   readdirSync,
   statSync,
+  lstatSync,
   constants as fsConstants,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -827,6 +828,47 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
         try { closeSync(fd); } catch { /* already closed */ }
       }
       res.json({ path: name });
+    } catch (err) {
+      mapEngineError(res, err);
+    }
+  });
+
+  // ---- GET /interactive/:sid/files/list — the Files tab's outputs listing ----
+  // Phase D3. A FLAT listing of the session's outputsDir ONLY: never
+  // uploadsDir (that direction is upload-only, never re-served), never
+  // recursive (the jail is one directory deep by construction), never
+  // dotfiles, never symlinks — lstatSync skips a symlink outright AND the
+  // size/mtime stat can therefore never be redirected through one (a racing
+  // child swapping a listed name for a link to ~/.crow/data/crow.db leaks
+  // nothing but a name the download route's own O_NOFOLLOW jail still
+  // refuses). There is NO user path input on this endpoint at all, so `..`
+  // is not merely refused — it is unrepresentable. Names + size + mtime,
+  // newest first, capped: a chatty bot's outputs dir must not balloon the
+  // response any more than /browse's 500 cap does.
+  router.get(P + "/interactive/:sid/files/list", async (req, res) => {
+    const sid = String(req.params.sid);
+    try {
+      const eng = resolveEngine();
+      const snap = await eng.get(sid);
+      // Same 404/409 shapes as the workspace download route below.
+      if (!snap) return jsonError(res, 404, "no_such_session");
+      if (!snap.outputsDir) return jsonError(res, 409, "no_session_dir");
+      let entries;
+      try {
+        entries = readdirSync(snap.outputsDir, { withFileTypes: true });
+      } catch {
+        return jsonError(res, 404, "not_found");
+      }
+      const items = [];
+      for (const e of entries) {
+        if (e.name.startsWith(".")) continue;              // dotfile: invisible here, as in the jail
+        let st;
+        try { st = lstatSync(join(snap.outputsDir, e.name)); } catch { continue; }
+        if (st.isSymbolicLink() || !st.isFile()) continue;  // symlinks skipped; dirs never recursed
+        items.push({ name: e.name, size: st.size, mtime: Math.round(st.mtimeMs) });
+      }
+      items.sort((a, b) => b.mtime - a.mtime);
+      res.json({ items: items.slice(0, 200) });
     } catch (err) {
       mapEngineError(res, err);
     }

--- a/tests/i18n-global-parity.test.js
+++ b/tests/i18n-global-parity.test.js
@@ -65,6 +65,7 @@ const IDENTICAL_OK = new Set([
   "botboard.labelBotSwitcher", // "Bot"
   "botboard.colBot",
   "perch.newSessionBot", // "Bot" — same as botboard.colBot above
+  "perch.tabChat", // "Chat" — same word in Spanish UIs
   "settings.ed25519", // key-algorithm name
   "settings.serif",
   "settings.local",

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -196,11 +196,12 @@ test("async continuations are guarded — a fast back button must not cross sess
   // listener (shared through on()), onStreamError's options probe, the
   // reconnect timer, loadHistory, loadOptions, send(), answerAsk, and
   // attachFile's upload continuation. 13 as of open-anywhere D2: the Session
-  // tab's control({cwd}) continuation. A regression that drops one — the count
+  // tab's control({cwd}) continuation. 14 as of D3: the Files tab's
+  // files/list fetch. A regression that drops one — the count
   // that shipped with only 6 asserted — is invisible until an operator hits
   // the exact race the dropped guard covered.
   const guards = (js.match(/current\.sid\s*!==/g) || []).length;
-  assert.equal(guards, 13, "expected exactly 13 identity guards, found " + guards);
+  assert.equal(guards, 14, "expected exactly 14 identity guards, found " + guards);
 });
 
 test("the emitted script never assigns to an innerHTML-class sink", async () => {
@@ -2632,4 +2633,83 @@ test("D2: an accepted cwd change writes the readout; the next state frame owns t
   es._serverFrame("state", { state: "hibernating", turnInFlight: false, cwd: "/home/tester" });
   await new Promise((r) => setTimeout(r, 0));
   assert.equal(hub.els["perch-session-cwd"].textContent, "/home/tester");
+});
+
+// ---------------------------------------------------------------------------
+// Phase D3: the Files tab — fetch on activation (never on open), rows link
+// the existing workspace download route, and empty/failed states never wear
+// each other's line.
+// ---------------------------------------------------------------------------
+
+function filesFetch(items, status = 200, counter) {
+  const std = stdFetch();
+  return (method, path) => {
+    if (path.endsWith("/files/list")) {
+      if (counter) counter.calls++;
+      return makeResponse(status, items === null ? { error: "no_session_dir" } : { items });
+    }
+    return std(method, path);
+  };
+}
+
+test("D3: the Files tab fetches on ACTIVATION only, and rows link the workspace download route", async () => {
+  const counter = { calls: 0 };
+  const hub = await mountHub({
+    fetchImpl: filesFetch([
+      { name: "report.md", size: 2048, mtime: 1757600000000 },
+      { name: "tiny.txt", size: 12, mtime: 1757500000000 },
+    ], 200, counter),
+  });
+  await openChatSession(hub);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(counter.calls, 0, "a session open must not fetch the list — the chat fast path stays one less round trip");
+
+  hub.els["perch-tab-btn-files"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(counter.calls, 1, "tab activation does");
+
+  const rows = hub.els["perch-files-list"].children;
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].tagName, "A");
+  assert.equal(rows[0].href, "/dashboard/perch-api/interactive/perchlive-aaaaaaaa/workspace/report.md",
+    "the whole row links the EXISTING download route — no new serving path");
+  assert.equal(rows[0].children[0].textContent, "report.md");
+  assert.match(rows[0].children[1].textContent, /^2K\b|2\.0K|M/, "size renders human");
+  assert.match(rows[1].children[1].textContent, /^12B/, "bytes stay bytes");
+
+  hub.els["perch-files-refresh"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(counter.calls, 2, "the labelled Refresh refetches");
+});
+
+test("D3: an empty outputs dir and a failed list say different true things", async () => {
+  const hub = await mountHub({ fetchImpl: filesFetch([]) });
+  await openChatSession(hub);
+  hub.els["perch-tab-btn-files"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const empty = hub.els["perch-files-list"].children;
+  assert.equal(empty.length, 1);
+  assert.match(empty[0].textContent, /Nothing here yet/, "empty is empty, in words");
+
+  const failed = await mountHub({ fetchImpl: filesFetch(null, 409) });
+  await openChatSession(failed);
+  failed.els["perch-tab-btn-files"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const rows = failed.els["perch-files-list"].children;
+  assert.equal(rows.length, 1);
+  assert.match(rows[0].textContent, /Could not list the files/, "a failure never wears the empty line");
+});
+
+test("D3: a file name is rendered as text, never as markup", async () => {
+  const hostile = '<img src=x onerror="window.__pwned=1">.md';
+  const hub = await mountHub({ fetchImpl: filesFetch([{ name: hostile, size: 1, mtime: 0 }]) });
+  await openChatSession(hub);
+  hub.els["perch-tab-btn-files"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const row = hub.els["perch-files-list"].children[0];
+  assert.equal(row.children[0].textContent, hostile,
+    "textContent end to end — the harness records the string, and the live" +
+    " browser check (render test) proves the DOM never parses it");
+  assert.ok(row.href.endsWith("/workspace/" + encodeURIComponent(hostile)),
+    "and the link carries the encoded name");
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -395,6 +395,12 @@ function makeEventTarget() {
   };
 }
 
+/* Open-anywhere C2: elements the SCRIPT mints at runtime (the browse modal)
+   carry ids a flat pre-seeded map cannot know. mountHub points this at a
+   per-mount registry; appendChild registers any child that has an id, which
+   mirrors what a real document's getElementById resolves after an append. */
+let ID_REGISTRY = null;
+
 function makeFakeElement(tag) {
   const target = makeEventTarget();
   const attrs = {};
@@ -410,7 +416,11 @@ function makeFakeElement(tag) {
     placeholder: "",
     type: "",
     files: null,
-    appendChild(child) { this.children.push(child); return child; },
+    appendChild(child) {
+      this.children.push(child);
+      if (ID_REGISTRY && child && child.id) ID_REGISTRY[child.id] = child;
+      return child;
+    },
     removeChild(child) { const i = this.children.indexOf(child); if (i >= 0) this.children.splice(i, 1); return child; },
     insertBefore(node, ref) {
       const i = ref ? this.children.indexOf(ref) : -1;
@@ -500,13 +510,20 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     // The launch-model picker.
     "perch-new-model", "perch-new-model-label",
     // Session rename: the header control and the name line it writes.
-    "perch-rename", "perch-session-name"];
+    "perch-rename", "perch-session-name",
+    // Open-anywhere C2: the launcher's directory field, its picker trigger,
+    // and the root the client-built modal appends itself to.
+    "perch-new-cwd", "perch-browse-btn", "perch-cwd-note", "perch-hub-root"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
   const bodyEl = makeFakeElement("body");
   const fetchCalls = [];
   const fetchFn = fetchImpl || (() => Promise.resolve(makeResponse(200, {})));
+  // Runtime-minted ids (the browse modal and its parts) resolve through this
+  // per-mount registry — see ID_REGISTRY's comment above.
+  const dynamic = {};
+  ID_REGISTRY = dynamic;
 
   // addEventListener on the DOCUMENT, not just window: the hub script now
   // listens for Turbo's turbo:before-render to retire itself when the shell
@@ -517,7 +534,7 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
   const doc = Object.assign(docTarget, {
     cookie: "crow_csrf=test-csrf-token",
     body: bodyEl,
-    getElementById(id) { return els[id] || null; },
+    getElementById(id) { return els[id] || dynamic[id] || null; },
     createElement(tag) { return makeFakeElement(tag); },
   });
 
@@ -2344,4 +2361,107 @@ test("R4: a reply buffered across the window is judged at flush, not lost", asyn
   settleBatch(makeResponse(200, batchEvents([])));
   await new Promise((r) => setTimeout(r, 0));
   assert.deepEqual(botEntries(hub), ["arrived while history was in flight"]);
+});
+
+// ---------------------------------------------------------------------------
+// Open-anywhere C2: the launcher's directory field and the browse picker.
+// The live browser walk is measured in perch-hub-render.test.js; these drive
+// the same emitted script through the vm harness for the logic a browser
+// test would only re-prove slowly: WHICH KEYS ride the spawn, and the
+// modal's navigate/choose/dismiss wiring.
+// ---------------------------------------------------------------------------
+
+test("C2: the launcher sends cwd only when the directory field is non-empty", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  const spawns = () => hub.fetchCalls.filter(
+    (c) => c.method === "POST" && /\/bots\/[^/]+\/interactive$/.test(c.path));
+
+  hub.els["perch-new-cwd"].value = "  /tmp/chosen  ";
+  hub.els["perch-new"].click();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(spawns().length, 1);
+  assert.deepEqual(JSON.parse(spawns()[0].opts.body), { cwd: "/tmp/chosen" },
+    "trimmed, and the ONLY key — the model pick was empty so no control rides");
+
+  hub.els["perch-new-cwd"].value = "   ";
+  hub.els["perch-new"].click();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(spawns().length, 2);
+  assert.equal(spawns()[1].opts.body, undefined,
+    "an empty field means 'the bot's default' — the key is never sent, and " +
+    "perchApi leaves the body (and the JSON content-type) off entirely");
+});
+
+test("C2: the picker navigates by server answers; Choose fills the field; Escape and Cancel both dismiss", async () => {
+  const TREE = {
+    "/home/u": { parent: "/home", dirs: [{ name: "a", path: "/home/u/a" }, { name: "b", path: "/home/u/b" }] },
+    "/home/u/a": { parent: "/home/u", dirs: [] },
+  };
+  const hub = await mountHub({
+    fetchImpl: (method, path) => {
+      if (path.startsWith("/browse")) {
+        const p = new URL("http://x" + path).searchParams.get("path") || "/home/u";
+        const hit = TREE[p];
+        if (!hit) return makeResponse(404, { error: "unreadable" });
+        return makeResponse(200, { path: p, parent: hit.parent, dirs: hit.dirs });
+      }
+      return makeResponse(200, {});
+    },
+  });
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  const rows = () => hub.doc.getElementById("perch-browse-list").children.map((b) => b.textContent);
+
+  hub.els["perch-browse-btn"].click();
+  await tick();
+  const modal = hub.doc.getElementById("perch-browse-modal");
+  assert.ok(modal, "the modal is minted into the document on first open");
+  assert.equal(modal.hidden, false);
+  assert.equal(modal.children[0].getAttribute("role"), "dialog", "the box inside the overlay is the dialog");
+  assert.equal(hub.doc.getElementById("perch-browse-path").textContent, "/home/u");
+  assert.deepEqual(rows(), ["..", "a", "b"], "'..' first, then the server's dirs");
+
+  // Navigate via the row's own onclick — the client never chops the path.
+  hub.doc.getElementById("perch-browse-list").children[1].click();
+  await tick();
+  assert.equal(hub.doc.getElementById("perch-browse-path").textContent, "/home/u/a");
+
+  hub.doc.getElementById("perch-browse-choose").click();
+  await tick();
+  assert.equal(hub.els["perch-new-cwd"].value, "/home/u/a", "Choose writes the field");
+  assert.equal(modal.hidden, true, "and closes");
+
+  // Escape (review S5, path one of two).
+  hub.els["perch-browse-btn"].click();
+  await tick();
+  assert.equal(modal.hidden, false);
+  hub.doc._dispatch("keydown", { key: "Escape" });
+  assert.equal(modal.hidden, true, "Escape dismisses");
+  assert.equal(hub.els["perch-new-cwd"].value, "/home/u/a", "a dismissed picker never writes");
+
+  // Cancel (path two of two).
+  hub.els["perch-browse-btn"].click();
+  await tick();
+  hub.doc.getElementById("perch-browse-cancel").click();
+  assert.equal(modal.hidden, true, "the visible Cancel dismisses too");
+
+  // An unreadable directory says so instead of rendering an empty list.
+  hub.els["perch-new-cwd"].value = "/home/u/gone";
+  hub.els["perch-browse-btn"].click();
+  await tick();
+  assert.deepEqual(rows(), ["Could not read that directory."]);
+  hub.doc.getElementById("perch-browse-cancel").click();
+});
+
+test("C2: a retired instance's Escape handler is inert — the keydown listener is generation-guarded", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  hub.els["perch-browse-btn"].click();
+  await new Promise((r) => setTimeout(r, 0));
+  const modal = hub.doc.getElementById("perch-browse-modal");
+  assert.equal(modal.hidden, false);
+  // Retire this instance the way Turbo does, then fire Escape: the handler is
+  // still the registered one (no successor overwrote it), and live() is what
+  // stops it from acting.
+  hub.win.__crowPerchHub.retire();
+  hub.doc._dispatch("keydown", { key: "Escape" });
+  assert.equal(modal.hidden, false, "a retired instance writes nothing, not even a close");
 });

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -195,11 +195,12 @@ test("async continuations are guarded — a fast back button must not cross sess
   // spawn continuation AND its launch-model control continuation, every SSE
   // listener (shared through on()), onStreamError's options probe, the
   // reconnect timer, loadHistory, loadOptions, send(), answerAsk, and
-  // attachFile's upload continuation. A regression that drops one — the count
+  // attachFile's upload continuation. 13 as of open-anywhere D2: the Session
+  // tab's control({cwd}) continuation. A regression that drops one — the count
   // that shipped with only 6 asserted — is invisible until an operator hits
   // the exact race the dropped guard covered.
   const guards = (js.match(/current\.sid\s*!==/g) || []).length;
-  assert.equal(guards, 12, "expected exactly 12 identity guards, found " + guards);
+  assert.equal(guards, 13, "expected exactly 13 identity guards, found " + guards);
 });
 
 test("the emitted script never assigns to an innerHTML-class sink", async () => {
@@ -513,7 +514,13 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     "perch-rename", "perch-session-name",
     // Open-anywhere C2: the launcher's directory field, its picker trigger,
     // and the root the client-built modal appends itself to.
-    "perch-new-cwd", "perch-browse-btn", "perch-cwd-note", "perch-hub-root"];
+    "perch-new-cwd", "perch-browse-btn", "perch-cwd-note", "perch-hub-root",
+    // Phase D: the four tab panels + their buttons, the Activity rail, the
+    // Session tab's cwd readout and its change trigger, the Files pane.
+    "perch-tab-chat", "perch-tab-session", "perch-tab-files", "perch-tab-activity",
+    "perch-tab-btn-chat", "perch-tab-btn-session", "perch-tab-btn-files", "perch-tab-btn-activity",
+    "perch-activity-list", "perch-session-cwd", "perch-change-cwd",
+    "perch-files-list", "perch-files-refresh"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
@@ -734,11 +741,12 @@ test("C2: a destroyed socket reaches onStreamError and schedules a reconnect", a
   await new Promise((r) => setTimeout(r, 0));
   await new Promise((r) => setTimeout(r, 0));  // one more hop: options probe -> scheduleReconnect
 
-  const notes = hub.els["perch-transcript"].children
-    .filter((c) => c.className.includes("note")).map((c) => c.textContent);
-  assert.ok(notes.includes("Reconnecting…"),
+  const notes = hub.els["perch-activity-list"].children
+    .map((c) => c.textContent);
+  assert.ok(notes.some((x) => x.includes("Reconnecting…")),
     "scheduleReconnect() must run — before this fix the options probe's promise " +
-    "never settled and this .then() body never ran at all");
+    "never settled and this .then() body never ran at all. Phase D2 routes the " +
+    "notice to the Activity rail; the transcript keeps the CAP (hard failure).");
 });
 
 test("C2: a failed send appends a visible note instead of vanishing silently", async () => {
@@ -762,21 +770,20 @@ test("I3: a native EventSource error prints nothing; a real error FRAME prints i
   await openChatSession(hub);
   const es = FakeEventSource.instances[0];
 
-  const notesBefore = hub.els["perch-transcript"].children.length;
+  const rowsOf = (elName) => hub.els[elName].children.map((c) => c.textContent);
   es._t._dispatch("error", {});               // native: no .data, addEventListener path only
   await new Promise((r) => setTimeout(r, 0));
-  const notesAfterNative = hub.els["perch-transcript"].children
-    .filter((c) => c.className.includes("note")).map((c) => c.textContent);
-  assert.ok(!notesAfterNative.includes("error"),
+  assert.ok(!rowsOf("perch-transcript").some((x) => x.includes("error")),
     "a native connection failure must not print a bare 'error' note");
+  assert.deepEqual(rowsOf("perch-activity-list"), [],
+    "nor an Activity row — the native error belongs to onStreamError alone");
 
+  // Phase D2: an engine error FRAME is gateway chrome, so it renders on the
+  // Activity rail rather than in the conversation.
   es._serverFrame("error", { text: "pi crashed" });
   await new Promise((r) => setTimeout(r, 0));
-  const notesAfterFrame = hub.els["perch-transcript"].children
-    .filter((c) => c.className.includes("note")).map((c) => c.textContent);
-  assert.ok(notesAfterFrame.includes("pi crashed"),
+  assert.ok(rowsOf("perch-activity-list").some((x) => x.includes("pi crashed")),
     "a real engine error FRAME must still render its text");
-  assert.ok(notesBefore <= notesAfterFrame.length - 1);
 });
 
 // ---- I2: bindings a green suite could previously delete undetected ----
@@ -2464,4 +2471,165 @@ test("C2: a retired instance's Escape handler is inert — the keydown listener 
   hub.win.__crowPerchHub.retire();
   hub.doc._dispatch("keydown", { key: "Escape" });
   assert.equal(modal.hidden, false, "a retired instance writes nothing, not even a close");
+});
+
+// ---------------------------------------------------------------------------
+// Phase D2: the tab surface — visibility-only switching, the Activity rail,
+// and the Session tab's cwd flow.
+// ---------------------------------------------------------------------------
+
+test("D2: log/tool/plan_state frames land in the Activity rail, not the transcript", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("log", { text: "warming provider" });
+  es._serverFrame("tool", { phase: "start", name: "crow_search_memories" });
+  es._serverFrame("tool", { phase: "end", name: "crow_search_memories" });
+  es._serverFrame("plan_state", { state: { enabled: true, executing: false, todosDone: 1, todosTotal: 4 } });
+  await new Promise((r) => setTimeout(r, 0));
+  const rows = hub.els["perch-activity-list"].children.map((c) => c.textContent);
+  assert.ok(rows.some((x) => x.includes("warming provider")), "log frame → activity");
+  assert.ok(rows.some((x) => x.includes("[tool: crow_search_memories]")),
+    "tool start → activity, in the drawer's [tool: name] formatting");
+  assert.equal(rows.filter((x) => x.includes("[tool:")).length, 1, "tool END frames print nothing");
+  assert.ok(rows.some((x) => x.includes("plan mode on (1/4)")), "plan state → activity");
+  // The conversation stays a conversation.
+  const transcript = hub.els["perch-transcript"].children.map((c) => c.textContent);
+  assert.ok(!transcript.some((x) => x.includes("warming provider") || x.includes("[tool:")),
+    "no frame chatter in the transcript");
+});
+
+test("D2: tab switching is pure visibility — the SSE lifecycle is untouched", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  assert.equal(es.closed, false);
+  hub.els["perch-tab-btn-session"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-tab-session"].hidden, false);
+  assert.equal(hub.els["perch-tab-chat"].hidden, true);
+  assert.equal(hub.els["perch-tab-btn-session"].getAttribute("aria-selected"), "true");
+  assert.equal(hub.els["perch-tab-btn-chat"].getAttribute("aria-selected"), "false");
+  hub.els["perch-tab-btn-activity"].onclick();
+  hub.els["perch-tab-btn-chat"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  // Review S6: the stream belongs to the SESSION, not the tab. Same instance,
+  // never closed, no second connection minted by the round trip.
+  assert.equal(es.closed, false, "no tab tap may close the stream");
+  assert.equal(FakeEventSource.instances.length, 1, "and none may open another");
+  assert.equal(hub.els["perch-tab-chat"].hidden, false);
+  assert.equal(hub.els["perch-tab-activity"].hidden, true);
+});
+
+test("D2: a session switch resets the tab to chat and clears the previous Activity", async () => {
+  const two = {
+    birds: [{ id: "r4", name: "R4", perch_attached: true, state: "working",
+      sessions: [
+        { sessionId: "perchlive-aaaaaaaa", state: "awake", cardId: null, pendingUi: false },
+        { sessionId: "perchlive-bbbbbbbb", state: "awake", cardId: null, pendingUi: false }] }],
+  };
+  const hub = await mountHub({
+    fetchImpl: (method, path) => {
+      if (path === "/roost") return makeResponse(200, two);
+      if (path.endsWith("/options")) return makeResponse(200, { models: [], thinkingLevels: [] });
+      if (path.endsWith("/transcript")) return makeResponse(200, { events: [] });
+      return makeResponse(200, {});
+    },
+  });
+  hub.location.hash = "perchlive-aaaaaaaa";
+  await new Promise((r) => setTimeout(r, 0));
+  hub.els["perch-tab-btn-activity"].onclick();
+  FakeEventSource.instances[0]._serverFrame("log", { text: "session A chatter" });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.ok(hub.els["perch-activity-list"].children.length > 0);
+
+  hub.location.hash = "perchlive-bbbbbbbb";
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-tab-chat"].hidden, false, "a session opens on the conversation");
+  assert.equal(hub.els["perch-tab-activity"].hidden, true);
+  assert.equal(hub.els["perch-activity-list"].children.length, 0,
+    "session A's log must not sit under session B's tabs");
+});
+
+test("D2: the state frame refreshes the Session tab's cwd readout — engine record, never an echo", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: false, cwd: "/home/kevin/projects" });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-session-cwd"].textContent, "/home/kevin/projects");
+  // null = the bot's default directory, stated in words, never blank and
+  // never a stale path from the previous session.
+  es._serverFrame("state", { state: "awake", turnInFlight: false, cwd: null });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-session-cwd"].textContent, "The bot's default directory");
+});
+
+test("D2: Change directory POSTs control({cwd}) through the browse modal; mid-turn refusal says why in chat", async () => {
+  const controls = [];
+  const TREE = { "/home/u": { parent: "/", dirs: [{ name: "work", path: "/home/u/work" }] },
+                   "/home/u/work": { parent: "/home/u", dirs: [] } };
+  const hub = await mountHub({
+    fetchImpl: (method, path, opts) => {
+      if (path.startsWith("/browse")) {
+        const p = new URL("http://x" + path).searchParams.get("path") || "/home/u";
+        const hit = TREE[p];
+        return hit ? makeResponse(200, { path: p, parent: hit.parent, dirs: hit.dirs })
+                   : makeResponse(404, { error: "unreadable" });
+      }
+      if (method === "POST" && path.endsWith("/control")) {
+        controls.push(JSON.parse(opts.body));
+        return makeResponse(409, { error: "turn_in_progress" });
+      }
+      if (path === "/roost") return makeResponse(200, ROOST_ONE_LIVE);
+      if (path.endsWith("/options")) return makeResponse(200, { models: [], thinkingLevels: [] });
+      if (path.endsWith("/transcript")) return makeResponse(200, { events: [] });
+      return makeResponse(200, {});
+    },
+  });
+  await openChatSession(hub);
+  hub.els["perch-session-cwd"].textContent = "/home/u";
+  hub.els["perch-change-cwd"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const modal = hub.doc.getElementById("perch-browse-modal");
+  assert.equal(modal.hidden, false, "the same picker the launcher uses");
+  assert.equal(hub.doc.getElementById("perch-browse-path").textContent, "/home/u",
+    "it starts where the session is");
+  assert.ok(hub.doc.getElementById("perch-browse-hint").textContent.includes("sleeps and wakes"),
+    "the hibernate-on-change is stated BEFORE the operator chooses");
+  hub.doc.getElementById("perch-browse-list").children[1].click();   // into work/
+  await new Promise((r) => setTimeout(r, 0));
+  hub.doc.getElementById("perch-browse-choose").click();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(controls, [{ cwd: "/home/u/work" }], "presence-keyed cwd, the only key");
+  // The engine refuses mid-turn; the refusal must be visible WHERE they read.
+  const notes = hub.els["perch-transcript"].children
+    .filter((c) => String(c.className).includes("note")).map((c) => c.textContent);
+  assert.ok(notes.some((x) => x.includes("mid-turn")), "a 409 turn_in_progress says so in chat");
+});
+
+test("D2: an accepted cwd change writes the readout; the next state frame owns the truth", async () => {
+  const hub = await mountHub({
+    fetchImpl: (method, path, opts) => {
+      if (method === "POST" && path.endsWith("/control")) return makeResponse(200, { ok: true });
+      if (path.startsWith("/browse")) {
+        return makeResponse(200, { path: "/home/tester", parent: "/home", dirs: [] });
+      }
+      return stdFetch()(method, path);
+    },
+  });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  hub.els["perch-session-cwd"].textContent = "The bot's default directory";
+  hub.els["perch-change-cwd"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  // The placeholder must not ride into the picker as a path — the picker
+  // starts from the server's home, and Choose takes THAT path.
+  hub.doc.getElementById("perch-browse-choose").click();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-session-cwd"].textContent, "/home/tester",
+    "optimistic write of the chosen path");
+  es._serverFrame("state", { state: "hibernating", turnInFlight: false, cwd: "/home/tester" });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-session-cwd"].textContent, "/home/tester");
 });

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -313,7 +313,7 @@ test("the launcher ships disabled, so the pre-data frame never claims there are 
   assert.ok(/id="perch-launch-note"[^>]*hidden/.test(html), "as does its note");
 });
 
-test("the chat-view close control is in the header, not in the sticky composer", async () => {
+test("the chat-view close control lives in the Session tab, not in the sticky composer", async () => {
   // Send stays reachable because #perch-chat{flex:1;min-height:0} and
   // #perch-transcript{flex:1;overflow:auto;min-height:0} make the TRANSCRIPT the
   // only scroller, so .content-body never scrolls and the composer never leaves
@@ -325,20 +325,113 @@ test("the chat-view close control is in the header, not in the sticky composer",
   // mechanism will delete the flex chain and the pre-existing reachability tests
   // stay GREEN through that deletion.
   //
-  // Either way a control added INTO the composer changes its box and puts the
-  // backstop in play, so .perch-head — a non-scrolling flex child of #perch-chat,
-  // permanently on screen — is where it belongs.
+  // Phase D moved Close (with rename and the state pill) out of .perch-head
+  // into the Session tab — the plan's D1/D2 shape, mirroring the original
+  // pi-lab hub. What must NOT change: a control added INTO the composer
+  // changes its box and puts the backstop in play, so the composer stays
+  // message-only, and Close stays reachable via the Session tab AND every
+  // list row's own Close button.
   const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
   const html = perchHubContent("en");
   const close = html.indexOf('id="perch-close"');
-  const head = html.indexOf('class="perch-head"');
-  const composer = html.indexOf('id="perch-composer"');
+  const sessionTab = html.indexOf('id="perch-tab-session"');
+  const filesTab = html.indexOf('id="perch-tab-files"');
   assert.ok(close > -1, "the open session needs a close control");
-  assert.ok(head > -1 && composer > -1);
-  assert.ok(close > head && close < composer, "close belongs to the header block");
-  // The composer's own markup must be untouched by this task.
+  assert.ok(sessionTab > -1 && filesTab > -1);
+  assert.ok(close > sessionTab && close < filesTab,
+    "close belongs to the Session tab section, between its open and the next section");
+  // The composer's own markup must stay untouched by this task.
+  const composer = html.indexOf('id="perch-composer"');
   const composerBlock = html.slice(composer, html.indexOf("</div>", html.indexOf("send-row")));
   assert.ok(!composerBlock.includes("perch-close"), "nothing new inside the sticky box");
+});
+
+// ---------------------------------------------------------------------------
+// Phase D1 — the tab surface, statically. The live measurements (Send
+// reachable in EVERY tab at both breakpoints, bar never overlapping it) run
+// in perch-hub-render.test.js over CDP.
+// ---------------------------------------------------------------------------
+
+test("the chat column is a tablist of four labelled tabs over four panels", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  assert.ok(/id="perch-tabs"[^>]*role="tablist"/.test(html));
+  for (const name of ["chat", "session", "files", "activity"]) {
+    // Attribute order inside the tag is the markup's business, not the
+    // test's — match the tag, then assert each attribute on it.
+    const tag = (html.match(new RegExp(`<button[^>]*id="perch-tab-btn-${name}"[^>]*>`)) || [null])[0];
+    assert.ok(tag, `${name} tab button exists`);
+    assert.ok(tag.includes('role="tab"'), `${name} carries role=tab`);
+    assert.ok(tag.includes(`aria-controls="perch-tab-${name}"`), `${name} tab button wires to its panel`);
+    assert.ok(html.includes(`id="perch-tab-${name}"`), `${name} panel exists`);
+    // House rule: no unlabelled controls — each button carries text after its
+    // aria-hidden glyph.
+    const seg = html.slice(html.indexOf(`id="perch-tab-btn-${name}"`));
+    assert.ok(/<\/svg>[^<]+$/.test(seg.slice(0, seg.indexOf("</button>"))),
+      `${name} tab has a visible text label beside the glyph`);
+  }
+  // Exactly one selected at rest, and it is chat — the client's switchTab()
+  // flips aria-selected from there.
+  const chatTag = html.match(/<button[^>]*id="perch-tab-btn-chat"[^>]*>/)[0];
+  assert.ok(chatTag.includes('aria-selected="true"'));
+  for (const name of ["session", "files", "activity"]) {
+    const tag = html.match(new RegExp(`<button[^>]*id="perch-tab-btn-${name}"[^>]*>`))[0];
+    assert.ok(tag.includes('aria-selected="false"'));
+    const sec = html.match(new RegExp(`<section[^>]*id="perch-tab-${name}"[^>]*>`))[0];
+    assert.ok(/(^|\s)hidden(=|>|\s)/.test(sec) || sec.endsWith("hidden>"),
+      `${name} panel ships hidden — only the active section is displayed`);
+  }
+});
+
+test("the chat panel keeps the transcript, ask pane and composer — in that order", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const chatTab = html.indexOf('id="perch-tab-chat"');
+  const sessionTab = html.indexOf('id="perch-tab-session"');
+  const tr = html.indexOf('id="perch-transcript"');
+  const ask = html.indexOf('id="perch-ask"');
+  const composer = html.indexOf('id="perch-composer"');
+  assert.ok(chatTab < tr && tr < ask && ask < composer && composer < sessionTab,
+    "the old column, wrapped — order is the flex chain's order");
+});
+
+test("the session panel carries the controls, the cwd readout and the head's old buttons", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const s = html.indexOf('id="perch-tab-session"');
+  const e = html.indexOf('id="perch-tab-files"');
+  const seg = html.slice(s, e);
+  for (const id of ["perch-model", "perch-thinking", "perch-permission", "perch-plan-mode",
+                    "perch-session-cwd", "perch-change-cwd", "perch-state",
+                    "perch-rename", "perch-close"]) {
+    assert.ok(seg.includes(`id="${id}"`), `${id} lives in the Session tab`);
+  }
+  // Identity stays in the head — the tabs must not orphan it.
+  const head = html.slice(html.indexOf('class="perch-head"'), html.indexOf('id="perch-tabs"'));
+  for (const id of ["perch-bot-name", "perch-session-name", "perch-session-meta"]) {
+    assert.ok(head.includes(`id="${id}"`), `${id} stays in the head`);
+  }
+});
+
+test("the tab CSS keeps the flex chain intact and hides panels by attribute", async () => {
+  const { perchHubCss } = await import("../servers/gateway/dashboard/perch-hub/css.js");
+  const css = perchHubCss().replace(/\s+/g, "");
+  // The chat panel must BE the column the old #perch-chat rules describe,
+  // or the reachability backstop comment becomes a lie again.
+  assert.ok(/#perch-tab-chat\{[^}]*flex:1/.test(css));
+  assert.ok(/#perch-tab-chat\{[^}]*min-height:0/.test(css));
+  assert.ok(/#perch-tab-chat\{[^}]*display:flex/.test(css));
+  // The bar is a non-shrinking sibling — if it can shrink, a long transcript
+  // squeezes it and the phone loses its navigation.
+  assert.ok(/#perch-tabs\{[^}]*flex-shrink:0/.test(css));
+  // Phone: the bar is LAST (bottom); desktop media query puts it back on top.
+  assert.ok(/#perch-tabs\{[^}]*order:10/.test(css));
+  assert.ok(/#perch-tabs\{order:0/.test(css), "the desktop strip returns to natural order");
+  // [hidden] outranks the panels' display rules, and does it by specificity
+  // (id+type+attr), not by !important. NOTE: the whitespace strip above also
+  // eats the descendant-selector space, hence the run-together pattern.
+  assert.ok(/#perch-hub-rootsection\[hidden\]\{display:none\}/.test(css));
+  assert.ok(!/!important/.test(css.match(/#perch-hub-rootsection\[hidden\]\{[^}]*\}/)[0]));
 });
 
 test("the launcher and the row close button cannot overflow a 412px column", async () => {

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -355,3 +355,47 @@ test("the launcher and the row close button cannot overflow a 412px column", asy
   assert.ok(/\.perch-head\{[^}]*flex-wrap:wrap/.test(css),
     "the bot name, the state word and Close must wrap rather than overflow the chat column");
 });
+
+// ---------------------------------------------------------------------------
+// Open-anywhere C2 — the launcher's directory field + picker, statically.
+// The live walk (browse → choose → spawn carries cwd) is measured in
+// perch-hub-render.test.js; these pin the markup/source properties a browser
+// test cannot see.
+// ---------------------------------------------------------------------------
+
+test("the launcher carries a labelled directory field, a Browse button and the default note", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  assert.ok(html.includes('id="perch-new-cwd-label"'), "the field needs a visible label");
+  assert.ok(/id="perch-new-cwd"[^>]*aria-labelledby="perch-new-cwd-label"/.test(html));
+  assert.ok(html.includes('id="perch-browse-btn"'), "the picker's trigger");
+  // House rule: no unlabelled controls — the Browse button carries its text.
+  assert.ok(/id="perch-browse-btn">[^<]+</.test(html), "Browse must carry a visible label");
+  assert.ok(html.includes('id="perch-cwd-note"'), "empty = the bot's default, stated on the page");
+  // The field lives in the launch row (before #perch-new), never inside the
+  // list body every poll clears — the same structural rule the launcher's
+  // own controls are pinned under above.
+  const cwd = html.indexOf('id="perch-new-cwd"');
+  assert.ok(cwd > html.indexOf('id="perch-launch"') && cwd < html.indexOf('id="perch-list-body"'));
+});
+
+test("the picker dismiss never depends on one path: Escape via the registry AND a visible Cancel", async () => {
+  const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
+  const js = perchHubJs("en");
+  // Review S5: both dismiss paths, and the keydown listener goes through the
+  // generation-checked bindOnce registry so the Turbo-leak guard covers it.
+  assert.match(js, /bindOnce\(\s*document\s*,\s*'keydown'\s*,\s*'browseEscape'/,
+    "Escape must be bound through the hub's one-listener-per-realm registry");
+  assert.match(js, /cancel\.id='perch-browse-cancel';\s*cancel\.textContent=ASK_CANCEL/,
+    "a visible, labelled Cancel button");
+  assert.match(js, /choose\.id='perch-browse-choose';\s*choose\.textContent=CHOOSE_LABEL/,
+    "Choose is labelled too");
+  // '..' navigates to the SERVER-resolved parent, never a client-side string
+  // chop (a symlinked dir would ping-pong — the C1 endpoint's whole reason
+  // for deriving parent from the realpath).
+  assert.match(js, /loadBrowseDir\(r\.j\.parent\)/);
+  // The modal is built with createElement/textContent only — the existing
+  // "never assigns to an innerHTML-class sink" pin in
+  // perch-hub-client.test.js already covers the whole emitted script, so
+  // directory names cannot reach a sink without tripping that one.
+});

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -46,12 +46,17 @@ function resetApi() {
   transcriptEvents = [];
   optionsHibernating = false;
   lastSpawnBody = null;
+  filesListCalls = 0;
 }
 
 let roostFails = false;
 /** Open-anywhere C2: the body of the last POST /bots/:id/interactive, so a
  *  test can prove the launcher sent (or never sent) the cwd key. */
 let lastSpawnBody = null;
+/** Phase D3: how many times the page fetched the Files tab's listing — the
+ *  activation-only discipline is half the design (the chat fast path stays
+ *  one less round trip), so it is measured, not trusted. */
+let filesListCalls = 0;
 /** The picker's scripted directory tree — names and paths only, exactly the
  *  shape GET /browse answers with (routes/perch-interactive-api.js). */
 const BROWSE_TREE = {
@@ -121,6 +126,13 @@ function serveApi(req, res) {
   });
   if (url.endsWith("/transcript")) return send(200, { events: transcriptEvents });
   if (url.endsWith("/rename")) return send(200, { label: "renamed" });
+  if (url.endsWith("/files/list")) {
+    filesListCalls++;
+    return send(200, { items: [
+      { name: "draft.md", size: 20480, mtime: Date.now() },
+      { name: "notes.txt", size: 512, mtime: Date.now() - 60000 },
+    ] });
+  }
   // Open-anywhere C2: the picker's server-backed listing. An unknown path is
   // the real endpoint's 404 shape; no path means "start at home".
   if (url.endsWith("/browse")) {
@@ -1191,6 +1203,47 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
         assert.ok(m.bar.h >= 44, `the bar is thumb-sized on ${n}: ${m.bar.h}px`);
         assert.equal(m.hScroll, false, `no horizontal scroll on the ${n} tab`);
       }
+    } finally { resetApi(); await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Phase D3, live — the Files tab in a real browser: the list is fetched on
+// ACTIVATION only, rows are real links through the existing workspace
+// download route, and a hostile file name reaches the DOM as text.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`D3 live @${w}x${h}: the Files tab lists outputs on activation and links the download route`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 900));
+      assert.equal(filesListCalls, 0, "a session open must not fetch the list");
+
+      const seen = await s.json(`(async function(){
+        document.getElementById('perch-tab-btn-files').click();
+        await new Promise(function(r){setTimeout(r,400);});
+        var rows=Array.from(document.querySelectorAll('#perch-files-list .file-row'));
+        return JSON.stringify({
+          n: rows.length,
+          first: rows.length?{text:rows[0].querySelector('.file-name').textContent,
+                              href:rows[0].getAttribute('href'),
+                              meta:rows[0].querySelector('.file-meta').textContent}:null,
+          inViewport: (function(){ var r=document.getElementById('perch-files-list').getBoundingClientRect();
+                                   return r.top>=0; })(),
+          hScroll: document.documentElement.scrollWidth>document.documentElement.clientWidth });
+      })()`);
+      assert.equal(filesListCalls, 1, "tab activation fetches exactly once");
+      assert.equal(seen.n, 2);
+      assert.equal(seen.first.text, "draft.md");
+      assert.ok(seen.first.href.endsWith("/interactive/perchlive-22222222/workspace/draft.md"),
+        `the row links the existing jail: ${seen.first.href}`);
+      assert.match(seen.first.meta, /20K|20\.0K/, "human size in the meta column");
+      assert.equal(seen.inViewport, true);
+      assert.equal(seen.hScroll, false, "no horizontal scroll on the files tab");
     } finally { resetApi(); await s.close(); }
   });
 }

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -45,9 +45,20 @@ function resetApi() {
   modelsDefault = "crow-local/qwen3.6-35b-a3b";
   transcriptEvents = [];
   optionsHibernating = false;
+  lastSpawnBody = null;
 }
 
 let roostFails = false;
+/** Open-anywhere C2: the body of the last POST /bots/:id/interactive, so a
+ *  test can prove the launcher sent (or never sent) the cwd key. */
+let lastSpawnBody = null;
+/** The picker's scripted directory tree — names and paths only, exactly the
+ *  shape GET /browse answers with (routes/perch-interactive-api.js). */
+const BROWSE_TREE = {
+  "/home/tester": { parent: "/home", dirs: ["projects", "docs", "zz-long-name", ".config"] },
+  "/home/tester/projects": { parent: "/home/tester", dirs: ["crow", "r4"] },
+  "/home/tester/projects/crow": { parent: "/home/tester/projects", dirs: [] },
+};
 function serveApi(req, res) {
   const url = req.url.split("?")[0];
   const send = (code, obj) => {
@@ -110,7 +121,27 @@ function serveApi(req, res) {
   });
   if (url.endsWith("/transcript")) return send(200, { events: transcriptEvents });
   if (url.endsWith("/rename")) return send(200, { label: "renamed" });
-  if (url.endsWith("/interactive") && req.method === "POST") return send(200, { sessionId: "perchlive-99999999" });
+  // Open-anywhere C2: the picker's server-backed listing. An unknown path is
+  // the real endpoint's 404 shape; no path means "start at home".
+  if (url.endsWith("/browse")) {
+    const u = new URL(req.url, "http://local");
+    const p = u.searchParams.get("path") || "/home/tester";
+    const hit = BROWSE_TREE[p];
+    if (!hit) return send(404, { error: "unreadable" });
+    return send(200, { path: p, parent: hit.parent,
+      dirs: hit.dirs.map((n) => ({ name: n, path: p + "/" + n })) });
+  }
+  if (url.endsWith("/interactive") && req.method === "POST") {
+    // Capture the spawn body: the C2 assertion is about WHICH KEYS the client
+    // sent, and an absent cwd must stay absent (never an empty string).
+    let raw = "";
+    req.on("data", (c) => { raw += c; });
+    req.on("end", () => {
+      try { lastSpawnBody = raw ? JSON.parse(raw) : null; } catch { lastSpawnBody = null; }
+      send(200, { sessionId: "perchlive-99999999" });
+    });
+    return;
+  }
   return send(200, {});
 }
 
@@ -992,6 +1023,113 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(seen.index, 2, "the browser's own selection");
       assert.match(seen.shown, /Flash Next/,
         "what the operator reads after a restart — measured as the FIRST option before the fix");
+    } finally { resetApi(); await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Open-anywhere C2, live — the directory picker in a real browser: browse
+// from the scripted home two levels down, Choose writes the field, the spawn
+// carries the cwd key, an EMPTY field never sends it, and BOTH dismiss paths
+// (Escape and the visible Cancel) close the modal — review S5's pair.
+// ---------------------------------------------------------------------------
+
+const sleepJs = (ms) => `await new Promise(function(r){setTimeout(r,${ms});})`;
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`C2 live @${w}x${h}: the picker browses, Choose fills the field, and the spawn carries cwd`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      // 1. Open the picker from the launcher's Browse button.
+      const opened = await s.json(`(async function(){
+        document.getElementById('perch-browse-btn').click();
+        ${sleepJs(400)}
+        var m=document.getElementById('perch-browse-modal');
+        var box=m.querySelector('.browse-box').getBoundingClientRect();
+        var names=[].slice.call(document.querySelectorAll('#perch-browse-list button'))
+          .map(function(b){return b.textContent;});
+        return JSON.stringify({visible:!m.hidden,
+          path:document.getElementById('perch-browse-path').textContent,
+          names:names, boxWidth:Math.round(box.width),
+          innerWidth:innerWidth,
+          hScroll:document.documentElement.scrollWidth>innerWidth});
+      })()`);
+      assert.equal(opened.visible, true, "the modal is on screen");
+      assert.equal(opened.path, "/home/tester", "an empty field starts the picker at home");
+      assert.deepEqual(opened.names, ["..", "projects", "docs", "zz-long-name", ".config"],
+        "directories only, dot-dirs last, '..' first");
+      assert.equal(opened.hScroll, false, "the modal must not give the page a horizontal scrollbar");
+      if (w < 900) {
+        assert.equal(opened.boxWidth, opened.innerWidth, "full-bleed at phone width");
+      } else {
+        assert.ok(opened.boxWidth <= 560, `desktop caps the box at 560px, measured ${opened.boxWidth}`);
+      }
+
+      // 2. Navigate two levels down and Choose.
+      const chosen = await s.json(`(async function(){
+        function tap(name){
+          var b=[].slice.call(document.querySelectorAll('#perch-browse-list button'))
+            .filter(function(x){return x.textContent===name;})[0];
+          if(!b) throw new Error('no row: '+name);
+          b.click();
+        }
+        tap('projects');
+        ${sleepJs(350)}
+        tap('crow');
+        ${sleepJs(350)}
+        var atPath=document.getElementById('perch-browse-path').textContent;
+        document.getElementById('perch-browse-choose').click();
+        ${sleepJs(80)}
+        return JSON.stringify({atPath:atPath,
+          field:document.getElementById('perch-new-cwd').value,
+          hidden:document.getElementById('perch-browse-modal').hidden});
+      })()`);
+      assert.equal(chosen.atPath, "/home/tester/projects/crow");
+      assert.equal(chosen.field, "/home/tester/projects/crow", "Choose writes the field");
+      assert.equal(chosen.hidden, true, "Choose closes the modal");
+
+      // 3. Escape dismisses (the S5 pair: never dependent on one path).
+      const escaped = await s.json(`(async function(){
+        document.getElementById('perch-browse-btn').click();
+        ${sleepJs(350)}
+        var reopened=!document.getElementById('perch-browse-modal').hidden;
+        document.dispatchEvent(new KeyboardEvent('keydown',{key:'Escape'}));
+        ${sleepJs(80)}
+        var afterEscape=document.getElementById('perch-browse-modal').hidden;
+        document.getElementById('perch-browse-btn').click();
+        ${sleepJs(350)}
+        document.getElementById('perch-browse-cancel').click();
+        ${sleepJs(80)}
+        var afterCancel=document.getElementById('perch-browse-modal').hidden;
+        var fieldUntouched=document.getElementById('perch-new-cwd').value;
+        return JSON.stringify({reopened:reopened,afterEscape:afterEscape,
+          afterCancel:afterCancel,fieldUntouched:fieldUntouched});
+      })()`);
+      assert.equal(escaped.reopened, true);
+      assert.equal(escaped.afterEscape, true, "Escape closes the picker");
+      assert.equal(escaped.afterCancel, true, "the visible Cancel closes it too");
+      assert.equal(escaped.fieldUntouched, "/home/tester/projects/crow",
+        "a dismissed picker never touches the field");
+
+      // 4. New session carries the chosen cwd.
+      await s.evalIn(`(async function(){
+        document.getElementById('perch-new').click();
+        ${sleepJs(400)}
+        return 'spawned';
+      })()`);
+      assert.deepEqual(lastSpawnBody, { cwd: "/home/tester/projects/crow" },
+        "the spawn body carries exactly the chosen directory");
+
+      // 5. An EMPTY field means "the bot's default" — the key is never sent.
+      await s.evalIn(`(async function(){
+        document.getElementById('perch-new-cwd').value='';
+        document.getElementById('perch-new').click();
+        ${sleepJs(400)}
+        return 'spawned';
+      })()`);
+      assert.equal(lastSpawnBody, null, "no cwd, no body at all — an empty string must never ride");
     } finally { resetApi(); await s.close(); }
   });
 }

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -464,6 +464,7 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(inChat.meta, "perchlive-22222222", "precondition: that session is the one open");
 
       const btn = await s.json(`(function(){
+        document.getElementById('perch-tab-btn-session').click();   /* Phase D: Close lives in the Session tab */
         var b=document.getElementById('perch-close'), r=b.getBoundingClientRect();
         return JSON.stringify({ inViewport: r.top>=0 && r.bottom<=innerHeight,
           hit: (function(){ var e=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
@@ -471,7 +472,7 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
           w: Math.round(r.width), h: Math.round(r.height),
           padding: getComputedStyle(b).padding, fontSize: getComputedStyle(b).fontSize });
       })()`);
-      assert.equal(btn.inViewport, true, "close must be reachable without scrolling the chat");
+      assert.equal(btn.inViewport, true, "close must be reachable without scrolling the Session tab");
       assert.equal(btn.hit, true);
       // The number this test already COLLECTED and never asserted. It measured
       // 36px live: a bare "#perch-close" rule is (1,0,0) and loses to
@@ -485,9 +486,10 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
         "the scoped rule must actually win the cascade, not merely be present in the sheet");
       assert.equal(btn.fontSize, "13px");
 
-      // Send must still be reachable — the close control must not have
-      // disturbed the sticky composer this page's mobile fix rests on.
+      // Send must still be reachable — on the CHAT tab, where the composer
+      // lives; a Session-tab control must not have disturbed the sticky box.
       const sendBox = await s.json(`(function(){
+        document.getElementById('perch-tab-btn-chat').click();
         var r=document.getElementById('perch-send').getBoundingClientRect();
         return JSON.stringify({ reachable: r.bottom<=innerHeight && r.top>=0,
                                 top: Math.round(r.top), bottom: Math.round(r.bottom), vp: innerHeight });
@@ -495,7 +497,7 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       assert.equal(sendBox.reachable, true,
         `Send at ${sendBox.top}-${sendBox.bottom} in a ${sendBox.vp}px viewport`);
 
-      await s.evalIn(`document.getElementById('perch-close').click(); 'clicked'`);
+      await s.evalIn(`document.getElementById('perch-tab-btn-session').click(); document.getElementById('perch-close').click(); 'clicked'`);
       await new Promise((r) => setTimeout(r, 800));
 
       assert.deepEqual(stopped, ["perchlive-22222222"]);
@@ -772,7 +774,7 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
     } finally { await s.close(); }
   });
 
-  test(`F3 live @${w}x${h}: the chat header's Rename is reachable and Send still is`, async (t) => {
+  test(`F3 live @${w}x${h}: the Session tab's Rename is reachable and Send still is`, async (t) => {
     if (!available) return t.skip("no CDP endpoint at " + CDP);
     resetApi();
     const s = await session(w, h);
@@ -780,9 +782,9 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
       await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
       await new Promise((r) => setTimeout(r, 900));
       const seen = await s.json(`(function(){
+        document.getElementById('perch-tab-btn-session').click();   /* Phase D: Rename lives in the Session tab */
         var b=document.getElementById('perch-rename'), r=b.getBoundingClientRect();
         var nm=document.getElementById('perch-session-name');
-        var send=document.getElementById('perch-send').getBoundingClientRect();
         return JSON.stringify({
           name: nm.hidden?null:nm.textContent,
           meta: document.getElementById('perch-session-meta').textContent,
@@ -790,17 +792,21 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
           inViewport: r.top>=0 && r.bottom<=innerHeight,
           hit:(function(){ var e=document.elementFromPoint(r.left+r.width/2,r.top+r.height/2);
                            return !!e && (e===b||b.contains(e)); })(),
-          sendReachable: send.bottom<=innerHeight && send.top>=0,
           hScroll: document.documentElement.scrollWidth > document.documentElement.clientWidth });
       })()`);
       assert.equal(seen.name, "November package copy pass, English and Spanish together",
-        "the open session's name is in the header");
+        "the open session's name stays in the head — identity never moved to a tab");
       assert.equal(seen.meta, "perchlive-22222222", "and the id line is untouched — it is the identity");
       assert.ok(seen.h >= 44, `Rename is ${seen.w}x${seen.h}`);
       assert.equal(seen.inViewport, true);
       assert.equal(seen.hit, true);
-      assert.equal(seen.sendReachable, true, "a second header control must not disturb the composer");
       assert.equal(seen.hScroll, false);
+      const send = await s.json(`(function(){
+        document.getElementById('perch-tab-btn-chat').click();
+        var r=document.getElementById('perch-send').getBoundingClientRect();
+        return JSON.stringify({ reachable: r.bottom<=innerHeight && r.top>=0 });
+      })()`);
+      assert.equal(send.reachable, true, "a Session-tab control must not disturb the composer");
     } finally { await s.close(); }
   });
 }
@@ -1130,6 +1136,61 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
         return 'spawned';
       })()`);
       assert.equal(lastSpawnBody, null, "no cwd, no body at all — an empty string must never ride");
+    } finally { resetApi(); await s.close(); }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Phase D1, live — the flex chain has killed a Send button before, so the
+// tab bar's arrival is measured, not argued: Send reachable with the
+// transcript scrolled to the TOP, the bar on screen in EVERY tab, the bar
+// never overlapping Send, and no horizontal scroll at either breakpoint.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`D1 live @${w}x${h}: Send is reachable on chat and the tab bar never covers it`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 900));
+      const seen = await s.json(`(async function(){
+        var tr=document.getElementById('perch-transcript');
+        for(var i=0;i<60;i++){ var d=document.createElement('div');
+          d.textContent='bot: a transcript line long enough to take a row or two, number '+i;
+          tr.appendChild(d); }
+        tr.scrollTop=0;                                   /* where a reader starts */
+        function rect(id){ var r=document.getElementById(id).getBoundingClientRect();
+          return {top:Math.round(r.top),bottom:Math.round(r.bottom),h:Math.round(r.height)}; }
+        var out={tabs:{}};
+        var names=['chat','session','files','activity'];
+        for(var i=0;i<names.length;i++){
+          var n=names[i];
+          document.getElementById('perch-tab-btn-'+n).click();
+          await new Promise(function(r){setTimeout(r,60);});
+          var bar=rect('perch-tabs');
+          out.tabs[n]={bar:bar,
+            barInViewport:bar.top>=0&&bar.bottom<=innerHeight,
+            hScroll:document.documentElement.scrollWidth>document.documentElement.clientWidth};
+          if(n==='chat'){
+            var snd=rect('perch-send');
+            out.send=snd;
+            out.sendReachable=snd.bottom<=innerHeight&&snd.top>=0;
+            out.barOverlapsSend=!(bar.top>=snd.bottom||snd.top>=bar.bottom);
+          }
+        }
+        return JSON.stringify(out);
+      })()`);
+      assert.equal(seen.sendReachable, true,
+        `Send at ${seen.send.top}-${seen.send.bottom} in a ${h}px viewport`);
+      assert.equal(seen.barOverlapsSend, false,
+        `the bar (${seen.tabs.chat.bar.top}-${seen.tabs.chat.bar.bottom}) must not cover Send`);
+      for (const [n, m] of Object.entries(seen.tabs)) {
+        assert.equal(m.barInViewport, true, `the bar is on screen on the ${n} tab`);
+        assert.ok(m.bar.h >= 44, `the bar is thumb-sized on ${n}: ${m.bar.h}px`);
+        assert.equal(m.hScroll, false, `no horizontal scroll on the ${n} tab`);
+      }
     } finally { resetApi(); await s.close(); }
   });
 }

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -398,3 +398,35 @@ test("N1 live: a reconnect WITHIN a turn does not duplicate that turn's answer",
       "the case a bare reset in openStream() would have broken — which is why this is a turn id");
   } finally { await s.close(); }
 });
+
+// ---------------------------------------------------------------------------
+// Phase D2 — the Activity rail under the same Turbo regime. A surviving
+// instance used to write every frame once per instance; the rail is a new
+// writer, so it gets the same treatment the transcript has: N visits, ONE
+// frame, ONE row.
+// ---------------------------------------------------------------------------
+
+test("a log/tool frame lands in the Activity rail ONCE, not once per surviving instance", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    for (let i = 0; i < 3; i++) await s.visit("/dashboard/perch");
+    await s.open();
+    broadcast("log", { text: "one line of gateway chatter" });
+    broadcast("tool", { phase: "start", name: "crow_search_memories" });
+    await sleep(500);
+    const rows = await s.json(`JSON.stringify(
+      Array.from(document.querySelectorAll('#perch-activity-list .activity-row'))
+        .map(function(n){return n.textContent;}))`);
+    assert.equal(rows.length, 2, "one row per frame, whatever the visit count: " + JSON.stringify(rows));
+    assert.ok(rows[0].includes("one line of gateway chatter"));
+    assert.ok(rows[1].includes("[tool: crow_search_memories]"));
+    // And the conversation stayed a conversation — the frames must not ALSO
+    // have landed in the transcript through a surviving pre-D2 instance.
+    const notes = await s.json(`JSON.stringify(
+      Array.from(document.querySelectorAll('#perch-transcript .note'))
+        .map(function(n){return n.textContent;}))`);
+    assert.ok(!notes.some((x) => x.includes("gateway chatter") || x.includes("[tool:")),
+      "no frame chatter in the transcript: " + JSON.stringify(notes));
+  } finally { await s.close(); }
+});

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -1745,3 +1745,90 @@ test("POST /interactive/:sid/control without cwd does not add the key (presence-
   assert.equal(status, 200);
   assert.ok(!("cwd" in engineCalls.control[0].opts), "a body without cwd leaves opts.cwd absent");
 });
+
+// ---------------------------------------------------------------------------
+// Phase D3 — GET /interactive/:sid/files/list. The jail's attack inventory,
+// mirrored at the LIST level: symlink absent, dotfile absent, uploadsDir
+// never listed, and no user path input anywhere (so `..` is unrepresentable,
+// not merely refused).
+// ---------------------------------------------------------------------------
+
+test("files/list lists the outputsDir flat: names, sizes, mtimes, newest first", async () => {
+  const outputsDir = mkdtempSync(join(tmpdir(), "perch-files-"));
+  writeFileSync(join(outputsDir, "older.md"), "aaa");
+  // Force a deterministic mtime ordering (filesystem granularity varies).
+  const { utimesSync } = await import("node:fs");
+  utimesSync(join(outputsDir, "older.md"), new Date(1000), new Date(1000));
+  writeFileSync(join(outputsDir, "newer.md"), "bbbbbb");
+  utimesSync(join(outputsDir, "newer.md"), new Date(2000000), new Date(2000000));
+  engineImpl.get = async (sid) => ({ sessionId: sid, uploadsDir: null, outputsDir });
+
+  const { status, body } = await getJson("/interactive/perchlive-11111111/files/list");
+  assert.equal(status, 200);
+  assert.deepEqual(body.items.map((i) => i.name), ["newer.md", "older.md"], "mtime desc");
+  const newer = body.items[0];
+  assert.equal(newer.size, 6, "the stat's size, never a re-read of contents");
+  assert.equal(typeof newer.mtime, "number");
+});
+
+test("files/list skips dotfiles, symlinks and subdirectories outright", async () => {
+  const outputsDir = mkdtempSync(join(tmpdir(), "perch-files-"));
+  writeFileSync(join(outputsDir, "real.md"), "x");
+  writeFileSync(join(outputsDir, ".hidden"), "secret");
+  mkdirSync(join(outputsDir, "subdir"), { recursive: true });
+  writeFileSync(join(outputsDir, "subdir", "deep.md"), "never seen");
+  // The jail's own attack, at the list level: a symlink whose target lives
+  // OUTSIDE outputsDir. The name must not appear — and even if it did, the
+  // download route's O_NOFOLLOW jail would refuse it. Both layers, tested
+  // in their own files.
+  const secret = join(dir, "files-list-secret.txt");
+  writeFileSync(secret, "crown jewels");
+  symlinkSync(secret, join(outputsDir, "link-to-secret"));
+  engineImpl.get = async (sid) => ({ sessionId: sid, uploadsDir: null, outputsDir });
+
+  const { status, body } = await getJson("/interactive/perchlive-11111111/files/list");
+  assert.equal(status, 200);
+  assert.deepEqual(body.items.map((i) => i.name), ["real.md"],
+    "dotfile, symlink and subdirectory are all absent; no recursion");
+});
+
+test("files/list NEVER lists uploadsDir, even when both dirs exist", async () => {
+  const outputsDir = mkdtempSync(join(tmpdir(), "perch-files-"));
+  const uploadsDir = mkdtempSync(join(tmpdir(), "perch-files-up-"));
+  writeFileSync(join(outputsDir, "output.md"), "o");
+  writeFileSync(join(uploadsDir, "operator-upload.png"), "u");
+  engineImpl.get = async (sid) => ({ sessionId: sid, uploadsDir, outputsDir });
+
+  const { status, body } = await getJson("/interactive/perchlive-11111111/files/list");
+  assert.equal(status, 200);
+  assert.deepEqual(body.items.map((i) => i.name), ["output.md"],
+    "uploads are upload-only; re-listing them would be a new serving path");
+});
+
+test("files/list caps at 200 entries", async () => {
+  const outputsDir = mkdtempSync(join(tmpdir(), "perch-files-"));
+  for (let i = 0; i < 205; i++) writeFileSync(join(outputsDir, `f${String(i).padStart(3, "0")}.txt`), "x");
+  engineImpl.get = async (sid) => ({ sessionId: sid, uploadsDir: null, outputsDir });
+  const { status, body } = await getJson("/interactive/perchlive-11111111/files/list");
+  assert.equal(status, 200);
+  assert.equal(body.items.length, 200);
+});
+
+test("files/list carries the download route's own 404/409 shapes", async () => {
+  engineImpl.get = async () => null;
+  let r = await getJson("/interactive/perchlive-dead0000/files/list");
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, "no_such_session");
+
+  engineImpl.get = async (sid) => ({ sessionId: sid, uploadsDir: null, outputsDir: null });
+  r = await getJson("/interactive/perchlive-11111111/files/list");
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, "no_session_dir");
+
+  // A directory that vanished under us reads as not_found, not a crash.
+  engineImpl.get = async (sid) => ({ sessionId: sid, uploadsDir: null,
+    outputsDir: join(dir, "files-list-gone") });
+  r = await getJson("/interactive/perchlive-11111111/files/list");
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, "not_found");
+});


### PR DESCRIPTION
## Perch open-anywhere PR3 — C2 (launcher picker) + Phase D (tabs) + Phase E (verify + docs)

Completes the operator-approved open-anywhere plan (`docs/superpowers/plans/2026-09-11-perch-hub-open-anywhere.md`). Phase A shipped in #357; Phase B + C1 in #360. This PR is the UI surface + the mandated live verification + docs.

### What lands

- **C2 — launcher directory field + server-backed picker.** `#perch-new-cwd` + **Browse…** join the launch row; empty means "the bot's default" and the `cwd` key is **never** sent (an empty string must not reach the route's `bad_cwd` gate). The modal is client-built with `createElement`/`textContent` only, fed by `GET /browse`, navigates `..` by the **server-resolved** parent, and ships **both** dismiss paths together (Escape via the generation-checked `bindOnce` registry + a visible Cancel — review S5). A `400 bad_cwd` on spawn lands as a note beside the field. Full-bleed at phone width, 560px-capped card on desktop.
- **D1 — tab markup + layout.** `#perch-tabs` tablist + four `<section role=tabpanel>` panels inside `#perch-chat`; glyphs ported from the original pi-lab hub icon set, recoloured via `currentColor`. Desktop: top strip in the right pane. Phone: the **same** element joins the `#perch-chat` flex chain as a non-shrinking last sibling (`order:10`) — a bottom bar without `position:fixed`, so the composer sits above it and the flex chain that keeps Send reachable is untouched.
- **D2 — client routing + Session/Activity content.** `switchTab` is **pure visibility toggling** — it never touches the EventSource/`openStream`/`closeSession`/SSE lifecycle (review S6); tab state is deliberately not in the hash; every session open resets to Chat. `log`/`tool`-start/`error`/`plan_state` frames route to the Activity rail; Chat keeps user/bot messages, ask cards, and the hard failures. Session tab: the controls row (ids unchanged), state pill + rename + close moved in, and the read-only cwd readout refreshed from state frames with a **Change directory** button that reopens the C2 picker and POSTs `control({cwd})` — 409 `turn_in_progress` and 400 refusals surface in Chat.
- **D3 — Files tab.** `GET /interactive/:sid/files/list` lists the session's **outputsDir only**: flat, dotfiles + symlinks skipped via `lstatSync` (a racing child swapping a name for a link leaks nothing but a name the download route's `O_NOFOLLOW` jail still refuses), no recursion, mtime-desc, capped 200, never uploadsDir. No user path input at all, so `..` is unrepresentable. Client fetches on tab **activation** only; rows are `<a>` links through the existing workspace route.
- **E2 — docs.** `docs/developers/bot-engine.md` (cwd model + endpoints, stale "roost strip + drawer" corrected), `docs/guide/bot-builder.md` EN+ES (hub walkthrough: open-anywhere + tabs + a not-a-jail security note), the #356 review status footer (R1/R2/R4 closed by #357), and the plan header ticked with named deviations.

### E1 — full suite + boot + live walk (measured, not read)

1. **`npm test`** — full scratch suite **4717 / 0** (up from 4686 at PR2; +31 new C2/D tests). `check-ports` OK (no new port), `build-registry --check` OK (all core gateway code, no bundle bump).
2. **`node servers/gateway/index.js --no-auth`** — boots clean (scratch home on :3199; only the expected deferred board migrations for a bundle-less scratch + nostr/instance-sync disabled by env). Raw boot on :3001 is `EADDRINUSE` against the live prod gateway, as expected.
3. **Live Perch walk on a real gateway** (scratch `CROW_HOME`, real pi child, real local model server):
   - start a session in a chosen non-default dir → **it wrote `walk-proof.txt` there** (proves `cwd` + `write_paths` widening).
   - **one tool call through the per-bot `crow-memory` MCP server from that dir → `TOOL_OK: walk-marker-4242`** (a real memory row returned). This is the silent-failure guard for the `.mcp.json` relocation — the deepest cut in the plan — and it passes.
   - switch model (awake `set_model`, the stronger path) → applied live, row's `model` persisted.
   - **restart the gateway** → session **adopted on the switched model, in the chosen dir** (`state` frame: `model=crow-local-122b/…`, `cwd=…/target`).
   - **disable that provider** → send → fail-open log line `recorded model crow-local-122b/qwen3.5-122b-a10b is not available — resumed on crow-local/qwen3.6-35b-a3b`, session runs on the def default, **the row keeps the dead key** (by design — a temporarily-disabled provider must not erase a real choice).
   - **change cwd mid-session** → refused `409 turn_in_progress` in-turn; works idle (`200`, `bindsAtWake.cwd`, hibernates the child with the log frame `working directory → …/target2 — resumes there on the next message`).
   - Files tab live: outputsDir listed (`report.md` with size+mtime; dotfile, symlink, subdir all absent), download returns content, a symlink download 404s at the jail.
   - fresh-session sanity: a **new** session wrote `fresh.txt` and replied with its path (the recycled session's later `pi_gone` was model-server fatigue — see deviations).
4. **CDP render checks against the real gateway** (real Chrome, both viewports): Send reachable in all four tabs, tab bar never overlaps it, no horizontal scroll in any tab, picker full-bleed at 412px / capped 560px on desktop, Escape dismisses. (The `perch-hub-render.test.js` fixture walk — real client + real shell over CDP — is green too.)

### Named deviations (measured, not asserted)

1. **Model switch was awake, not hibernating.** The plan's E1 said "switch model while hibernating"; the walk switched while **awake** (the stronger `set_model`-the-live-child path) and proved the hibernate-bind path separately via the cwd-change leg (which hibernates) + the restart-adopt leg. The model `bindsAtWake` path stays covered by `perch-interactive-controls.test.js`.
2. **`pi_gone` on the 5×-recycled session is environmental.** The scratch local model (`qwen3.6-35b-a3b`) is a **reasoning** model that spends its budget on `reasoning_content` (direct curl: `finish_reason: length`, empty `content`); after several wakes the child died. A **fresh** session on the same gateway wrote its file and replied cleanly, isolating this to model-server fatigue, not a PR3 regression.
3. **`docs/architecture/gateway-server.md` does not exist.** The perch-interactive architecture note landed in `docs/developers/bot-engine.md`'s existing "Long-lived (interactive) children" home instead.

### Test seams

`perch-hub-client.test.js` gained a dynamic id-registry in the vm harness (the client-built modal mints ids a flat map cannot know); identity-guard count 12→14 (the `control({cwd})` and `files/list` continuations). `perch-hub-render.test.js` + `perch-hub-stream-leak.test.js` extended with the C2/D live walks and the Activity-rail-under-Turbo guard.
