### PR TITLE
Perch hub Wave 1: Enter-to-send, auto-grow, copy buttons, attention banner, upload paths, SSE resync + watchdog

### DIFF
--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -62,7 +62,7 @@ export function perchHubJs(lang = "en") {
   function live(){ return !retired&&HUB.gen===GEN; }
   HUB.retire=function(){
     retired=true;
-    stopListPolling(); cancelReconnect(); closeStream();
+    stopListPolling(); cancelReconnect(); stopWatchdog(); closeStream();
     /* Anything left in the registry belongs to an instance older still (or to
        a session this one never held): close it by identity — that is the
        whole point of keeping the registry. */
@@ -137,6 +137,59 @@ export function perchHubJs(lang = "en") {
      failed render, an older gateway, or a non-prose frame all produce. */
   function setSanitizedHtml(node,html){ node.innerHTML=html; }
 
+  /* Wave 1: one-tap copy, ported from pi-lab's behaviour verbatim — a ✓
+     flash for 1.2s, execCommand fallback for non-secure contexts
+     (navigator.clipboard is undefined there; the dashboard can be served
+     over plain http on the LAN). typeof-guarded for the vm test harness,
+     which has no navigator at all. */
+  function copyText(text,btn){
+    var flash=function(){
+      if(!btn) return;
+      var orig=btn.textContent;
+      btn.textContent='\\u2713';
+      if(btn.classList) btn.classList.add('copied');
+      setTimeout(function(){
+        btn.textContent=orig;
+        if(btn.classList) btn.classList.remove('copied');
+      },1200);
+    };
+    if(typeof navigator!=='undefined'&&navigator.clipboard&&navigator.clipboard.writeText){
+      navigator.clipboard.writeText(String(text==null?'':text)).then(flash,function(){});
+      return;
+    }
+    try{
+      var ta=document.createElement('textarea');
+      ta.value=String(text==null?'':text);
+      ta.style.position='fixed'; ta.style.opacity='0';
+      document.body.appendChild(ta); ta.select();
+      document.execCommand('copy');
+      flash();
+      document.body.removeChild(ta);
+    }catch(e){}
+  }
+
+  /* Wave 1: every server-rendered code fence gets a copy button. The
+     wrapper is minted HERE (client-side DOM surgery, never innerHTML): the
+     button must be a SIBLING of the <pre>, not a child, or its own glyph
+     pollutes pre.textContent — the copy source. Guarded on querySelectorAll
+     because vm-harness elements do not carry it; the live CDP test measures
+     the real thing. */
+  function enhancePres(what){
+    if(!what.querySelectorAll) return;
+    var pres=what.querySelectorAll('pre');
+    for(var i=0;i<pres.length;i++){
+      var pre=pres[i];
+      if(!pre.parentNode||pre.parentNode.className==='prewrap') continue;
+      var wrap=document.createElement('div'); wrap.className='prewrap';
+      pre.parentNode.insertBefore(wrap,pre);
+      wrap.appendChild(pre);
+      var b=document.createElement('button'); b.type='button'; b.className='copy-pre';
+      b.textContent='\\u29c9'; b.setAttribute('aria-label',COPY_CODE_LABEL);
+      b.onclick=(function(p,btn){ return function(){ copyText(p.textContent,btn); }; })(pre,b);
+      wrap.appendChild(b);
+    }
+  }
+
   /* \`html\` is optional and server-rendered; without it this is byte-for-byte
      the old textContent behaviour. */
   function appendMessage(cls,who,text,html){
@@ -147,9 +200,19 @@ export function perchHubJs(lang = "en") {
       var what=document.createElement('div');
       what.className='what md';
       setSanitizedHtml(what,html);
+      enhancePres(what);                     /* Wave 1: copy buttons on fences */
       row.appendChild(what);
     } else {
       row.appendChild(line('what',text));   /* textContent, never innerHTML */
+    }
+    /* Wave 1: every BOT row is one tap from the clipboard — and the copy
+       source is the RAW text (the markdown the model wrote), never the
+       rendered DOM's textContent, which has lost the fences and links. */
+    if(cls==='bot'){
+      var cp=document.createElement('button'); cp.type='button'; cp.className='copy-msg';
+      cp.textContent='\\u29c9'; cp.setAttribute('aria-label',COPY_MSG_LABEL);
+      cp.onclick=(function(t,btn){ return function(){ copyText(t,btn); }; })(text,cp);
+      row.appendChild(cp);
     }
     tr.appendChild(row);
     tr.scrollTop=tr.scrollHeight;
@@ -286,6 +349,11 @@ export function perchHubJs(lang = "en") {
   /* Phase D3: the Files tab. */
   var FILES_EMPTY='${tJs("perch.filesEmpty", lang)}';
   var FILES_FAILED='${tJs("perch.filesFailed", lang)}';
+  /* Wave 1: copy buttons + non-image upload path injection. */
+  var COPY_MSG_LABEL='${tJs("perch.copyMessage", lang)}';
+  var COPY_CODE_LABEL='${tJs("perch.copyCode", lang)}';
+  var FILE_QUEUED_PATH='${tJs("perch.fileQueuedPath", lang)}';
+  var UPLOADED_HEADER='${tJs("perch.uploadedHeader", lang)}';
 
   /* Row identity. One bot with eight sessions renders eight rows that read
      "R4 Assistant / awake" and nothing else — measured verbatim in a browser
@@ -874,19 +942,28 @@ export function perchHubJs(lang = "en") {
     if(listOnScreen()) loadList();
   });
 
-  /* Phone unlock / tab re-focus: a dozed socket is rediscovered NOW, not at
-     the next backoff slot (which can be up to 30s away on a long streak).
-     onStreamError closeStreams FIRST, so \'stream\' is null exactly in the
-     window where a retry is pending or the radio just came back; a live
-     stream is left alone. Guarded like every document listener (bindOnce +
-     live()) so a retired instance never re-opens from here. */
-  bindOnce(document,'visibilitychange','visibility',function(){
+  /* Phone unlock / tab re-focus / pageshow / back online: a dozed socket is
+     rediscovered NOW, not at the next backoff slot (which can be up to 30s
+     away on a long streak). onStreamError closeStreams FIRST, so \'stream\' is
+     null exactly in the window where a retry is pending or the radio just
+     came back; a live stream is left alone. The re-open carries resync=true:
+     the engine replays only state + the pending card on subscribe, so frames
+     that COMPLETED while the socket was dead are re-fetched with the
+     transcript instead of silently missing until a manual reload (Wave 1
+     item 19; pi-lab has reloaded on every reconnect since day one). Guarded
+     like every document/window listener (bindOnce + live()). */
+  function reviveStream(){
     if(!live()) return;
-    if(document.visibilityState!=='visible') return;
+    if(document.visibilityState&&document.visibilityState!=='visible') return;
     if(!current.sid||stream) return;
     cancelReconnect(); retries=0;
-    openStream(current.sid);
+    openStream(current.sid,true);
+  }
+  bindOnce(document,'visibilitychange','visibility',function(){
+    if(document.visibilityState==='visible') reviveStream();
   });
+  bindOnce(window,'pageshow','pageshow',reviveStream);
+  bindOnce(window,'online','online',reviveStream);
 
   /* Engine-minted ids only: "perchlive-" + 8 hex (perch-interactive.js:1473).
      A loose pattern would admit ".." and this value is concatenated into an
@@ -903,6 +980,11 @@ export function perchHubJs(lang = "en") {
      follows, then clear regardless of outcome. resetControls() also clears
      this so a new session never inherits a stale queue. */
   var pendingImages=[];
+  /* Wave 1: non-image uploads. The file is already on disk in the session's
+     uploadsDir, and the model can no more SEE the upload than it can see
+     the wire — so its PATH rides the next outgoing message (pi-lab's
+     idiom, its wording). Images ride the wire; files ride the filesystem. */
+  var pendingFilePaths=[];
 
   function openSession(sid){
     if(current.sid===sid) return;          /* a re-entered hash is a no-op */
@@ -1010,12 +1092,13 @@ export function perchHubJs(lang = "en") {
 
   function closeStream(){
     cancelReconnect();                 /* timer only — NOT the retry counter */
+    stopWatchdog();                    /* Wave 1: no stream, nothing to watchdog */
     var es=stream; stream=null;        /* null FIRST: idempotent under a double call
                                           from openSession + hashchange */
     if(es){ try{ es.close(); }catch(e){} unregisterStream(es); }
   }
 
-  function openStream(sid){
+  function openStream(sid,resync){
     closeStream();
     /* EXPLICIT REPLACE, by identity. closeStream() above can only reach the
        connection THIS instance holds; a stream opened for this session by an
@@ -1027,7 +1110,14 @@ export function perchHubJs(lang = "en") {
     var es=new EventSource(API+'/interactive/'+encodeURIComponent(sid)+'/events');
     stream=es;
     HUB.streams[sid]=es;
-    es.onopen=function(){ resetBackoff(); };
+    noteEvent();   /* Wave 1: a fresh socket starts with a fresh silence budget — the watchdog measures from HERE, not from the last frame of the previous stream */
+    es.onopen=function(){ resetBackoff(); noteEvent(); if(resync) resyncHistory(); };
+    /* Wave 1 item 20 fuel: the server's 30s named ping (sse.js) is the only
+       traffic an IDLE-but-healthy stream sees, so it is what the watchdog
+       measures silence against. Raw listener, not on(): a ping carries no
+       session semantics and must never touch the transcript. */
+    es.addEventListener('ping',function(){ if(live()) noteEvent(); });
+    startWatchdog();
 
     var on=function(type,fn){
       es.addEventListener(type,function(ev){
@@ -1040,6 +1130,7 @@ export function perchHubJs(lang = "en") {
            printed a bare "error" note here before onStreamError (bound
            through the single-slot es.onerror property) ever got to reconnect. */
         if(typeof ev.data!=='string') return;
+        noteEvent();                              /* Wave 1: any frame is liveness */
         var d={}; try{ d=JSON.parse(ev.data); }catch(e){ d={}; }
         fn(d);
       });
@@ -1152,6 +1243,10 @@ export function perchHubJs(lang = "en") {
     e.hidden=!label;
   }
   function showHeader(botId,botName){
+    /* Wave 1: the bot id is remembered for the session's life —
+       resync-on-reconnect re-fetches the transcript BY BOT, and the cold
+       deep-link path learns it from /roost before ever calling this. */
+    current.botId=botId;
     el('perch-bot-name').textContent=botName||botId;
     /* The session id stays here, unchanged and on its own: it is the identity
        the close confirm and every API path use. */
@@ -1193,8 +1288,50 @@ export function perchHubJs(lang = "en") {
       retryTimer=null;
       if(!live()) return;                           /* retired mid-backoff */
       if(current.sid!==mySid) return;               /* navigated away mid-backoff */
-      openStream(mySid);
+      openStream(mySid,true);                       /* resync: the gap is exactly what this stream missed */
     },reconnectDelayMs());
+  }
+
+  /* Wave 1 item 20: the stale-ping watchdog. A dozed phone can leave a
+     ZOMBIE socket that fires NO error event at all — visibilitychange
+     covers the unlock, but a silently-dead socket on a FOREGROUND tab is
+     only discoverable by the absence of traffic. The server pings every
+     30s (sse.js's named ping), so 75s of silence while visible with a
+     held stream is two missed pings plus scheduling slack: proved dead.
+     Drop it and re-open WITH resync, because whatever completed during
+     the zombie window is exactly what the transcript refetch is for.
+     15s tick: worst-case discovery is 90s, versus never. */
+  var lastEventAt=0, watchTimer=null;
+  function noteEvent(){ lastEventAt=Date.now(); }
+  function startWatchdog(){
+    stopWatchdog();
+    watchTimer=setInterval(function(){
+      if(!live()) return;
+      if(document.visibilityState&&document.visibilityState!=='visible') return;
+      if(!current.sid||!stream) return;
+      if(Date.now()-lastEventAt>75000){ closeStream(); openStream(current.sid,true); }
+    },15000);
+  }
+  function stopWatchdog(){ if(watchTimer){ clearInterval(watchTimer); watchTimer=null; } }
+
+  /* Wave 1 item 19: the resync itself. A REPLACE, never an append: the
+     whole transcript refetches (the engine's own history endpoint is the
+     source of truth), and the history seam re-opens so frames arriving
+     DURING the refetch still dedupe through histBuf exactly as they do at
+     first open. The turn-render bookkeeping (renderedTurn/turnRendered) is
+     deliberately KEPT across a resync: the batch re-renders every completed
+     message the live frames already showed, and that memory is what
+     suppresses the in-flight turn's reply from appending its concatenation
+     on top (the N1-within-turn duplicate). Clearing it re-broke exactly
+     what N1 pins — measured red before this comment existed. The ask pane
+     is untouched: the engine replays a pending card on the fresh subscribe,
+     and renderAsk clears before it draws. */
+  function resyncHistory(){
+    var sid=current.sid, botId=current.botId;
+    if(!sid||!botId) return;
+    clearEl(el('perch-transcript'));
+    histSettled=false; histBuf=[];
+    loadHistory(botId,sid);
   }
 
   function loadHistory(botId,sid){
@@ -1378,6 +1515,8 @@ export function perchHubJs(lang = "en") {
     histSettled=false;
     histBuf=[];
     pendingImages=[];            /* nor its queued-but-unsent image */
+    pendingFilePaths=[];         /* nor its queued upload paths (Wave 1) */
+    setAttn(false);              /* nor its unanswered-question banner */
   }
 
   /* routes/perch-interactive-api.js:531-540 reads permission_mode and
@@ -1460,7 +1599,16 @@ export function perchHubJs(lang = "en") {
     var mySid=current.sid;
     appendMessage('user','you',text);      /* echo before the round trip */
     input.value='';
+    input.style.height='auto';             /* Wave 1: the auto-grow collapses back after a send */
     var body={message:text};
+    /* Wave 1: non-image uploads ride the message as PATHS — the file is
+       already in the session's uploadsDir on this machine, and pi's read
+       tool is not write-jailed, so the bot can open what the operator
+       attached. The local echo stays the operator's own words; the prefix
+       is for the model, not for the human. */
+    if(pendingFilePaths.length){
+      body.message=UPLOADED_HEADER+'\\n'+pendingFilePaths.map(function(p){return '- '+p;}).join('\\n')+'\\n\\n'+text;
+    }
     /* routes/perch-interactive-api.js's normalizeMessageImages reads
        body.images on /message only — /steer never looks at it, so attaching
        here regardless of path is harmless on a steer. Cleared immediately,
@@ -1468,6 +1616,7 @@ export function perchHubJs(lang = "en") {
        the queue, and re-attaching is one tap away. */
     if(pendingImages.length) body.images=pendingImages;
     pendingImages=[];
+    pendingFilePaths=[];
     perchApi('POST',sendPath(mySid,turnInFlight),body).then(function(r){
       if(current.sid!==mySid) return;
       if(r.status===409){ setTurnInFlight(true); return; }   /* raced a turn start */
@@ -1518,6 +1667,7 @@ export function perchHubJs(lang = "en") {
                     answerPayloadFor(card,choice)).then(function(r){
       if(current.sid!==mySid) return;
       clearEl(el('perch-ask'));
+      setAttn(false);                          /* the banner dies with the card */
       if(r.status===409) appendNote(ASK_STALE);
     });
   }
@@ -1526,10 +1676,11 @@ export function perchHubJs(lang = "en") {
      ask_user frame blocks the turn until answered, so it must not be
      scrollable past inside the transcript. Built with createElement/
      textContent only — never innerHTML. */
+  function setAttn(show){ var b=el('perch-attn'); if(b) b.hidden=!show; }
   function renderAsk(card){
     var pane=el('perch-ask'); if(!pane) return;
     clearEl(pane);
-    if(!card||!card.requestId) return;
+    if(!card||!card.requestId){ setAttn(false); return; }
     var frame=document.createElement('div'); frame.className='ask-card';
     if(card.title) frame.appendChild(line('ask-title',card.title));
     if(card.message) frame.appendChild(line('ask-message',card.message));
@@ -1569,6 +1720,7 @@ export function perchHubJs(lang = "en") {
 
     frame.appendChild(controls);
     pane.appendChild(frame);
+    setAttn(true);                             /* Wave 1: say why the bot went quiet */
   }
 
   function attachFile(file){
@@ -1582,11 +1734,14 @@ export function perchHubJs(lang = "en") {
                {name:file.name,data_b64:b64}).then(function(r){
         if(current.sid!==mySid) return;
         if(r.ok){
-          /* Queued onto send()'s pendingImages, in pi's wire shape
-             {mime,data_b64} — an upload that isn't an image has nothing to
-             queue: the model reads images, not arbitrary files. */
+          /* Images queue onto send()'s pendingImages in pi's wire shape
+             {mime,data_b64}. Everything else queues its on-disk PATH
+             (Wave 1): the upload landed in uploadsDir, and a path in the
+             next message is what turns it from stored bytes into something
+             the bot can actually read. */
           if(isImage) pendingImages.push({mime:file.type,data_b64:b64});
-          appendNote(FILE_QUEUED);
+          else if(r.j&&r.j.full_path) pendingFilePaths.push(r.j.full_path);
+          appendNote(isImage?FILE_QUEUED:FILE_QUEUED_PATH);
         } else {
           appendNote((r.j&&r.j.error)||FILE_FAILED);
         }
@@ -1610,6 +1765,23 @@ export function perchHubJs(lang = "en") {
      rather than calling closeSession() directly, so applyHash -> hashchange
      -> closeSession runs and browser history stays correct. */
   el('perch-send').onclick=send;
+  /* Wave 1: Enter sends, Shift+Enter newlines (pi-lab's composer rule
+     verbatim — phone soft keyboards included, which is what its own
+     mobile-first page ships), and the textarea grows with its content up
+     to the CSS 120px ceiling, then scrolls inside itself. */
+  var composerInput=el('perch-input');
+  if(composerInput){
+    composerInput.onkeydown=function(ev){
+      if(ev&&ev.key==='Enter'&&!ev.shiftKey){
+        if(ev.preventDefault) ev.preventDefault();
+        send();
+      }
+    };
+    composerInput.oninput=function(){
+      this.style.height='auto';
+      this.style.height=Math.min(this.scrollHeight||72,120)+'px';
+    };
+  }
   el('perch-back').onclick=function(){ location.hash=''; };
   function abortTurn(){
     if(!current.sid) return;

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -236,7 +236,26 @@ body[data-view="chat"] #perch-chat{display:flex;flex-direction:column;flex:1;min
 #perch-working svg{width:15px;height:15px;color:var(--teal);flex-shrink:0;animation:perch-spin 1.4s linear infinite}
 @keyframes perch-spin{to{transform:rotate(360deg)}}
 @media (prefers-reduced-motion:reduce){#perch-working svg{animation-duration:6s}}
-#perch-composer textarea{min-height:72px}
+#perch-composer textarea{min-height:72px;max-height:120px;overflow-y:auto}
+/* Wave 1: the composer auto-grows (client.js oninput, pi-lab's exact idiom)
+   up to the 120px ceiling above, then scrolls inside itself — a pasted
+   essay must not push Send off screen, the one sin this page's whole flex
+   chain exists to prevent. */
+/* Wave 1: copy buttons, ported from pi-lab (copy-msg floats in the message,
+   copy-pre pins to its code fence's corner). Deliberately quiet: they are
+   chrome on somebody's answer, not controls competing with the composer.
+   The prewrap wrapper is minted client-side around each server-rendered
+   <pre> (enhancePres) so the button is a SIBLING of the pre — inside it,
+   the button's own glyph would pollute pre.textContent, the copy source. */
+#perch-hub-root .copy-msg{align-self:flex-start;flex-shrink:0;margin:0 0 0 4px;background:none;border:none;color:inherit;opacity:.45;font-size:13px;cursor:pointer;padding:2px 6px;min-height:24px}
+#perch-hub-root .prewrap{position:relative}
+#perch-hub-root .copy-pre{position:absolute;top:6px;right:6px;z-index:1;background:var(--card);border:1px solid var(--line);border-radius:6px;color:var(--dim);font-size:12px;padding:1px 7px;cursor:pointer;opacity:.75;min-height:24px}
+#perch-hub-root .copy-msg.copied,#perch-hub-root .copy-pre.copied{opacity:1;color:var(--teal)}
+/* Wave 1: the attention banner (html.js's #perch-attn). [hidden] on an id
+   with its own display rule needs the attribute selector to outrank it —
+   (1,1,0) over (1,0,0), same discipline as the tab sections. */
+#perch-hub-root .attn-banner{display:flex;align-items:center;gap:8px;background:var(--teal-soft);border:1px solid var(--attn);color:var(--attn);border-radius:10px;padding:9px 12px;font-size:13px;font-weight:500;margin:8px 0 0;flex-shrink:0}
+#perch-hub-root .attn-banner[hidden]{display:none}
 #perch-back{align-self:flex-start}
 /* --- Phase D1: the tab surface ------------------------------------------
    ONE strip, two placements. Desktop: a top strip in the right pane (natural

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -120,6 +120,12 @@ ${engineBanner(engine, lang)}
          flex:1/min-height:0/display:flex column in css.js) so the transcript
          stays the ONLY scroller and the sticky composer backstop is intact. -->
     <section id="perch-tab-chat" role="tabpanel" aria-labelledby="perch-tab-btn-chat">
+    <!-- Wave 1: the attention banner. An ask card blocks the turn until
+         answered; on a phone the card can be a scroll away, so the banner
+         says why the bot went quiet. Toggled by renderAsk/answerAsk — the
+         same pendingUi lifecycle the list row's "waiting on you" state and
+         the engine's replay-on-subscribe already ride. -->
+    <div id="perch-attn" class="attn-banner" hidden>⚠ ${escapeHtml(t("perch.waitingBanner", lang))}</div>
     <div id="perch-transcript"></div>
     <div id="perch-ask"></div>
     <!-- The working strip: the chat tab's own "the bot is busy" signal.

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2350,6 +2350,20 @@ export const translations = {
     es: "No se pudo listar los archivos.",
   },
   "perch.working": { en: "Working…", es: "Trabajando…" },
+  "perch.copyMessage": { en: "Copy message", es: "Copiar mensaje" },
+  "perch.copyCode": { en: "Copy code", es: "Copiar código" },
+  "perch.waitingBanner": {
+    en: "Waiting on your answer — respond to the question card below.",
+    es: "Esperando tu respuesta — contesta la tarjeta de abajo.",
+  },
+  "perch.fileQueuedPath": {
+    en: "File uploaded — its path rides your next message.",
+    es: "Archivo subido — su ruta viaja con tu próximo mensaje.",
+  },
+  "perch.uploadedHeader": {
+    en: "I uploaded files for you to look at:",
+    es: "Subí archivos para que los revises:",
+  },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -827,7 +827,13 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
       } finally {
         try { closeSync(fd); } catch { /* already closed */ }
       }
-      res.json({ path: name });
+      // Wave 1: full_path is the on-disk location the client injects into the
+      // next message for non-image uploads ("I uploaded files: <path>"), so
+      // the bot can actually READ what was uploaded — pi's read tool is not
+      // write-jailed and uploadsDir is a real path the child's user owns.
+      // The dashboard operator is the machine owner (same posture as
+      // /browse), so disclosing the path discloses nothing new.
+      res.json({ path: name, full_path: join(snap.uploadsDir, name) });
     } catch (err) {
       mapEngineError(res, err);
     }

--- a/servers/gateway/streams/sse.js
+++ b/servers/gateway/streams/sse.js
@@ -72,8 +72,16 @@ export function openStream(res, { heartbeatMs = 30000 } = {}) {
     sendRaw(`event: ${event}\ndata: ${payload}\n\n`);
   };
 
+  // Heartbeat: a NAMED ping event, not a `: keepalive` comment (Wave 1).
+  // Comments are invisible to EventSource clients — a phone whose socket
+  // zombied through a screen-doze never fires an error and had nothing to
+  // notice the silence with. A named frame carries the same proxy-keepalive
+  // bytes AND feeds the perch hub's stale-ping watchdog. Every other
+  // consumer (turbo stream sources, board, messages, ramble) listens by
+  // name and ignores 'ping' — EventSource only delivers named events to
+  // matching listeners.
   const heartbeat = setInterval(() => {
-    sendRaw(": keepalive\n\n");
+    sendRaw("event: ping\ndata: {}\n\n");
   }, heartbeatMs);
 
   const close = () => {

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -274,7 +274,9 @@ test("a failing reconnect schedules the NEXT slot at the doubled delay, and one 
   FakeEventSource.instances[0]._nativeError();
   await new Promise((r) => setTimeout(r, 0));
   await new Promise((r) => setTimeout(r, 0));   // probe rejection -> schedule
-  assert.deepEqual([...hub.timerDelays.values()], [2000], "first retry at 2s");
+  // Wave 1: the watchdog (15000) shares the delay map — assert on the retry slots.
+  const retryDelays = () => [...hub.timerDelays.values()].filter((d) => d !== 15000);
+  assert.deepEqual(retryDelays(), [2000], "first retry at 2s");
   let notes = hub.els["perch-activity-list"].children.map((c) => c.textContent);
   assert.equal(notes.filter((x) => x.includes("Reconnecting…")).length, 1);
 
@@ -287,7 +289,7 @@ test("a failing reconnect schedules the NEXT slot at the doubled delay, and one 
   FakeEventSource.instances[1]._nativeError();
   await new Promise((r) => setTimeout(r, 0));
   await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual([...hub.timerDelays.values()], [4000], "second slot doubles");
+  assert.deepEqual(retryDelays(), [4000], "second slot doubles");
   notes = hub.els["perch-activity-list"].children.map((c) => c.textContent);
   assert.equal(notes.filter((x) => x.includes("Reconnecting…")).length, 1,
     "still ONE rail note for the streak — a note per slot would be noise");
@@ -297,7 +299,10 @@ test("a failing reconnect schedules the NEXT slot at the doubled delay, and one 
   hub.doc._dispatch("visibilitychange", {});
   await new Promise((r) => setTimeout(r, 0));
   assert.equal(FakeEventSource.instances.length, 3, "re-opens immediately, not at the next slot");
-  assert.equal(hub.timers.size, 0, "the pending backoff slot is cancelled, not stacked");
+  // Wave 1: the watchdog interval (15000) is a legitimate resident now —
+  // assert the RETRY SLOT is gone, not that the map is empty.
+  assert.equal([...hub.timerDelays.values()].filter((d) => d !== 15000).length, 0,
+    "the pending backoff slot is cancelled, not stacked");
 });
 
 test("a live stream is left alone by the visibility handler", async () => {
@@ -580,7 +585,7 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     "perch-tab-chat", "perch-tab-session", "perch-tab-files", "perch-tab-activity",
     "perch-tab-btn-chat", "perch-tab-btn-session", "perch-tab-btn-files", "perch-tab-btn-activity",
     "perch-activity-list", "perch-session-cwd", "perch-change-cwd", "perch-working",
-    "perch-files-list", "perch-files-refresh"];
+    "perch-files-list", "perch-files-refresh", "perch-attn"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
@@ -695,8 +700,8 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     },
     setTimeout(fn, delay) { const id = timerSeq++; timers.set(id, fn); timerDelays.set(id, delay == null ? undefined : delay); return id; },
     clearTimeout(id) { timers.delete(id); timerDelays.delete(id); },
-    setInterval(fn) { const id = timerSeq++; timers.set(id, fn); return id; },
-    clearInterval(id) { timers.delete(id); },
+    setInterval(fn, delay) { const id = timerSeq++; timers.set(id, fn); timerDelays.set(id, delay == null ? undefined : delay); return id; },
+    clearInterval(id) { timers.delete(id); timerDelays.delete(id); },
     FileReader: class {
       constructor() { this.onload = null; this.result = null; }
       readAsDataURL(file) {
@@ -1710,7 +1715,10 @@ test("below the breakpoint, opening a session stops the list poll — the list r
   const hub = await mountHub({ fetchImpl: stdFetch(), split: false });
   assert.equal(hub.timers.size > 0, true, "the list view polls");
   await openChatSession(hub);
-  assert.equal(hub.timers.size, 0, "nothing left ticking behind a hidden list");
+  // Wave 1: the stream watchdog (15s) now also lives in the timer map while a
+  // session is open — count the LIST POLL by its delay, not the map's size.
+  const polls = () => [...hub.timerDelays.values()].filter((d) => d === 10000).length;
+  assert.equal(polls(), 0, "nothing left polling behind a hidden list");
 });
 
 test("in SPLIT view, opening a session keeps the list polling and refreshes it at once", async () => {
@@ -1726,13 +1734,16 @@ test("in SPLIT view, opening a session keeps the list polling and refreshes it a
 test("crossing the breakpoint with a chat open starts and stops the poll, with no navigation at all", async () => {
   const hub = await mountHub({ fetchImpl: stdFetch(), split: false });
   await openChatSession(hub);
-  assert.equal(hub.timers.size, 0);
+  // Wave 1: filter to the list poll's own delay — the stream watchdog shares
+  // the timer map while a session is open.
+  const polls = () => [...hub.timerDelays.values()].filter((d) => d === 10000).length;
+  assert.equal(polls(), 0);
   hub.mq._set(true);                       // the operator widened the window
   await new Promise((r) => setTimeout(r, 0));
-  assert.ok(hub.timers.size > 0, "the list just came on screen; it must not sit there stale");
+  assert.ok(polls() > 0, "the list just came on screen; it must not sit there stale");
   hub.mq._set(false);                      // and narrowed it again
   await new Promise((r) => setTimeout(r, 0));
-  assert.equal(hub.timers.size, 0);
+  assert.equal(polls(), 0);
 });
 
 test("in split view the poll renders the newly opened session as a live row with a Close", async () => {
@@ -2061,10 +2072,13 @@ test("the sentinel is still an explicit choice: picking a real model from it swi
 test("the breakpoint listener binds through addListener where that is the only spelling", async () => {
   const hub = await mountHub({ fetchImpl: stdFetch(), split: false, legacyMediaQuery: true });
   await openChatSession(hub);
-  assert.equal(hub.timers.size, 0, "precondition: narrow, chat open, list hidden, nothing polling");
+  // Wave 1: count the LIST POLL by its delay — the stream watchdog (15000)
+  // shares the timer map while a chat is open.
+  const polls = () => [...hub.timerDelays.values()].filter((d) => d === 10000).length;
+  assert.equal(polls(), 0, "precondition: narrow, chat open, list hidden, nothing polling");
   hub.mq._set(true);
   await new Promise((r) => setTimeout(r, 0));
-  assert.ok(hub.timers.size > 0,
+  assert.ok(polls() > 0,
     "on that browser the re-evaluation would otherwise silently never bind");
 });
 
@@ -2805,4 +2819,153 @@ test("the working strip tracks turnInFlight through state frames, replies and ab
   es._serverFrame("state", { state: "stopped", turnInFlight: true });
   await new Promise((r) => setTimeout(r, 0));
   assert.equal(strip.hidden, true, "a stopped session never shows the gear");
+});
+
+// ---------------------------------------------------------------------------
+// Wave 1 (pi-lab parity quick wins): Enter-to-send, auto-grow, copy buttons,
+// the attention banner, non-image upload path injection, resync-on-reconnect,
+// the stale-ping watchdog, and the pageshow/online revive signals.
+// ---------------------------------------------------------------------------
+
+test("W1: Enter sends, Shift+Enter does not (it is a newline)", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const input = hub.els["perch-input"];
+  input.value = "hello";
+  input.onkeydown({ key: "Enter", shiftKey: true, preventDefault() { throw new Error("must not preventDefault a newline"); } });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.fetchCalls.filter((c) => /\/message$/.test(c.path)).length, 0,
+    "Shift+Enter is a newline, never a send");
+  let prevented = false;
+  input.onkeydown({ key: "Enter", shiftKey: false, preventDefault() { prevented = true; } });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(prevented, true, "plain Enter preventDefaults (so the textarea does not also insert a newline)");
+  assert.equal(hub.fetchCalls.filter((c) => /\/message$/.test(c.path)).length, 1, "and sends");
+});
+
+test("W1: auto-grow caps at the CSS ceiling and collapses back after a send", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const input = hub.els["perch-input"];
+  input.scrollHeight = 300;                 // a pasted essay
+  input.oninput.call(input);
+  assert.equal(input.style.height, "120px", "grows to the ceiling, never past it (Send must stay reachable)");
+  input.value = "x";
+  hub.els["perch-send"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(input.style.height, "auto", "and collapses back after the send");
+});
+
+test("W1: a bot message carries a copy button whose source is the RAW text, and a code fence gets its own", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("text", { text: "**bold** answer", turnId: "t1" });   // no html → textContent path
+  await new Promise((r) => setTimeout(r, 0));
+  const rows = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("bot"));
+  const copyBtn = rows[0].children.filter((c) => String(c.className).includes("copy-msg"))[0];
+  assert.ok(copyBtn, "every bot row is one tap from the clipboard");
+  assert.equal(copyBtn.getAttribute("aria-label"), "Copy message", "and it is labelled, not glyph-only");
+  // The copy source is the raw markdown, captured in the closure — proven by
+  // what copyText receives. navigator is absent in the vm, so copyText falls
+  // to the execCommand branch; intercept document.execCommand to read the value.
+  let copied = null;
+  hub.doc.createElement_orig = hub.doc.createElement;
+  const realCreate = hub.doc.createElement.bind(hub.doc);
+  hub.doc.createElement = (tag) => { const n = realCreate(tag); if (tag === "textarea") { Object.defineProperty(n, "value", { set(v) { copied = v; }, get() { return copied; } }); } return n; };
+  hub.doc.execCommand = () => true;
+  copyBtn.onclick();
+  assert.equal(copied, "**bold** answer", "copies the markdown the model wrote, not the rendered DOM");
+  hub.doc.createElement = hub.doc.createElement_orig;
+});
+
+test("W1: an ask card raises the attention banner; answering lowers it", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const attn = hub.els["perch-attn"];
+  assert.ok(attn.hidden !== false, "no card, no banner");
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("ask_user", { requestId: "r1", method: "select", title: "Pick one", options: ["a", "b"] });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(attn.hidden, false, "a pending card says why the bot went quiet");
+  // Answer it: the pane clears and the banner drops with it.
+  hub.els["perch-ask"].children[0].querySelectorAll = undefined; // n/a
+  const answerBtn = hub.els["perch-ask"].children[0].children[1].children[0]; // first option button
+  answerBtn.onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(attn.hidden, true, "the banner dies with the card");
+});
+
+test("W1: a non-image upload injects its PATH into the next message; an image still rides the wire", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/files": () => makeResponse(200, { path: "report.pdf", full_path: "/tmp/up/report.pdf" }) }),
+  });
+  await openChatSession(hub);
+  hub.els["perch-file-input"].files = [{ name: "report.pdf", type: "application/pdf", b64: "AAA" }];
+  hub.els["perch-file-input"].onchange();
+  await new Promise((r) => setTimeout(r, 0));
+  const notes = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("note")).map((c) => c.textContent);
+  assert.ok(notes.some((x) => x.includes("path rides your next message")), "a file upload says what will happen to it");
+
+  hub.els["perch-input"].value = "summarize this";
+  hub.els["perch-send"].onclick();
+  await new Promise((r) => setTimeout(r, 0));
+  const msg = hub.fetchCalls.filter((c) => /\/message$/.test(c.path)).pop();
+  const body = JSON.parse(msg.opts.body);
+  assert.match(body.message, /\u0055ploads?|uploaded files/i, "the model is TOLD about the file");
+  assert.ok(body.message.includes("/tmp/up/report.pdf"), "with its on-disk path so pi's read tool can open it");
+  assert.ok(body.message.includes("summarize this"), "and the operator's own words survive");
+  assert.equal(body.images, undefined, "a PDF is not an image — nothing rides the wire");
+});
+
+test("W1: reconnect RESYNCS — the transcript refetches whole instead of silently missing the gap", async () => {
+  let transcriptCalls = 0;
+  const hub = await mountHub({
+    fetchImpl: stdFetch({
+      "/transcript": () => { transcriptCalls++; return makeResponse(200, { events: [] }); },
+      "/options": () => Promise.reject(new Error("network down")),   // probe fails → scheduleReconnect
+    }),
+  });
+  await openChatSession(hub);
+  assert.equal(transcriptCalls, 1, "first open loads history once");
+  const first = FakeEventSource.instances[0];
+  first._nativeError();
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  // Fire the scheduled reconnect, then open the new stream: onopen must resync.
+  for (const [id, fn] of [...hub.timers.entries()]) { hub.timers.delete(id); hub.timerDelays.delete(id); fn(); }
+  await new Promise((r) => setTimeout(r, 0));
+  const second = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+  assert.ok(second && second !== first, "a fresh EventSource was built");
+  second._open();                             // fires onopen → resyncHistory
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(transcriptCalls, 2,
+    "the reconnect refetches the transcript — messages that completed during the drop are recovered, not lost until a manual reload");
+});
+
+test("W1: the watchdog and revive listeners are registered once per realm and retire cleanly", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  // The watchdog interval is live while a stream is held.
+  assert.ok([...hub.timerDelays.values()].includes(15000), "a 15s watchdog tick is armed");
+  // pageshow/online/visibilitychange go through bindOnce — one listener each per realm.
+  assert.equal(hub.win._listenerCount("pageshow"), 1);
+  assert.equal(hub.win._listenerCount("online"), 1);
+  assert.equal(hub.doc._listenerCount("visibilitychange"), 1);
+  // Retire must stop the watchdog (closeStream does), leaving no interval behind.
+  hub.win.__crowPerchHub.retire();
+  assert.ok(![...hub.timerDelays.values()].includes(15000), "retiring stops the watchdog");
+});
+
+test("W1: a held stream is left alone by a revive — no double-subscribe on focus/pageshow", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const n = FakeEventSource.instances.length;
+  hub.doc.visibilityState = "visible";
+  hub.doc._dispatch("visibilitychange", {});
+  hub.win._dispatch("pageshow", {});
+  hub.win._dispatch("online", {});
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(FakeEventSource.instances.length, n,
+    "a live stream is never re-opened by a wake signal — that would double-subscribe");
 });

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -526,3 +526,70 @@ test("the working strip CSS spins, hides by attribute, and calms under reduced m
   assert.ok(/prefers-reduced-motion:reduce\)\{#perch-workingsvg\{animation-duration:6s\}/.test(css),
     "reduced motion slows the gear instead of freezing the signal");
 });
+
+// ---------------------------------------------------------------------------
+// Wave 1 — the pi-lab parity quick wins, statically. Live measurements (copy
+// buttons in seeded markdown, the auto-grow ceiling) run in
+// perch-hub-render.test.js.
+// ---------------------------------------------------------------------------
+
+test("the attention banner ships hidden, inside the chat tab, above the transcript", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const banner = html.match(/<div id="perch-attn"[^>]*>/);
+  assert.ok(banner, "the banner exists");
+  assert.ok(banner[0].includes("hidden"), "ships hidden — only a pending card raises it");
+  const chatTab = html.indexOf('id="perch-tab-chat"');
+  const attn = html.indexOf('id="perch-attn"');
+  const tr = html.indexOf('id="perch-transcript"');
+  assert.ok(chatTab < attn && attn < tr, "it sits above the transcript, inside the chat tab");
+  assert.ok(/⚠ [^<]+</.test(html.slice(attn, tr)), "and it carries a visible sentence");
+});
+
+test("the Wave-1 CSS: grow ceiling, copy chrome, banner [hidden] discipline", async () => {
+  const { perchHubCss } = await import("../servers/gateway/dashboard/perch-hub/css.js");
+  const css = perchHubCss().replace(/\s+/g, "");
+  assert.ok(/#perch-composertextarea\{[^}]*max-height:120px/.test(css),
+    "the auto-grow ceiling — a pasted essay must not push Send off screen");
+  assert.ok(/#perch-composertextarea\{[^}]*overflow-y:auto/.test(css),
+    "past the ceiling the textarea scrolls inside itself");
+  assert.ok(/\.prewrap\{position:relative\}/.test(css), "the copy-pre button anchors to its fence");
+  assert.ok(/\.copy-pre\{position:absolute/.test(css));
+  assert.ok(/\.attn-banner\[hidden\]\{display:none\}/.test(css),
+    "[hidden] must outrank the banner's own display:flex");
+});
+
+test("the Wave-1 client wiring: Enter/Shift rule, grow-on-input, watchdog, revive signals, resync", async () => {
+  const { perchHubJs } = await import("../servers/gateway/dashboard/perch-hub/client.js");
+  const js = perchHubJs("en");
+  // Enter sends, Shift+Enter newlines — the rule itself, not the word "Enter".
+  assert.match(js, /ev\.key==='Enter'&&!ev\.shiftKey/);
+  // Auto-grow, pi-lab's exact ceiling.
+  assert.match(js, /Math\.min\(this\.scrollHeight\|\|72,120\)/);
+  // Watchdog: 15s tick, 75s silence threshold (two missed 30s server pings),
+  // visibility-gated, and it re-opens WITH resync.
+  assert.match(js, /setInterval\(function\(\)\{/, "the watchdog is an interval");
+  assert.ok(js.includes("Date.now()-lastEventAt>75000"), "75s = two missed pings plus slack");
+  assert.ok(js.includes("},15000);"), "15s tick");
+  assert.match(js, /openStream\(current\.sid,true\)/, "the watchdog's re-open resyncs");
+  // The server ping is what the watchdog measures silence against.
+  assert.match(js, /addEventListener\('ping'/);
+  // Revive on pageshow and online too, through the generation-checked registry.
+  assert.match(js, /bindOnce\(window,'pageshow','pageshow',reviveStream\)/);
+  assert.match(js, /bindOnce\(window,'online','online',reviveStream\)/);
+  // Resync-on-reconnect: the retry slot carries it.
+  assert.match(js, /openStream\(mySid,true\)/);
+  // And the refetch REPLACES the transcript rather than appending to it.
+  const resync = js.slice(js.indexOf("function resyncHistory"));
+  const body = resync.slice(0, resync.indexOf("loadHistory(botId,sid)"));
+  assert.ok(body.includes("clearEl(el('perch-transcript'))"),
+    "resync clears before loadHistory refetches — an append would double every message");
+});
+
+test("the SSE heartbeat is a named ping frame, visible to client watchdogs", async () => {
+  // Wave 1 item 20's server half: a `: keepalive` COMMENT is invisible to
+  // EventSource, so a zombie socket on a foreground tab was undiscoverable.
+  const src = readFileSync(join(REPO, "servers/gateway/streams/sse.js"), "utf8");
+  assert.match(src, /event: ping\\ndata: \{\}\\n\\n/);
+  assert.ok(!src.includes(': keepalive\\n\\n"'), "the comment-only heartbeat is gone");
+});

--- a/tests/perch-hub-render.test.js
+++ b/tests/perch-hub-render.test.js
@@ -1256,3 +1256,58 @@ for (const [w, h] of [[412, 730], [1280, 900]]) {
     } finally { resetApi(); await s.close(); }
   });
 }
+
+// ---------------------------------------------------------------------------
+// Wave 1, live — copy buttons on real server-rendered markdown fences, and
+// the auto-grow composer measured against its own ceiling.
+// ---------------------------------------------------------------------------
+
+for (const [w, h] of [[412, 730], [1280, 900]]) {
+  test(`W1 live @${w}x${h}: code fences get a working copy button; the composer grows to its ceiling and stops`, async (t) => {
+    if (!available) return t.skip("no CDP endpoint at " + CDP);
+    resetApi();
+    // Seed a transcript whose assistant message carries a real server-rendered
+    // <pre> — the exact shape routes/perch.js's assistantHtml produces.
+    transcriptEvents = [{
+      type: "message",
+      message: { role: "assistant", content: [{ text: "run this:\n```\nls -la\n```" }] },
+      html: "<p>run this:</p>\n<pre><code>ls -la\n</code></pre>\n",
+    }];
+    const s = await session(w, h);
+    try {
+      await s.evalIn(`location.hash='perchlive-22222222'; 'go'`);
+      await new Promise((r) => setTimeout(r, 900));
+      const seen = await s.json(`(function(){
+        var pre=document.querySelector('#perch-transcript .what.md pre');
+        var wrap=pre&&pre.parentElement;
+        var btn=wrap&&wrap.querySelector('.copy-pre');
+        var msgBtn=document.querySelector('#perch-transcript .entry.bot .copy-msg');
+        var out={pre:!!pre, wrapped:wrap&&wrap.className==='prewrap', btn:!!btn,
+                 btnOutsidePre:btn?!pre.contains(btn):null,
+                 msgBtn:!!msgBtn};
+        if(btn){ btn.click(); out.flashed=btn.classList.contains('copied'); }
+        // The composer: ten lines must grow it, but never past 120px.
+        var ta=document.getElementById('perch-input');
+        ta.value='1\\n2\\n3\\n4\\n5\\n6\\n7\\n8\\n9\\n10';
+        ta.dispatchEvent(new Event('input',{bubbles:true}));
+        var r2=ta.getBoundingClientRect();
+        out.grew=Math.round(r2.height);
+        out.hScroll=document.documentElement.scrollWidth>document.documentElement.clientWidth;
+        var send=document.getElementById('perch-send').getBoundingClientRect();
+        out.sendReachable=send.bottom<=innerHeight&&send.top>=0;
+        return JSON.stringify(out);
+      })()`);
+      assert.equal(seen.pre, true, "fixture check: the seeded fence rendered");
+      assert.equal(seen.wrapped, true, "the fence is wrapped client-side (.prewrap)");
+      assert.equal(seen.btn, true, "and carries a copy button");
+      assert.equal(seen.btnOutsidePre, true,
+        "the button is a SIBLING of the pre — inside it, the glyph would pollute the copy source");
+      assert.equal(seen.flashed, true, "a tap flashes ✓ (clipboard API or the execCommand fallback)");
+      assert.equal(seen.msgBtn, true, "bot rows carry the per-message copy too");
+      assert.ok(seen.grew > 72 && seen.grew <= 121,
+        `ten lines grew the composer to ${seen.grew}px — above the floor, at/under the 120px ceiling`);
+      assert.equal(seen.sendReachable, true, "a grown composer must never push Send off screen");
+      assert.equal(seen.hScroll, false);
+    } finally { resetApi(); await s.close(); }
+  });
+}

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -32,6 +32,12 @@ const SID = "perchlive-aaaaaaaa";
 let available = false, server = null, port = 0;
 /** Every open SSE response, so a test can count concurrency and broadcast. */
 let openStreams = [];
+/** Wave 1: the server-side history the transcript endpoint reads. A `text`
+ *  frame IS a completed assistant message (message-level streaming), and in
+ *  the real engine every one of them lands in the session file — so the
+ *  fixture accumulates them. A transcript stuck at [] would test the new
+ *  resync-on-reconnect against a server that forgets, which no engine does. */
+let historyEvents = [];
 
 function serveApi(req, res) {
   const url = req.url.split("?")[0];
@@ -55,15 +61,20 @@ function serveApi(req, res) {
     req.on("close", () => { openStreams = openStreams.filter((r) => r !== res); });
     return;
   }
-  // An EMPTY transcript, which is what a freshly spawned session has and what
-  // made "No transcript yet." the correct line to print — once.
-  if (url.endsWith("/transcript")) return send(200, { events: [] });
+  // The transcript the resync refetches: whatever this fixture has broadcast
+  // as completed messages (see historyEvents).
+  if (url.endsWith("/transcript")) return send(200, { events: historyEvents });
   if (url.endsWith("/options")) return send(200, { models: [], thinkingLevels: [] });
   return send(200, {});
 }
 
 /** Push one named SSE frame to every connection the page currently holds. */
 function broadcast(type, data) {
+  // Model the server-side truth: every completed assistant message lands in
+  // the history the transcript endpoint serves (see historyEvents).
+  if (type === "text" && data && typeof data.text === "string") {
+    historyEvents.push({ type: "message", message: { role: "assistant", content: [{ text: data.text }] } });
+  }
   for (const res of openStreams) res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
@@ -102,7 +113,7 @@ before(async () => {
   port = server.address().port;
 });
 
-beforeEach(() => { openStreams = []; });
+beforeEach(() => { openStreams = []; historyEvents = []; });
 after(() => { if (server) server.close(); });
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -1065,7 +1065,8 @@ test("POST /interactive/:sid/files writes a sanitized-name file into the session
     name: "notes.txt", data_b64: data.toString("base64"),
   });
   assert.equal(status, 200);
-  assert.deepEqual(body, { path: "notes.txt" });
+  assert.deepEqual(body, { path: "notes.txt", full_path: join(uploadsDir, "notes.txt") },
+    "Wave 1: full_path is the on-disk location the client injects into the next message for non-image uploads");
   assert.deepEqual(readFileSync(join(uploadsDir, "notes.txt")), data);
 });
 


### PR DESCRIPTION
Implements **Wave 1** of the approved parity audit (`docs/superpowers/specs/2026-09-12-perch-hub-pi-lab-parity-audit.md`) — items 1, 2, 3, 7, 8, 19, 20, 21. One commit, eight operator-visible wins, no engine changes beyond one additive response key and the SSE heartbeat format.

## Chat ergonomics
- **Enter sends / Shift+Enter newlines** (pi-lab's composer rule verbatim).
- **Auto-growing composer** to a 120px ceiling, then it scrolls inside itself — a pasted essay can never push Send off screen. Measured live at 412×730 and 1280×900: grew to the ceiling, Send still reachable, no horizontal scroll.
- **Copy buttons**: per bot message (source = the RAW markdown, not the rendered DOM) + per code fence, minted client-side as a SIBLING of each `<pre>` (inside it the glyph would pollute the copy source). Clipboard API + execCommand fallback for plain-http LAN, ✓ flash, aria-labelled. Live-clicked over CDP at both viewports.
- **Attention banner**: a pending ask card raises "⚠ Waiting on your answer" above the transcript; answering drops it. On a phone the card can be a scroll away — the banner says why the bot went quiet.
- **Non-image uploads stop being dead** (audit item 8): the upload route now also returns `full_path`, and the next outgoing message carries "I uploaded files for you to look at: - <path>" so pi's read tool can open what was attached. Images still ride the wire; the local echo stays the operator's own words.

## Stream robustness (the reconnect half of last night's phone finding)
- **Named ping heartbeat** (item 20, server half): `sse.js`'s 30s `: keepalive` comment became `event: ping` — comments are invisible to EventSource, so a foreground zombie socket was undiscoverable. Every other consumer (turbo streams, board, messages, ramble) listens by name and ignores ping; no test pinned the comment format.
- **Resync-on-reconnect** (item 19, the correctness edge): any re-open past the first — backoff slot, unlock revive, watchdog — refetches the transcript WHOLE. Messages that completed during a drop are recovered instead of silently missing until a manual reload.
- **Stale-ping watchdog** (item 20): 15s tick; 75s of server silence while visible with a held stream = two missed pings = the socket lies → drop and re-open with resync.
- **pageshow + online revive** (item 21) join visibilitychange, all through the generation-checked bindOnce registry; a held stream is never re-opened by a wake signal (no double-subscribe).

## The regression N1 caught (and why the fixture changed)
First draft of resync cleared the turn-render bookkeeping; the live N1-within-turn test went **red**: the in-flight turn's reply re-appended its concatenation over the refetched batch. Fixed by KEEPING `renderedTurn`/`turnRendered` across a resync (the batch re-renders everything; the memory is exactly what suppresses the duplicate). The leak fixture also now models server-side history (accumulates broadcast `text` frames into the transcript it serves) — a fixture stuck at `events: []` would test resync against a server that forgets, which no engine does.

## Verification
- Full suite **4746 / 0** (+14 tests: vm-harness behavior for every item, static pins, two live-CDP measurements, routes `full_path` shapes).
- Docs untouched (no guide changes needed for these items).
- After merge: gateway restart (or convergence) picks up the ping heartbeat; phones get the rest on next page load.

Remaining from the audit: Wave 2 (context-% meter, agent facts, plan progress bar), Wave 3 (inline tool chips with args/results relay, combined multi-question ask card, slash-command menu), and the five ⚠ operator decisions.