### PR TITLE
Migration rail: bot_sessions.label + cwd — co-hosted instances self-heal at boot

### DIFF
--- a/scripts/migrations/0005-bot-sessions-label-cwd.mjs
+++ b/scripts/migrations/0005-bot-sessions-label-cwd.mjs
@@ -1,0 +1,56 @@
+// scripts/migrations/0005-bot-sessions-label-cwd.mjs
+//
+// bot_sessions.label (session rename, shipped with the perch rename wave) and
+// bot_sessions.cwd (open-anywhere PR2, #360) are ADDITIVE columns with no
+// SCHEMA_GENERATION bump — by design, so the boot schema guard never fires
+// for them and init-db's DROP TABLE rail is never re-run against a live DB.
+// The flip side, measured live on 2026-09-12: co-hosted instances converge
+// onto the shared checkout's new code on their own restart schedule, and
+// their boot guard skips init-db (generation matches), so nothing ever adds
+// the columns. The R4 instance restarted onto post-#360 code at 17:53 with a
+// bot_sessions table carrying NEITHER column: routes/perch.js's /roost
+// SELECT (… control, label FROM bot_sessions …) 500'd — every Perch hub on
+// R4 read "Could not reach the session list" and no bot could be opened —
+// while the engine's writeRow cwd= stamp failed silently per session. The
+// primary instance only escaped because its operator ran init-db by hand
+// after deploying #360; a rail that depends on that is exactly the drift
+// this registry exists to end (same story as 0001's header).
+//
+// Guarded additive ALTERs, idempotent, absent-table tolerant. SQLite ADD
+// COLUMN never rebuilds the table, so the bot_sessions control-CHECK rebuild
+// block in init-db.js is unaffected either way.
+import Database from "better-sqlite3";
+
+export const id = "0005-bot-sessions-label-cwd";
+
+/** "added" | "no-op" | "absent" — never throws on a missing table. */
+export function addColumnIfMissing(db, table, column, ddl) {
+  const t = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table);
+  if (!t) return "absent";
+  const have = db.prepare(`PRAGMA table_info(${table})`).all().map((c) => c.name);
+  if (have.includes(column)) return "no-op";
+  db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`).run();
+  return "added";
+}
+
+export function run({ dbPath, log = () => {} }) {
+  const results = [];
+  const db = new Database(dbPath);
+  db.pragma("busy_timeout = 10000");
+  try {
+    // DDL matches init-db.js's own addColumnIfMissing calls verbatim
+    // (label: ~2657, cwd: ~2668) — one shape, two rails.
+    for (const col of ["label", "cwd"]) {
+      const r = addColumnIfMissing(db, "bot_sessions", col, "TEXT");
+      log(`  bot_sessions.${col}: ${r}`);
+      results.push(r);
+    }
+  } finally {
+    db.close();
+  }
+  // bot_sessions is CORE crow.db (init-db creates it on every instance), so
+  // an "absent" read here is a store that predates the bot tables entirely —
+  // recording applied is correct: when init-db creates the table it carries
+  // both columns in the CREATE body, and there is nothing left to retry.
+  return { applied: true, results };
+}

--- a/tests/bot-sessions-label-cwd-migration.test.js
+++ b/tests/bot-sessions-label-cwd-migration.test.js
@@ -1,0 +1,100 @@
+// 0005-bot-sessions-label-cwd — the rail that keeps a co-hosted instance's
+// bot_sessions table current with additive columns that carry no
+// SCHEMA_GENERATION bump. Written from the measured 2026-09-12 R4 outage:
+// convergence restarted R4 onto post-#360 code whose /roost SELECT names
+// `label` and whose writeRow stamps `cwd`; R4's DB had neither, so every
+// Perch hub surface on that instance 500'd until init-db was run by hand.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { run, id } from "../scripts/migrations/0005-bot-sessions-label-cwd.mjs";
+
+function scratchCrowDb(withTable = true) {
+  const dir = mkdtempSync(join(tmpdir(), "bs-mig-"));
+  const dbPath = join(dir, "crow.db");
+  const db = new Database(dbPath);
+  if (withTable) {
+    // The pre-label/cwd shape: an R4-as-found table (kind/narrowed_tools
+    // present from 0001-era rails, label/cwd absent).
+    db.exec(`CREATE TABLE bot_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      bot_id TEXT NOT NULL, pi_session_id TEXT, pi_session_dir TEXT,
+      gateway_type TEXT, gateway_thread_id TEXT, project_id INTEGER, card_id INTEGER,
+      plan_path TEXT, status TEXT NOT NULL DEFAULT 'active',
+      control TEXT NOT NULL DEFAULT 'run', model TEXT, escalated INTEGER DEFAULT 0,
+      kind TEXT NOT NULL DEFAULT 'chat', narrowed_tools TEXT,
+      created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now')))`);
+    db.prepare("INSERT INTO bot_sessions (bot_id, gateway_thread_id, kind, status) VALUES ('b','perchlive-x','perch-live','waiting-user')").run();
+  }
+  db.close();
+  return dbPath;
+}
+
+function cols(dbPath) {
+  const d = new Database(dbPath);
+  const names = d.prepare("PRAGMA table_info(bot_sessions)").all().map((c) => c.name);
+  d.close();
+  return names;
+}
+
+test("adds label and cwd to a legacy bot_sessions table, idempotently", () => {
+  const dbPath = scratchCrowDb();
+  const before = cols(dbPath);
+  assert.ok(!before.includes("label") && !before.includes("cwd"), "fixture is the legacy shape");
+
+  const first = run({ dbPath, log: () => {} });
+  assert.deepEqual(first.results, ["added", "added"]);
+  const after = cols(dbPath);
+  assert.ok(after.includes("label"));
+  assert.ok(after.includes("cwd"));
+
+  const second = run({ dbPath, log: () => {} });
+  assert.deepEqual(second.results, ["no-op", "no-op"], "a second run is a clean no-op");
+  assert.equal(cols(dbPath).filter((c) => c === "cwd").length, 1);
+});
+
+test("existing rows survive — the column is NULL, the row is intact", () => {
+  const dbPath = scratchCrowDb();
+  run({ dbPath, log: () => {} });
+  const d = new Database(dbPath);
+  const row = d.prepare("SELECT bot_id, gateway_thread_id, label, cwd FROM bot_sessions").get();
+  d.close();
+  assert.equal(row.bot_id, "b");
+  assert.equal(row.label, null, "NULL reads as 'no name' — the rename feature's own default");
+  assert.equal(row.cwd, null, "NULL reads as 'the bot's default directory' — the open-anywhere default");
+});
+
+test("the /roost query that 500'd on R4 runs after the migration", () => {
+  const dbPath = scratchCrowDb();
+  // Before: this exact SELECT is what broke (routes/perch.js ~:507).
+  const d0 = new Database(dbPath);
+  assert.throws(() =>
+    d0.prepare("SELECT gateway_thread_id, card_id, control, label FROM bot_sessions WHERE kind='perch-live' AND status != 'stopped'").all(),
+    /no such column: label/);
+  d0.close();
+  run({ dbPath, log: () => {} });
+  const d = new Database(dbPath);
+  const rows = d.prepare("SELECT gateway_thread_id, card_id, control, label, cwd FROM bot_sessions WHERE kind='perch-live' AND status != 'stopped'").all();
+  d.close();
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].gateway_thread_id, "perchlive-x");
+});
+
+test("tolerates a DB with no bot_sessions table at all, and records applied", () => {
+  const dbPath = scratchCrowDb(false);
+  const r = run({ dbPath, log: () => {} });
+  assert.deepEqual(r.results, ["absent", "absent"]);
+  assert.equal(r.applied, true,
+    "core table absent = a store that predates bot tables; init-db's CREATE body carries both columns, so there is nothing to retry");
+});
+
+test("the id matches the filename convention the runner discovers", async () => {
+  assert.equal(id, "0005-bot-sessions-label-cwd");
+  const { discoverMigrations } = await import("../scripts/migrations/runner.mjs");
+  const found = discoverMigrations(new URL("../scripts/migrations", import.meta.url).pathname);
+  assert.ok(found.some((p) => p.endsWith("0005-bot-sessions-label-cwd.mjs")),
+    "the runner must discover the new migration by filename");
+});


