### PR TITLE
Perch hub: the working gear, ask_user for bots, and the pi-lab parity audit

### DIFF
--- a/docs/es/guide/bot-builder.md
+++ b/docs/es/guide/bot-builder.md
@@ -89,7 +89,7 @@ Por defecto solo una sesión por agente corre a la vez, y cada sesión compite p
 
 ### 4. Acota las herramientas de un agente para una sola sesión
 
-Abre **Envoltura y herramientas** de la sesión. Verás el envelope completo del agente: todas las herramientas que tiene permitidas, cada una con una casilla, además de su modelo y sus skills.
+El acotado de herramientas por sesión vive en el **tablero**: abre la tarjeta en la que trabaja una sesión (o inicia la sesión desde una tarjeta) y abre **Envoltura y herramientas** en el panel lateral de la tarjeta. Verás el envelope completo del agente: todas las herramientas que tiene permitidas, cada una con una casilla, además de su modelo y sus skills. (El hub no tiene panel de envelope — las concesiones son solo del Bot Builder, y los recortes van por el panel de la tarjeta.)
 
 Desmarca una herramienta y queda apagada **solo para esa sesión**, a partir del siguiente mensaje. La definición del agente no se toca, y todas las demás sesiones conservan el conjunto completo. Esto es para el momento en que quieres que un agente responda sin tocar tus archivos, sin editar nada, sin salir a la red: en esta sesión, ahora mismo.
 

--- a/docs/guide/bot-builder.md
+++ b/docs/guide/bot-builder.md
@@ -89,7 +89,7 @@ Only one session per agent runs at a time by default, and every session competes
 
 ### 4. Narrow an agent's tools for one session
 
