### PR TITLE
Perch: a dozed phone socket no longer kills the live view — unbounded SSE reconnect backoff + unlock retry

### DIFF
--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -250,7 +250,6 @@ export function perchHubJs(lang = "en") {
   var NO_TRANSCRIPT='${tJs("perch.noTranscript", lang)}';
   var TRANSCRIPT_FAILED='${tJs("perch.transcriptFailed", lang)}';
   var RECONNECTING='${tJs("perch.reconnecting", lang)}';
-  var RECONNECT_FAILED='${tJs("perch.reconnectFailed", lang)}';
   var ASK_STALE='${tJs("perch.askStale", lang)}';
   var STEER_LABEL='${tJs("perch.steer", lang)}';
   var SEND_LABEL='${tJs("perch.send", lang)}';
@@ -875,6 +874,20 @@ export function perchHubJs(lang = "en") {
     if(listOnScreen()) loadList();
   });
 
+  /* Phone unlock / tab re-focus: a dozed socket is rediscovered NOW, not at
+     the next backoff slot (which can be up to 30s away on a long streak).
+     onStreamError closeStreams FIRST, so \'stream\' is null exactly in the
+     window where a retry is pending or the radio just came back; a live
+     stream is left alone. Guarded like every document listener (bindOnce +
+     live()) so a retired instance never re-opens from here. */
+  bindOnce(document,'visibilitychange','visibility',function(){
+    if(!live()) return;
+    if(document.visibilityState!=='visible') return;
+    if(!current.sid||stream) return;
+    cancelReconnect(); retries=0;
+    openStream(current.sid);
+  });
+
   /* Engine-minted ids only: "perchlive-" + 8 hex (perch-interactive.js:1473).
      A loose pattern would admit ".." and this value is concatenated into an
      API path. Encoded at every use site as well, belt and braces. */
@@ -1146,25 +1159,42 @@ export function perchHubJs(lang = "en") {
     var known=rowIndex[current.sid];
     showSessionName(known?known.label:null);
   }
-  /* Bounded backoff. TWO separate operations, and conflating them is what made
-     an earlier draft of this dead code: cancelling the TIMER must not reset the
+  /* Unbounded exponential backoff — the 2026-09-12 phone finding. The old cap
+     (5 tries, fixed 2s) was written for a desktop browser and a gateway
+     restart; on a phone the socket dies every time the screen dozes, and the
+     radio can take longer than the whole 10s retry window to come back — so
+     the operator unlocked their phone to a permanent "Lost the connection to
+     this session" over a session that was perfectly alive (measured: the
+     engine row sat at waiting-user with its last turn completed while the UI
+     declared death). Now: retries never give up, 2s doubling to a 30s cap,
+     reset ONLY on a stream that actually opened (resetBackoff, via onopen).
+     Truly dead sessions are still detected — not by a retry budget but by
+     onStreamError's options probe, whose 404/410/401 terminal statuses leave
+     to the list. ONE "Reconnecting…" line per failure streak (first miss
+     only) rides the Activity rail; repeating it every slot would paper the
+     rail with noise.
+     The two operations below stay separate, and conflating them is what made
+     an earlier draft dead code: cancelling the TIMER must not reset the
      COUNTER, because onStreamError calls closeStream() (which cancels) before
-     every scheduleReconnect(), so a combined reset meant retries could never
-     reach 5 and the cap was unreachable. The counter resets only when a stream
+     every scheduleReconnect(). The counter resets only when a stream
      actually opens. */
   var retries=0, retryTimer=null;
   function cancelReconnect(){ if(retryTimer){ clearTimeout(retryTimer); retryTimer=null; } }
   function resetBackoff(){ retries=0; }            /* called from onopen ONLY */