### PR DESCRIPTION
Adds scripts/migrations/0005-bot-sessions-label-cwd.mjs so every co-hosted instance self-heals the additive bot_sessions columns at boot.

**Why (measured outage, 2026-09-12):** label (rename wave) and cwd (open-anywhere #360) are additive with no SCHEMA_GENERATION bump by design — so the boot schema guard skips init-db and nothing adds them on a converging instance. The R4 gateway auto-restarted onto post-#360 code at 17:53 with NEITHER column: routes/perch.js's /roost SELECT names label, so every Perch hub surface on R4 500'd ("Could not reach the session list", no bot openable) until init-db was run by hand. The primary instance only escaped because its operator ran init-db manually after deploying #360. This is the same drift class 0001-board-stages was created for (its header names an identical r4 500).

**The migration:** guarded additive ALTERs (PRAGMA presence check), idempotent, absent-table tolerant, DDL byte-identical to init-db.js's own addColumnIfMissing calls. Records applied even when the table is absent (init-db's CREATE body carries both columns on any store it creates).

**Tests:** tests/bot-sessions-label-cwd-migration.test.js (5) — legacy-shape ALTER + idempotence, existing rows keep NULL semantics, the EXACT /roost query throws before / passes after, absent-table tolerance, runner discovery. Full suite 4722/0.

R4 itself was already repaired live (init-db + restart; addons rebuilt for node 24) — this rail prevents the next instance from needing that.