-Open **Envelope & tools** for the session. You see the agent's full envelope: every tool it is allowed to use, each with a checkbox, plus its model and skills.
+Per-session tool narrowing lives on the **board**: open the card a session is working (or start the session from a card) and open **Envelope & tools** in the card's drawer. You see the agent's full envelope: every tool it is allowed to use, each with a checkbox, plus its model and skills. (The hub itself has no envelope pane — grants are Bot Builder's alone, and removals ride the card drawer.)
 
 Uncheck a tool and it is switched off **for that session only**, from the next message onward. The agent's definition is untouched, and every other session keeps the full set. This is for the moment when you want an agent to answer without touching your files, without editing anything, without reaching out over the network — for this one session, right now.
 

--- a/docs/superpowers/specs/2026-09-12-perch-hub-pi-lab-parity-audit.md
+++ b/docs/superpowers/specs/2026-09-12-perch-hub-pi-lab-parity-audit.md
@@ -1,0 +1,88 @@
+# Perch Hub ↔ pi-lab web hub — parity audit
+
+**Date:** 2026-09-12 · **Requested by:** operator ("bring parity of tools and features from the pi-lab perch hub over to the crow perch hub")
+**Sources measured (not remembered):** `~/pi-lab/extensions/web/public/app.html` (919-line preact client), `~/pi-lab/extensions/web/{mobile.ts,server.ts}` (endpoint surface), `~/pi-lab/extensions/ask-user.ts` + `shared/bot-mode.mjs` (the ask gate), crow's `servers/gateway/dashboard/perch-hub/*`, `routes/perch-interactive-api.js`, `perch-interactive.js`, `scripts/pi-bots/{bridge,bot-world,pi_extensions_allowlist}.mjs`, and the live R4 instance.
+
+Scope note: the two hubs answer to different masters. pi-lab's hub drives ONE pi session that owns its own web server; crow's hub drives an engine of many bot sessions inside the dashboard's auth/funnel/Turbo regime, with Bot Builder as the single writer of what a bot may do. "Parity" below means operator-visible capability, not architecture — items marked **DIVERGENT BY DESIGN** are places where copying pi-lab would undo a deliberate crow decision.
+
+## 1. Already at parity (or beyond)
+
+| Capability | pi-lab | crow | Notes |
+|---|---|---|---|
+| Chat / Session / Files / Activity tabs | ✓ | ✓ (Phase D, #362) | crow's desktop split view is the one pi-lab lacks |
+| Open a session in any directory | — | ✓ (open-anywhere, #360/#362) | **crow-only**: server-backed picker + persisted `cwd` + wake-in-place; pi-lab sessions are born in their server's cwd |
+| Model switching | sheet, local-run dots ●/○, vision 👁, "will start server" | select, availability annotations ("not running"/"starts on demand"), persisted explicit choice, fail-open at wake | crow's row-provenance + dead-provider rails (#357) go beyond pi-lab |
+| Permission modes | ask / accept-edits / auto / bypass (+ classifier picker) | guarded / ask / bypass | **DIVERGENT BY DESIGN** — crow's vocabulary is engine-owned (`PERMISSION_MODES`) and enforced by pi-lab's permission-gating through `PI_BOT_PERMISSION_POLICY`; the auto-mode classifier has no crow analogue yet |
+| Plan mode | on/off + planning-model sheet | checkbox control + plan_state notes | partial — see gaps 11–13 |
+| Ask cards (ask_user) | combined multi-question card: headers, label+description options, multi-select, "Other…", one submit, answered state | sequential native cards: select/input/confirm/editor via `ctx.ui` relay, "Other…" fallback | tool now unlocked for perch spawns (this PR); **richness gap** = item 5 below |
+| Working indicator | "pi is working…" + bird color + per-tool spinners | gear strip on chat tab (this PR) | per-tool spinners = item 4 below |
+| Activity log | tool start/end rows, newest-first, capped 150, error-colored | timestamped rail (log/tool/error/plan_state), ascending, uncapped per session | minor formatting divergence |
+| Image attach | thumbnails pre-send, removable chips | upload-now + queue onto next send | parity in effect; pi-lab's pre-send chips are nicer (item 8) |
+| Rename / close | rename + archive | rename + close (terminal) | archive = item 14 |
+| SSE keepalive | server data-ping every 15s | server `: keepalive` comment every 30s (`streams/sse.js`) | parity |
+| Reconnect | fixed 3s retry + wake signals + watchdog | unbounded exponential backoff 2→30s, unlock retry, terminal probe (#364) | crow now ahead on backoff; pi-lab ahead on resync/watchdog — items 19–21 |
+| Safe-area insets, dark mode, thumb floors | ✓ | ✓ | crow measures thumb targets in CDP tests; pi-lab doesn't |
+| Tool governance | per-project `.mcp.json` toggles live in the Session tab | Bot Builder envelope (single writer) + per-session narrowing in the board card drawer | **DIVERGENT BY DESIGN**; hub-side surface = item 15 |
+
+## 2. Tool audit
+
+pi's tool surface for a bot = built-ins + pi-lab extension tools + MCP, filtered by the always-pinned `--tools` csv (`toolAllowlist` = `def.tools.pi_builtin` + `def.tools.crow_mcp` + conditional appends).
+
+| Tool | Source | Offered to crow bots? | Status |
+|---|---|---|---|
+| read, edit, write, bash, list, glob, grep | pi built-ins | ✓ `PI_BUILTIN` catalog | parity |
+| todo | pi-lab `todo.ts` | ✓ extension checkbox (`PI_EXT_ALLOWLIST`) | parity |
+| plan-mode | pi-lab `plan-mode/` | ✓ extension checkbox | parity |
+| subagent | pi-lab `subagent/` | ✓ extension checkbox + `multi_agent` policy + capability gate; name appended by the bridge | parity |
+| **ask_user** | pi-lab `ask-user.ts` (registers ONLY under `PI_BOT_INTERACTIVE=1`) | **was missing** — `--tools` filtered it even on perch spawns | **FIXED this PR**: appended for interactive spawns exactly where the extension registers it; narrowing can remove it; channel csvs byte-identical (goldens pin it) |
+| send_user_file | pi harness/web surface; pi-lab's mobile.ts serves the files as inline cards | ✗ not in crow's catalog; no engine relay for agent-sent files | **investigate** (item 12): needs an SSE frame + a serving route; crow's Files tab covers the download half |
+| MCP tools (crow servers, addons, remote peers) | mcp.json per instance | ✓ `crow_mcp` picker + remote capability gate | parity (crow's is richer: instance-bound, journal-guarded) |
+
+## 3. Gaps — pi-lab has, crow lacks
+
+Sized S/M/L; ⚠ = needs an operator decision before building.
+
+**Chat ergonomics**
+1. **S** — Enter sends / Shift+Enter newline (desktop composer).
+2. **S** — Auto-growing composer textarea (crow: fixed 72px min-height).
+3. **S** — Copy buttons: per message + per code fence (one-tap, ✓ flash, execCommand fallback).
+4. **M** — Inline tool chips in chat: running spinner per tool call, tap to expand args + result (result truncated ~2k). Requires the engine to relay tool args/results over SSE (frames today carry name+phase only).
+5. **M** — Combined multi-question ask card: the extension's native shape is a `questions[]` array (up to 4, headers, descriptions, multi-select, one submit). Crow's relay walks `ctx.ui` dialogs one at a time, so a 4-question ask_user arrives as up to 4 sequential cards and multi-select degrades into a toggle-loop selector. True parity = a `questions`-shaped card in `cardFrom`/`renderAsk` (engine + hub), which the extension's `pi-lab:ask-user` event already carries verbatim.
+6. **M** — Slash-command menu: typing `/` opens a live-filtered command list (`/chat/commands` equivalent for the bot's pi). 
+7. **S** — Attention banner above the chat when a card is waiting ("Session is waiting on a prompt — answer the question card").
+8. **S** — Non-image uploads: pi-lab lands them on disk and injects "I uploaded files: `<paths>`" into the message; crow uploads to uploadsDir but never tells the bot the path — a non-image attach is currently near-dead.
+
+**Session insight (Session tab)**
+9. **M** — Context meter: % + tokens/window (`getSessionStats` already flows through the engine for metering — surface it on the state frame or options).
+10. **S** — Agent card facts: uptime, child RSS, tool count.
+11. **M** — Plan progress: bar + step checklist (☑/▶/☐) from the plan_state todos array (the frame already carries it; the client prints one line).
+12. **L ⚠** — send_user_file parity: agent-sent file cards inline in chat (images inline, View/Download, caption). Needs tool availability research + an engine relay + a serving route under the existing jail discipline.
+13. **S** — Model-start lifecycle lines: "loading X…", "freeing RAM: Y shutting down", "now on X", start-failed. Crow's Activity rail has the warm lines; the *pending* state (a cold local model can take minutes) is invisible.
+
+**Session management**
+14. **S ⚠** — Archive: hide a session from the list without stopping it. Crow's list is live-sessions-only by design; archive presumes a session roster. Decide whether crow wants that.
+15. **M ⚠** — Envelope/narrowing surface in the hub: today the per-session tool narrowing pane lives in the board's card drawer (`panels/bot-board/drawer.js`), so hub-only sessions have no narrowing UI. (The operator guide claimed otherwise — corrected alongside this audit.) pi-lab additionally toggles MCP servers live per project; crow's single-writer model says Bot Builder owns grants, narrowing owns removals — a hub Session-tab narrowing pane would match that model.
+16. **— N/A** — Quick actions (/critique, /critique frontier, /todos buttons): pi-lab-specific extensions; crow bots get skills through Bot Builder instead.
+17. **— N/A** — Executor/agent-leg model rebinding: belongs to pi-lab's plan-execution machine; crow's plan mode doesn't spawn legs with bound models.
+
+**Files**
+18. **M ⚠** — Full cwd browse + in-app text viewer vs crow's outputs-only jail. Crow's download route is fd-based `O_NOFOLLOW`-jailed to outputsDir *by deliberate hardening* (final-review C2). Open-anywhere changed the premise — the operator now chooses the cwd — so a read-only browse of the SESSION'S cwd (reusing `/browse` + a realpath-under-cwd read jail) is defensible, but it is a security-posture decision, not a port.
+
+**Stream robustness**
+19. **S** — Resync on reconnect: pi-lab reloads history + status on every `connected` frame. Crow replays only the state frame + pending card, so messages that completed during a drop are missing from the live view until a manual reload. (This is the one gap with a correctness edge, not just cosmetics.)
+20. **S** — Stale-ping watchdog: if no event (including keepalives) arrives for ~40s while the tab is visible, reconnect — catches zombie sockets no error event ever fires for.
+21. **S** — Wake signals: crow has visibilitychange (#364) + focus; pi-lab also revives on `pageshow` and `online`.
+
+**Shell**
+22. **L ⚠** — PWA: pi-lab's mobile page is installable (manifest + service worker + standalone). Crow's hub lives inside the dashboard; making the DASHBOARD installable is a shell-level decision (CSP, SW scope, auth) well beyond perch.
+
+## 4. Suggested waves (if the operator greenlights parity work)
+
+- **Wave 1 — quick wins, no engine changes:** 1, 2, 3, 7, 8, 19, 20, 21 (+13's log lines are engine-side but trivial).
+- **Wave 2 — session insight:** 9, 10, 11 (all read from frames/RPC that already exist).
+- **Wave 3 — deeper ports:** 4 (tool args/results relay), 5 (combined ask card), 6 (slash menu).
+- **Decisions first:** 12 (send_user_file), 14 (archive), 15 (hub narrowing pane), 18 (cwd browsing posture), 22 (PWA).
+
+## 5. Corrections shipped alongside this audit
+
+- `docs/guide/bot-builder.md` (EN+ES) step 4 said "Open **Envelope & tools** for the session" as if the hub had it — the narrowing pane lives in the board's card drawer. Fixed to say so.

--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -190,6 +190,21 @@ export class PiRpc {
     // hand DB-edit bypasses this.
     let tools = toolAllowlist(def, { remoteEnabled: opts.remoteEnabled });
     if (maOptIn && maCapable) tools = [tools, "subagent"].filter(Boolean).join(",");
+    // PL-3 completion, same belt as subagent above. pi-lab's ask-user
+    // extension REGISTERS ask_user only under PI_BOT_INTERACTIVE=1
+    // (shared/bot-mode.mjs askUserPath: "ui" for interactive, "off" for
+    // channel bots — no user to ask there), and `--tools` filters
+    // extension-registered tools too (R7). Without this append the perch
+    // unlock the engine's extraEnv was built for never reached the model:
+    // the tool was registered but invisible, so a bot asked "can you give me
+    // choices?" truthfully answered no (measured live on r4-assistant,
+    // 2026-09-12). Appended exactly where the tool exists — interactive
+    // spawns — so every channel caller's csv stays byte-identical, and the
+    // per-session narrowing below can still take it away (envelope model:
+    // narrowing only ever removes).
+    if (opts.extraEnv && opts.extraEnv.PI_BOT_INTERACTIVE === "1") {
+      tools = [tools, "ask_user"].filter(Boolean).join(",");
+    }
     // C-6: per-session narrowing is applied to the FINAL csv — AFTER the
     // subagent append — so a session can narrow `subagent` away too. Narrowing
     // only ever removes (applySessionNarrowing); opts.narrowedTools absent (every

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -1448,6 +1448,9 @@ export function perchHubJs(lang = "en") {
     turnInFlight=next;
     el('perch-send').textContent=turnInFlight?STEER_LABEL:SEND_LABEL;
     el('perch-abort').style.display=turnInFlight?'':'none';
+    /* The working strip rides the SAME flag as the composer buttons — one
+       source of truth, so the gear and the Steer flip can never disagree. */
+    var w=el('perch-working'); if(w) w.hidden=!turnInFlight;
   }
 
   function send(){

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -224,6 +224,18 @@ body[data-view="chat"] #perch-chat{display:flex;flex-direction:column;flex:1;min
    ~3000px below the fold. Keep both rules; neither is dead. */
 #perch-composer{position:sticky;bottom:0;background:var(--card);border-top:1px solid var(--line);padding:10px 0;display:grid;gap:8px}
 #perch-composer .send-row{display:flex;gap:8px}
+/* The working strip (html.js's #perch-working): a turning gear + one word,
+   sitting between the ask pane and the composer as a non-shrinking flex
+   child — it must never squeeze the transcript or push Send off screen, and
+   [hidden] must outrank the display:flex on the same id (id+attr = (1,1,0)
+   beats id = (1,0,0)). The spin slows instead of stopping under
+   prefers-reduced-motion, matching pi-lab's own tool-spinner choice: motion
+   is the signal here, so the honest reduction is "calmer", not "frozen". */
+#perch-working{display:flex;align-items:center;gap:8px;padding:6px 2px 0;color:var(--dim);font-size:12.5px;flex-shrink:0}
+#perch-working[hidden]{display:none}
+#perch-working svg{width:15px;height:15px;color:var(--teal);flex-shrink:0;animation:perch-spin 1.4s linear infinite}
+@keyframes perch-spin{to{transform:rotate(360deg)}}
+@media (prefers-reduced-motion:reduce){#perch-working svg{animation-duration:6s}}
 #perch-composer textarea{min-height:72px}
 #perch-back{align-self:flex-start}
 /* --- Phase D1: the tab surface ------------------------------------------

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -122,6 +122,17 @@ ${engineBanner(engine, lang)}
     <section id="perch-tab-chat" role="tabpanel" aria-labelledby="perch-tab-btn-chat">
     <div id="perch-transcript"></div>
     <div id="perch-ask"></div>
+    <!-- The working strip: the chat tab's own "the bot is busy" signal.
+         Since Phase D moved the state pill into the Session tab, the only
+         in-chat evidence of a running turn was Send flipping to Steer —
+         which reads as a button change, not as activity. A turning gear
+         beside one word, driven by the SAME turnInFlight flag that flips
+         the composer (setTurnInFlight), so the two can never disagree.
+         aria-live=polite: a screen reader announces the state change
+         without interrupting mid-sentence. -->
+    <div id="perch-working" hidden aria-live="polite">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      <span>${escapeHtml(t("perch.working", lang))}</span></div>
     <div id="perch-composer">
       <textarea id="perch-input" placeholder="${escapeHtml(t("perch.composerPlaceholder", lang))}"></textarea>
       <div class="send-row">

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2349,6 +2349,7 @@ export const translations = {
     en: "Could not list the files.",
     es: "No se pudo listar los archivos.",
   },
+  "perch.working": { en: "Working…", es: "Trabajando…" },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -579,7 +579,7 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     // Session tab's cwd readout and its change trigger, the Files pane.
     "perch-tab-chat", "perch-tab-session", "perch-tab-files", "perch-tab-activity",
     "perch-tab-btn-chat", "perch-tab-btn-session", "perch-tab-btn-files", "perch-tab-btn-activity",
-    "perch-activity-list", "perch-session-cwd", "perch-change-cwd",
+    "perch-activity-list", "perch-session-cwd", "perch-change-cwd", "perch-working",
     "perch-files-list", "perch-files-refresh"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
@@ -2776,4 +2776,33 @@ test("D3: a file name is rendered as text, never as markup", async () => {
     " browser check (render test) proves the DOM never parses it");
   assert.ok(row.href.endsWith("/workspace/" + encodeURIComponent(hostile)),
     "and the link carries the encoded name");
+});
+
+// ---------------------------------------------------------------------------
+// The working strip: one flag, two surfaces. The gear must agree with the
+// composer's Send→Steer flip on EVERY transition, because a strip that lies
+// is worse than no strip.
+// ---------------------------------------------------------------------------
+
+test("the working strip tracks turnInFlight through state frames, replies and aborts", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const strip = hub.els["perch-working"];
+  const es = FakeEventSource.instances[0];
+
+  es._serverFrame("state", { state: "awake", turnInFlight: true });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(strip.hidden, false, "a turn starting shows the gear");
+  assert.equal(hub.els["perch-send"].textContent, "Steer", "and the composer flips in the same breath");
+
+  es._serverFrame("reply", { text: "done", turnId: "t1" });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(strip.hidden, true, "the reply hides it");
+  assert.equal(hub.els["perch-send"].textContent, "Send");
+
+  // A stopped session is never in flight, whatever a stale frame claims —
+  // the gear must obey turnFlagFor, not the raw frame.
+  es._serverFrame("state", { state: "stopped", turnInFlight: true });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(strip.hidden, true, "a stopped session never shows the gear");
 });

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -492,3 +492,37 @@ test("the picker dismiss never depends on one path: Escape via the registry AND 
   // perch-hub-client.test.js already covers the whole emitted script, so
   // directory names cannot reach a sink without tripping that one.
 });
+
+// ---------------------------------------------------------------------------
+// The working strip — the chat tab's "the bot is busy" signal (a turning
+// gear + one word), driven by the same turnInFlight flag as the composer.
+// ---------------------------------------------------------------------------
+
+test("the working strip ships hidden, labelled, and polite — between ask pane and composer", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const strip = html.match(/<div id="perch-working"[^>]*>/);
+  assert.ok(strip, "the strip exists");
+  assert.ok(strip[0].includes("hidden"), "ships hidden — an idle session must not claim to be working");
+  assert.ok(strip[0].includes('aria-live="polite"'), "a screen reader announces the state change");
+  const ask = html.indexOf('id="perch-ask"');
+  const w = html.indexOf('id="perch-working"');
+  const composer = html.indexOf('id="perch-composer"');
+  assert.ok(ask < w && w < composer, "it sits between the ask pane and the composer, inside the chat tab");
+  // House rule: visible label beside the glyph.
+  const seg = html.slice(w, composer);
+  assert.ok(/<\/svg>\s*<span>[^<]+<\/span>/.test(seg), "the gear carries a visible word");
+});
+
+test("the working strip CSS spins, hides by attribute, and calms under reduced motion", async () => {
+  const { perchHubCss } = await import("../servers/gateway/dashboard/perch-hub/css.js");
+  const css = perchHubCss().replace(/\s+/g, "");
+  assert.ok(/#perch-working\{[^}]*flex-shrink:0/.test(css),
+    "a non-shrinking flex child — it must never squeeze the transcript or push Send off screen");
+  assert.ok(/#perch-working\[hidden\]\{display:none\}/.test(css),
+    "[hidden] must outrank the strip's own display:flex");
+  assert.ok(/@keyframesperch-spin\{to\{transform:rotate\(360deg\)\}\}/.test(css));
+  assert.ok(/animation:perch-spin/.test(css));
+  assert.ok(/prefers-reduced-motion:reduce\)\{#perch-workingsvg\{animation-duration:6s\}/.test(css),
+    "reduced motion slows the gear instead of freezing the signal");
+});

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -730,9 +730,18 @@ test("F1b live: crossing the breakpoint with a chat open refreshes the list that
     assert.equal((await s.json(ROW_COUNT)).rows, 3, "still stale, as it should be at this width");
 
     await s.metrics(1280, 900);            // the operator widens the window
-    await new Promise((r) => setTimeout(r, 1200));
-
-    const after = await s.json(ROW_COUNT);
+    // POLL, do not sleep a fixed budget: the refresh is async (matchMedia
+    // change → syncListPolling → loadList → render) and the whole suite's CDP
+    // tests share ONE Chrome, so under full-suite load a fixed 1200ms flakes
+    // (measured twice: rows still 3 when the budget ran out). The property
+    // under test is that the crossing REFRESHES the list at all — nothing
+    // else would — not how fast it lands.
+    let after = null;
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 200));
+      after = await s.json(ROW_COUNT);
+      if (after.rows === 2) break;
+    }
     assert.equal(after.listVisible, true);
     assert.equal(after.rows, 2,
       "a breakpoint crossing is not a navigation, so nothing else would have refreshed it");

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -430,3 +430,23 @@ test("a log/tool frame lands in the Activity rail ONCE, not once per surviving i
       "no frame chatter in the transcript: " + JSON.stringify(notes));
   } finally { await s.close(); }
 });
+
+test("the working strip is live in the real DOM: shown by a turn-start frame, hidden by the reply", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    broadcast("state", { state: "awake", turnInFlight: true });
+    await sleep(300);
+    assert.equal(await s.evalIn(`document.getElementById('perch-working').hidden`), false,
+      "the gear shows while the turn runs");
+    assert.equal(await s.evalIn(`getComputedStyle(document.getElementById('perch-working').querySelector('svg')).animationName`),
+      "perch-spin", "and it is actually spinning");
+    broadcast("state", { state: "awake", turnInFlight: true });
+    broadcast("text", { text: "answer", turnId: "t-1" });
+    broadcast("reply", { text: "answer", turnId: "t-1" });
+    await sleep(300);
+    assert.equal(await s.evalIn(`document.getElementById('perch-working').hidden`), true,
+      "the turn ending hides it");
+  } finally { await s.close(); }
+});

--- a/tests/pibot-tools-envelope.test.js
+++ b/tests/pibot-tools-envelope.test.js
@@ -19,7 +19,7 @@ import { join } from "node:path";
 const { PiRpc } = await import("../scripts/pi-bots/bridge.mjs");
 
 /** Spawn PiRpc against a stub that dumps argv, and return the args pi saw. */
-async function spawnArgs(def, narrowedTools) {
+async function spawnArgs(def, narrowedTools, extraEnv = {}) {
   const scratch = mkdtempSync(join(tmpdir(), "crow-tools-"));
   mkdirSync(join(scratch, "sessions"), { recursive: true });
   const out = join(scratch, "argv.json");
@@ -35,7 +35,7 @@ async function spawnArgs(def, narrowedTools) {
     nodeBin: process.execPath,
     cliPath: stub,
     narrowedTools,
-    extraEnv: { CROW_TEST_ARGV_OUT: out },
+    extraEnv: { CROW_TEST_ARGV_OUT: out, ...extraEnv },
   });
   for (let i = 0; i < 100 && !existsSync(out); i++) await new Promise((r) => setTimeout(r, 50));
   try { pi.close(); } catch { /* already exited */ }
@@ -66,4 +66,47 @@ test("narrowing every tool away still pins --tools \"\"", async () => {
     { tools: { pi_builtin: ["read"], crow_mcp: [] } },
     JSON.stringify(["read"]));
   assert.equal(toolsFlag(argv), "");
+});
+
+// ---------------------------------------------------------------------------
+// PL-3 completion: ask_user rides ONLY the interactive spawn — exactly where
+// pi-lab's ask-user extension registers it (PI_BOT_INTERACTIVE=1 → askUserPath
+// "ui"). A channel csv that grew the name would be a dangling entry at best
+// and a lie about the envelope at worst; an interactive csv WITHOUT it filters
+// the registered tool away, which is the bug this pins shut.
+// ---------------------------------------------------------------------------
+
+test("an interactive spawn appends ask_user; the channel spawn's csv is byte-identical without it", async () => {
+  const def = { tools: { pi_builtin: ["read"], crow_mcp: ["tasks/tasks_list"] } };
+  const channel = await spawnArgs(def);
+  assert.equal(toolsFlag(channel), "read,mcp__tasks__tasks_list",
+    "no marker, no append — every channel caller stays exactly as before");
+  const interactive = await spawnArgs(def, undefined, { PI_BOT_INTERACTIVE: "1" });
+  assert.equal(toolsFlag(interactive), "read,mcp__tasks__tasks_list,ask_user");
+});
+
+test("an empty envelope still gains ask_user on an interactive spawn", async () => {
+  const argv = await spawnArgs({ tools: { pi_builtin: [], crow_mcp: [] } },
+    undefined, { PI_BOT_INTERACTIVE: "1" });
+  assert.equal(toolsFlag(argv), "ask_user",
+    "the join must not leave a leading comma on an otherwise-empty csv");
+});
+
+test("a session can narrow ask_user away — it joins the csv BEFORE narrowing", async () => {
+  const argv = await spawnArgs({ tools: { pi_builtin: ["read"], crow_mcp: [] } },
+    JSON.stringify(["ask_user"]), { PI_BOT_INTERACTIVE: "1" });
+  assert.equal(toolsFlag(argv), "read",
+    "narrowing only ever removes, and it can remove this too — the envelope model holds");
+});
+
+test("a def cannot fake the marker: spawn_env hygiene strips PI_BOT_* before the append decision", async () => {
+  // C-12 strips engine-reserved keys from def.spawn_env; the append reads
+  // opts.extraEnv (the engine's own channel), never the def-merged env — so a
+  // bot def claiming PI_BOT_INTERACTIVE cannot grant itself ask_user on a
+  // channel turn.
+  const argv = await spawnArgs({
+    tools: { pi_builtin: ["read"], crow_mcp: [] },
+    spawn_env: { PI_BOT_INTERACTIVE: "1" },
+  });
+  assert.equal(toolsFlag(argv), "read");
 });


### PR DESCRIPTION
## Perch hub: the working gear, ask_user for bots, and the pi-lab parity audit

Three operator asks from one mobile session, one branch:

### 1. The working indicator (chat tab)
Since Phase D moved the state pill into the Session tab, the chat tab's only evidence of a running turn was Send flipping to Steer. Now a turning gear + "Working…" sits between the ask pane and the composer, toggled by the SAME `setTurnInFlight` that flips the composer — one source of truth, so the gear and Steer can never disagree. `aria-live=polite`; non-shrinking flex child (can never squeeze Send off screen); `[hidden]` outranks its `display:flex` by specificity; `prefers-reduced-motion` slows the spin instead of freezing the signal (pi-lab's own choice — motion IS the signal). Measured live over CDP: shown by a turn-start frame, actually spinning (`animationName: perch-spin`), hidden by the reply.

### 2. Perch bots can ask multiple-choice questions (`ask_user`)
r4-assistant truthfully answered "I don't have that ability" — measured root cause: pi-lab's ask-user extension REGISTERS `ask_user` only under `PI_BOT_INTERACTIVE=1` (the engine's own marker, PL-3's designed unlock), but `--tools` filters extension-registered tools too (the R7 belt) and the name never rode the csv. The tool was registered and invisible.

Fix mirrors the `subagent` precedent exactly: appended after `toolAllowlist`, **before** per-session narrowing (envelope model holds — a session can narrow it away), gated on `opts.extraEnv` (the engine's channel), never on `def.spawn_env` (C-12 strips `PI_BOT_*` from defs — pinned by a test). Channel csvs stay byte-identical; the goldens pin that. In the hub, questions render as the existing ask cards: `runTuiFlow` drives `ctx.ui.select/input` per question → the engine's `cardFrom` relay → tappable select cards with an "Other…" free-text fallback. No bot-def edits needed: every Perch session gets it on next wake.

### 3. The parity audit (`docs/superpowers/specs/2026-09-12-perch-hub-pi-lab-parity-audit.md`)
Full feature + tool inventory of pi-lab's web hub (`app.html`/`mobile.ts`/`ask-user.ts`) vs crow's, measured from source on both sides: what's at parity (or beyond — open-anywhere, model provenance rails, reconnect backoff), **22 gaps sized S/M/L**, five flagged as operator decisions (cwd-browsing posture, archive, hub narrowing pane, send_user_file, PWA), and three suggested build waves. Headline: the tool surface is now at parity (ask_user was the one true gap; todo/plan-mode/subagent were already selectable); the interesting gaps are chat ergonomics (Enter-to-send, copy buttons), stream resync-on-reconnect (a correctness edge — messages completed during a drop are missing until reload), the context-% meter, and the combined multi-question ask card.

### Also in this branch
- **Guide correction (EN+ES):** step 4 claimed the hub has an "Envelope & tools" pane — it lives in the board's card drawer (found while auditing; audit item 15 tracks the hub-side surface).
- **F1b test hardening:** the breakpoint-crossing render test slept a fixed 1200ms and flaked twice under full-suite CDP contention (rows read 3 before the async refresh settled). Now polls up to 6s for the same assertion; 3/3 stable.

**Verification:** full suite **4732/0**; docs build clean (both locales); spinner + ask-card paths covered by vm-harness, static, and live-CDP tests (see commits). After merge, R4 converges at its next auto-update (~00:26) or on restart.
