### PR TITLE
Perch Waves 2+3: session facts, plan progress, inline tool chips, slash-command menu

### DIFF
--- a/scripts/pi-bots/bridge.mjs
+++ b/scripts/pi-bots/bridge.mjs
@@ -211,6 +211,10 @@ export class PiRpc {
     // non-perch caller) leaves `tools` untouched and the branch below identical
     // to what shipped before.
     const narrowedTools = applySessionNarrowing(tools, opts.narrowedTools);
+    // Wave 2: the FINAL csv, exposed so the interactive engine's Session-tab
+    // facts can report the tool count the child was actually pinned with
+    // (envelope + appends − narrowing) without re-deriving this assembly.
+    this.toolsCsv = narrowedTools;
     // `--tools` is ALWAYS pinned. pi parses "" to an empty allowlist
     // (dist/cli/args.js:85-89 → core/sdk.js:133-136, verified on 0.82.0),
     // whereas OMITTING the flag hands pi defaultActiveToolNames — bash, edit,

--- a/servers/gateway/dashboard/perch-hub/client.js
+++ b/servers/gateway/dashboard/perch-hub/client.js
@@ -354,6 +354,12 @@ export function perchHubJs(lang = "en") {
   var COPY_CODE_LABEL='${tJs("perch.copyCode", lang)}';
   var FILE_QUEUED_PATH='${tJs("perch.fileQueuedPath", lang)}';
   var UPLOADED_HEADER='${tJs("perch.uploadedHeader", lang)}';
+  /* Wave 2/3: facts card, plan checklist, tool chips, slash menu. */
+  var PLAN_HEAD='${tJs("perch.planProgress", lang)}';
+  var TOOL_RUNNING='${tJs("perch.toolRunning", lang)}';
+  var TOOL_DONE='${tJs("perch.toolDone", lang)}';
+  var TOOL_FAILED='${tJs("perch.toolFailed", lang)}';
+  var COMMANDS_HIBERNATING='${tJs("perch.commandsHibernating", lang)}';
 
   /* Row identity. One bot with eight sessions renders eight rows that read
      "R4 Assistant / awake" and nothing else — measured verbatim in a browser
@@ -726,7 +732,10 @@ export function perchHubJs(lang = "en") {
      window/document listener in this file. */
   bindOnce(document,'keydown','browseEscape',function(ev){
     if(!live()) return;
-    if(ev.key==='Escape'&&browse.open) closeBrowseModal();
+    if(ev.key!=='Escape') return;
+    if(browse.open){ closeBrowseModal(); return; }
+    var m=el('perch-cmdmenu');            /* Wave 3: Escape closes the slash menu too */
+    if(m&&!m.hidden) m.hidden=true;
   });
 
   var browseBtn=el('perch-browse-btn');
@@ -998,6 +1007,7 @@ export function perchHubJs(lang = "en") {
     syncListPolling();
     clearEl(el('perch-transcript')); clearEl(el('perch-ask'));
     clearEl(el('perch-activity-list'));   /* the previous session's log is not this one's */
+    toolChips={};                         /* Wave 3: the chip index dies with the transcript */
     resetControls();                        /* the PREVIOUS session's picker must not bleed in */
     var known=rowIndex[sid];
     if(known){ showHeader(known.botId,known.botName); afterHeader(mySid,known.botId); return; }
@@ -1159,6 +1169,9 @@ export function perchHubJs(lang = "en") {
          textContent only: the value is a filesystem path, never markup. */
       var cwdEl=el('perch-session-cwd');
       if(cwdEl) cwdEl.textContent=d.cwd||CWD_DEFAULT_TEXT;
+      /* Wave 2: the facts card rides the same frame — one source, one
+         refresh path, no polling of its own. */
+      renderFacts(d);
     });
     /* MESSAGE-LEVEL, not delta-level (perch-interactive.js:1257 says so
        outright): one frame per COMPLETED assistant message, so each is
@@ -1173,7 +1186,14 @@ export function perchHubJs(lang = "en") {
       if(!histSettled){ histBuf.push(d); return; }   /* round 3 R4, see flushHistBuf */
       renderTextFrame(d);
     });
-    on('tool',function(d){ if(d.phase==='start') appendActivity('[tool: '+(d.name||'?')+']'); });
+    on('tool',function(d){
+      if(d.phase==='start'){
+        appendActivity('[tool: '+(d.name||'?')+']');
+        appendToolChip(d);            /* Wave 3: the chat gets the live chip */
+      } else if(d.phase==='end'){
+        finishToolChip(d);
+      }
+    });
     on('log',function(d){ if(d.text) appendActivity(d.text); });
     /* \`reply\` carries replyTextOf(end) — every assistant message of the turn
        CONCATENATED — so appending it unconditionally rendered a two-message
@@ -1206,7 +1226,11 @@ export function perchHubJs(lang = "en") {
     });
     on('ask_user',function(d){ renderAsk(d); });
     on('error',function(d){ appendActivity(d.text||'error'); });
-    on('plan_state',function(d){ var t=planStateText(d.state); if(t) appendActivity(t); });
+    on('plan_state',function(d){
+      var t=planStateText(d.state); if(t) appendActivity(t);
+      planState=(d&&d.state&&typeof d.state==='object')?d.state:null;
+      renderPlan();                   /* Wave 2: bar + step checklist */
+    });
     /* No 'attention' listener: attention is not a stream event —
        perch-interactive.js:1243/:1360 push it through pushAttention into the
        notification pipeline, and perch-interactive-api.js:349-351 enumerates
@@ -1330,6 +1354,7 @@ export function perchHubJs(lang = "en") {
     var sid=current.sid, botId=current.botId;
     if(!sid||!botId) return;
     clearEl(el('perch-transcript'));
+    toolChips={};                    /* the chips just died with the transcript; a stale index would write into detached DOM */
     histSettled=false; histBuf=[];
     loadHistory(botId,sid);
   }
@@ -1517,6 +1542,10 @@ export function perchHubJs(lang = "en") {
     pendingImages=[];            /* nor its queued-but-unsent image */
     pendingFilePaths=[];         /* nor its queued upload paths (Wave 1) */
     setAttn(false);              /* nor its unanswered-question banner */
+    /* Wave 2/3: the new session inherits none of the old one's readings. */
+    planState=null; renderPlan();
+    toolChips={}; commandsCache=null; hideCmdMenu();
+    resetFacts();
   }
 
   /* routes/perch-interactive-api.js:531-540 reads permission_mode and
@@ -1601,6 +1630,7 @@ export function perchHubJs(lang = "en") {
     input.value='';
     input.style.height='auto';             /* Wave 1: the auto-grow collapses back after a send */
     var body={message:text};
+    hideCmdMenu();                         /* Wave 3: a sent command closes its own menu */
     /* Wave 1: non-image uploads ride the message as PATHS — the file is
        already in the session's uploadsDir on this machine, and pi's read
        tool is not write-jailed, so the bot can open what the operator
@@ -1780,6 +1810,7 @@ export function perchHubJs(lang = "en") {
     composerInput.oninput=function(){
       this.style.height='auto';
       this.style.height=Math.min(this.scrollHeight||72,120)+'px';
+      maybeCmdMenu(this.value);            /* Wave 3: '/' opens the command menu */
     };
   }
   el('perch-back').onclick=function(){ location.hash=''; };
@@ -1895,6 +1926,187 @@ export function perchHubJs(lang = "en") {
   }
   var filesRefresh=el('perch-files-refresh');
   if(filesRefresh) filesRefresh.onclick=loadFiles;