+  function reconnectDelayMs(){
+    var d=2000*Math.pow(2,retries-1);
+    return d>30000?30000:d;
+  }
   function scheduleReconnect(){
-    if(retries>=5){ appendNote(RECONNECT_FAILED); return; }
     retries++;
-    appendActivity(RECONNECTING);   /* D2: chatter to the rail; the CAP is a hard failure and stays in chat */
+    if(retries===1) appendActivity(RECONNECTING);
     var mySid=current.sid;                          /* no parameter to get wrong */
     retryTimer=setTimeout(function(){
+      retryTimer=null;
       if(!live()) return;                           /* retired mid-backoff */
       if(current.sid!==mySid) return;               /* navigated away mid-backoff */
       openStream(mySid);
-    },2000);
+    },reconnectDelayMs());
   }
 
   function loadHistory(botId,sid){

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2253,7 +2253,6 @@ export const translations = {
     es: "No se pudo cargar el historial de esta sesión.",
   },
   "perch.reconnecting": { en: "Reconnecting…", es: "Reconectando…" },
-  "perch.reconnectFailed": { en: "Lost the connection to this session.", es: "Se perdió la conexión con esta sesión." },
   "perch.modelLabel": { en: "Model", es: "Modelo" },
   "perch.thinkingLabel": { en: "Thinking", es: "Razonamiento" },
   "perch.permissionLabel": { en: "Permissions", es: "Permisos" },

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -179,7 +179,7 @@ test("every string constant the script references is bound", async () => {
   // missing constant — it surfaces as a ReferenceError on the error path, which
   // is the path nobody exercises by hand.
   for (const name of ["SESSION_GONE", "NO_TRANSCRIPT", "RECONNECTING",
-                      "RECONNECT_FAILED", "ASK_STALE", "STEER_LABEL", "SEND_LABEL"]) {
+                      "ASK_STALE", "STEER_LABEL", "SEND_LABEL"]) {
     if (!js.includes(name)) continue;               // not every task binds all of them
     assert.ok(new RegExp("var\\s+" + name + "\\s*=").test(js), name + " is used but never bound");
   }
@@ -244,12 +244,71 @@ async function fnSrc(name) {
   return src.slice(start, end + 1);
 }
 
-test("the reconnect cap is actually reachable", async () => {
+test("the reconnect backoff grows exponentially, caps at 30s, and the cancel/reset split survives", async () => {
   const js = (await import("../servers/gateway/dashboard/perch-hub/client.js")).perchHubJs("en");
   assert.ok(!(await fnSrc("cancelReconnect")).includes("retries=0"),
     "cancelling the timer must not reset the counter — closeStream() runs before every schedule");
   assert.ok(js.includes("function resetBackoff"), "the counter resets on a stream that opened, not on cancel");
   assert.ok(/scheduleReconnect\(\)/.test(js), "no argument — the arity mismatch that made this dead code");
+  // The growth itself, extracted with a shadowed `retries` (the harness's
+  // extra-parameter idiom): 2s doubling, hard cap 30s. The 2026-09-12 phone
+  // finding: a FIXED 2s × 5 budget died inside one screen-doze cycle; the
+  // cap-at-30s keeps a long outage at 2 probes/min instead of 30.
+  const seq = [];
+  for (const n of [1, 2, 3, 4, 5, 6, 10]) {
+    const f = await extract("reconnectDelayMs", `var retries=${n};`);
+    seq.push(f());
+  }
+  assert.deepEqual(seq, [2000, 4000, 8000, 16000, 30000, 30000, 30000]);
+  // The cap no longer exists as a give-up: no retry budget may declare death.
+  assert.ok(!/retries\s*>=\s*\d/.test(js), "no strikes-out cap — dead sessions are the probe's job, not the budget's");
+});
+
+test("a failing reconnect schedules the NEXT slot at the doubled delay, and one rail note per streak", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/options": () => Promise.reject(new Error("network down")) }),
+  });
+  await openChatSession(hub);
+  assert.equal(FakeEventSource.instances.length, 1);
+
+  FakeEventSource.instances[0]._nativeError();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));   // probe rejection -> schedule
+  assert.deepEqual([...hub.timerDelays.values()], [2000], "first retry at 2s");
+  let notes = hub.els["perch-activity-list"].children.map((c) => c.textContent);
+  assert.equal(notes.filter((x) => x.includes("Reconnecting…")).length, 1);
+
+  // Fire the retry the way the real clock would: the entry LEAVES both maps
+  // when it fires (the harness only deletes on clearTimeout), then runs.
+  for (const [id, fn] of [...hub.timers.entries()]) {
+    hub.timers.delete(id); hub.timerDelays.delete(id); fn();
+  }
+  assert.equal(FakeEventSource.instances.length, 2, "the retry really re-opened a stream");
+  FakeEventSource.instances[1]._nativeError();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual([...hub.timerDelays.values()], [4000], "second slot doubles");
+  notes = hub.els["perch-activity-list"].children.map((c) => c.textContent);
+  assert.equal(notes.filter((x) => x.includes("Reconnecting…")).length, 1,
+    "still ONE rail note for the streak — a note per slot would be noise");
+
+  // Unlock the phone: the visibility handler retries NOW and clears the slot.
+  hub.doc.visibilityState = "visible";
+  hub.doc._dispatch("visibilitychange", {});
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(FakeEventSource.instances.length, 3, "re-opens immediately, not at the next slot");
+  assert.equal(hub.timers.size, 0, "the pending backoff slot is cancelled, not stacked");
+});
+
+test("a live stream is left alone by the visibility handler", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  assert.equal(FakeEventSource.instances.length, 1);
+  hub.doc.visibilityState = "visible";
+  hub.doc._dispatch("visibilitychange", {});
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(FakeEventSource.instances.length, 1,
+    "a stream that is still held must not be re-opened by an unlock — that would double-subscribe");
 });
 
 test("a model option shows its human name and says when it is not serving", async () => {
@@ -601,6 +660,11 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
   // handle past the end of every test that mounts this harness.
   let timerSeq = 1;
   const timers = new Map();
+  /* Parallel record of each pending timer's DELAY (id → ms). The reconnect
+     backoff test needs to see the 2s→4s→…→30s growth, and the timers Map
+     deliberately keeps storing bare fns — a dozen existing call sites fire
+     `for (const fn of hub.timers.values()) fn()`. */
+  const timerDelays = new Map();
   // Every confirm() the script asks is recorded with the exact prompt text, so
   // a test can prove BOTH that the gate was consulted and what it said.
   // Default: the operator cancels. A stop that fires anyway under this default
@@ -629,8 +693,8 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
       fetchCalls.push({ method, path, opts });
       return Promise.resolve(fetchFn(method, path, opts));
     },
-    setTimeout(fn) { const id = timerSeq++; timers.set(id, fn); return id; },
-    clearTimeout(id) { timers.delete(id); },
+    setTimeout(fn, delay) { const id = timerSeq++; timers.set(id, fn); timerDelays.set(id, delay == null ? undefined : delay); return id; },
+    clearTimeout(id) { timers.delete(id); timerDelays.delete(id); },
     setInterval(fn) { const id = timerSeq++; timers.set(id, fn); return id; },
     clearInterval(id) { timers.delete(id); },
     FileReader: class {
@@ -650,7 +714,7 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
   // fetchCalls or the DOM it produced.
   await new Promise((r) => setTimeout(r, 0));
 
-  return { els, doc, win, location, fetchCalls, sandbox, timers, confirms, prompts, history, mq };
+  return { els, doc, win, location, fetchCalls, sandbox, timers, timerDelays, confirms, prompts, history, mq };
 }
 
 /** Opens a chat session the same way a real click does: seed a /roost


### PR DESCRIPTION
## The disconnect Kevin keeps hitting on his phone

**Symptom:** a Perch session on the R4 instance declares itself disconnected when he unlocks his phone; same experience Friday. **Measured, not theorized:** during the 19:37 report the engine side was perfectly healthy — session `perchlive-b1a9c03b` sat at `waiting-user` with its last turn completed at 19:32 local, gateway up since 18:20, no restarts. The dead thing was the client's SSE view.

**Mechanism (two facts, one defect):**
1. The phone reaches the R4 dashboard through the tailscale serve proxy (`:8449 -> localhost:3008`). Screen-doze kills the socket; the server already does its part — `sse.js` heartbeats `: keepalive` every 30s for exactly these proxies (so no server change is needed or made).
2. The hub client's reconnect budget was **5 tries at a fixed 2s** — a 10-second window. A phone radio waking from doze routinely takes longer. Strike five and the UI printed "Lost the connection to this session." **permanently** (no further retries) over a live session, until the operator reopened it by hand.

**The fix (client-only):**
- **Unbounded exponential backoff**: 2s doubling to a 30s cap (a long outage costs 2 probes/min, not 30); counter resets only on a stream that actually opened (the existing cancel-vs-reset discipline is preserved and re-pinned).
- **Dead sessions are still detected** — by `onStreamError`'s options probe (404/410/401 terminal statuses leave to the list), never by a retry budget. `RECONNECT_FAILED` and its i18n key are deleted so no client-side budget can declare a live session dead again.
- **One "Reconnecting…" Activity note per failure streak** (was: one per slot).
- **`visibilitychange` unlock retry** (bindOnce + live() guarded, so the Turbo-leak regime covers it): unlocking the phone with no held stream re-opens IMMEDIATELY instead of waiting out the backoff slot; a held stream is left alone (no double-subscribe).

**Tests:** the growth curve is asserted, not described — the vm harness gained a `timerDelays` record (2000→4000 observed live through real failures; delay sequence 2/4/8/16/30/30/30 extracted), the one-note-per-streak and unlock-retry paths are driven end to end, and the existing browser-level N1 reconnect tests (real EventSource, real dropped connection, cross-turn and within-turn) stay green — the first retry is still 2s, so nothing that passed on the old budget passes for a new reason. Full suite **4724/0**.

**Note:** R4 picks this up at its next convergence (auto-update check ~00:26) or on restart; the phone gets the new client on the next page load after that. The same doze behavior existed Friday because this retry budget predates the open-anywhere work — it is not a PR3 regression.