+
+  /* ---- Wave 2: Session-tab facts + plan progress -------------------------
+     All readings ride the state/plan_state frames the engine already emits
+     (contextUsage = pi's own numbers captured at turn end; uptime/RSS are
+     per-CHILD, so a hibernating session honestly shows dashes). A value
+     that cannot be measured renders as an em dash — never a guess, never a
+     stale reading from the previous session (resetControls clears). */
+  var planState=null;
+  function fmtUptime(sec){
+    sec=Math.max(0,Math.round(Number(sec)||0));
+    if(sec<60) return sec+'s';
+    if(sec<3600) return Math.floor(sec/60)+'m';
+    var h=Math.floor(sec/3600);
+    return h+'h '+Math.floor((sec%3600)/60)+'m';
+  }
+  function resetFacts(){
+    ['perch-fact-context','perch-fact-uptime','perch-fact-memory','perch-fact-tools'].forEach(function(id){
+      var e=el(id); if(e) e.textContent='\\u2014';
+    });
+    var bar=el('perch-ctxbar'); if(bar) bar.hidden=true;
+  }
+  function renderFacts(d){
+    if(!d) return;
+    var cu=d.contextUsage;
+    if(cu!==undefined){
+      var c=el('perch-fact-context'), bar=el('perch-ctxbar'), fill=el('perch-ctxbar-fill');
+      if(cu&&cu.percent!=null){
+        var txt=Math.round(cu.percent)+'%';
+        if(cu.tokens!=null&&cu.contextWindow) txt+=' \\u00b7 '+Math.round(cu.tokens/1000)+'k/'+Math.round(cu.contextWindow/1000)+'k';
+        if(c) c.textContent=txt;
+        if(fill) fill.style.width=Math.max(0,Math.min(100,Number(cu.percent)||0))+'%';
+        if(bar) bar.hidden=false;
+      } else {
+        if(c) c.textContent='\\u2014';
+        if(bar) bar.hidden=true;
+      }
+    }
+    if(d.uptimeSeconds!==undefined){
+      var u=el('perch-fact-uptime');
+      if(u) u.textContent=d.uptimeSeconds==null?'\\u2014':fmtUptime(d.uptimeSeconds);
+    }
+    if(d.memoryMB!==undefined){
+      var m=el('perch-fact-memory');
+      if(m) m.textContent=d.memoryMB==null?'\\u2014':d.memoryMB+' MB';
+    }
+    if(d.toolCount!==undefined){
+      var tc=el('perch-fact-tools');
+      if(tc) tc.textContent=d.toolCount==null?'\\u2014':String(d.toolCount);
+    }
+  }
+  function renderPlan(){
+    var st=planState;
+    var active=!!(st&&(st.enabled||st.executing));
+    var card=el('perch-plan-card'), bar=el('perch-planbar'), fill=el('perch-planbar-fill');
+    if(card) card.hidden=!active;
+    var total=active?Number(st.todosTotal||0):0;
+    if(bar) bar.hidden=!(active&&total>0);
+    if(!active) return;
+    var done=Number(st.todosDone||0);
+    if(fill&&total>0) fill.style.width=Math.round(100*done/total)+'%';
+    var head=el('perch-plan-head');
+    if(head) head.textContent=PLAN_HEAD+(total>0?' \\u2014 '+done+'/'+total:'')+(st.executing?' \\u25b6':'');
+    var steps=el('perch-plan-steps');
+    if(!steps) return;
+    clearEl(steps);
+    var todos=Array.isArray(st.todos)?st.todos:[];
+    var curIdx=-1;
+    for(var i=0;i<todos.length;i++){ if(todos[i]&&!todos[i].completed){ curIdx=i; break; } }
+    todos.forEach(function(td,i){
+      if(!td) return;
+      var row=document.createElement('div');
+      row.className='plan-step'+(td.completed?' done':(i===curIdx?' cur':''));
+      row.appendChild(line('sbox',td.completed?'\\u2611':(i===curIdx?'\\u25b6':'\\u2610')));
+      row.appendChild(line('stxt',(td.step!=null?td.step+'. ':'')+String(td.text==null?'':td.text)));
+      steps.appendChild(row);
+    });
+  }
+
+  /* ---- Wave 3: inline tool chips -----------------------------------------
+     pi-lab's shape: a pill per tool call with a spinner while running, tap
+     to expand args/result. Chips are LIVE-TURN UI: they exist in the
+     transcript only while this client watched them happen — a reload or a
+     resync drops them (the transcript endpoint carries messages, not tool
+     calls), and the Activity rail keeps the durable record. Args/results
+     arrive pre-truncated by the engine (600/2000 chars) and land via
+     textContent only — child-controlled bytes never reach a markup sink. */
+  var toolChips={};
+  function appendToolChip(d){
+    var tr=el('perch-transcript'); if(!tr) return;
+    var wrap=document.createElement('div'); wrap.className='entry toolwrap';
+    var chip=document.createElement('button'); chip.type='button'; chip.className='tool-chip';
+    var spin=document.createElement('span'); spin.className='spin';
+    var name=document.createElement('span'); name.className='tn'; name.textContent=(d&&d.name)||'?';
+    var status=document.createElement('span'); status.textContent=TOOL_RUNNING;
+    chip.appendChild(spin); chip.appendChild(name); chip.appendChild(status);
+    var details=document.createElement('div'); details.className='tool-details'; details.hidden=true;
+    if(d&&d.argsText!=null){
+      details.appendChild(line('td-h','args'));
+      var pa=document.createElement('pre'); pa.textContent=String(d.argsText);
+      details.appendChild(pa);
+    }
+    chip.onclick=function(){ details.hidden=!details.hidden; };
+    wrap.appendChild(chip); wrap.appendChild(details);
+    tr.appendChild(wrap);
+    tr.scrollTop=tr.scrollHeight;
+    if(d&&d.toolCallId!=null) toolChips[d.toolCallId]={chip:chip,spin:spin,status:status,details:details};
+  }
+  function finishToolChip(d){
+    var rec=(d&&d.toolCallId!=null)?toolChips[d.toolCallId]:null;
+    /* An end without a start means the operator opened mid-call: the rail
+       has the line, and minting a chip for a call nobody watched begin
+       would show a "done" with no story. */
+    if(!rec) return;
+    if(rec.spin&&rec.spin.parentNode) rec.spin.parentNode.removeChild(rec.spin);
+    rec.status.textContent=(d&&d.isError)?TOOL_FAILED:TOOL_DONE;
+    if(d&&d.isError) rec.chip.className='tool-chip err';
+    if(d&&d.resultText!=null){
+      rec.details.appendChild(line('td-h',(d&&d.isError)?'error':'result'));
+      var pr=document.createElement('pre'); pr.textContent=String(d.resultText);
+      rec.details.appendChild(pr);
+    }
+    if(d&&d.toolCallId!=null) delete toolChips[d.toolCallId];
+  }
+
+  /* ---- Wave 3: the slash-command menu ------------------------------------
+     Fed by pi's OWN get_commands registry through the engine (never a
+     hardcoded list — a bot's commands depend on its loaded extensions and
+     skills). One fetch per session, cached; the menu opens on a bare
+     "/…" composer and filters as you type. A hibernating child has no
+     registry to ask, and waking one because the operator typed "/" would
+     be a lie of availability — the menu says "asleep" instead. */
+  var commandsCache=null;              /* {list:[],hibernating:bool} per session */
+  function hideCmdMenu(){ var m=el('perch-cmdmenu'); if(m){ m.hidden=true; clearEl(m); } }
+  function maybeCmdMenu(val){
+    var m=el('perch-cmdmenu'); if(!m) return;
+    var v=String(val==null?'':val);
+    if(!/^\\/[^\\s]*$/.test(v)){ m.hidden=true; return; }
+    var q=v.slice(1).toLowerCase();
+    if(commandsCache){ renderCmdList(q); return; }
+    if(!current.sid) return;
+    var mySid=current.sid;
+    perchApi('GET','/interactive/'+encodeURIComponent(mySid)+'/commands').then(function(r){
+      if(current.sid!==mySid) return;                     /* identity guard, as everywhere */
+      commandsCache=(r.ok&&r.j&&Array.isArray(r.j.commands))
+        ? {list:r.j.commands,hibernating:!!r.j.hibernating}
+        : {list:[],hibernating:false};
+      var inp=el('perch-input');
+      var cur=inp?String(inp.value||''):'';
+      if(/^\\/[^\\s]*$/.test(cur)) renderCmdList(cur.slice(1).toLowerCase());
+    });
+  }
+  function renderCmdList(q){
+    var m=el('perch-cmdmenu'); if(!m||!commandsCache) return;
+    clearEl(m);
+    var hits=commandsCache.list.filter(function(c){
+      return String(c&&c.name||'').toLowerCase().indexOf(q)>=0;
+    }).slice(0,30);
+    if(!hits.length){
+      if(commandsCache.hibernating){ m.appendChild(line('cmd-empty',COMMANDS_HIBERNATING)); m.hidden=false; }
+      else m.hidden=true;
+      return;
+    }
+    hits.forEach(function(c){
+      var b=document.createElement('button'); b.type='button';
+      var n=document.createElement('span'); n.className='cmd-name'; n.textContent='/'+c.name;
+      b.appendChild(n);
+      if(c.description){
+        var ds=document.createElement('span'); ds.className='cmd-desc'; ds.textContent=String(c.description);
+        b.appendChild(ds);
+      }
+      b.onclick=function(){
+        var inp=el('perch-input');
+        if(inp){ inp.value='/'+c.name+' '; if(inp.focus) inp.focus();
+          /* the value changed without an input event — keep the grow in sync */
+          inp.style.height='auto'; }
+        m.hidden=true;
+      };
+      m.appendChild(b);
+    });
+    m.hidden=false;
+  }
 
   /* iOS does not shrink the layout viewport for the keyboard, so dvh alone
      leaves the composer behind it. Offset the chat column by the hidden part. */

--- a/servers/gateway/dashboard/perch-hub/css.js
+++ b/servers/gateway/dashboard/perch-hub/css.js
@@ -302,6 +302,67 @@ font-family:"JetBrains Mono",ui-monospace,monospace}
 #perch-activity-list{display:grid;gap:6px;padding:12px 0;align-content:start}
 #perch-hub-root .activity-row{color:var(--dim);font-size:12.5px;word-break:break-word;
 font-family:"JetBrains Mono",ui-monospace,monospace}
+/* --- Wave 2: Session-tab facts + plan progress -------------------------- */
+#perch-hub-root .facts{margin:6px 0 10px}
+#perch-hub-root .facts .kv{display:flex;justify-content:space-between;gap:12px;padding:6px 0;
+border-bottom:1px solid var(--line);font-size:13.5px}
+#perch-hub-root .facts .kv:last-child{border-bottom:0}
+#perch-hub-root .facts .k{color:var(--dim);flex-shrink:0}
+#perch-hub-root .facts .v{font:12.5px "JetBrains Mono",ui-monospace,monospace;text-align:right;
+overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#perch-hub-root .ctxbar{height:4px;background:var(--line);border-radius:2px;overflow:hidden;margin:2px 0 6px}
+#perch-ctxbar-fill,#perch-planbar-fill{height:100%;background:var(--teal);width:0%;transition:width .4s}
+/* One rule for every Wave-2/3 panel that ships hidden: [hidden] must outrank
+   each panel's own display rule — attribute on class/id beats either alone. */
+#perch-hub-root .ctxbar[hidden],#perch-hub-root .plan-card[hidden],
+#perch-planbar[hidden],#perch-cmdmenu[hidden],#perch-hub-root .tool-details[hidden]{display:none}
+#perch-planbar{height:3px;background:var(--line);border-radius:2px;overflow:hidden;margin:8px 0 0;flex-shrink:0}
+#perch-hub-root .plan-card{border:1px solid var(--line);border-radius:10px;background:var(--sky);
+padding:10px 12px;margin:6px 0 10px}
+#perch-hub-root .plan-head{font:11px/1 "JetBrains Mono",ui-monospace,monospace;text-transform:uppercase;
+letter-spacing:.06em;color:var(--dim);margin-bottom:8px}
+#perch-hub-root .plan-step{display:flex;gap:8px;padding:4px 0;font-size:13.5px;align-items:baseline}
+#perch-hub-root .plan-step .sbox{font-family:"JetBrains Mono",ui-monospace,monospace;flex-shrink:0;color:var(--dim)}
+#perch-hub-root .plan-step .stxt{word-break:break-word}
+#perch-hub-root .plan-step.done{color:var(--dim)}
+#perch-hub-root .plan-step.done .stxt{text-decoration:line-through}
+#perch-hub-root .plan-step.done .sbox{color:var(--alive)}
+#perch-hub-root .plan-step.cur{color:var(--teal);font-weight:600}
+#perch-hub-root .plan-step.cur .sbox{color:var(--teal)}
+/* --- Wave 3: inline tool chips + the slash menu --------------------------
+   Chips are pi-lab's shape: a pill with a spinner while running, tap to
+   expand args/result. The details <pre>s are textContent-only (tool args
+   and results are child-controlled data) and cap at 240px scrolling inside
+   themselves — a 2000-char result must not become a second transcript. */
+#perch-hub-root .toolwrap{align-self:flex-start;max-width:90%;min-width:0}
+#perch-hub-root .tool-chip{display:inline-flex;align-items:center;gap:7px;background:var(--sky);
+border:1px solid var(--line);border-radius:999px;padding:5px 12px;min-height:32px;max-width:100%;
+font:12px "JetBrains Mono",ui-monospace,monospace;color:var(--dim);cursor:pointer;text-align:left}
+#perch-hub-root .tool-chip .tn{color:var(--teal);font-weight:600;word-break:break-all}
+#perch-hub-root .tool-chip.err{border-color:var(--attn)}
+#perch-hub-root .tool-chip.err .tn{color:var(--attn)}
+#perch-hub-root .tool-chip .spin{width:10px;height:10px;border:2px solid var(--line);
+border-top-color:var(--teal);border-radius:50%;animation:perch-spin .8s linear infinite;flex-shrink:0}
+#perch-hub-root .tool-details{background:var(--card);border:1px solid var(--line);border-radius:10px;
+margin-top:5px;padding:8px 10px;font-size:12px}
+#perch-hub-root .tool-details .td-h{font:600 10px "JetBrains Mono",ui-monospace,monospace;
+text-transform:uppercase;letter-spacing:.07em;color:var(--dim);margin:6px 0 3px}
+#perch-hub-root .tool-details .td-h:first-child{margin-top:0}
+#perch-hub-root .tool-details pre{background:var(--sky);padding:7px 9px;border-radius:6px;
+overflow-x:auto;overflow-y:auto;max-height:240px;margin:0;white-space:pre-wrap;word-break:break-word;
+font:11px/1.5 "JetBrains Mono",ui-monospace,monospace}
+/* The menu anchors to #perch-composer (position:sticky = its containing
+   block) and grows UPWARD — bottom:100% — so it can never cover Send. */
+#perch-cmdmenu{position:absolute;bottom:100%;left:0;right:0;margin-bottom:6px;background:var(--card);
+border:1px solid var(--line);border-radius:10px;box-shadow:0 6px 24px rgba(0,0,0,.18);
+max-height:40vh;overflow-y:auto;z-index:20}
+#perch-hub-root #perch-cmdmenu button{display:block;width:100%;text-align:left;background:none;
+border:0;border-bottom:1px solid var(--line);border-radius:0;padding:10px 14px;color:var(--ink);
+font-size:13.5px;cursor:pointer;min-height:44px}
+#perch-cmdmenu button:last-child{border-bottom:0}
+#perch-cmdmenu .cmd-name{font-family:"JetBrains Mono",ui-monospace,monospace;color:var(--teal);font-weight:600}
+#perch-cmdmenu .cmd-desc{color:var(--dim);font-size:12px;display:block;margin-top:1px}
+#perch-cmdmenu .cmd-empty{padding:10px 14px;color:var(--dim);font-size:13px}
 /* --- open-anywhere C2: the directory-picker modal ---------------------
    Built client-side (client.js buildBrowseModal) and appended INSIDE
    #perch-hub-root, so every class rule here stays scoped the way the

--- a/servers/gateway/dashboard/perch-hub/html.js
+++ b/servers/gateway/dashboard/perch-hub/html.js
@@ -126,6 +126,10 @@ ${engineBanner(engine, lang)}
          same pendingUi lifecycle the list row's "waiting on you" state and
          the engine's replay-on-subscribe already ride. -->
     <div id="perch-attn" class="attn-banner" hidden>⚠ ${escapeHtml(t("perch.waitingBanner", lang))}</div>
+    <!-- Wave 2: plan execution progress bar — visible only while a plan is
+         enabled/executing with steps, fed by the same plan_state frames the
+         Activity rail prints. The step checklist lives in the Session tab. -->
+    <div id="perch-planbar" hidden><div id="perch-planbar-fill"></div></div>
     <div id="perch-transcript"></div>
     <div id="perch-ask"></div>
     <!-- The working strip: the chat tab's own "the bot is busy" signal.
@@ -140,6 +144,11 @@ ${engineBanner(engine, lang)}
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
       <span>${escapeHtml(t("perch.working", lang))}</span></div>
     <div id="perch-composer">
+      <!-- Wave 3: the slash-command menu, anchored above the composer (which
+           is position:sticky, so it IS the containing block). Rows are
+           client-rendered from pi's own get_commands registry — never a
+           hardcoded list. -->
+      <div id="perch-cmdmenu" hidden></div>
       <textarea id="perch-input" placeholder="${escapeHtml(t("perch.composerPlaceholder", lang))}"></textarea>
       <div class="send-row">
         <button type="button" id="perch-attach" class="quiet">${escapeHtml(t("perch.attachFile", lang))}</button>
@@ -173,6 +182,23 @@ ${engineBanner(engine, lang)}
       <div class="field"><span class="field-label" id="perch-cwd-label">${escapeHtml(t("perch.cwdLabel", lang))}</span>
         <div class="meta" id="perch-session-cwd"></div>
         <button type="button" id="perch-change-cwd">${escapeHtml(t("perch.changeDirectory", lang))}</button></div>
+    </div>
+    <!-- Wave 2: the facts card. Values ride the state frames (pi's own
+         contextUsage at turn end, the child's uptime/RSS while awake, the
+         pinned --tools count) — a fact that cannot be measured renders as
+         an em dash, never as a guess. -->
+    <div class="facts" id="perch-facts">
+      <div class="kv"><span class="k">${escapeHtml(t("perch.factContext", lang))}</span><span class="v" id="perch-fact-context">—</span></div>
+      <div class="ctxbar" id="perch-ctxbar" hidden><div id="perch-ctxbar-fill"></div></div>
+      <div class="kv"><span class="k">${escapeHtml(t("perch.factUptime", lang))}</span><span class="v" id="perch-fact-uptime">—</span></div>
+      <div class="kv"><span class="k">${escapeHtml(t("perch.factMemory", lang))}</span><span class="v" id="perch-fact-memory">—</span></div>
+      <div class="kv"><span class="k">${escapeHtml(t("perch.factTools", lang))}</span><span class="v" id="perch-fact-tools">—</span></div>
+    </div>
+    <!-- Wave 2: the plan step checklist (☑ done / ▶ current / ☐ todo), from
+         the plan_state frame's todos array. -->
+    <div class="plan-card" id="perch-plan-card" hidden>
+      <div class="plan-head" id="perch-plan-head"></div>
+      <div id="perch-plan-steps"></div>
     </div>
     <div class="session-row">
       <div class="state" id="perch-state"></div>

--- a/servers/gateway/dashboard/shared/i18n.js
+++ b/servers/gateway/dashboard/shared/i18n.js
@@ -2364,6 +2364,18 @@ export const translations = {
     en: "I uploaded files for you to look at:",
     es: "Subí archivos para que los revises:",
   },
+  "perch.factContext": { en: "Context", es: "Contexto" },
+  "perch.factUptime": { en: "Uptime", es: "Tiempo activo" },
+  "perch.factMemory": { en: "Memory", es: "Memoria" },
+  "perch.factTools": { en: "Tools", es: "Herramientas" },
+  "perch.planProgress": { en: "Plan progress", es: "Progreso del plan" },
+  "perch.toolRunning": { en: "running", es: "ejecutando" },
+  "perch.toolDone": { en: "done", es: "listo" },
+  "perch.toolFailed": { en: "failed", es: "falló" },
+  "perch.commandsHibernating": {
+    en: "The session is asleep — send a message first.",
+    es: "La sesión está dormida — envía un mensaje primero.",
+  },
 };
 
 export const SUPPORTED_LANGS = ["en", "es"];

--- a/servers/gateway/perch-interactive.js
+++ b/servers/gateway/perch-interactive.js
@@ -236,6 +236,62 @@ function normalizeLabel(raw) {
   return text ? text : null;
 }
 
+/** Wave 2/3 helpers — truncating relays for child payloads. A frame is
+ *  broadcast to every subscriber and stored in nothing; these caps keep a
+ *  write-tool's full file payload (args) or a 200KB tool result from riding
+ *  the SSE wire to every phone on the tailnet. */
+function safeSnippet(v, cap) {
+  if (v == null) return null;
+  try {
+    const s = typeof v === "string" ? v : JSON.stringify(v);
+    if (s == null) return null;
+    return s.length > cap ? s.slice(0, cap) + "\u2026" : s;
+  } catch { return null; }
+}
+
+/** A tool result is {content:[{type:'text',text},…]} in the normal case and
+ *  an arbitrary value in the odd one — take the text blocks when they exist
+ *  (that is what an operator wants to read), else stringify. pi-lab's own
+ *  mobile relay does the same 2000-char slice. */
+function toolResultSnippet(result, cap) {
+  let text = null;
+  try {
+    if (result && Array.isArray(result.content)) {
+      const joined = result.content
+        .filter((b) => b && typeof b.text === "string")
+        .map((b) => b.text).join("\n");
+      if (joined) text = joined;
+    }
+  } catch { /* fall through to stringify */ }
+  if (text == null) text = safeSnippet(result, cap);
+  if (text == null) return null;
+  return text.length > cap ? text.slice(0, cap) + "\u2026" : text;
+}
+
+/** Wave 2: how many tools the child's pinned --tools csv actually exposes
+ *  ("" is a real, deliberate zero — the empty-envelope case). */
+function countCsvTools(csv) {
+  if (csv == null) return null;
+  const n = String(csv).split(",").filter((x) => x.trim()).length;
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Wave 2: the child's RSS from /proc — Linux-only, best-effort, one small
+ *  read, cheap enough to ride every state frame while the child is awake.
+ *  statm field 2 is resident pages; the page size is 4096 on every Linux
+ *  arch crow ships on. null whenever anything is missing or unparseable —
+ *  a facts row that cannot be measured renders as "—", never as a guess. */
+function childMemoryMB(s) {
+  try {
+    const pid = s.pi && s.pi.proc && s.pi.proc.pid;
+    if (!pid) return null;
+    const fields = readFileSync("/proc/" + pid + "/statm", "utf8").trim().split(/\s+/);
+    const pages = Number(fields[1]);
+    if (!Number.isFinite(pages) || pages <= 0) return null;
+    return Math.round((pages * 4096) / (1024 * 1024));
+  } catch { return null; }
+}
+
 /**
  * Build a pendingUi card from an `extension_ui_request`.
  *
@@ -402,6 +458,16 @@ export function createInteractiveEngine({
        *  world root (sessionDir) keeps storage duty (sessions/outputs/uploads).
        *  Persisted on the row so a wake after restart runs in the same place. */
       cwd: null,
+      /** Wave 2 session facts. childSince: when the CURRENT child spawned
+       *  (null while hibernating — an uptime that survives a hibernate would
+       *  be a lie about the process). contextUsage: pi's own {tokens,
+       *  contextWindow, percent} captured at the last turn end (the only
+       *  moment get_session_stats is consulted anyway — metering). toolCount:
+       *  the size of the child's pinned --tools csv, i.e. what the model can
+       *  actually reach, envelope minus narrowing. */
+      childSince: null,
+      contextUsage: null,
+      toolCount: null,
       // Track 3 Task 4: binds at wake, never applied to a live child (pi's
       // permission policy is fixed via env at spawn time). Reset to
       // "guarded" on every adoptRow (gateway restart) — see adoptRow's
@@ -484,6 +550,12 @@ export function createInteractiveEngine({
       // startChild; null until the first spawn/wake). The Session/Files tabs
       // and the launcher read it to show where the bot actually runs.
       cwd: s.cwd || null,
+      // Wave 2: the Session tab's facts, on both shapes (snapshot feeds the
+      // engine's get()/routes; stateEvent feeds every live subscriber).
+      contextUsage: s.contextUsage || null,
+      uptimeSeconds: s.childSince ? Math.max(0, Math.round((Date.now() - s.childSince) / 1000)) : null,
+      memoryMB: childMemoryMB(s),
+      toolCount: s.toolCount == null ? null : s.toolCount,
       // I3 (final review): neither stateEvent() nor snapshot() used to
       // expose whether a turn is actually in flight, and drawer.js's
       // bd.turnInFlight was set only by the SENDING tab — so on the primary
@@ -553,6 +625,12 @@ export function createInteractiveEngine({
       permissionMode: s.permissionMode,
       planMode: s.planMode,
       cwd: s.cwd || null,
+      // Wave 2: same four facts as snapshot() above, same rule — the state
+      // frame is what a LIVE subscriber (the Session tab) refreshes from.
+      contextUsage: s.contextUsage || null,
+      uptimeSeconds: s.childSince ? Math.max(0, Math.round((Date.now() - s.childSince) / 1000)) : null,
+      memoryMB: childMemoryMB(s),
+      toolCount: s.toolCount == null ? null : s.toolCount,
       // I3 (final review): same addition, same reasoning, as snapshot()
       // above — see its comment.
       turnInFlight: !!s.turn,
@@ -1338,6 +1416,11 @@ export function createInteractiveEngine({
     }));
     s.pi = pi;
     s.piSessionId = resume;
+    // Wave 2: facts for the Session tab — the child's start time (uptime is
+    // per-CHILD, never per-session) and the effective tool count straight
+    // from the pinned --tools csv the PiRpc just computed.
+    s.childSince = Date.now();
+    s.toolCount = countCsvTools(pi.toolsCsv);
     attachExit(s, pi);
 
     await writeRow(s, {
@@ -1430,11 +1513,19 @@ export function createInteractiveEngine({
     s.lastEventAt = now();                           // Track 3 Task 7: eviction recency
     switch (m.type) {
       case "tool_execution_start":
-        emit(s, { type: "tool", name: m.toolName, phase: "start", isError: false });
+        // Wave 3: the chat's inline tool chips show what the call CARRIED,
+        // not just its name — args ride the start frame, truncated (600
+        // chars: enough to recognize a bash command or a file path, not
+        // enough to balloon a frame on a write-tool payload).
+        emit(s, { type: "tool", name: m.toolName, phase: "start", isError: false,
+          toolCallId: m.toolCallId || null, argsText: safeSnippet(m.args, 600) });
         return;
       case "tool_execution_end":
         if (s.turn && m.toolName) s.turn.toolNames.push(m.toolName);
-        emit(s, { type: "tool", name: m.toolName, phase: "end", isError: !!m.isError });
+        // Wave 3: same for the outcome — the result's TEXT blocks, pi-lab's
+        // own 2000-char cap, stringified fallback for non-text payloads.
+        emit(s, { type: "tool", name: m.toolName, phase: "end", isError: !!m.isError,
+          toolCallId: m.toolCallId || null, resultText: toolResultSnippet(m.result, 2000) });
         return;
       case "message_end": {
         // Message-level streaming; delta-level is a recorded non-goal.
@@ -1574,6 +1665,12 @@ export function createInteractiveEngine({
 
     const S = await loadSeams();
     const statsAfter = s.pi ? await s.pi.getSessionStats().catch(() => null) : null;
+    // Wave 2: the context meter's source. pi's own SessionStats carries
+    // contextUsage {tokens, contextWindow, percent} — captured here, at the
+    // only moment stats are already being fetched (metering), so the meter
+    // costs zero extra RPCs. null right after a compaction or before the
+    // first turn ends; the Session tab renders "—" for it.
+    s.contextUsage = (statsAfter && statsAfter.data && statsAfter.data.contextUsage) || null;
     // r2 CR6: every other bot turn meters AND audits (bridge handleInbound,
     // job_runner). An interactive turn is a bot turn.
     try {
@@ -2370,6 +2467,30 @@ export function createInteractiveEngine({
    * when an operator wants to. Renaming is reversible and touches no child, so
    * unlike stop() it is never refused mid-turn.
    */
+  /** Wave 3: the child's own slash-command list for the composer's "/" menu
+   *  (pi's get_commands RPC — the same source pi-lab's /chat/commands
+   *  serves). Awake only: a hibernating child has no command registry to
+   *  ask, and waking one because the operator typed a "/" would be a lie of
+   *  availability — the honest answer is {commands:[], hibernating:true} and
+   *  the menu says so. Names are mapped, never passed through raw: this
+   *  reaches every subscriber's DOM. */
+  async function commands(sessionId) {
+    const s = await resolveSession(sessionId);
+    if (!s) throw engineError("no_such_session");
+    if (!s.pi) return { commands: [], hibernating: true };
+    const res = await s.pi.commandSince({ type: "get_commands" }).catch(() => null);
+    const raw = (res && res.data && Array.isArray(res.data.commands)) ? res.data.commands : [];
+    const commands = raw
+      .map((c) => ({
+        name: String((c && c.name) || ""),
+        description: String((c && c.description) || ""),
+        source: String((c && c.source) || ""),
+      }))
+      .filter((c) => c.name)
+      .slice(0, 100);
+    return { commands, hibernating: false };
+  }
+
   async function rename(sessionId, label) {
     const s = await resolveSession(sessionId);
     if (!s) throw engineError("no_such_session");
@@ -2531,6 +2652,7 @@ export function createInteractiveEngine({
     if (!s.pi) return;
     const pi = s.pi;
     s.pi = null;
+    s.childSince = null;               // Wave 2: uptime belongs to the CHILD
     clearIdle(s);
     clearStall(s);
     s.pendingUi = null;
@@ -2595,6 +2717,7 @@ export function createInteractiveEngine({
     cycle,
     control,
     options,
+    commands,
     rename,
     answer,
     abort,

--- a/servers/gateway/routes/perch-interactive-api.js
+++ b/servers/gateway/routes/perch-interactive-api.js
@@ -772,6 +772,22 @@ export default function perchInteractiveApiRouter(dashboardAuth, { engine = getI
     }
   });
 
+  // ---- GET /interactive/:sid/commands — the composer's "/" menu feed ----
+  // Wave 3: pi's own get_commands registry, relayed by the engine (awake
+  // only; a hibernating child answers {commands:[], hibernating:true} and
+  // the menu says so instead of faking an empty list). Under the same
+  // dashboardAuth as every perch-api route; the engine maps the names, the
+  // client renders them with textContent.
+  router.get(P + "/interactive/:sid/commands", async (req, res) => {
+    try {
+      const eng = resolveEngine();
+      const out = await eng.commands(String(req.params.sid));
+      res.json(out);
+    } catch (err) {
+      mapEngineError(res, err);
+    }
+  });
+
   // ---- POST /interactive/:sid/files — upload into the session's uploads dir ----
   // base64 JSON body (no new dependency — multipart would need one): {name,
   // data_b64}, cap 5 MB post-decode. `name` is basename()'d and any leading

--- a/tests/perch-hub-client.test.js
+++ b/tests/perch-hub-client.test.js
@@ -179,7 +179,9 @@ test("every string constant the script references is bound", async () => {
   // missing constant — it surfaces as a ReferenceError on the error path, which
   // is the path nobody exercises by hand.
   for (const name of ["SESSION_GONE", "NO_TRANSCRIPT", "RECONNECTING",
-                      "ASK_STALE", "STEER_LABEL", "SEND_LABEL"]) {
+                      "ASK_STALE", "STEER_LABEL", "SEND_LABEL",
+                      "PLAN_HEAD", "TOOL_RUNNING", "TOOL_DONE", "TOOL_FAILED",
+                      "COMMANDS_HIBERNATING"]) {
     if (!js.includes(name)) continue;               // not every task binds all of them
     assert.ok(new RegExp("var\\s+" + name + "\\s*=").test(js), name + " is used but never bound");
   }
@@ -199,9 +201,10 @@ test("async continuations are guarded — a fast back button must not cross sess
   // tab's control({cwd}) continuation. 14 as of D3: the Files tab's
   // files/list fetch. A regression that drops one — the count
   // that shipped with only 6 asserted — is invisible until an operator hits
-  // the exact race the dropped guard covered.
+  // the exact race the dropped guard covered. 15 as of Wave 3: the slash
+  // menu's commands fetch.
   const guards = (js.match(/current\.sid\s*!==/g) || []).length;
-  assert.equal(guards, 14, "expected exactly 14 identity guards, found " + guards);
+  assert.equal(guards, 15, "expected exactly 15 identity guards, found " + guards);
 });
 
 test("the emitted script never assigns to an innerHTML-class sink", async () => {
@@ -484,13 +487,20 @@ function makeFakeElement(tag) {
     files: null,
     appendChild(child) {
       this.children.push(child);
+      if (child && typeof child === "object") child.parentNode = this;   // real DOM semantics — client code walks parentNode
       if (ID_REGISTRY && child && child.id) ID_REGISTRY[child.id] = child;
       return child;
     },
-    removeChild(child) { const i = this.children.indexOf(child); if (i >= 0) this.children.splice(i, 1); return child; },
+    removeChild(child) {
+      const i = this.children.indexOf(child);
+      if (i >= 0) this.children.splice(i, 1);
+      if (child && typeof child === "object") child.parentNode = null;
+      return child;
+    },
     insertBefore(node, ref) {
       const i = ref ? this.children.indexOf(ref) : -1;
       if (i < 0) this.children.unshift(node); else this.children.splice(i, 0, node);
+      if (node && typeof node === "object") node.parentNode = this;
       return node;
     },
     setAttribute(name, val) { attrs[name] = String(val); },
@@ -585,7 +595,11 @@ async function mountHub({ fetchImpl, confirmImpl, promptImpl, initialHash = "", 
     "perch-tab-chat", "perch-tab-session", "perch-tab-files", "perch-tab-activity",
     "perch-tab-btn-chat", "perch-tab-btn-session", "perch-tab-btn-files", "perch-tab-btn-activity",
     "perch-activity-list", "perch-session-cwd", "perch-change-cwd", "perch-working",
-    "perch-files-list", "perch-files-refresh", "perch-attn"];
+    "perch-files-list", "perch-files-refresh", "perch-attn",
+    // Wave 2/3: the facts card, plan bar + card, and the slash menu.
+    "perch-fact-context", "perch-fact-uptime", "perch-fact-memory", "perch-fact-tools",
+    "perch-ctxbar", "perch-ctxbar-fill", "perch-planbar", "perch-planbar-fill",
+    "perch-plan-card", "perch-plan-head", "perch-plan-steps", "perch-cmdmenu"];
   const els = {};
   for (const id of IDS) els[id] = makeFakeElement(id === "perch-plan-mode" ? "input" : "div");
 
@@ -2968,4 +2982,164 @@ test("W1: a held stream is left alone by a revive — no double-subscribe on foc
   await new Promise((r) => setTimeout(r, 0));
   assert.equal(FakeEventSource.instances.length, n,
     "a live stream is never re-opened by a wake signal — that would double-subscribe");
+});
+
+// ---------------------------------------------------------------------------
+// Wave 2 live in the harness: the facts card and the plan checklist render
+// from the frames alone — no polling, no second source.
+// ---------------------------------------------------------------------------
+
+test("W2: state frames drive the facts card; unmeasurable values render as em dashes", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("state", { state: "awake", turnInFlight: false,
+    contextUsage: { tokens: 110163, contextWindow: 262144, percent: 42 },
+    uptimeSeconds: 3725, memoryMB: 830, toolCount: 14 });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-fact-context"].textContent, "42% \u00b7 110k/262k");
+  assert.equal(hub.els["perch-ctxbar"].hidden, false);
+  assert.equal(hub.els["perch-ctxbar-fill"].style.width, "42%");
+  assert.equal(hub.els["perch-fact-uptime"].textContent, "1h 2m", "an uptime reads as an uptime");
+  assert.equal(hub.els["perch-fact-memory"].textContent, "830 MB");
+  assert.equal(hub.els["perch-fact-tools"].textContent, "14");
+
+  // A hibernating session: the child facts go honest-dash, the bar hides.
+  es._serverFrame("state", { state: "hibernating", turnInFlight: false,
+    contextUsage: null, uptimeSeconds: null, memoryMB: null, toolCount: 14 });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-fact-context"].textContent, "\u2014");
+  assert.equal(hub.els["perch-ctxbar"].hidden, true);
+  assert.equal(hub.els["perch-fact-uptime"].textContent, "\u2014");
+  assert.equal(hub.els["perch-fact-memory"].textContent, "\u2014");
+  assert.equal(hub.els["perch-fact-tools"].textContent, "14", "the envelope fact survives a hibernate");
+});
+
+test("W2: plan_state renders the progress bar and the step checklist", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("plan_state", { state: { enabled: true, executing: true, todosDone: 1, todosTotal: 3,
+    todos: [ { step: 1, text: "read the brief", completed: true },
+             { step: 2, text: "draft the answer", completed: false },
+             { step: 3, text: "send it", completed: false } ] } });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-plan-card"].hidden, false);
+  assert.equal(hub.els["perch-planbar"].hidden, false);
+  assert.equal(hub.els["perch-planbar-fill"].style.width, "33%");
+  assert.match(hub.els["perch-plan-head"].textContent, /1\/3/);
+  const steps = hub.els["perch-plan-steps"].children;
+  assert.equal(steps.length, 3);
+  assert.match(steps[0].className, /done/);
+  assert.match(steps[1].className, /cur/, "the first incomplete step is the current one");
+  assert.equal(steps[0].children[0].textContent, "\u2611", "done box");
+  assert.equal(steps[1].children[0].textContent, "\u25b6", "current marker");
+  assert.equal(steps[2].children[0].textContent, "\u2610", "todo box");
+  assert.match(steps[1].children[1].textContent, /^2\. draft the answer$/);
+
+  // A session switch wipes the previous session's plan.
+  hub.location.hash = "";
+  await new Promise((r) => setTimeout(r, 0));
+  hub.location.hash = "perchlive-aaaaaaaa";
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-plan-card"].hidden, true);
+  assert.equal(hub.els["perch-planbar"].hidden, true);
+});
+
+// ---------------------------------------------------------------------------
+// Wave 3 live in the harness: the inline tool chips and the slash menu.
+// ---------------------------------------------------------------------------
+
+test("W3: a tool call grows a chip that spins, expands, and settles to done/failed", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  const es = FakeEventSource.instances[0];
+  es._serverFrame("tool", { phase: "start", name: "bash", toolCallId: "tc-1", argsText: '{"command":"ls"}' });
+  await new Promise((r) => setTimeout(r, 0));
+  const wrap = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("toolwrap"))[0];
+  assert.ok(wrap, "the chip lives in the transcript, where the operator is looking");
+  const chip = wrap.children[0], details = wrap.children[1];
+  assert.equal(chip.children.length, 3, "spinner + name + status");
+  assert.equal(chip.children[1].textContent, "bash");
+  assert.equal(chip.children[2].textContent, "running");
+  assert.equal(details.hidden, true);
+  assert.equal(details.children[1].textContent, '{"command":"ls"}', "args are there before the result");
+  chip.onclick();
+  assert.equal(details.hidden, false, "a tap expands");
+
+  es._serverFrame("tool", { phase: "end", name: "bash", toolCallId: "tc-1", resultText: "total 8", isError: false });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(chip.children.length, 2, "the spinner is gone");
+  assert.equal(chip.children[1].textContent, "done");
+  assert.equal(details.children[2].textContent, "result");
+  assert.equal(details.children[3].textContent, "total 8");
+
+  // A failed call reads as failed.
+  es._serverFrame("tool", { phase: "start", name: "edit", toolCallId: "tc-2" });
+  es._serverFrame("tool", { phase: "end", name: "edit", toolCallId: "tc-2", resultText: "no such file", isError: true });
+  await new Promise((r) => setTimeout(r, 0));
+  const wrap2 = hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("toolwrap"))[1];
+  assert.match(wrap2.children[0].className, /err/);
+  assert.equal(wrap2.children[0].children[1].textContent, "failed");
+});
+
+test("W3: a tool END with no seen start mints nothing — the rail already has the line", async () => {
+  const hub = await mountHub({ fetchImpl: stdFetch() });
+  await openChatSession(hub);
+  FakeEventSource.instances[0]._serverFrame("tool", { phase: "end", name: "bash", toolCallId: "ghost", resultText: "x" });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(hub.els["perch-transcript"].children.filter((c) => String(c.className).includes("toolwrap")).length, 0);
+});
+
+test("W3: '/' opens the slash menu from pi's OWN registry, filtered, one fetch per session", async () => {
+  let cmdCalls = 0;
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/commands": () => { cmdCalls++;
+      return makeResponse(200, { commands: [
+        { name: "plan", description: "plan mode", source: "extension" },
+        { name: "todos", description: "show todos", source: "extension" },
+        { name: "compact", description: "compact context", source: "extension" } ], hibernating: false }); } }),
+  });
+  await openChatSession(hub);
+  const input = hub.els["perch-input"];
+  const menu = hub.els["perch-cmdmenu"];
+
+  input.value = "/";
+  input.oninput.call(input);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(cmdCalls, 1);
+  assert.equal(menu.hidden, false);
+  assert.equal(menu.children.length, 3, "the whole registry at a bare slash");
+  assert.equal(menu.children[0].children[0].textContent, "/plan");
+
+  input.value = "/to";
+  input.oninput.call(input);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(cmdCalls, 1, "cached — one fetch per session, not per keystroke");
+  assert.equal(menu.children.length, 1);
+  assert.equal(menu.children[0].children[0].textContent, "/todos");
+
+  // Picking a command fills the composer for its argument and closes.
+  menu.children[0].onclick();
+  assert.equal(input.value, "/todos ");
+  assert.equal(menu.hidden, true);
+
+  // A message with a space in it is not a command — the menu stays shut.
+  input.value = "/todos now please";
+  input.oninput.call(input);
+  assert.equal(menu.hidden, true);
+});
+
+test("W3: a hibernating session's menu says asleep instead of faking an empty registry", async () => {
+  const hub = await mountHub({
+    fetchImpl: stdFetch({ "/commands": () => makeResponse(200, { commands: [], hibernating: true }) }),
+  });
+  await openChatSession(hub);
+  const input = hub.els["perch-input"];
+  input.value = "/";
+  input.oninput.call(input);
+  await new Promise((r) => setTimeout(r, 0));
+  const menu = hub.els["perch-cmdmenu"];
+  assert.equal(menu.hidden, false);
+  assert.match(menu.children[0].textContent, /asleep/);
 });

--- a/tests/perch-hub-page.test.js
+++ b/tests/perch-hub-page.test.js
@@ -593,3 +593,57 @@ test("the SSE heartbeat is a named ping frame, visible to client watchdogs", asy
   assert.match(src, /event: ping\\ndata: \{\}\\n\\n/);
   assert.ok(!src.includes(': keepalive\\n\\n"'), "the comment-only heartbeat is gone");
 });
+
+// ---------------------------------------------------------------------------
+// Wave 2/3 — the facts card, plan surfaces, and the slash menu, statically.
+// ---------------------------------------------------------------------------
+
+test("the Session tab carries the facts card and the plan checklist; the chat carries the plan bar", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const s = html.indexOf('id="perch-tab-session"');
+  const e = html.indexOf('id="perch-tab-files"');
+  const seg = html.slice(s, e);
+  for (const id of ["perch-facts", "perch-fact-context", "perch-fact-uptime", "perch-fact-memory",
+                    "perch-fact-tools", "perch-ctxbar", "perch-plan-card", "perch-plan-steps"]) {
+    assert.ok(seg.includes(`id="${id}"`), `${id} lives in the Session tab`);
+  }
+  assert.ok(/id="perch-plan-card"[^>]*hidden/.test(html), "the plan card ships hidden until a plan exists");
+  assert.ok(/id="perch-ctxbar"[^>]*hidden/.test(html), "so does the context bar");
+  // The chat tab's progress bar sits above the transcript.
+  const chat = html.indexOf('id="perch-tab-chat"');
+  const bar = html.indexOf('id="perch-planbar"');
+  const tr = html.indexOf('id="perch-transcript"');
+  assert.ok(chat < bar && bar < tr, "the plan bar rides above the transcript");
+  assert.ok(/id="perch-planbar"[^>]*hidden/.test(html));
+  // Facts labels are visible text, every one.
+  for (const word of ["Context", "Uptime", "Memory", "Tools"]) {
+    assert.ok(seg.includes(`>${word}<`), `the ${word} row is labelled`);
+  }
+});
+
+test("the slash menu lives INSIDE the sticky composer, so it anchors above Send and never covers it", async () => {
+  const { perchHubContent } = await import("../servers/gateway/dashboard/perch-hub/html.js");
+  const html = perchHubContent("en");
+  const composer = html.indexOf('id="perch-composer"');
+  const menu = html.indexOf('id="perch-cmdmenu"');
+  const input = html.indexOf('id="perch-input"');
+  assert.ok(composer < menu && menu < input, "the menu is the composer's first child");
+  assert.ok(/id="perch-cmdmenu"[^>]*hidden/.test(html), "and ships hidden");
+  const { perchHubCss } = await import("../servers/gateway/dashboard/perch-hub/css.js");
+  const css = perchHubCss().replace(/\s+/g, "");
+  assert.ok(/#perch-cmdmenu\{position:absolute;bottom:100%/.test(css),
+    "anchored to the sticky composer, growing UPWARD — bottom:100% can never cover Send");
+  assert.ok(/#perch-cmdmenu\[hidden\]/.test(css) || /#perch-cmdmenu\[hidden\],/.test(css) ||
+    css.includes("#perch-planbar[hidden],#perch-cmdmenu[hidden]"), "[hidden] outranks its display rules");
+});
+
+test("the tool-chip CSS reuses the one spin keyframe and keeps results scrolling inside themselves", async () => {
+  const { perchHubCss } = await import("../servers/gateway/dashboard/perch-hub/css.js");
+  const css = perchHubCss().replace(/\s+/g, "");
+  assert.equal((css.match(/@keyframesperch-spin/g) || []).length, 1,
+    "ONE keyframe definition — the gear and the chip spinner share it");
+  assert.ok(/\.tool-chip\.spin|\.tool-chip \.spin/.test(css.replace(/\s+/g, " ")) || css.includes(".tool-chip .spin".replace(/ /g, "")));
+  assert.ok(/\.tool-detailspre\{[^}]*max-height:240px/.test(css), "a 2000-char result scrolls in its own box");
+  assert.ok(/\.tool-detailspre\{[^}]*word-break:break-word/.test(css));
+});

--- a/tests/perch-hub-stream-leak.test.js
+++ b/tests/perch-hub-stream-leak.test.js
@@ -461,3 +461,59 @@ test("the working strip is live in the real DOM: shown by a turn-start frame, hi
       "the turn ending hides it");
   } finally { await s.close(); }
 });
+
+// ---------------------------------------------------------------------------
+// Wave 2/3 in the real browser: the frames the engine emits drive the facts
+// card, the plan surfaces, and an inline tool chip that settles to done —
+// against the real DOM, not the vm's flat map.
+// ---------------------------------------------------------------------------
+
+test("W2/W3 live: facts, plan bar, and a tool chip that spins then settles", async (t) => {
+  if (!available) return t.skip("no CDP endpoint at " + CDP);
+  const s = await session();
+  try {
+    await s.open();
+    broadcast("state", { state: "awake", turnInFlight: false,
+      contextUsage: { tokens: 131072, contextWindow: 262144, percent: 50 },
+      uptimeSeconds: 90, memoryMB: 512, toolCount: 14, cwd: "/tmp/x" });
+    broadcast("plan_state", { state: { enabled: true, executing: true, todosDone: 1, todosTotal: 2,
+      todos: [ { step: 1, text: "one", completed: true }, { step: 2, text: "two", completed: false } ] } });
+    broadcast("tool", { phase: "start", name: "bash", toolCallId: "tc-live", argsText: '{"command":"ls"}' });
+    await sleep(300);
+    const mid = await s.json(`JSON.stringify({
+      ctx: document.getElementById('perch-fact-context').textContent,
+      bar: document.getElementById('perch-ctxbar-fill').style.width,
+      uptime: document.getElementById('perch-fact-uptime').textContent,
+      planbar: !document.getElementById('perch-planbar').hidden,
+      planfill: document.getElementById('perch-planbar-fill').style.width,
+      steps: document.querySelectorAll('#perch-plan-steps .plan-step').length,
+      chipSpin: !!document.querySelector('#perch-transcript .tool-chip .spin'),
+      chipName: (document.querySelector('#perch-transcript .tool-chip .tn')||{}).textContent,
+      spinAnim: getComputedStyle(document.querySelector('#perch-transcript .tool-chip .spin')).animationName })`);
+    assert.equal(mid.ctx, "50% \u00b7 131k/262k");
+    assert.equal(mid.bar, "50%");
+    assert.equal(mid.uptime, "1m", "minute granularity under an hour — pi-lab's own idiom");
+    assert.equal(mid.planbar, true);
+    assert.equal(mid.planfill, "50%");
+    assert.equal(mid.steps, 2);
+    assert.equal(mid.chipSpin, true, "the chip spins while the tool runs");
+    assert.equal(mid.chipName, "bash");
+    assert.equal(mid.spinAnim, "perch-spin");
+
+    broadcast("tool", { phase: "end", name: "bash", toolCallId: "tc-live", resultText: "total 8", isError: false });
+    await sleep(200);
+    const done = await s.json(`(function(){
+      var chip=document.querySelector('#perch-transcript .tool-chip');
+      chip.click();                                   /* expand */
+      var d=chip.parentElement.querySelector('.tool-details');
+      return JSON.stringify({ spin: !!chip.querySelector('.spin'),
+        status: chip.lastElementChild.textContent,
+        open: !d.hidden,
+        pres: Array.from(d.querySelectorAll('pre')).map(function(p){return p.textContent;}) });
+    })()`);
+    assert.equal(done.spin, false, "the spinner is removed when the call ends");
+    assert.equal(done.status, "done");
+    assert.equal(done.open, true, "and a tap expands args + result");
+    assert.deepEqual(done.pres, ['{"command":"ls"}', "total 8"]);
+  } finally { await s.close(); }
+});

--- a/tests/perch-interactive-controls.test.js
+++ b/tests/perch-interactive-controls.test.js
@@ -111,6 +111,10 @@ function makeBridge(opts = {}) {
       this._exitCode = null;
       this.proc = { pid: ++pidSeq };
       this.piSessionId = "pisess-" + this.proc.pid;
+      // Wave 2: PiRpc exposes the FINAL --tools csv it pinned; the engine's
+      // Session-tab tool count reads it. A fixed, known list so tests can
+      // assert the exact number.
+      this.toolsCsv = "read,write,ask_user";
       this.statsSeq = 0;
       let done;
       this.exited = new Promise((r) => { done = r; });
@@ -1359,4 +1363,97 @@ test("B4: control({cwd}) refuses a relative path, a nonexistent path, and a file
   const filePath = join(dir, "b4-a-file.txt");
   writeFileSync(filePath, "not a dir");
   await assert.rejects(() => engine.control(s.sessionId, { cwd: filePath }), (e) => e.code === "bad_request", "a file is not a directory");
+});
+
+// ---------------------------------------------------------------------------
+// Wave 2/3 — the Session tab's facts on the engine's own shapes, the tool
+// frame relay's args/result payloads, and the get_commands relay behind the
+// composer's slash menu.
+// ---------------------------------------------------------------------------
+
+test("Wave 2: snapshot carries the facts; a hibernating child reports honest nulls", async () => {
+  const { engine } = makeEngine();
+  const s = await spawned(engine);
+  const snap = await engine.get(s.sessionId);
+  assert.equal(snap.toolCount, 3, "the pinned --tools csv, counted — envelope minus narrowing, as spawned");
+  assert.ok(snap.uptimeSeconds >= 0, "awake since just now");
+  assert.equal(snap.memoryMB, null,
+    "a fake pid has no /proc entry — a fact that cannot be measured is null, never a guess");
+  assert.equal(snap.contextUsage, null, "no turn has ended yet, so pi has no context number");
+
+  await engine._hibernateForTest(s.sessionId);
+  const after = await engine.get(s.sessionId);
+  assert.equal(after.uptimeSeconds, null, "uptime belongs to the CHILD, not the session");
+  assert.equal(after.toolCount, 3, "the envelope fact survives a hibernate — it is what the next wake pins");
+});
+
+test("Wave 2: contextUsage is captured at turn end from pi's own stats and rides the state frame", async () => {
+  const { engine, bridge } = makeEngine();
+  const Base = bridge.PiRpc;
+  bridge.PiRpc = class StatsPi extends Base {
+    async getSessionStats() {
+      const r = await super.getSessionStats();
+      r.data.contextUsage = { tokens: 110163, contextWindow: 262144, percent: 42 };
+      return r;
+    }
+  };
+  const s = await spawned(engine);
+  const pi = bridge._state.instances[bridge._state.instances.length - 1];
+  await engine.message(s.sessionId, "go");
+  pi.lastTurn().resolve({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "ok" }] }] });
+  await tick();
+  const snap = await engine.get(s.sessionId);
+  assert.deepEqual(snap.contextUsage, { tokens: 110163, contextWindow: 262144, percent: 42 },
+    "captured at the only moment stats are already being fetched — metering — so the meter costs zero extra RPCs");
+  const { events, off, ofType } = await collect(engine, s.sessionId);
+  const states = ofType("state");
+  assert.ok(states.length, "subscribe replays state");
+  assert.deepEqual(states[states.length - 1].contextUsage, snap.contextUsage);
+  off();
+});
+
+test("Wave 3: tool frames relay args and results, capped at the engine's truncation", async () => {
+  const { engine, bridge } = makeEngine();
+  const s = await spawned(engine);
+  const pi = bridge._state.instances[bridge._state.instances.length - 1];
+  const { events, off, ofType } = await collect(engine, s.sessionId);
+
+  pi.emit({ type: "tool_execution_start", toolCallId: "tc-1", toolName: "bash", args: { command: "ls -la" } });
+  const start = ofType("tool").filter((e) => e.phase === "start").pop();
+  assert.equal(start.toolCallId, "tc-1");
+  assert.ok(start.argsText.includes('"command":"ls -la"'), "the chip shows what the call CARRIED");
+
+  const huge = "x".repeat(700);
+  pi.emit({ type: "tool_execution_start", toolCallId: "tc-2", toolName: "write", args: huge });
+  const start2 = ofType("tool").filter((e) => e.phase === "start").pop();
+  assert.equal(start2.argsText.length, 601, "600 chars + the ellipsis — a write payload never balloons a frame");
+
+  pi.emit({ type: "tool_execution_end", toolCallId: "tc-1", toolName: "bash",
+    result: { content: [{ type: "text", text: "total 8" }, { type: "text", text: "drwx" }] }, isError: false });
+  const end = ofType("tool").filter((e) => e.phase === "end").pop();
+  assert.equal(end.resultText, "total 8\ndrwx", "text blocks joined — what an operator wants to read");
+  assert.equal(end.isError, false);
+  off();
+});
+
+test("Wave 3: commands() relays pi's get_commands registry; a hibernating child says so instead of faking empty", async () => {
+  const { engine, state } = makeEngine();
+  state.commandScript = (pi, payload) =>
+    payload.type === "get_commands"
+      ? { success: true, data: { commands: [
+          { name: "plan", description: "plan mode", source: "extension" },
+          { name: "", description: "junk row" },
+          null ] } }
+      : null;
+  const s = await spawned(engine);
+  const out = await engine.commands(s.sessionId);
+  assert.deepEqual(out.commands, [{ name: "plan", description: "plan mode", source: "extension" }],
+    "mapped to name/description/source, junk filtered, never passed through raw");
+  assert.equal(out.hibernating, false);
+
+  await engine._hibernateForTest(s.sessionId);
+  const asleep = await engine.commands(s.sessionId);
+  assert.deepEqual(asleep, { commands: [], hibernating: true },
+    "waking a child because the operator typed '/' would be a lie of availability");
+  await assert.rejects(() => engine.commands("perchlive-deadbeef"), /no_such_session/);
 });

--- a/tests/perch-interactive-routes.test.js
+++ b/tests/perch-interactive-routes.test.js
@@ -1833,3 +1833,25 @@ test("files/list carries the download route's own 404/409 shapes", async () => {
   assert.equal(r.status, 404);
   assert.equal(r.body.error, "not_found");
 });
+
+// ---------------------------------------------------------------------------
+// Wave 3 — GET /interactive/:sid/commands, the slash menu's feed.
+// ---------------------------------------------------------------------------
+
+test("GET /interactive/:sid/commands relays the engine's registry and carries its error shapes", async () => {
+  engineImpl.commands = async (sid) => ({
+    commands: [{ name: "plan", description: "plan mode", source: "extension" }],
+    hibernating: false,
+  });
+  let r = await getJson("/interactive/perchlive-11111111/commands");
+  assert.equal(r.status, 200);
+  assert.deepEqual(r.body, {
+    commands: [{ name: "plan", description: "plan mode", source: "extension" }],
+    hibernating: false,
+  });
+
+  engineImpl.commands = async () => { throw engineErr("no_such_session"); };
+  r = await getJson("/interactive/perchlive-dead0000/commands");
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, "no_such_session");
+});


### PR DESCRIPTION
Implements **Waves 2 + 3** of the approved parity audit (docs/superpowers/specs/2026-09-12-perch-hub-pi-lab-parity-audit.md): audit items 4, 6, 9, 10, 11. Item 5 (combined multi-question ask card) is the one Wave-3 item NOT here — see below.

## Engine relays (commit 1) — additive, riding RPCs already being made
- **Session facts** on snapshot()+state frames: pi's own `contextUsage {tokens, contextWindow, percent}` captured at turn end from the getSessionStats call **metering already makes** (the meter costs zero extra RPCs); per-child `uptimeSeconds` + `memoryMB` (/proc RSS, null-over-guess, honest nulls while hibernating); `toolCount` = the size of the FINAL pinned --tools csv (PiRpc now exposes `toolsCsv`).
- **Tool frames carry payloads**: start relays toolCallId + args (600-char cap), end relays the result's text blocks joined (2000-char cap, pi-lab's own) + isError — truncated ENGINE-side so a 200KB result never rides the SSE wire to every phone on the tailnet.
- **`commands(sid)`**: pi's own get_commands registry, mapped/junk-filtered/capped; a hibernating child answers `{commands:[], hibernating:true}` instead of being woken by a stray "/". New route `GET /interactive/:sid/commands` under the same dashboardAuth, never funnel-public.

## Hub UI (commit 2)
- **Session tab facts card**: Context % + 110k/262k with a bar, Uptime, Memory, Tools — refreshed by state frames alone (no polling); em dash for anything unmeasurable; wiped on session switch.
- **Plan progress**: 3px execution bar above the transcript + a Session-tab checklist (☑/▶/☐) from the plan_state todos array.
- **Inline tool chips** (audit item 4): pill + spinner (the gear's own keyframe) while running, tap to expand args/result in 240px-scrolling boxes, settles to done/failed with the error styling. Live-turn UI by design: a resync/reload drops chips (the transcript endpoint carries messages, not tool calls), the Activity rail keeps the durable record, and the chip index dies WITH the transcript so it can never write into detached DOM.
- **Slash menu** (item 6): "/" opens pi's own registry (one fetch per session, filters as you type, fills the composer on pick, Escape closes via the generation-guarded registry). Anchored `bottom:100%` of the sticky composer — grows upward, can never cover Send. A hibernating session says "asleep — send a message first".

## Why item 5 (combined ask card) is deferred
The extension's rich `questions[]` payload (multi-select, per-option descriptions, one submit) travels via an in-process pi event that pi-lab's OWN web server consumes — it never crosses the RPC boundary; crow's engine only sees the sequential `ctx.ui.select/input` dialogs (which already carry (i/n) progress, headers and "label — description" rows, and work end-to-end since last night's ask_user fix). True parity needs a small pi-lab-side relay change (ask-user.ts emitting the questions payload over ctx.ui or a custom RPC frame) — that repo has a deliberate human-flow gate (pi_extensions_allowlist.mjs's header), so it is flagged for a separate operator-approved pi-lab change rather than smuggled in here.

## Verification
Full suite **4761 / 0** (+15: engine facts/relay/commands unit tests through the controls harness, route shapes, vm-harness UI behavior, static pins, and one live-CDP test broadcasting real frames — facts text, bar widths, plan classes, chip spin (animationName measured as perch-spin) → settle → expand). Docs build untouched (no doc changes in this PR — the audit already describes these items).

After merge: gateway restart/convergence picks up the engine relays; phones get the UI on next page load.